### PR TITLE
fix(Multilayer): preserve dashboard context for embedded

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.test.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.test.tsx
@@ -545,7 +545,7 @@ describe('DeckMulti Component Rendering', () => {
       formData: {
         ...baseMockProps.formData,
         dashboardId: 456,
-        extra_filters: [{ col: 'test', op: '==', val: 'value' }],
+        extra_filters: [{ col: 'test', op: 'IN' as const, val: ['value'] }],
       },
     };
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.test.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.test.tsx
@@ -485,6 +485,89 @@ describe('DeckMulti Component Rendering', () => {
     });
   });
 
+  it('should include dashboardId in child slice requests when present', async () => {
+    const props = {
+      ...baseMockProps,
+      formData: {
+        ...baseMockProps.formData,
+        dashboardId: 123, // Simulate embedded dashboard context
+      },
+    };
+
+    renderWithProviders(<DeckMulti {...props} />);
+
+    // Wait for child slice requests
+    await waitFor(() => {
+      expect(SupersetClient.get).toHaveBeenCalled();
+    });
+
+    // Check that all requests include the dashboardId
+    const calls = (SupersetClient.get as jest.Mock).mock.calls;
+    calls.forEach(call => {
+      const url = call[0].endpoint;
+      const urlParams = new URLSearchParams(url.split('?')[1]);
+      const formDataString = urlParams.get('form_data');
+      const formData = JSON.parse(formDataString || '{}');
+      expect(formData.dashboardId).toBe(123);
+    });
+  });
+
+  it('should not include dashboardId when not present', async () => {
+    const props = {
+      ...baseMockProps,
+      formData: {
+        ...baseMockProps.formData,
+        // No dashboardId
+      },
+    };
+
+    renderWithProviders(<DeckMulti {...props} />);
+
+    // Wait for child slice requests
+    await waitFor(() => {
+      expect(SupersetClient.get).toHaveBeenCalled();
+    });
+
+    // Check that requests don't include dashboardId
+    const calls = (SupersetClient.get as jest.Mock).mock.calls;
+    calls.forEach(call => {
+      const url = call[0].endpoint;
+      const formData = JSON.parse(
+        new URLSearchParams(url.split('?')[1]).get('form_data') || '{}',
+      );
+      expect(formData.dashboardId).toBeUndefined();
+    });
+  });
+
+  it('should preserve dashboardId through filter updates', async () => {
+    const props = {
+      ...baseMockProps,
+      formData: {
+        ...baseMockProps.formData,
+        dashboardId: 456,
+        extra_filters: [{ col: 'test', op: '==', val: 'value' }],
+      },
+    };
+
+    renderWithProviders(<DeckMulti {...props} />);
+
+    // Wait for child slice requests
+    await waitFor(() => {
+      expect(SupersetClient.get).toHaveBeenCalled();
+    });
+
+    // Verify dashboardId is preserved with filters
+    const calls = (SupersetClient.get as jest.Mock).mock.calls;
+    calls.forEach(call => {
+      const url = call[0].endpoint;
+      const formData = JSON.parse(
+        new URLSearchParams(url.split('?')[1]).get('form_data') || '{}',
+      );
+      expect(formData.dashboardId).toBe(456);
+      expect(formData.extra_filters).toBeDefined();
+    });
+  });
+
   it('should handle viewport changes', async () => {
     const { rerender } = renderWithProviders(<DeckMulti {...baseMockProps} />);
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
@@ -287,6 +287,8 @@ const DeckMulti = (props: DeckMultiProps) => {
           ...subslice.form_data,
           extra_filters: extraFilters,
           adhoc_filters: adhocFilters,
+          // Preserve dashboard context for embedded mode permissions
+          ...(formData.dashboardId && { dashboardId: formData.dashboardId }),
         },
       } as any as JsonObject & { slice_id: number };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

  Fixes deck.gl Multiple Layers charts failing to load in embedded mode with datasource permission errors. The issue occurs because child layer requests don't include the dashboard
  context (dashboardId) in their form data, causing the security check to fail even though the guest user has access to the dashboard.

  The fix ensures that when deck.gl Multiple Layers loads child slices via separate API calls, it preserves the dashboard context from the parent chart, allowing the backend to properly
  validate guest user permissions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

  1. Create a deck.gl Multiple Layers chart with 2+ child layers (Arc, Path, Scatter, etc.)
  2. Add it to a dashboard and enable embedded mode
  3. Set up guest role with minimal permissions:
    - can read on Dashboard
    - can explore on Superset
    - can explore_json on Superset
    - can dashboard on Superset
    - can read on CurrentUserRestApi
    - Do NOT grant datasource-specific permissions
  4. Generate guest token and access embedded dashboard
  5. Verify deck.gl Multiple Layers chart loads data correctly without permission errors

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
