### PR TITLE
fix(dataset-editor): include calculated columns in currency code dropdown

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -1092,8 +1092,13 @@ class DatasourceEditor extends PureComponent {
       }));
 
     // Get string-type columns for the currency code dropdown
+    // Include calculated columns (identified by truthy expression) even when
+    // type_generic is unresolved, since the backend only populates type metadata
+    // for physical columns. Currency detection handles invalid codes gracefully.
     const stringColumns = allColumns
-      .filter(col => col.type_generic === GenericDataType.String)
+      .filter(
+        col => col.type_generic === GenericDataType.String || col.expression,
+      )
       .map(col => ({
         value: col.column_name,
         label: col.verbose_name || col.column_name,

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -1091,13 +1091,12 @@ class DatasourceEditor extends PureComponent {
         label: col.verbose_name || col.column_name,
       }));
 
-    // Get string-type columns for the currency code dropdown
-    // Include calculated columns (identified by truthy expression) even when
-    // type_generic is unresolved, since the backend only populates type metadata
-    // for physical columns. Currency detection handles invalid codes gracefully.
+    // String columns + untyped calculated columns for the currency code dropdown
     const stringColumns = allColumns
       .filter(
-        col => col.type_generic === GenericDataType.String || col.expression,
+        col =>
+          col.type_generic === GenericDataType.String ||
+          (col.expression && col.type_generic == null),
       )
       .map(col => ({
         value: col.column_name,

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
@@ -138,7 +138,7 @@ test('changes currency symbol from USD to GBP', async () => {
   expect(updatedMetric?.currency?.symbolPosition).toBe('prefix');
 }, 60000);
 
-test('currency code column dropdown shows string and calculated columns but excludes numeric columns', async () => {
+test('currency code column dropdown shows string and untyped calculated columns but excludes numeric and typed non-string calculated columns', async () => {
   const baseProps = createProps();
   const testProps = {
     ...baseProps,
@@ -179,6 +179,17 @@ test('currency code column dropdown shows string and calculated columns but excl
           groupby: true,
           column_name: 'derived_currency',
         },
+        {
+          id: 103,
+          type: 'NUMERIC',
+          type_generic: GenericDataType.Numeric,
+          filterable: true,
+          is_dttm: false,
+          is_active: true,
+          expression: 'price * quantity',
+          groupby: false,
+          column_name: 'total_amount',
+        },
         ...baseProps.datasource.columns,
       ],
     },
@@ -215,9 +226,15 @@ test('currency code column dropdown shows string and calculated columns but excl
   );
   expect(derivedCurrencyOption).toBeDefined();
 
-  // Verify NUMERIC column is NOT available
+  // Verify NUMERIC physical column is NOT available
   const amountOption = Array.from(options).find(o =>
     o.textContent?.includes('amount'),
   );
   expect(amountOption).toBeUndefined();
+
+  // Verify NUMERIC calculated column is also NOT available
+  const totalAmountOption = Array.from(options).find(o =>
+    o.textContent?.includes('total_amount'),
+  );
+  expect(totalAmountOption).toBeUndefined();
 }, 60000);

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
@@ -226,15 +226,9 @@ test('currency code column dropdown shows string and untyped calculated columns 
   );
   expect(derivedCurrencyOption).toBeDefined();
 
-  // Verify NUMERIC physical column is NOT available
-  const amountOption = Array.from(options).find(o =>
-    o.textContent?.includes('amount'),
+  // Verify NUMERIC columns (physical and calculated) are NOT available
+  const numericOptions = Array.from(options).filter(o =>
+    ['amount', 'total_amount'].includes(o.textContent?.trim() ?? ''),
   );
-  expect(amountOption).toBeUndefined();
-
-  // Verify NUMERIC calculated column is also NOT available
-  const totalAmountOption = Array.from(options).find(o =>
-    o.textContent?.includes('total_amount'),
-  );
-  expect(totalAmountOption).toBeUndefined();
+  expect(numericOptions).toHaveLength(0);
 }, 60000);

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
@@ -138,7 +138,7 @@ test('changes currency symbol from USD to GBP', async () => {
   expect(updatedMetric?.currency?.symbolPosition).toBe('prefix');
 }, 60000);
 
-test('currency code column dropdown shows only string columns', async () => {
+test('currency code column dropdown shows string and calculated columns but excludes numeric columns', async () => {
   const baseProps = createProps();
   const testProps = {
     ...baseProps,
@@ -166,6 +166,18 @@ test('currency code column dropdown shows only string columns', async () => {
           expression: '',
           groupby: false,
           column_name: 'amount',
+        },
+        {
+          id: 102,
+          type: null,
+          type_generic: null,
+          filterable: true,
+          is_dttm: false,
+          is_active: true,
+          expression:
+            "CASE WHEN country = 'US' THEN 'USD' ELSE 'EUR' END",
+          groupby: true,
+          column_name: 'derived_currency',
         },
         ...baseProps.datasource.columns,
       ],
@@ -196,8 +208,14 @@ test('currency code column dropdown shows only string columns', async () => {
     expect(currencyCodeOption).toBeDefined();
   });
 
-  // Verify NUMERIC column is NOT available
+  // Verify CALCULATED column is available despite null type_generic
   const options = document.querySelectorAll('.ant-select-item-option');
+  const derivedCurrencyOption = Array.from(options).find(o =>
+    o.textContent?.includes('derived_currency'),
+  );
+  expect(derivedCurrencyOption).toBeDefined();
+
+  // Verify NUMERIC column is NOT available
   const amountOption = Array.from(options).find(o =>
     o.textContent?.includes('amount'),
   );

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
@@ -169,7 +169,7 @@ test('currency code column dropdown shows string and untyped calculated columns 
         },
         {
           id: 102,
-          type: null,
+          type: '',
           type_generic: null,
           filterable: true,
           is_dttm: false,

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.tsx
@@ -174,8 +174,7 @@ test('currency code column dropdown shows string and untyped calculated columns 
           filterable: true,
           is_dttm: false,
           is_active: true,
-          expression:
-            "CASE WHEN country = 'US' THEN 'USD' ELSE 'EUR' END",
+          expression: "CASE WHEN country = 'US' THEN 'USD' ELSE 'EUR' END",
           groupby: true,
           column_name: 'derived_currency',
         },


### PR DESCRIPTION
### SUMMARY

The **Currency code column** dropdown in the Dataset Editor excludes calculated columns that don't have a data type set, even though they are valid choices for currency code mapping (e.g. a `CASE` statement that maps country values to ISO currency codes like `USD`, `EUR`).

**Root cause:** The dropdown filters on `type_generic === GenericDataType.String`, but the backend only resolves `type_generic` for physical columns. Calculated columns without an explicitly set data type have `type_generic` as `null`, so they fail the check.

**Fix:** Include calculated columns whose `type_generic` is `null` (untyped), while still excluding calculated columns the user explicitly typed as NUMERIC, BOOLEAN, or DATETIME via the Data Type dropdown:

```diff
 const stringColumns = allColumns
-  .filter(col => col.type_generic === GenericDataType.String)
+  .filter(
+    col =>
+      col.type_generic === GenericDataType.String ||
+      (col.expression && col.type_generic == null),
+  )
```

Fixes #37620

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before** — calculated column `num_california` is missing from the dropdown:
<img width="882" height="577" alt="before" src="https://github.com/user-attachments/assets/4b91fde3-a7df-4286-a450-25ed608e376e" />

**After** — calculated column `num_california` now appears in the dropdown:
<img width="888" height="389" alt="after" src="https://github.com/user-attachments/assets/1a75c57a-8ec6-4188-9b27-08ede4d0194d" />

### TESTING INSTRUCTIONS

1. Open a dataset in the Dataset Editor (e.g. `birth_names`)
2. Go to the **Calculated columns** tab and verify a calculated column exists (or add one, e.g. `CASE WHEN state = 'CA' THEN 'USD' ELSE 'EUR' END`)
3. In the **Default Column Settings** section at the top, open the **Currency code column** dropdown
4. Verify the calculated column appears in the dropdown alongside the physical string columns
5. Add another calculated column typed as NUMERIC — verify it does **not** appear
6. Verify numeric physical columns (e.g. `num`, `num_boys`) do **not** appear
7. Select the calculated column and click Save — verify it persists

**Unit tests:**
```bash
npm run test -- --testPathPatterns='DatasourceEditorCurrency' --no-coverage
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: #37620
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API