### PR TITLE
fix(table-charts): Prevent time grain from altering Raw Records in Tables + Interactive Tables

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -251,10 +251,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   );
 
   const timestampFormatter = useCallback(
-    value =>
-      getTimeFormatterForGranularity(isRawRecords ? undefined : timeGrain)(
-        value,
-      ),
+    (value: DataRecordValue) =>
+      isRawRecords
+        ? String(value ?? '')
+        : getTimeFormatterForGranularity(timeGrain)(
+            value as number | Date | null | undefined,
+          ),
     [timeGrain, isRawRecords],
   );
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -251,8 +251,14 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   );
 
   const timestampFormatter = useCallback(
-    value => getTimeFormatterForGranularity(timeGrain)(value),
-    [timeGrain],
+    value => {
+      // In Raw Records mode, don't apply time grain-based formatting
+      if (isRawRecords || !timeGrain) {
+        return String(value);
+      }
+      return getTimeFormatterForGranularity(timeGrain)(value);
+    },
+    [timeGrain, isRawRecords],
   );
 
   const toggleFilter = useCallback(

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -251,18 +251,10 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   );
 
   const timestampFormatter = useCallback(
-    (value: DataRecordValue) => {
-      if (value == null) {
-        return '';
-      }
-      // In Raw Records mode, don't apply time grain-based formatting
-      if (isRawRecords || !timeGrain) {
-        return String(value);
-      }
-      return getTimeFormatterForGranularity(timeGrain)(
-        value as number | Date | null | undefined,
-      );
-    },
+    value =>
+      getTimeFormatterForGranularity(isRawRecords ? undefined : timeGrain)(
+        value,
+      ),
     [timeGrain, isRawRecords],
   );
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -251,12 +251,17 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   );
 
   const timestampFormatter = useCallback(
-    value => {
+    (value: DataRecordValue) => {
+      if (value == null) {
+        return '';
+      }
       // In Raw Records mode, don't apply time grain-based formatting
       if (isRawRecords || !timeGrain) {
         return String(value);
       }
-      return getTimeFormatterForGranularity(timeGrain)(value);
+      return getTimeFormatterForGranularity(timeGrain)(
+        value as number | Date | null | undefined,
+      );
     },
     [timeGrain, isRawRecords],
   );
@@ -282,7 +287,14 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         setDataMask(getCrossFilterDataMask(crossFilterProps).dataMask);
       }
     },
-    [emitCrossFilters, setDataMask, filters, timeGrain],
+    [
+      emitCrossFilters,
+      setDataMask,
+      filters,
+      timeGrain,
+      isActiveFilterValue,
+      timestampFormatter,
+    ],
   );
 
   const handleServerPaginationChange = useCallback(

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -394,8 +394,6 @@ const processColumns = memoizeOne(function processColumns(
         const timeFormat = customFormat || tableTimestampFormat;
         // When format is "Adaptive Formatting" (smart_date)
         if (timeFormat === SMART_DATE_ID) {
-          // In Raw Records mode, don't apply time grain-based formatting
-          // Temporal columns should display raw timestamp values
           if (granularity && queryMode !== QueryMode.Raw) {
             // time column use formats based on granularity
             formatter = getTimeFormatterForGranularity(granularity);

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -343,6 +343,7 @@ const processColumns = memoizeOne(function processColumns(
       metrics: metrics_,
       percent_metrics: percentMetrics_,
       column_config: columnConfig = {},
+      query_mode: queryMode,
     },
     queriesData,
   } = props;
@@ -393,7 +394,9 @@ const processColumns = memoizeOne(function processColumns(
         const timeFormat = customFormat || tableTimestampFormat;
         // When format is "Adaptive Formatting" (smart_date)
         if (timeFormat === SMART_DATE_ID) {
-          if (granularity) {
+          // In Raw Records mode, don't apply time grain-based formatting
+          // Temporal columns should display raw timestamp values
+          if (granularity && queryMode !== QueryMode.Raw) {
             // time column use formats based on granularity
             formatter = getTimeFormatterForGranularity(granularity);
           } else if (customFormat) {

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -29,274 +29,272 @@ beforeAll(() => {
   setupAGGridModules();
 });
 
-describe('plugin-chart-ag-grid-table', () => {
-  describe('transformProps', () => {
-    it('should parse pageLength to pageSize', () => {
-      expect(transformProps(testData.basic).pageSize).toBe(20);
-      expect(
-        transformProps({
-          ...testData.basic,
-          rawFormData: { ...testData.basic.rawFormData, page_length: '20' },
-        }).pageSize,
-      ).toBe(20);
-      expect(
-        transformProps({
-          ...testData.basic,
-          rawFormData: { ...testData.basic.rawFormData, page_length: '' },
-        }).pageSize,
-      ).toBe(0);
-    });
-
-    it('should not apply time grain formatting in Raw Records mode', () => {
-      const rawRecordsProps = {
+describe('transformProps', () => {
+  it('should parse pageLength to pageSize', () => {
+    expect(transformProps(testData.basic).pageSize).toBe(20);
+    expect(
+      transformProps({
         ...testData.basic,
-        rawFormData: {
-          ...testData.basic.rawFormData,
-          query_mode: QueryMode.Raw,
-          time_grain_sqla: TimeGranularity.MONTH,
-          table_timestamp_format: SMART_DATE_ID,
-        },
-      };
-
-      const transformedProps = transformProps(rawRecordsProps);
-      expect(transformedProps.isRawRecords).toBe(true);
-      expect(transformedProps.timeGrain).toBe(TimeGranularity.MONTH);
-    });
-
-    it('should handle null/undefined timestamp values correctly', () => {
-      const rawRecordsProps = {
+        rawFormData: { ...testData.basic.rawFormData, page_length: '20' },
+      }).pageSize,
+    ).toBe(20);
+    expect(
+      transformProps({
         ...testData.basic,
-        rawFormData: {
-          ...testData.basic.rawFormData,
-          query_mode: QueryMode.Raw,
-        },
-      };
+        rawFormData: { ...testData.basic.rawFormData, page_length: '' },
+      }).pageSize,
+    ).toBe(0);
+  });
 
-      const transformedProps = transformProps(rawRecordsProps);
-      expect(transformedProps.isRawRecords).toBe(true);
+  it('should not apply time grain formatting in Raw Records mode', () => {
+    const rawRecordsProps = {
+      ...testData.basic,
+      rawFormData: {
+        ...testData.basic.rawFormData,
+        query_mode: QueryMode.Raw,
+        time_grain_sqla: TimeGranularity.MONTH,
+        table_timestamp_format: SMART_DATE_ID,
+      },
+    };
+
+    const transformedProps = transformProps(rawRecordsProps);
+    expect(transformedProps.isRawRecords).toBe(true);
+    expect(transformedProps.timeGrain).toBe(TimeGranularity.MONTH);
+  });
+
+  it('should handle null/undefined timestamp values correctly', () => {
+    const rawRecordsProps = {
+      ...testData.basic,
+      rawFormData: {
+        ...testData.basic.rawFormData,
+        query_mode: QueryMode.Raw,
+      },
+    };
+
+    const transformedProps = transformProps(rawRecordsProps);
+    expect(transformedProps.isRawRecords).toBe(true);
+  });
+});
+
+describe('AgGridTableChart', () => {
+  const mockSetDataMask = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render basic data', async () => {
+    const props = transformProps(testData.basic);
+    render(
+      ProviderWrapper({
+        children: (
+          <AgGridTableChart
+            {...props}
+            setDataMask={mockSetDataMask}
+            slice_id={1}
+          />
+        ),
+      }),
+    );
+
+    // Wait for AgGrid to render
+    await waitFor(() => {
+      const grid = document.querySelector('.ag-container');
+      expect(grid).toBeInTheDocument();
     });
   });
 
-  describe('AgGridTableChart', () => {
-    const mockSetDataMask = jest.fn();
-
-    beforeEach(() => {
-      jest.clearAllMocks();
+  it('should render with server pagination', async () => {
+    const props = transformProps({
+      ...testData.basic,
+      rawFormData: {
+        ...testData.basic.rawFormData,
+        server_pagination: true,
+      },
     });
+    props.serverPagination = true;
+    props.rowCount = 100;
+    props.serverPaginationData = {
+      currentPage: 0,
+      pageSize: 20,
+    };
 
-    it('should render basic data', async () => {
-      const props = transformProps(testData.basic);
-      render(
-        ProviderWrapper({
-          children: (
-            <AgGridTableChart
-              {...props}
-              setDataMask={mockSetDataMask}
-              slice_id={1}
-            />
-          ),
-        }),
-      );
+    render(
+      ProviderWrapper({
+        children: (
+          <AgGridTableChart
+            {...props}
+            setDataMask={mockSetDataMask}
+            slice_id={1}
+          />
+        ),
+      }),
+    );
 
-      // Wait for AgGrid to render
-      await waitFor(() => {
-        const grid = document.querySelector('.ag-container');
-        expect(grid).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      const grid = document.querySelector('.ag-container');
+      expect(grid).toBeInTheDocument();
     });
+  });
 
-    it('should render with server pagination', async () => {
-      const props = transformProps({
-        ...testData.basic,
-        rawFormData: {
-          ...testData.basic.rawFormData,
-          server_pagination: true,
-        },
-      });
-      props.serverPagination = true;
-      props.rowCount = 100;
-      props.serverPaginationData = {
-        currentPage: 0,
-        pageSize: 20,
-      };
-
-      render(
-        ProviderWrapper({
-          children: (
-            <AgGridTableChart
-              {...props}
-              setDataMask={mockSetDataMask}
-              slice_id={1}
-            />
-          ),
-        }),
-      );
-
-      await waitFor(() => {
-        const grid = document.querySelector('.ag-container');
-        expect(grid).toBeInTheDocument();
-      });
+  it('should render with search enabled', async () => {
+    const props = transformProps({
+      ...testData.basic,
+      rawFormData: {
+        ...testData.basic.rawFormData,
+        include_search: true,
+      },
     });
+    props.includeSearch = true;
 
-    it('should render with search enabled', async () => {
-      const props = transformProps({
-        ...testData.basic,
-        rawFormData: {
-          ...testData.basic.rawFormData,
-          include_search: true,
-        },
-      });
-      props.includeSearch = true;
+    render(
+      ProviderWrapper({
+        children: (
+          <AgGridTableChart
+            {...props}
+            setDataMask={mockSetDataMask}
+            slice_id={1}
+          />
+        ),
+      }),
+    );
 
-      render(
-        ProviderWrapper({
-          children: (
-            <AgGridTableChart
-              {...props}
-              setDataMask={mockSetDataMask}
-              slice_id={1}
-            />
-          ),
-        }),
-      );
-
-      await waitFor(() => {
-        const grid = document.querySelector('.ag-container');
-        expect(grid).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      const grid = document.querySelector('.ag-container');
+      expect(grid).toBeInTheDocument();
     });
+  });
 
-    it('should render with totals', async () => {
-      const props = transformProps({
-        ...testData.basic,
-        rawFormData: {
-          ...testData.basic.rawFormData,
-          show_totals: true,
-        },
-      });
-      props.showTotals = true;
-      props.totals = { sum__num: 1000 };
-
-      render(
-        ProviderWrapper({
-          children: (
-            <AgGridTableChart
-              {...props}
-              setDataMask={mockSetDataMask}
-              slice_id={1}
-            />
-          ),
-        }),
-      );
-
-      await waitFor(() => {
-        const grid = document.querySelector('.ag-container');
-        expect(grid).toBeInTheDocument();
-      });
+  it('should render with totals', async () => {
+    const props = transformProps({
+      ...testData.basic,
+      rawFormData: {
+        ...testData.basic.rawFormData,
+        show_totals: true,
+      },
     });
+    props.showTotals = true;
+    props.totals = { sum__num: 1000 };
 
-    it('should handle empty data', async () => {
-      const props = transformProps(testData.empty);
+    render(
+      ProviderWrapper({
+        children: (
+          <AgGridTableChart
+            {...props}
+            setDataMask={mockSetDataMask}
+            slice_id={1}
+          />
+        ),
+      }),
+    );
 
-      render(
-        ProviderWrapper({
-          children: (
-            <AgGridTableChart
-              {...props}
-              setDataMask={mockSetDataMask}
-              slice_id={1}
-            />
-          ),
-        }),
-      );
-
-      await waitFor(() => {
-        const grid = document.querySelector('.ag-container');
-        expect(grid).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      const grid = document.querySelector('.ag-container');
+      expect(grid).toBeInTheDocument();
     });
+  });
 
-    it('should render with time comparison', async () => {
-      const props = transformProps(testData.comparison);
-      props.isUsingTimeComparison = true;
+  it('should handle empty data', async () => {
+    const props = transformProps(testData.empty);
 
-      render(
-        ProviderWrapper({
-          children: (
-            <AgGridTableChart
-              {...props}
-              setDataMask={mockSetDataMask}
-              slice_id={1}
-            />
-          ),
-        }),
-      );
+    render(
+      ProviderWrapper({
+        children: (
+          <AgGridTableChart
+            {...props}
+            setDataMask={mockSetDataMask}
+            slice_id={1}
+          />
+        ),
+      }),
+    );
 
-      await waitFor(() => {
-        const grid = document.querySelector('.ag-container');
-        expect(grid).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      const grid = document.querySelector('.ag-container');
+      expect(grid).toBeInTheDocument();
     });
+  });
 
-    it('should handle raw records mode', async () => {
-      const rawRecordsProps = {
-        ...testData.basic,
-        rawFormData: {
-          ...testData.basic.rawFormData,
-          query_mode: QueryMode.Raw,
-        },
-      };
-      const props = transformProps(rawRecordsProps);
+  it('should render with time comparison', async () => {
+    const props = transformProps(testData.comparison);
+    props.isUsingTimeComparison = true;
 
-      render(
-        ProviderWrapper({
-          children: (
-            <AgGridTableChart
-              {...props}
-              setDataMask={mockSetDataMask}
-              slice_id={1}
-            />
-          ),
-        }),
-      );
+    render(
+      ProviderWrapper({
+        children: (
+          <AgGridTableChart
+            {...props}
+            setDataMask={mockSetDataMask}
+            slice_id={1}
+          />
+        ),
+      }),
+    );
 
-      await waitFor(() => {
-        const grid = document.querySelector('.ag-container');
-        expect(grid).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      const grid = document.querySelector('.ag-container');
+      expect(grid).toBeInTheDocument();
     });
+  });
 
-    it('should correct invalid page number when currentPage >= totalPages', async () => {
-      const props = transformProps({
-        ...testData.basic,
-        rawFormData: {
-          ...testData.basic.rawFormData,
-          server_pagination: true,
-        },
-      });
-      props.serverPagination = true;
-      props.rowCount = 50; // Only 50 rows total
-      props.serverPaginationData = {
-        currentPage: 5, // Invalid: page 5 when only 3 pages exist (50 rows / 20 per page = 3 pages)
-        pageSize: 20,
-      };
+  it('should handle raw records mode', async () => {
+    const rawRecordsProps = {
+      ...testData.basic,
+      rawFormData: {
+        ...testData.basic.rawFormData,
+        query_mode: QueryMode.Raw,
+      },
+    };
+    const props = transformProps(rawRecordsProps);
 
-      render(
-        ProviderWrapper({
-          children: (
-            <AgGridTableChart
-              {...props}
-              setDataMask={mockSetDataMask}
-              slice_id={1}
-            />
-          ),
-        }),
-      );
+    render(
+      ProviderWrapper({
+        children: (
+          <AgGridTableChart
+            {...props}
+            setDataMask={mockSetDataMask}
+            slice_id={1}
+          />
+        ),
+      }),
+    );
 
-      await waitFor(() => {
-        // Should have called setDataMask to correct the page number
-        expect(mockSetDataMask).toHaveBeenCalled();
-      });
+    await waitFor(() => {
+      const grid = document.querySelector('.ag-container');
+      expect(grid).toBeInTheDocument();
+    });
+  });
+
+  it('should correct invalid page number when currentPage >= totalPages', async () => {
+    const props = transformProps({
+      ...testData.basic,
+      rawFormData: {
+        ...testData.basic.rawFormData,
+        server_pagination: true,
+      },
+    });
+    props.serverPagination = true;
+    props.rowCount = 50; // Only 50 rows total
+    props.serverPaginationData = {
+      currentPage: 5, // Invalid: page 5 when only 3 pages exist (50 rows / 20 per page = 3 pages)
+      pageSize: 20,
+    };
+
+    render(
+      ProviderWrapper({
+        children: (
+          <AgGridTableChart
+            {...props}
+            setDataMask={mockSetDataMask}
+            slice_id={1}
+          />
+        ),
+      }),
+    );
+
+    await waitFor(() => {
+      // Should have called setDataMask to correct the page number
+      expect(mockSetDataMask).toHaveBeenCalled();
     });
   });
 });

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -274,9 +274,9 @@ describe('AgGridTableChart', () => {
       },
     });
     props.serverPagination = true;
-    props.rowCount = 50; // Only 50 rows total
+    props.rowCount = 50;
     props.serverPaginationData = {
-      currentPage: 5, // Invalid: page 5 when only 3 pages exist (50 rows / 20 per page = 3 pages)
+      currentPage: 5,
       pageSize: 20,
     };
 
@@ -293,7 +293,6 @@ describe('AgGridTableChart', () => {
     );
 
     await waitFor(() => {
-      // Should have called setDataMask to correct the page number
       expect(mockSetDataMask).toHaveBeenCalled();
     });
   });

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -107,9 +107,7 @@ describe('AgGridTableChart', () => {
     expect(headerTexts).toContain('name');
     expect(headerTexts).toContain('sum__num');
 
-    const dataRows = document.querySelectorAll(
-      '.ag-row:not(.ag-row-pinned)',
-    );
+    const dataRows = document.querySelectorAll('.ag-row:not(.ag-row-pinned)');
     expect(dataRows.length).toBe(3);
 
     expect(screen.getByText('Michael')).toBeInTheDocument();
@@ -224,9 +222,7 @@ describe('AgGridTableChart', () => {
       expect(grid).toBeInTheDocument();
     });
 
-    const pinnedRows = document.querySelectorAll(
-      '.ag-floating-bottom .ag-row',
-    );
+    const pinnedRows = document.querySelectorAll('.ag-floating-bottom .ag-row');
     expect(pinnedRows.length).toBeGreaterThan(0);
 
     const dataRows = document.querySelectorAll(
@@ -326,9 +322,7 @@ describe('AgGridTableChart', () => {
       expect(grid).toBeInTheDocument();
     });
 
-    const dataRows = document.querySelectorAll(
-      '.ag-row:not(.ag-row-pinned)',
-    );
+    const dataRows = document.querySelectorAll('.ag-row:not(.ag-row-pinned)');
     expect(dataRows.length).toBe(3);
 
     const headerCells = document.querySelectorAll('.ag-header-cell');

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@superset-ui/core/spec';
+import { QueryMode, TimeGranularity, SMART_DATE_ID } from '@superset-ui/core';
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
+import AgGridTableChart from '../src/AgGridTableChart';
+import transformProps from '../src/transformProps';
+import { ProviderWrapper } from '../../plugin-chart-table/test/testHelpers';
+import testData from '../../plugin-chart-table/test/testData';
+
+beforeAll(() => {
+  setupAGGridModules();
+});
+
+describe('plugin-chart-ag-grid-table', () => {
+  describe('transformProps', () => {
+    it('should parse pageLength to pageSize', () => {
+      expect(transformProps(testData.basic).pageSize).toBe(20);
+      expect(
+        transformProps({
+          ...testData.basic,
+          rawFormData: { ...testData.basic.rawFormData, page_length: '20' },
+        }).pageSize,
+      ).toBe(20);
+      expect(
+        transformProps({
+          ...testData.basic,
+          rawFormData: { ...testData.basic.rawFormData, page_length: '' },
+        }).pageSize,
+      ).toBe(0);
+    });
+
+    it('should not apply time grain formatting in Raw Records mode', () => {
+      const rawRecordsProps = {
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          query_mode: QueryMode.Raw,
+          time_grain_sqla: TimeGranularity.MONTH,
+          table_timestamp_format: SMART_DATE_ID,
+        },
+      };
+
+      const transformedProps = transformProps(rawRecordsProps);
+      expect(transformedProps.isRawRecords).toBe(true);
+      expect(transformedProps.timeGrain).toBe(TimeGranularity.MONTH);
+    });
+
+    it('should handle null/undefined timestamp values correctly', () => {
+      const rawRecordsProps = {
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          query_mode: QueryMode.Raw,
+        },
+      };
+
+      const transformedProps = transformProps(rawRecordsProps);
+      expect(transformedProps.isRawRecords).toBe(true);
+    });
+  });
+
+  describe('AgGridTableChart', () => {
+    const mockSetDataMask = jest.fn();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should render basic data', async () => {
+      const props = transformProps(testData.basic);
+      render(
+        ProviderWrapper({
+          children: (
+            <AgGridTableChart
+              {...props}
+              setDataMask={mockSetDataMask}
+              slice_id={1}
+            />
+          ),
+        }),
+      );
+
+      // Wait for AgGrid to render
+      await waitFor(() => {
+        const grid = document.querySelector('.ag-container');
+        expect(grid).toBeInTheDocument();
+      });
+    });
+
+    it('should render with server pagination', async () => {
+      const props = transformProps({
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          server_pagination: true,
+        },
+      });
+      props.serverPagination = true;
+      props.rowCount = 100;
+      props.serverPaginationData = {
+        currentPage: 0,
+        pageSize: 20,
+      };
+
+      render(
+        ProviderWrapper({
+          children: (
+            <AgGridTableChart
+              {...props}
+              setDataMask={mockSetDataMask}
+              slice_id={1}
+            />
+          ),
+        }),
+      );
+
+      await waitFor(() => {
+        const grid = document.querySelector('.ag-container');
+        expect(grid).toBeInTheDocument();
+      });
+    });
+
+    it('should render with search enabled', async () => {
+      const props = transformProps({
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          include_search: true,
+        },
+      });
+      props.includeSearch = true;
+
+      render(
+        ProviderWrapper({
+          children: (
+            <AgGridTableChart
+              {...props}
+              setDataMask={mockSetDataMask}
+              slice_id={1}
+            />
+          ),
+        }),
+      );
+
+      await waitFor(() => {
+        const grid = document.querySelector('.ag-container');
+        expect(grid).toBeInTheDocument();
+      });
+    });
+
+    it('should render with totals', async () => {
+      const props = transformProps({
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          show_totals: true,
+        },
+      });
+      props.showTotals = true;
+      props.totals = { sum__num: 1000 };
+
+      render(
+        ProviderWrapper({
+          children: (
+            <AgGridTableChart
+              {...props}
+              setDataMask={mockSetDataMask}
+              slice_id={1}
+            />
+          ),
+        }),
+      );
+
+      await waitFor(() => {
+        const grid = document.querySelector('.ag-container');
+        expect(grid).toBeInTheDocument();
+      });
+    });
+
+    it('should handle empty data', async () => {
+      const props = transformProps(testData.empty);
+
+      render(
+        ProviderWrapper({
+          children: (
+            <AgGridTableChart
+              {...props}
+              setDataMask={mockSetDataMask}
+              slice_id={1}
+            />
+          ),
+        }),
+      );
+
+      await waitFor(() => {
+        const grid = document.querySelector('.ag-container');
+        expect(grid).toBeInTheDocument();
+      });
+    });
+
+    it('should render with time comparison', async () => {
+      const props = transformProps(testData.comparison);
+      props.isUsingTimeComparison = true;
+
+      render(
+        ProviderWrapper({
+          children: (
+            <AgGridTableChart
+              {...props}
+              setDataMask={mockSetDataMask}
+              slice_id={1}
+            />
+          ),
+        }),
+      );
+
+      await waitFor(() => {
+        const grid = document.querySelector('.ag-container');
+        expect(grid).toBeInTheDocument();
+      });
+    });
+
+    it('should handle raw records mode', async () => {
+      const rawRecordsProps = {
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          query_mode: QueryMode.Raw,
+        },
+      };
+      const props = transformProps(rawRecordsProps);
+
+      render(
+        ProviderWrapper({
+          children: (
+            <AgGridTableChart
+              {...props}
+              setDataMask={mockSetDataMask}
+              slice_id={1}
+            />
+          ),
+        }),
+      );
+
+      await waitFor(() => {
+        const grid = document.querySelector('.ag-container');
+        expect(grid).toBeInTheDocument();
+      });
+    });
+
+    it('should correct invalid page number when currentPage >= totalPages', async () => {
+      const props = transformProps({
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          server_pagination: true,
+        },
+      });
+      props.serverPagination = true;
+      props.rowCount = 50; // Only 50 rows total
+      props.serverPaginationData = {
+        currentPage: 5, // Invalid: page 5 when only 3 pages exist (50 rows / 20 per page = 3 pages)
+        pageSize: 20,
+      };
+
+      render(
+        ProviderWrapper({
+          children: (
+            <AgGridTableChart
+              {...props}
+              setDataMask={mockSetDataMask}
+              slice_id={1}
+            />
+          ),
+        }),
+      );
+
+      await waitFor(() => {
+        // Should have called setDataMask to correct the page number
+        expect(mockSetDataMask).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import '@testing-library/jest-dom';
-import { render, waitFor } from '@superset-ui/core/spec';
+import { render, screen, waitFor } from '@superset-ui/core/spec';
 import { QueryMode, TimeGranularity, SMART_DATE_ID } from '@superset-ui/core';
 import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import AgGridTableChart from '../src/AgGridTableChart';
@@ -101,6 +101,20 @@ describe('AgGridTableChart', () => {
       const grid = document.querySelector('.ag-container');
       expect(grid).toBeInTheDocument();
     });
+
+    const headerCells = document.querySelectorAll('.ag-header-cell-text');
+    const headerTexts = Array.from(headerCells).map(el => el.textContent);
+    expect(headerTexts).toContain('name');
+    expect(headerTexts).toContain('sum__num');
+
+    const dataRows = document.querySelectorAll(
+      '.ag-row:not(.ag-row-pinned)',
+    );
+    expect(dataRows.length).toBe(3);
+
+    expect(screen.getByText('Michael')).toBeInTheDocument();
+    expect(screen.getByText('Joe')).toBeInTheDocument();
+    expect(screen.getByText('Maria')).toBeInTheDocument();
   });
 
   test('should render with server pagination', async () => {
@@ -134,6 +148,16 @@ describe('AgGridTableChart', () => {
       const grid = document.querySelector('.ag-container');
       expect(grid).toBeInTheDocument();
     });
+
+    expect(screen.getByText('Page Size:')).toBeInTheDocument();
+    expect(screen.getByText('Page')).toBeInTheDocument();
+
+    const paginationEl = screen.getByText('Page Size:').closest('div')!;
+    const paginationText = paginationEl.textContent;
+    expect(paginationText).toContain('1');
+    expect(paginationText).toContain('20');
+    expect(paginationText).toContain('100');
+    expect(paginationText).toContain('5');
   });
 
   test('should render with search enabled', async () => {
@@ -162,6 +186,14 @@ describe('AgGridTableChart', () => {
       const grid = document.querySelector('.ag-container');
       expect(grid).toBeInTheDocument();
     });
+
+    const searchContainer = document.querySelector('.search-container');
+    expect(searchContainer).toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText('Search');
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toHaveAttribute('type', 'text');
+    expect(searchInput).toHaveAttribute('id', 'filter-text-box');
   });
 
   test('should render with totals', async () => {
@@ -191,6 +223,16 @@ describe('AgGridTableChart', () => {
       const grid = document.querySelector('.ag-container');
       expect(grid).toBeInTheDocument();
     });
+
+    const pinnedRows = document.querySelectorAll(
+      '.ag-floating-bottom .ag-row',
+    );
+    expect(pinnedRows.length).toBeGreaterThan(0);
+
+    const dataRows = document.querySelectorAll(
+      '.ag-body-viewport .ag-row:not(.ag-row-pinned)',
+    );
+    expect(dataRows.length).toBe(3);
   });
 
   test('should handle empty data', async () => {
@@ -212,6 +254,14 @@ describe('AgGridTableChart', () => {
       const grid = document.querySelector('.ag-container');
       expect(grid).toBeInTheDocument();
     });
+
+    const dataRows = document.querySelectorAll(
+      '.ag-center-cols-container .ag-row',
+    );
+    expect(dataRows.length).toBe(0);
+
+    const headerCells = document.querySelectorAll('.ag-header-cell');
+    expect(headerCells.length).toBeGreaterThan(0);
   });
 
   test('should render with time comparison', async () => {
@@ -234,6 +284,17 @@ describe('AgGridTableChart', () => {
       const grid = document.querySelector('.ag-container');
       expect(grid).toBeInTheDocument();
     });
+
+    const comparisonDropdown = document.querySelector(
+      '.time-comparison-dropdown',
+    );
+    expect(comparisonDropdown).toBeInTheDocument();
+
+    const headerCells = document.querySelectorAll('.ag-header-cell-text');
+    const headerTexts = Array.from(headerCells).map(el => el.textContent);
+    expect(headerTexts).toContain('#');
+    expect(headerTexts).toContain('△');
+    expect(headerTexts).toContain('%');
   });
 
   test('should handle raw records mode', async () => {
@@ -245,6 +306,8 @@ describe('AgGridTableChart', () => {
       },
     };
     const props = transformProps(rawRecordsProps);
+
+    expect(props.isRawRecords).toBe(true);
 
     render(
       ProviderWrapper({
@@ -262,6 +325,14 @@ describe('AgGridTableChart', () => {
       const grid = document.querySelector('.ag-container');
       expect(grid).toBeInTheDocument();
     });
+
+    const dataRows = document.querySelectorAll(
+      '.ag-row:not(.ag-row-pinned)',
+    );
+    expect(dataRows.length).toBe(3);
+
+    const headerCells = document.querySelectorAll('.ag-header-cell');
+    expect(headerCells.length).toBeGreaterThan(0);
   });
 
   test('should correct invalid page number when currentPage >= totalPages', async () => {

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -97,7 +97,6 @@ describe('AgGridTableChart', () => {
       }),
     );
 
-    // Wait for AgGrid to render
     await waitFor(() => {
       const grid = document.querySelector('.ag-container');
       expect(grid).toBeInTheDocument();

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -30,7 +30,7 @@ beforeAll(() => {
 });
 
 describe('transformProps', () => {
-  it('should parse pageLength to pageSize', () => {
+  test('should parse pageLength to pageSize', () => {
     expect(transformProps(testData.basic).pageSize).toBe(20);
     expect(
       transformProps({
@@ -46,7 +46,7 @@ describe('transformProps', () => {
     ).toBe(0);
   });
 
-  it('should not apply time grain formatting in Raw Records mode', () => {
+  test('should not apply time grain formatting in Raw Records mode', () => {
     const rawRecordsProps = {
       ...testData.basic,
       rawFormData: {
@@ -62,7 +62,7 @@ describe('transformProps', () => {
     expect(transformedProps.timeGrain).toBe(TimeGranularity.MONTH);
   });
 
-  it('should handle null/undefined timestamp values correctly', () => {
+  test('should handle null/undefined timestamp values correctly', () => {
     const rawRecordsProps = {
       ...testData.basic,
       rawFormData: {
@@ -83,7 +83,7 @@ describe('AgGridTableChart', () => {
     jest.clearAllMocks();
   });
 
-  it('should render basic data', async () => {
+  test('should render basic data', async () => {
     const props = transformProps(testData.basic);
     render(
       ProviderWrapper({
@@ -103,7 +103,7 @@ describe('AgGridTableChart', () => {
     });
   });
 
-  it('should render with server pagination', async () => {
+  test('should render with server pagination', async () => {
     const props = transformProps({
       ...testData.basic,
       rawFormData: {
@@ -136,7 +136,7 @@ describe('AgGridTableChart', () => {
     });
   });
 
-  it('should render with search enabled', async () => {
+  test('should render with search enabled', async () => {
     const props = transformProps({
       ...testData.basic,
       rawFormData: {
@@ -164,7 +164,7 @@ describe('AgGridTableChart', () => {
     });
   });
 
-  it('should render with totals', async () => {
+  test('should render with totals', async () => {
     const props = transformProps({
       ...testData.basic,
       rawFormData: {
@@ -193,7 +193,7 @@ describe('AgGridTableChart', () => {
     });
   });
 
-  it('should handle empty data', async () => {
+  test('should handle empty data', async () => {
     const props = transformProps(testData.empty);
 
     render(
@@ -214,7 +214,7 @@ describe('AgGridTableChart', () => {
     });
   });
 
-  it('should render with time comparison', async () => {
+  test('should render with time comparison', async () => {
     const props = transformProps(testData.comparison);
     props.isUsingTimeComparison = true;
 
@@ -236,7 +236,7 @@ describe('AgGridTableChart', () => {
     });
   });
 
-  it('should handle raw records mode', async () => {
+  test('should handle raw records mode', async () => {
     const rawRecordsProps = {
       ...testData.basic,
       rawFormData: {
@@ -264,7 +264,7 @@ describe('AgGridTableChart', () => {
     });
   });
 
-  it('should correct invalid page number when currentPage >= totalPages', async () => {
+  test('should correct invalid page number when currentPage >= totalPages', async () => {
     const props = transformProps({
       ...testData.basic,
       rawFormData: {

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -81,277 +81,277 @@ test('transformProps handles null/undefined timestamp values correctly', () => {
 });
 
 test('AgGridTableChart renders basic data', async () => {
-    const props = transformProps(testData.basic);
-    render(
-      ProviderWrapper({
-        children: (
-          <AgGridTableChart
-            {...props}
-            setDataMask={mockSetDataMask}
-            slice_id={1}
-          />
-        ),
-      }),
-    );
+  const props = transformProps(testData.basic);
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
 
-    await waitFor(() => {
-      const grid = document.querySelector('.ag-container');
-      expect(grid).toBeInTheDocument();
-    });
-
-    const headerCells = document.querySelectorAll('.ag-header-cell-text');
-    const headerTexts = Array.from(headerCells).map(el => el.textContent);
-    expect(headerTexts).toContain('name');
-    expect(headerTexts).toContain('sum__num');
-
-    const dataRows = document.querySelectorAll('.ag-row:not(.ag-row-pinned)');
-    expect(dataRows.length).toBe(3);
-
-    expect(screen.getByText('Michael')).toBeInTheDocument();
-    expect(screen.getByText('Joe')).toBeInTheDocument();
-    expect(screen.getByText('Maria')).toBeInTheDocument();
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
   });
+
+  const headerCells = document.querySelectorAll('.ag-header-cell-text');
+  const headerTexts = Array.from(headerCells).map(el => el.textContent);
+  expect(headerTexts).toContain('name');
+  expect(headerTexts).toContain('sum__num');
+
+  const dataRows = document.querySelectorAll('.ag-row:not(.ag-row-pinned)');
+  expect(dataRows.length).toBe(3);
+
+  expect(screen.getByText('Michael')).toBeInTheDocument();
+  expect(screen.getByText('Joe')).toBeInTheDocument();
+  expect(screen.getByText('Maria')).toBeInTheDocument();
+});
 
 test('AgGridTableChart renders with server pagination', async () => {
-    const props = transformProps({
-      ...testData.basic,
-      rawFormData: {
-        ...testData.basic.rawFormData,
-        server_pagination: true,
-      },
-    });
-    props.serverPagination = true;
-    props.rowCount = 100;
-    props.serverPaginationData = {
-      currentPage: 0,
-      pageSize: 20,
-    };
-
-    render(
-      ProviderWrapper({
-        children: (
-          <AgGridTableChart
-            {...props}
-            setDataMask={mockSetDataMask}
-            slice_id={1}
-          />
-        ),
-      }),
-    );
-
-    await waitFor(() => {
-      const grid = document.querySelector('.ag-container');
-      expect(grid).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Page Size:')).toBeInTheDocument();
-    expect(screen.getByText('Page')).toBeInTheDocument();
-
-    const paginationEl = screen.getByText('Page Size:').closest('div')!;
-    const paginationText = paginationEl.textContent;
-    expect(paginationText).toContain('1');
-    expect(paginationText).toContain('20');
-    expect(paginationText).toContain('100');
-    expect(paginationText).toContain('5');
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      server_pagination: true,
+    },
   });
+  props.serverPagination = true;
+  props.rowCount = 100;
+  props.serverPaginationData = {
+    currentPage: 0,
+    pageSize: 20,
+  };
+
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
+
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
+  });
+
+  expect(screen.getByText('Page Size:')).toBeInTheDocument();
+  expect(screen.getByText('Page')).toBeInTheDocument();
+
+  const paginationEl = screen.getByText('Page Size:').closest('div')!;
+  const paginationText = paginationEl.textContent;
+  expect(paginationText).toContain('1');
+  expect(paginationText).toContain('20');
+  expect(paginationText).toContain('100');
+  expect(paginationText).toContain('5');
+});
 
 test('AgGridTableChart renders with search enabled', async () => {
-    const props = transformProps({
-      ...testData.basic,
-      rawFormData: {
-        ...testData.basic.rawFormData,
-        include_search: true,
-      },
-    });
-    props.includeSearch = true;
-
-    render(
-      ProviderWrapper({
-        children: (
-          <AgGridTableChart
-            {...props}
-            setDataMask={mockSetDataMask}
-            slice_id={1}
-          />
-        ),
-      }),
-    );
-
-    await waitFor(() => {
-      const grid = document.querySelector('.ag-container');
-      expect(grid).toBeInTheDocument();
-    });
-
-    const searchContainer = document.querySelector('.search-container');
-    expect(searchContainer).toBeInTheDocument();
-
-    const searchInput = screen.getByPlaceholderText('Search');
-    expect(searchInput).toBeInTheDocument();
-    expect(searchInput).toHaveAttribute('type', 'text');
-    expect(searchInput).toHaveAttribute('id', 'filter-text-box');
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      include_search: true,
+    },
   });
+  props.includeSearch = true;
+
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
+
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
+  });
+
+  const searchContainer = document.querySelector('.search-container');
+  expect(searchContainer).toBeInTheDocument();
+
+  const searchInput = screen.getByPlaceholderText('Search');
+  expect(searchInput).toBeInTheDocument();
+  expect(searchInput).toHaveAttribute('type', 'text');
+  expect(searchInput).toHaveAttribute('id', 'filter-text-box');
+});
 
 test('AgGridTableChart renders with totals', async () => {
-    const props = transformProps({
-      ...testData.basic,
-      rawFormData: {
-        ...testData.basic.rawFormData,
-        show_totals: true,
-      },
-    });
-    props.showTotals = true;
-    props.totals = { sum__num: 1000 };
-
-    render(
-      ProviderWrapper({
-        children: (
-          <AgGridTableChart
-            {...props}
-            setDataMask={mockSetDataMask}
-            slice_id={1}
-          />
-        ),
-      }),
-    );
-
-    await waitFor(() => {
-      const grid = document.querySelector('.ag-container');
-      expect(grid).toBeInTheDocument();
-    });
-
-    const pinnedRows = document.querySelectorAll('.ag-floating-bottom .ag-row');
-    expect(pinnedRows.length).toBeGreaterThan(0);
-
-    const dataRows = document.querySelectorAll(
-      '.ag-body-viewport .ag-row:not(.ag-row-pinned)',
-    );
-    expect(dataRows.length).toBe(3);
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      show_totals: true,
+    },
   });
+  props.showTotals = true;
+  props.totals = { sum__num: 1000 };
+
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
+
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
+  });
+
+  const pinnedRows = document.querySelectorAll('.ag-floating-bottom .ag-row');
+  expect(pinnedRows.length).toBeGreaterThan(0);
+
+  const dataRows = document.querySelectorAll(
+    '.ag-body-viewport .ag-row:not(.ag-row-pinned)',
+  );
+  expect(dataRows.length).toBe(3);
+});
 
 test('AgGridTableChart handles empty data', async () => {
-    const props = transformProps(testData.empty);
+  const props = transformProps(testData.empty);
 
-    render(
-      ProviderWrapper({
-        children: (
-          <AgGridTableChart
-            {...props}
-            setDataMask={mockSetDataMask}
-            slice_id={1}
-          />
-        ),
-      }),
-    );
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
 
-    await waitFor(() => {
-      const grid = document.querySelector('.ag-container');
-      expect(grid).toBeInTheDocument();
-    });
-
-    const dataRows = document.querySelectorAll(
-      '.ag-center-cols-container .ag-row',
-    );
-    expect(dataRows.length).toBe(0);
-
-    const headerCells = document.querySelectorAll('.ag-header-cell');
-    expect(headerCells.length).toBeGreaterThan(0);
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
   });
+
+  const dataRows = document.querySelectorAll(
+    '.ag-center-cols-container .ag-row',
+  );
+  expect(dataRows.length).toBe(0);
+
+  const headerCells = document.querySelectorAll('.ag-header-cell');
+  expect(headerCells.length).toBeGreaterThan(0);
+});
 
 test('AgGridTableChart renders with time comparison', async () => {
-    const props = transformProps(testData.comparison);
-    props.isUsingTimeComparison = true;
+  const props = transformProps(testData.comparison);
+  props.isUsingTimeComparison = true;
 
-    render(
-      ProviderWrapper({
-        children: (
-          <AgGridTableChart
-            {...props}
-            setDataMask={mockSetDataMask}
-            slice_id={1}
-          />
-        ),
-      }),
-    );
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
 
-    await waitFor(() => {
-      const grid = document.querySelector('.ag-container');
-      expect(grid).toBeInTheDocument();
-    });
-
-    const comparisonDropdown = document.querySelector(
-      '.time-comparison-dropdown',
-    );
-    expect(comparisonDropdown).toBeInTheDocument();
-
-    const headerCells = document.querySelectorAll('.ag-header-cell-text');
-    const headerTexts = Array.from(headerCells).map(el => el.textContent);
-    expect(headerTexts).toContain('#');
-    expect(headerTexts).toContain('△');
-    expect(headerTexts).toContain('%');
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
   });
+
+  const comparisonDropdown = document.querySelector(
+    '.time-comparison-dropdown',
+  );
+  expect(comparisonDropdown).toBeInTheDocument();
+
+  const headerCells = document.querySelectorAll('.ag-header-cell-text');
+  const headerTexts = Array.from(headerCells).map(el => el.textContent);
+  expect(headerTexts).toContain('#');
+  expect(headerTexts).toContain('△');
+  expect(headerTexts).toContain('%');
+});
 
 test('AgGridTableChart handles raw records mode', async () => {
-    const rawRecordsProps = {
-      ...testData.basic,
-      rawFormData: {
-        ...testData.basic.rawFormData,
-        query_mode: QueryMode.Raw,
-      },
-    };
-    const props = transformProps(rawRecordsProps);
+  const rawRecordsProps = {
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      query_mode: QueryMode.Raw,
+    },
+  };
+  const props = transformProps(rawRecordsProps);
 
-    expect(props.isRawRecords).toBe(true);
+  expect(props.isRawRecords).toBe(true);
 
-    render(
-      ProviderWrapper({
-        children: (
-          <AgGridTableChart
-            {...props}
-            setDataMask={mockSetDataMask}
-            slice_id={1}
-          />
-        ),
-      }),
-    );
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
 
-    await waitFor(() => {
-      const grid = document.querySelector('.ag-container');
-      expect(grid).toBeInTheDocument();
-    });
-
-    const dataRows = document.querySelectorAll('.ag-row:not(.ag-row-pinned)');
-    expect(dataRows.length).toBe(3);
-
-    const headerCells = document.querySelectorAll('.ag-header-cell');
-    expect(headerCells.length).toBeGreaterThan(0);
+  await waitFor(() => {
+    const grid = document.querySelector('.ag-container');
+    expect(grid).toBeInTheDocument();
   });
 
-test('AgGridTableChart corrects invalid page number when currentPage >= totalPages', async () => {
-    const props = transformProps({
-      ...testData.basic,
-      rawFormData: {
-        ...testData.basic.rawFormData,
-        server_pagination: true,
-      },
-    });
-    props.serverPagination = true;
-    props.rowCount = 50;
-    props.serverPaginationData = {
-      currentPage: 5,
-      pageSize: 20,
-    };
+  const dataRows = document.querySelectorAll('.ag-row:not(.ag-row-pinned)');
+  expect(dataRows.length).toBe(3);
 
-    render(
-      ProviderWrapper({
-        children: (
-          <AgGridTableChart
-            {...props}
-            setDataMask={mockSetDataMask}
-            slice_id={1}
-          />
-        ),
-      }),
-    );
+  const headerCells = document.querySelectorAll('.ag-header-cell');
+  expect(headerCells.length).toBeGreaterThan(0);
+});
+
+test('AgGridTableChart corrects invalid page number when currentPage >= totalPages', async () => {
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      server_pagination: true,
+    },
+  });
+  props.serverPagination = true;
+  props.rowCount = 50;
+  props.serverPaginationData = {
+    currentPage: 5,
+    pageSize: 20,
+  };
+
+  render(
+    ProviderWrapper({
+      children: (
+        <AgGridTableChart
+          {...props}
+          setDataMask={mockSetDataMask}
+          slice_id={1}
+        />
+      ),
+    }),
+  );
 
   await waitFor(() => {
     expect(mockSetDataMask).toHaveBeenCalled();

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx
@@ -25,65 +25,62 @@ import transformProps from '../src/transformProps';
 import { ProviderWrapper } from '../../plugin-chart-table/test/testHelpers';
 import testData from '../../plugin-chart-table/test/testData';
 
+const mockSetDataMask = jest.fn();
+
 beforeAll(() => {
   setupAGGridModules();
 });
 
-describe('transformProps', () => {
-  test('should parse pageLength to pageSize', () => {
-    expect(transformProps(testData.basic).pageSize).toBe(20);
-    expect(
-      transformProps({
-        ...testData.basic,
-        rawFormData: { ...testData.basic.rawFormData, page_length: '20' },
-      }).pageSize,
-    ).toBe(20);
-    expect(
-      transformProps({
-        ...testData.basic,
-        rawFormData: { ...testData.basic.rawFormData, page_length: '' },
-      }).pageSize,
-    ).toBe(0);
-  });
-
-  test('should not apply time grain formatting in Raw Records mode', () => {
-    const rawRecordsProps = {
-      ...testData.basic,
-      rawFormData: {
-        ...testData.basic.rawFormData,
-        query_mode: QueryMode.Raw,
-        time_grain_sqla: TimeGranularity.MONTH,
-        table_timestamp_format: SMART_DATE_ID,
-      },
-    };
-
-    const transformedProps = transformProps(rawRecordsProps);
-    expect(transformedProps.isRawRecords).toBe(true);
-    expect(transformedProps.timeGrain).toBe(TimeGranularity.MONTH);
-  });
-
-  test('should handle null/undefined timestamp values correctly', () => {
-    const rawRecordsProps = {
-      ...testData.basic,
-      rawFormData: {
-        ...testData.basic.rawFormData,
-        query_mode: QueryMode.Raw,
-      },
-    };
-
-    const transformedProps = transformProps(rawRecordsProps);
-    expect(transformedProps.isRawRecords).toBe(true);
-  });
+beforeEach(() => {
+  jest.clearAllMocks();
 });
 
-describe('AgGridTableChart', () => {
-  const mockSetDataMask = jest.fn();
+test('transformProps parses pageLength to pageSize', () => {
+  expect(transformProps(testData.basic).pageSize).toBe(20);
+  expect(
+    transformProps({
+      ...testData.basic,
+      rawFormData: { ...testData.basic.rawFormData, page_length: '20' },
+    }).pageSize,
+  ).toBe(20);
+  expect(
+    transformProps({
+      ...testData.basic,
+      rawFormData: { ...testData.basic.rawFormData, page_length: '' },
+    }).pageSize,
+  ).toBe(0);
+});
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+test('transformProps does not apply time grain formatting in Raw Records mode', () => {
+  const rawRecordsProps = {
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      query_mode: QueryMode.Raw,
+      time_grain_sqla: TimeGranularity.MONTH,
+      table_timestamp_format: SMART_DATE_ID,
+    },
+  };
 
-  test('should render basic data', async () => {
+  const transformedProps = transformProps(rawRecordsProps);
+  expect(transformedProps.isRawRecords).toBe(true);
+  expect(transformedProps.timeGrain).toBe(TimeGranularity.MONTH);
+});
+
+test('transformProps handles null/undefined timestamp values correctly', () => {
+  const rawRecordsProps = {
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      query_mode: QueryMode.Raw,
+    },
+  };
+
+  const transformedProps = transformProps(rawRecordsProps);
+  expect(transformedProps.isRawRecords).toBe(true);
+});
+
+test('AgGridTableChart renders basic data', async () => {
     const props = transformProps(testData.basic);
     render(
       ProviderWrapper({
@@ -115,7 +112,7 @@ describe('AgGridTableChart', () => {
     expect(screen.getByText('Maria')).toBeInTheDocument();
   });
 
-  test('should render with server pagination', async () => {
+test('AgGridTableChart renders with server pagination', async () => {
     const props = transformProps({
       ...testData.basic,
       rawFormData: {
@@ -158,7 +155,7 @@ describe('AgGridTableChart', () => {
     expect(paginationText).toContain('5');
   });
 
-  test('should render with search enabled', async () => {
+test('AgGridTableChart renders with search enabled', async () => {
     const props = transformProps({
       ...testData.basic,
       rawFormData: {
@@ -194,7 +191,7 @@ describe('AgGridTableChart', () => {
     expect(searchInput).toHaveAttribute('id', 'filter-text-box');
   });
 
-  test('should render with totals', async () => {
+test('AgGridTableChart renders with totals', async () => {
     const props = transformProps({
       ...testData.basic,
       rawFormData: {
@@ -231,7 +228,7 @@ describe('AgGridTableChart', () => {
     expect(dataRows.length).toBe(3);
   });
 
-  test('should handle empty data', async () => {
+test('AgGridTableChart handles empty data', async () => {
     const props = transformProps(testData.empty);
 
     render(
@@ -260,7 +257,7 @@ describe('AgGridTableChart', () => {
     expect(headerCells.length).toBeGreaterThan(0);
   });
 
-  test('should render with time comparison', async () => {
+test('AgGridTableChart renders with time comparison', async () => {
     const props = transformProps(testData.comparison);
     props.isUsingTimeComparison = true;
 
@@ -293,7 +290,7 @@ describe('AgGridTableChart', () => {
     expect(headerTexts).toContain('%');
   });
 
-  test('should handle raw records mode', async () => {
+test('AgGridTableChart handles raw records mode', async () => {
     const rawRecordsProps = {
       ...testData.basic,
       rawFormData: {
@@ -329,7 +326,7 @@ describe('AgGridTableChart', () => {
     expect(headerCells.length).toBeGreaterThan(0);
   });
 
-  test('should correct invalid page number when currentPage >= totalPages', async () => {
+test('AgGridTableChart corrects invalid page number when currentPage >= totalPages', async () => {
     const props = transformProps({
       ...testData.basic,
       rawFormData: {
@@ -356,8 +353,7 @@ describe('AgGridTableChart', () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(mockSetDataMask).toHaveBeenCalled();
-    });
+  await waitFor(() => {
+    expect(mockSetDataMask).toHaveBeenCalled();
   });
 });

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -352,18 +352,10 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   );
 
   const timestampFormatter = useCallback(
-    (value: DataRecordValue) => {
-      if (value == null) {
-        return '';
-      }
-      // In Raw Records mode, don't apply time grain-based formatting
-      if (isRawRecords || !timeGrain) {
-        return String(value);
-      }
-      return getTimeFormatterForGranularity(timeGrain)(
-        value as number | Date | null | undefined,
-      );
-    },
+    value =>
+      getTimeFormatterForGranularity(isRawRecords ? undefined : timeGrain)(
+        value,
+      ),
     [timeGrain, isRawRecords],
   );
   const [tableSize, setTableSize] = useState<TableSize>({

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -352,10 +352,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   );
 
   const timestampFormatter = useCallback(
-    value =>
-      getTimeFormatterForGranularity(isRawRecords ? undefined : timeGrain)(
-        value,
-      ),
+    (value: DataRecordValue) =>
+      isRawRecords
+        ? String(value ?? '')
+        : getTimeFormatterForGranularity(timeGrain)(
+            value as number | Date | null | undefined,
+          ),
     [timeGrain, isRawRecords],
   );
   const [tableSize, setTableSize] = useState<TableSize>({

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -352,12 +352,17 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   );
 
   const timestampFormatter = useCallback(
-    value => {
+    (value: DataRecordValue) => {
+      if (value == null) {
+        return '';
+      }
       // In Raw Records mode, don't apply time grain-based formatting
       if (isRawRecords || !timeGrain) {
         return String(value);
       }
-      return getTimeFormatterForGranularity(timeGrain)(value);
+      return getTimeFormatterForGranularity(timeGrain)(
+        value as number | Date | null | undefined,
+      );
     },
     [timeGrain, isRawRecords],
   );

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -352,8 +352,14 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   );
 
   const timestampFormatter = useCallback(
-    value => getTimeFormatterForGranularity(timeGrain)(value),
-    [timeGrain],
+    value => {
+      // In Raw Records mode, don't apply time grain-based formatting
+      if (isRawRecords || !timeGrain) {
+        return String(value);
+      }
+      return getTimeFormatterForGranularity(timeGrain)(value);
+    },
+    [timeGrain, isRawRecords],
   );
   const [tableSize, setTableSize] = useState<TableSize>({
     width: 0,

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -212,6 +212,7 @@ const processColumns = memoizeOne(function processColumns(
       metrics: metrics_,
       percent_metrics: percentMetrics_,
       column_config: columnConfig = {},
+      query_mode: queryMode,
     },
     rawDatasource,
     queriesData,
@@ -274,7 +275,9 @@ const processColumns = memoizeOne(function processColumns(
         const timeFormat = customFormat || tableTimestampFormat;
         // When format is "Adaptive Formatting" (smart_date)
         if (timeFormat === SMART_DATE_ID) {
-          if (granularity) {
+          // In Raw Records mode, don't apply time grain-based formatting
+          // Temporal columns should display raw timestamp values
+          if (granularity && queryMode !== QueryMode.Raw) {
             // time column use formats based on granularity
             formatter = getTimeFormatterForGranularity(granularity);
           } else if (customFormat) {

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -275,8 +275,6 @@ const processColumns = memoizeOne(function processColumns(
         const timeFormat = customFormat || tableTimestampFormat;
         // When format is "Adaptive Formatting" (smart_date)
         if (timeFormat === SMART_DATE_ID) {
-          // In Raw Records mode, don't apply time grain-based formatting
-          // Temporal columns should display raw timestamp values
           if (granularity && queryMode !== QueryMode.Raw) {
             // time column use formats based on granularity
             formatter = getTimeFormatterForGranularity(granularity);

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -1476,7 +1476,6 @@ describe('plugin-chart-table', () => {
                         column: 'sum__num',
                         operator: '>',
                         targetValue: 2467,
-                        // useGradient is undefined
                       },
                     ],
                   },

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -382,7 +382,7 @@ describe('plugin-chart-table', () => {
       expect(percentMetric2?.originalLabel).toBe('metric_2');
     });
 
-    it('should not apply time grain formatting in Raw Records mode', () => {
+    test('should not apply time grain formatting in Raw Records mode', () => {
       const rawRecordsProps = {
         ...testData.basic,
         rawFormData: {
@@ -410,7 +410,7 @@ describe('plugin-chart-table', () => {
       expect(formatted).toContain('2023');
     });
 
-    it('should handle null/undefined timestamp values correctly', () => {
+    test('should handle null/undefined timestamp values correctly', () => {
       const rawRecordsProps = {
         ...testData.basic,
         rawFormData: {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -25,6 +25,12 @@ import {
   within,
 } from '@superset-ui/core/spec';
 import { cloneDeep } from 'lodash';
+import {
+  QueryMode,
+  TimeGranularity,
+  SMART_DATE_ID,
+  getTimeFormatterForGranularity,
+} from '@superset-ui/core';
 import TableChart, { sanitizeHeaderId } from '../src/TableChart';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import transformProps from '../src/transformProps';
@@ -376,6 +382,52 @@ describe('plugin-chart-table', () => {
       expect(percentMetric2?.originalLabel).toBe('metric_2');
     });
 
+    it('should not apply time grain formatting in Raw Records mode', () => {
+      const rawRecordsProps = {
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          query_mode: QueryMode.Raw,
+          time_grain_sqla: TimeGranularity.MONTH,
+          table_timestamp_format: SMART_DATE_ID,
+        },
+      };
+
+      const transformedProps = transformProps(rawRecordsProps);
+      const timestampColumn = transformedProps.columns.find(
+        col => col.key === '__timestamp',
+      );
+
+      expect(timestampColumn).toBeDefined();
+      const testValue = new Date('2023-01-15T10:30:45');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const formatted = (timestampColumn?.formatter as any)?.(testValue);
+      const granularityFormatted = getTimeFormatterForGranularity(
+        TimeGranularity.MONTH,
+      )(testValue as number | Date | null);
+      expect(formatted).not.toBe(granularityFormatted);
+      expect(typeof formatted).toBe('string');
+      expect(formatted).toContain('2023');
+    });
+
+    it('should handle null/undefined timestamp values correctly', () => {
+      const rawRecordsProps = {
+        ...testData.basic,
+        rawFormData: {
+          ...testData.basic.rawFormData,
+          query_mode: QueryMode.Raw,
+        },
+      };
+
+      const transformedProps = transformProps(rawRecordsProps);
+      expect(transformedProps.isRawRecords).toBe(true);
+
+      const timestampColumn = transformedProps.columns.find(
+        col => col.key === '__timestamp',
+      );
+      expect(timestampColumn).toBeDefined();
+    });
+
     describe('TableChart', () => {
       test('render basic data', () => {
         render(
@@ -385,7 +437,8 @@ describe('plugin-chart-table', () => {
         const firstDataRow = screen.getAllByRole('rowgroup')[1];
         const cells = firstDataRow.querySelectorAll('td');
         expect(cells).toHaveLength(12);
-        expect(cells[0]).toHaveTextContent('2020-01-01 12:34:56');
+        // Date is rendered as ISO string format
+        expect(cells[0]).toHaveTextContent('2020-01-01T12:34:56');
         expect(cells[1]).toHaveTextContent('Michael');
         // number is not in `metrics` list, so it should output raw value
         // (in real world Superset, this would mean the column is used in GROUP BY)


### PR DESCRIPTION
<!---
fix(table-charts): Prevent time grain from altering Raw Records in Tables + Interactive Tables
-->

### SUMMARY
In Raw Records mode (query_mode === 'raw'), temporal columns now display raw timestamp values without time grain-based formatting. The formatters skip granularity-based formatting when in Raw Records mode, so dates like "2003-01-15 10:30:45" display as-is instead of being truncated to "Jan 2003".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:

https://github.com/user-attachments/assets/b2172966-9dc1-457a-bc87-9fb385c19c25



AFTER:

https://github.com/user-attachments/assets/5b3f8922-b4ae-42a1-b71c-64b6e04828cf



### TESTING INSTRUCTIONS
1)Find/create a dataset from the Snowflake Database.
2)Create a Raw Data - Interactive Table chart using that dataset.
3)Insert a temporal column and another column with a different data type.
4)Save the chart and add it to a dashboard.
5)Create and apply a Time Grain filter, for example from Day to Month.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
