### PR TITLE
fix(sqllab): pass queryLimit on data preview queries and fix Decimal TypeError in results handler

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -46,6 +46,7 @@ import type { QueryEditor, SqlLabRootState, Table } from '../types';
 import { newQueryTabName } from '../utils/newQueryTabName';
 import getInitialState from '../reducers/getInitialState';
 import { rehydratePersistedState } from '../utils/reduxStateToLocalStorageHelper';
+import { PREVIEW_QUERY_LIMIT } from '../constants';
 
 // Type definitions for SqlLab actions
 export interface Query {
@@ -1317,6 +1318,7 @@ export function runTablePreviewQuery(
         runAsync: database.allow_run_async,
         ctas: false,
         isDataPreview: true,
+        queryLimit: PREVIEW_QUERY_LIMIT,
       };
       if (runPreviewOnly) {
         return dispatch(runQuery(dataPreviewQuery, runPreviewOnly));

--- a/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
@@ -41,6 +41,7 @@ import {
   useTableMetadataQuery,
 } from 'src/hooks/apiResources';
 import { runTablePreviewQuery } from 'src/SqlLab/actions/sqlLab';
+import { PREVIEW_QUERY_LIMIT } from 'src/SqlLab/constants';
 import { ActionButton } from '@superset-ui/core/components/ActionButton';
 import ResultSet from '../ResultSet';
 import ShowSQL from '../ShowSQL';
@@ -63,7 +64,6 @@ const TABS_KEYS = {
   SAMPLE: 'sample',
 };
 const TAB_HEADER_HEIGHT = 80;
-const PREVIEW_QUERY_LIMIT = 100;
 
 const Title = styled.div`
   ${({ theme }) => css`

--- a/superset-frontend/src/SqlLab/constants.ts
+++ b/superset-frontend/src/SqlLab/constants.ts
@@ -87,6 +87,8 @@ export const LOCALSTORAGE_MAX_QUERY_RESULTS_KB = 1 * 1024; // 1M
 export const LOCALSTORAGE_WARNING_THRESHOLD = 0.9;
 export const LOCALSTORAGE_WARNING_MESSAGE_THROTTLE_MS = 8000; // danger type toast duration
 
+export const PREVIEW_QUERY_LIMIT = 100;
+
 // autocomplete score weights
 export const SQL_KEYWORD_AUTOCOMPLETE_SCORE = 100;
 export const SQL_FUNCTIONS_AUTOCOMPLETE_SCORE = 90;

--- a/superset/commands/sql_lab/results.py
+++ b/superset/commands/sql_lab/results.py
@@ -94,7 +94,7 @@ class SqlExecutionResultsCommand(BaseCommand):
         if not self._blob:
             # Query exists in DB but results not in S3 - enhanced diagnostics
             query_age_seconds = now_as_float() - (
-                self._query.end_time if self._query.end_time else now_as_float()
+                float(self._query.end_time) if self._query.end_time else now_as_float()
             )
             logger.warning(
                 "410 Error - Query exists in DB but results not in results backend"


### PR DESCRIPTION
### SUMMARY
The data preview tab in SQL Lab was spinning forever on large tables due to two compounding bugs:

1. `runTablePreviewQuery` never set `queryLimit` on the query payload, so the backend fell back to `SQL_MAX_ROW` (default 100,000) instead of the intended 100-row preview limit. This caused `LIMIT 100001` on the actual DB query.

2. When the oversized result failed to persist in the results backend, the error handler in `SqlExecutionResultsCommand.validate()` crashed with a TypeError attempting to subtract a `decimal.Decimal` (from the SQLAlchemy Numeric column) from a `float`, masking the 410 error as a 500 and leaving the frontend spinner running indefinitely.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->


<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/37612
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
