### PR TITLE
feat: AWS Cross-Account IAM Authentication for Aurora

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
         args: [--check-untyped-defs]
         exclude: ^superset-extensions-cli/
         additional_dependencies: [
+            types-cachetools,
             types-simplejson,
             types-python-dateutil,
             types-requests,

--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -107,8 +107,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     user: *superset-user
-    ports:
-      - "${SUPERSET_PORT:-8088}:8088"
     depends_on:
       superset-init-light:
         condition: service_completed_successfully

--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -107,6 +107,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     user: *superset-user
+    ports:
+      - "${SUPERSET_PORT:-8088}:8088"
     depends_on:
       superset-init-light:
         condition: service_completed_successfully

--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -115,6 +115,12 @@
         "description": "Allow users to export full CSV of table viz type. Warning: Could cause server memory/compute issues with large datasets."
       },
       {
+        "name": "AWS_DATABASE_IAM_AUTH",
+        "default": false,
+        "lifecycle": "testing",
+        "description": "Enable AWS IAM authentication for database connections (Aurora, Redshift). Allows cross-account role assumption via STS AssumeRole. Security note: When enabled, ensure Superset's IAM role has restricted sts:AssumeRole permissions to prevent unauthorized access."
+      },
+      {
         "name": "CACHE_IMPERSONATION",
         "default": false,
         "lifecycle": "testing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,7 @@ ydb = ["ydb-sqlalchemy>=0.1.2"]
 development = [
     # no bounds for apache-superset-extensions-cli until a stable version
     "apache-superset-extensions-cli",
+    "boto3",
     "docker",
     "flask-testing",
     "freezegun",

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -76,6 +76,12 @@ blinker==1.9.0
     # via
     #   -c requirements/base-constraint.txt
     #   flask
+boto3==1.42.39
+    # via apache-superset
+botocore==1.42.39
+    # via
+    #   boto3
+    #   s3transfer
 bottleneck==1.5.0
     # via
     #   -c requirements/base-constraint.txt
@@ -460,6 +466,10 @@ jinja2==3.1.6
     #   apache-superset-extensions-cli
     #   flask
     #   flask-babel
+jmespath==1.1.0
+    # via
+    #   boto3
+    #   botocore
 jsonpath-ng==1.7.0
     # via
     #   -c requirements/base-constraint.txt
@@ -812,6 +822,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset
+    #   botocore
     #   celery
     #   croniter
     #   flask-appbuilder
@@ -915,6 +926,8 @@ rsa==4.9.1
     #   google-auth
 ruff==0.9.7
     # via apache-superset
+s3transfer==0.16.0
+    # via boto3
 secretstorage==3.5.0
     # via keyring
 selenium==4.32.0
@@ -1066,6 +1079,7 @@ url-normalize==2.2.1
 urllib3==2.6.3
     # via
     #   -c requirements/base-constraint.txt
+    #   botocore
     #   docker
     #   requests
     #   requests-cache

--- a/superset/config.py
+++ b/superset/config.py
@@ -656,6 +656,12 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # @lifecycle: testing
     # @docs: https://superset.apache.org/docs/configuration/setup-ssh-tunneling
     "SSH_TUNNELING": False,
+    # Enable AWS IAM authentication for database connections (Aurora, Redshift).
+    # Allows cross-account role assumption via STS AssumeRole.
+    # Security note: When enabled, ensure Superset's IAM role has restricted
+    # sts:AssumeRole permissions to prevent unauthorized access.
+    # @lifecycle: testing
+    "AWS_DATABASE_IAM_AUTH": False,
     # Use analogous colors in charts
     # @lifecycle: testing
     "USE_ANALOGOUS_COLORS": False,

--- a/superset/db_engine_specs/aurora.py
+++ b/superset/db_engine_specs/aurora.py
@@ -54,3 +54,16 @@ class AuroraPostgresDataAPI(PostgresEngineSpec):
         "secret_arn={secret_arn}&"
         "region_name={region_name}"
     )
+
+
+class AuroraPostgresEngineSpec(PostgresEngineSpec):
+    """
+    Aurora PostgreSQL engine spec.
+
+    IAM authentication is handled by the parent PostgresEngineSpec via
+    the aws_iam config in encrypted_extra.
+    """
+
+    engine = "postgresql"
+    engine_name = "Aurora PostgreSQL"
+    default_driver = "psycopg2"

--- a/superset/db_engine_specs/aurora.py
+++ b/superset/db_engine_specs/aurora.py
@@ -56,6 +56,19 @@ class AuroraPostgresDataAPI(PostgresEngineSpec):
     )
 
 
+class AuroraMySQLEngineSpec(MySQLEngineSpec):
+    """
+    Aurora MySQL engine spec.
+
+    IAM authentication is handled by the parent MySQLEngineSpec via
+    the aws_iam config in encrypted_extra.
+    """
+
+    engine = "mysql"
+    engine_name = "Aurora MySQL"
+    default_driver = "mysqldb"
+
+
 class AuroraPostgresEngineSpec(PostgresEngineSpec):
     """
     Aurora PostgreSQL engine spec.

--- a/superset/db_engine_specs/aws_iam.py
+++ b/superset/db_engine_specs/aws_iam.py
@@ -95,8 +95,6 @@ class AWSIAMAuthMixin:
     }
     """
 
-    supports_iam_authentication = True
-
     # AWS error patterns for actionable error messages
     aws_iam_custom_errors: dict[str, tuple[SupersetErrorType, str]] = {
         "AccessDenied": (

--- a/superset/db_engine_specs/aws_iam.py
+++ b/superset/db_engine_specs/aws_iam.py
@@ -408,6 +408,19 @@ class AWSIAMAuthMixin:
         :param default_port: Default port if not specified in URI
         :raises SupersetSecurityException: If any step fails
         """
+        from superset import feature_flag_manager
+
+        if not feature_flag_manager.is_feature_enabled("AWS_DATABASE_IAM_AUTH"):
+            raise SupersetSecurityException(
+                SupersetError(
+                    message="AWS IAM database authentication is not enabled. "
+                    "Set the AWS_DATABASE_IAM_AUTH feature flag to True in your "
+                    "Superset configuration to enable this feature.",
+                    error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+                    level=ErrorLevel.ERROR,
+                )
+            )
+
         if ssl_args is None:
             ssl_args = {"sslmode": "require"}
 
@@ -517,6 +530,19 @@ class AWSIAMAuthMixin:
         :param iam_config: IAM configuration from encrypted_extra
         :raises SupersetSecurityException: If any step fails
         """
+        from superset import feature_flag_manager
+
+        if not feature_flag_manager.is_feature_enabled("AWS_DATABASE_IAM_AUTH"):
+            raise SupersetSecurityException(
+                SupersetError(
+                    message="AWS IAM database authentication is not enabled. "
+                    "Set the AWS_DATABASE_IAM_AUTH feature flag to True in your "
+                    "Superset configuration to enable this feature.",
+                    error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+                    level=ErrorLevel.ERROR,
+                )
+            )
+
         # Extract configuration
         role_arn = iam_config.get("role_arn")
         region = iam_config.get("region")

--- a/superset/db_engine_specs/aws_iam.py
+++ b/superset/db_engine_specs/aws_iam.py
@@ -51,9 +51,11 @@ DEFAULT_POSTGRES_PORT = 5432
 DEFAULT_MYSQL_PORT = 3306
 DEFAULT_REDSHIFT_PORT = 5439
 
-# Cache STS credentials: key = (role_arn, region, external_id), TTL = 50 min
+# Cache STS credentials: key = (role_arn, region, external_id), TTL = 10 min
+# Using a TTL shorter than the minimum supported session duration (900s) avoids
+# reusing expired STS credentials when a short session_duration is configured.
 _credentials_cache: TTLCache[tuple[str, str, str | None], dict[str, Any]] = TTLCache(
-    maxsize=100, ttl=3000
+    maxsize=100, ttl=600
 )
 _credentials_lock = threading.RLock()
 

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -303,7 +303,9 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
         "mysqlconnector": {"allow_local_infile": 0},
     }
 
-    # Sensitive fields that should be masked in encrypted_extra
+    # Sensitive fields that should be masked in encrypted_extra.
+    # This follows the pattern used by other engine specs (bigquery, snowflake, etc.)
+    # that specify exact paths rather than using the base class's catch-all "$.*".
     encrypted_extra_sensitive_fields = {
         "$.aws_iam.external_id",
         "$.aws_iam.role_arn",
@@ -338,7 +340,10 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
                 database,
                 params,
                 iam_config,
-                ssl_args={"ssl_mode": "REQUIRED"},
+                # MySQL drivers (mysqlclient) use 'ssl' dict, not 'ssl_mode'.
+                # SSL is typically configured via the database's extra settings,
+                # so we pass empty ssl_args here to avoid driver compatibility issues.
+                ssl_args={},
                 default_port=3306,
             )
 

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -492,7 +492,13 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
         if iam_config and iam_config.get("enabled"):
             from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
 
-            AWSIAMAuthMixin._apply_iam_authentication(database, params, iam_config)
+            AWSIAMAuthMixin._apply_iam_authentication(
+                database,
+                params,
+                iam_config,
+                ssl_args={"sslmode": "require"},
+                default_port=5432,
+            )
 
         # Standard behavior: merge remaining keys into params
         if encrypted_extra:

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -202,7 +202,9 @@ class RedshiftEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
             schema_name.lower() if schema_name else None,
         )
 
-    # Sensitive fields that should be masked in encrypted_extra
+    # Sensitive fields that should be masked in encrypted_extra.
+    # This follows the pattern used by other engine specs (bigquery, snowflake, etc.)
+    # that specify exact paths rather than using the base class's catch-all "$.*".
     encrypted_extra_sensitive_fields = {
         "$.aws_iam.external_id",
         "$.aws_iam.role_arn",

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -31,6 +31,7 @@ from superset.errors import SupersetErrorType
 from superset.models.core import Database
 from superset.models.sql_lab import Query
 from superset.sql.parse import Table
+from superset.utils import json
 
 logger = logging.getLogger()
 
@@ -200,6 +201,45 @@ class RedshiftEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
             table_name.lower(),
             schema_name.lower() if schema_name else None,
         )
+
+    # Sensitive fields that should be masked in encrypted_extra
+    encrypted_extra_sensitive_fields = {
+        "$.aws_iam.external_id",
+        "$.aws_iam.role_arn",
+    }
+
+    @staticmethod
+    def update_params_from_encrypted_extra(
+        database: Database,
+        params: dict[str, Any],
+    ) -> None:
+        """
+        Extract sensitive parameters from encrypted_extra.
+
+        Handles AWS IAM authentication for Redshift Serverless if configured,
+        then merges any remaining encrypted_extra keys into params.
+        """
+        if not database.encrypted_extra:
+            return
+
+        try:
+            encrypted_extra = json.loads(database.encrypted_extra)
+        except json.JSONDecodeError as ex:
+            logger.error(ex, exc_info=True)
+            raise
+
+        # Handle AWS IAM auth: pop the key so it doesn't reach create_engine()
+        iam_config = encrypted_extra.pop("aws_iam", None)
+        if iam_config and iam_config.get("enabled"):
+            from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+
+            AWSIAMAuthMixin._apply_redshift_iam_authentication(
+                database, params, iam_config
+            )
+
+        # Standard behavior: merge remaining keys into params
+        if encrypted_extra:
+            params.update(encrypted_extra)
 
     @classmethod
     def df_to_sql(

--- a/tests/unit_tests/db_engine_specs/test_aurora.py
+++ b/tests/unit_tests/db_engine_specs/test_aurora.py
@@ -1,0 +1,239 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=import-outside-toplevel
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.utils import json
+
+
+def test_aurora_postgres_engine_spec_properties() -> None:
+    from superset.db_engine_specs.aurora import AuroraPostgresEngineSpec
+
+    assert AuroraPostgresEngineSpec.engine == "postgresql"
+    assert AuroraPostgresEngineSpec.engine_name == "Aurora PostgreSQL"
+    assert AuroraPostgresEngineSpec.default_driver == "psycopg2"
+
+
+def test_update_params_from_encrypted_extra_without_iam() -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps({})
+    database.sqlalchemy_uri_decrypted = (
+        "postgresql://user:password@mydb.us-east-1.rds.amazonaws.com:5432/mydb"
+    )
+
+    params: dict[str, Any] = {}
+    PostgresEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    # No modifications should be made
+    assert params == {}
+
+
+def test_update_params_from_encrypted_extra_iam_disabled() -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": False,
+                "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+                "region": "us-east-1",
+                "db_username": "superset_user",
+            }
+        }
+    )
+    database.sqlalchemy_uri_decrypted = (
+        "postgresql://user:password@mydb.us-east-1.rds.amazonaws.com:5432/mydb"
+    )
+
+    params: dict[str, Any] = {}
+    PostgresEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    # No modifications should be made when IAM is disabled
+    assert params == {}
+
+
+def test_update_params_from_encrypted_extra_with_iam() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": True,
+                "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+                "region": "us-east-1",
+                "db_username": "superset_iam_user",
+            }
+        }
+    )
+    database.sqlalchemy_uri_decrypted = (
+        "postgresql://user@mydb.cluster-xyz.us-east-1.rds.amazonaws.com:5432/mydb"
+    )
+
+    params: dict[str, Any] = {}
+
+    with (
+        patch.object(
+            AWSIAMAuthMixin,
+            "get_iam_credentials",
+            return_value={
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "secret...",
+                "SessionToken": "token...",
+            },
+        ),
+        patch.object(
+            AWSIAMAuthMixin,
+            "generate_rds_auth_token",
+            return_value="iam-auth-token",
+        ),
+    ):
+        PostgresEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "connect_args" in params
+    assert params["connect_args"]["password"] == "iam-auth-token"  # noqa: S105
+    assert params["connect_args"]["user"] == "superset_iam_user"
+    assert params["connect_args"]["sslmode"] == "require"
+
+
+def test_update_params_merges_remaining_encrypted_extra() -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {"enabled": False},
+            "pool_size": 10,
+        }
+    )
+    database.sqlalchemy_uri_decrypted = (
+        "postgresql://user:password@mydb.us-east-1.rds.amazonaws.com:5432/mydb"
+    )
+
+    params: dict[str, Any] = {}
+    PostgresEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    # aws_iam should be consumed, pool_size should be merged
+    assert "aws_iam" not in params
+    assert params["pool_size"] == 10
+
+
+def test_update_params_from_encrypted_extra_no_encrypted_extra() -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = None
+
+    params: dict[str, Any] = {}
+    PostgresEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    # No modifications should be made
+    assert params == {}
+
+
+def test_update_params_from_encrypted_extra_invalid_json() -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = "not-valid-json"
+
+    params: dict[str, Any] = {}
+
+    with pytest.raises(json.JSONDecodeError):
+        PostgresEngineSpec.update_params_from_encrypted_extra(database, params)
+
+
+def test_encrypted_extra_sensitive_fields() -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    # Verify sensitive fields are properly defined
+    assert (
+        "$.aws_iam.external_id" in PostgresEngineSpec.encrypted_extra_sensitive_fields
+    )
+    assert "$.aws_iam.role_arn" in PostgresEngineSpec.encrypted_extra_sensitive_fields
+
+
+def test_mask_encrypted_extra() -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": True,
+                "role_arn": "arn:aws:iam::123456789012:role/SecretRole",
+                "external_id": "secret-external-id-12345",
+                "region": "us-east-1",
+                "db_username": "superset_user",
+            }
+        }
+    )
+
+    masked = PostgresEngineSpec.mask_encrypted_extra(encrypted_extra)
+    assert masked is not None
+
+    masked_config = json.loads(masked)
+
+    # role_arn and external_id should be masked
+    assert (
+        masked_config["aws_iam"]["role_arn"]
+        != "arn:aws:iam::123456789012:role/SecretRole"
+    )
+    assert masked_config["aws_iam"]["external_id"] != "secret-external-id-12345"
+
+    # Non-sensitive fields should remain unchanged
+    assert masked_config["aws_iam"]["enabled"] is True
+    assert masked_config["aws_iam"]["region"] == "us-east-1"
+    assert masked_config["aws_iam"]["db_username"] == "superset_user"
+
+
+def test_aurora_postgres_inherits_from_postgres() -> None:
+    from superset.db_engine_specs.aurora import AuroraPostgresEngineSpec
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    # Verify inheritance
+    assert issubclass(AuroraPostgresEngineSpec, PostgresEngineSpec)
+
+    # Verify it inherits PostgreSQL capabilities
+    assert AuroraPostgresEngineSpec.supports_dynamic_schema is True
+    assert AuroraPostgresEngineSpec.supports_catalog is True
+
+
+def test_aurora_data_api_classes_unchanged() -> None:
+    from superset.db_engine_specs.aurora import (
+        AuroraMySQLDataAPI,
+        AuroraPostgresDataAPI,
+    )
+
+    # Verify Data API classes are still available and unchanged
+    assert AuroraMySQLDataAPI.engine == "mysql"
+    assert AuroraMySQLDataAPI.default_driver == "auroradataapi"
+    assert AuroraMySQLDataAPI.engine_name == "Aurora MySQL (Data API)"
+
+    assert AuroraPostgresDataAPI.engine == "postgresql"
+    assert AuroraPostgresDataAPI.default_driver == "auroradataapi"
+    assert AuroraPostgresDataAPI.engine_name == "Aurora PostgreSQL (Data API)"

--- a/tests/unit_tests/db_engine_specs/test_aurora.py
+++ b/tests/unit_tests/db_engine_specs/test_aurora.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from superset.utils import json
+from tests.unit_tests.conftest import with_feature_flags
 
 
 def test_aurora_postgres_engine_spec_properties() -> None:
@@ -76,6 +77,7 @@ def test_update_params_from_encrypted_extra_iam_disabled() -> None:
     assert params == {}
 
 
+@with_feature_flags(AWS_DATABASE_IAM_AUTH=True)
 def test_update_params_from_encrypted_extra_with_iam() -> None:
     from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
     from superset.db_engine_specs.postgres import PostgresEngineSpec
@@ -252,6 +254,7 @@ def test_aurora_mysql_has_iam_support() -> None:
     )
 
 
+@with_feature_flags(AWS_DATABASE_IAM_AUTH=True)
 def test_aurora_mysql_update_params_from_encrypted_extra_with_iam() -> None:
     from superset.db_engine_specs.aurora import AuroraMySQLEngineSpec
     from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin

--- a/tests/unit_tests/db_engine_specs/test_aurora.py
+++ b/tests/unit_tests/db_engine_specs/test_aurora.py
@@ -294,7 +294,8 @@ def test_aurora_mysql_update_params_from_encrypted_extra_with_iam() -> None:
     assert "connect_args" in params
     assert params["connect_args"]["password"] == "iam-auth-token"  # noqa: S105
     assert params["connect_args"]["user"] == "superset_iam_user"
-    assert params["connect_args"]["ssl_mode"] == "REQUIRED"
+    # Note: ssl_mode is not set because MySQL drivers don't support it.
+    # SSL should be configured via the database's extra settings.
 
 
 def test_aurora_data_api_classes_unchanged() -> None:

--- a/tests/unit_tests/db_engine_specs/test_aws_iam.py
+++ b/tests/unit_tests/db_engine_specs/test_aws_iam.py
@@ -1,0 +1,383 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=import-outside-toplevel, protected-access
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.exceptions import SupersetSecurityException
+
+
+def test_get_iam_credentials_success() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+
+    mock_credentials = {
+        "AccessKeyId": "ASIA...",
+        "SecretAccessKey": "secret...",
+        "SessionToken": "token...",
+        "Expiration": "2025-01-01T00:00:00Z",
+    }
+
+    with patch("boto3.client") as mock_boto3_client:
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {"Credentials": mock_credentials}
+        mock_boto3_client.return_value = mock_sts
+
+        credentials = AWSIAMAuthMixin.get_iam_credentials(
+            role_arn="arn:aws:iam::123456789012:role/TestRole",
+            region="us-east-1",
+        )
+
+        assert credentials == mock_credentials
+        mock_boto3_client.assert_called_once_with("sts", region_name="us-east-1")
+        mock_sts.assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::123456789012:role/TestRole",
+            RoleSessionName="superset-iam-session",
+            DurationSeconds=3600,
+        )
+
+
+def test_get_iam_credentials_with_external_id() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+
+    mock_credentials = {
+        "AccessKeyId": "ASIA...",
+        "SecretAccessKey": "secret...",
+        "SessionToken": "token...",
+    }
+
+    with patch("boto3.client") as mock_boto3_client:
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {"Credentials": mock_credentials}
+        mock_boto3_client.return_value = mock_sts
+
+        credentials = AWSIAMAuthMixin.get_iam_credentials(
+            role_arn="arn:aws:iam::123456789012:role/TestRole",
+            region="us-west-2",
+            external_id="external-id-12345",
+            session_duration=900,
+        )
+
+        assert credentials == mock_credentials
+        mock_sts.assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::123456789012:role/TestRole",
+            RoleSessionName="superset-iam-session",
+            DurationSeconds=900,
+            ExternalId="external-id-12345",
+        )
+
+
+def test_get_iam_credentials_access_denied() -> None:
+    from botocore.exceptions import ClientError
+
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+
+    with patch("boto3.client") as mock_boto3_client:
+        mock_sts = MagicMock()
+        mock_sts.assume_role.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
+            "AssumeRole",
+        )
+        mock_boto3_client.return_value = mock_sts
+
+        with pytest.raises(SupersetSecurityException) as exc_info:
+            AWSIAMAuthMixin.get_iam_credentials(
+                role_arn="arn:aws:iam::123456789012:role/TestRole",
+                region="us-east-1",
+            )
+
+        assert "Unable to assume IAM role" in str(exc_info.value)
+
+
+def test_get_iam_credentials_external_id_mismatch() -> None:
+    from botocore.exceptions import ClientError
+
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+
+    with patch("boto3.client") as mock_boto3_client:
+        mock_sts = MagicMock()
+        mock_sts.assume_role.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDenied",
+                    "Message": "The external id does not match",
+                }
+            },
+            "AssumeRole",
+        )
+        mock_boto3_client.return_value = mock_sts
+
+        with pytest.raises(SupersetSecurityException) as exc_info:
+            AWSIAMAuthMixin.get_iam_credentials(
+                role_arn="arn:aws:iam::123456789012:role/TestRole",
+                region="us-east-1",
+                external_id="wrong-id",
+            )
+
+        assert "External ID mismatch" in str(exc_info.value)
+
+
+def test_generate_rds_auth_token() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+
+    credentials = {
+        "AccessKeyId": "ASIA...",
+        "SecretAccessKey": "secret...",
+        "SessionToken": "token...",
+    }
+
+    with patch("boto3.client") as mock_boto3_client:
+        mock_rds = MagicMock()
+        mock_rds.generate_db_auth_token.return_value = "iam-token-12345"
+        mock_boto3_client.return_value = mock_rds
+
+        token = AWSIAMAuthMixin.generate_rds_auth_token(
+            credentials=credentials,
+            hostname="mydb.cluster-xyz.us-east-1.rds.amazonaws.com",
+            port=5432,
+            username="superset_user",
+            region="us-east-1",
+        )
+
+        assert token == "iam-token-12345"  # noqa: S105
+        mock_boto3_client.assert_called_once_with(
+            "rds",
+            region_name="us-east-1",
+            aws_access_key_id="ASIA...",
+            aws_secret_access_key="secret...",  # noqa: S106
+            aws_session_token="token...",  # noqa: S106
+        )
+        mock_rds.generate_db_auth_token.assert_called_once_with(
+            DBHostname="mydb.cluster-xyz.us-east-1.rds.amazonaws.com",
+            Port=5432,
+            DBUsername="superset_user",
+        )
+
+
+def test_apply_iam_authentication() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin, AWSIAMConfig
+
+    mock_database = MagicMock()
+    mock_database.sqlalchemy_uri_decrypted = (
+        "postgresql://user@mydb.cluster-xyz.us-east-1.rds.amazonaws.com:5432/mydb"
+    )
+
+    iam_config: AWSIAMConfig = {
+        "enabled": True,
+        "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+        "region": "us-east-1",
+        "db_username": "superset_iam_user",
+    }
+
+    params: dict[str, Any] = {}
+
+    with (
+        patch.object(
+            AWSIAMAuthMixin,
+            "get_iam_credentials",
+            return_value={
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "secret...",
+                "SessionToken": "token...",
+            },
+        ) as mock_get_creds,
+        patch.object(
+            AWSIAMAuthMixin,
+            "generate_rds_auth_token",
+            return_value="iam-auth-token",
+        ) as mock_gen_token,
+    ):
+        AWSIAMAuthMixin._apply_iam_authentication(mock_database, params, iam_config)
+
+    mock_get_creds.assert_called_once_with(
+        role_arn="arn:aws:iam::123456789012:role/TestRole",
+        region="us-east-1",
+        external_id=None,
+        session_duration=3600,
+    )
+
+    mock_gen_token.assert_called_once()
+    token_call_kwargs = mock_gen_token.call_args[1]
+    assert (
+        token_call_kwargs["hostname"] == "mydb.cluster-xyz.us-east-1.rds.amazonaws.com"
+    )
+    assert token_call_kwargs["port"] == 5432
+    assert token_call_kwargs["username"] == "superset_iam_user"
+
+    assert params["connect_args"]["password"] == "iam-auth-token"  # noqa: S105
+    assert params["connect_args"]["user"] == "superset_iam_user"
+    assert params["connect_args"]["sslmode"] == "require"
+
+
+def test_apply_iam_authentication_with_external_id() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin, AWSIAMConfig
+
+    mock_database = MagicMock()
+    mock_database.sqlalchemy_uri_decrypted = (
+        "postgresql://user@mydb.us-west-2.rds.amazonaws.com:5432/mydb"
+    )
+
+    iam_config: AWSIAMConfig = {
+        "enabled": True,
+        "role_arn": "arn:aws:iam::222222222222:role/CrossAccountRole",
+        "external_id": "superset-prod-12345",
+        "region": "us-west-2",
+        "db_username": "iam_user",
+        "session_duration": 1800,
+    }
+
+    params: dict[str, Any] = {}
+
+    with (
+        patch.object(
+            AWSIAMAuthMixin,
+            "get_iam_credentials",
+            return_value={
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "secret...",
+                "SessionToken": "token...",
+            },
+        ) as mock_get_creds,
+        patch.object(
+            AWSIAMAuthMixin,
+            "generate_rds_auth_token",
+            return_value="iam-auth-token",
+        ),
+    ):
+        AWSIAMAuthMixin._apply_iam_authentication(mock_database, params, iam_config)
+
+    mock_get_creds.assert_called_once_with(
+        role_arn="arn:aws:iam::222222222222:role/CrossAccountRole",
+        region="us-west-2",
+        external_id="superset-prod-12345",
+        session_duration=1800,
+    )
+
+
+def test_apply_iam_authentication_missing_role_arn() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin, AWSIAMConfig
+
+    mock_database = MagicMock()
+    mock_database.sqlalchemy_uri_decrypted = (
+        "postgresql://user@mydb.us-east-1.rds.amazonaws.com:5432/mydb"
+    )
+
+    iam_config: AWSIAMConfig = {
+        "enabled": True,
+        "region": "us-east-1",
+        "db_username": "superset_iam_user",
+    }
+
+    params: dict[str, Any] = {}
+
+    with pytest.raises(SupersetSecurityException) as exc_info:
+        AWSIAMAuthMixin._apply_iam_authentication(mock_database, params, iam_config)
+
+    assert "role_arn" in str(exc_info.value)
+
+
+def test_apply_iam_authentication_missing_db_username() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin, AWSIAMConfig
+
+    mock_database = MagicMock()
+    mock_database.sqlalchemy_uri_decrypted = (
+        "postgresql://user@mydb.us-east-1.rds.amazonaws.com:5432/mydb"
+    )
+
+    iam_config: AWSIAMConfig = {
+        "enabled": True,
+        "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+        "region": "us-east-1",
+    }
+
+    params: dict[str, Any] = {}
+
+    with pytest.raises(SupersetSecurityException) as exc_info:
+        AWSIAMAuthMixin._apply_iam_authentication(mock_database, params, iam_config)
+
+    assert "db_username" in str(exc_info.value)
+
+
+def test_apply_iam_authentication_default_port() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin, AWSIAMConfig
+
+    mock_database = MagicMock()
+    # URI without explicit port
+    mock_database.sqlalchemy_uri_decrypted = (
+        "postgresql://user@mydb.us-east-1.rds.amazonaws.com/mydb"
+    )
+
+    iam_config: AWSIAMConfig = {
+        "enabled": True,
+        "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+        "region": "us-east-1",
+        "db_username": "superset_iam_user",
+    }
+
+    params: dict[str, Any] = {}
+
+    with (
+        patch.object(
+            AWSIAMAuthMixin,
+            "get_iam_credentials",
+            return_value={
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "secret...",
+                "SessionToken": "token...",
+            },
+        ),
+        patch.object(
+            AWSIAMAuthMixin,
+            "generate_rds_auth_token",
+            return_value="iam-auth-token",
+        ) as mock_gen_token,
+    ):
+        AWSIAMAuthMixin._apply_iam_authentication(mock_database, params, iam_config)
+
+    # Should use default port 5432
+    token_call_kwargs = mock_gen_token.call_args[1]
+    assert token_call_kwargs["port"] == 5432
+
+
+def test_get_iam_credentials_boto3_not_installed() -> None:
+    import sys
+
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+
+    # Temporarily hide boto3
+    boto3_module = sys.modules.get("boto3")
+    sys.modules["boto3"] = None  # type: ignore
+
+    try:
+        with pytest.raises(SupersetSecurityException) as exc_info:
+            AWSIAMAuthMixin.get_iam_credentials(
+                role_arn="arn:aws:iam::123456789012:role/TestRole",
+                region="us-east-1",
+            )
+
+        assert "boto3 is required" in str(exc_info.value)
+    finally:
+        # Restore boto3
+        if boto3_module is not None:
+            sys.modules["boto3"] = boto3_module
+        else:
+            del sys.modules["boto3"]

--- a/tests/unit_tests/db_engine_specs/test_mysql_iam.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql_iam.py
@@ -1,0 +1,232 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=import-outside-toplevel
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.utils import json
+
+
+def test_mysql_encrypted_extra_sensitive_fields() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    assert "$.aws_iam.external_id" in MySQLEngineSpec.encrypted_extra_sensitive_fields
+    assert "$.aws_iam.role_arn" in MySQLEngineSpec.encrypted_extra_sensitive_fields
+
+
+def test_mysql_update_params_no_encrypted_extra() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = None
+
+    params: dict[str, Any] = {}
+    MySQLEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert params == {}
+
+
+def test_mysql_update_params_empty_encrypted_extra() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps({})
+
+    params: dict[str, Any] = {}
+    MySQLEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert params == {}
+
+
+def test_mysql_update_params_iam_disabled() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": False,
+                "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+                "region": "us-east-1",
+                "db_username": "superset_user",
+            }
+        }
+    )
+
+    params: dict[str, Any] = {}
+    MySQLEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert params == {}
+
+
+def test_mysql_update_params_with_iam() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": True,
+                "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+                "region": "us-east-1",
+                "db_username": "superset_iam_user",
+            }
+        }
+    )
+    database.sqlalchemy_uri_decrypted = (
+        "mysql://user@mydb.cluster-xyz.us-east-1.rds.amazonaws.com:3306/mydb"
+    )
+
+    params: dict[str, Any] = {}
+
+    with (
+        patch.object(
+            AWSIAMAuthMixin,
+            "get_iam_credentials",
+            return_value={
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "secret...",
+                "SessionToken": "token...",
+            },
+        ),
+        patch.object(
+            AWSIAMAuthMixin,
+            "generate_rds_auth_token",
+            return_value="iam-auth-token",
+        ),
+    ):
+        MySQLEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "connect_args" in params
+    assert params["connect_args"]["password"] == "iam-auth-token"  # noqa: S105
+    assert params["connect_args"]["user"] == "superset_iam_user"
+    assert params["connect_args"]["ssl_mode"] == "REQUIRED"
+
+
+def test_mysql_update_params_iam_uses_mysql_port() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": True,
+                "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+                "region": "us-east-1",
+                "db_username": "superset_iam_user",
+            }
+        }
+    )
+    # URI without explicit port
+    database.sqlalchemy_uri_decrypted = (
+        "mysql://user@mydb.cluster-xyz.us-east-1.rds.amazonaws.com/mydb"
+    )
+
+    params: dict[str, Any] = {}
+
+    with (
+        patch.object(
+            AWSIAMAuthMixin,
+            "get_iam_credentials",
+            return_value={
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "secret...",
+                "SessionToken": "token...",
+            },
+        ),
+        patch.object(
+            AWSIAMAuthMixin,
+            "generate_rds_auth_token",
+            return_value="iam-auth-token",
+        ) as mock_gen_token,
+    ):
+        MySQLEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    # Should use default MySQL port 3306
+    token_call_kwargs = mock_gen_token.call_args[1]
+    assert token_call_kwargs["port"] == 3306
+
+
+def test_mysql_update_params_merges_remaining_encrypted_extra() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {"enabled": False},
+            "pool_size": 10,
+        }
+    )
+
+    params: dict[str, Any] = {}
+    MySQLEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "aws_iam" not in params
+    assert params["pool_size"] == 10
+
+
+def test_mysql_update_params_invalid_json() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = "not-valid-json"
+
+    params: dict[str, Any] = {}
+
+    with pytest.raises(json.JSONDecodeError):
+        MySQLEngineSpec.update_params_from_encrypted_extra(database, params)
+
+
+def test_mysql_mask_encrypted_extra() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": True,
+                "role_arn": "arn:aws:iam::123456789012:role/SecretRole",
+                "external_id": "secret-external-id-12345",
+                "region": "us-east-1",
+                "db_username": "superset_user",
+            }
+        }
+    )
+
+    masked = MySQLEngineSpec.mask_encrypted_extra(encrypted_extra)
+    assert masked is not None
+
+    masked_config = json.loads(masked)
+
+    # role_arn and external_id should be masked
+    assert (
+        masked_config["aws_iam"]["role_arn"]
+        != "arn:aws:iam::123456789012:role/SecretRole"
+    )
+    assert masked_config["aws_iam"]["external_id"] != "secret-external-id-12345"
+
+    # Non-sensitive fields should remain unchanged
+    assert masked_config["aws_iam"]["enabled"] is True
+    assert masked_config["aws_iam"]["region"] == "us-east-1"
+    assert masked_config["aws_iam"]["db_username"] == "superset_user"

--- a/tests/unit_tests/db_engine_specs/test_mysql_iam.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql_iam.py
@@ -121,7 +121,8 @@ def test_mysql_update_params_with_iam() -> None:
     assert "connect_args" in params
     assert params["connect_args"]["password"] == "iam-auth-token"  # noqa: S105
     assert params["connect_args"]["user"] == "superset_iam_user"
-    assert params["connect_args"]["ssl_mode"] == "REQUIRED"
+    # Note: ssl_mode is not set because MySQL drivers don't support it.
+    # SSL should be configured via the database's extra settings.
 
 
 def test_mysql_update_params_iam_uses_mysql_port() -> None:

--- a/tests/unit_tests/db_engine_specs/test_mysql_iam.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql_iam.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from superset.utils import json
+from tests.unit_tests.conftest import with_feature_flags
 
 
 def test_mysql_encrypted_extra_sensitive_fields() -> None:
@@ -79,6 +80,7 @@ def test_mysql_update_params_iam_disabled() -> None:
     assert params == {}
 
 
+@with_feature_flags(AWS_DATABASE_IAM_AUTH=True)
 def test_mysql_update_params_with_iam() -> None:
     from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
     from superset.db_engine_specs.mysql import MySQLEngineSpec
@@ -125,6 +127,7 @@ def test_mysql_update_params_with_iam() -> None:
     # SSL should be configured via the database's extra settings.
 
 
+@with_feature_flags(AWS_DATABASE_IAM_AUTH=True)
 def test_mysql_update_params_iam_uses_mysql_port() -> None:
     from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
     from superset.db_engine_specs.mysql import MySQLEngineSpec

--- a/tests/unit_tests/db_engine_specs/test_redshift_iam.py
+++ b/tests/unit_tests/db_engine_specs/test_redshift_iam.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from superset.utils import json
+from tests.unit_tests.conftest import with_feature_flags
 
 
 def test_redshift_encrypted_extra_sensitive_fields() -> None:
@@ -82,6 +83,7 @@ def test_redshift_update_params_iam_disabled() -> None:
     assert params == {}
 
 
+@with_feature_flags(AWS_DATABASE_IAM_AUTH=True)
 def test_redshift_update_params_with_iam() -> None:
     from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
     from superset.db_engine_specs.redshift import RedshiftEngineSpec
@@ -129,6 +131,7 @@ def test_redshift_update_params_with_iam() -> None:
     assert params["connect_args"]["sslmode"] == "verify-ca"
 
 
+@with_feature_flags(AWS_DATABASE_IAM_AUTH=True)
 def test_redshift_update_params_with_external_id() -> None:
     from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
     from superset.db_engine_specs.redshift import RedshiftEngineSpec
@@ -245,6 +248,7 @@ def test_redshift_mask_encrypted_extra() -> None:
     assert masked_config["aws_iam"]["db_name"] == "dev"
 
 
+@with_feature_flags(AWS_DATABASE_IAM_AUTH=True)
 def test_redshift_update_params_with_iam_provisioned_cluster() -> None:
     from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
     from superset.db_engine_specs.redshift import RedshiftEngineSpec
@@ -293,6 +297,7 @@ def test_redshift_update_params_with_iam_provisioned_cluster() -> None:
     assert params["connect_args"]["sslmode"] == "verify-ca"
 
 
+@with_feature_flags(AWS_DATABASE_IAM_AUTH=True)
 def test_redshift_update_params_provisioned_cluster_with_external_id() -> None:
     from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
     from superset.db_engine_specs.redshift import RedshiftEngineSpec

--- a/tests/unit_tests/db_engine_specs/test_redshift_iam.py
+++ b/tests/unit_tests/db_engine_specs/test_redshift_iam.py
@@ -1,0 +1,245 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=import-outside-toplevel
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.utils import json
+
+
+def test_redshift_encrypted_extra_sensitive_fields() -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    assert (
+        "$.aws_iam.external_id" in RedshiftEngineSpec.encrypted_extra_sensitive_fields
+    )
+    assert "$.aws_iam.role_arn" in RedshiftEngineSpec.encrypted_extra_sensitive_fields
+
+
+def test_redshift_update_params_no_encrypted_extra() -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = None
+
+    params: dict[str, Any] = {}
+    RedshiftEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert params == {}
+
+
+def test_redshift_update_params_empty_encrypted_extra() -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps({})
+
+    params: dict[str, Any] = {}
+    RedshiftEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert params == {}
+
+
+def test_redshift_update_params_iam_disabled() -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": False,
+                "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+                "region": "us-east-1",
+                "workgroup_name": "my-workgroup",
+                "db_name": "dev",
+            }
+        }
+    )
+
+    params: dict[str, Any] = {}
+    RedshiftEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert params == {}
+
+
+def test_redshift_update_params_with_iam() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": True,
+                "role_arn": "arn:aws:iam::123456789012:role/RedshiftRole",
+                "region": "us-east-1",
+                "workgroup_name": "my-workgroup",
+                "db_name": "dev",
+            }
+        }
+    )
+    database.sqlalchemy_uri_decrypted = (
+        "redshift+psycopg2://user@my-workgroup.123456789012.us-east-1"
+        ".redshift-serverless.amazonaws.com:5439/dev"
+    )
+
+    params: dict[str, Any] = {}
+
+    with (
+        patch.object(
+            AWSIAMAuthMixin,
+            "get_iam_credentials",
+            return_value={
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "secret...",
+                "SessionToken": "token...",
+            },
+        ),
+        patch.object(
+            AWSIAMAuthMixin,
+            "generate_redshift_credentials",
+            return_value=("IAM:admin", "redshift-temp-password"),
+        ),
+    ):
+        RedshiftEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "connect_args" in params
+    assert params["connect_args"]["password"] == "redshift-temp-password"  # noqa: S105
+    assert params["connect_args"]["user"] == "IAM:admin"
+    assert params["connect_args"]["sslmode"] == "verify-ca"
+
+
+def test_redshift_update_params_with_external_id() -> None:
+    from superset.db_engine_specs.aws_iam import AWSIAMAuthMixin
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": True,
+                "role_arn": "arn:aws:iam::222222222222:role/CrossAccountRedshift",
+                "external_id": "superset-prod-12345",
+                "region": "us-west-2",
+                "workgroup_name": "prod-workgroup",
+                "db_name": "analytics",
+                "session_duration": 1800,
+            }
+        }
+    )
+    database.sqlalchemy_uri_decrypted = (
+        "redshift+psycopg2://user@prod-workgroup.222222222222.us-west-2"
+        ".redshift-serverless.amazonaws.com:5439/analytics"
+    )
+
+    params: dict[str, Any] = {}
+
+    with (
+        patch.object(
+            AWSIAMAuthMixin,
+            "get_iam_credentials",
+            return_value={
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "secret...",
+                "SessionToken": "token...",
+            },
+        ) as mock_get_creds,
+        patch.object(
+            AWSIAMAuthMixin,
+            "generate_redshift_credentials",
+            return_value=("IAM:admin", "redshift-temp-password"),
+        ),
+    ):
+        RedshiftEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    mock_get_creds.assert_called_once_with(
+        role_arn="arn:aws:iam::222222222222:role/CrossAccountRedshift",
+        region="us-west-2",
+        external_id="superset-prod-12345",
+        session_duration=1800,
+    )
+
+
+def test_redshift_update_params_merges_remaining_encrypted_extra() -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "aws_iam": {"enabled": False},
+            "pool_size": 5,
+        }
+    )
+
+    params: dict[str, Any] = {}
+    RedshiftEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "aws_iam" not in params
+    assert params["pool_size"] == 5
+
+
+def test_redshift_update_params_invalid_json() -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    database = MagicMock()
+    database.encrypted_extra = "not-valid-json"
+
+    params: dict[str, Any] = {}
+
+    with pytest.raises(json.JSONDecodeError):
+        RedshiftEngineSpec.update_params_from_encrypted_extra(database, params)
+
+
+def test_redshift_mask_encrypted_extra() -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    encrypted_extra = json.dumps(
+        {
+            "aws_iam": {
+                "enabled": True,
+                "role_arn": "arn:aws:iam::123456789012:role/SecretRole",
+                "external_id": "secret-external-id-12345",
+                "region": "us-east-1",
+                "workgroup_name": "my-workgroup",
+                "db_name": "dev",
+            }
+        }
+    )
+
+    masked = RedshiftEngineSpec.mask_encrypted_extra(encrypted_extra)
+    assert masked is not None
+
+    masked_config = json.loads(masked)
+
+    # role_arn and external_id should be masked
+    assert (
+        masked_config["aws_iam"]["role_arn"]
+        != "arn:aws:iam::123456789012:role/SecretRole"
+    )
+    assert masked_config["aws_iam"]["external_id"] != "secret-external-id-12345"
+
+    # Non-sensitive fields should remain unchanged
+    assert masked_config["aws_iam"]["enabled"] is True
+    assert masked_config["aws_iam"]["region"] == "us-east-1"
+    assert masked_config["aws_iam"]["workgroup_name"] == "my-workgroup"
+    assert masked_config["aws_iam"]["db_name"] == "dev"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds AWS cross-account IAM authentication support for Aurora PostgreSQL, Aurora MySQL, Redshift Serverless, and provisioned Redshift clusters. This eliminates the need to store long-lived database credentials in Superset by using AWS STS AssumeRole to obtain temporary credentials.

#### Key changes:

- New `AWSIAMAuthMixin` class in `superset/db_engine_specs/aws_iam.py` that handles:
  - Cross-account role assumption via STS AssumeRole
  - RDS IAM auth token generation for Aurora databases
  - Redshift credential generation for both Serverless and provisioned clusters
  - Credential caching (50-min TTL) to reduce STS API calls
  - Actionable error messages for common IAM misconfigurations
- Updated engine specs (`PostgresEngineSpec`, `MySQLEngineSpec`, `RedshiftEngineSpec`) to support IAM auth via `encrypted_extra configuration`
- New `AuroraPostgresEngineSpec` and `AuroraMySQLEngineSpec` classes for explicit Aurora support
- Sensitive field masking for `role_arn` and `external_id` in the UI

#### Configuration example:

```json
  {
    "aws_iam": {
      "enabled": true,
      "role_arn": "arn:aws:iam::DATA_ACCOUNT_ID:role/SupersetDatabaseAccess",
      "external_id": "your-unique-external-id",
      "region": "us-east-1",
      "db_username": "superset_iam_user"
    }
  }
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
