### PR TITLE
feat(bar-chart): add option to color bars by primary axis when no dimensions are set 

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -40,7 +40,8 @@ import {
   xAxisBounds,
   xAxisLabelRotation,
   xAxisLabelInterval,
-  forceMaxInterval, colorByPrimaryAxisSection,
+  forceMaxInterval,
+  colorByPrimaryAxisSection,
 } from '../../../controls';
 
 import { OrientationType } from '../../types';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -40,7 +40,7 @@ import {
   xAxisBounds,
   xAxisLabelRotation,
   xAxisLabelInterval,
-  forceMaxInterval, showColorByXAxisSection,
+  forceMaxInterval, colorByPrimaryAxisSection,
 } from '../../../controls';
 
 import { OrientationType } from '../../types';
@@ -328,7 +328,7 @@ const config: ControlPanelConfig = {
         ['color_scheme'],
         ['time_shift_color'],
         ...showValueSectionWithoutStream,
-        ...showColorByXAxisSection,
+        ...colorByPrimaryAxisSection,
         [
           {
             name: 'stackDimension',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -40,7 +40,7 @@ import {
   xAxisBounds,
   xAxisLabelRotation,
   xAxisLabelInterval,
-  forceMaxInterval,
+  forceMaxInterval, showColorByXAxisSection,
 } from '../../../controls';
 
 import { OrientationType } from '../../types';
@@ -328,6 +328,7 @@ const config: ControlPanelConfig = {
         ['color_scheme'],
         ['time_shift_color'],
         ...showValueSectionWithoutStream,
+        ...showColorByXAxisSection,
         [
           {
             name: 'stackDimension',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -175,6 +175,7 @@ export default function transformProps(
     seriesType,
     showLegend,
     showValue,
+    showColorByXAxis,
     sliceId,
     sortSeriesType,
     sortSeriesAscending,
@@ -421,6 +422,7 @@ export default function transformProps(
         timeShiftColor,
         theme,
         hasDimensions: (groupBy?.length ?? 0) > 0,
+        showColorByXAxis,
       },
     );
     if (transformedSeries) {
@@ -437,6 +439,53 @@ export default function transformProps(
       }
     }
   });
+
+  // Add x-axis color legend when showColorByXAxis is enabled
+  if (showColorByXAxis && groupBy.length === 0 && series.length > 0) {
+    // Hide original series from legend
+    series.forEach(s => {
+      s.legendHoverLink = false;
+    });
+
+    // Get x-axis values from the first series
+    const firstSeries = series[0];
+    if (firstSeries && Array.isArray(firstSeries.data)) {
+      const xAxisValues: (string | number)[] = [];
+
+      // Extract x-axis values
+      (firstSeries.data as any[]).forEach(point => {
+        let xValue;
+        if (point && typeof point === 'object' && 'value' in point) {
+          const val = point.value;
+          xValue = Array.isArray(val) ? val[0] : val;
+        } else if (Array.isArray(point)) {
+          xValue = point[0];
+        } else {
+          xValue = point;
+        }
+        xAxisValues.push(xValue);
+      });
+
+      // Create hidden series for legend (using 'line' type to not affect bar width)
+      xAxisValues.forEach(xValue => {
+        const colorKey = String(xValue);
+        series.push({
+          name: String(xValue),
+          type: 'line', // Use line type to not affect bar positioning
+          data: [], // Empty - doesn't render
+          itemStyle: {
+            color: colorScale(colorKey, sliceId),
+          },
+          lineStyle: {
+            color: colorScale(colorKey, sliceId),
+          },
+          silent: true,
+          legendHoverLink: false,
+          showSymbol: false,
+        });
+      });
+    }
+  }
 
   if (stack === StackControlsValue.Stream) {
     const baselineSeries = getBaselineSeriesForStream(
@@ -592,14 +641,34 @@ export default function transformProps(
     isHorizontal,
   );
 
-  const legendData = rawSeries
-    .filter(
-      entry =>
-        extractForecastSeriesContext(entry.name || '').type ===
-        ForecastSeriesEnum.Observation,
-    )
-    .map(entry => entry.name || '')
-    .concat(extractAnnotationLabels(annotationLayers));
+  const legendData = showColorByXAxis && groupBy.length === 0 && series.length > 0
+    ? // When showColorByXAxis is enabled, show only x-axis values
+    (() => {
+      const firstSeries = series[0];
+      if (firstSeries && Array.isArray(firstSeries.data)) {
+        return (firstSeries.data as any[]).map(point => {
+          if (point && typeof point === 'object' && 'value' in point) {
+            const val = point.value;
+            return String(Array.isArray(val) ? val[0] : val);
+          } else if (Array.isArray(point)) {
+            return String(point[0]);
+          } else {
+            return String(point);
+          }
+        });
+      }
+      return [];
+    })()
+    : // Otherwise show original series names
+    rawSeries
+      .filter(
+        entry =>
+          extractForecastSeriesContext(entry.name || '').type ===
+          ForecastSeriesEnum.Observation,
+      )
+      .map(entry => entry.name || '')
+      .concat(extractAnnotationLabels(annotationLayers));
+
 
   let xAxis: any = {
     type: xAxisType,
@@ -792,10 +861,24 @@ export default function transformProps(
         padding,
       ),
       scrollDataIndex: legendIndex || 0,
-      data: legendData.sort((a: string, b: string) => {
-        if (!legendSort) return 0;
-        return legendSort === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
-      }) as string[],
+      data: showColorByXAxis && groupBy.length === 0
+        ? // When showColorByXAxis, configure legend items with roundRect icons
+        legendData.map(name => ({
+          name,
+          icon: 'roundRect',
+        }))
+        : // Otherwise use normal legend data
+        legendData.sort((a: string, b: string) => {
+          if (!legendSort) return 0;
+          return legendSort === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
+        }),
+      // Disable legend selection and buttons when showColorByXAxis is enabled
+      ...(showColorByXAxis && groupBy.length === 0
+        ? {
+          selectedMode: false, // Disable clicking legend items
+          selector: false, // Hide All/Invert buttons
+        }
+        : {}),
     },
     series: dedupSeries(reorderForecastSeries(series) as SeriesOption[]),
     toolbox: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -452,14 +452,16 @@ export default function transformProps(
     if (firstSeries && Array.isArray(firstSeries.data)) {
       const xAxisValues: (string | number)[] = [];
 
-      // Extract x-axis values
+      // Extract primary axis values (category axis)
+      // For horizontal charts the category is at index 1, for vertical at index 0
+      const primaryAxisIndex = isHorizontal ? 1 : 0;
       (firstSeries.data as any[]).forEach(point => {
         let xValue;
         if (point && typeof point === 'object' && 'value' in point) {
           const val = point.value;
-          xValue = Array.isArray(val) ? val[0] : val;
+          xValue = Array.isArray(val) ? val[primaryAxisIndex] : val;
         } else if (Array.isArray(point)) {
-          xValue = point[0];
+          xValue = point[primaryAxisIndex];
         } else {
           xValue = point;
         }
@@ -467,10 +469,14 @@ export default function transformProps(
       });
 
       // Create hidden series for legend (using 'line' type to not affect bar width)
-      xAxisValues.forEach(xValue => {
-        const colorKey = String(xValue);
+      // Deduplicate x-axis values to avoid duplicate legend entries and unnecessary series
+      const uniqueXAxisValues = Array.from(
+        new Set(xAxisValues.map(v => String(v))),
+      );
+      uniqueXAxisValues.forEach(xValue => {
+        const colorKey = xValue;
         series.push({
-          name: String(xValue),
+          name: xValue,
           type: 'line', // Use line type to not affect bar positioning
           data: [], // Empty - doesn't render
           itemStyle: {
@@ -641,34 +647,43 @@ export default function transformProps(
     isHorizontal,
   );
 
-  const legendData = colorByPrimaryAxis && groupBy.length === 0 && series.length > 0
-    ? // When colorByPrimaryAxis is enabled, show only x-axis values
-    (() => {
-      const firstSeries = series[0];
-      if (firstSeries && Array.isArray(firstSeries.data)) {
-        return (firstSeries.data as any[]).map(point => {
-          if (point && typeof point === 'object' && 'value' in point) {
-            const val = point.value;
-            return String(Array.isArray(val) ? val[0] : val);
-          } else if (Array.isArray(point)) {
-            return String(point[0]);
-          } else {
-            return String(point);
+  const legendData =
+    colorByPrimaryAxis && groupBy.length === 0 && series.length > 0
+      ? // When colorByPrimaryAxis is enabled, show only primary axis values (deduped + filtered)
+        (() => {
+          const firstSeries = series[0];
+          // For horizontal charts the category is at index 1, for vertical at index 0
+          const primaryAxisIndex = isHorizontal ? 1 : 0;
+          if (firstSeries && Array.isArray(firstSeries.data)) {
+            const names = (firstSeries.data as any[])
+              .map(point => {
+                if (point && typeof point === 'object' && 'value' in point) {
+                  const val = point.value;
+                  return String(
+                    Array.isArray(val) ? val[primaryAxisIndex] : val,
+                  );
+                }
+                if (Array.isArray(point)) {
+                  return String(point[primaryAxisIndex]);
+                }
+                return String(point);
+              })
+              .filter(
+                name => name !== '' && name !== 'undefined' && name !== 'null',
+              );
+            return Array.from(new Set(names));
           }
-        });
-      }
-      return [];
-    })()
-    : // Otherwise show original series names
-    rawSeries
-      .filter(
-        entry =>
-          extractForecastSeriesContext(entry.name || '').type ===
-          ForecastSeriesEnum.Observation,
-      )
-      .map(entry => entry.name || '')
-      .concat(extractAnnotationLabels(annotationLayers));
-
+          return [];
+        })()
+      : // Otherwise show original series names
+        rawSeries
+          .filter(
+            entry =>
+              extractForecastSeriesContext(entry.name || '').type ===
+              ForecastSeriesEnum.Observation,
+          )
+          .map(entry => entry.name || '')
+          .concat(extractAnnotationLabels(annotationLayers));
 
   let xAxis: any = {
     type: xAxisType,
@@ -861,23 +876,26 @@ export default function transformProps(
         padding,
       ),
       scrollDataIndex: legendIndex || 0,
-      data: colorByPrimaryAxis && groupBy.length === 0
-        ? // When colorByPrimaryAxis, configure legend items with roundRect icons
-        legendData.map(name => ({
-          name,
-          icon: 'roundRect',
-        }))
-        : // Otherwise use normal legend data
-        legendData.sort((a: string, b: string) => {
-          if (!legendSort) return 0;
-          return legendSort === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
-        }),
+      data:
+        colorByPrimaryAxis && groupBy.length === 0
+          ? // When colorByPrimaryAxis, configure legend items with roundRect icons
+            legendData.map(name => ({
+              name,
+              icon: 'roundRect',
+            }))
+          : // Otherwise use normal legend data
+            legendData.sort((a: string, b: string) => {
+              if (!legendSort) return 0;
+              return legendSort === 'asc'
+                ? a.localeCompare(b)
+                : b.localeCompare(a);
+            }),
       // Disable legend selection and buttons when colorByPrimaryAxis is enabled
       ...(colorByPrimaryAxis && groupBy.length === 0
         ? {
-          selectedMode: false, // Disable clicking legend items
-          selector: false, // Hide All/Invert buttons
-        }
+            selectedMode: false, // Disable clicking legend items
+            selector: false, // Hide All/Invert buttons
+          }
         : {}),
     },
     series: dedupSeries(reorderForecastSeries(series) as SeriesOption[]),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -175,7 +175,7 @@ export default function transformProps(
     seriesType,
     showLegend,
     showValue,
-    showColorByXAxis,
+    colorByPrimaryAxis,
     sliceId,
     sortSeriesType,
     sortSeriesAscending,
@@ -422,7 +422,7 @@ export default function transformProps(
         timeShiftColor,
         theme,
         hasDimensions: (groupBy?.length ?? 0) > 0,
-        showColorByXAxis,
+        colorByPrimaryAxis,
       },
     );
     if (transformedSeries) {
@@ -440,8 +440,8 @@ export default function transformProps(
     }
   });
 
-  // Add x-axis color legend when showColorByXAxis is enabled
-  if (showColorByXAxis && groupBy.length === 0 && series.length > 0) {
+  // Add x-axis color legend when colorByPrimaryAxis is enabled
+  if (colorByPrimaryAxis && groupBy.length === 0 && series.length > 0) {
     // Hide original series from legend
     series.forEach(s => {
       s.legendHoverLink = false;
@@ -641,8 +641,8 @@ export default function transformProps(
     isHorizontal,
   );
 
-  const legendData = showColorByXAxis && groupBy.length === 0 && series.length > 0
-    ? // When showColorByXAxis is enabled, show only x-axis values
+  const legendData = colorByPrimaryAxis && groupBy.length === 0 && series.length > 0
+    ? // When colorByPrimaryAxis is enabled, show only x-axis values
     (() => {
       const firstSeries = series[0];
       if (firstSeries && Array.isArray(firstSeries.data)) {
@@ -861,8 +861,8 @@ export default function transformProps(
         padding,
       ),
       scrollDataIndex: legendIndex || 0,
-      data: showColorByXAxis && groupBy.length === 0
-        ? // When showColorByXAxis, configure legend items with roundRect icons
+      data: colorByPrimaryAxis && groupBy.length === 0
+        ? // When colorByPrimaryAxis, configure legend items with roundRect icons
         legendData.map(name => ({
           name,
           icon: 'roundRect',
@@ -872,8 +872,8 @@ export default function transformProps(
           if (!legendSort) return 0;
           return legendSort === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
         }),
-      // Disable legend selection and buttons when showColorByXAxis is enabled
-      ...(showColorByXAxis && groupBy.length === 0
+      // Disable legend selection and buttons when colorByPrimaryAxis is enabled
+      ...(colorByPrimaryAxis && groupBy.length === 0
         ? {
           selectedMode: false, // Disable clicking legend items
           selector: false, // Hide All/Invert buttons

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -181,6 +181,27 @@ export function optimizeBarLabelPlacement(
   return (series.data as TimeseriesDataRecord[]).map(transformValue);
 }
 
+export function applyColorByXAxis(
+  series: SeriesOption,
+  colorScale: CategoricalColorScale,
+  sliceId: number | undefined,
+  opacity: number,
+): TimeseriesDataRecord[] {
+  return (series.data as [string | number, number][]).map(value => {
+    // Use x-axis value as color key so same values get same colors across charts
+    const colorKey = String(value[0]);
+
+    return {
+      value,
+      itemStyle: {
+        color: colorScale(colorKey, sliceId),
+        opacity,
+        borderWidth: 0,
+      },
+    };
+  });
+}
+
 export function transformSeries(
   series: SeriesOption,
   colorScale: CategoricalColorScale,
@@ -214,6 +235,7 @@ export function transformSeries(
     timeShiftColor?: boolean;
     theme?: SupersetTheme;
     hasDimensions?: boolean;
+    showColorByXAxis?: boolean;
   },
 ): SeriesOption | undefined {
   const { name, data } = series;
@@ -244,6 +266,7 @@ export function transformSeries(
     timeCompare = [],
     timeShiftColor,
     theme,
+    showColorByXAxis = false,
   } = opts;
   const contexts = seriesContexts[name || ''] || [];
   const hasForecast =
@@ -349,17 +372,19 @@ export function transformSeries(
 
   return {
     ...series,
-    ...(Array.isArray(data) && seriesType === 'bar'
-      ? {
-          data: optimizeBarLabelPlacement(series, isHorizontal),
-        }
+    ...(Array.isArray(data)
+      ? showColorByXAxis
+        ? { data: applyColorByXAxis(series, colorScale, sliceId, opacity) }
+        : seriesType === 'bar' && !stack
+          ? { data: optimizeBarLabelPlacement(series, isHorizontal) }
+          : null
       : null),
     connectNulls,
     queryIndex,
     yAxisIndex,
     name: forecastSeries.name,
-    itemStyle,
-    // @ts-expect-error
+    ...(showColorByXAxis ? {} : { itemStyle }),
+    // @ts-ignore
     type: plotType,
     smooth: seriesType === 'smooth',
     triggerLineEvent: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -181,7 +181,7 @@ export function optimizeBarLabelPlacement(
   return (series.data as TimeseriesDataRecord[]).map(transformValue);
 }
 
-export function applyColorByXAxis(
+export function applyColorByPrimaryAxis(
   series: SeriesOption,
   colorScale: CategoricalColorScale,
   sliceId: number | undefined,
@@ -374,7 +374,7 @@ export function transformSeries(
     ...series,
     ...(Array.isArray(data)
       ? colorByPrimaryAxis
-        ? { data: applyColorByXAxis(series, colorScale, sliceId, opacity) }
+        ? { data: applyColorByPrimaryAxis(series, colorScale, sliceId, opacity) }
         : seriesType === 'bar' && !stack
           ? { data: optimizeBarLabelPlacement(series, isHorizontal) }
           : null

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -186,7 +186,7 @@ export function applyColorByXAxis(
   colorScale: CategoricalColorScale,
   sliceId: number | undefined,
   opacity: number,
-): TimeseriesDataRecord[] {
+): { value: [string | number, number]; itemStyle: { color: string; opacity: number; borderWidth: number } }[] {
   return (series.data as [string | number, number][]).map(value => {
     // Use x-axis value as color key so same values get same colors across charts
     const colorKey = String(value[0]);
@@ -235,7 +235,7 @@ export function transformSeries(
     timeShiftColor?: boolean;
     theme?: SupersetTheme;
     hasDimensions?: boolean;
-    showColorByXAxis?: boolean;
+    colorByPrimaryAxis?: boolean;
   },
 ): SeriesOption | undefined {
   const { name, data } = series;
@@ -266,7 +266,7 @@ export function transformSeries(
     timeCompare = [],
     timeShiftColor,
     theme,
-    showColorByXAxis = false,
+    colorByPrimaryAxis = false,
   } = opts;
   const contexts = seriesContexts[name || ''] || [];
   const hasForecast =
@@ -373,7 +373,7 @@ export function transformSeries(
   return {
     ...series,
     ...(Array.isArray(data)
-      ? showColorByXAxis
+      ? colorByPrimaryAxis
         ? { data: applyColorByXAxis(series, colorScale, sliceId, opacity) }
         : seriesType === 'bar' && !stack
           ? { data: optimizeBarLabelPlacement(series, isHorizontal) }
@@ -383,7 +383,7 @@ export function transformSeries(
     queryIndex,
     yAxisIndex,
     name: forecastSeries.name,
-    ...(showColorByXAxis ? {} : { itemStyle }),
+    ...(colorByPrimaryAxis ? {} : { itemStyle }),
     // @ts-ignore
     type: plotType,
     smooth: seriesType === 'smooth',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -186,10 +186,14 @@ export function applyColorByPrimaryAxis(
   colorScale: CategoricalColorScale,
   sliceId: number | undefined,
   opacity: number,
-): { value: [string | number, number]; itemStyle: { color: string; opacity: number; borderWidth: number } }[] {
+  isHorizontal = false,
+): {
+  value: [string | number, number];
+  itemStyle: { color: string; opacity: number; borderWidth: number };
+}[] {
   return (series.data as [string | number, number][]).map(value => {
-    // Use x-axis value as color key so same values get same colors across charts
-    const colorKey = String(value[0]);
+    // For horizontal charts the primary axis is index 1 (category), not index 0 (numeric)
+    const colorKey = String(isHorizontal ? value[1] : value[0]);
 
     return {
       value,
@@ -374,7 +378,15 @@ export function transformSeries(
     ...series,
     ...(Array.isArray(data)
       ? colorByPrimaryAxis
-        ? { data: applyColorByPrimaryAxis(series, colorScale, sliceId, opacity) }
+        ? {
+            data: applyColorByPrimaryAxis(
+              series,
+              colorScale,
+              sliceId,
+              opacity,
+              isHorizontal,
+            ),
+          }
         : seriesType === 'bar' && !stack
           ? { data: optimizeBarLabelPlacement(series, isHorizontal) }
           : null

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -97,6 +97,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   onlyTotal: boolean;
   showExtraControls: boolean;
   percentageThreshold: number;
+  showColorByXAxis?: boolean;
   orientation?: OrientationType;
 } & LegendFormData &
   TitleFormData;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -97,7 +97,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   onlyTotal: boolean;
   showExtraControls: boolean;
   percentageThreshold: number;
-  showColorByXAxis?: boolean;
+  colorByPrimaryAxis?: boolean;
   orientation?: OrientationType;
 } & LegendFormData &
   TitleFormData;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -140,6 +140,20 @@ export const showValueControl: ControlSetItem = {
   },
 };
 
+export const showColorbyXAxisControl: ControlSetItem = {
+  name: 'show_color_by_x_axis',
+  config: {
+    type: 'CheckboxControl',
+    label: t('Color By X-Axis'),
+    default: false,
+    renderTrigger: true,
+    description: t('Color bars by x-axis'),
+    visibility: ({ controls }: { controls: any }) =>
+      (!controls?.stack?.value || controls?.stack?.value === null) &&
+      (!controls?.groupby?.value || controls?.groupby?.value?.length === 0),
+  },
+};
+
 export const stackControl: ControlSetItem = {
   name: 'stack',
   config: {
@@ -198,6 +212,10 @@ export const showValueSection: ControlSetRow[] = [
   [stackControl],
   [onlyTotalControl],
   [percentageThresholdControl],
+];
+
+export const showColorByXAxisSection: ControlSetRow[] = [
+  [showColorbyXAxisControl],
 ];
 
 export const showValueSectionWithoutStack: ControlSetRow[] = [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -140,8 +140,8 @@ export const showValueControl: ControlSetItem = {
   },
 };
 
-export const showColorbyXAxisControl: ControlSetItem = {
-  name: 'show_color_by_x_axis',
+export const colorByPrimaryAxisControl: ControlSetItem = {
+  name: 'color_by_primary_axis',
   config: {
     type: 'CheckboxControl',
     label: t('Color By X-Axis'),
@@ -151,6 +151,16 @@ export const showColorbyXAxisControl: ControlSetItem = {
     visibility: ({ controls }: { controls: any }) =>
       (!controls?.stack?.value || controls?.stack?.value === null) &&
       (!controls?.groupby?.value || controls?.groupby?.value?.length === 0),
+    shouldMapStateToProps: () => true,
+    mapStateToProps: (state: any) => {
+      const isHorizontal = state?.controls?.orientation?.value === 'horizontal';
+      return {
+        label: isHorizontal ? t('Color By Y-Axis') : t('Color By X-Axis'),
+        description: isHorizontal
+          ? t('Color bars by y-axis')
+          : t('Color bars by x-axis'),
+      };
+    },
   },
 };
 
@@ -214,8 +224,8 @@ export const showValueSection: ControlSetRow[] = [
   [percentageThresholdControl],
 ];
 
-export const showColorByXAxisSection: ControlSetRow[] = [
-  [showColorbyXAxisControl],
+export const colorByPrimaryAxisSection: ControlSetRow[] = [
+  [colorByPrimaryAxisControl],
 ];
 
 export const showValueSectionWithoutStack: ControlSetRow[] = [

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -21,10 +21,7 @@ import { supersetTheme } from '@apache-superset/core/ui';
 import { EchartsTimeseriesChartProps } from '../../../src/types';
 import transformProps from '../../../src/Timeseries/transformProps';
 import { DEFAULT_FORM_DATA } from '../../../src/Timeseries/constants';
-import {
-  EchartsTimeseriesFormData,
-  EchartsTimeseriesSeriesType,
-} from '../../../src/Timeseries/types';
+import { EchartsTimeseriesSeriesType } from '../../../src/Timeseries/types';
 
 describe('Bar Chart X-axis Time Formatting', () => {
   const baseFormData: SqlaFormData = {
@@ -380,11 +377,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Should have hidden legend series for each x-axis value
@@ -418,11 +415,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Legend data should NOT contain x-axis values when dimensions exist
@@ -443,11 +440,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       const series = transformedProps.echartOptions.series as any[];
@@ -484,11 +481,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       const legend = transformedProps.echartOptions.legend as any;
@@ -509,11 +506,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Should still create legend with x-axis values
@@ -534,11 +531,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Legend should not be disabled when feature is off
@@ -559,11 +556,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Legend should contain category values (A, B, C), not numeric values
@@ -597,11 +594,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: repeatedData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       const legendData = transformedProps.legendData as string[];
@@ -622,11 +619,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData: formData as EchartsTimeseriesFormData,
+        formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       const series = transformedProps.echartOptions.series as any[];

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -63,7 +63,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Check that the x-axis has a formatter applied
@@ -85,7 +85,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Should still have a formatter since DEFAULT_FORM_DATA includes xAxisTimeFormat
@@ -108,7 +108,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Verify the formatter function exists and is applied
@@ -144,7 +144,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
         });
 
         const transformedProps = transformProps(
-          chartProps as unknown as EchartsTimeseriesChartProps,
+          chartProps as EchartsTimeseriesChartProps,
         );
 
         const xAxis = transformedProps.echartOptions.xAxis as any;
@@ -168,7 +168,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // In vertical orientation, time should be on x-axis
@@ -190,7 +190,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // In horizontal orientation, axes are swapped, so time should be on y-axis
@@ -215,7 +215,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       const xAxis = transformedProps.echartOptions.xAxis as any;
@@ -237,7 +237,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       const xAxis = transformedProps.echartOptions.xAxis as any;
@@ -258,7 +258,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Both axis and tooltip should have formatters
@@ -283,7 +283,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Verify formatter exists - this is the key fix, ensuring xAxisTimeFormat is used
@@ -381,7 +381,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Should have hidden legend series for each x-axis value
@@ -419,7 +419,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Legend data should NOT contain x-axis values when dimensions exist
@@ -444,7 +444,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       const series = transformedProps.echartOptions.series as any[];
@@ -485,7 +485,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       const legend = transformedProps.echartOptions.legend as any;
@@ -510,7 +510,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Should still create legend with x-axis values
@@ -535,7 +535,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Legend should not be disabled when feature is off
@@ -560,7 +560,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       // Legend should contain category values (A, B, C), not numeric values
@@ -598,7 +598,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       const legendData = transformedProps.legendData as string[];
@@ -623,7 +623,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as unknown as EchartsTimeseriesChartProps,
+        chartProps as EchartsTimeseriesChartProps,
       );
 
       const series = transformedProps.echartOptions.series as any[];

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -21,7 +21,10 @@ import { supersetTheme } from '@apache-superset/core/ui';
 import { EchartsTimeseriesChartProps } from '../../../src/types';
 import transformProps from '../../../src/Timeseries/transformProps';
 import { DEFAULT_FORM_DATA } from '../../../src/Timeseries/constants';
-import { EchartsTimeseriesSeriesType } from '../../../src/Timeseries/types';
+import {
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
+} from '../../../src/Timeseries/types';
 
 describe('Bar Chart X-axis Time Formatting', () => {
   const baseFormData: SqlaFormData = {
@@ -377,7 +380,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(
@@ -415,7 +418,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(
@@ -440,7 +443,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(
@@ -481,7 +484,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(
@@ -506,7 +509,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(
@@ -531,7 +534,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(
@@ -556,7 +559,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(
@@ -594,7 +597,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: repeatedData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(
@@ -619,7 +622,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const chartProps = new ChartProps({
         ...baseChartPropsConfig,
         queriesData: categoricalData,
-        formData,
+        formData: formData as EchartsTimeseriesFormData,
       });
 
       const transformedProps = transformProps(

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -63,7 +63,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Check that the x-axis has a formatter applied
@@ -85,7 +85,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Should still have a formatter since DEFAULT_FORM_DATA includes xAxisTimeFormat
@@ -108,7 +108,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Verify the formatter function exists and is applied
@@ -144,7 +144,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
         });
 
         const transformedProps = transformProps(
-          chartProps as EchartsTimeseriesChartProps,
+          chartProps as unknown as EchartsTimeseriesChartProps,
         );
 
         const xAxis = transformedProps.echartOptions.xAxis as any;
@@ -168,7 +168,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // In vertical orientation, time should be on x-axis
@@ -190,7 +190,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // In horizontal orientation, axes are swapped, so time should be on y-axis
@@ -215,7 +215,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       const xAxis = transformedProps.echartOptions.xAxis as any;
@@ -237,7 +237,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       const xAxis = transformedProps.echartOptions.xAxis as any;
@@ -258,7 +258,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Both axis and tooltip should have formatters
@@ -283,7 +283,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Verify formatter exists - this is the key fix, ensuring xAxisTimeFormat is used
@@ -368,7 +368,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
     it('should apply color by x-axis when enabled with no dimensions', () => {
       const formData = {
         ...baseFormData,
-        showColorByXAxis: true,
+        colorByPrimaryAxis: true,
         groupby: [],
         x_axis: 'category',
         metric: 'value',
@@ -378,11 +378,10 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-        rawFormData: formData,
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Should have hidden legend series for each x-axis value
@@ -407,7 +406,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
     it('should NOT apply color by x-axis when dimensions are present', () => {
       const formData = {
         ...baseFormData,
-        showColorByXAxis: true,
+        colorByPrimaryAxis: true,
         groupby: ['region'],
         x_axis: 'category',
         metric: 'value',
@@ -417,11 +416,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-        rawFormData: formData,
+
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Legend data should NOT contain x-axis values when dimensions exist
@@ -433,7 +432,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
     it('should use x-axis values as color keys for consistent colors', () => {
       const formData = {
         ...baseFormData,
-        showColorByXAxis: true,
+        colorByPrimaryAxis: true,
         groupby: [],
         x_axis: 'category',
         metric: 'value',
@@ -443,11 +442,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-        rawFormData: formData,
+
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       const series = transformedProps.echartOptions.series as any[];
@@ -471,7 +470,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
     it('should disable legend selection when color by x-axis is enabled', () => {
       const formData = {
         ...baseFormData,
-        showColorByXAxis: true,
+        colorByPrimaryAxis: true,
         groupby: [],
         x_axis: 'category',
         metric: 'value',
@@ -481,11 +480,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-        rawFormData: formData,
+
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       const legend = transformedProps.echartOptions.legend as any;
@@ -496,7 +495,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
     it('should work without stacking enabled', () => {
       const formData = {
         ...baseFormData,
-        showColorByXAxis: true,
+        colorByPrimaryAxis: true,
         groupby: [],
         stack: null,
         x_axis: 'category',
@@ -507,11 +506,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-        rawFormData: formData,
+
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Should still create legend with x-axis values
@@ -520,10 +519,10 @@ describe('Bar Chart X-axis Time Formatting', () => {
       expect(legendData).toContain('A');
     });
 
-    it('should handle when showColorByXAxis is disabled', () => {
+    it('should handle when colorByPrimaryAxis is disabled', () => {
       const formData = {
         ...baseFormData,
-        showColorByXAxis: false,
+        colorByPrimaryAxis: false,
         groupby: [],
         x_axis: 'category',
         metric: 'value',
@@ -533,11 +532,11 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-        rawFormData: formData,
+
       });
 
       const transformedProps = transformProps(
-        chartProps as EchartsTimeseriesChartProps,
+        chartProps as unknown as EchartsTimeseriesChartProps,
       );
 
       // Legend should not be disabled when feature is off

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -365,7 +365,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       },
     ];
 
-    it('should apply color by x-axis when enabled with no dimensions', () => {
+    test('should apply color by x-axis when enabled with no dimensions', () => {
       const formData = {
         ...baseFormData,
         colorByPrimaryAxis: true,
@@ -403,7 +403,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       }
     });
 
-    it('should NOT apply color by x-axis when dimensions are present', () => {
+    test('should NOT apply color by x-axis when dimensions are present', () => {
       const formData = {
         ...baseFormData,
         colorByPrimaryAxis: true,
@@ -416,7 +416,6 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-
       });
 
       const transformedProps = transformProps(
@@ -429,7 +428,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       expect(legendData.length).toBeLessThan(10);
     });
 
-    it('should use x-axis values as color keys for consistent colors', () => {
+    test('should use x-axis values as color keys for consistent colors', () => {
       const formData = {
         ...baseFormData,
         colorByPrimaryAxis: true,
@@ -442,7 +441,6 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-
       });
 
       const transformedProps = transformProps(
@@ -460,14 +458,18 @@ describe('Bar Chart X-axis Time Formatting', () => {
       // Check that data points have individual itemStyle with colors
       if (dataSeries && Array.isArray(dataSeries.data)) {
         const dataPoint = dataSeries.data[0];
-        if (dataPoint && typeof dataPoint === 'object' && 'itemStyle' in dataPoint) {
+        if (
+          dataPoint &&
+          typeof dataPoint === 'object' &&
+          'itemStyle' in dataPoint
+        ) {
           expect(dataPoint.itemStyle).toBeDefined();
           expect(dataPoint.itemStyle.color).toBeDefined();
         }
       }
     });
 
-    it('should disable legend selection when color by x-axis is enabled', () => {
+    test('should disable legend selection when color by x-axis is enabled', () => {
       const formData = {
         ...baseFormData,
         colorByPrimaryAxis: true,
@@ -480,7 +482,6 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-
       });
 
       const transformedProps = transformProps(
@@ -492,7 +493,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       expect(legend.selector).toBe(false);
     });
 
-    it('should work without stacking enabled', () => {
+    test('should work without stacking enabled', () => {
       const formData = {
         ...baseFormData,
         colorByPrimaryAxis: true,
@@ -506,7 +507,6 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-
       });
 
       const transformedProps = transformProps(
@@ -519,7 +519,7 @@ describe('Bar Chart X-axis Time Formatting', () => {
       expect(legendData).toContain('A');
     });
 
-    it('should handle when colorByPrimaryAxis is disabled', () => {
+    test('should handle when colorByPrimaryAxis is disabled', () => {
       const formData = {
         ...baseFormData,
         colorByPrimaryAxis: false,
@@ -532,7 +532,6 @@ describe('Bar Chart X-axis Time Formatting', () => {
         ...baseChartPropsConfig,
         queriesData: categoricalData,
         formData,
-
       });
 
       const transformedProps = transformProps(

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -542,5 +542,96 @@ describe('Bar Chart X-axis Time Formatting', () => {
       const legend = transformedProps.echartOptions.legend as any;
       expect(legend.selectedMode).not.toBe(false);
     });
+
+    test('should use category axis (Y) as color key for horizontal bar charts', () => {
+      const formData = {
+        ...baseFormData,
+        colorByPrimaryAxis: true,
+        groupby: [],
+        orientation: 'horizontal',
+        x_axis: 'category',
+        metric: 'value',
+      };
+
+      const chartProps = new ChartProps({
+        ...baseChartPropsConfig,
+        queriesData: categoricalData,
+        formData,
+      });
+
+      const transformedProps = transformProps(
+        chartProps as unknown as EchartsTimeseriesChartProps,
+      );
+
+      // Legend should contain category values (A, B, C), not numeric values
+      const legendData = transformedProps.legendData as string[];
+      expect(legendData).toContain('A');
+      expect(legendData).toContain('B');
+      expect(legendData).toContain('C');
+    });
+
+    test('should deduplicate legend entries when x-axis has repeated values', () => {
+      const repeatedData = [
+        {
+          data: [
+            { category: 'A', value: 100 },
+            { category: 'A', value: 200 },
+            { category: 'B', value: 150 },
+          ],
+          colnames: ['category', 'value'],
+          coltypes: ['STRING', 'BIGINT'],
+        },
+      ];
+
+      const formData = {
+        ...baseFormData,
+        colorByPrimaryAxis: true,
+        groupby: [],
+        x_axis: 'category',
+        metric: 'value',
+      };
+
+      const chartProps = new ChartProps({
+        ...baseChartPropsConfig,
+        queriesData: repeatedData,
+        formData,
+      });
+
+      const transformedProps = transformProps(
+        chartProps as unknown as EchartsTimeseriesChartProps,
+      );
+
+      const legendData = transformedProps.legendData as string[];
+      // 'A' should appear only once despite being in the data twice
+      expect(legendData.filter(v => v === 'A').length).toBe(1);
+      expect(legendData).toContain('B');
+    });
+
+    test('should create exactly one hidden legend series per unique category', () => {
+      const formData = {
+        ...baseFormData,
+        colorByPrimaryAxis: true,
+        groupby: [],
+        x_axis: 'category',
+        metric: 'value',
+      };
+
+      const chartProps = new ChartProps({
+        ...baseChartPropsConfig,
+        queriesData: categoricalData,
+        formData,
+      });
+
+      const transformedProps = transformProps(
+        chartProps as unknown as EchartsTimeseriesChartProps,
+      );
+
+      const series = transformedProps.echartOptions.series as any[];
+      const hiddenSeries = series.filter(
+        s => s.type === 'line' && Array.isArray(s.data) && s.data.length === 0,
+      );
+      // One hidden series per unique category (A, B, C)
+      expect(hiddenSeries.length).toBe(3);
+    });
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a "Color by primary axis" option to the ECharts Bar Chart that colors each bar individually by its category value.
                                                                                                                                                                                                           
- Adds a new "Color by primary axis" control option to the Bar Chart (ECharts Timeseries Bar) that colors each bar individually based on its category/axis value, rather than using a single series color
- The option is only available when no dimensions (groupby) are set, since coloring by series already handles the multi-dimension case
- The control label is dynamic: shows "Color by X axis" for vertical bars and "Color by Y axis" for horizontal bars
- Colors are consistent with the chart's categorical color scale, so the same category value always gets the same color across charts on a dashboard
- When enabled, the legend shows each category value with a color swatch, and legend selection/toggling is disabled since each bar maps 1:1 to a legend entry


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Unchecked color by x axis (Identical to original behavior)- 

<img width="1714" height="910" alt="image" src="https://github.com/user-attachments/assets/85c420f8-8b33-4ac4-8a3b-27521e469210" />


Checked color by x axis- 

<img width="1713" height="913" alt="image" src="https://github.com/user-attachments/assets/5b8d815e-8ce0-4464-8330-9fe3c6828cc6" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API



