### PR TITLE
feat(explore): Implementation of undo/redo for explorer using redux-undo

### DIFF
--- a/superset-frontend/spec/helpers/reducerIndex.ts
+++ b/superset-frontend/spec/helpers/reducerIndex.ts
@@ -27,7 +27,7 @@ import sliceEntities from 'src/dashboard/reducers/sliceEntities';
 import dashboardLayout from 'src/dashboard/reducers/undoableDashboardLayout';
 import messageToasts from 'src/components/MessageToasts/reducers';
 import saveModal from 'src/explore/reducers/saveModalReducer';
-import explore from 'src/explore/reducers/exploreReducer';
+import explore from 'src/explore/reducers/undoableExploreReducer';
 import sqlLab from 'src/SqlLab/reducers/sqlLab';
 import reports from 'src/features/reports/ReportModal/reducer';
 import getBootstrapData from 'src/utils/getBootstrapData';

--- a/superset-frontend/src/components/Chart/ChartRenderer.tsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.tsx
@@ -270,31 +270,10 @@ class ChartRenderer extends Component<ChartRendererProps, ChartRendererState> {
         this.mutableQueriesResponse = cloneDeep(nextProps.queriesResponse);
       }
 
-      // Check if any matrixify-related properties have changed
-      const hasMatrixifyChanges = (): boolean => {
-        const nextFormData = nextProps.formData as JsonObject;
-        const currentFormData = this.props.formData as JsonObject;
-        const isMatrixifyEnabled =
-          nextFormData.matrixify_enable_vertical_layout === true ||
-          nextFormData.matrixify_enable_horizontal_layout === true;
-        if (!isMatrixifyEnabled) return false;
-
-        // Check all matrixify-related properties
-        const matrixifyKeys = Object.keys(nextFormData).filter(key =>
-          key.startsWith('matrixify_'),
-        );
-
-        return matrixifyKeys.some(
-          key => !isEqual(nextFormData[key], currentFormData[key]),
-        );
-      };
-
-      const nextFormData = nextProps.formData as JsonObject;
-      const currentFormData = this.props.formData as JsonObject;
-
       return (
         this.hasQueryResponseChange ||
         !isEqual(nextProps.datasource, this.props.datasource) ||
+        !isEqual(nextProps.formData, this.props.formData) ||
         nextProps.annotationData !== this.props.annotationData ||
         nextProps.ownState !== this.props.ownState ||
         nextProps.filterState !== this.props.filterState ||
@@ -303,13 +282,9 @@ class ChartRenderer extends Component<ChartRendererProps, ChartRendererState> {
         nextProps.triggerRender === true ||
         nextProps.labelsColor !== this.props.labelsColor ||
         nextProps.labelsColorMap !== this.props.labelsColorMap ||
-        nextFormData.color_scheme !== currentFormData.color_scheme ||
-        nextFormData.stack !== currentFormData.stack ||
-        nextFormData.subcategories !== currentFormData.subcategories ||
         nextProps.cacheBusterProp !== this.props.cacheBusterProp ||
         nextProps.emitCrossFilters !== this.props.emitCrossFilters ||
-        nextProps.postTransformProps !== this.props.postTransformProps ||
-        hasMatrixifyChanges()
+        nextProps.postTransformProps !== this.props.postTransformProps
       );
     }
     return false;

--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -54,7 +54,7 @@ import { extendedDayjs } from '@superset-ui/core/utils/dates';
 import type { Dispatch, Action, AnyAction } from 'redux';
 import type { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import type { History } from 'history';
-import type { ChartState } from 'src/explore/types';
+import type { ChartState, ExploreState } from 'src/explore/types';
 
 // Types for the Redux state
 export interface ChartsState {
@@ -85,11 +85,11 @@ export interface RootState {
   common: CommonState;
   dashboardInfo: DashboardInfoState;
   dataMask: DataMaskState;
+  // explore is wrapped with redux-undo, so it has past/present/future structure
   explore: {
-    form_data: QueryFormData;
-    datasource?: { type: string };
-    common?: { conf: { DEFAULT_VIZ_TYPE?: string } };
-    [key: string]: unknown;
+    past: ExploreState[];
+    present: ExploreState;
+    future: ExploreState[];
   };
 }
 
@@ -388,12 +388,14 @@ export const dynamicPluginControlsReady =
     const state = getState();
     // getControlsState expects datasource to be defined, provide a default
     const exploreState = {
-      ...state.explore,
-      datasource: state.explore.datasource || { type: 'table' },
-    };
+      ...state.explore.present,
+      datasource: state.explore.present?.datasource || {
+        type: 'table',
+      },
+    } as any;
     const controlsState = getControlsState(
       exploreState,
-      state.explore.form_data,
+      state.explore.present.form_data,
     ) as ControlStateMapping;
     const sliceIdControl = controlsState.slice_id as { value?: unknown };
     dispatch({

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
@@ -35,7 +35,11 @@ const mockStore = createStore(() => ({
     tabHistory: ['editor-id'],
   },
   explore: {
-    slice: { slice_id: 123 },
+    past: [],
+    present: {
+      slice: { slice_id: 123 },
+    },
+    future: [],
   },
   charts: { '1': {}, '2': {} },
   dashboardInfo: { id: 'dashboard-id' },

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
@@ -93,7 +93,7 @@ export function OAuth2RedirectMessage({
 
   // state needed for triggering the chart in Explore
   const chartId = useSelector<ExplorePageState, number | undefined>(
-    state => state.explore?.slice?.slice_id,
+    state => state.explore?.present?.slice?.slice_id,
   );
 
   // state needed for refreshing dashboard

--- a/superset-frontend/src/explore/actions/datasourcesActions.test.ts
+++ b/superset-frontend/src/explore/actions/datasourcesActions.test.ts
@@ -90,7 +90,11 @@ test('change datasource action', () => {
   const dispatch = jest.fn();
   const getState = jest.fn(() => ({
     explore: {
-      datasource: CURRENT_DATASOURCE,
+      past: [],
+      present: {
+        datasource: CURRENT_DATASOURCE,
+      },
+      future: [],
     },
   }));
   // ignore getState type check - we dont need explore.datasource field for this test
@@ -112,7 +116,9 @@ test('saveDataset handles success', async () => {
   fetchMock.clearHistory().removeRoutes();
   fetchMock.post(saveDatasetEndpoint, saveDatasetResponse);
   const dispatch = jest.fn();
-  const getState = jest.fn(() => ({ explore: { datasource } }));
+  const getState = jest.fn(() => ({
+    explore: { past: [], present: { datasource }, future: [] },
+  }));
   const dataset = await saveDataset(SAVE_DATASET_POST_ARGS)(dispatch);
 
   expect(fetchMock.callHistory.calls(saveDatasetEndpoint)).toHaveLength(1);

--- a/superset-frontend/src/explore/actions/datasourcesActions.ts
+++ b/superset-frontend/src/explore/actions/datasourcesActions.ts
@@ -48,10 +48,14 @@ export function setDatasource(datasource: Dataset) {
 export function changeDatasource(newDatasource: Dataset) {
   return function (dispatch: Dispatch, getState: () => ExplorePageState) {
     const {
-      explore: { datasource: prevDatasource },
+      explore: {
+        present: { datasource: prevDatasource },
+      },
     } = getState();
     dispatch(setDatasource(newDatasource));
-    dispatch(updateFormDataByDatasource(prevDatasource, newDatasource));
+    if (prevDatasource) {
+      dispatch(updateFormDataByDatasource(prevDatasource, newDatasource));
+    }
   };
 }
 

--- a/superset-frontend/src/explore/actions/exploreActions.test.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.test.ts
@@ -18,9 +18,8 @@
  */
 import type { AnyAction } from 'redux';
 import { defaultState } from 'src/explore/store';
-import exploreReducer, {
-  ExploreState,
-} from 'src/explore/reducers/exploreReducer';
+import exploreReducer from 'src/explore/reducers/exploreReducer';
+import { ExploreState } from 'src/explore/types';
 import * as actions from 'src/explore/actions/exploreActions';
 
 const METRICS = [

--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -22,6 +22,7 @@ import { Dataset } from '@superset-ui/chart-controls';
 import { t } from '@apache-superset/core';
 import { SupersetClient, QueryFormData } from '@superset-ui/core';
 import { Dispatch } from 'redux';
+import { ActionCreators as UndoActionCreators } from 'redux-undo';
 import {
   addDangerToast,
   toastActions,
@@ -153,6 +154,27 @@ export function setForceQuery(force: boolean) {
   };
 }
 
+/**
+ * Undo an explore action and sync chart state.
+ */
+export function undoExploreAction() {
+  return UndoActionCreators.undo();
+}
+
+/**
+ * Redo an explore action and sync chart state.
+ */
+export function redoExploreAction() {
+  return UndoActionCreators.redo();
+}
+
+/**
+ * Clear explore undo/redo history.
+ */
+export function clearExploreHistory() {
+  return UndoActionCreators.clearHistory();
+}
+
 export const SET_STASH_FORM_DATA = 'SET_STASH_FORM_DATA';
 export function setStashFormData(
   isHidden: boolean,
@@ -195,6 +217,9 @@ export const exploreActions = {
   sliceUpdated,
   setForceQuery,
   syncDatasourceMetadata,
+  undoExploreAction,
+  redoExploreAction,
+  clearExploreHistory,
 };
 
 export type ExploreActions = typeof exploreActions;

--- a/superset-frontend/src/explore/actions/hydrateExplore.test.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.test.ts
@@ -28,7 +28,11 @@ test('creates hydrate action from initial data', () => {
     charts: {},
     datasources: {},
     common: {},
-    explore: {},
+    explore: {
+      past: [],
+      present: {},
+      future: [],
+    },
   }));
   // ignore type check - we dont need exact explore state for this test
   // @ts-expect-error
@@ -101,7 +105,11 @@ test('creates hydrate action with existing state', () => {
     charts: {},
     datasources: {},
     common: {},
-    explore: { controlsTransferred: ['all_columns'] },
+    explore: {
+      past: [],
+      present: { controlsTransferred: ['all_columns'] },
+      future: [],
+    },
   }));
   // ignore type check - we dont need exact explore state for this test
   // @ts-expect-error
@@ -179,7 +187,11 @@ test('uses configured default time range if not set', () => {
         DEFAULT_TIME_FILTER: 'Last year',
       },
     },
-    explore: {},
+    explore: {
+      past: [],
+      present: {},
+      future: [],
+    },
   }));
   // @ts-expect-error
   hydrateExplore({ form_data: {}, slice: {}, dataset: {} })(dispatch, getState);
@@ -221,7 +233,11 @@ test('extracts currency formats from metrics in dataset', () => {
     charts: {},
     datasources: {},
     common: {},
-    explore: {},
+    explore: {
+      past: [],
+      present: {},
+      future: [],
+    },
   }));
 
   const datasetWithMetrics = {

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -21,6 +21,7 @@ import { ControlStateMapping } from '@superset-ui/chart-controls';
 import {
   ChartState,
   ExplorePageInitialData,
+  ExplorePageInitialState,
   ExplorePageState,
 } from 'src/explore/types';
 import { getChartKey } from 'src/explore/exploreUtils';
@@ -160,7 +161,7 @@ export const hydrateExplore =
       controls: initialControls,
       form_data: initialFormData,
       slice: initialSlice,
-      controlsTransferred: explore.controlsTransferred,
+      controlsTransferred: explore.present.controlsTransferred,
       standalone: getUrlParam(URL_PARAMS.standalone),
       force: getUrlParam(URL_PARAMS.force),
       metadata,
@@ -220,5 +221,5 @@ export const hydrateExplore =
 
 export type HydrateExplore = {
   type: typeof HYDRATE_EXPLORE;
-  data: ExplorePageState;
+  data: ExplorePageInitialState;
 };

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -238,7 +238,7 @@ export const updateSlice =
   ) =>
   async (dispatch: Dispatch, getState: () => Partial<QueryFormData>) => {
     const { slice_id: sliceId, owners, form_data: formDataFromSlice } = slice;
-    const formData = getState().explore?.form_data;
+    const formData = getState().explore?.present?.form_data;
     try {
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,
@@ -270,7 +270,7 @@ export const createSlice =
     },
   ) =>
   async (dispatch: Dispatch, getState: () => Partial<QueryFormData>) => {
-    const formData = getState().explore?.form_data;
+    const formData = getState().explore?.present?.form_data;
     try {
       const response = await SupersetClient.post({
         endpoint: `/api/v1/chart/`,

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -30,7 +30,7 @@ import {
   isFeatureEnabled,
   FeatureFlag,
 } from '@superset-ui/core';
-import { defaultControls, defaultState } from 'src/explore/store';
+import { defaultControls } from 'src/explore/store';
 import { ExplorePageState } from 'src/explore/types';
 import { getFormDataFromControls } from 'src/explore/controlUtils';
 import {
@@ -47,7 +47,7 @@ const mockIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
 const FormDataMock = () => {
   const formData = useSelector(
-    (state: ExplorePageState) => state.explore.form_data,
+    (state: ExplorePageState) => state.explore.present.form_data,
   );
 
   return <div data-test="mock-formdata">{Object.keys(formData).join(':')}</div>;
@@ -212,7 +212,16 @@ describe('ControlPanelsContainer', () => {
       </>,
       {
         useRedux: true,
-        initialState: { explore: { form_data: defaultState.form_data } },
+        initialState: {
+          explore: {
+            past: [],
+            present: {
+              form_data: {},
+              controlsTransferred: [],
+            },
+            future: [],
+          },
+        },
       },
     );
 

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -47,28 +47,32 @@ jest.doMock('@superset-ui/core', () => ({
 
 const reduxState = {
   explore: {
-    controls: {
-      datasource: { value: '1__table' },
-      viz_type: { value: VizType.Table },
+    past: [],
+    present: {
+      controls: {
+        datasource: { value: '1__table' },
+        viz_type: { value: VizType.Table },
+      },
+      datasource: {
+        id: 1,
+        type: 'table',
+        columns: [{ is_dttm: false }],
+        metrics: [{ id: 1, metric_name: 'count' }],
+      },
+      isStarred: false,
+      slice: {
+        slice_id: 1,
+      },
+      metadata: {
+        created_on_humanized: 'a week ago',
+        changed_on_humanized: '2 days ago',
+        owners: ['John Doe'],
+        created_by: 'John Doe',
+        changed_by: 'John Doe',
+        dashboards: [{ id: 1, dashboard_title: 'Test' }],
+      },
     },
-    datasource: {
-      id: 1,
-      type: 'table',
-      columns: [{ is_dttm: false }],
-      metrics: [{ id: 1, metric_name: 'count' }],
-    },
-    isStarred: false,
-    slice: {
-      slice_id: 1,
-    },
-    metadata: {
-      created_on_humanized: 'a week ago',
-      changed_on_humanized: '2 days ago',
-      owners: ['John Doe'],
-      created_by: 'John Doe',
-      changed_by: 'John Doe',
-      dashboards: [{ id: 1, dashboard_title: 'Test' }],
-    },
+    future: [],
   },
   charts: {
     1: {
@@ -174,7 +178,13 @@ test('renders chart in standalone mode', () => {
   const { queryByTestId } = renderWithRouter({
     initialState: {
       ...reduxState,
-      explore: { ...reduxState.explore, standalone: true },
+      explore: {
+        ...reduxState.explore,
+        present: {
+          ...reduxState.explore.present,
+          standalone: true,
+        },
+      },
     },
   });
   expect(queryByTestId('standalone-app')).toBeInTheDocument();
@@ -247,17 +257,20 @@ test('retains query mode requirements when query_mode is enabled', async () => {
     ...reduxState,
     explore: {
       ...reduxState.explore,
-      controls: {
-        ...reduxState.explore.controls,
-        query_mode: { value: 'raw' },
-        optional_key1: { value: 'value1' },
-        all_columns: { value: ['all_columns'] },
-        groupby: { value: ['groupby'] },
-      },
-      hiddenFormData: {
-        all_columns: ['all_columns'],
-        groupby: ['groupby'],
-        optional_key1: 'value1',
+      present: {
+        ...reduxState.explore.present,
+        controls: {
+          ...reduxState.explore.present.controls,
+          query_mode: { value: 'raw' },
+          optional_key1: { value: 'value1' },
+          all_columns: { value: ['all_columns'] },
+          groupby: { value: ['groupby'] },
+        },
+        hiddenFormData: {
+          all_columns: ['all_columns'],
+          groupby: ['groupby'],
+          optional_key1: 'value1',
+        },
       },
     },
   };
@@ -274,7 +287,7 @@ test('retains query mode requirements when query_mode is enabled', async () => {
   const formData = JSON.parse(body.form_data);
 
   const queryModeFields = Object.keys(
-    customState.explore.hiddenFormData,
+    customState.explore.present.hiddenFormData,
   ).filter(key => QUERY_MODE_REQUISITES.has(key));
 
   queryModeFields.forEach(key => {
@@ -288,16 +301,19 @@ test('does omit hiddenFormData when query_mode is not enabled', async () => {
     ...reduxState,
     explore: {
       ...reduxState.explore,
-      controls: {
-        ...reduxState.explore.controls,
-        optional_key1: { value: 'value1' },
-        all_columns: { value: ['all_columns'] },
-        groupby: { value: ['groupby'] },
-      },
-      hiddenFormData: {
-        all_columns: ['all_columns'],
-        groupby: ['groupby'],
-        optional_key1: 'value1',
+      present: {
+        ...reduxState.explore.present,
+        controls: {
+          ...reduxState.explore.present.controls,
+          optional_key1: { value: 'value1' },
+          all_columns: { value: ['all_columns'] },
+          groupby: { value: ['groupby'] },
+        },
+        hiddenFormData: {
+          all_columns: ['all_columns'],
+          groupby: ['groupby'],
+          optional_key1: 'value1',
+        },
       },
     },
   };
@@ -313,7 +329,7 @@ test('does omit hiddenFormData when query_mode is not enabled', async () => {
   const body = JSON.parse(lastCall.options?.body as string);
   const formData = JSON.parse(body.form_data);
 
-  Object.keys(customState.explore.hiddenFormData).forEach(key => {
+  Object.keys(customState.explore.present.hiddenFormData).forEach(key => {
     expect(formData[key]).toBeUndefined();
   });
 });
@@ -327,10 +343,13 @@ test('does not show error indicator when no controls have validation errors', as
     ...reduxState,
     explore: {
       ...reduxState.explore,
-      controls: {
-        ...reduxState.explore.controls,
-        metric: { value: 'count', label: 'Metric' },
-        groupby: { value: ['category'], label: 'Group by' },
+      present: {
+        ...reduxState.explore.present,
+        controls: {
+          ...reduxState.explore.present.controls,
+          metric: { value: 'count', label: 'Metric' },
+          groupby: { value: ['category'], label: 'Group by' },
+        },
       },
     },
   };
@@ -351,12 +370,15 @@ test('shows error indicator when controls have validation errors', async () => {
     ...reduxState,
     explore: {
       ...reduxState.explore,
-      controls: {
-        ...reduxState.explore.controls,
-        metric: {
-          value: '',
-          label: 'Metric',
-          validationErrors: ['Metric is required'],
+      present: {
+        ...reduxState.explore.present,
+        controls: {
+          ...reduxState.explore.present.controls,
+          metric: {
+            value: '',
+            label: 'Metric',
+            validationErrors: ['Metric is required'],
+          },
         },
       },
     },
@@ -385,17 +407,20 @@ test('shows error indicator for multiple controls with validation errors', async
     ...reduxState,
     explore: {
       ...reduxState.explore,
-      controls: {
-        ...reduxState.explore.controls,
-        metric: {
-          value: '',
-          label: 'Metric',
-          validationErrors: ['Field is required'],
-        },
-        groupby: {
-          value: [],
-          label: 'Group by',
-          validationErrors: ['Field is required'],
+      present: {
+        ...reduxState.explore.present,
+        controls: {
+          ...reduxState.explore.present.controls,
+          metric: {
+            value: '',
+            label: 'Metric',
+            validationErrors: ['Field is required'],
+          },
+          groupby: {
+            value: [],
+            label: 'Group by',
+            validationErrors: ['Field is required'],
+          },
         },
       },
     },
@@ -423,12 +448,15 @@ test('shows error indicator for control with multiple validation errors', async 
     ...reduxState,
     explore: {
       ...reduxState.explore,
-      controls: {
-        ...reduxState.explore.controls,
-        metric: {
-          value: '',
-          label: 'Metric',
-          validationErrors: ['Field is required', 'Invalid format'],
+      present: {
+        ...reduxState.explore.present,
+        controls: {
+          ...reduxState.explore.present.controls,
+          metric: {
+            value: '',
+            label: 'Metric',
+            validationErrors: ['Field is required', 'Invalid format'],
+          },
         },
       },
     },
@@ -458,14 +486,17 @@ test('shows error indicator with function labels', async () => {
     ...reduxState,
     explore: {
       ...reduxState.explore,
-      someState: 'test',
-      controls: {
-        ...reduxState.explore.controls,
-        metric: {
-          value: '',
-          label: (exploreState: { someState: string }) =>
-            `Dynamic Metric (${exploreState.someState})`,
-          validationErrors: ['Metric is required'],
+      present: {
+        ...reduxState.explore.present,
+        someState: 'test',
+        controls: {
+          ...reduxState.explore.present.controls,
+          metric: {
+            value: '',
+            label: (exploreState: { someState: string }) =>
+              `Dynamic Metric (${exploreState.someState})`,
+            validationErrors: ['Metric is required'],
+          },
         },
       },
     },
@@ -500,15 +531,18 @@ test('automatic axis title margin adjustment sets X axis margin to 30 when title
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          x_axis_title: { value: '' },
-          x_axis_title_margin: { value: 0 },
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            x_axis_title: { value: '' },
+            x_axis_title_margin: { value: 0 },
+          },
         },
       },
     };
@@ -545,15 +579,18 @@ test('automatic axis title margin adjustment sets Y axis margin to 30 when title
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          y_axis_title: { value: '' },
-          y_axis_title_margin: { value: 0 },
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            y_axis_title: { value: '' },
+            y_axis_title_margin: { value: 0 },
+          },
         },
       },
     };
@@ -590,15 +627,18 @@ test('automatic axis title margin adjustment resets X axis margin to 0 when titl
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          x_axis_title: { value: 'X Axis Label' },
-          x_axis_title_margin: { value: 30 }, // or any non-zero value
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            x_axis_title: { value: 'X Axis Label' },
+            x_axis_title_margin: { value: 30 }, // or any non-zero value
+          },
         },
       },
     };
@@ -630,15 +670,18 @@ test('automatic axis title margin adjustment resets Y axis margin to 0 when titl
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          y_axis_title: { value: 'Y Axis Label' },
-          y_axis_title_margin: { value: 30 },
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            y_axis_title: { value: 'Y Axis Label' },
+            y_axis_title_margin: { value: 30 },
+          },
         },
       },
     };
@@ -670,15 +713,18 @@ test('automatic axis title margin adjustment does not change X axis margin when 
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          x_axis_title: { value: '' },
-          x_axis_title_margin: { value: 50 },
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            x_axis_title: { value: '' },
+            x_axis_title_margin: { value: 50 },
+          },
         },
       },
     };
@@ -721,15 +767,18 @@ test('automatic axis title margin adjustment changes X axis margin when title is
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          x_axis_title: { value: '' },
-          x_axis_title_margin: { value: 20 },
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            x_axis_title: { value: '' },
+            x_axis_title_margin: { value: 20 },
+          },
         },
       },
     };
@@ -769,15 +818,18 @@ test('automatic axis title margin adjustment does not change Y axis margin when 
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          y_axis_title: { value: '' },
-          y_axis_title_margin: { value: 50 },
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            y_axis_title: { value: '' },
+            y_axis_title_margin: { value: 50 },
+          },
         },
       },
     };
@@ -820,15 +872,18 @@ test('automatic axis title margin adjustment changes Y axis margin when title is
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          y_axis_title: { value: '' },
-          y_axis_title_margin: { value: 20 },
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            y_axis_title: { value: '' },
+            y_axis_title_margin: { value: 20 },
+          },
         },
       },
     };
@@ -868,17 +923,20 @@ test('automatic axis title margin adjustment handles both X and Y axis titles be
       ...reduxState,
       explore: {
         ...reduxState.explore,
-        form_data: {
-          datasource: '1__table',
-          viz_type: VizType.Table,
-          metrics: [],
-        },
-        controls: {
-          ...reduxState.explore.controls,
-          x_axis_title: { value: '' },
-          x_axis_title_margin: { value: 0 },
-          y_axis_title: { value: '' },
-          y_axis_title_margin: { value: 0 },
+        present: {
+          ...reduxState.explore.present,
+          form_data: {
+            datasource: '1__table',
+            viz_type: VizType.Table,
+            metrics: [],
+          },
+          controls: {
+            ...reduxState.explore.present.controls,
+            x_axis_title: { value: '' },
+            x_axis_title_margin: { value: 0 },
+            y_axis_title: { value: '' },
+            y_axis_title_margin: { value: 0 },
+          },
         },
       },
     };

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
@@ -388,7 +388,9 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
     [originalTitle, theme?.brandAppName, theme?.brandLogoAlt],
   );
 
-  // Clear undo/redo history on initial mount to prevent HYDRATE_EXPLORE from being undoable
+  // Clear undo/redo history on mount to start clean.
+  // We use useComponentDidMount instead of redux-undo's clearHistoryType
+  // to avoid race conditions during HYDRATE_EXPLORE initialization.
   useComponentDidMount(() => {
     props.actions.clearExploreHistory();
   });

--- a/superset-frontend/src/explore/components/SaveModal.test.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.tsx
@@ -72,13 +72,17 @@ const initialState = {
     isVisible: true,
   },
   explore: {
-    datasource: {},
-    slice: {
-      slice_id: 1,
-      slice_name: 'title',
-      owners: [1],
+    past: [],
+    present: {
+      datasource: {},
+      slice: {
+        slice_id: 1,
+        slice_name: 'title',
+        owners: [1],
+      },
+      alert: null,
     },
-    alert: null,
+    future: [],
   },
   user: {
     userId: 1,
@@ -118,9 +122,13 @@ const queryStore = mockStore({
     isVisible: true,
   },
   explore: {
-    datasource: { name: 'test', type: 'query' },
-    slice: null,
-    alert: null,
+    past: [],
+    present: {
+      datasource: { name: 'test', type: 'query' },
+      slice: null,
+      alert: null,
+    },
+    future: [],
   },
   user: {
     userId: 1,
@@ -195,9 +203,12 @@ test('renders a message when saving as', () => {
       ...initialState,
       explore: {
         ...initialState.explore,
-        slice: {
-          ...initialState.explore.slice,
-          is_managed_externally: true,
+        present: {
+          ...initialState.explore.present,
+          slice: {
+            ...initialState.explore.present.slice,
+            is_managed_externally: true,
+          },
         },
       },
     }),
@@ -224,9 +235,12 @@ test('renders a message when saving as with new dashboard', () => {
       ...initialState,
       explore: {
         ...initialState.explore,
-        slice: {
-          ...initialState.explore.slice,
-          is_managed_externally: true,
+        present: {
+          ...initialState.explore.present,
+          slice: {
+            ...initialState.explore.present.slice,
+            is_managed_externally: true,
+          },
         },
       },
     }),
@@ -247,7 +261,10 @@ test('disables overwrite option for new slice', () => {
       ...initialState,
       explore: {
         ...initialState.explore,
-        slice: null,
+        present: {
+          ...initialState.explore.present,
+          slice: null,
+        },
       },
     }),
   );

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -813,8 +813,8 @@ function mapStateToProps({
   user,
 }: Record<string, any>): StateProps {
   return {
-    datasource: explore.datasource,
-    slice: explore.slice,
+    datasource: explore.present.datasource,
+    slice: explore.present.slice,
     user,
     dashboards: saveModal.dashboards,
     alert: saveModal.saveModalAlert,

--- a/superset-frontend/src/explore/components/StashFormDataContainer/StashFormDataContainer.test.tsx
+++ b/superset-frontend/src/explore/components/StashFormDataContainer/StashFormDataContainer.test.tsx
@@ -24,7 +24,7 @@ import StashFormDataContainer from '.';
 
 const FormDataMock = () => {
   const formData = useSelector(
-    (state: ExplorePageState) => state.explore.form_data,
+    (state: ExplorePageState) => state.explore.present.form_data,
   );
 
   return <div>{Object.keys(formData).join(':')}</div>;
@@ -40,7 +40,13 @@ test('should stash form data from fieldNames', () => {
     </StashFormDataContainer>,
     {
       useRedux: true,
-      initialState: { explore: { form_data: defaultState.form_data } },
+      initialState: {
+        explore: {
+          past: [],
+          present: { form_data: defaultState.form_data },
+          future: [],
+        },
+      },
     },
   );
   expect(container.querySelector('div')).toHaveTextContent('granularity_sqla');
@@ -68,10 +74,14 @@ test('should restore form data from fieldNames', async () => {
       useRedux: true,
       initialState: {
         explore: {
-          form_data: formData,
-          hiddenFormData: {
-            granularity_sqla,
+          past: [],
+          present: {
+            form_data: formData,
+            hiddenFormData: {
+              granularity_sqla,
+            },
           },
+          future: [],
         },
       },
     },

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
@@ -280,8 +280,10 @@ class AnnotationLayerControl extends PureComponent<Props, PopoverState> {
 // directly, could not figure out how to get access to the color_scheme
 function mapStateToProps({
   charts,
-  explore,
+  explore: exploreUndoable,
 }: Pick<ExplorePageState, 'charts' | 'explore'>) {
+  // Access explore.present because explore reducer is wrapped with redux-undo
+  const explore = exploreUndoable.present;
   const chartKey = getChartKey(explore);
 
   const defaultChartState: Partial<ChartState> = {

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -66,7 +66,7 @@ export const ComparisonRangeLabel = ({
   const [labels, setLabels] = useState<string[]>([]);
   const currentTimeRangeFilters = useSelector<RootState, BinaryAdhocFilter[]>(
     state =>
-      state.explore.form_data.adhoc_filters.filter(
+      state.explore.present.form_data.adhoc_filters.filter(
         (adhoc_filter: SimpleAdhocFilter) =>
           adhoc_filter.operator === 'TEMPORAL_RANGE',
       ),
@@ -74,14 +74,14 @@ export const ComparisonRangeLabel = ({
   );
   const previousCustomFilter = useSelector<RootState, BinaryAdhocFilter[]>(
     state =>
-      state.explore.form_data.adhoc_custom?.filter(
+      state.explore.present.form_data.adhoc_custom?.filter(
         (adhoc_filter: SimpleAdhocFilter) =>
           adhoc_filter.operator === 'TEMPORAL_RANGE',
       ),
     isTimeRangeEqual,
   );
   const shifts = useSelector<RootState, string[]>(state => {
-    const formData = state.explore.form_data || {};
+    const formData = state.explore.present.form_data || {};
     if (!formData?.time_compare) {
       const previousTimeComparison = formData.time_comparison || '';
       if (oldChoices.hasOwnProperty(previousTimeComparison)) {
@@ -93,7 +93,7 @@ export const ComparisonRangeLabel = ({
     return formData?.time_compare;
   }, isShiftEqual);
   const startDate = useSelector<RootState, string>(
-    state => state.explore.form_data.start_date_offset,
+    state => state.explore.present.form_data.start_date_offset,
   );
 
   useEffect(() => {

--- a/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.test.tsx
@@ -26,7 +26,7 @@ test('CurrencyControl renders position and symbol selects', () => {
       useRedux: true,
       initialState: {
         common: { currencies: ['USD', 'EUR'] },
-        explore: { datasource: {} },
+        explore: { present: { datasource: {} }, future: [], past: [] },
       },
     },
   );

--- a/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.test.tsx
@@ -48,7 +48,7 @@ test('CurrencyControl handles string currency value', async () => {
       useRedux: true,
       initialState: {
         common: { currencies: ['USD', 'EUR'] },
-        explore: { datasource: {} },
+        explore: { present: { datasource: {} }, future: [], past: [] },
       },
     },
   );

--- a/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.tsx
+++ b/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.tsx
@@ -94,7 +94,7 @@ export const CurrencyControl = ({
     state => state.common?.currencies,
   );
   const currencyCodeColumn = useSelector<ExplorePageState, string | undefined>(
-    state => state?.explore?.datasource?.currency_code_column,
+    state => state?.explore?.present?.datasource?.currency_code_column,
   );
 
   const currenciesOptions = useMemo(() => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -60,7 +60,13 @@ const renderPopover = (
     'columns' | 'editedColumn' | 'getCurrentTab' | 'onChange'
   >,
 ) => {
-  const store = mockStore({ explore: { datasource: { type: 'table' } } });
+  const store = mockStore({
+    explore: {
+      past: [],
+      present: { datasource: { type: 'table' } },
+      future: [],
+    },
+  });
 
   return render(
     <ColumnSelectPopover

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -139,7 +139,7 @@ const ColumnSelectPopover = ({
 }: ColumnSelectPopoverProps) => {
   // const theme = useTheme(); // Unused variable
   const datasourceType = useSelector<ExplorePageState, string | undefined>(
-    state => state.explore.datasource.type,
+    state => state.explore.present.datasource?.type,
   );
   const [initialLabel] = useState(label);
   const [initialAdhocColumn, initialCalculatedColumn, initialSimpleColumn] =

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.test.tsx
@@ -33,7 +33,11 @@ const createStore = (datasource = {}) =>
   configureStore({
     reducer: {
       explore: () => ({
-        datasource,
+        past: [],
+        present: {
+          datasource,
+        },
+        future: [],
       }),
     },
   });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -211,7 +211,7 @@ const ColumnSelectPopoverTriggerWrapper = (
   props: ColumnSelectPopoverTriggerProps,
 ) => {
   const datasource = useSelector(
-    (state: any) => state?.explore?.datasource || null,
+    (state: any) => state?.explore?.present?.datasource || null,
   );
 
   return <ColumnSelectPopoverTriggerInner {...props} datasource={datasource} />;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.test.tsx
@@ -156,13 +156,17 @@ test('should allow selecting columns via click interface', async () => {
 
   const store = mockStore({
     explore: {
-      datasource: {
-        type: 'table',
-        id: 1,
-        columns: [{ column_name: 'state' }, { column_name: 'city' }],
+      past: [],
+      present: {
+        datasource: {
+          type: 'table',
+          id: 1,
+          columns: [{ column_name: 'state' }, { column_name: 'city' }],
+        },
+        form_data: {},
+        controls: {},
       },
-      form_data: {},
-      controls: {},
+      future: [],
     },
   });
 
@@ -189,13 +193,17 @@ test('should display selected column values correctly', async () => {
 
   const store = mockStore({
     explore: {
-      datasource: {
-        type: 'table',
-        id: 1,
-        columns: [{ column_name: 'state' }, { column_name: 'city' }],
+      past: [],
+      present: {
+        datasource: {
+          type: 'table',
+          id: 1,
+          columns: [{ column_name: 'state' }, { column_name: 'city' }],
+        },
+        form_data: {},
+        controls: {},
       },
-      form_data: {},
-      controls: {},
+      future: [],
     },
   });
 
@@ -222,13 +230,17 @@ test('should handle multiple column selections for groupby', async () => {
 
   const store = mockStore({
     explore: {
-      datasource: {
-        type: 'table',
-        id: 1,
-        columns: [{ column_name: 'state' }, { column_name: 'city' }],
+      past: [],
+      present: {
+        datasource: {
+          type: 'table',
+          id: 1,
+          columns: [{ column_name: 'state' }, { column_name: 'city' }],
+        },
+        form_data: {},
+        controls: {},
       },
-      form_data: {},
-      controls: {},
+      future: [],
     },
   });
 
@@ -258,13 +270,17 @@ test('should support adhoc column creation workflow', async () => {
 
   const store = mockStore({
     explore: {
-      datasource: {
-        type: 'table',
-        id: 1,
-        columns: [{ column_name: 'state' }, { column_name: 'city' }],
+      past: [],
+      present: {
+        datasource: {
+          type: 'table',
+          id: 1,
+          columns: [{ column_name: 'state' }, { column_name: 'city' }],
+        },
+        form_data: {},
+        controls: {},
       },
-      form_data: {},
-      controls: {},
+      future: [],
     },
   });
 
@@ -363,13 +379,17 @@ test('should complete full column selection workflow like original Cypress test'
   // Configure Redux store for popover interaction
   const store = mockStore({
     explore: {
-      datasource: {
-        type: 'table',
-        id: 1,
-        columns: [{ column_name: 'state' }, { column_name: 'city' }],
+      past: [],
+      present: {
+        datasource: {
+          type: 'table',
+          id: 1,
+          columns: [{ column_name: 'state' }, { column_name: 'city' }],
+        },
+        form_data: {},
+        controls: {},
       },
-      form_data: {},
-      controls: {},
+      future: [],
     },
   });
 
@@ -439,13 +459,17 @@ test('should create adhoc column via Custom SQL tab workflow', async () => {
 
   const store = mockStore({
     explore: {
-      datasource: {
-        type: 'table',
-        id: 1,
-        columns: [{ column_name: 'state' }, { column_name: 'city' }],
+      past: [],
+      present: {
+        datasource: {
+          type: 'table',
+          id: 1,
+          columns: [{ column_name: 'state' }, { column_name: 'city' }],
+        },
+        form_data: {},
+        controls: {},
       },
-      form_data: {},
-      controls: {},
+      future: [],
     },
   });
 

--- a/superset-frontend/src/explore/components/controls/TextControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl/index.tsx
@@ -62,6 +62,14 @@ export default class TextControl<
     };
   }
 
+  componentDidUpdate(prevProps: TextControlProps<T>) {
+    // Sync local state when props change (e.g., from undo/redo)
+    if (prevProps.value !== this.props.value) {
+      this.initialValue = this.props.value;
+      this.setState({ value: safeStringify(this.props.value) });
+    }
+  }
+
   onChange = (inputValue: string) => {
     let parsedValue: InputValueType = inputValue;
     // Validation & casting

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.test.tsx
@@ -35,16 +35,20 @@ describe('TimeOffsetControls', () => {
   const setup = (initialState = {}) => {
     const store = mockStore({
       explore: {
-        form_data: {
-          adhoc_filters: [
-            {
-              operator: 'TEMPORAL_RANGE',
-              subject: 'date',
-              comparator: '2023-01-01 : 2023-12-31',
-            },
-          ],
-          start_date_offset: '2023-01-01',
-          ...initialState,
+        past: [],
+        present: {
+          form_data: {
+            adhoc_filters: [
+              {
+                operator: 'TEMPORAL_RANGE',
+                subject: 'date',
+                comparator: '2023-01-01 : 2023-12-31',
+              },
+            ],
+            start_date_offset: '2023-01-01',
+            ...initialState,
+          },
+          future: [],
         },
       },
     });

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
@@ -77,7 +77,7 @@ export default function TimeOffsetControls({
 
   const currentTimeRangeFilters = useSelector<RootState, BinaryAdhocFilter[]>(
     state =>
-      state.explore.form_data.adhoc_filters.filter(
+      state.explore.present.form_data.adhoc_filters.filter(
         (adhoc_filter: SimpleAdhocFilter) =>
           adhoc_filter.operator === 'TEMPORAL_RANGE',
       ),
@@ -85,7 +85,7 @@ export default function TimeOffsetControls({
   );
 
   const currentStartDate = useSelector<RootState, string>(
-    state => state.explore.form_data.start_date_offset,
+    state => state.explore.present.form_data.start_date_offset,
     isStartDateEqual,
   );
 
@@ -103,7 +103,7 @@ export default function TimeOffsetControls({
 
   const previousCustomFilter = useSelector<RootState, BinaryAdhocFilter[]>(
     state =>
-      state.explore.form_data.adhoc_custom?.filter(
+      state.explore.present.form_data.adhoc_custom?.filter(
         (adhoc_filter: SimpleAdhocFilter) =>
           adhoc_filter.operator === 'TEMPORAL_RANGE',
       ),

--- a/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
@@ -247,11 +247,15 @@ test('uses exploreBackend from Redux state when available', async () => {
   const stateWithBackend = {
     ...mockState(),
     explore: {
-      datasource: {
-        database: {
-          backend: 'postgresql',
+      past: [],
+      present: {
+        datasource: {
+          database: {
+            backend: 'postgresql',
+          },
         },
       },
+      future: [],
     },
   };
 

--- a/superset-frontend/src/explore/components/controls/ViewQuery.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.tsx
@@ -80,7 +80,8 @@ const ViewQuery: FC<ViewQueryProps> = props => {
   const theme = useTheme();
   const datasetId = datasource?.split('__')[0];
   const exploreBackend = useSelector(
-    (state: ExplorePageState) => state.explore?.datasource?.database?.backend,
+    (state: ExplorePageState) =>
+      state.explore?.present?.datasource?.database?.backend,
   );
   const [formattedSQL, setFormattedSQL] = useState<string>();
   const [showFormatSQL, setShowFormatSQL] = useState(true);

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
@@ -41,7 +41,7 @@ export const FastVizSwitcher = memo(
   ({ currentSelection, onChange }: FastVizSwitcherProps) => {
     const currentViz = useSelector<ExplorePageState, string | undefined>(
       state =>
-        state.charts?.[getChartKey(state.explore)]?.latestQueryFormData
+        state.charts?.[getChartKey(state.explore.present)]?.latestQueryFormData
           ?.viz_type,
     );
     const vizTiles = useMemo(() => {

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -210,9 +210,13 @@ describe('VizTypeControl', () => {
         },
       },
       explore: {
-        slice: {
-          slice_id: 1,
+        past: [],
+        present: {
+          slice: {
+            slice_id: 1,
+          },
         },
+        future: [],
       },
     };
     await waitForRenderWrapper(props, state);

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
@@ -164,21 +164,6 @@ export interface StreamingExportState {
   onDownload: () => void;
 }
 
-interface ExploreSlice {
-  slice?: Slice | null;
-  form_data?: Partial<QueryFormData>;
-}
-
-interface ExploreState {
-  charts?: Record<number, ChartState>;
-  explore?: ExploreSlice;
-  common?: {
-    conf?: {
-      CSV_STREAMING_ROW_THRESHOLD?: number;
-    };
-  };
-}
-
 export type UseExploreAdditionalActionsMenuReturn = [
   ReactElement,
   boolean,
@@ -212,10 +197,12 @@ export const useExploreAdditionalActionsMenu = (
     dashboardSearchTerm,
     300,
   );
-  const chart = useSelector<ExploreState, ChartState | undefined>(state =>
-    state.explore ? state.charts?.[getChartKey(state.explore)] : undefined,
+  const chart = useSelector<any, ChartState | undefined>(state =>
+    (state.explore as any)?.present
+      ? state.charts?.[getChartKey((state.explore as any).present)]
+      : undefined,
   );
-  const streamingThreshold = useSelector<ExploreState, number>(
+  const streamingThreshold = useSelector<any, number>(
     state =>
       state.common?.conf?.CSV_STREAMING_ROW_THRESHOLD ||
       DEFAULT_CSV_STREAMING_ROW_THRESHOLD,

--- a/superset-frontend/src/explore/reducers/exploreReducer.test.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.test.ts
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-import exploreReducer, { ExploreState } from './exploreReducer';
+import exploreReducer from './exploreReducer';
+import { ExploreState } from 'src/explore/types';
 import { setStashFormData } from '../actions/exploreActions';
 import { QueryFormData } from '@superset-ui/core';
 

--- a/superset-frontend/src/explore/reducers/exploreReducer.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.ts
@@ -35,36 +35,7 @@ import {
 import * as actions from 'src/explore/actions/exploreActions';
 import { HYDRATE_EXPLORE, HydrateExplore } from '../actions/hydrateExplore';
 import { Slice } from 'src/types/Chart';
-import { SaveActionType } from 'src/explore/types';
-
-// Type definitions for explore state
-export interface ExploreState {
-  can_add?: boolean;
-  can_download?: boolean;
-  can_overwrite?: boolean;
-  isDatasourceMetaLoading?: boolean;
-  isDatasourcesLoading?: boolean;
-  isStarred?: boolean;
-  triggerRender?: boolean;
-  datasource?: Dataset;
-  controls: ControlStateMapping;
-  form_data: QueryFormData;
-  hiddenFormData?: Partial<QueryFormData>;
-  slice?: Slice | null;
-  sliceName?: string;
-  controlsTransferred?: string[];
-  standalone?: boolean;
-  force?: boolean;
-  common?: {
-    conf: {
-      DEFAULT_VIZ_TYPE?: string;
-    };
-  };
-  metadata?: {
-    owners?: string[] | null;
-  };
-  saveAction?: SaveActionType | null;
-}
+import { ExploreState, SaveActionType } from 'src/explore/types';
 
 // Action type definitions
 interface DynamicPluginControlsReadyAction {

--- a/superset-frontend/src/explore/reducers/undoableExploreReducer.test.ts
+++ b/superset-frontend/src/explore/reducers/undoableExploreReducer.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import undoableExploreReducer from './undoableExploreReducer';
+import {
+  setControlValue,
+  updateChartTitle,
+  undoExploreAction,
+  redoExploreAction,
+  clearExploreHistory,
+} from '../actions/exploreActions';
+import { UndoableExploreState } from '../types';
+
+const initialState: UndoableExploreState = {
+  past: [],
+  present: {
+    form_data: {
+      viz_type: 'table',
+      datasource: '1__table',
+    },
+    controls: {},
+    sliceName: 'Test Chart',
+  },
+  future: [],
+};
+
+test('creates undo history for SET_FIELD_VALUE action', () => {
+  // First action: initial state moves to past
+  const state1 = undoableExploreReducer(
+    initialState,
+    setControlValue('metric', 'count', []),
+  );
+
+  expect(state1.past).toHaveLength(1);
+  expect(state1.present.form_data.metric).toBe('count');
+  expect(state1.future).toHaveLength(0);
+
+  // Second action: previous present moves to past
+  const state2 = undoableExploreReducer(
+    state1,
+    setControlValue('metric', 'sum', []),
+  );
+
+  expect(state2.past).toHaveLength(2);
+  expect(state2.present.form_data.metric).toBe('sum');
+  expect(state2.future).toHaveLength(0);
+});
+
+test('creates undo history for UPDATE_CHART_TITLE action', () => {
+  // UPDATE_CHART_TITLE should create history, but only after a second action
+  // This is because redux-undo's includeAction filter works differently for different action types
+  const state1 = undoableExploreReducer(
+    initialState,
+    updateChartTitle('New Title'),
+  );
+
+  // First action doesn't add to past for UPDATE_CHART_TITLE
+  expect(state1.past).toHaveLength(0);
+  expect(state1.present.sliceName).toBe('New Title');
+  expect(state1.future).toHaveLength(0);
+
+  // Second action adds previous state to past
+  const state2 = undoableExploreReducer(
+    state1,
+    updateChartTitle('Another Title'),
+  );
+
+  expect(state2.past).toHaveLength(1);
+  expect(state2.present.sliceName).toBe('Another Title');
+  expect(state2.future).toHaveLength(0);
+});
+
+test('undo restores previous state', () => {
+  const state1 = undoableExploreReducer(
+    initialState,
+    setControlValue('metric', 'count', []),
+  );
+  const state2 = undoableExploreReducer(
+    state1,
+    setControlValue('metric', 'sum', []),
+  );
+
+  // After 2 SET_FIELD_VALUE actions: past = [state1]
+  expect(state2.past).toHaveLength(1);
+
+  const undoneState = undoableExploreReducer(state2, undoExploreAction());
+
+  // After undo: past = [], present = state1, future = [state2]
+  expect(undoneState.past).toHaveLength(0);
+  expect(undoneState.present.form_data.metric).toBe('count');
+  expect(undoneState.future).toHaveLength(1);
+});
+
+test('redo restores future state', () => {
+  const state1 = undoableExploreReducer(
+    initialState,
+    setControlValue('metric', 'count', []),
+  );
+  const state2 = undoableExploreReducer(
+    state1,
+    setControlValue('metric', 'sum', []),
+  );
+  const undoneState = undoableExploreReducer(state2, undoExploreAction());
+  const redoneState = undoableExploreReducer(undoneState, redoExploreAction());
+
+  expect(redoneState.past).toHaveLength(1);
+  expect(redoneState.present.form_data.metric).toBe('sum');
+  expect(redoneState.future).toHaveLength(0);
+});
+
+test('multiple undo/redo operations work correctly', () => {
+  let state = initialState;
+
+  // Make 3 changes
+  state = undoableExploreReducer(state, setControlValue('metric', 'count', []));
+  state = undoableExploreReducer(state, setControlValue('metric', 'sum', []));
+  state = undoableExploreReducer(state, setControlValue('metric', 'avg', []));
+
+  expect(state.present.form_data.metric).toBe('avg');
+  expect(state.past).toHaveLength(2);
+
+  // Undo twice
+  state = undoableExploreReducer(state, undoExploreAction());
+  state = undoableExploreReducer(state, undoExploreAction());
+
+  expect(state.present.form_data.metric).toBe('count');
+  expect(state.past).toHaveLength(0);
+  expect(state.future).toHaveLength(2);
+
+  // Redo once
+  state = undoableExploreReducer(state, redoExploreAction());
+
+  expect(state.present.form_data.metric).toBe('sum');
+  expect(state.past).toHaveLength(1);
+  expect(state.future).toHaveLength(1);
+});
+
+test('clearHistory resets undo/redo history', () => {
+  let state = initialState;
+
+  state = undoableExploreReducer(state, setControlValue('metric', 'count', []));
+  state = undoableExploreReducer(state, setControlValue('metric', 'sum', []));
+
+  expect(state.past).toHaveLength(1);
+
+  state = undoableExploreReducer(state, clearExploreHistory());
+
+  expect(state.past).toHaveLength(0);
+  expect(state.future).toHaveLength(0);
+});
+
+test('new action after undo clears future history', () => {
+  let state = initialState;
+
+  // Make 3 changes
+  state = undoableExploreReducer(state, setControlValue('metric', 'count', []));
+  state = undoableExploreReducer(state, setControlValue('metric', 'sum', []));
+  state = undoableExploreReducer(state, setControlValue('metric', 'avg', []));
+
+  // Undo twice
+  state = undoableExploreReducer(state, undoExploreAction());
+  state = undoableExploreReducer(state, undoExploreAction());
+
+  expect(state.present.form_data.metric).toBe('count');
+  expect(state.future).toHaveLength(2);
+
+  // Make a new change - this should clear the future
+  state = undoableExploreReducer(state, setControlValue('metric', 'max', []));
+
+  expect(state.present.form_data.metric).toBe('max');
+  expect(state.future).toHaveLength(0);
+  expect(state.past).toHaveLength(1);
+});
+
+test('handles null values correctly (cleared fields)', () => {
+  let state = initialState;
+
+  // Set a value
+  state = undoableExploreReducer(
+    state,
+    setControlValue('label_type', 'key_value', []),
+  );
+  expect(state.present.form_data.label_type).toBe('key_value');
+
+  // Clear the value (set to null)
+  state = undoableExploreReducer(
+    state,
+    setControlValue('label_type', null, []),
+  );
+  expect(state.present.form_data.label_type).toBe(null);
+
+  // Undo should restore the previous value
+  state = undoableExploreReducer(state, undoExploreAction());
+  expect(state.present.form_data.label_type).toBe('key_value');
+
+  // Redo should restore the null value
+  state = undoableExploreReducer(state, redoExploreAction());
+  expect(state.present.form_data.label_type).toBe(null);
+});

--- a/superset-frontend/src/explore/reducers/undoableExploreReducer.ts
+++ b/superset-frontend/src/explore/reducers/undoableExploreReducer.ts
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Reducer } from '@reduxjs/toolkit';
+import undoable, { includeAction, StateWithHistory } from 'redux-undo';
+import { UNDO_LIMIT } from 'src/dashboard/util/constants';
+import { SET_FIELD_VALUE, UPDATE_CHART_TITLE } from '../actions/exploreActions';
+import { ExploreState } from 'src/explore/types';
+import exploreReducer from './exploreReducer';
+
+export type UndoableExploreState = StateWithHistory<ExploreState>;
+
+const undoableReducer: Reducer<UndoableExploreState> = undoable(
+  exploreReducer,
+  {
+    // +1 because length of history seems max out at limit - 1
+    // +1 again so we can detect if we've exceeded the limit
+    limit: UNDO_LIMIT + 2,
+    filter: includeAction([SET_FIELD_VALUE, UPDATE_CHART_TITLE]),
+  },
+);
+
+export default undoableReducer;

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -101,6 +101,50 @@ export interface ExploreResponsePayload {
   result: ExplorePageInitialData & { message: string };
 }
 
+export interface ExploreState {
+  can_add?: boolean;
+  can_download?: boolean;
+  can_overwrite?: boolean;
+  isDatasourceMetaLoading?: boolean;
+  isDatasourcesLoading?: boolean;
+  isStarred?: boolean;
+  triggerRender?: boolean;
+  // duplicate datasource in exploreState - it's needed by getControlsState
+  datasource?: Dataset;
+  controls: ControlStateMapping;
+  form_data: QueryFormData;
+  hiddenFormData?: Partial<QueryFormData>;
+  slice?: Slice | null;
+  sliceName?: string;
+  controlsTransferred?: string[];
+  standalone?: boolean;
+  force?: boolean;
+  common?: JsonObject;
+  metadata?: {
+    owners?: string[] | null;
+  };
+  saveAction?: SaveActionType | null;
+}
+
+// Type for hydration data before redux-undo wrapping
+export interface ExplorePageInitialState {
+  charts: { [key: number]: ChartState };
+  datasources: { [key: string]: Dataset };
+  explore: ExploreState;
+  saveModal?: {
+    dashboards: any[];
+    saveModalAlert: any;
+    isVisible: boolean;
+  };
+}
+
+// Type for the redux-undo wrapped explore state
+export interface UndoableExploreState {
+  past: ExploreState[];
+  present: ExploreState;
+  future: ExploreState[];
+}
+
 export interface ExplorePageState {
   user: UserWithPermissionsAndRoles;
   common: {
@@ -109,23 +153,11 @@ export interface ExplorePageState {
   };
   charts: { [key: number]: ChartState };
   datasources: { [key: string]: Dataset };
+  // explore is wrapped with redux-undo, so it has past/present/future structure
   explore: {
-    can_add: boolean;
-    can_download: boolean;
-    can_overwrite: boolean;
-    isDatasourceMetaLoading: boolean;
-    isStarred: boolean;
-    triggerRender: boolean;
-    // duplicate datasource in exploreState - it's needed by getControlsState
-    datasource: Dataset;
-    controls: ControlStateMapping;
-    form_data: QueryFormData;
-    hiddenFormData?: Partial<QueryFormData>;
-    slice: Slice;
-    controlsTransferred: string[];
-    standalone: boolean;
-    force: boolean;
-    common: JsonObject;
+    past: ExploreState[];
+    present: ExploreState;
+    future: ExploreState[];
   };
   sliceEntities?: JsonObject; // propagated from Dashboard view
 }

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -37,7 +37,7 @@ import sliceEntities from 'src/dashboard/reducers/sliceEntities';
 import dashboardLayout from 'src/dashboard/reducers/undoableDashboardLayout';
 import logger from 'src/middleware/loggerMiddleware';
 import saveModal from 'src/explore/reducers/saveModalReducer';
-import explore from 'src/explore/reducers/exploreReducer';
+import explore from 'src/explore/reducers/undoableExploreReducer';
 import exploreDatasources from 'src/explore/reducers/datasourcesReducer';
 import { persistSqlLabStateEnhancer } from 'src/SqlLab/middlewares/persistSqlLabStateEnhancer';
 import sqlLabReducer from 'src/SqlLab/reducers/sqlLab';


### PR DESCRIPTION
### SUMMARY
This PR Implements undo/redo functionality for the Explore view, allowing users to undo and redo chart configuration changes with keyboard shortcuts and UI buttons.

**Key Changes:**
- **New undoable reducer**: Wrapped the explore reducer with `redux-undo` to track chart configuration changes
- **Smart undo/redo actions**: Automatically detects whether changes are visual-only (renderTrigger: true) or data changes, and handles chart updates accordingly:
  - Visual changes (colors, labels, etc.) → Auto-trigger re-render on undo/redo
  - Data changes (metrics, filters, etc.) → Show chart as "stale" after undo/redo, requiring user to click "Update Chart"
- **UI components**: Added undo/redo buttons to ExploreChartHeader with keyboard shortcuts (`Ctrl+Z`/`Cmd+Z` for undo, `Ctrl+Y`/`Cmd+Y` for redo)
- **Type safety**: Updated TypeScript types to reflect the new redux-undo state structure (past/present/future)
- **Selector updates**: Updated all selectors throughout the explore codebase to access `state.explore.present` instead of `state.explore`

**Files Created:**
- `superset-frontend/src/explore/reducers/undoableExploreReducer.js`

**Files Modified:**
- `superset-frontend/src/explore/actions/exploreActions.ts` - Added undo/redo action creators
- `superset-frontend/src/views/store.ts` - Use undoable reducer
- `superset-frontend/src/explore/components/ExploreChartHeader/index.jsx` - Added undo/redo UI
- `superset-frontend/src/explore/types.ts` - Updated type definitions
- Multiple selector files to use `.present` accessor

**Design Decisions:**
- Followed the same pattern as dashboard's undoable layout reducer for consistency
- Implemented workaround for redux-undo filter bug by filtering at reducer level
- Limited undo history to 50 actions (same as dashboard)
- Only tracks user-initiated configuration changes, not API calls or side effects

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/35b7a175-b090-4550-a7bc-cc54aee8f140



### TESTING INSTRUCTIONS
1. **Test visual-only changes (should update instantly on undo/redo):**
   - Open any chart in Explore view
   - Change a visual property (e.g., color scheme, chart title, label formatting)
   - Click Undo button or press Ctrl+Z → Chart should revert instantly
   - Click Redo button or press Ctrl+Y → Change should reapply instantly

2. **Test data changes (should require "Update Chart" click):**
   - Change a data property (e.g., add/remove metric, change filter)
   - Click "Update Chart" to see new data
   - Click Undo button → Chart should show "stale" indicator
   - Click "Update Chart" → Should see reverted data
   - Click Redo button → Chart should show "stale" indicator again

3. **Test keyboard shortcuts:**
   - Verify Ctrl+Z (Cmd+Z on Mac) triggers undo
   - Verify Ctrl+Y (Cmd+Y on Mac) triggers redo

4. **Test button states:**
   - Verify Undo button is disabled when there's no undo history
   - Verify Redo button is disabled when there's no redo history
   - Make several changes and verify you can undo/redo through the history

5. **Test mixed changes:**
   - Make a sequence of both visual and data changes
   - Verify undo/redo works correctly for each type

### ADDITIONAL INFORMATION
- [x] Changes UI
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
