### PR TITLE
chore: clean up deprecated utcnow

### DIFF
--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -189,7 +189,7 @@ class CustomPrestoTemplateProcessor(PrestoTemplateProcessor):
         """Processes a sql template with $ style macro using regex."""
         # Add custom macros functions.
         macros = {
-            "DATE": partial(DATE, datetime.utcnow())
+            "DATE": partial(DATE, datetime.now(timezone.utc))
         }  # type: Dict[str, Any]
         # Update with macros defined in context and kwargs.
         macros.update(self.context)

--- a/docs/versioned_docs/version-6.0.0/configuration/sql-templating.mdx
+++ b/docs/versioned_docs/version-6.0.0/configuration/sql-templating.mdx
@@ -180,7 +180,7 @@ class CustomPrestoTemplateProcessor(PrestoTemplateProcessor):
         """Processes a sql template with $ style macro using regex."""
         # Add custom macros functions.
         macros = {
-            "DATE": partial(DATE, datetime.utcnow())
+            "DATE": partial(DATE, datetime.now(timezone.utc))
         }  # type: Dict[str, Any]
         # Update with macros defined in context and kwargs.
         macros.update(self.context)

--- a/superset/commands/report/log_prune.py
+++ b/superset/commands/report/log_prune.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -41,7 +41,7 @@ class AsyncPruneReportScheduleLogCommand(BaseCommand):
 
         for report_schedule in db.session.query(ReportSchedule).all():
             if report_schedule.log_retention is not None:
-                from_date = datetime.utcnow() - timedelta(
+                from_date = datetime.now(timezone.utc) - timedelta(
                     days=report_schedule.log_retention
                 )
                 try:

--- a/superset/daos/log.py
+++ b/superset/daos/log.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import humanize
@@ -142,7 +142,7 @@ class LogDAO(BaseDAO[Log]):
                     "item_title": item_title,
                     "time": datetime_to_epoch(log.dttm),
                     "time_delta_humanized": humanize.naturaltime(
-                        datetime.utcnow() - log.dttm
+                        datetime.now(timezone.utc) - log.dttm
                     ),
                 }
             )

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 from typing import Any, Callable
 
@@ -73,7 +73,7 @@ def set_and_log_cache(
     if timeout == CACHE_DISABLED_TIMEOUT:
         return
     try:
-        dttm = datetime.utcnow().isoformat().split(".")[0]
+        dttm = datetime.now(timezone.utc).isoformat().split(".")[0]
         value = {**cache_value, "dttm": dttm}
         cache_instance.set(cache_key, value, timeout=timeout)
         stats_logger = app.config["STATS_LOGGER"]
@@ -226,7 +226,7 @@ def etag_cache(  # noqa: C901
 
             # Check if the cache is stale. Default the content_changed_time to now
             # if we don't know when it was last modified.
-            content_changed_time = datetime.utcnow()
+            content_changed_time = datetime.now(timezone.utc)
             if get_last_modified:
                 content_changed_time = get_last_modified(*args, **kwargs)
                 if (

--- a/superset/utils/dates.py
+++ b/superset/utils/dates.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytz
 
@@ -31,4 +31,4 @@ def datetime_to_epoch(dttm: datetime) -> float:
 
 
 def now_as_float() -> float:
-    return datetime_to_epoch(datetime.utcnow())
+    return datetime_to_epoch(datetime.now(timezone.utc))

--- a/tests/integration_tests/queries/api_tests.py
+++ b/tests/integration_tests/queries/api_tests.py
@@ -17,7 +17,7 @@
 # isort:skip_file
 """Unit tests for Superset"""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import random
 import string
 
@@ -403,7 +403,7 @@ class TestQueryApi(SupersetTestCase):
         """
         Query API: Test get queries updated since timestamp
         """
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         client_id = self.get_random_string()
 
         admin = self.get_user("admin")
@@ -485,7 +485,7 @@ class TestQueryApi(SupersetTestCase):
             sql="SELECT col1, col2 from table1",
             select_sql="SELECT col1, col2 from table1",
             executed_sql="SELECT col1, col2 from table1 LIMIT 100",
-            changed_on=datetime.utcnow() - timedelta(days=1),
+            changed_on=datetime.now(timezone.utc) - timedelta(days=1),
         )
         self.login(ADMIN_USERNAME)
         rv = self.client.post(

--- a/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
+++ b/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -59,7 +59,7 @@ def test_report_for_dashboard_with_tabs(
     ) as report_schedule:
         dashboard: Dashboard = report_schedule.dashboard
         AsyncExecuteReportScheduleCommand(
-            str(uuid4()), report_schedule.id, datetime.utcnow()
+            str(uuid4()), report_schedule.id, datetime.now(timezone.utc)
         ).run()
         dashboard_state = report_schedule.extra.get("dashboard", {})
         permalink_key = CreateDashboardPermalinkCommand(
@@ -102,7 +102,7 @@ def test_report_with_header_data(
     ) as report_schedule:
         dashboard: Dashboard = report_schedule.dashboard
         AsyncExecuteReportScheduleCommand(
-            str(uuid4()), report_schedule.id, datetime.utcnow()
+            str(uuid4()), report_schedule.id, datetime.now(timezone.utc)
         ).run()
         dashboard_state = report_schedule.extra.get("dashboard", {})
         permalink_key = CreateDashboardPermalinkCommand(
@@ -150,7 +150,7 @@ def test_report_schedule_stale_data_error_preserves_cause(
             # Execute the report and expect ReportScheduleUnexpectedError
             with pytest.raises(ReportScheduleUnexpectedError) as exc_info:
                 AsyncExecuteReportScheduleCommand(
-                    str(uuid4()), report_schedule.id, datetime.utcnow()
+                    str(uuid4()), report_schedule.id, datetime.now(timezone.utc)
                 ).run()
 
             # Verify the original StaleDataError is preserved as the cause

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -674,7 +674,9 @@ def test_email_chart_report_schedule_with_cc_bcc(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart_with_cc_and_bcc.id, datetime.utcnow()
+            TEST_ID,
+            create_report_email_chart_with_cc_and_bcc.id,
+            datetime.now(timezone.utc),
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -740,7 +742,7 @@ def test_email_chart_report_schedule(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart.id, datetime.now(timezone.utc)
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -794,7 +796,7 @@ def test_email_chart_report_schedule_alpha_owner(
         AsyncExecuteReportScheduleCommand(
             TEST_ID,
             create_report_email_chart_alpha_owner.id,
-            datetime.utcnow(),
+            datetime.now(timezone.utc),
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -844,7 +846,7 @@ def test_email_chart_report_schedule_force_screenshot(
         AsyncExecuteReportScheduleCommand(
             TEST_ID,
             create_report_email_chart_force_screenshot.id,
-            datetime.utcnow(),
+            datetime.now(timezone.utc),
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -883,7 +885,7 @@ def test_email_chart_alert_schedule(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_alert_email_chart.id, datetime.utcnow()
+            TEST_ID, create_alert_email_chart.id, datetime.now(timezone.utc)
         ).run()
 
         notification_targets = get_target_from_report_schedule(create_alert_email_chart)
@@ -920,7 +922,7 @@ def test_email_chart_report_dry_run(
     app.config["ALERT_REPORTS_NOTIFICATION_DRY_RUN"] = True
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart.id, datetime.now(timezone.utc)
         ).run()
 
         email_mock.assert_not_called()
@@ -954,7 +956,7 @@ def test_email_chart_report_schedule_with_csv(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart_with_csv.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart_with_csv.id, datetime.now(timezone.utc)
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -1009,7 +1011,7 @@ def test_email_chart_report_schedule_with_csv_no_query_context(
         AsyncExecuteReportScheduleCommand(
             TEST_ID,
             create_report_email_chart_with_csv_no_query_context.id,
-            datetime.utcnow(),
+            datetime.now(timezone.utc),
         ).run()
 
         # verify that when query context is null we request a screenshot
@@ -1060,7 +1062,7 @@ def test_email_chart_report_schedule_with_text(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart_with_text.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart_with_text.id, datetime.now(timezone.utc)
         ).run()
 
         # assert that the data is embedded correctly
@@ -1115,7 +1117,7 @@ def test_email_chart_report_schedule_with_text(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart_with_text.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart_with_text.id, datetime.now(timezone.utc)
         ).run()
 
         # assert that the data is embedded correctly
@@ -1166,7 +1168,7 @@ def test_email_dashboard_report_schedule(
             "superset.extensions.stats_logger_manager.instance.gauge"
         ) as statsd_mock:
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_report_email_dashboard.id, datetime.utcnow()
+                TEST_ID, create_report_email_dashboard.id, datetime.now(timezone.utc)
             ).run()
 
             notification_targets = get_target_from_report_schedule(
@@ -1215,7 +1217,7 @@ def test_email_dashboard_report_schedule_with_tab_anchor(
                 },
             )
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, report_schedule.id, datetime.utcnow()
+                TEST_ID, report_schedule.id, datetime.now(timezone.utc)
             ).run()
 
             # Assert logs are correct
@@ -1271,7 +1273,7 @@ def test_email_dashboard_report_schedule_disabled_tabs(
                 },
             )
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, report_schedule.id, datetime.utcnow()
+                TEST_ID, report_schedule.id, datetime.now(timezone.utc)
             ).run()
 
             # Assert logs are correct
@@ -1306,7 +1308,7 @@ def test_email_dashboard_report_schedule_force_screenshot(
         AsyncExecuteReportScheduleCommand(
             TEST_ID,
             create_report_email_dashboard_force_screenshot.id,
-            datetime.utcnow(),
+            datetime.now(timezone.utc),
         ).run()
 
         notification_targets = get_target_from_report_schedule(
@@ -1355,7 +1357,7 @@ def test_slack_chart_report_schedule_converts_to_v2(
             "superset.extensions.stats_logger_manager.instance.gauge"
         ) as statsd_mock:
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_report_slack_chart.id, datetime.utcnow()
+                TEST_ID, create_report_slack_chart.id, datetime.now(timezone.utc)
             ).run()
 
             assert (
@@ -1420,7 +1422,7 @@ def test_slack_chart_report_schedule_converts_to_v2_channel_with_hash(
             "superset.extensions.stats_logger_manager.instance.gauge"
         ) as statsd_mock:
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, report_schedule.id, datetime.utcnow()
+                TEST_ID, report_schedule.id, datetime.now(timezone.utc)
             ).run()
 
             assert (
@@ -1480,7 +1482,7 @@ def test_slack_chart_report_schedule_fails_to_converts_to_v2(
 
     with pytest.raises(ReportScheduleSystemErrorsException):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, report_schedule.id, datetime.utcnow()
+            TEST_ID, report_schedule.id, datetime.now(timezone.utc)
         ).run()
 
     # Assert failuer with proper log
@@ -1520,7 +1522,7 @@ def test_slack_chart_report_schedule_v2(
             "superset.extensions.stats_logger_manager.instance.gauge"
         ) as statsd_mock:
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_report_slack_chartv2.id, datetime.utcnow()
+                TEST_ID, create_report_slack_chartv2.id, datetime.now(timezone.utc)
             ).run()
 
             assert (
@@ -1570,7 +1572,7 @@ def test_slack_chart_report_schedule_with_errors(
 
         with pytest.raises(ReportScheduleClientErrorsException):
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_report_slack_chart.id, datetime.utcnow()
+                TEST_ID, create_report_slack_chart.id, datetime.now(timezone.utc)
             ).run()
 
         db.session.commit()
@@ -1625,7 +1627,7 @@ def test_slack_chart_report_schedule_with_csv(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_slack_chart_with_csv.id, datetime.utcnow()
+            TEST_ID, create_report_slack_chart_with_csv.id, datetime.now(timezone.utc)
         ).run()
 
         assert (
@@ -1684,7 +1686,7 @@ def test_slack_chart_report_schedule_with_text(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_slack_chart_with_text.id, datetime.utcnow()
+            TEST_ID, create_report_slack_chart_with_text.id, datetime.now(timezone.utc)
         ).run()
 
         table_markdown = """|    | t1   | t2   | t3__sum   |
@@ -1715,7 +1717,9 @@ def test_report_schedule_not_found(create_report_slack_chart):
     """
     max_id = db.session.query(func.max(ReportSchedule.id)).scalar()
     with pytest.raises(ReportScheduleNotFoundError):
-        AsyncExecuteReportScheduleCommand(TEST_ID, max_id + 1, datetime.utcnow()).run()
+        AsyncExecuteReportScheduleCommand(
+            TEST_ID, max_id + 1, datetime.now(timezone.utc)
+        ).run()
 
 
 @pytest.mark.usefixtures("create_report_slack_chart_working")
@@ -1729,7 +1733,7 @@ def test_report_schedule_working(create_report_slack_chart_working):
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_report_slack_chart_working.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
 
         assert_log(
@@ -1752,7 +1756,7 @@ def test_report_schedule_working_timeout(create_report_slack_chart_working):
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_report_slack_chart_working.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
 
     logs = db.session.query(ReportExecutionLog).all()
@@ -1776,7 +1780,7 @@ def test_report_schedule_success_grace(create_alert_slack_chart_success):
 
     with freeze_time(current_time):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_alert_slack_chart_success.id, datetime.utcnow()
+            TEST_ID, create_alert_slack_chart_success.id, datetime.now(timezone.utc)
         ).run()
 
     db.session.commit()
@@ -1817,7 +1821,7 @@ def test_report_schedule_success_grace_end(
 
     with freeze_time(current_time):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_alert_slack_chart_grace.id, datetime.utcnow()
+            TEST_ID, create_alert_slack_chart_grace.id, datetime.now(timezone.utc)
         ).run()
 
     db.session.commit()
@@ -1846,7 +1850,7 @@ def test_alert_limit_is_applied(
             return_value=[],
         ):  # noqa: F841
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_alert_email_chart.id, datetime.utcnow()
+                TEST_ID, create_alert_email_chart.id, datetime.now(timezone.utc)
             ).run()
             assert "LIMIT 2" in execute_mock.call_args[0][1]
 
@@ -1870,7 +1874,7 @@ def test_email_dashboard_report_fails(
 
     with pytest.raises(ReportScheduleSystemErrorsException):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_dashboard.id, datetime.utcnow()
+            TEST_ID, create_report_email_dashboard.id, datetime.now(timezone.utc)
         ).run()
 
     assert_log(ReportState.ERROR, error_message="Could not connect to SMTP XPTO")
@@ -1897,7 +1901,7 @@ def test_email_dashboard_report_fails_uncaught_exception(
 
     with pytest.raises(Exception):  # noqa: B017, PT011
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_dashboard.id, datetime.utcnow()
+            TEST_ID, create_report_email_dashboard.id, datetime.now(timezone.utc)
         ).run()
 
     assert_log(ReportState.ERROR, error_message="Uncaught exception")
@@ -1930,7 +1934,7 @@ def test_slack_chart_alert(
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_alert_email_chart.id, datetime.utcnow()
+            TEST_ID, create_alert_email_chart.id, datetime.now(timezone.utc)
         ).run()
 
         notification_targets = get_target_from_report_schedule(create_alert_email_chart)
@@ -1959,7 +1963,7 @@ def test_slack_chart_alert_no_attachment(email_mock, create_alert_email_chart):
 
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_alert_email_chart.id, datetime.utcnow()
+            TEST_ID, create_alert_email_chart.id, datetime.now(timezone.utc)
         ).run()
 
         notification_targets = get_target_from_report_schedule(create_alert_email_chart)
@@ -2001,7 +2005,7 @@ def test_slack_token_callable_chart_report(
 
         with freeze_time("2020-01-01T00:00:00Z"):
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_report_slack_chart.id, datetime.utcnow()
+                TEST_ID, create_report_slack_chart.id, datetime.now(timezone.utc)
             ).run()
             slack_token_mock.assert_called()
             slack_client_mock_class.assert_called_with(token="cool_code", proxy=None)  # noqa: S106
@@ -2015,7 +2019,7 @@ def test_email_chart_no_alert(create_no_alert_email_chart):
     """
     with freeze_time("2020-01-01T00:00:00Z"):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_no_alert_email_chart.id, datetime.utcnow()
+            TEST_ID, create_no_alert_email_chart.id, datetime.now(timezone.utc)
         ).run()
     assert_log(ReportState.NOOP)
 
@@ -2030,7 +2034,7 @@ def test_email_mul_alert(create_mul_alert_email_chart):
             (AlertQueryMultipleRowsError, AlertQueryMultipleColumnsError)
         ):
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_mul_alert_email_chart.id, datetime.utcnow()
+                TEST_ID, create_mul_alert_email_chart.id, datetime.now(timezone.utc)
             ).run()
 
 
@@ -2052,7 +2056,7 @@ def test_soft_timeout_alert(email_mock, create_alert_email_chart):
         execute_mock.side_effect = SoftTimeLimitExceeded()
         with pytest.raises(AlertQueryTimeout):
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_alert_email_chart.id, datetime.utcnow()
+                TEST_ID, create_alert_email_chart.id, datetime.now(timezone.utc)
             ).run()
 
     get_target_from_report_schedule(create_alert_email_chart)  # noqa: F841
@@ -2082,7 +2086,7 @@ def test_soft_timeout_screenshot(screenshot_mock, email_mock, create_alert_email
     screenshot_mock.side_effect = SoftTimeLimitExceeded()
     with pytest.raises(ReportScheduleScreenshotTimeout):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_alert_email_chart.id, datetime.utcnow()
+            TEST_ID, create_alert_email_chart.id, datetime.now(timezone.utc)
         ).run()
 
     # Assert the email smtp address, asserts a notification was sent with the error
@@ -2119,7 +2123,7 @@ def test_soft_timeout_csv(
 
     with pytest.raises(ReportScheduleCsvTimeout):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart_with_csv.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart_with_csv.id, datetime.now(timezone.utc)
         ).run()
 
     get_target_from_report_schedule(create_report_email_chart_with_csv)  # noqa: F841
@@ -2157,7 +2161,7 @@ def test_generate_no_csv(
 
     with pytest.raises(ReportScheduleCsvFailedError):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart_with_csv.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart_with_csv.id, datetime.now(timezone.utc)
         ).run()
 
     get_target_from_report_schedule(create_report_email_chart_with_csv)  # noqa: F841
@@ -2186,7 +2190,7 @@ def test_fail_screenshot(screenshot_mock, email_mock, create_report_email_chart)
     screenshot_mock.side_effect = Exception("Unexpected error")
     with pytest.raises(ReportScheduleScreenshotFailedError):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart.id, datetime.now(timezone.utc)
         ).run()
 
     get_target_from_report_schedule(create_report_email_chart)  # noqa: F841
@@ -2219,7 +2223,7 @@ def test_fail_csv(
 
     with pytest.raises(ReportScheduleCsvFailedError):
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_report_email_chart_with_csv.id, datetime.utcnow()
+            TEST_ID, create_report_email_chart_with_csv.id, datetime.now(timezone.utc)
         ).run()
 
     get_target_from_report_schedule(create_report_email_chart_with_csv)
@@ -2245,7 +2249,7 @@ def test_email_disable_screenshot(email_mock, create_alert_email_chart):
     """
 
     AsyncExecuteReportScheduleCommand(
-        TEST_ID, create_alert_email_chart.id, datetime.utcnow()
+        TEST_ID, create_alert_email_chart.id, datetime.now(timezone.utc)
     ).run()
 
     notification_targets = get_target_from_report_schedule(create_alert_email_chart)
@@ -2267,7 +2271,7 @@ def test_invalid_sql_alert(email_mock, create_invalid_sql_alert_email_chart):
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_invalid_sql_alert_email_chart.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
 
         # Assert the email smtp address, asserts a notification was sent with the error
@@ -2285,7 +2289,7 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_invalid_sql_alert_email_chart.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
 
         # Assert the email smtp address, asserts a notification was sent with the error
@@ -2299,7 +2303,7 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_invalid_sql_alert_email_chart.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
         db.session.commit()
         assert (
@@ -2312,7 +2316,7 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_invalid_sql_alert_email_chart.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
         db.session.commit()
         assert (
@@ -2335,7 +2339,7 @@ def test_grace_period_error_flap(
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_invalid_sql_alert_email_chart.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
         db.session.commit()
         # Assert we have 1 notification sent on the log
@@ -2348,7 +2352,7 @@ def test_grace_period_error_flap(
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_invalid_sql_alert_email_chart.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
         db.session.commit()
         assert (
@@ -2363,11 +2367,11 @@ def test_grace_period_error_flap(
     with freeze_time("2020-01-01T00:31:00Z"):
         # One success
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+            TEST_ID, create_invalid_sql_alert_email_chart.id, datetime.now(timezone.utc)
         ).run()
         # Grace period ends
         AsyncExecuteReportScheduleCommand(
-            TEST_ID, create_invalid_sql_alert_email_chart.id, datetime.utcnow()
+            TEST_ID, create_invalid_sql_alert_email_chart.id, datetime.now(timezone.utc)
         ).run()
 
         db.session.commit()
@@ -2383,7 +2387,7 @@ def test_grace_period_error_flap(
             AsyncExecuteReportScheduleCommand(
                 TEST_ID,
                 create_invalid_sql_alert_email_chart.id,
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
             ).run()
         db.session.commit()
         assert (

--- a/tests/integration_tests/superset_test_custom_template_processors.py
+++ b/tests/integration_tests/superset_test_custom_template_processors.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from typing import Any, Dict, SupportsInt  # noqa: F401
 
@@ -40,7 +40,7 @@ class CustomPrestoTemplateProcessor(PrestoTemplateProcessor):
     def process_template(self, sql: str, **kwargs) -> str:
         """Processes a sql template with $ style macro using regex."""
         # Add custom macros functions.
-        macros = {"DATE": partial(DATE, datetime.utcnow())}  # type: Dict[str, Any]
+        macros = {"DATE": partial(DATE, datetime.now(timezone.utc))}  # type: Dict[str, Any]
         # Update with macros defined in context and kwargs.
         macros.update(self._context)
         macros.update(kwargs)

--- a/tests/unit_tests/dao/queries_test.py
+++ b/tests/unit_tests/dao/queries_test.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -69,7 +69,7 @@ def test_query_dao_get_queries_changed_after(session: Session) -> None:
 
     database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     old_query_obj = Query(
         client_id="foo",


### PR DESCRIPTION
### SUMMARY
Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
