### PR TITLE
fix(db): Add MariaDB DDL fix for `NOCYCLE` syntax

### DIFF
--- a/superset/extensions/__init__.py
+++ b/superset/extensions/__init__.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
+import logging
 import os
 from typing import Any, Callable, Optional
 
@@ -52,8 +53,10 @@ from superset.utils.machine_auth import MachineAuthProviderFactory
 from superset.utils.profiler import SupersetProfiler
 
 # Apply MariaDB DDL fix early in the import chain
-apply_mariadb_ddl_fix()
-
+try:
+    apply_mariadb_ddl_fix()
+except Exception as ex:
+    logging.exception("Applying MariaDB DDL fix failed; continuing without patch: %s", ex)
 
 class ResultsBackendManager:
     def __init__(self) -> None:

--- a/superset/extensions/__init__.py
+++ b/superset/extensions/__init__.py
@@ -45,10 +45,14 @@ from superset.extensions.ssh import SSHManagerFactory
 from superset.extensions.stats_logger import BaseStatsLoggerManager
 from superset.security.manager import SupersetSecurityManager
 from superset.utils.cache_manager import CacheManager
+from superset.utils.database import apply_mariadb_ddl_fix
 from superset.utils.encrypt import EncryptedFieldFactory
 from superset.utils.feature_flag_manager import FeatureFlagManager
 from superset.utils.machine_auth import MachineAuthProviderFactory
 from superset.utils.profiler import SupersetProfiler
+
+# Apply MariaDB DDL fix early in the import chain
+apply_mariadb_ddl_fix()
 
 
 class ResultsBackendManager:

--- a/superset/extensions/__init__.py
+++ b/superset/extensions/__init__.py
@@ -56,7 +56,10 @@ from superset.utils.profiler import SupersetProfiler
 try:
     apply_mariadb_ddl_fix()
 except Exception as ex:
-    logging.exception("Applying MariaDB DDL fix failed; continuing without patch: %s", ex)
+    logging.exception(
+        "Applying MariaDB DDL fix failed; continuing without patch: %s", ex
+    )
+
 
 class ResultsBackendManager:
     def __init__(self) -> None:

--- a/superset/utils/database.py
+++ b/superset/utils/database.py
@@ -98,7 +98,8 @@ def apply_mariadb_ddl_fix() -> None:
 
     def patched_visit_create_sequence(self: Any, create: Any, **kw: Any) -> str:
         text = original_visit_create_sequence(self, create, **kw)
-        if self.dialect.name == "mariadb":
+        dialect_name = getattr(self.dialect, "name", "") or ""
+        if "mariadb" in dialect_name.lower():
             return text.replace("NO CYCLE", "NOCYCLE")
         return text
 

--- a/tests/unit_tests/utils/test_database.py
+++ b/tests/unit_tests/utils/test_database.py
@@ -16,6 +16,7 @@
 # under the License.
 """Tests for superset.utils.database module."""
 
+import pytest
 from sqlalchemy import Sequence
 from sqlalchemy.dialects import mysql, postgresql
 from sqlalchemy.schema import CreateSequence
@@ -23,7 +24,11 @@ from sqlalchemy.sql.compiler import DDLCompiler
 
 from superset.utils.database import apply_mariadb_ddl_fix
 
-apply_mariadb_ddl_fix()
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_mariadb_ddl_fix():
+    """Apply MariaDB DDL fix once per module before tests run."""
+    apply_mariadb_ddl_fix()
 
 
 def test_mariadb_nocycle_fix_applied():

--- a/tests/unit_tests/utils/test_database.py
+++ b/tests/unit_tests/utils/test_database.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for superset.utils.database module."""
+
+from sqlalchemy import Sequence
+from sqlalchemy.dialects import mysql, postgresql
+from sqlalchemy.schema import CreateSequence
+from sqlalchemy.sql.compiler import DDLCompiler
+
+from superset.utils.database import apply_mariadb_ddl_fix
+
+apply_mariadb_ddl_fix()
+
+
+def test_mariadb_nocycle_fix_applied():
+    """Test that 'NO CYCLE' is replaced with 'NOCYCLE' for MariaDB dialect."""
+    dialect = mysql.dialect()
+    dialect.name = "mariadb"
+    ddl_compiler = DDLCompiler(dialect, None)
+    seq = Sequence("test_seq", cycle=False)
+
+    result = ddl_compiler.visit_create_sequence(CreateSequence(seq))
+    assert "NOCYCLE" in result
+    assert "NO CYCLE" not in result
+
+
+def test_nocycle_fix_not_applied_for_postgresql():
+    """Test that 'NO CYCLE' is NOT replaced for PostgreSQL dialect."""
+    dialect = postgresql.dialect()
+    compiler = DDLCompiler(dialect, None)
+    seq = Sequence("test_seq", cycle=False)
+
+    result = compiler.visit_create_sequence(CreateSequence(seq))
+    assert "NO CYCLE" in result


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This pull request introduces a fix for a MariaDB-specific DDL syntax issue in Superset by patching SQLAlchemy's sequence creation logic. The main change ensures that when creating sequences for MariaDB, the generated SQL uses `NOCYCLE` instead of the incorrect `NO CYCLE` syntax. The fix is applied early in the import chain to guarantee it takes effect throughout the application. Unit tests have also been added to verify the patch works as intended.

> This issue breaks table creation during `superset db upgrade` when using MariaDB database.

**MariaDB DDL syntax fix:**

* Added `apply_mariadb_ddl_fix()` to `superset/utils/database.py`, which patches SQLAlchemy's `DDLCompiler.visit_create_sequence` method to replace `NO CYCLE` with `NOCYCLE` for MariaDB dialects. This prevents SQL errors when creating sequences in MariaDB.
* Called `apply_mariadb_ddl_fix()` early in the `superset/extensions/__init__.py` import chain to ensure the fix is active before any database operations occur.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

* Added new unit tests in `tests/unit_tests/utils/test_database.py` to verify that the patch correctly modifies the generated SQL for MariaDB and does not affect other dialects like PostgreSQL.

```
pytest tests/unit_tests/utils/test_database.py -v                                                                                                                                                                                                                                                                                                                                                                                                                                                 

tests/unit_tests/utils/test_database.py::test_mariadb_nocycle_fix_applied PASSED                                                                                                                                                                                                                                                                                                                                                                                                       [ 50%]
tests/unit_tests/utils/test_database.py::test_nocycle_fix_not_applied_for_postgresql PASSED   
```


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
