### PR TITLE
fix(security): update jspdf to 4.0.0 to address CVE-2025-68428

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -41348,9 +41348,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
-      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -388,7 +388,7 @@
     "puppeteer": "^22.4.1",
     "remark-gfm": "^3.0.1",
     "underscore": "^1.13.7",
-    "jspdf": "^3.0.2",
+    "jspdf": "^4.0.0",
     "nwsapi": "^2.2.13",
     "@deck.gl/aggregation-layers": "~9.2.2",
     "@deck.gl/core": "~9.2.2",


### PR DESCRIPTION
## Summary

Updates the transitive dependency `jspdf` from `^3.0.2` to `^4.0.0` to fix a critical security vulnerability.

**CVE-2025-68428**: Local File Inclusion/Path Traversal vulnerability in jsPDF that could allow arbitrary file reads in Node.js environments.

## Changes

- Updated `jspdf` version constraint in `superset-frontend/package.json` from `^3.0.2` to `^4.0.0`

## Impact Assessment

**Low risk of breakage:**
- Superset uses jspdf indirectly through `dom-to-pdf` for browser-based PDF export
- The jspdf v4.0.0 breaking change only affects Node.js file system access (which is the vulnerability fix)
- No API changes for browser-based PDF generation
- The PDF export functionality (`downloadAsPdf.ts`) should continue working without modification

## Security Advisory

- [GHSA-f8cm-6447-x5h2](https://github.com/parallax/jsPDF/security/advisories/GHSA-f8cm-6447-x5h2)
- [CVE-2025-68428](https://github.com/advisories/GHSA-f8cm-6447-x5h2)

## Test Plan

- [x] Run existing frontend tests
- [x] Verify PDF export functionality works (Dashboard → Export to PDF)
- [x] Run `npm audit` to confirm vulnerability is resolved