### PR TITLE
fix(deckgl): remove dataset field from Deck.gl Layer Visibility Display controls

### DIFF
--- a/superset-frontend/src/chartCustomizations/components/DeckglLayerVisibility/index.ts
+++ b/superset-frontend/src/chartCustomizations/components/DeckglLayerVisibility/index.ts
@@ -31,6 +31,7 @@ export default class DeckglLayerVisibilityCustomizationPlugin extends ChartPlugi
       tags: [t('Deckgl'), t('Experimental')],
       thumbnail: '',
       enableNoResults: false,
+      datasourceCount: 0,
     });
 
     super({


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The selected dataset doesn't matter in multi layer deck.gl charts, so we shouldn't have the dataset select field when creating the Deck.gl Layer Visibility Display control.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="884" height="483" alt="Screenshot 2026-02-02 at 15 21 36" src="https://github.com/user-attachments/assets/7eeebd37-de16-4186-a89c-57009937ffd8" />

After:
<img width="882" height="406" alt="Screenshot 2026-02-02 at 15 18 25" src="https://github.com/user-attachments/assets/77deec8f-1615-4294-be87-c1e6ac4f5c9b" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
