### PR TITLE
fix(docs): add consistent dev-mode logging for Matomo page views

### DIFF
--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -74,6 +74,14 @@ export default function Root({ children }) {
         window._paq.push(['trackSiteSearch', keyword, category, resultsCount]);
       };
 
+      // Helper to track page views
+      const trackPageView = (url, title) => {
+        if (devMode) {
+          console.log('Matomo trackPageView:', { url, title });
+        }
+        window._paq.push(['trackPageView']);
+      };
+
 
       // Track external link clicks using domain as category (vendor-agnostic)
       const handleLinkClick = (event) => {
@@ -221,7 +229,6 @@ export default function Root({ children }) {
           trackDocsVersion();
 
           if (devMode) {
-            console.log('Tracking page view:', currentPath, currentTitle);
             window._paq.push(['setDomains', ['superset.apache.org']]);
             window._paq.push([
               'setCustomUrl',
@@ -233,7 +240,7 @@ export default function Root({ children }) {
 
           window._paq.push(['setReferrerUrl', window.location.href]);
           window._paq.push(['setDocumentTitle', currentTitle]);
-          window._paq.push(['trackPageView']);
+          trackPageView(currentPath, currentTitle);
 
           // Check for 404 after page renders
           setTimeout(track404, 500);


### PR DESCRIPTION
## Summary

Adds consistent dev-mode console logging for Matomo page view tracking to match the existing `trackEvent` logging pattern.

**The Problem:**
When running the docs site locally, developers see console logs like:
```
Matomo trackEvent: {category: 'User Preference', action: 'Color Mode', name: 'light'}
Matomo trackEvent: {category: 'User Preference', action: 'Docs Version', name: 'latest'}
```

But there was no equivalent log for `trackPageView`, making it seem like only events were being tracked when page views were actually being tracked correctly.

**The Fix:**
Added a `trackPageView` helper function that mirrors the `trackEvent` pattern:
```javascript
const trackPageView = (url, title) => {
  if (devMode) {
    console.log('Matomo trackPageView:', { url, title });
  }
  window._paq.push(['trackPageView']);
};
```

Now developers will see:
```
Matomo trackPageView: { url: '/docs/databases/bigquery', title: 'BigQuery | Superset' }
```

This provides clarity that page views ARE being tracked for all pages, including dynamically generated ones like database docs.

## Test plan

- [x] Run docs site locally (`yarn start` in `/docs`)
- [x] Navigate between pages
- [x] Verify console shows `Matomo trackPageView:` logs alongside event logs
- [x] No changes to production behavior (logging only happens in dev mode)

🤖 Generated with [Claude Code](https://claude.ai/code)