### PR TITLE
chore(deps): bump dependencies to address security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -437,6 +437,7 @@ authorized_licenses = [
     "apache software",
     "apache software, bsd",
     "bsd",
+    "bsd-2-clause",
     "bsd-3-clause",
     "isc license (iscl)",
     "isc license",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,12 +18,12 @@
 #
 # Security: CVE-2026-21441 - decompression bomb bypass on redirects
 urllib3>=2.6.3,<3.0.0
-# Security: GHSA-87hc-h4r5-73f7, multipart boundary fix
-werkzeug>=3.1.5
+# Security: GHSA-87hc-h4r5-73f7 - Windows path traversal fix
+werkzeug>=3.1.5,<4.0.0
 # Security: CVE-2025-68146 - TOCTOU symlink vulnerability
-filelock>=3.20.3
+filelock>=3.20.3,<4.0.0
 # Security: decompression bomb fix (required by aiohttp 3.13.3)
-brotli>=1.2.0
+brotli>=1.2.0,<2.0.0
 numexpr>=2.9.0
 
 # 5.0.0 has a sensitive deprecation used in other libs

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,8 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-urllib3>=2.6.0,<3.0.0
-werkzeug>=3.0.1
+# Security: CVE-2026-21441 - decompression bomb bypass on redirects
+urllib3>=2.6.3,<3.0.0
+# Security: GHSA-87hc-h4r5-73f7, multipart boundary fix
+werkzeug>=3.1.5
+# Security: CVE-2025-68146 - TOCTOU symlink vulnerability
+filelock>=3.20.3
+# Security: decompression bomb fix (required by aiohttp 3.13.3)
+brotli>=1.2.0
 numexpr>=2.9.0
 
 # 5.0.0 has a sensitive deprecation used in other libs

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -164,7 +164,6 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
-    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,8 +36,10 @@ blinker==1.9.0
     # via flask
 bottleneck==1.5.0
     # via apache-superset (pyproject.toml)
-brotli==1.1.0
-    # via flask-compress
+brotli==1.2.0
+    # via
+    #   -r requirements/base.in
+    #   flask-compress
 cachelib==0.13.0
     # via
     #   flask-caching
@@ -101,6 +103,8 @@ email-validator==2.2.0
     # via flask-appbuilder
 et-xmlfile==2.0.0
     # via openpyxl
+filelock==3.20.3
+    # via -r requirements/base.in
 flask==2.3.3
     # via
     #   apache-superset (pyproject.toml)
@@ -289,7 +293,7 @@ prompt-toolkit==3.0.51
     # via click-repl
 pyarrow==16.1.0
     # via apache-superset (pyproject.toml)
-pyasn1==0.6.1
+pyasn1==0.6.2
     # via
     #   pyasn1-modules
     #   rsa
@@ -436,7 +440,7 @@ tzdata==2025.2
     #   pandas
 url-normalize==2.2.1
     # via requests-cache
-urllib3==2.6.0
+urllib3==2.6.3
     # via
     #   -r requirements/base.in
     #   requests
@@ -453,7 +457,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via selenium
-werkzeug==3.1.3
+werkzeug==3.1.5
     # via
     #   -r requirements/base.in
     #   flask

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -164,6 +164,7 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
+    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -80,7 +80,7 @@ bottleneck==1.5.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset
-brotli==1.1.0
+brotli==1.2.0
     # via
     #   -c requirements/base-constraint.txt
     #   flask-compress
@@ -179,7 +179,6 @@ cryptography==44.0.3
     #   paramiko
     #   pyjwt
     #   pyopenssl
-    #   secretstorage
 cycler==0.12.1
     # via matplotlib
 cyclopts==4.2.4
@@ -235,8 +234,10 @@ fakeredis==2.32.1
     # via pydocket
 fastmcp==2.14.3
     # via apache-superset
-filelock==3.12.2
-    # via virtualenv
+filelock==3.20.3
+    # via
+    #   -c requirements/base-constraint.txt
+    #   virtualenv
 flask==2.3.3
     # via
     #   -c requirements/base-constraint.txt
@@ -373,7 +374,6 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
-    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -448,10 +448,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.3.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -c requirements/base-constraint.txt
@@ -714,7 +710,7 @@ pyarrow==16.1.0
     #   apache-superset
     #   db-dtypes
     #   pandas-gbq
-pyasn1==0.6.1
+pyasn1==0.6.2
     # via
     #   -c requirements/base-constraint.txt
     #   pyasn1-modules
@@ -913,8 +909,6 @@ rsa==4.9.1
     #   google-auth
 ruff==0.9.7
     # via apache-superset
-secretstorage==3.5.0
-    # via keyring
 selenium==4.32.0
     # via
     #   -c requirements/base-constraint.txt
@@ -1061,7 +1055,7 @@ url-normalize==2.2.1
     # via
     #   -c requirements/base-constraint.txt
     #   requests-cache
-urllib3==2.6.0
+urllib3==2.6.3
     # via
     #   -c requirements/base-constraint.txt
     #   docker
@@ -1095,7 +1089,7 @@ websocket-client==1.8.0
     #   selenium
 websockets==15.0.1
     # via fastmcp
-werkzeug==3.1.3
+werkzeug==3.1.5
     # via
     #   -c requirements/base-constraint.txt
     #   flask

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -179,6 +179,7 @@ cryptography==44.0.3
     #   paramiko
     #   pyjwt
     #   pyopenssl
+    #   secretstorage
 cycler==0.12.1
     # via matplotlib
 cyclopts==4.2.4
@@ -374,6 +375,7 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
+    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -448,6 +450,10 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.3.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via
     #   -c requirements/base-constraint.txt
@@ -909,6 +915,8 @@ rsa==4.9.1
     #   google-auth
 ruff==0.9.7
     # via apache-superset
+secretstorage==3.5.0
+    # via keyring
 selenium==4.32.0
     # via
     #   -c requirements/base-constraint.txt


### PR DESCRIPTION
## Summary

Bump dependencies to address security vulnerabilities:

| Package | From | To | CVE/Advisory |
|---------|------|-----|--------------|
| urllib3 | 2.6.0 | 2.6.3 | CVE-2026-21441 - decompression bomb bypass on redirects |
| werkzeug | 3.1.3 | 3.1.5 | GHSA-87hc-h4r5-73f7, multipart boundary fix |
| brotli | 1.1.0 | 1.2.0 | Decompression bomb fix |
| filelock | - | 3.20.3 | CVE-2025-68146 - TOCTOU symlink vulnerability |
| pyasn1 | 0.6.1 | 0.6.2 | Security fix |

## Changelog links
- [urllib3 2.6.3](https://github.com/urllib3/urllib3/releases/tag/2.6.3)
- [werkzeug 3.1.5](https://github.com/pallets/werkzeug/releases/tag/3.1.5)
- [brotli 1.2.0](https://github.com/google/brotli/releases/tag/v1.2.0)
- [filelock 3.20.3](https://github.com/tox-dev/filelock/releases/tag/3.20.3)
- [pyasn1 0.6.2](https://github.com/pyasn1/pyasn1/releases/tag/v0.6.2)

## Test plan
- [ ] CI passes
- [ ] Verify no breaking changes in dependency compatibility