### PR TITLE
fix(dashboard): catch DatasourceNotFound in get_datasets to prevent 404

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -76,6 +76,7 @@ from superset.connectors.sqla.utils import (
     get_physical_table_metadata,
     get_virtual_table_metadata,
 )
+from superset.daos.exceptions import DatasourceNotFound
 from superset.db_engine_specs.base import BaseEngineSpec, TimestampExpression
 from superset.exceptions import (
     ColumnNotFoundException,
@@ -513,7 +514,13 @@ class BaseDatasource(
             # for legacy dashboard imports which have the wrong query_context in them
             try:
                 query_context = slc.get_query_context()
-            except DatasetNotFoundError:
+            except (DatasetNotFoundError, DatasourceNotFound):
+                logger.warning(
+                    "Failed to load query_context for chart '%s' (id=%s): "
+                    "referenced datasource not found",
+                    slc.slice_name,
+                    slc.id,
+                )
                 query_context = None
 
             # legacy charts don't have query_context charts


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a chart on a dashboard has a stale `query_context` that references a datasource that no longer exists, loading the dashboard returns a `404` on the `get_datasets` endpoint and shows a toast error: **"Error loading chart datasources. Filters may not work correctly."**

The fix gracefully handles the missing datasource by catching the exception and logging a warning, so the dashboard loads normally.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
 1. Start a local Superset instance via Docker Compose:
 ```bash
docker compose up --build
```
2. Connect to the Superset metadata database:
```bash
docker exec -it superset-db-1 psql -U superset -d superset
```
3. Identify a dashboard and one of its charts:
```sql
SELECT d.id AS dash_id, d.dashboard_title, s.id AS slice_id, s.slice_name
FROM dashboards d
JOIN dashboard_slices ds ON d.id = ds.dashboard_id
JOIN slices s ON ds.slice_id = s.id
ORDER BY d.id, s.id;
```
4. Pick a `dash_id` and `slice_id` from the results (e.g., dashboard 5 "Video Game Sales", chart 51 "Games").
5. Inject a `query_context` that references a non-existent datasource into the chosen chart:
```sql
UPDATE slices
SET query_context = '{"datasource": {"id": 9999, "type": "table"}, "queries": [{}]}'
WHERE id = 51;
```
6. Without the fix, verify the bug exists:
  - Open the dashboard in the browser. You should see a toast: "Error loading chart datasources. Filters may not work correctly."

7. With the fix verify the fix works:
  - Open the same dashboard. No toast error should appear.
  - Check the Superset logs for the warning:
  - You should see: `Failed to load query_context for chart 'Games' (id=51): referenced datasource not found`