### PR TITLE
fix(dashboard): handle favorite fetch for deleted dashboards

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/FaveStar/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/FaveStar/index.tsx
@@ -42,7 +42,11 @@ export const FaveStar = ({
 }: FaveStarProps) => {
   const theme = useTheme();
   useEffect(() => {
-    fetchFaveStar?.(itemId);
+    // Only attempt to fetch favorite status if itemId is valid
+    // This prevents unnecessary API calls for deleted or invalid items
+    if (itemId && fetchFaveStar) {
+      fetchFaveStar(itemId);
+    }
   }, [fetchFaveStar, itemId]);
 
   const onClick = useCallback(

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -113,15 +113,29 @@ export function fetchFaveStar(id) {
       .then(({ json }) => {
         dispatch(toggleFaveStar(!!json?.result?.[0]?.value));
       })
-      .catch(() =>
+      .catch(async error => {
+        const errorObject = await getClientErrorObject(error);
+        
+        // HTTP 404: Dashboard no longer exists (expected case after deletion)
+        // This is a normal scenario when navigating after a dashboard has been deleted.
+        // Skipping error toast to prevent user-facing errors for expected behavior.
+        if (errorObject.status === 404) {
+          logging.debug(
+            `Favorite status fetch returned 404 for dashboard ID ${id}. ` +
+            `Dashboard may have been deleted. Skipping error notification.`
+          );
+          return;
+        }
+
+        // All other errors are unexpected and should be reported to the user
         dispatch(
           addDangerToast(
             t(
               'There was an issue fetching the favorite status of this dashboard.',
             ),
           ),
-        ),
-      );
+        );
+      });
   };
 }
 

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -115,14 +115,14 @@ export function fetchFaveStar(id) {
       })
       .catch(async error => {
         const errorObject = await getClientErrorObject(error);
-        
+
         // HTTP 404: Dashboard no longer exists (expected case after deletion)
         // This is a normal scenario when navigating after a dashboard has been deleted.
         // Skipping error toast to prevent user-facing errors for expected behavior.
         if (errorObject.status === 404) {
           logging.debug(
             `Favorite status fetch returned 404 for dashboard ID ${id}. ` +
-            `Dashboard may have been deleted. Skipping error notification.`
+              `Dashboard may have been deleted. Skipping error notification.`,
           );
           return;
         }

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.js
@@ -27,6 +27,7 @@ import {
   fetchFaveStar,
   TOGGLE_FAVE_STAR,
 } from 'src/dashboard/actions/dashboardState';
+import { ADD_TOAST } from 'src/components/MessageToasts/actions';
 import { UPDATE_COMPONENTS_PARENTS_LIST } from 'src/dashboard/actions/dashboardLayout';
 import {
   DASHBOARD_GRID_ID,
@@ -261,10 +262,15 @@ describe('dashboardState actions', () => {
     test('does not dispatch error toast on 404 response', async () => {
       const dashboardId = 999;
       const dispatch = sinon.stub();
-      
+
       getStub.restore();
-      const error404 = new Error('Not found');
-      error404.status = 404;
+      const error404 = {
+        response: {
+          status: 404,
+          statusText: 'Not Found',
+          bodyUsed: false,
+        },
+      };
       getStub = sinon.stub(SupersetClient, 'get').rejects(error404);
 
       const thunk = fetchFaveStar(dashboardId);
@@ -277,10 +283,15 @@ describe('dashboardState actions', () => {
     test('dispatches error toast on non-404 errors', async () => {
       const dashboardId = 123;
       const dispatch = sinon.stub();
-      
+
       getStub.restore();
-      const error500 = new Error('Internal server error');
-      error500.status = 500;
+      const error500 = {
+        response: {
+          status: 500,
+          statusText: 'Internal Server Error',
+          bodyUsed: false,
+        },
+      };
       getStub = sinon.stub(SupersetClient, 'get').rejects(error500);
 
       const thunk = fetchFaveStar(dashboardId);
@@ -289,7 +300,7 @@ describe('dashboardState actions', () => {
       await waitFor(() => expect(dispatch.callCount).toBe(1));
       // Verify error toast action was dispatched (ADD_TOAST with danger type)
       const dispatchedAction = dispatch.getCall(0).args[0];
-      expect(dispatchedAction.type).toBe('ADD_TOAST');
+      expect(dispatchedAction.type).toBe(ADD_TOAST);
       expect(dispatchedAction.payload.toastType).toBe('danger');
     });
   });

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -592,7 +592,12 @@ const Header = () => {
   const faveStarProps = useMemo(
     () => ({
       itemId: dashboardInfo.id,
-      fetchFaveStar: boundActionCreators.fetchFaveStar,
+      // Only fetch favorite status for valid, existing dashboards
+      // Skip fetch entirely if dashboard ID is falsy to prevent
+      // 404 errors when navigating after dashboard deletion
+      fetchFaveStar: dashboardInfo.id
+        ? boundActionCreators.fetchFaveStar
+        : undefined,
       saveFaveStar: boundActionCreators.saveFaveStar,
       isStarred,
       showTooltip: true,

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -592,9 +592,9 @@ const Header = () => {
   const faveStarProps = useMemo(
     () => ({
       itemId: dashboardInfo.id,
-      // Only fetch favorite status for valid, existing dashboards
-      // Skip fetch entirely if dashboard ID is falsy to prevent
-      // 404 errors when navigating after dashboard deletion
+      // Only fetch favorite status when dashboard ID exists.
+      // Falsy IDs indicate the dashboard hasn't been created yet or the component
+      // is unmounting. The fetchFaveStar action handles 404s for deleted dashboards.
       fetchFaveStar: dashboardInfo.id
         ? boundActionCreators.fetchFaveStar
         : undefined,


### PR DESCRIPTION
### SUMMARY

Fixes an issue where navigating to another dashboard after deleting a dashboard
could trigger an error toast when fetching the dashboard favorite status.

After dashboard deletion, a stale dashboard ID could still be used by the
frontend to fetch favorite metadata. The backend correctly returns a 404 for
deleted dashboards, but the frontend previously treated this as an unexpected
error.

This change:
- Prevents favorite status fetches for invalid or unmounted dashboards
- Explicitly handles expected 404 responses without showing a user-facing error
- Preserves existing error handling for real failures (network, permissions, 5xx)
- Adds focused regression tests to prevent future regressions

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable.

### TESTING INSTRUCTIONS

**Manual testing:**
1. Create a dashboard
2. Delete the dashboard
3. Navigate to another dashboard
4. Verify no error toast appears when the dashboard loads

**Automated testing:**
- Added unit tests covering:
  - Expected 404 responses after dashboard deletion (no error toast)
  - Non-404 failures (existing error handling preserved)
  - Successful favorite toggle behavior

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #32533
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in SIP-59)
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
