### PR TITLE
chore(mcp): remove unused MCP_SERVICE feature flag

### DIFF
--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -33,11 +33,6 @@ SUPERSET_WEBSERVER_ADDRESS = "http://localhost:9001"
 WEBDRIVER_BASEURL = "http://localhost:9001/"
 WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 
-# Feature flags for MCP
-MCP_FEATURE_FLAGS: Dict[str, Any] = {
-    "MCP_SERVICE": True,
-}
-
 # MCP Service Host/Port
 MCP_SERVICE_HOST = "localhost"
 MCP_SERVICE_PORT = 5008


### PR DESCRIPTION
### SUMMARY
The `MCP_FEATURE_FLAGS` dict in `superset/mcp_service/mcp_config.py` contained a single `MCP_SERVICE: True` flag that was never imported or referenced anywhere in the codebase. This PR removes the unused dict to reduce dead code.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - no UI changes.

### TESTING INSTRUCTIONS
1. Verify the MCP service starts and functions correctly without the removed flag
2. Grep the codebase for `MCP_FEATURE_FLAGS` — should have zero results

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [x] Removes existing feature or API