### PR TITLE
feat(timeseries): remove stream style for bar charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -50,7 +50,10 @@ import {
   DEFAULT_FORM_DATA,
   TIME_SERIES_DESCRIPTION_TEXT,
 } from '../../constants';
-import { BarChartStackControlOptions, StackControlsValue } from '../../../constants';
+import {
+  BarChartStackControlOptions,
+  StackControlsValue,
+} from '../../../constants';
 
 const { logAxis, minorSplitLine, truncateYAxis, yAxisBounds, orientation } =
   DEFAULT_FORM_DATA;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -33,11 +33,9 @@ import {
 import {
   legendSection,
   minorTicks,
-  onlyTotalControl,
-  percentageThresholdControl,
   richTooltipSection,
   seriesOrderSection,
-  showValueControl,
+  showValueSectionWithoutStream,
   truncateXAxis,
   xAxisBounds,
   xAxisLabelRotation,
@@ -50,10 +48,7 @@ import {
   DEFAULT_FORM_DATA,
   TIME_SERIES_DESCRIPTION_TEXT,
 } from '../../constants';
-import {
-  BarChartStackControlOptions,
-  StackControlsValue,
-} from '../../../constants';
+import { StackControlsValue } from '../../../constants';
 
 const { logAxis, minorSplitLine, truncateYAxis, yAxisBounds, orientation } =
   DEFAULT_FORM_DATA;
@@ -332,22 +327,7 @@ const config: ControlPanelConfig = {
         ...seriesOrderSection,
         ['color_scheme'],
         ['time_shift_color'],
-        [showValueControl],
-        [
-          {
-            name: 'stack',
-            config: {
-              type: 'SelectControl',
-              label: t('Stacked Style'),
-              renderTrigger: true,
-              choices: BarChartStackControlOptions,
-              default: null,
-              description: t('Stack series on top of each other'),
-            },
-          },
-        ],
-        [onlyTotalControl],
-        [percentageThresholdControl],
+        ...showValueSectionWithoutStream,
         [
           {
             name: 'stackDimension',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -33,9 +33,11 @@ import {
 import {
   legendSection,
   minorTicks,
+  onlyTotalControl,
+  percentageThresholdControl,
   richTooltipSection,
   seriesOrderSection,
-  showValueSection,
+  showValueControl,
   truncateXAxis,
   xAxisBounds,
   xAxisLabelRotation,
@@ -48,7 +50,7 @@ import {
   DEFAULT_FORM_DATA,
   TIME_SERIES_DESCRIPTION_TEXT,
 } from '../../constants';
-import { StackControlsValue } from '../../../constants';
+import { BarChartStackControlOptions, StackControlsValue } from '../../../constants';
 
 const { logAxis, minorSplitLine, truncateYAxis, yAxisBounds, orientation } =
   DEFAULT_FORM_DATA;
@@ -327,7 +329,22 @@ const config: ControlPanelConfig = {
         ...seriesOrderSection,
         ['color_scheme'],
         ['time_shift_color'],
-        ...showValueSection,
+        [showValueControl],
+        [
+          {
+            name: 'stack',
+            config: {
+              type: 'SelectControl',
+              label: t('Stacked Style'),
+              renderTrigger: true,
+              choices: BarChartStackControlOptions,
+              default: null,
+              description: t('Stack series on top of each other'),
+            },
+          },
+        ],
+        [onlyTotalControl],
+        [percentageThresholdControl],
         [
           {
             name: 'stackDimension',
@@ -375,11 +392,18 @@ const config: ControlPanelConfig = {
       ],
     },
   ],
-  formDataOverrides: formData => ({
-    ...formData,
-    metrics: getStandardizedControls().popAllMetrics(),
-    groupby: getStandardizedControls().popAllColumns(),
-  }),
+  formDataOverrides: formData => {
+    // Reset stack to null if it's Stream when switching to Bar chart
+    const formDataWithStack = formData as Record<string, unknown>;
+    return {
+      ...formData,
+      metrics: getStandardizedControls().popAllMetrics(),
+      groupby: getStandardizedControls().popAllColumns(),
+      ...(formDataWithStack.stack === StackControlsValue.Stream && {
+        stack: null,
+      }),
+    };
+  },
 };
 
 export default config;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -76,7 +76,7 @@ export const AreaChartStackControlOptions: [
   Exclude<ReactNode, null | undefined | boolean>,
 ][] = [...StackControlOptions, [StackControlsValue.Expand, t('Expand')]];
 
-export const BarChartStackControlOptions: [
+export const StackControlOptionsWithoutStream: [
   JsonValue,
   Exclude<ReactNode, null | undefined | boolean>,
 ][] = [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -76,6 +76,14 @@ export const AreaChartStackControlOptions: [
   Exclude<ReactNode, null | undefined | boolean>,
 ][] = [...StackControlOptions, [StackControlsValue.Expand, t('Expand')]];
 
+export const BarChartStackControlOptions: [
+  JsonValue,
+  Exclude<ReactNode, null | undefined | boolean>,
+][] = [
+  [null, t('None')],
+  [StackControlsValue.Stack, t('Stack')],
+];
+
 export const TIMEGRAIN_TO_TIMESTAMP = {
   [TimeGranularity.HOUR]: 3600 * 1000,
   [TimeGranularity.DAY]: 3600 * 1000 * 24,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -28,7 +28,11 @@ import {
   SORT_SERIES_CHOICES,
   sharedControls,
 } from '@superset-ui/chart-controls';
-import { DEFAULT_LEGEND_FORM_DATA, StackControlOptions } from './constants';
+import {
+  DEFAULT_LEGEND_FORM_DATA,
+  StackControlOptions,
+  StackControlOptionsWithoutStream,
+} from './constants';
 import { DEFAULT_FORM_DATA } from './Timeseries/constants';
 import { defaultXAxis } from './defaults';
 
@@ -148,6 +152,14 @@ export const stackControl: ControlSetItem = {
   },
 };
 
+export const stackControlWithoutStream: ControlSetItem = {
+  ...stackControl,
+  config: {
+    ...stackControl.config,
+    choices: StackControlOptionsWithoutStream,
+  },
+};
+
 export const onlyTotalControl: ControlSetItem = {
   name: 'only_total',
   config: {
@@ -191,6 +203,13 @@ export const showValueSection: ControlSetRow[] = [
 export const showValueSectionWithoutStack: ControlSetRow[] = [
   [showValueControl],
   [onlyTotalControl],
+];
+
+export const showValueSectionWithoutStream: ControlSetRow[] = [
+  [showValueControl],
+  [stackControlWithoutStream],
+  [onlyTotalControl],
+  [percentageThresholdControl],
 ];
 
 const richTooltipControl: ControlSetItem = {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
@@ -139,7 +139,7 @@ test('should use StackControlOptionsWithoutStream for stack control', () => {
 test('should not include Stream option in stack control choices', () => {
   const stackControl: any = getControl('stack');
   expect(stackControl).toBeDefined();
-  const choices = stackControl.config.choices;
+  const {choices} = stackControl.config;
   const streamOption = choices.find(
     (choice: any[]) => choice[0] === StackControlsValue.Stream,
   );
@@ -149,7 +149,7 @@ test('should not include Stream option in stack control choices', () => {
 test('should include None and Stack options in stack control choices', () => {
   const stackControl: any = getControl('stack');
   expect(stackControl).toBeDefined();
-  const choices = stackControl.config.choices;
+  const {choices} = stackControl.config;
   const noneOption = choices.find((choice: any[]) => choice[0] === null);
   const stackOption = choices.find(
     (choice: any[]) => choice[0] === StackControlsValue.Stack,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
@@ -18,7 +18,7 @@
  */
 import controlPanel from '../../../src/Timeseries/Regular/Bar/controlPanel';
 import {
-  BarChartStackControlOptions,
+  StackControlOptionsWithoutStream,
   StackControlsValue,
 } from '../../../src/constants';
 
@@ -129,11 +129,11 @@ test('should include stack control in the panel', () => {
   expect(stackControl).toBeDefined();
 });
 
-test('should use BarChartStackControlOptions for stack control', () => {
+test('should use StackControlOptionsWithoutStream for stack control', () => {
   const stackControl: any = getControl('stack');
   expect(stackControl).toBeDefined();
   expect(stackControl.config).toBeDefined();
-  expect(stackControl.config.choices).toBe(BarChartStackControlOptions);
+  expect(stackControl.config.choices).toBe(StackControlOptionsWithoutStream);
 });
 
 test('should not include Stream option in stack control choices', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
@@ -17,188 +17,204 @@
  * under the License.
  */
 import controlPanel from '../../../src/Timeseries/Regular/Bar/controlPanel';
+import {
+  BarChartStackControlOptions,
+  StackControlsValue,
+} from '../../../src/constants';
 
-describe('Bar Chart Control Panel', () => {
-  describe('x_axis_time_format control', () => {
-    test('should include x_axis_time_format control in the panel', () => {
-      const config = controlPanel;
+const config = controlPanel;
 
-      // Look for x_axis_time_format control in all sections and rows
-      let foundTimeFormatControl = false;
-
-      for (const section of config.controlPanelSections) {
-        if (section && section.controlSetRows) {
-          for (const row of section.controlSetRows) {
-            for (const control of row) {
-              if (
-                typeof control === 'object' &&
-                control !== null &&
-                'name' in control &&
-                control.name === 'x_axis_time_format'
-              ) {
-                foundTimeFormatControl = true;
-                break;
-              }
-            }
-            if (foundTimeFormatControl) break;
+const getControl = (controlName: string) => {
+  for (const section of config.controlPanelSections) {
+    if (section && section.controlSetRows) {
+      for (const row of section.controlSetRows) {
+        for (const control of row) {
+          if (
+            typeof control === 'object' &&
+            control !== null &&
+            'name' in control &&
+            control.name === controlName
+          ) {
+            return control;
           }
-          if (foundTimeFormatControl) break;
         }
       }
+    }
+  }
 
-      expect(foundTimeFormatControl).toBe(true);
-    });
+  return null;
+};
 
-    test('should have correct default value for x_axis_time_format', () => {
-      const config = controlPanel;
+// Mock getStandardizedControls
+jest.mock('@superset-ui/chart-controls', () => {
+  const actual = jest.requireActual('@superset-ui/chart-controls');
+  return {
+    ...actual,
+    getStandardizedControls: jest.fn(() => ({
+      popAllMetrics: jest.fn(() => []),
+      popAllColumns: jest.fn(() => []),
+    })),
+  };
+});
 
-      // Find the x_axis_time_format control
-      let timeFormatControl: any = null;
+test('should include x_axis_time_format control in the panel', () => {
+  const timeFormatControl = getControl('x_axis_time_format');
+  expect(timeFormatControl).toBeDefined();
+});
 
-      for (const section of config.controlPanelSections) {
-        if (section && section.controlSetRows) {
-          for (const row of section.controlSetRows) {
-            for (const control of row) {
-              if (
-                typeof control === 'object' &&
-                control !== null &&
-                'name' in control &&
-                control.name === 'x_axis_time_format'
-              ) {
-                timeFormatControl = control;
-                break;
-              }
-            }
-            if (timeFormatControl) break;
-          }
-          if (timeFormatControl) break;
-        }
-      }
+test('should have correct default value for x_axis_time_format', () => {
+  const timeFormatControl: any = getControl('x_axis_time_format');
+  expect(timeFormatControl).toBeDefined();
+  expect(timeFormatControl.config).toBeDefined();
+  expect(timeFormatControl.config.default).toBe('smart_date');
+});
 
-      expect(timeFormatControl).toBeDefined();
-      expect(timeFormatControl.config).toBeDefined();
-      expect(timeFormatControl.config.default).toBe('smart_date');
-    });
+test('should have visibility function for x_axis_time_format', () => {
+  const timeFormatControl: any = getControl('x_axis_time_format');
+  expect(timeFormatControl).toBeDefined();
+  expect(timeFormatControl.config.visibility).toBeDefined();
+  expect(typeof timeFormatControl.config.visibility).toBe('function');
+});
 
-    test('should have visibility function for x_axis_time_format', () => {
-      const config = controlPanel;
-
-      // Find the x_axis_time_format control
-      let timeFormatControl: any = null;
-
-      for (const section of config.controlPanelSections) {
-        if (section && section.controlSetRows) {
-          for (const row of section.controlSetRows) {
-            for (const control of row) {
-              if (
-                typeof control === 'object' &&
-                control !== null &&
-                'name' in control &&
-                control.name === 'x_axis_time_format'
-              ) {
-                timeFormatControl = control;
-                break;
-              }
-            }
-            if (timeFormatControl) break;
-          }
-          if (timeFormatControl) break;
-        }
-      }
-
-      expect(timeFormatControl).toBeDefined();
-      expect(timeFormatControl.config.visibility).toBeDefined();
-      expect(typeof timeFormatControl.config.visibility).toBe('function');
-
-      // The visibility function exists - the exact logic is tested implicitly through UI behavior
-      // The important part is that the control has proper visibility configuration
-    });
-
-    test('should have proper control configuration', () => {
-      const config = controlPanel;
-
-      // Find the x_axis_time_format control
-      let timeFormatControl: any = null;
-
-      for (const section of config.controlPanelSections) {
-        if (section && section.controlSetRows) {
-          for (const row of section.controlSetRows) {
-            for (const control of row) {
-              if (
-                typeof control === 'object' &&
-                control !== null &&
-                'name' in control &&
-                control.name === 'x_axis_time_format'
-              ) {
-                timeFormatControl = control;
-                break;
-              }
-            }
-            if (timeFormatControl) break;
-          }
-          if (timeFormatControl) break;
-        }
-      }
-
-      expect(timeFormatControl).toBeDefined();
-      expect(timeFormatControl.config).toMatchObject({
-        default: 'smart_date',
-        disableStash: true,
-        resetOnHide: false,
-      });
-
-      // Should have a description that includes D3 time format docs
-      expect(timeFormatControl.config.description).toContain('D3');
-    });
+test('should have proper control configuration for x_axis_time_format', () => {
+  const timeFormatControl: any = getControl('x_axis_time_format');
+  expect(timeFormatControl).toBeDefined();
+  expect(timeFormatControl.config).toMatchObject({
+    default: 'smart_date',
+    disableStash: true,
+    resetOnHide: false,
   });
+  expect(timeFormatControl.config.description).toContain('D3');
+});
 
-  describe('Control panel structure for bar charts', () => {
-    test('should have Chart Orientation section', () => {
-      const config = controlPanel;
+test('should have Chart Orientation section', () => {
+  const orientationSection = config.controlPanelSections.find(
+    section => section && section.label === 'Chart Orientation',
+  );
+  expect(orientationSection).toBeDefined();
+  expect(orientationSection!.expanded).toBe(true);
+});
 
-      const orientationSection = config.controlPanelSections.find(
-        section => section && section.label === 'Chart Orientation',
-      );
+test('should have Chart Options section with X Axis controls', () => {
+  const chartOptionsSection = config.controlPanelSections.find(
+    section => section && section.label === 'Chart Options',
+  );
+  expect(chartOptionsSection).toBeDefined();
+  expect(chartOptionsSection!.expanded).toBe(true);
+  expect(chartOptionsSection!.controlSetRows).toBeDefined();
+  expect(chartOptionsSection!.controlSetRows!.length).toBeGreaterThan(0);
+});
 
-      expect(orientationSection).toBeDefined();
-      expect(orientationSection!.expanded).toBe(true);
-    });
+test('should have proper form data overrides', () => {
+  expect(config.formDataOverrides).toBeDefined();
+  expect(typeof config.formDataOverrides).toBe('function');
 
-    test('should have Chart Options section with X Axis controls', () => {
-      const config = controlPanel;
+  const mockFormData = {
+    datasource: '1__table',
+    viz_type: 'echarts_timeseries_bar',
+    metrics: ['test_metric'],
+    groupby: ['test_column'],
+    other_field: 'test',
+  };
 
-      const chartOptionsSection = config.controlPanelSections.find(
-        section => section && section.label === 'Chart Options',
-      );
+  const result = config.formDataOverrides!(mockFormData);
 
-      expect(chartOptionsSection).toBeDefined();
-      expect(chartOptionsSection!.expanded).toBe(true);
+  expect(result).toHaveProperty('metrics');
+  expect(result).toHaveProperty('groupby');
+  expect(result).toHaveProperty('other_field', 'test');
+});
 
-      // Should contain X Axis subsection header - this is sufficient proof
-      expect(chartOptionsSection!.controlSetRows).toBeDefined();
-      expect(chartOptionsSection!.controlSetRows!.length).toBeGreaterThan(0);
-    });
+test('should include stack control in the panel', () => {
+  const stackControl = getControl('stack');
+  expect(stackControl).toBeDefined();
+});
 
-    test('should have proper form data overrides', () => {
-      const config = controlPanel;
+test('should use BarChartStackControlOptions for stack control', () => {
+  const stackControl: any = getControl('stack');
+  expect(stackControl).toBeDefined();
+  expect(stackControl.config).toBeDefined();
+  expect(stackControl.config.choices).toBe(BarChartStackControlOptions);
+});
 
-      expect(config.formDataOverrides).toBeDefined();
-      expect(typeof config.formDataOverrides).toBe('function');
+test('should not include Stream option in stack control choices', () => {
+  const stackControl: any = getControl('stack');
+  expect(stackControl).toBeDefined();
+  const choices = stackControl.config.choices;
+  const streamOption = choices.find(
+    (choice: any[]) => choice[0] === StackControlsValue.Stream,
+  );
+  expect(streamOption).toBeUndefined();
+});
 
-      // Test the form data override function
-      const mockFormData = {
-        datasource: '1__table',
-        viz_type: 'echarts_timeseries_bar',
-        metrics: ['test_metric'],
-        groupby: ['test_column'],
-        other_field: 'test',
-      };
+test('should include None and Stack options in stack control choices', () => {
+  const stackControl: any = getControl('stack');
+  expect(stackControl).toBeDefined();
+  const choices = stackControl.config.choices;
+  const noneOption = choices.find((choice: any[]) => choice[0] === null);
+  const stackOption = choices.find(
+    (choice: any[]) => choice[0] === StackControlsValue.Stack,
+  );
+  expect(noneOption).toBeDefined();
+  expect(stackOption).toBeDefined();
+});
 
-      const result = config.formDataOverrides!(mockFormData);
+test('should have correct default value for stack control', () => {
+  const stackControl: any = getControl('stack');
+  expect(stackControl).toBeDefined();
+  expect(stackControl.config.default).toBe(null);
+});
 
-      expect(result).toHaveProperty('metrics');
-      expect(result).toHaveProperty('groupby');
-      expect(result).toHaveProperty('other_field', 'test');
-    });
-  });
+test('should reset stack to null when formData has Stream value', () => {
+  const mockFormData = {
+    datasource: '1__table',
+    viz_type: 'echarts_timeseries_bar',
+    metrics: ['test_metric'],
+    groupby: ['test_column'],
+    stack: StackControlsValue.Stream,
+  };
+
+  const result = config.formDataOverrides!(mockFormData);
+
+  expect(result.stack).toBe(null);
+});
+
+test('should preserve stack value when formData has Stack value', () => {
+  const mockFormData = {
+    datasource: '1__table',
+    viz_type: 'echarts_timeseries_bar',
+    metrics: ['test_metric'],
+    groupby: ['test_column'],
+    stack: StackControlsValue.Stack,
+  };
+
+  const result = config.formDataOverrides!(mockFormData);
+
+  expect(result.stack).toBe(StackControlsValue.Stack);
+});
+
+test('should preserve stack value when formData has null value', () => {
+  const mockFormData = {
+    datasource: '1__table',
+    viz_type: 'echarts_timeseries_bar',
+    metrics: ['test_metric'],
+    groupby: ['test_column'],
+    stack: null,
+  };
+
+  const result = config.formDataOverrides!(mockFormData);
+
+  expect(result.stack).toBe(null);
+});
+
+test('should preserve stack value when formData does not have stack property', () => {
+  const mockFormData = {
+    datasource: '1__table',
+    viz_type: 'echarts_timeseries_bar',
+    metrics: ['test_metric'],
+    groupby: ['test_column'],
+  };
+
+  const result = config.formDataOverrides!(mockFormData);
+
+  expect(result).not.toHaveProperty('stack');
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
@@ -139,7 +139,7 @@ test('should use StackControlOptionsWithoutStream for stack control', () => {
 test('should not include Stream option in stack control choices', () => {
   const stackControl: any = getControl('stack');
   expect(stackControl).toBeDefined();
-  const {choices} = stackControl.config;
+  const { choices } = stackControl.config;
   const streamOption = choices.find(
     (choice: any[]) => choice[0] === StackControlsValue.Stream,
   );
@@ -149,7 +149,7 @@ test('should not include Stream option in stack control choices', () => {
 test('should include None and Stack options in stack control choices', () => {
   const stackControl: any = getControl('stack');
   expect(stackControl).toBeDefined();
-  const {choices} = stackControl.config;
+  const { choices } = stackControl.config;
   const noneOption = choices.find((choice: any[]) => choice[0] === null);
   const stackOption = choices.find(
     (choice: any[]) => choice[0] === StackControlsValue.Stack,


### PR DESCRIPTION
### SUMMARY

Removes the Stream style option from Bar charts while keeping it for Area and Line charts.

- Removed Stream option from Bar charts: The "Stacked Style" dropdown for Bar charts now only shows "None" and "Stack" (Stream removed).
- Backward compatibility: Existing Bar charts with Stream style remain unchanged; the option no longer appears when editing.
- Chart type switching: When switching from a Streamed Area/Line chart to a Bar chart, the Stream value is reset to null.

Note: previous tests were flattened on `"superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts"`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
### BEFORE
<img width="1456" height="1130" alt="89481-before" src="https://github.com/user-attachments/assets/929720b7-d970-4b84-b3fe-e9b286d6714b" />

### AFTER
https://github.com/user-attachments/assets/32f5d374-fecb-460c-922f-31194cfc9f2c

### TESTING INSTRUCTIONS
1. Create a chart or edit a previously created one.
2. Go to Customize -> Stacked Style
3. Steam must not appear.

When changing from a line chart (or another one that can have Stream style) to a bar chart, the bar chart must not appear with Stream style.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #33820 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
