### PR TITLE
fix(examples): skip URI safety check for system imports

### DIFF
--- a/superset/commands/database/importers/v1/utils.py
+++ b/superset/commands/database/importers/v1/utils.py
@@ -52,8 +52,8 @@ def import_database(  # noqa: C901
         raise ImportFailedError(
             "Database doesn't exist and user doesn't have permission to create databases"  # noqa: E501
         )
-    # Check if this URI is allowed
-    if app.config["PREVENT_UNSAFE_DB_CONNECTIONS"]:
+    # Check if this URI is allowed (skip for system imports like examples)
+    if app.config["PREVENT_UNSAFE_DB_CONNECTIONS"] and not ignore_permissions:
         try:
             check_sqlalchemy_uri(make_url_safe(config["sqlalchemy_uri"]))
         except SupersetSecurityException as exc:

--- a/superset/examples/data_loading.py
+++ b/superset/examples/data_loading.py
@@ -40,6 +40,7 @@ def get_dataset_config_from_yaml(example_dir: Path) -> Dict[str, Optional[str]]:
         "table_name": None,
         "schema": None,
         "data_file": None,
+        "uuid": None,
     }
     dataset_yaml = example_dir / "dataset.yaml"
     if dataset_yaml.exists():
@@ -48,6 +49,7 @@ def get_dataset_config_from_yaml(example_dir: Path) -> Dict[str, Optional[str]]:
                 config = yaml.safe_load(f)
                 result["table_name"] = config.get("table_name")
                 result["data_file"] = config.get("data_file")
+                result["uuid"] = config.get("uuid")
                 schema = config.get("schema")
                 # Treat SQLite's 'main' schema as null (use target database default)
                 result["schema"] = None if schema == "main" else schema
@@ -81,6 +83,7 @@ def _get_multi_dataset_config(
         with open(datasets_yaml) as f:
             yaml_config = yaml.safe_load(f)
             result["table_name"] = yaml_config.get("table_name") or dataset_name
+            result["uuid"] = yaml_config.get("uuid")
             raw_schema = yaml_config.get("schema")
             result["schema"] = None if raw_schema == "main" else raw_schema
 
@@ -142,6 +145,7 @@ def discover_datasets() -> Dict[str, Callable[..., None]]:
             table_name=table_name,
             schema=config["schema"],
             data_file=resolved_file,
+            uuid=config.get("uuid"),
         )
 
     # Discover multiple parquet files in data/ folders (complex examples)
@@ -160,6 +164,7 @@ def discover_datasets() -> Dict[str, Callable[..., None]]:
                 table_name=config["table_name"],
                 schema=config["schema"],
                 data_file=config["data_file"],
+                uuid=config.get("uuid"),
             )
 
     return loaders

--- a/superset/examples/generic_loader.py
+++ b/superset/examples/generic_loader.py
@@ -57,6 +57,7 @@ def load_parquet_table(  # noqa: C901
     sample_rows: Optional[int] = None,
     data_file: Optional[Any] = None,
     schema: Optional[str] = None,
+    uuid: Optional[str] = None,
 ) -> SqlaTable:
     """Load a Parquet file into the example database.
 
@@ -175,6 +176,10 @@ def load_parquet_table(  # noqa: C901
         # Set the database reference
         tbl.database = database
 
+    # Set UUID from YAML config so the YAML import path can find this dataset
+    if uuid and not tbl.uuid:
+        tbl.uuid = uuid
+
     if not only_metadata:
         # Ensure database reference is set before fetching metadata
         if not tbl.database:
@@ -194,6 +199,7 @@ def create_generic_loader(
     sample_rows: Optional[int] = None,
     data_file: Optional[Any] = None,
     schema: Optional[str] = None,
+    uuid: Optional[str] = None,
 ) -> Callable[[Database, SqlaTable], None]:
     """Create a loader function for a specific Parquet file.
 
@@ -230,6 +236,7 @@ def create_generic_loader(
             sample_rows=rows,
             data_file=data_file,
             schema=schema,
+            uuid=uuid,
         )
 
         if description and tbl:


### PR DESCRIPTION
### SUMMARY

PR #36538 modernized example loading to use the import/export framework, routing through `import_database()`. This function checks `PREVENT_UNSAFE_DB_CONNECTIONS`, which blocks SQLite URIs. In CI/showtime environments where this flag is enabled and `SQLALCHEMY_EXAMPLES_URI` is SQLite, example loading now fails with:

```
SupersetSecurityException: SQLiteDialect_pysqlite cannot be used as a data source for security reasons.
```

The fix skips the URI safety check when `ignore_permissions=True`, since system imports (like examples) use URIs from server config (`SQLALCHEMY_EXAMPLES_URI`), not untrusted user input.

### TESTING INSTRUCTIONS

1. Set `PREVENT_UNSAFE_DB_CONNECTIONS = True` and `SQLALCHEMY_EXAMPLES_URI` to a SQLite URI
2. Run `superset load-examples`
3. Confirm examples load without the `SupersetSecurityException`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)