### PR TITLE
fix(mcp): always filter list responses by columns_requested

### DIFF
--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -137,20 +137,17 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
             % (count, total_pages)
         )
 
-        # Apply field filtering via serialization context if select_columns specified
+        # Apply field filtering via serialization context
+        # Always use columns_requested (either explicit select_columns or defaults)
         # This triggers ChartInfo._filter_fields_by_context for each chart
-        if request.select_columns:
-            await ctx.debug(
-                "Applying field filtering via serialization context: select_columns=%s"
-                % (request.select_columns,)
-            )
-            # Return dict with context - FastMCP handles serialization
-            return result.model_dump(
-                mode="json", context={"select_columns": request.select_columns}
-            )
-
-        # No filtering - return full result as dict
-        return result.model_dump(mode="json")
+        columns_to_filter = result.columns_requested
+        await ctx.debug(
+            "Applying field filtering via serialization context: columns=%s"
+            % (columns_to_filter,)
+        )
+        return result.model_dump(
+            mode="json", context={"select_columns": columns_to_filter}
+        )
     except Exception as e:
         await ctx.error("Failed to list charts: %s" % (str(e),))
         raise

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -139,17 +139,12 @@ async def list_dashboards(
         % (count, total_pages)
     )
 
-    # Apply field filtering via serialization context if select_columns specified
+    # Apply field filtering via serialization context
+    # Always use columns_requested (either explicit select_columns or defaults)
     # This triggers DashboardInfo._filter_fields_by_context for each dashboard
-    if request.select_columns:
-        await ctx.debug(
-            "Applying field filtering via serialization context: select_columns=%s"
-            % (request.select_columns,)
-        )
-        # Return dict with context - FastMCP handles serialization
-        return result.model_dump(
-            mode="json", context={"select_columns": request.select_columns}
-        )
-
-    # No filtering - return full result as dict
-    return result.model_dump(mode="json")
+    columns_to_filter = result.columns_requested
+    await ctx.debug(
+        "Applying field filtering via serialization context: columns=%s"
+        % (columns_to_filter,)
+    )
+    return result.model_dump(mode="json", context={"select_columns": columns_to_filter})

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -148,20 +148,17 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
             )
         )
 
-        # Apply field filtering via serialization context if select_columns specified
+        # Apply field filtering via serialization context
+        # Always use columns_requested (either explicit select_columns or defaults)
         # This triggers DatasetInfo._filter_fields_by_context for each dataset
-        if request.select_columns:
-            await ctx.debug(
-                "Applying field filtering via serialization context: select_columns=%s"
-                % (request.select_columns,)
-            )
-            # Return dict with context - FastMCP handles serialization
-            return result.model_dump(
-                mode="json", context={"select_columns": request.select_columns}
-            )
-
-        # No filtering - return full result as dict
-        return result.model_dump(mode="json")
+        columns_to_filter = result.columns_requested
+        await ctx.debug(
+            "Applying field filtering via serialization context: columns=%s"
+            % (columns_to_filter,)
+        )
+        return result.model_dump(
+            mode="json", context={"select_columns": columns_to_filter}
+        )
 
     except Exception as e:
         await ctx.error(


### PR DESCRIPTION
### SUMMARY

Fixes a regression from #37213 where MCP list tools (`list_datasets`, `list_charts`, `list_dashboards`) were not filtering response data when using default columns.

**Root Cause:**
PR #37213 fixed the `model_validate()` bug but accidentally changed the filtering logic to only apply when `select_columns` was explicitly provided:

```python
if request.select_columns:  # Only filters when explicitly provided
    return result.model_dump(mode="json", context={"select_columns": request.select_columns})
return result.model_dump(mode="json")  # No filtering for defaults!
```

This meant that when no `select_columns` was specified (using defaults), all 40+ columns were returned with `null` values, even though `columns_requested` showed only the minimal default columns.

**Fix:**
Always filter based on `columns_requested` (which contains either explicit `select_columns` or the defaults):

```python
columns_to_filter = result.columns_requested
return result.model_dump(mode="json", context={"select_columns": columns_to_filter})
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Request:** `{"page": 2}` (no select_columns)

**Before (broken):** Each dataset has all 40+ fields with null values
```json
{"datasets":[
  {"id":34,"table_name":"threads","schema_name":"public","database_name":null,"description":null,"changed_by":null,"changed_on":null,"changed_on_humanized":null,"created_by":null,"created_on":null,"columns":[],"metrics":[],...},
  ...
]}
```

**After (fixed):** Only the default columns are returned
```json
{"datasets":[
  {"id":34,"table_name":"threads","schema_name":"public","uuid":"d7438be6-..."},
  ...
]}
```

### TESTING INSTRUCTIONS

1. Start Superset with MCP service enabled
2. Call `list_datasets` with just `{"page": 1}` (no select_columns)
3. Verify response datasets only contain default columns: `id`, `table_name`, `schema_name`, `uuid`
4. Verify non-default columns like `description`, `database_name`, `changed_by`, etc. are NOT present (not even with null values)
5. Repeat for `list_charts` and `list_dashboards`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API