### PR TITLE
fix(table-chart): support orderby adhoc columns with server-side pagination

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2800,6 +2800,21 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 col = self.convert_tbl_column_to_sqla_col(
                     columns_by_name[col], template_processor=template_processor
                 )
+            elif isinstance(col, str) and columns:
+                # Check if this is a label reference to an adhoc column
+                adhoc_col = next(
+                    (
+                        c
+                        for c in columns
+                        if utils.is_adhoc_column(c) and c.get("label") == col
+                    ),
+                    None,
+                )
+                if adhoc_col:
+                    col = self.adhoc_column_to_sqla(
+                        col=adhoc_col,
+                        template_processor=template_processor,
+                    )
 
             if isinstance(col, ColumnElement):
                 orderby_exprs.append(col)

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -477,9 +477,9 @@ def test_apply_series_others_grouping_sql_compilation(database: Database) -> Non
     has_single_quotes = "'Others'" in select_sql and "'Others'" in groupby_sql
     has_double_quotes = '"Others"' in select_sql and '"Others"' in groupby_sql
 
-    assert has_single_quotes or has_double_quotes, (
-        "Others literal should be quoted with either single or double quotes"
-    )
+    assert (
+        has_single_quotes or has_double_quotes
+    ), "Others literal should be quoted with either single or double quotes"
 
     # Verify the structure of the generated SQL
     assert "CASE WHEN" in select_sql
@@ -1121,13 +1121,13 @@ def test_process_select_expression_end_to_end(database: Database) -> None:
         # sqlglot may normalize the SQL slightly, so we check the result exists
         # and doesn't contain the SELECT prefix
         assert result is not None, f"Failed to process: {expression}"
-        assert not result.upper().startswith("SELECT"), (
-            f"Result still has SELECT prefix: {result}"
-        )
+        assert not result.upper().startswith(
+            "SELECT"
+        ), f"Result still has SELECT prefix: {result}"
         # The result should contain the core expression (case-insensitive check)
-        assert expected.replace(" ", "").lower() in result.replace(" ", "").lower(), (
-            f"Expected '{expected}' to be in result '{result}' for input '{expression}'"
-        )
+        assert (
+            expected.replace(" ", "").lower() in result.replace(" ", "").lower()
+        ), f"Expected '{expected}' to be in result '{result}' for input '{expression}'"
 
 
 def test_reapply_query_filters_with_granularity(database: Database) -> None:
@@ -1641,9 +1641,9 @@ def test_adhoc_column_with_spaces_generates_quoted_sql(database: Database) -> No
             )
         )
 
-    assert '"Order Total"' in sql_numeric, (
-        f"Expected quoted column name in SQL: {sql_numeric}"
-    )
+    assert (
+        '"Order Total"' in sql_numeric
+    ), f"Expected quoted column name in SQL: {sql_numeric}"
 
 
 def test_adhoc_column_with_spaces_in_full_query(database: Database) -> None:
@@ -1703,3 +1703,43 @@ def test_adhoc_column_with_spaces_in_full_query(database: Database) -> None:
     # Verify SELECT and FROM clauses are present
     assert "SELECT" in sql
     assert "FROM" in sql
+
+
+def test_orderby_adhoc_column(database: Database) -> None:
+    """
+    Test that orderby works with adhoc column labels.
+
+    When orderby contains a string that matches the label of an adhoc column
+    in the columns list, it should correctly convert to a SQLAlchemy column
+    instead of raising QueryObjectValidationError.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[
+            TableColumn(column_name="a"),
+            TableColumn(column_name="b"),
+        ],
+    )
+
+    # Should not raise QueryObjectValidationError
+    result = table.get_sqla_query(
+        columns=[
+            {"expressionType": "SQL", "label": "custom_col", "sqlExpression": "a + 1"},
+            "b",
+        ],
+        orderby=[("custom_col", False)],  # Order by adhoc column label
+        metrics=[],
+        extras={},
+        filter=[],
+        granularity=None,
+        is_timeseries=False,
+    )
+    assert result is not None
+
+    # Verify the SQL contains the expression from the adhoc column
+    sql = str(result.sqla_query)
+    assert "ORDER BY" in sql.upper()

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -477,9 +477,9 @@ def test_apply_series_others_grouping_sql_compilation(database: Database) -> Non
     has_single_quotes = "'Others'" in select_sql and "'Others'" in groupby_sql
     has_double_quotes = '"Others"' in select_sql and '"Others"' in groupby_sql
 
-    assert (
-        has_single_quotes or has_double_quotes
-    ), "Others literal should be quoted with either single or double quotes"
+    assert has_single_quotes or has_double_quotes, (
+        "Others literal should be quoted with either single or double quotes"
+    )
 
     # Verify the structure of the generated SQL
     assert "CASE WHEN" in select_sql
@@ -1121,13 +1121,13 @@ def test_process_select_expression_end_to_end(database: Database) -> None:
         # sqlglot may normalize the SQL slightly, so we check the result exists
         # and doesn't contain the SELECT prefix
         assert result is not None, f"Failed to process: {expression}"
-        assert not result.upper().startswith(
-            "SELECT"
-        ), f"Result still has SELECT prefix: {result}"
+        assert not result.upper().startswith("SELECT"), (
+            f"Result still has SELECT prefix: {result}"
+        )
         # The result should contain the core expression (case-insensitive check)
-        assert (
-            expected.replace(" ", "").lower() in result.replace(" ", "").lower()
-        ), f"Expected '{expected}' to be in result '{result}' for input '{expression}'"
+        assert expected.replace(" ", "").lower() in result.replace(" ", "").lower(), (
+            f"Expected '{expected}' to be in result '{result}' for input '{expression}'"
+        )
 
 
 def test_reapply_query_filters_with_granularity(database: Database) -> None:
@@ -1641,9 +1641,9 @@ def test_adhoc_column_with_spaces_generates_quoted_sql(database: Database) -> No
             )
         )
 
-    assert (
-        '"Order Total"' in sql_numeric
-    ), f"Expected quoted column name in SQL: {sql_numeric}"
+    assert '"Order Total"' in sql_numeric, (
+        f"Expected quoted column name in SQL: {sql_numeric}"
+    )
 
 
 def test_adhoc_column_with_spaces_in_full_query(database: Database) -> None:


### PR DESCRIPTION
### SUMMARY
  When using server-side pagination in table charts, sorting by custom SQL expression columns (adhoc columns) fails with:                                                          
  Error: Unknown column used in orderby: <column_label> 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1166" height="288" alt="image" src="https://github.com/user-attachments/assets/09231e46-4be9-4f16-a223-8bad2d4970db" />
After:
<img width="621" height="348" alt="image" src="https://github.com/user-attachments/assets/289e3a1e-7fa9-4237-a89e-6b1d3bb1b584" />

### ROOT CAUSE
  In superset/models/helpers.py, the orderby validation loop (lines ~2767-2810) handles:                                                                                           
  - Adhoc metrics via utils.is_adhoc_metric(col)                                                                                                                                   
  - Named metrics via lookup in metrics_exprs_by_label                                                                                                                             
  - Physical columns via lookup in columns_by_name    
However, it does NOT handle adhoc columns (SQL expression columns with expressionType: "SQL"). When the orderby value is a string label that matches an adhoc column, the code fails to recognize it and raises QueryObjectValidationError.                    
### TESTING INSTRUCTIONS
  1. Create a table chart with server-side pagination enabled                                                                                                                      
  2. Add a custom SQL expression column (e.g., {"expressionType": "SQL", "label": "custom_col", "sqlExpression": "column_a + 1"})                                                  
  3. Click the adhoc column header to sort                                                                                                                                         
  4. Verify sorting works without error    
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #37520   
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
