### PR TITLE
fix(world-map): reset hover highlight on mouse out

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -244,7 +244,27 @@ function WorldMap(element, props) {
       datamap.svg
         .selectAll('.datamaps-subunit')
         .on('contextmenu', handleContextMenu)
-        .on('click', handleClick);
+        .on('click', handleClick)
+        .on('mouseover', function onMouseOver() {
+          if (inContextMenu) {
+            return;
+          }
+          const countryId = d3.select(this).attr('class').split(' ')[1];
+          // Store original fill color for restoration
+          d3.select(this).attr('data-original-fill', d3.select(this).style('fill'));
+        })
+        .on('mouseout', function onMouseOut() {
+          if (inContextMenu) {
+            return;
+          }
+          const countryId = d3.select(this).attr('class').split(' ')[1];
+          const originalFill = d3.select(this).attr('data-original-fill');
+          // Restore the original fill color (data-based or default no-data color)
+          if (originalFill) {
+            d3.select(this).style('fill', originalFill);
+            d3.select(this).attr('data-original-fill', null);
+          }
+        });
     },
   });
 

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import d3 from 'd3';
+import WorldMap from '../src/WorldMap';
+
+// Mock Datamap
+const mockBubbles = jest.fn();
+const mockUpdateChoropleth = jest.fn();
+const mockSvg = {
+  selectAll: jest.fn().mockReturnThis(),
+  on: jest.fn().mockReturnThis(),
+  attr: jest.fn().mockReturnThis(),
+  style: jest.fn().mockReturnThis(),
+};
+
+jest.mock('datamaps/dist/datamaps.all.min', () => {
+  return jest.fn().mockImplementation((config) => {
+    // Call the done callback immediately to simulate Datamap initialization
+    if (config.done) {
+      config.done({
+        svg: mockSvg,
+      });
+    }
+    return {
+      bubbles: mockBubbles,
+      updateChoropleth: mockUpdateChoropleth,
+      svg: mockSvg,
+    };
+  });
+});
+
+describe('WorldMap hover behavior', () => {
+  let container: HTMLElement;
+  const mockFormatter = jest.fn((val) => String(val));
+
+  const baseProps = {
+    data: [
+      { country: 'USA', name: 'United States', m1: 100, m2: 200, code: 'US' },
+      { country: 'CAN', name: 'Canada', m1: 50, m2: 100, code: 'CA' },
+    ],
+    width: 600,
+    height: 400,
+    maxBubbleSize: 25,
+    showBubbles: false,
+    linearColorScheme: 'schemeRdYlBu',
+    color: '#61B0B7',
+    colorBy: 'country',
+    colorScheme: 'supersetColors',
+    sliceId: 123,
+    theme: {
+      colorBorder: '#e0e0e0',
+      colorSplit: '#333',
+      colorIcon: '#000',
+      colorTextSecondary: '#666',
+    },
+    countryFieldtype: 'code',
+    entity: 'country',
+    onContextMenu: jest.fn(),
+    setDataMask: jest.fn(),
+    inContextMenu: false,
+    filterState: { selectedValues: [] },
+    emitCrossFilters: false,
+    formatter: mockFormatter,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  test('sets up mouseover and mouseout handlers on countries', () => {
+    WorldMap(container, baseProps);
+
+    expect(mockSvg.selectAll).toHaveBeenCalledWith('.datamaps-subunit');
+    const onCalls = mockSvg.on.mock.calls;
+
+    // Find mouseover and mouseout handler registrations
+    const hasMouseover = onCalls.some(call => call[0] === 'mouseover');
+    const hasMouseout = onCalls.some(call => call[0] === 'mouseout');
+
+    expect(hasMouseover).toBe(true);
+    expect(hasMouseout).toBe(true);
+  });
+
+  test('stores original fill color on mouseover', () => {
+    // Create a mock DOM element with d3 selection capabilities
+    const mockElement = document.createElement('path');
+    mockElement.setAttribute('class', 'datamaps-subunit USA');
+    mockElement.style.fill = 'rgb(100, 150, 200)';
+    container.appendChild(mockElement);
+
+    let mouseoverHandler: ((this: HTMLElement) => void) | null = null;
+
+    // Mock d3.select to return the mock element
+    const mockD3Selection = {
+      attr: jest.fn((attrName: string, value?: string) => {
+        if (value !== undefined) {
+          mockElement.setAttribute(attrName, value);
+        } else {
+          return mockElement.getAttribute(attrName);
+        }
+        return mockD3Selection;
+      }),
+      style: jest.fn((styleName: string, value?: string) => {
+        if (value !== undefined) {
+          mockElement.style[styleName as any] = value;
+        } else {
+          return mockElement.style[styleName as any];
+        }
+        return mockD3Selection;
+      }),
+    };
+
+    jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
+
+    // Capture the mouseover handler
+    mockSvg.on.mockImplementation((event: string, handler: any) => {
+      if (event === 'mouseover') {
+        mouseoverHandler = handler;
+      }
+      return mockSvg;
+    });
+
+    WorldMap(container, baseProps);
+
+    // Simulate mouseover
+    if (mouseoverHandler) {
+      mouseoverHandler.call(mockElement);
+    }
+
+    // Verify that data-original-fill attribute was set
+    expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', expect.any(String));
+  });
+
+  test('restores original fill color on mouseout for country with data', () => {
+    const mockElement = document.createElement('path');
+    mockElement.setAttribute('class', 'datamaps-subunit USA');
+    mockElement.style.fill = 'rgb(100, 150, 200)';
+    mockElement.setAttribute('data-original-fill', 'rgb(100, 150, 200)');
+    container.appendChild(mockElement);
+
+    let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+
+    const mockD3Selection = {
+      attr: jest.fn((attrName: string, value?: string | null) => {
+        if (value !== undefined) {
+          if (value === null) {
+            mockElement.removeAttribute(attrName);
+          } else {
+            mockElement.setAttribute(attrName, value);
+          }
+        }
+        return mockElement.getAttribute(attrName) || mockD3Selection;
+      }),
+      style: jest.fn((styleName: string, value?: string) => {
+        if (value !== undefined) {
+          mockElement.style[styleName as any] = value;
+        }
+        return mockElement.style[styleName as any] || mockD3Selection;
+      }),
+    };
+
+    jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
+
+    // Capture the mouseout handler
+    mockSvg.on.mockImplementation((event: string, handler: any) => {
+      if (event === 'mouseout') {
+        mouseoutHandler = handler;
+      }
+      return mockSvg;
+    });
+
+    WorldMap(container, baseProps);
+
+    // Simulate mouseout
+    if (mouseoutHandler) {
+      mouseoutHandler.call(mockElement);
+    }
+
+    // Verify that original fill was restored
+    expect(mockD3Selection.style).toHaveBeenCalledWith('fill', 'rgb(100, 150, 200)');
+    expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', null);
+  });
+
+  test('restores default fill color on mouseout for country with no data', () => {
+    const mockElement = document.createElement('path');
+    mockElement.setAttribute('class', 'datamaps-subunit XXX');
+    mockElement.style.fill = '#e0e0e0'; // Default border color
+    mockElement.setAttribute('data-original-fill', '#e0e0e0');
+    container.appendChild(mockElement);
+
+    let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+
+    const mockD3Selection = {
+      attr: jest.fn((attrName: string, value?: string | null) => {
+        if (value !== undefined) {
+          if (value === null) {
+            mockElement.removeAttribute(attrName);
+          } else {
+            mockElement.setAttribute(attrName, value);
+          }
+        }
+        return mockElement.getAttribute(attrName) || mockD3Selection;
+      }),
+      style: jest.fn((styleName: string, value?: string) => {
+        if (value !== undefined) {
+          mockElement.style[styleName as any] = value;
+        }
+        return mockElement.style[styleName as any] || mockD3Selection;
+      }),
+    };
+
+    jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
+
+    mockSvg.on.mockImplementation((event: string, handler: any) => {
+      if (event === 'mouseout') {
+        mouseoutHandler = handler;
+      }
+      return mockSvg;
+    });
+
+    WorldMap(container, baseProps);
+
+    // Simulate mouseout
+    if (mouseoutHandler) {
+      mouseoutHandler.call(mockElement);
+    }
+
+    // Verify that default fill was restored (no-data color)
+    expect(mockD3Selection.style).toHaveBeenCalledWith('fill', '#e0e0e0');
+    expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', null);
+  });
+
+  test('does not handle mouse events when inContextMenu is true', () => {
+    const propsWithContextMenu = {
+      ...baseProps,
+      inContextMenu: true,
+    };
+
+    const mockElement = document.createElement('path');
+    mockElement.setAttribute('class', 'datamaps-subunit USA');
+    mockElement.style.fill = 'rgb(100, 150, 200)';
+    container.appendChild(mockElement);
+
+    let mouseoverHandler: ((this: HTMLElement) => void) | null = null;
+    let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+
+    const mockD3Selection = {
+      attr: jest.fn(() => mockD3Selection),
+      style: jest.fn(() => mockD3Selection),
+    };
+
+    jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
+
+    mockSvg.on.mockImplementation((event: string, handler: any) => {
+      if (event === 'mouseover') {
+        mouseoverHandler = handler;
+      }
+      if (event === 'mouseout') {
+        mouseoutHandler = handler;
+      }
+      return mockSvg;
+    });
+
+    WorldMap(container, propsWithContextMenu);
+
+    // Simulate mouseover and mouseout
+    if (mouseoverHandler) {
+      mouseoverHandler.call(mockElement);
+    }
+    if (mouseoutHandler) {
+      mouseoutHandler.call(mockElement);
+    }
+
+    // When inContextMenu is true, handlers should exit early without modifying anything
+    // We verify this by checking that attr and style weren't called to change fill
+    const attrCalls = mockD3Selection.attr.mock.calls;
+    const fillChangeCalls = attrCalls.filter(call => 
+      call[0] === 'data-original-fill' && call[1] !== undefined
+    );
+    
+    // The handlers should return early, so no state changes
+    expect(fillChangeCalls.length).toBe(0);
+  });
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
@@ -31,7 +31,7 @@ const mockSvg = {
 };
 
 jest.mock('datamaps/dist/datamaps.all.min', () => {
-  return jest.fn().mockImplementation((config) => {
+  return jest.fn().mockImplementation(config => {
     // Call the done callback immediately to simulate Datamap initialization
     if (config.done) {
       config.done({
@@ -46,262 +46,274 @@ jest.mock('datamaps/dist/datamaps.all.min', () => {
   });
 });
 
-describe('WorldMap hover behavior', () => {
-  let container: HTMLElement;
-  const mockFormatter = jest.fn((val) => String(val));
+let container: HTMLElement;
+const mockFormatter = jest.fn(val => String(val));
 
-  const baseProps = {
-    data: [
-      { country: 'USA', name: 'United States', m1: 100, m2: 200, code: 'US' },
-      { country: 'CAN', name: 'Canada', m1: 50, m2: 100, code: 'CA' },
-    ],
-    width: 600,
-    height: 400,
-    maxBubbleSize: 25,
-    showBubbles: false,
-    linearColorScheme: 'schemeRdYlBu',
-    color: '#61B0B7',
-    colorBy: 'country',
-    colorScheme: 'supersetColors',
-    sliceId: 123,
-    theme: {
-      colorBorder: '#e0e0e0',
-      colorSplit: '#333',
-      colorIcon: '#000',
-      colorTextSecondary: '#666',
-    },
-    countryFieldtype: 'code',
-    entity: 'country',
-    onContextMenu: jest.fn(),
-    setDataMask: jest.fn(),
-    inContextMenu: false,
-    filterState: { selectedValues: [] },
-    emitCrossFilters: false,
-    formatter: mockFormatter,
+const baseProps = {
+  data: [
+    { country: 'USA', name: 'United States', m1: 100, m2: 200, code: 'US' },
+    { country: 'CAN', name: 'Canada', m1: 50, m2: 100, code: 'CA' },
+  ],
+  width: 600,
+  height: 400,
+  maxBubbleSize: 25,
+  showBubbles: false,
+  linearColorScheme: 'schemeRdYlBu',
+  color: '#61B0B7',
+  colorBy: 'country',
+  colorScheme: 'supersetColors',
+  sliceId: 123,
+  theme: {
+    colorBorder: '#e0e0e0',
+    colorSplit: '#333',
+    colorIcon: '#000',
+    colorTextSecondary: '#666',
+  },
+  countryFieldtype: 'code',
+  entity: 'country',
+  onContextMenu: jest.fn(),
+  setDataMask: jest.fn(),
+  inContextMenu: false,
+  filterState: { selectedValues: [] },
+  emitCrossFilters: false,
+  formatter: mockFormatter,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  document.body.removeChild(container);
+});
+
+test('sets up mouseover and mouseout handlers on countries', () => {
+  WorldMap(container, baseProps);
+
+  expect(mockSvg.selectAll).toHaveBeenCalledWith('.datamaps-subunit');
+  const onCalls = mockSvg.on.mock.calls;
+
+  // Find mouseover and mouseout handler registrations
+  const hasMouseover = onCalls.some(call => call[0] === 'mouseover');
+  const hasMouseout = onCalls.some(call => call[0] === 'mouseout');
+
+  expect(hasMouseover).toBe(true);
+  expect(hasMouseout).toBe(true);
+});
+
+test('stores original fill color on mouseover', () => {
+  // Create a mock DOM element with d3 selection capabilities
+  const mockElement = document.createElement('path');
+  mockElement.setAttribute('class', 'datamaps-subunit USA');
+  mockElement.style.fill = 'rgb(100, 150, 200)';
+  container.appendChild(mockElement);
+
+  let mouseoverHandler: ((this: HTMLElement) => void) | null = null;
+
+  // Mock d3.select to return the mock element
+  const mockD3Selection = {
+    attr: jest.fn((attrName: string, value?: string) => {
+      if (value !== undefined) {
+        mockElement.setAttribute(attrName, value);
+      } else {
+        return mockElement.getAttribute(attrName);
+      }
+      return mockD3Selection;
+    }),
+    style: jest.fn((styleName: string, value?: string) => {
+      if (value !== undefined) {
+        mockElement.style[styleName as any] = value;
+      } else {
+        return mockElement.style[styleName as any];
+      }
+      return mockD3Selection;
+    }),
+    classed: jest.fn().mockReturnThis(),
+    selectAll: jest.fn().mockReturnValue({ remove: jest.fn() }),
   };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    container = document.createElement('div');
-    document.body.appendChild(container);
+  jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
+
+  // Capture the mouseover handler
+  mockSvg.on.mockImplementation((event: string, handler: any) => {
+    if (event === 'mouseover') {
+      mouseoverHandler = handler;
+    }
+    return mockSvg;
   });
 
-  afterEach(() => {
-    document.body.removeChild(container);
-  });
+  WorldMap(container, baseProps);
 
-  test('sets up mouseover and mouseout handlers on countries', () => {
-    WorldMap(container, baseProps);
+  // Simulate mouseover
+  if (mouseoverHandler) {
+    mouseoverHandler.call(mockElement);
+  }
 
-    expect(mockSvg.selectAll).toHaveBeenCalledWith('.datamaps-subunit');
-    const onCalls = mockSvg.on.mock.calls;
+  // Verify that data-original-fill attribute was set
+  expect(mockD3Selection.attr).toHaveBeenCalledWith(
+    'data-original-fill',
+    expect.any(String),
+  );
+});
 
-    // Find mouseover and mouseout handler registrations
-    const hasMouseover = onCalls.some(call => call[0] === 'mouseover');
-    const hasMouseout = onCalls.some(call => call[0] === 'mouseout');
+test('restores original fill color on mouseout for country with data', () => {
+  const mockElement = document.createElement('path');
+  mockElement.setAttribute('class', 'datamaps-subunit USA');
+  mockElement.style.fill = 'rgb(100, 150, 200)';
+  mockElement.setAttribute('data-original-fill', 'rgb(100, 150, 200)');
+  container.appendChild(mockElement);
 
-    expect(hasMouseover).toBe(true);
-    expect(hasMouseout).toBe(true);
-  });
+  let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
 
-  test('stores original fill color on mouseover', () => {
-    // Create a mock DOM element with d3 selection capabilities
-    const mockElement = document.createElement('path');
-    mockElement.setAttribute('class', 'datamaps-subunit USA');
-    mockElement.style.fill = 'rgb(100, 150, 200)';
-    container.appendChild(mockElement);
-
-    let mouseoverHandler: ((this: HTMLElement) => void) | null = null;
-
-    // Mock d3.select to return the mock element
-    const mockD3Selection = {
-      attr: jest.fn((attrName: string, value?: string) => {
-        if (value !== undefined) {
+  const mockD3Selection = {
+    attr: jest.fn((attrName: string, value?: string | null) => {
+      if (value !== undefined) {
+        if (value === null) {
+          mockElement.removeAttribute(attrName);
+        } else {
           mockElement.setAttribute(attrName, value);
+        }
+      }
+      return mockElement.getAttribute(attrName) || mockD3Selection;
+    }),
+    style: jest.fn((styleName: string, value?: string) => {
+      if (value !== undefined) {
+        mockElement.style[styleName as any] = value;
+      }
+      return mockElement.style[styleName as any] || mockD3Selection;
+    }),
+    classed: jest.fn().mockReturnThis(),
+    selectAll: jest.fn().mockReturnValue({ remove: jest.fn() }),
+  };
+
+  jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
+
+  // Capture the mouseout handler
+  mockSvg.on.mockImplementation((event: string, handler: any) => {
+    if (event === 'mouseout') {
+      mouseoutHandler = handler;
+    }
+    return mockSvg;
+  });
+
+  WorldMap(container, baseProps);
+
+  // Simulate mouseout
+  if (mouseoutHandler) {
+    mouseoutHandler.call(mockElement);
+  }
+
+  // Verify that original fill was restored
+  expect(mockD3Selection.style).toHaveBeenCalledWith(
+    'fill',
+    'rgb(100, 150, 200)',
+  );
+  expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', null);
+});
+
+test('restores default fill color on mouseout for country with no data', () => {
+  const mockElement = document.createElement('path');
+  mockElement.setAttribute('class', 'datamaps-subunit XXX');
+  mockElement.style.fill = '#e0e0e0'; // Default border color
+  mockElement.setAttribute('data-original-fill', '#e0e0e0');
+  container.appendChild(mockElement);
+
+  let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+
+  const mockD3Selection = {
+    attr: jest.fn((attrName: string, value?: string | null) => {
+      if (value !== undefined) {
+        if (value === null) {
+          mockElement.removeAttribute(attrName);
         } else {
-          return mockElement.getAttribute(attrName);
+          mockElement.setAttribute(attrName, value);
         }
-        return mockD3Selection;
-      }),
-      style: jest.fn((styleName: string, value?: string) => {
-        if (value !== undefined) {
-          mockElement.style[styleName as any] = value;
-        } else {
-          return mockElement.style[styleName as any];
-        }
-        return mockD3Selection;
-      }),
-    };
-
-    jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
-
-    // Capture the mouseover handler
-    mockSvg.on.mockImplementation((event: string, handler: any) => {
-      if (event === 'mouseover') {
-        mouseoverHandler = handler;
       }
-      return mockSvg;
-    });
+      return mockElement.getAttribute(attrName) || mockD3Selection;
+    }),
+    style: jest.fn((styleName: string, value?: string) => {
+      if (value !== undefined) {
+        mockElement.style[styleName as any] = value;
+      }
+      return mockElement.style[styleName as any] || mockD3Selection;
+    }),
+    classed: jest.fn().mockReturnThis(),
+    selectAll: jest.fn().mockReturnValue({ remove: jest.fn() }),
+  };
 
-    WorldMap(container, baseProps);
+  jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
 
-    // Simulate mouseover
-    if (mouseoverHandler) {
-      mouseoverHandler.call(mockElement);
+  mockSvg.on.mockImplementation((event: string, handler: any) => {
+    if (event === 'mouseout') {
+      mouseoutHandler = handler;
     }
-
-    // Verify that data-original-fill attribute was set
-    expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', expect.any(String));
+    return mockSvg;
   });
 
-  test('restores original fill color on mouseout for country with data', () => {
-    const mockElement = document.createElement('path');
-    mockElement.setAttribute('class', 'datamaps-subunit USA');
-    mockElement.style.fill = 'rgb(100, 150, 200)';
-    mockElement.setAttribute('data-original-fill', 'rgb(100, 150, 200)');
-    container.appendChild(mockElement);
+  WorldMap(container, baseProps);
 
-    let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+  // Simulate mouseout
+  if (mouseoutHandler) {
+    mouseoutHandler.call(mockElement);
+  }
 
-    const mockD3Selection = {
-      attr: jest.fn((attrName: string, value?: string | null) => {
-        if (value !== undefined) {
-          if (value === null) {
-            mockElement.removeAttribute(attrName);
-          } else {
-            mockElement.setAttribute(attrName, value);
-          }
-        }
-        return mockElement.getAttribute(attrName) || mockD3Selection;
-      }),
-      style: jest.fn((styleName: string, value?: string) => {
-        if (value !== undefined) {
-          mockElement.style[styleName as any] = value;
-        }
-        return mockElement.style[styleName as any] || mockD3Selection;
-      }),
-    };
+  // Verify that default fill was restored (no-data color)
+  expect(mockD3Selection.style).toHaveBeenCalledWith('fill', '#e0e0e0');
+  expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', null);
+});
 
-    jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
+test('does not handle mouse events when inContextMenu is true', () => {
+  const propsWithContextMenu = {
+    ...baseProps,
+    inContextMenu: true,
+  };
 
-    // Capture the mouseout handler
-    mockSvg.on.mockImplementation((event: string, handler: any) => {
-      if (event === 'mouseout') {
-        mouseoutHandler = handler;
-      }
-      return mockSvg;
-    });
+  const mockElement = document.createElement('path');
+  mockElement.setAttribute('class', 'datamaps-subunit USA');
+  mockElement.style.fill = 'rgb(100, 150, 200)';
+  container.appendChild(mockElement);
 
-    WorldMap(container, baseProps);
+  let mouseoverHandler: ((this: HTMLElement) => void) | null = null;
+  let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
 
-    // Simulate mouseout
-    if (mouseoutHandler) {
-      mouseoutHandler.call(mockElement);
+  const mockD3Selection = {
+    attr: jest.fn(() => mockD3Selection),
+    style: jest.fn(() => mockD3Selection),
+    classed: jest.fn().mockReturnThis(),
+    selectAll: jest.fn().mockReturnValue({ remove: jest.fn() }),
+  };
+
+  jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
+
+  mockSvg.on.mockImplementation((event: string, handler: any) => {
+    if (event === 'mouseover') {
+      mouseoverHandler = handler;
     }
-
-    // Verify that original fill was restored
-    expect(mockD3Selection.style).toHaveBeenCalledWith('fill', 'rgb(100, 150, 200)');
-    expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', null);
+    if (event === 'mouseout') {
+      mouseoutHandler = handler;
+    }
+    return mockSvg;
   });
 
-  test('restores default fill color on mouseout for country with no data', () => {
-    const mockElement = document.createElement('path');
-    mockElement.setAttribute('class', 'datamaps-subunit XXX');
-    mockElement.style.fill = '#e0e0e0'; // Default border color
-    mockElement.setAttribute('data-original-fill', '#e0e0e0');
-    container.appendChild(mockElement);
+  WorldMap(container, propsWithContextMenu);
 
-    let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+  // Simulate mouseover and mouseout
+  if (mouseoverHandler) {
+    mouseoverHandler.call(mockElement);
+  }
+  if (mouseoutHandler) {
+    mouseoutHandler.call(mockElement);
+  }
 
-    const mockD3Selection = {
-      attr: jest.fn((attrName: string, value?: string | null) => {
-        if (value !== undefined) {
-          if (value === null) {
-            mockElement.removeAttribute(attrName);
-          } else {
-            mockElement.setAttribute(attrName, value);
-          }
-        }
-        return mockElement.getAttribute(attrName) || mockD3Selection;
-      }),
-      style: jest.fn((styleName: string, value?: string) => {
-        if (value !== undefined) {
-          mockElement.style[styleName as any] = value;
-        }
-        return mockElement.style[styleName as any] || mockD3Selection;
-      }),
-    };
+  // When inContextMenu is true, handlers should exit early without modifying anything
+  // We verify this by checking that attr and style weren't called to change fill
+  const attrCalls = mockD3Selection.attr.mock.calls;
+  const fillChangeCalls = attrCalls.filter(
+    call => call[0] === 'data-original-fill' && call[1] !== undefined,
+  );
 
-    jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
-
-    mockSvg.on.mockImplementation((event: string, handler: any) => {
-      if (event === 'mouseout') {
-        mouseoutHandler = handler;
-      }
-      return mockSvg;
-    });
-
-    WorldMap(container, baseProps);
-
-    // Simulate mouseout
-    if (mouseoutHandler) {
-      mouseoutHandler.call(mockElement);
-    }
-
-    // Verify that default fill was restored (no-data color)
-    expect(mockD3Selection.style).toHaveBeenCalledWith('fill', '#e0e0e0');
-    expect(mockD3Selection.attr).toHaveBeenCalledWith('data-original-fill', null);
-  });
-
-  test('does not handle mouse events when inContextMenu is true', () => {
-    const propsWithContextMenu = {
-      ...baseProps,
-      inContextMenu: true,
-    };
-
-    const mockElement = document.createElement('path');
-    mockElement.setAttribute('class', 'datamaps-subunit USA');
-    mockElement.style.fill = 'rgb(100, 150, 200)';
-    container.appendChild(mockElement);
-
-    let mouseoverHandler: ((this: HTMLElement) => void) | null = null;
-    let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
-
-    const mockD3Selection = {
-      attr: jest.fn(() => mockD3Selection),
-      style: jest.fn(() => mockD3Selection),
-    };
-
-    jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
-
-    mockSvg.on.mockImplementation((event: string, handler: any) => {
-      if (event === 'mouseover') {
-        mouseoverHandler = handler;
-      }
-      if (event === 'mouseout') {
-        mouseoutHandler = handler;
-      }
-      return mockSvg;
-    });
-
-    WorldMap(container, propsWithContextMenu);
-
-    // Simulate mouseover and mouseout
-    if (mouseoverHandler) {
-      mouseoverHandler.call(mockElement);
-    }
-    if (mouseoutHandler) {
-      mouseoutHandler.call(mockElement);
-    }
-
-    // When inContextMenu is true, handlers should exit early without modifying anything
-    // We verify this by checking that attr and style weren't called to change fill
-    const attrCalls = mockD3Selection.attr.mock.calls;
-    const fillChangeCalls = attrCalls.filter(call => 
-      call[0] === 'data-original-fill' && call[1] !== undefined
-    );
-    
-    // The handlers should return early, so no state changes
-    expect(fillChangeCalls.length).toBe(0);
-  });
+  // The handlers should return early, so no state changes
+  expect(fillChangeCalls.length).toBe(0);
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
@@ -20,6 +20,15 @@
 import d3 from 'd3';
 import WorldMap from '../src/WorldMap';
 
+type MouseEventHandler = (this: HTMLElement) => void;
+
+interface MockD3Selection {
+  attr: jest.Mock;
+  style: jest.Mock;
+  classed: jest.Mock;
+  selectAll: jest.Mock;
+}
+
 // Mock Datamap
 const mockBubbles = jest.fn();
 const mockUpdateChoropleth = jest.fn();
@@ -110,10 +119,10 @@ test('stores original fill color on mouseover', () => {
   mockElement.style.fill = 'rgb(100, 150, 200)';
   container.appendChild(mockElement);
 
-  let mouseoverHandler: ((this: HTMLElement) => void) | null = null;
+  let mouseoverHandler: MouseEventHandler | null = null;
 
   // Mock d3.select to return the mock element
-  const mockD3Selection = {
+  const mockD3Selection: MockD3Selection = {
     attr: jest.fn((attrName: string, value?: string) => {
       if (value !== undefined) {
         mockElement.setAttribute(attrName, value);
@@ -137,7 +146,7 @@ test('stores original fill color on mouseover', () => {
   jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
 
   // Capture the mouseover handler
-  mockSvg.on.mockImplementation((event: string, handler: any) => {
+  mockSvg.on.mockImplementation((event: string, handler: MouseEventHandler) => {
     if (event === 'mouseover') {
       mouseoverHandler = handler;
     }
@@ -148,7 +157,7 @@ test('stores original fill color on mouseover', () => {
 
   // Simulate mouseover
   if (mouseoverHandler) {
-    mouseoverHandler.call(mockElement);
+    (mouseoverHandler as MouseEventHandler).call(mockElement);
   }
 
   // Verify that data-original-fill attribute was set
@@ -165,9 +174,9 @@ test('restores original fill color on mouseout for country with data', () => {
   mockElement.setAttribute('data-original-fill', 'rgb(100, 150, 200)');
   container.appendChild(mockElement);
 
-  let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+  let mouseoutHandler: MouseEventHandler | null = null;
 
-  const mockD3Selection = {
+  const mockD3Selection: MockD3Selection = {
     attr: jest.fn((attrName: string, value?: string | null) => {
       if (value !== undefined) {
         if (value === null) {
@@ -191,7 +200,7 @@ test('restores original fill color on mouseout for country with data', () => {
   jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
 
   // Capture the mouseout handler
-  mockSvg.on.mockImplementation((event: string, handler: any) => {
+  mockSvg.on.mockImplementation((event: string, handler: MouseEventHandler) => {
     if (event === 'mouseout') {
       mouseoutHandler = handler;
     }
@@ -202,7 +211,7 @@ test('restores original fill color on mouseout for country with data', () => {
 
   // Simulate mouseout
   if (mouseoutHandler) {
-    mouseoutHandler.call(mockElement);
+    (mouseoutHandler as MouseEventHandler).call(mockElement);
   }
 
   // Verify that original fill was restored
@@ -220,9 +229,9 @@ test('restores default fill color on mouseout for country with no data', () => {
   mockElement.setAttribute('data-original-fill', '#e0e0e0');
   container.appendChild(mockElement);
 
-  let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+  let mouseoutHandler: MouseEventHandler | null = null;
 
-  const mockD3Selection = {
+  const mockD3Selection: MockD3Selection = {
     attr: jest.fn((attrName: string, value?: string | null) => {
       if (value !== undefined) {
         if (value === null) {
@@ -245,7 +254,7 @@ test('restores default fill color on mouseout for country with no data', () => {
 
   jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
 
-  mockSvg.on.mockImplementation((event: string, handler: any) => {
+  mockSvg.on.mockImplementation((event: string, handler: MouseEventHandler) => {
     if (event === 'mouseout') {
       mouseoutHandler = handler;
     }
@@ -256,7 +265,7 @@ test('restores default fill color on mouseout for country with no data', () => {
 
   // Simulate mouseout
   if (mouseoutHandler) {
-    mouseoutHandler.call(mockElement);
+    (mouseoutHandler as MouseEventHandler).call(mockElement);
   }
 
   // Verify that default fill was restored (no-data color)
@@ -275,10 +284,10 @@ test('does not handle mouse events when inContextMenu is true', () => {
   mockElement.style.fill = 'rgb(100, 150, 200)';
   container.appendChild(mockElement);
 
-  let mouseoverHandler: ((this: HTMLElement) => void) | null = null;
-  let mouseoutHandler: ((this: HTMLElement) => void) | null = null;
+  let mouseoverHandler: MouseEventHandler | null = null;
+  let mouseoutHandler: MouseEventHandler | null = null;
 
-  const mockD3Selection = {
+  const mockD3Selection: MockD3Selection = {
     attr: jest.fn(() => mockD3Selection),
     style: jest.fn(() => mockD3Selection),
     classed: jest.fn().mockReturnThis(),
@@ -287,7 +296,7 @@ test('does not handle mouse events when inContextMenu is true', () => {
 
   jest.spyOn(d3, 'select').mockReturnValue(mockD3Selection as any);
 
-  mockSvg.on.mockImplementation((event: string, handler: any) => {
+  mockSvg.on.mockImplementation((event: string, handler: MouseEventHandler) => {
     if (event === 'mouseover') {
       mouseoverHandler = handler;
     }
@@ -301,17 +310,18 @@ test('does not handle mouse events when inContextMenu is true', () => {
 
   // Simulate mouseover and mouseout
   if (mouseoverHandler) {
-    mouseoverHandler.call(mockElement);
+    (mouseoverHandler as MouseEventHandler).call(mockElement);
   }
   if (mouseoutHandler) {
-    mouseoutHandler.call(mockElement);
+    (mouseoutHandler as MouseEventHandler).call(mockElement);
   }
 
   // When inContextMenu is true, handlers should exit early without modifying anything
   // We verify this by checking that attr and style weren't called to change fill
   const attrCalls = mockD3Selection.attr.mock.calls;
   const fillChangeCalls = attrCalls.filter(
-    call => call[0] === 'data-original-fill' && call[1] !== undefined,
+    (call: [string, unknown]) =>
+      call[0] === 'data-original-fill' && call[1] !== undefined,
   );
 
   // The handlers should return early, so no state changes

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/test/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.options.json",
+  "include": ["**/*"],
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "types": ["jest", "node"]
+  }
+}


### PR DESCRIPTION
### SUMMARY

Fixes an issue in the World Map chart where hover highlighting did not reset
correctly after mouse-out for countries with no data. This caused countries
without data to remain highlighted even after the cursor moved away, leading
to an incorrect visual state in both Explore and Dashboards.

This change ensures that on mouse-out, each country correctly returns to its
original fill color:
- data-driven color for countries with data
- neutral “no data” color for countries without data

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable.

### TESTING INSTRUCTIONS

**Manual testing:**
1. Create or open a World Map chart with some countries that have no data.
2. Hover over a country with no data and observe the hover highlight.
3. Move the mouse away from the country.
4. Verify that the country returns to the neutral “no data” color.
5. Repeat the same steps for a country with data and confirm it resets to the
   original data-driven color.

**Automated testing:**
- Updated/added frontend tests to verify that hover state is correctly cleared
  on mouse-out for both data and no-data regions.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #37569
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in SIP-59)
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API