### PR TITLE
feat(mcp): add config toggle to disable parse_request decorator

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -136,6 +136,11 @@ General usage tips:
 - All tools return structured, Pydantic-typed responses
 - Chart previews are served as PNG images via custom screenshot endpoints
 
+Input format:
+- Tool request parameters accept structured objects (dicts/JSON)
+- When MCP_PARSE_REQUEST_ENABLED is True (default), string-serialized JSON is also
+  accepted as input, which works around double-serialization bugs in some MCP clients
+
 If you are unsure which tool to use, start with get_instance_info
 or use the quickstart prompt for an interactive guide.
 """

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -45,6 +45,13 @@ MCP_SERVICE_PORT = 5008
 # MCP Debug mode - shows suppressed initialization output in stdio mode
 MCP_DEBUG = False
 
+# Enable parse_request decorator for MCP tools.
+# When True (default), tool requests are automatically parsed from JSON strings
+# to Pydantic models, working around a Claude Code double-serialization bug
+# (https://github.com/anthropics/claude-code/issues/5504).
+# Set to False to disable and let FastMCP handle request parsing natively.
+MCP_PARSE_REQUEST_ENABLED = True
+
 # Session configuration for local development
 MCP_SESSION_CONFIG = {
     "SESSION_COOKIE_HTTPONLY": True,

--- a/superset/mcp_service/utils/schema_utils.py
+++ b/superset/mcp_service/utils/schema_utils.py
@@ -389,14 +389,14 @@ def _is_parse_request_enabled() -> bool:
         from flask import current_app, has_app_context
 
         if has_app_context():
-            return current_app.config.get("MCP_PARSE_REQUEST_ENABLED", True)
-    except (ImportError, RuntimeError):
+            return bool(current_app.config["MCP_PARSE_REQUEST_ENABLED"])
+    except (ImportError, RuntimeError, KeyError):
         pass
     try:
         from superset.mcp_service.flask_singleton import app as flask_app
 
-        return flask_app.config.get("MCP_PARSE_REQUEST_ENABLED", True)
-    except (ImportError, RuntimeError, AttributeError):
+        return bool(flask_app.config["MCP_PARSE_REQUEST_ENABLED"])
+    except (ImportError, RuntimeError, AttributeError, KeyError):
         pass
     return True
 


### PR DESCRIPTION
### SUMMARY

Add `MCP_PARSE_REQUEST_ENABLED` config option (default: `True`) to control whether the `parse_request` decorator applies its string-to-model parsing workaround for MCP tools.

**The problem:** The `parse_request` decorator was introduced to work around a [Claude Code double-serialization bug](https://github.com/anthropics/claude-code/issues/5504) where requests arrive as JSON strings instead of objects. To handle this, tool signatures are annotated as `str | RequestModel`. However, for MCP clients that don't have this bug (Claude Desktop, LangChain, etc.), the `str | RequestModel` union type makes the tool schema less deterministic — the LLM sees two valid input types and may inconsistently choose between them. By disabling `parse_request`, these clients get clean `RequestModel`-only signatures, which leads to more reliable tool calling.

**Changes:**
- Add `MCP_PARSE_REQUEST_ENABLED = True` default in `mcp_config.py`
- When `False`, string-to-model parsing is skipped but `ctx` injection and signature stripping still apply (tools don't break)
- When `False`, tool signatures use `RequestModel` instead of `str | RequestModel`
- Extract signature manipulation into helpers (`_apply_signature_for_fastmcp`, `_is_context_param`) to satisfy C901 complexity limit
- Add input format note to LLM instructions

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - no UI changes

### TESTING INSTRUCTIONS
1. **Default behavior (enabled):** Verify MCP tools continue to accept both JSON string and object requests as before
2. **Disabled:** Set `MCP_PARSE_REQUEST_ENABLED = False` in `superset_config.py`, restart MCP service, verify tools work with clean `RequestModel` signatures (no `| str` union in schema)
3. **Verify with Claude Desktop or LangChain:** Confirm tool calls are more deterministic with the config disabled

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API