### PR TITLE
fix(sqllab): Resolve stale closure bug causing text selection to break

### DIFF
--- a/superset-frontend/src/SqlLab/components/EditorWrapper/EditorWrapper.test.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/EditorWrapper.test.tsx
@@ -17,7 +17,12 @@
  * under the License.
  */
 import reducerIndex from 'spec/helpers/reducerIndex';
-import { render, waitFor, createStore } from 'spec/helpers/testing-library';
+import {
+  render,
+  waitFor,
+  createStore,
+  act,
+} from 'spec/helpers/testing-library';
 import { QueryEditor } from 'src/SqlLab/types';
 import { Store } from 'redux';
 import { initialState, defaultQueryEditor } from 'src/SqlLab/fixtures';
@@ -150,12 +155,16 @@ describe('EditorWrapper', () => {
       moveCursorToPosition: jest.fn(),
       scrollToLine: jest.fn(),
     };
-    onReady(mockHandle);
+    act(() => {
+      onReady(mockHandle);
+    });
 
     // Simulate selection change with empty selection (cursor moved without selecting)
-    onSelectionChange([
-      { start: { line: 0, column: 5 }, end: { line: 0, column: 5 } },
-    ]);
+    act(() => {
+      onSelectionChange([
+        { start: { line: 0, column: 5 }, end: { line: 0, column: 5 } },
+      ]);
+    });
 
     // Verify selectedText was cleared in the store
     await waitFor(() => {

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/EditorWrapper.test.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/EditorWrapper.test.tsx
@@ -26,6 +26,7 @@ import type { editors } from '@apache-superset/core';
 import {
   queryEditorSetCursorPosition,
   queryEditorSetDb,
+  queryEditorSetSelectedText,
 } from 'src/SqlLab/actions/sqlLab';
 import fetchMock from 'fetch-mock';
 
@@ -123,5 +124,48 @@ describe('EditorWrapper', () => {
     expect(MockEditorHost).toHaveBeenCalledTimes(renderCount);
     store.dispatch(queryEditorSetDb(defaultQueryEditor, 2));
     expect(MockEditorHost).toHaveBeenCalledTimes(renderCount + 1);
+  });
+
+  test('clears selectedText when selection becomes empty', async () => {
+    const store = createStore(initialState, reducerIndex);
+    // Set initial selected text in store
+    store.dispatch(
+      queryEditorSetSelectedText(defaultQueryEditor, 'SELECT * FROM table'),
+    );
+    setup(defaultQueryEditor, store);
+
+    await waitFor(() => expect(MockEditorHost).toHaveBeenCalled());
+
+    // Get the onSelectionChange and onReady callbacks from the mock
+    const lastCall =
+      MockEditorHost.mock.calls[MockEditorHost.mock.calls.length - 1][0];
+    const { onSelectionChange, onReady } = lastCall;
+
+    // Simulate editor ready with a mock handle that returns empty selection
+    const mockHandle = {
+      getSelectedText: jest.fn().mockReturnValue(''),
+      getValue: jest.fn().mockReturnValue(''),
+      setValue: jest.fn(),
+      focus: jest.fn(),
+      moveCursorToPosition: jest.fn(),
+      scrollToLine: jest.fn(),
+    };
+    onReady(mockHandle);
+
+    // Simulate selection change with empty selection (cursor moved without selecting)
+    onSelectionChange([
+      { start: { line: 0, column: 5 }, end: { line: 0, column: 5 } },
+    ]);
+
+    // Verify selectedText was cleared in the store
+    await waitFor(() => {
+      const state = store.getState() as unknown as {
+        sqlLab: { queryEditors: QueryEditor[] };
+      };
+      const editor = state.sqlLab.queryEditors.find(
+        qe => qe.id === defaultQueryEditor.id,
+      );
+      expect(editor?.selectedText).toBeFalsy();
+    });
   });
 });

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
@@ -231,8 +231,10 @@ const EditorWrapper = ({
         return;
       }
 
-      // Skip 1-character selections (backspace triggers these)
-      // but still update cache to track state
+      // Skip 1-character selections to avoid noise from backspace operations
+      // which briefly select single characters. Trade-off: genuine single-char
+      // selections won't update Redux, but this is acceptable since running
+      // a single character as a query is not a practical use case.
       if (selectedText.length === 1) {
         currentSelectionCache.current = selectedText;
         return;

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
@@ -216,16 +216,33 @@ const EditorWrapper = ({
         end: { line: number; column: number };
       }>,
     ) => {
-      if (editorHandleRef.current && selections.length > 0) {
-        const selectedText = editorHandleRef.current.getSelectedText();
-        if (
-          selectedText !== currentSelectionCache.current &&
-          selectedText.length !== 1
-        ) {
-          dispatch(queryEditorSetSelectedText(queryEditor, selectedText));
-        }
-        currentSelectionCache.current = selectedText;
+      if (!editorHandleRef.current || selections.length === 0) {
+        return;
       }
+
+      const selectedText = editorHandleRef.current.getSelectedText();
+
+      // Always clear selection state when text is empty, regardless of cache
+      if (!selectedText) {
+        if (currentSelectionCache.current) {
+          dispatch(queryEditorSetSelectedText(queryEditor, null));
+        }
+        currentSelectionCache.current = '';
+        return;
+      }
+
+      // Skip 1-character selections (backspace triggers these)
+      // but still update cache to track state
+      if (selectedText.length === 1) {
+        currentSelectionCache.current = selectedText;
+        return;
+      }
+
+      // Only dispatch if selection actually changed
+      if (selectedText !== currentSelectionCache.current) {
+        dispatch(queryEditorSetSelectedText(queryEditor, selectedText));
+      }
+      currentSelectionCache.current = selectedText;
     },
     [dispatch, queryEditor],
   );

--- a/superset-frontend/src/core/editors/AceEditorProvider.test.tsx
+++ b/superset-frontend/src/core/editors/AceEditorProvider.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useState, ReactElement } from 'react';
+import {
+  render as rtlRender,
+  screen,
+  waitFor,
+  cleanup,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, supersetTheme } from '@apache-superset/core/ui';
+import type { editors } from '@apache-superset/core';
+
+type EditorProps = editors.EditorProps;
+
+const mockEventHandlers: Record<string, (() => void) | undefined> = {};
+
+const mockEditor = {
+  focus: jest.fn(),
+  getCursorPosition: jest.fn(() => ({ row: 1, column: 5 })),
+  getSelection: jest.fn(() => ({
+    getRange: () => ({
+      start: { row: 0, column: 0 },
+      end: { row: 0, column: 10 },
+    }),
+  })),
+  commands: { addCommand: jest.fn() },
+  selection: {
+    on: jest.fn((event: string, handler: () => void) => {
+      mockEventHandlers[event] = handler;
+    }),
+  },
+};
+
+let mockOnLoadCallback: ((editor: typeof mockEditor) => void) | undefined;
+
+jest.mock('@superset-ui/core/components', () => ({
+  __esModule: true,
+  FullSQLEditor: jest.fn((props: { onLoad?: () => void }) => {
+    mockOnLoadCallback = props.onLoad;
+    return <div data-test="sql-editor" />;
+  }),
+  JsonEditor: () => <div data-test="json-editor" />,
+  MarkdownEditor: () => <div data-test="markdown-editor" />,
+  CssEditor: () => <div data-test="css-editor" />,
+  ConfigEditor: () => <div data-test="config-editor" />,
+}));
+
+import AceEditorProvider from './AceEditorProvider';
+
+const render = (ui: ReactElement) =>
+  rtlRender(<ThemeProvider theme={supersetTheme}>{ui}</ThemeProvider>);
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+  mockOnLoadCallback = undefined;
+  Object.keys(mockEventHandlers).forEach(key => delete mockEventHandlers[key]);
+});
+
+const defaultProps: EditorProps = {
+  id: 'test-editor',
+  value: 'SELECT * FROM table',
+  onChange: jest.fn(),
+  language: 'sql',
+};
+
+const renderEditor = (props: Partial<EditorProps> = {}) => {
+  const result = render(<AceEditorProvider {...defaultProps} {...props} />);
+  if (mockOnLoadCallback) {
+    mockOnLoadCallback(mockEditor);
+  }
+  return result;
+};
+
+test('onSelectionChange uses latest callback after prop change', async () => {
+  const firstCallback = jest.fn();
+  const secondCallback = jest.fn();
+
+  const CallbackSwitcher = () => {
+    const [useSecond, setUseSecond] = useState(false);
+    return (
+      <>
+        <button type="button" onClick={() => setUseSecond(true)}>
+          Switch
+        </button>
+        <AceEditorProvider
+          {...defaultProps}
+          onSelectionChange={useSecond ? secondCallback : firstCallback}
+        />
+      </>
+    );
+  };
+
+  render(<CallbackSwitcher />);
+
+  if (mockOnLoadCallback) {
+    mockOnLoadCallback(mockEditor);
+  }
+
+  await waitFor(() => expect(mockEventHandlers.changeSelection).toBeDefined());
+
+  mockEventHandlers.changeSelection!();
+  expect(firstCallback).toHaveBeenCalled();
+  expect(secondCallback).not.toHaveBeenCalled();
+  firstCallback.mockClear();
+
+  userEvent.click(screen.getByRole('button', { name: /switch/i }));
+  mockEventHandlers.changeSelection!();
+
+  expect(secondCallback).toHaveBeenCalled();
+  expect(firstCallback).not.toHaveBeenCalled();
+});
+
+test('onCursorPositionChange uses latest callback after prop change', async () => {
+  const firstCallback = jest.fn();
+  const secondCallback = jest.fn();
+
+  const CallbackSwitcher = () => {
+    const [useSecond, setUseSecond] = useState(false);
+    return (
+      <>
+        <button type="button" onClick={() => setUseSecond(true)}>
+          Switch
+        </button>
+        <AceEditorProvider
+          {...defaultProps}
+          onCursorPositionChange={useSecond ? secondCallback : firstCallback}
+        />
+      </>
+    );
+  };
+
+  render(<CallbackSwitcher />);
+
+  if (mockOnLoadCallback) {
+    mockOnLoadCallback(mockEditor);
+  }
+
+  await waitFor(() => expect(mockEventHandlers.changeCursor).toBeDefined());
+
+  mockEventHandlers.changeCursor!();
+  expect(firstCallback).toHaveBeenCalled();
+  expect(secondCallback).not.toHaveBeenCalled();
+  firstCallback.mockClear();
+
+  userEvent.click(screen.getByRole('button', { name: /switch/i }));
+  mockEventHandlers.changeCursor!();
+
+  expect(secondCallback).toHaveBeenCalled();
+  expect(firstCallback).not.toHaveBeenCalled();
+});
+
+test('cursor position callback receives correct position format', async () => {
+  const onCursorPositionChange = jest.fn();
+  renderEditor({ onCursorPositionChange });
+
+  await waitFor(() => expect(mockEventHandlers.changeCursor).toBeDefined());
+  mockEventHandlers.changeCursor!();
+
+  expect(onCursorPositionChange).toHaveBeenCalledWith({ line: 1, column: 5 });
+});
+
+test('selection callback receives correct range format', async () => {
+  const onSelectionChange = jest.fn();
+  renderEditor({ onSelectionChange });
+
+  await waitFor(() => expect(mockEventHandlers.changeSelection).toBeDefined());
+  mockEventHandlers.changeSelection!();
+
+  expect(onSelectionChange).toHaveBeenCalledWith([
+    { start: { line: 0, column: 0 }, end: { line: 0, column: 10 } },
+  ]);
+});

--- a/superset-frontend/src/core/editors/AceEditorProvider.test.tsx
+++ b/superset-frontend/src/core/editors/AceEditorProvider.test.tsx
@@ -122,7 +122,7 @@ test('onSelectionChange uses latest callback after prop change', async () => {
   expect(secondCallback).not.toHaveBeenCalled();
   firstCallback.mockClear();
 
-  userEvent.click(screen.getByRole('button', { name: /switch/i }));
+  await userEvent.click(screen.getByRole('button', { name: /switch/i }));
   mockEventHandlers.changeSelection!();
 
   expect(secondCallback).toHaveBeenCalled();
@@ -161,7 +161,7 @@ test('onCursorPositionChange uses latest callback after prop change', async () =
   expect(secondCallback).not.toHaveBeenCalled();
   firstCallback.mockClear();
 
-  userEvent.click(screen.getByRole('button', { name: /switch/i }));
+  await userEvent.click(screen.getByRole('button', { name: /switch/i }));
   mockEventHandlers.changeCursor!();
 
   expect(secondCallback).toHaveBeenCalled();


### PR DESCRIPTION
### SUMMARY

This PR fixes a bug in SQL Lab where text selection using keyboard shortcuts (e.g., `Cmd+Shift+Arrow`) would break after certain operations like selecting text, deleting it, and then undoing the deletion.

**Root Cause:**
The `AceEditorProvider` component registered event listeners for `changeCursor` and `changeSelection` events during editor initialization. These listeners captured callback references at registration time, creating stale closures when the parent component re-rendered with new callback functions.

**Fix:**
- Added refs (`onCursorPositionChangeRef` and `onSelectionChangeRef`) to store the latest callback references
- Event listeners now access callbacks through refs, ensuring they always use the most recent function
- Memoized the `handle` object with `useMemo` to prevent unnecessary recreation on every render
- Added a guard ref (`onReadyCalledRef`) to ensure `onReady` is only called once

**Additional Fix:**
- Updated `EditorWrapper` to properly clear `selectedText` in Redux when selection becomes empty (cursor moved without selecting)

### TESTING INSTRUCTIONS

1. Open SQL Lab and create a new tab
2. Select the default "SELECT..." text using `Cmd+Shift+Arrow Right`
3. Delete the selected text
4. Press `Cmd+Z` to undo
5. Try to select the text again using `Cmd+Shift+Arrow Right`
6. Verify the text is properly selected and highlighted
7. Press Enter to move text to line 2, then use Arrow Down to move cursor
8. Verify the cursor moves correctly to line 2

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
