### PR TITLE
refactor: Move frontend related artifacts into frontend gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,10 +73,6 @@ superset/static/assets/*
 superset/static/uploads/*
 !superset/static/uploads/.gitkeep
 superset/static/version_info.json
-superset-frontend/**/esm/*
-superset-frontend/**/lib/*
-superset-frontend/**/storybook-static/*
-superset-frontend/migration-storybook.log
 yarn-error.log
 *.map
 *.min.js

--- a/superset-frontend/.gitignore
+++ b/superset-frontend/.gitignore
@@ -8,3 +8,7 @@ src/temp
 .temp_cache/
 .tsbuildinfo
 .swc/
+**/esm/*
+**/lib/*
+**/storybook-static/*
+migration-storybook.log


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move root gitignore patterns related to frontend into the frontend gitignore. This was prompted by ripgrep usage inside `superset-frontend`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
