### PR TITLE
fix(build/backend): migrate to deps-free `pygeohash` with pre-built wheels at runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "pyparsing>=3.0.6, <4",
     "python-dateutil",
     "python-dotenv", # optional dependencies for Flask but required for Superset, see https://flask.palletsprojects.com/en/stable/installation/#optional-dependencies
-    "python-geohash",
+    "pygeohash",
     "pyarrow>=16.1.0, <19", # before upgrading pyarrow, check that all db dependencies support this, see e.g. https://github.com/apache/superset/pull/34693
     "pyyaml>=6.0.0, <7.0.0",
     "PyJWT>=2.4.0, <3.0",
@@ -457,8 +457,6 @@ authorized_licenses = [
 # Seems ok, might need legal review
 # https://github.com/urschrei/pypolyline/blob/master/LICENSE.md
 polyline = "2"
-# Apache 2.0 https://github.com/hkwi/python-geohash
-python-geohash = "0"
 # --------------------------------------------------------------
 
 # TODO REMOVE THESE DEPS FROM CODEBASE

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -303,6 +303,8 @@ pydantic==2.11.7
     #   apache-superset-core
 pydantic-core==2.33.2
     # via pydantic
+pygeohash==3.2.2
+    # via apache-superset (pyproject.toml)
 pygments==2.19.1
     # via rich
 pyjwt==2.10.1
@@ -329,8 +331,6 @@ python-dateutil==2.9.0.post0
     #   pandas
     #   shillelagh
 python-dotenv==1.1.0
-    # via apache-superset (pyproject.toml)
-python-geohash==0.8.5
     # via apache-superset (pyproject.toml)
 pytz==2025.2
     # via

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -752,6 +752,10 @@ pydruid==0.6.9
     # via apache-superset
 pyfakefs==5.3.5
     # via apache-superset
+pygeohash==3.2.2
+    # via
+    #   -c requirements/base-constraint.txt
+    #   apache-superset
 pygments==2.19.1
     # via
     #   -c requirements/base-constraint.txt
@@ -827,10 +831,6 @@ python-dotenv==1.1.0
     #   apache-superset
     #   fastmcp
     #   pydantic-settings
-python-geohash==0.8.5
-    # via
-    #   -c requirements/base-constraint.txt
-    #   apache-superset
 python-json-logger==4.0.0
     # via pydocket
 python-ldap==3.4.4

--- a/superset/utils/pandas_postprocessing/geography.py
+++ b/superset/utils/pandas_postprocessing/geography.py
@@ -16,7 +16,7 @@
 # under the License.
 from typing import Optional
 
-import geohash as geohash_lib
+import pygeohash as geohash_lib
 from flask_babel import gettext as _
 from geopy.point import Point
 from pandas import DataFrame
@@ -68,7 +68,9 @@ def geohash_encode(
         encode_df = df[[latitude, longitude]]
         encode_df.columns = ["latitude", "longitude"]
         encode_df["geohash"] = encode_df.apply(
-            lambda row: geohash_lib.encode(row["latitude"], row["longitude"]),
+            lambda row: geohash_lib.encode(
+                latitude=row["latitude"], longitude=row["longitude"]
+            ),
             axis=1,
         )
         return _append_columns(df, encode_df, {"geohash": geohash})

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -32,10 +32,10 @@ from datetime import datetime, timedelta
 from itertools import product
 from typing import Any, cast, Optional, TYPE_CHECKING
 
-import geohash
 import numpy as np
 import pandas as pd
 import polyline
+import pygeohash
 from dateutil import relativedelta as rdelta
 from deprecation import deprecated
 from flask import current_app, request
@@ -1830,7 +1830,7 @@ class BaseDeckGLViz(BaseViz):
     @staticmethod
     @deprecated(deprecated_in="3.0")
     def reverse_geohash_decode(geohash_code: str) -> tuple[str, str]:
-        lat, lng = geohash.decode(geohash_code)
+        lat, lng = pygeohash.decode(geohash_code)
         return (lng, lat)
 
     @staticmethod
@@ -2133,13 +2133,21 @@ class DeckGrid(BaseDeckGLViz):
 
 @deprecated(deprecated_in="3.0")
 def geohash_to_json(geohash_code: str) -> list[list[float]]:
-    bbox = geohash.bbox(geohash_code)
+    # Get the center and the error margins
+    lat, lon, lat_err, lon_err = pygeohash.decode_exactly(geohash_code)
+    # Calculate the Bounding Box
+    bbox = {
+        "n": lat + lat_err,
+        "s": lat - lat_err,
+        "e": lon + lon_err,
+        "w": lon - lon_err,
+    }
     return [
-        [bbox.get("w"), bbox.get("n")],
-        [bbox.get("e"), bbox.get("n")],
-        [bbox.get("e"), bbox.get("s")],
-        [bbox.get("w"), bbox.get("s")],
-        [bbox.get("w"), bbox.get("n")],
+        [bbox["w"], bbox["n"]],
+        [bbox["e"], bbox["n"]],
+        [bbox["e"], bbox["s"]],
+        [bbox["w"], bbox["s"]],
+        [bbox["w"], bbox["n"]],
     ]
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(build/backend): migrate to deps-free `pygeohash` with pre-built wheels at runtime

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #37297 

Allows users to run Superset container without `pip/uv` trying to compile C++ extension for `python-geohash`. The library introduced in this PR, `pygeohash`, provides pre-built wheels that play well with modern platforms. API-wise, there are little changes except for `.bbox()` method but thanks to Gemini's solution, this can be considered as patched.

While the newly migrated library is slower than the status quo, it definitely helps with cross-platform usability as a whole. 

CI should be green as acceptance threshold.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
