### PR TITLE
feat(fe): migrate to readily tree-shakeable `es-toolkit`

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -69,6 +69,7 @@
         "dom-to-image-more": "^3.7.2",
         "dom-to-pdf": "^0.3.2",
         "echarts": "^5.6.0",
+        "es-toolkit": "^1.44.0",
         "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
         "fast-glob": "^3.3.2",
         "fs-extra": "^11.3.3",
@@ -30107,6 +30108,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -63629,10 +63640,10 @@
         "d3-time-format": "^4.1.0",
         "dayjs": "^1.11.19",
         "dompurify": "^3.3.1",
+        "es-toolkit": "^1.44.0",
         "fetch-retry": "^6.0.0",
         "handlebars": "^4.7.8",
         "jed": "^1.1.1",
-        "lodash": "^4.17.23",
         "math-expression-evaluator": "^2.0.7",
         "pretty-ms": "^9.3.0",
         "re-resizable": "^6.11.2",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -150,6 +150,7 @@
     "dom-to-image-more": "^3.7.2",
     "dom-to-pdf": "^0.3.2",
     "echarts": "^5.6.0",
+    "es-toolkit": "^1.44.0",
     "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.3.3",

--- a/superset-frontend/packages/superset-core/src/ui/theme/Theme.tsx
+++ b/superset-frontend/packages/superset-core/src/ui/theme/Theme.tsx
@@ -25,7 +25,7 @@ import {
   CacheProvider as EmotionCacheProvider,
 } from '@emotion/react';
 import createCache from '@emotion/cache';
-import { noop, mergeWith } from 'lodash';
+import { mergeWith } from 'es-toolkit/compat';
 import { GlobalStyles } from './GlobalStyles';
 import {
   AntdThemeConfig,
@@ -161,7 +161,7 @@ export class Theme {
     antdConfig: AntdThemeConfig,
     emotionCache: any,
   ): void {
-    noop(theme, antdConfig, emotionCache);
+    () => ({ theme, antdConfig, emotionCache });
     // Overridden at runtime by SupersetThemeProvider using setThemeState
   }
 

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/CertifiedIconWithTooltip.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/CertifiedIconWithTooltip.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'es-toolkit';
 import { t } from '@apache-superset/core';
 import { useTheme, styled } from '@apache-superset/core/ui';
 import { Tooltip } from '@superset-ui/core/components';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/sortOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/sortOperator.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import {
   ensureIsArray,
   getMetricLabel,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -32,7 +32,7 @@
  * here's a list of the keys that are common to all controls, and as a result define the
  * control interface.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import { t } from '@apache-superset/core';
 import {
   getCategoricalSchemeRegistry,

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/histogramOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/histogramOperator.test.ts
@@ -18,7 +18,7 @@
  */
 import { histogramOperator } from '@superset-ui/chart-controls';
 import { SqlaFormData, VizType } from '@superset-ui/core';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit';
 
 const formData: SqlaFormData = {
   bins: 5,

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -45,7 +45,7 @@
     "fetch-retry": "^6.0.0",
     "handlebars": "^4.7.8",
     "jed": "^1.1.1",
-    "lodash": "^4.17.23",
+    "es-toolkit": "^1.44.0",
     "math-expression-evaluator": "^2.0.7",
     "pretty-ms": "^9.3.0",
     "re-resizable": "^6.11.2",

--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorNamespace.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorNamespace.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'es-toolkit';
 import CategoricalColorScale from './CategoricalColorScale';
 import { ColorsLookup } from './types';
 import getCategoricalSchemeRegistry from './CategoricalSchemeRegistrySingleton';

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Dropdown } from 'antd';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'es-toolkit';
 import { css, useTheme } from '@apache-superset/core/ui';
 import { Tooltip } from '../Tooltip';
 import type { DropdownButtonProps } from './types';

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.stories.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useRef, useCallback, useState } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit';
 import { css } from '@apache-superset/core/ui';
 import { Button } from '../Button';
 import { Select } from '../Select';

--- a/superset-frontend/packages/superset-ui-core/src/components/InfoTooltip/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/InfoTooltip/index.tsx
@@ -18,7 +18,7 @@
  */
 import { KeyboardEvent, useMemo } from 'react';
 import { SerializedStyles, CSSObject } from '@emotion/react';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'es-toolkit';
 import { t } from '@apache-superset/core';
 import { css, useTheme, getFontSize } from '@apache-superset/core/ui';
 import {
@@ -118,7 +118,7 @@ export const InfoTooltip = ({
 
   return (
     <Tooltip
-      id={`${kebabCase(label) || Math.floor(Math.random() * 10000)}-tooltip`}
+      id={`${kebabCase(label ?? '') || Math.floor(Math.random() * 10000)}-tooltip`}
       title={tooltip}
       placement={placement}
     >

--- a/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/MetadataBar.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/MetadataBar.tsx
@@ -18,7 +18,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
-import { uniqWith } from 'lodash';
+import { uniqWith } from 'es-toolkit';
 import { styled } from '@apache-superset/core/ui';
 import { Tooltip } from '../Tooltip';
 import { TooltipPlacement } from '../Tooltip/types';

--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { isValidElement, cloneElement, useMemo, useRef, useState } from 'react';
-import { isNil } from 'lodash';
+import { isNil } from 'es-toolkit';
 import { t } from '@apache-superset/core';
 import { css, styled, useTheme } from '@apache-superset/core/ui';
 import { Modal as AntdModal, ModalProps as AntdModalProps } from 'antd';

--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -22,7 +22,7 @@ import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 // remark-gfm v4+ requires react-markdown v9+, which requires React 18.
 // Currently pinned to v3.0.1 for compatibility with react-markdown v8 and React 17.
 import remarkGfm from 'remark-gfm';
-import { mergeWith } from 'lodash';
+import { mergeWith } from 'es-toolkit/compat';
 import { FeatureFlag, isFeatureEnabled } from '../../utils';
 
 interface SafeMarkdownProps {

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
@@ -41,7 +41,7 @@ import {
   LabeledValue as AntdLabeledValue,
   RefSelectProps,
 } from 'antd/es/select';
-import { debounce, isEqual, uniq } from 'lodash';
+import { debounce, isEqual, uniq } from 'es-toolkit';
 import { Constants, Icons } from '@superset-ui/core/components';
 import { Space } from '../Space';
 import {

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.stories.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.stories.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { StoryObj } from '@storybook/react';
-import { noop } from 'lodash';
 import { SelectOptionsType, SelectProps } from './types';
 import { Select } from '.';
 
@@ -95,7 +94,7 @@ export const InteractiveSelect: StoryObj = {
     optionsCount,
     ...args
   }: SelectProps & { header: string; optionsCount: number }) => {
-    noop(header);
+    () => header;
     return (
       <div
         style={{

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -37,7 +37,7 @@ import {
   LabeledValue as AntdLabeledValue,
   RefSelectProps,
 } from 'antd/es/select';
-import { debounce, isEqual, uniq } from 'lodash';
+import { debounce, isEqual, uniq } from 'es-toolkit';
 import {
   dropDownRenderHelper,
   getOption,

--- a/superset-frontend/packages/superset-ui-core/src/components/TableView/TableView.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableView/TableView.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { memo, useEffect, useRef, useMemo, useCallback } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit';
 import { styled } from '@apache-superset/core/ui';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 import { Empty } from '@superset-ui/core/components';

--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import _JSONbig from 'json-bigint';
-import { cloneDeepWith } from 'lodash';
+import { cloneDeepWith } from 'es-toolkit';
 
 import { ParseMethod, TextResponse, JsonResponse } from '../types';
 

--- a/superset-frontend/packages/superset-ui-core/src/query/normalizeOrderBy.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/normalizeOrderBy.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 
 import { QueryObject } from './types';
 

--- a/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit';
 
 import {
   AdhocColumn,

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/fetchTimeRange.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/fetchTimeRange.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import rison from 'rison';
-import { isEmpty } from 'lodash';
 import {
   SupersetClient,
   getClientErrorObject,
@@ -67,7 +66,7 @@ export const fetchTimeRange = async (
 ) => {
   let query;
   let endpoint;
-  if (!isEmpty(shifts)) {
+  if (shifts && shifts.length > 0) {
     const timeRanges = ensureIsArray(shifts).map(shift => ({
       timeRange,
       shift,
@@ -80,7 +79,7 @@ export const fetchTimeRange = async (
   }
   try {
     const response = await SupersetClient.get({ endpoint });
-    if (isEmpty(shifts)) {
+    if (!shifts || shifts.length === 0) {
       const timeRangeString = buildTimeRangeString(
         response?.json?.result[0]?.since || '',
         response?.json?.result[0]?.until || '',

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
 import { ensureIsArray } from '../utils';
 import { customTimeRangeDecode } from './customTimeRangeDecode';
 
@@ -116,7 +115,7 @@ export const parseDttmToDate = (
   }
   const parts = dttm?.split('-');
   let parsed: Date | null = null;
-  if (parts && !isEmpty(parts)) {
+  if (parts && parts.length > 0) {
     if (parts.length === 1) {
       parsed = new Date(Date.UTC(parseInt(parts[0], 10), 0));
     } else if (parts.length === 2) {

--- a/superset-frontend/packages/superset-ui-core/src/utils/convertKeysToCamelCase.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/convertKeysToCamelCase.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { camelCase, isPlainObject, mapKeys } from 'lodash';
+import { camelCase, isPlainObject, mapKeys } from 'es-toolkit';
 
 export default function convertKeysToCamelCase<T>(object: T) {
   if (object === null || object === undefined) {
@@ -26,7 +26,7 @@ export default function convertKeysToCamelCase<T>(object: T) {
   if (isPlainObject(object)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return mapKeys(object as { [key: string]: any }, (_, k) =>
-      camelCase(k),
+      camelCase(String(k)),
     ) as T;
   }
   throw new Error(`Cannot convert input that is not a plain object: ${object}`);

--- a/superset-frontend/packages/superset-ui-core/src/utils/merge.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/merge.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { mergeWith } from 'lodash';
+import { mergeWith } from 'es-toolkit/compat';
 
 /**
  * Merges objects using lodash.mergeWith, but replaces arrays instead of concatenating them.

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/DeckGLContainer.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/DeckGLContainer.tsx
@@ -32,7 +32,7 @@ import {
   isValidElement,
   useRef,
 } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit';
 import { StaticMap } from 'react-map-gl';
 import DeckGL from '@deck.gl/react';
 import type { Layer } from '@deck.gl/core';

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
@@ -21,7 +21,7 @@
  */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit';
 import { createSelector } from '@reduxjs/toolkit';
 import {
   AdhocFilter,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/factory.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/factory.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit';
 import type { Layer } from '@deck.gl/core';
 import {
   Datasource,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/HandlebarsRenderer.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/HandlebarsRenderer.tsx
@@ -22,7 +22,7 @@ import { sanitizeHtml } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/ui';
 import { extendedDayjs as dayjs } from '@superset-ui/core/utils/dates';
 import Handlebars from 'handlebars';
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from 'es-toolkit';
 
 export interface HandlebarsRendererProps {
   templateSource: string;

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/TooltipTemplateControl.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/TooltipTemplateControl.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useCallback } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import { t } from '@apache-superset/core';
 import { useTheme } from '@apache-superset/core/ui';
 import { InfoTooltip, Constants } from '@superset-ui/core/components';

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { kebabCase, throttle } from 'lodash';
+import { kebabCase, throttle } from 'es-toolkit';
 import d3 from 'd3';
 import utc from 'dayjs/plugin/utc';
 import nv from 'nvd3-fork';

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
@@ -50,7 +50,7 @@ import {
   JsonObject,
 } from '@superset-ui/core';
 import { SearchOutlined } from '@ant-design/icons';
-import { debounce, isEqual } from 'lodash';
+import { debounce, isEqual } from 'es-toolkit';
 import Pagination from './components/Pagination';
 import SearchSelectDropdown from './components/SearchSelectDropdown';
 import { SearchOption, SortByItem } from '../types';

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -24,7 +24,7 @@ import {
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import { useCallback, useEffect, useState, useMemo } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit';
 
 import {
   CellClickedEvent,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -38,7 +38,6 @@ import {
   isTimeComparison,
   timeCompareOperator,
 } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
 import { TableChartFormData } from './types';
 import { updateTableOwnState } from './utils/externalAPIs';
 
@@ -102,7 +101,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (
     // Shifts for non-custom or non inherit time comparison
     if (
       isTimeComparison(formData, baseQueryObject) &&
-      !isEmpty(nonCustomNorInheritShifts)
+      nonCustomNorInheritShifts.length > 0
     ) {
       timeOffsets = nonCustomNorInheritShifts;
     }
@@ -110,7 +109,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (
     // Shifts for custom or inherit time comparison
     if (
       isTimeComparison(formData, baseQueryObject) &&
-      !isEmpty(customOrInheritShifts)
+      nonCustomNorInheritShifts.length > 0
     ) {
       if (customOrInheritShifts.includes('custom')) {
         timeOffsets = timeOffsets.concat([formData.start_date_offset]);
@@ -168,7 +167,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (
         ];
       }
       // Add the operator for the time comparison if some is selected
-      if (!isEmpty(timeOffsets)) {
+      if (timeOffsets.length > 0) {
         postProcessing.push(timeCompareOperator(formData, baseQueryObject));
       }
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -53,7 +53,8 @@ import {
   validateServerPagination,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
-import { isEmpty, last } from 'lodash';
+import { last } from 'es-toolkit';
+import { isEmpty } from 'es-toolkit/compat';
 import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';
 import { ColorSchemeEnum } from './types';
 
@@ -518,7 +519,7 @@ const config: ControlPanelConfig = {
                 const childColumnMap: Record<string, boolean> = {};
                 const timeComparisonColumnMap: Record<string, boolean> = {};
 
-                if (!isEmpty(timeComparisonValue)) {
+                if (timeComparisonValue) {
                   /**
                    * Replace numeric columns with sets of comparison columns.
                    */

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -36,7 +36,7 @@ import {
   TimeFormatter,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
-import { isEmpty, isEqual, merge } from 'lodash';
+import { isEmpty, isEqual, merge } from 'es-toolkit/compat';
 import {
   ConditionalFormattingConfig,
   getColorFormatters,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/extent.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/extent.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { isNil } from 'lodash';
+import { isNil } from 'es-toolkit';
 
 export default function extent<T = number | string | Date | undefined | null>(
   values: T[],

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/getInitialFilterModel.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/getInitialFilterModel.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import type { AgGridChartState } from '@superset-ui/core';
 
 const getInitialFilterModel = (

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/OlChartMap.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/OlChartMap.tsx
@@ -24,7 +24,7 @@ import { View } from 'ol';
 import BaseEvent from 'ol/events/Event';
 import { unByKey } from 'ol/Observable';
 import { toLonLat } from 'ol/proj';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import { fitMapToCharts } from '../util/mapUtil';
 import { ChartLayer } from './ChartLayer';
 import { createLayer } from '../util/layerUtil';

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/transformPropsUtil.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/transformPropsUtil.ts
@@ -22,7 +22,7 @@ import {
   convertKeysToCamelCase,
   DataRecord,
 } from '@superset-ui/core';
-import { isObject } from 'lodash';
+import { isObject } from 'es-toolkit/compat';
 import {
   LocationConfigMapping,
   SelectedChartConfig,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
@@ -26,7 +26,7 @@ import {
 import { css, styled, useTheme } from '@apache-superset/core/ui';
 import { Tooltip } from '@superset-ui/core/components';
 import { DEFAULT_DATE_PATTERN } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import {
   ColorSchemeEnum,
   PopKPIComparisonSymbolStyleProps,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
@@ -26,7 +26,7 @@ import {
   isTimeComparison,
   timeCompareOperator,
 } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 
 export default function buildQuery(formData: QueryFormData) {
   const { cols: groupby } = formData;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -24,7 +24,7 @@ import {
   sharedControls,
   sections,
 } from '@superset-ui/chart-controls';
-import { noop } from 'lodash';
+import { noop } from 'es-toolkit/compat';
 import {
   headerFontSize,
   subheaderFontSize,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/useOverflowDetection.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/useOverflowDetection.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useEffect, useRef, useState } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 
 export const useOverflowDetection = (flexGap: number) => {
   const symbolContainerRef = useRef<HTMLDivElement>(null);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -30,7 +30,7 @@ import type { EChartsCoreOption } from 'echarts/core';
 import type { GaugeSeriesOption } from 'echarts/charts';
 import type { GaugeDataItemOption } from 'echarts/types/src/chart/gauge/GaugeSeries';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';
-import { range } from 'lodash';
+import { range } from 'es-toolkit/compat';
 import { parseNumbersList } from '../utils/controls';
 import {
   DEFAULT_FORM_DATA as DEFAULT_GAUGE_FORM_DATA,
@@ -242,7 +242,8 @@ export default function transformProps(
   const max = isValidNumber(maxVal)
     ? Number(maxVal)
     : calculateMax(transformedData);
-  const axisLabels = range(min, max, (max - min) / splitNumber);
+  const step = (max - min) / splitNumber;
+  const axisLabels = range(min, max, step);
   const axisLabelLength = Math.max(
     ...axisLabels.map(label => numberFormatter(label).length).concat([1]),
   );

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
@@ -32,7 +32,7 @@ import {
 import { logging } from '@apache-superset/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import memoizeOne from 'memoize-one';
-import { maxBy, minBy } from 'lodash';
+import { maxBy, minBy } from 'es-toolkit/compat';
 import type { ComposeOption } from 'echarts/core';
 import type { HeatmapSeriesOption } from 'echarts/charts';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
@@ -20,7 +20,7 @@ import type { ComposeOption } from 'echarts/core';
 import type { BarSeriesOption } from 'echarts/charts';
 import type { GridComponentOption } from 'echarts/components';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import {
   CategoricalColorNamespace,
   NumberFormats,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -18,7 +18,7 @@
  */
 import { t } from '@apache-superset/core';
 import { ensureIsArray } from '@superset-ui/core';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'es-toolkit';
 import {
   ControlPanelsContainerProps,
   ControlPanelConfig,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint-disable camelcase */
-import { invert } from 'lodash';
+import { invert } from 'es-toolkit/compat';
 import {
   AnnotationLayer,
   AxisType,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint-disable camelcase */
-import { invert } from 'lodash';
+import { invert } from 'es-toolkit/compat';
 import { t } from '@apache-superset/core';
 import {
   AnnotationLayer,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/annotation.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/annotation.ts
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 
 import {
   Annotation,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -37,7 +37,14 @@ import { SortSeriesType, LegendPaddingType } from '@superset-ui/chart-controls';
 import { format } from 'echarts/core';
 import type { LegendComponentOption } from 'echarts/components';
 import type { SeriesOption } from 'echarts';
-import { isEmpty, maxBy, meanBy, minBy, orderBy, sumBy } from 'lodash';
+import {
+  isEmpty,
+  maxBy,
+  meanBy,
+  minBy,
+  orderBy,
+  sumBy,
+} from 'es-toolkit/compat';
 import {
   NULL_STRING,
   StackControlsValue,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { DataRecord, DataRecordValue } from '@superset-ui/core';
-import { groupBy as _groupBy, transform } from 'lodash';
+import { groupBy as _groupBy, transform } from 'es-toolkit/compat';
 
 export type TreeNode = {
   name: DataRecordValue;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -263,7 +263,7 @@ test('sortRows by max descending', () => {
   ]);
 });
 
-test('sortAndFilterSeries by min ascending', () => {
+test.only('sortAndFilterSeries by min ascending', () => {
   expect(
     sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Min, true),
   ).toEqual(['y', 'x', 'z']);

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
@@ -22,7 +22,7 @@ import { SafeMarkdown } from '@superset-ui/core/components';
 import { extendedDayjs as dayjs } from '@superset-ui/core/utils/dates';
 import Handlebars from 'handlebars';
 import { useMemo, useState } from 'react';
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from 'es-toolkit';
 import Helpers from 'just-handlebars-helpers';
 import HandlebarsGroupBy from 'handlebars-group-by';
 

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/consts.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/consts.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import { Constants } from '@superset-ui/core/components';
 
 export const debounceFunc = debounce(

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/orderBy.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/orderBy.tsx
@@ -18,7 +18,7 @@
  */
 import { ControlSetItem, Dataset } from '@superset-ui/chart-controls';
 import { t } from '@apache-superset/core';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import { isAggMode, isRawMode } from './shared';
 
 export const orderByControlSetItem: ControlSetItem = {

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -42,7 +42,7 @@ import {
   Row,
 } from 'react-table';
 import { matchSorter, rankings } from 'match-sorter';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit';
 import { Flex, Space } from '@superset-ui/core/components';
 import GlobalFilter, { GlobalFilterProps } from './components/GlobalFilter';
 import SelectPageSize, {

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -73,7 +73,8 @@ import {
   PlusCircleOutlined,
   TableOutlined,
 } from '@ant-design/icons';
-import { isEmpty, debounce, isEqual } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
+import { debounce, isEqual } from 'es-toolkit';
 import { ColorFormatters } from '@superset-ui/chart-controls';
 import {
   ColorSchemeEnum,

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -34,7 +34,7 @@ import {
   isTimeComparison,
   timeCompareOperator,
 } from '@superset-ui/chart-controls';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import { TableChartFormData } from './types';
 import { updateTableOwnState } from './DataTable/utils/externalAPIs';
 

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -54,7 +54,8 @@ import {
   validateServerPagination,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
-import { isEmpty, last } from 'lodash';
+import { last } from 'es-toolkit';
+import { isEmpty } from 'es-toolkit/compat';
 import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';
 import { ColorSchemeEnum } from './types';
 

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -43,7 +43,7 @@ import {
   getColorFormatters,
 } from '@superset-ui/chart-controls';
 
-import { isEmpty, merge } from 'lodash';
+import { isEmpty, merge } from 'es-toolkit/compat';
 import isEqualColumns from './utils/isEqualColumns';
 import DateWithFormatter from './utils/DateWithFormatter';
 import {

--- a/superset-frontend/plugins/plugin-chart-table/src/utils/extent.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/extent.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { isNil } from 'lodash';
+import { isNil } from 'es-toolkit';
 
 export default function extent<T = number | string | Date | undefined | null>(
   values: T[],

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -24,7 +24,7 @@ import {
   waitFor,
   within,
 } from '@superset-ui/core/spec';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'es-toolkit';
 import TableChart, { sanitizeHeaderId } from '../src/TableChart';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import transformProps from '../src/transformProps';

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
@@ -21,7 +21,7 @@ import cloudLayout from 'd3-cloud';
 import { scaleLinear } from 'd3-scale';
 import { seed, CategoricalColorNamespace } from '@superset-ui/core';
 import { SupersetTheme, withTheme } from '@apache-superset/core/ui';
-import { isEqual } from 'lodash';
+import { isEqual } from 'es-toolkit';
 
 const seedRandom = seed('superset-ui');
 

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/ColorSchemeControl/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/ColorSchemeControl/index.tsx
@@ -27,7 +27,7 @@ import {
   CategoricalColorNamespace,
 } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/ui';
-import { sortBy } from 'lodash';
+import { sortBy } from 'es-toolkit/compat';
 import { ControlHeader } from '@superset-ui/chart-controls';
 import {
   Tooltip,

--- a/superset-frontend/src/SqlLab/components/App/index.tsx
+++ b/superset-frontend/src/SqlLab/components/App/index.tsx
@@ -22,7 +22,7 @@ import { Redirect } from 'react-router-dom';
 import Mousetrap from 'mousetrap';
 import { t } from '@apache-superset/core';
 import { css, styled } from '@apache-superset/core/ui';
-import { throttle } from 'lodash';
+import { throttle } from 'es-toolkit';
 import {
   LOCALSTORAGE_MAX_USAGE_KB,
   LOCALSTORAGE_WARNING_THRESHOLD,
@@ -126,7 +126,7 @@ class App extends PureComponent<AppProps, AppState> {
     this.showLocalStorageUsageWarning = throttle(
       this.showLocalStorageUsageWarning,
       LOCALSTORAGE_WARNING_MESSAGE_THROTTLE_MS,
-      { trailing: false },
+      { edges: ['leading'] },
     );
   }
 

--- a/superset-frontend/src/SqlLab/components/AppLayout/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AppLayout/index.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { useSelector } from 'react-redux';
-import { noop } from 'lodash';
 import type { SqlLabRootState } from 'src/SqlLab/types';
 import { css, styled } from '@apache-superset/core';
 import { useComponentDidUpdate } from '@superset-ui/core';
@@ -105,7 +104,7 @@ const AppLayout: React.FC = ({ children }) => {
         `}
         lazy
         onResizeEnd={onSidebarChange}
-        onResize={noop}
+        onResize={(_: number[]) => {}}
       >
         <Splitter.Panel
           collapsible={{

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -29,7 +29,7 @@ import {
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit';
 import {
   Button,
   ButtonGroup,

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -32,7 +32,6 @@ import { t } from '@apache-superset/core';
 import { styled, css } from '@apache-superset/core/ui';
 import { TableSelectorMultiple } from 'src/components/TableSelector';
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
-import { noop } from 'lodash';
 import TableElement from '../TableElement';
 import useDatabaseSelector from '../SqlEditorTopBar/useDatabaseSelector';
 
@@ -83,7 +82,7 @@ const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
     [allSelectedTables, dbId, schema],
   );
 
-  noop(_emptyResultsWithSearch); // This is to avoid unused variable warning, can be removed if not needed
+  _emptyResultsWithSearch; // This is to avoid unused variable warning, can be removed if not needed
 
   const onEmptyResults = useCallback((searchText?: string) => {
     setEmptyResultsWithSearch(!!searchText);

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -33,7 +33,7 @@ import {
 import { CopyToClipboard } from 'src/components';
 import { t } from '@apache-superset/core';
 import { styled, useTheme } from '@apache-superset/core/ui';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 
 import {
   removeDataPreview,

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -19,7 +19,7 @@
 import { useState, useEffect } from 'react';
 import { t } from '@apache-superset/core';
 import { styled } from '@apache-superset/core/ui';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import {
   Badge,
   ConfigEditor,

--- a/superset-frontend/src/components/Chart/DrillBy/DrillBySubmenu.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillBySubmenu.tsx
@@ -43,7 +43,7 @@ import {
   Popover,
   Icons,
 } from '@superset-ui/core/components';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import { FixedSizeList as List } from 'react-window';
 import { InputRef } from 'antd';
 import { MenuItemTooltip } from '../DisabledMenuItemTooltip';

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardWrapper.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardWrapper.tsx
@@ -24,7 +24,7 @@ import { RootState } from 'src/dashboard/types';
 import { useSelector } from 'react-redux';
 import { useDragDropManager } from 'react-dnd';
 import classNames from 'classnames';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 
 const StyledDiv = styled.div`
   ${({ theme }) => css`

--- a/superset-frontend/src/dashboard/components/dnd/handleHover.ts
+++ b/superset-frontend/src/dashboard/components/dnd/handleHover.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { throttle } from 'lodash';
+import { throttle } from 'es-toolkit';
 import { DropTargetMonitor } from 'react-dnd';
 import { DASHBOARD_ROOT_TYPE } from 'src/dashboard/util/componentTypes';
 import getDropPosition from 'src/dashboard/util/getDropPosition';

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
@@ -21,7 +21,7 @@ import { useCallback, useEffect, useRef, useMemo, useState, memo } from 'react';
 import PropTypes from 'prop-types';
 import { logging } from '@apache-superset/core';
 import { styled, t } from '@apache-superset/core/ui';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import { useHistory } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { useDispatch, useSelector } from 'react-redux';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/utils.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import { Dispatch } from 'react';
 import {
   setFocusedNativeFilter,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -18,7 +18,7 @@
  */
 
 /* eslint-disable no-param-reassign */
-import { throttle } from 'lodash';
+import { throttle } from 'es-toolkit';
 import {
   memo,
   useEffect,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { flatMapDeep } from 'lodash';
+import { flatMapDeep } from 'es-toolkit/compat';
 import type { FormInstance } from '@superset-ui/core/components';
 import { useState, useCallback } from 'react';
 import { CustomControlItem, Dataset } from '@superset-ui/chart-controls';

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -22,7 +22,7 @@ import { getTimeFormatter, safeHtmlSpan, TimeFormats } from '@superset-ui/core';
 import { css, styled, useTheme } from '@apache-superset/core/ui';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import { Column } from 'react-table';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import {
   Constants,
   Button,

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
@@ -27,7 +27,7 @@ import {
   CategoricalColorNamespace,
 } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/ui';
-import { sortBy } from 'lodash';
+import { sortBy } from 'es-toolkit/compat';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import {
   Tooltip,

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/ControlForm/index.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/ControlForm/index.tsx
@@ -25,7 +25,7 @@ import {
 import { JsonObject, JsonValue } from '@superset-ui/core';
 import { useTheme } from '@apache-superset/core/ui';
 import { Constants } from '@superset-ui/core/components';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import { ControlFormItemNode } from './ControlFormItem';
 
 export * from './ControlFormItem';

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnMetricSelect.tsx
@@ -29,7 +29,6 @@ import {
 } from '@superset-ui/core';
 import { tn } from '@apache-superset/core';
 import { ColumnMeta, isColumnMeta } from '@superset-ui/chart-controls';
-import { isString } from 'lodash';
 import DndSelectLabel from 'src/explore/components/controls/DndColumnSelectControl/DndSelectLabel';
 import OptionWrapper from 'src/explore/components/controls/DndColumnSelectControl/OptionWrapper';
 import { DatasourcePanelDndItem } from 'src/explore/components/DatasourcePanel/types';
@@ -148,7 +147,7 @@ function DndColumnMetricSelect(props: DndColumnMetricSelectProps) {
       }
 
       return selectedMetrics.some(metric => {
-        if (isString(metric)) {
+        if (typeof metric === 'string') {
           return metric === metricName;
         }
         if (metric instanceof AdhocMetric) {
@@ -171,11 +170,14 @@ function DndColumnMetricSelect(props: DndColumnMetricSelectProps) {
 
     const valueArray = ensureIsArray(value);
     return valueArray.map(item => {
-      if (isString(item) && combinedOptionsMap[item]) {
+      if (typeof item === 'string' && combinedOptionsMap[item]) {
         return item;
       }
 
-      if (isString(item) && savedMetrics.some(m => m.metric_name === item)) {
+      if (
+        typeof item === 'string' &&
+        savedMetrics.some(m => m.metric_name === item)
+      ) {
         return item;
       }
 
@@ -268,7 +270,7 @@ function DndColumnMetricSelect(props: DndColumnMetricSelectProps) {
   );
 
   const isColumnValue = (val: unknown): val is string =>
-    isString(val) && !!combinedOptionsMap[val];
+    typeof val === 'string' && !!combinedOptionsMap[val];
 
   const valuesRenderer = useCallback(
     () =>

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/useAdvancedDataTypes.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/useAdvancedDataTypes.ts
@@ -19,7 +19,7 @@
 import { useCallback, useState } from 'react';
 import { t } from '@apache-superset/core';
 import { ensureIsArray, SupersetClient } from '@superset-ui/core';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import rison from 'rison';
 import { AdvancedDataTypesState, Props } from './index';
 

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
@@ -18,7 +18,7 @@
  */
 import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import {
   Input,
   Tooltip,

--- a/superset-frontend/src/explore/components/controls/TextControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl/index.tsx
@@ -18,7 +18,7 @@
  */
 import { Component, ChangeEvent } from 'react';
 import { legacyValidateNumber, legacyValidateInteger } from '@superset-ui/core';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { Constants, Input } from '@superset-ui/core/components';
 

--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
@@ -27,7 +27,7 @@ import {
   JsonValue,
   SimpleAdhocFilter,
 } from '@superset-ui/core';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
 
 const isControlValueCompatibleWithDatasource = (

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -22,7 +22,7 @@ import { Link, useHistory } from 'react-router-dom';
 import { t } from '@apache-superset/core';
 import { styled, SupersetTheme, css, useTheme } from '@apache-superset/core/ui';
 import cx from 'classnames';
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 import { Menu, MenuMode, MainNav } from '@superset-ui/core/components/Menu';
 import {
   Button,

--- a/superset-frontend/src/features/reports/ReportModal/actions.js
+++ b/superset-frontend/src/features/reports/ReportModal/actions.js
@@ -24,7 +24,7 @@ import {
   addDangerToast,
   addSuccessToast,
 } from 'src/components/MessageToasts/actions';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 
 export const SET_REPORT = 'SET_REPORT';
 export function setReport(report, resourceId, creationMethod, filterField) {

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -28,7 +28,6 @@ import { styled, useTheme, css } from '@apache-superset/core/ui';
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { FilterBarOrientation } from 'src/dashboard/types';
 // import Metadata from '@superset-ui/core/components/Metadata';
-import { isNumber } from 'lodash';
 import { InputNumber } from '@superset-ui/core/components/Input';
 import Slider from '@superset-ui/core/components/Slider';
 import { FormItem, Tooltip, Icons } from '@superset-ui/core/components';
@@ -165,11 +164,11 @@ const validateRange = (
       enableSingleValue === SingleValueType.Exact;
     const value = isSingleMin ? inputMin : inputMax;
 
-    if (!isNumber(value)) {
+    if (typeof value !== 'number') {
       return { isValid: false, errorMessage: requiredError };
     }
 
-    if (isNumber(value) && (value < min || value > max)) {
+    if (typeof value === 'number' && (value < min || value > max)) {
       return { isValid: false, errorMessage: rangeError };
     }
 

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -31,7 +31,7 @@ import {
 import { tn } from '@apache-superset/core';
 import { styled } from '@apache-superset/core/ui';
 import { GenericDataType } from '@apache-superset/core/api/core';
-import { debounce, isUndefined } from 'lodash';
+import { debounce } from 'lodash';
 import { useImmerReducer } from 'use-immer';
 import {
   FormItem,
@@ -166,7 +166,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     [data, col],
   );
   const [excludeFilterValues, setExcludeFilterValues] = useState(
-    isUndefined(filterState?.excludeFilterValues)
+    filterState?.excludeFilterValues === undefined
       ? true
       : filterState?.excludeFilterValues,
   );

--- a/superset-frontend/src/types/bootstrapTypes.ts
+++ b/superset-frontend/src/types/bootstrapTypes.ts
@@ -18,7 +18,7 @@
  */
 import { FormatLocaleDefinition } from 'd3-format';
 import { TimeLocaleDefinition } from 'd3-time-format';
-import { isPlainObject } from 'lodash';
+import { isPlainObject } from 'es-toolkit';
 import { Languages } from 'src/features/home/LanguagePicker';
 import type {
   AnyThemeConfig,

--- a/superset-frontend/src/utils/DebouncedMessageQueue.ts
+++ b/superset-frontend/src/utils/DebouncedMessageQueue.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { debounce } from 'lodash';
+import { debounce } from 'es-toolkit';
 
 export interface DebouncedMessageQueueOptions<T> {
   callback?: (events: T[]) => void;

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -18,7 +18,7 @@
  */
 import { SyntheticEvent } from 'react';
 import domToImage from 'dom-to-image-more';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'es-toolkit';
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@apache-superset/core';
 import { SupersetTheme } from '@apache-superset/core/ui';

--- a/superset-frontend/src/utils/downloadAsPdf.ts
+++ b/superset-frontend/src/utils/downloadAsPdf.ts
@@ -18,7 +18,7 @@
  */
 import { SyntheticEvent } from 'react';
 import domToPdf from 'dom-to-pdf';
-import { kebabCase } from 'lodash';
+import { kebabCase } from 'es-toolkit';
 import { t } from '@apache-superset/core';
 import { logging } from '@apache-superset/core';
 import { addWarningToast } from 'src/components/MessageToasts/actions';

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -24,7 +24,7 @@ import {
 } from '@superset-ui/core';
 import Switchboard from '@superset-ui/switchboard';
 import rison from 'rison';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'es-toolkit/compat';
 import {
   RESERVED_CHART_URL_PARAMS,
   RESERVED_DASHBOARD_URL_PARAMS,

--- a/superset-websocket/package-lock.json
+++ b/superset-websocket/package-lock.json
@@ -10,10 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "cookie": "^1.1.1",
+        "es-toolkit": "^1.44.0",
         "hot-shots": "^13.1.0",
         "ioredis": "^5.9.2",
         "jsonwebtoken": "^9.0.3",
-        "lodash": "^4.17.23",
         "uuid": "^11.1.0",
         "winston": "^3.19.0",
         "ws": "^8.19.0"
@@ -24,7 +24,6 @@
         "@types/ioredis": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.10",
-        "@types/lodash": "^4.17.23",
         "@types/node": "^25.0.10",
         "@types/uuid": "^10.0.0",
         "@types/ws": "^8.18.1",
@@ -1808,13 +1807,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -2791,6 +2783,16 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.1.2",
@@ -5116,6 +5118,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -7931,12 +7934,6 @@
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
-      "dev": true
-    },
     "@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -8614,6 +8611,11 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="
     },
     "escalade": {
       "version": "3.1.2",
@@ -10355,7 +10357,8 @@
     "lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true
     },
     "lodash.defaults": {
       "version": "4.2.0",

--- a/superset-websocket/package.json
+++ b/superset-websocket/package.json
@@ -21,7 +21,7 @@
     "hot-shots": "^13.1.0",
     "ioredis": "^5.9.2",
     "jsonwebtoken": "^9.0.3",
-    "lodash": "^4.17.23",
+    "es-toolkit": "^1.44.0",
     "uuid": "^11.1.0",
     "winston": "^3.19.0",
     "ws": "^8.19.0"
@@ -32,7 +32,6 @@
     "@types/ioredis": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/lodash": "^4.17.23",
     "@types/node": "^25.0.10",
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.18.1",

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { merge as _merge } from 'lodash';
+import { merge as _merge } from 'es-toolkit';
 
 export interface RedisConfig {
   port: number;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(fe): migrate to readily tree-shakeable `es-toolkit`

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
