### PR TITLE
fix(tests): update DatasetList tests to new fetch-mock API

### DIFF
--- a/superset-frontend/src/pages/DatasetList/DatasetList.behavior.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.behavior.test.tsx
@@ -136,10 +136,15 @@ test('typing in search triggers debounced API call with search filter', async ()
 test('500 error triggers danger toast with error message', async () => {
   const addDangerToast = jest.fn();
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    status: 500,
-    body: { message: 'Internal Server Error' },
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      status: 500,
+      body: { message: 'Internal Server Error' },
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   // Pass toast spy directly via props to bypass withToasts HOC
   renderDatasetList(mockAdminUser, {
@@ -172,9 +177,12 @@ test('500 error triggers danger toast with error message', async () => {
 test('network timeout triggers danger toast', async () => {
   const addDangerToast = jest.fn();
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    throws: new Error('Network timeout'),
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { throws: new Error('Network timeout') },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   // Pass toast spy directly via props to bypass withToasts HOC
   renderDatasetList(mockAdminUser, {
@@ -211,10 +219,15 @@ test('clicking delete opens modal with related objects count', async () => {
   // Set up delete mocks
   setupDeleteMocks(datasetToDelete.id);
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetToDelete],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetToDelete],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -251,10 +264,15 @@ test('clicking delete opens modal with related objects count', async () => {
 test('clicking export calls handleResourceExport with dataset ID', async () => {
   const datasetToExport = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetToExport],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetToExport],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -284,15 +302,24 @@ test('clicking duplicate opens modal and submits duplicate request', async () =>
     kind: 'virtual',
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetToDuplicate],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetToDuplicate],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
-  fetchMock.post(API_ENDPOINTS.DATASET_DUPLICATE, {
-    id: 999,
-    table_name: 'Copy of Dataset',
-  });
+  fetchMock.post(
+    API_ENDPOINTS.DATASET_DUPLICATE,
+    {
+      id: 999,
+      table_name: 'Copy of Dataset',
+    },
+    { name: API_ENDPOINTS.DATASET_DUPLICATE },
+  );
 
   const addSuccessToast = jest.fn();
 
@@ -371,10 +398,15 @@ test('certified dataset shows badge and tooltip with certification details', asy
     }),
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [certifiedDataset],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [certifiedDataset],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -411,10 +443,15 @@ test('dataset with warning shows icon and tooltip with markdown content', async 
     }),
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetWithWarning],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetWithWarning],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -445,7 +482,12 @@ test('dataset with warning shows icon and tooltip with markdown content', async 
 test('dataset name links to Explore with correct URL and accessible label', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.behavior.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.behavior.test.tsx
@@ -97,7 +97,9 @@ test('typing in search triggers debounced API call with search filter', async ()
   const searchInput = within(searchContainer).getByRole('textbox');
 
   // Record initial API calls
-  const initialCallCount = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS).length;
+  const initialCallCount = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   // Type search query and submit with Enter to trigger the debounced fetch
   await userEvent.type(searchInput, 'sales{enter}');
@@ -134,14 +136,10 @@ test('typing in search triggers debounced API call with search filter', async ()
 test('500 error triggers danger toast with error message', async () => {
   const addDangerToast = jest.fn();
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    {
-      status: 500,
-      body: { message: 'Internal Server Error' },
-    },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    status: 500,
+    body: { message: 'Internal Server Error' },
+  });
 
   // Pass toast spy directly via props to bypass withToasts HOC
   renderDatasetList(mockAdminUser, {
@@ -162,7 +160,7 @@ test('500 error triggers danger toast with error message', async () => {
 
   // Verify toast message contains error keywords
   expect(addDangerToast.mock.calls.length).toBeGreaterThan(0);
-  const toastMessage = String(addDangerToast.mock.calls[0].url);
+  const toastMessage = String(addDangerToast.mock.calls[0][0]);
   expect(
     toastMessage.includes('error') ||
       toastMessage.includes('Error') ||
@@ -174,11 +172,9 @@ test('500 error triggers danger toast with error message', async () => {
 test('network timeout triggers danger toast', async () => {
   const addDangerToast = jest.fn();
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { throws: new Error('Network timeout') },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    throws: new Error('Network timeout'),
+  });
 
   // Pass toast spy directly via props to bypass withToasts HOC
   renderDatasetList(mockAdminUser, {
@@ -199,7 +195,7 @@ test('network timeout triggers danger toast', async () => {
 
   // Verify toast message contains timeout/network keywords
   expect(addDangerToast.mock.calls.length).toBeGreaterThan(0);
-  const toastMessage = String(addDangerToast.mock.calls[0].url);
+  const toastMessage = String(addDangerToast.mock.calls[0][0]);
   expect(
     toastMessage.includes('timeout') ||
       toastMessage.includes('Timeout') ||
@@ -215,11 +211,10 @@ test('clicking delete opens modal with related objects count', async () => {
   // Set up delete mocks
   setupDeleteMocks(datasetToDelete.id);
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [datasetToDelete], count: 1 },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [datasetToDelete],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -256,11 +251,10 @@ test('clicking delete opens modal with related objects count', async () => {
 test('clicking export calls handleResourceExport with dataset ID', async () => {
   const datasetToExport = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [datasetToExport], count: 1 },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [datasetToExport],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -290,17 +284,15 @@ test('clicking duplicate opens modal and submits duplicate request', async () =>
     kind: 'virtual',
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [datasetToDuplicate], count: 1 },
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [datasetToDuplicate],
+    count: 1,
+  });
 
-  );
-
-  fetchMock.post(
-    API_ENDPOINTS.DATASET_DUPLICATE,
-    { id: 999, table_name: 'Copy of Dataset' },
-
-  );
+  fetchMock.post(API_ENDPOINTS.DATASET_DUPLICATE, {
+    id: 999,
+    table_name: 'Copy of Dataset',
+  });
 
   const addSuccessToast = jest.fn();
 
@@ -379,11 +371,10 @@ test('certified dataset shows badge and tooltip with certification details', asy
     }),
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [certifiedDataset], count: 1 },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [certifiedDataset],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -420,11 +411,10 @@ test('dataset with warning shows icon and tooltip with markdown content', async 
     }),
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [datasetWithWarning], count: 1 },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [datasetWithWarning],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -455,11 +445,7 @@ test('dataset with warning shows icon and tooltip with markdown content', async 
 test('dataset name links to Explore with correct URL and accessible label', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
@@ -62,8 +62,8 @@ afterEach(async () => {
   // Reset browser history state to prevent query params leaking between tests
   window.history.replaceState({}, '', '/');
 
-  fetchMock.resetHistory();
-  fetchMock.restore();
+  fetchMock.clearHistory();
+  fetchMock.removeRoutes();
   jest.restoreAllMocks();
 });
 
@@ -72,11 +72,10 @@ test('ListView provider correctly merges filter + sort + pagination state on ref
   // the ListView provider correctly merges them for the API call.
   // Component tests verify individual pieces persist; this verifies they COMBINE correctly.
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: mockDatasets, count: mockDatasets.length },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: mockDatasets,
+    count: mockDatasets.length,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -90,30 +89,34 @@ test('ListView provider correctly merges filter + sort + pagination state on ref
     name: /Name/i,
   });
 
-  const callsBeforeSort = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const callsBeforeSort = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
   await userEvent.click(nameHeader);
 
   // Wait for sort-triggered refetch to complete before applying filter
   await waitFor(() => {
-    expect(fetchMock.calls(API_ENDPOINTS.DATASETS).length).toBeGreaterThan(
-      callsBeforeSort,
-    );
+    expect(
+      fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS).length,
+    ).toBeGreaterThan(callsBeforeSort);
   });
 
   // 2. Apply a filter using selectOption helper
-  const beforeFilterCallCount = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const beforeFilterCallCount = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
   await selectOption('Virtual', 'Type');
 
   // Wait for filter API call to complete
   await waitFor(() => {
-    const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+    const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
     expect(calls.length).toBeGreaterThan(beforeFilterCallCount);
   });
 
   // 3. Verify the final API call contains ALL three state pieces merged correctly
-  const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+  const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
   const latestCall = calls[calls.length - 1];
-  const url = latestCall[0] as string;
+  const url = latestCall.url as string;
 
   // Decode the rison payload using URL parser
   const risonPayload = new URL(url, 'http://localhost').searchParams.get('q');
@@ -147,11 +150,10 @@ test('bulk action orchestration: selection → action → cleanup cycle works co
 
   setupBulkDeleteMocks();
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: mockDatasets, count: mockDatasets.length },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: mockDatasets,
+    count: mockDatasets.length,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -213,7 +215,7 @@ test('bulk action orchestration: selection → action → cleanup cycle works co
   await userEvent.type(confirmInput, 'DELETE');
 
   // Capture datasets call count before confirming
-  const datasetsCallCountBeforeDelete = fetchMock.calls(
+  const datasetsCallCountBeforeDelete = fetchMock.callHistory.calls(
     API_ENDPOINTS.DATASETS,
   ).length;
 
@@ -224,7 +226,9 @@ test('bulk action orchestration: selection → action → cleanup cycle works co
 
   // 3. Wait for bulk delete API call to be made
   await waitFor(() => {
-    const deleteCalls = fetchMock.calls(API_ENDPOINTS.DATASET_BULK_DELETE);
+    const deleteCalls = fetchMock.callHistory.calls(
+      API_ENDPOINTS.DATASET_BULK_DELETE,
+    );
     expect(deleteCalls.length).toBeGreaterThan(0);
   });
 
@@ -235,7 +239,9 @@ test('bulk action orchestration: selection → action → cleanup cycle works co
 
   // Wait for datasets refetch after delete
   await waitFor(() => {
-    const datasetsCallCount = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+    const datasetsCallCount = fetchMock.callHistory.calls(
+      API_ENDPOINTS.DATASETS,
+    ).length;
     expect(datasetsCallCount).toBeGreaterThan(datasetsCallCountBeforeDelete);
   });
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
@@ -33,6 +33,7 @@ import {
   mockHandleResourceExport,
   assertOnlyExpectedCalls,
   API_ENDPOINTS,
+  DELETE_ROUTE_NAME,
 } from './DatasetList.testHelpers';
 
 const mockAddDangerToast = jest.fn();
@@ -112,7 +113,12 @@ const setupErrorTestScenario = ({
   });
 
   // Configure fetchMock to return single dataset
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   // Render component with toast mocks
   renderDatasetList(mockAdminUser, {
@@ -195,7 +201,12 @@ test('renders all required column headers', async () => {
 test('displays dataset name in Name column', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -208,10 +219,15 @@ test('displays dataset type as Physical or Virtual', async () => {
   const physicalDataset = mockDatasets[0]; // kind: 'physical'
   const virtualDataset = mockDatasets[1]; // kind: 'virtual'
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [physicalDataset, virtualDataset],
-    count: 2,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [physicalDataset, virtualDataset],
+      count: 2,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -225,7 +241,12 @@ test('displays dataset type as Physical or Virtual', async () => {
 test('displays database name in Database column', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -239,7 +260,12 @@ test('displays database name in Database column', async () => {
 test('displays schema name in Schema column', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -251,7 +277,12 @@ test('displays schema name in Schema column', async () => {
 test('displays last modified date in humanized format', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -356,7 +387,12 @@ test('sorting by Last modified column updates sort parameter', async () => {
 test('export button triggers handleResourceExport with dataset ID', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -384,7 +420,12 @@ test('delete button opens modal with dataset details', async () => {
 
   setupDeleteMocks(dataset.id);
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -406,10 +447,15 @@ test('delete action successfully deletes dataset and refreshes list', async () =
   const datasetToDelete = mockDatasets[0];
   setupDeleteMocks(datasetToDelete.id);
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetToDelete],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetToDelete],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser, {
     addSuccessToast: mockAddSuccessToast,
@@ -443,13 +489,8 @@ test('delete action successfully deletes dataset and refreshes list', async () =
 
   // Wait for delete API call
   await waitFor(() => {
-    const deleteCalls = fetchMock.callHistory.calls(
-      `glob:*/api/v1/dataset/${datasetToDelete.id}`,
-    );
-    const hasDelete = deleteCalls.some(
-      call => (call.options as RequestInit)?.method === 'DELETE',
-    );
-    expect(hasDelete).toBe(true);
+    const deleteCalls = fetchMock.callHistory.calls(DELETE_ROUTE_NAME);
+    expect(deleteCalls.length).toBeGreaterThan(0);
   });
 
   // Success toast shown and modal closes
@@ -470,7 +511,12 @@ test('delete action cancel closes modal without deleting', async () => {
   const dataset = mockDatasets[0];
   setupDeleteMocks(dataset.id);
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -510,7 +556,12 @@ test('duplicate action successfully duplicates virtual dataset', async () => {
   const virtualDataset = mockDatasets[1]; // Virtual dataset (kind: 'virtual')
   setupDuplicateMocks();
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [virtualDataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [virtualDataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser, {
     addSuccessToast: mockAddSuccessToast,
@@ -564,10 +615,15 @@ test('duplicate button visible only for virtual datasets', async () => {
   const physicalDataset = mockDatasets[0]; // kind: 'physical'
   const virtualDataset = mockDatasets[1]; // kind: 'virtual'
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [physicalDataset, virtualDataset],
-    count: 2,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [physicalDataset, virtualDataset],
+      count: 2,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -623,10 +679,15 @@ test('bulk select enables checkboxes', async () => {
 }, 30000);
 
 test('selecting all datasets shows correct count in toolbar', async () => {
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: mockDatasets,
-    count: mockDatasets.length,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: mockDatasets,
+      count: mockDatasets.length,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -662,10 +723,15 @@ test('selecting all datasets shows correct count in toolbar', async () => {
 }, 30000);
 
 test('bulk export triggers export with selected IDs', async () => {
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [mockDatasets[0]],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [mockDatasets[0]],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -704,10 +770,15 @@ test('bulk export triggers export with selected IDs', async () => {
 test('bulk delete opens confirmation modal', async () => {
   setupBulkDeleteMocks();
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [mockDatasets[0]],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [mockDatasets[0]],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -810,10 +881,15 @@ test('certified badge appears for certified datasets', async () => {
     }),
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [certifiedDataset],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [certifiedDataset],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -840,10 +916,15 @@ test('warning icon appears for datasets with warnings', async () => {
     }),
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetWithWarning],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetWithWarning],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -868,10 +949,15 @@ test('info tooltip appears for datasets with descriptions', async () => {
     description: 'Sales data from Q4 2024',
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetWithDescription],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetWithDescription],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -893,7 +979,12 @@ test('info tooltip appears for datasets with descriptions', async () => {
 test('dataset name links to Explore page', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -913,10 +1004,15 @@ test('dataset name links to Explore page', async () => {
 test('physical dataset shows delete, export, and edit actions (no duplicate)', async () => {
   const physicalDataset = mockDatasets[0]; // kind: 'physical'
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [physicalDataset],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [physicalDataset],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -944,7 +1040,12 @@ test('physical dataset shows delete, export, and edit actions (no duplicate)', a
 test('virtual dataset shows delete, export, edit, and duplicate actions', async () => {
   const virtualDataset = mockDatasets[1]; // kind: 'virtual'
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [virtualDataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [virtualDataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -973,7 +1074,12 @@ test('edit action is enabled for dataset owner', async () => {
     owners: [{ id: mockAdminUser.userId, username: 'admin' }],
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -996,7 +1102,12 @@ test('edit action is disabled for non-owner', async () => {
     owners: [{ id: 999, username: 'other_user' }], // Different user
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   // Use a non-admin user to test ownership check
   const regularUser = {
@@ -1025,7 +1136,12 @@ test('all action buttons are clickable and enabled for admin user', async () => 
     owners: [{ id: mockAdminUser.userId, username: 'admin' }],
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [virtualDataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [virtualDataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -1060,10 +1176,15 @@ test('all action buttons are clickable and enabled for admin user', async () => 
 });
 
 test('displays error when initial dataset fetch fails with 500', async () => {
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    status: 500,
-    body: { message: 'Internal Server Error' },
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      status: 500,
+      body: { message: 'Internal Server Error' },
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: mockAddDangerToast,
@@ -1081,10 +1202,15 @@ test('displays error when initial dataset fetch fails with 500', async () => {
 });
 
 test('displays error when initial dataset fetch fails with 403 permission denied', async () => {
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    status: 403,
-    body: { message: 'Access Denied' },
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      status: 403,
+      body: { message: 'Access Denied' },
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: mockAddDangerToast,
@@ -1428,10 +1554,15 @@ test('sort order persists after deleting a dataset', async () => {
 // test. Component tests here focus on individual behaviors.
 
 test('bulk selection clears when filter changes', async () => {
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: mockDatasets,
-    count: mockDatasets.length,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: mockDatasets,
+      count: mockDatasets.length,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -1691,7 +1822,12 @@ test('edit action shows error toast when dataset fetch fails', async () => {
     ],
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [ownedDataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [ownedDataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   // Mock SupersetClient.get to fail for the specific dataset endpoint
   jest.spyOn(SupersetClient, 'get').mockImplementation(async request => {
@@ -1734,10 +1870,15 @@ test('bulk export error shows toast and clears loading state', async () => {
   // Mock handleResourceExport to throw an error
   mockHandleResourceExport.mockRejectedValueOnce(new Error('Export failed'));
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [mockDatasets[0]],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [mockDatasets[0]],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: mockAddDangerToast,
@@ -1798,10 +1939,15 @@ test('bulk delete error shows toast without refreshing list', async () => {
     body: { message: 'Bulk delete failed' },
   });
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [mockDatasets[0]],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [mockDatasets[0]],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: mockAddDangerToast,
@@ -1874,10 +2020,15 @@ test('bulk select shows "N Selected (Virtual)" for virtual-only selection', asyn
   // Use only virtual datasets
   const virtualDatasets = mockDatasets.filter(d => d.kind === 'virtual');
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: virtualDatasets,
-    count: virtualDatasets.length,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: virtualDatasets,
+      count: virtualDatasets.length,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -1920,10 +2071,15 @@ test('bulk select shows "N Selected (Physical)" for physical-only selection', as
   // Use only physical datasets
   const physicalDatasets = mockDatasets.filter(d => d.kind === 'physical');
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: physicalDatasets,
-    count: physicalDatasets.length,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: physicalDatasets,
+      count: physicalDatasets.length,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -1970,10 +2126,15 @@ test('bulk select shows mixed count for virtual and physical selection', async (
     mockDatasets.find(d => d.kind === 'virtual')!,
   ];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: mixedDatasets,
-    count: mixedDatasets.length,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: mixedDatasets,
+      count: mixedDatasets.length,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -2033,7 +2194,12 @@ test('delete modal shows affected dashboards with overflow for >10 items', async
     title: `Dashboard ${i + 1}`,
   }));
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   fetchMock.get(`glob:*/api/v1/dataset/${dataset.id}/related_objects*`, {
     charts: { count: 0, result: [] },
@@ -2070,7 +2236,12 @@ test('delete modal shows affected dashboards with overflow for >10 items', async
 test('delete modal hides affected dashboards section when count is zero', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   fetchMock.get(`glob:*/api/v1/dataset/${dataset.id}/related_objects*`, {
     charts: { count: 2, result: [{ id: 1, slice_name: 'Chart 1' }] },
@@ -2108,7 +2279,12 @@ test('delete modal shows affected charts with overflow for >10 items', async () 
     slice_name: `Chart ${i + 1}`,
   }));
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   fetchMock.get(`glob:*/api/v1/dataset/${dataset.id}/related_objects*`, {
     charts: { count: 12, result: manyCharts },

--- a/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
@@ -112,11 +112,7 @@ const setupErrorTestScenario = ({
   });
 
   // Configure fetchMock to return single dataset
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   // Render component with toast mocks
   renderDatasetList(mockAdminUser, {
@@ -143,8 +139,8 @@ afterEach(async () => {
   // QueryParamProvider reads from window.history, which persists across renders
   window.history.replaceState({}, '', '/');
 
-  fetchMock.resetHistory();
-  fetchMock.restore();
+  fetchMock.clearHistory();
+  fetchMock.removeRoutes();
   jest.restoreAllMocks();
 });
 
@@ -199,11 +195,7 @@ test('renders all required column headers', async () => {
 test('displays dataset name in Name column', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -216,11 +208,10 @@ test('displays dataset type as Physical or Virtual', async () => {
   const physicalDataset = mockDatasets[0]; // kind: 'physical'
   const virtualDataset = mockDatasets[1]; // kind: 'virtual'
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [physicalDataset, virtualDataset], count: 2 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [physicalDataset, virtualDataset],
+    count: 2,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -234,11 +225,7 @@ test('displays dataset type as Physical or Virtual', async () => {
 test('displays database name in Database column', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -252,11 +239,7 @@ test('displays database name in Database column', async () => {
 test('displays schema name in Schema column', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -268,11 +251,7 @@ test('displays schema name in Schema column', async () => {
 test('displays last modified date in humanized format', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -296,21 +275,23 @@ test('sorting by Name column updates API call with sort parameter', async () => 
   });
 
   // Record initial calls
-  const initialCalls = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const initialCalls = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   // Click Name header to sort
   await userEvent.click(nameHeader);
 
   // Wait for new API call
   await waitFor(() => {
-    const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+    const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
     expect(calls.length).toBeGreaterThan(initialCalls);
   });
 
   // Verify latest call includes sort parameter
-  const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+  const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
   const latestCall = calls[calls.length - 1];
-  const url = latestCall[0] as string;
+  const url = latestCall.url as string;
 
   // URL should contain order_column for sorting
   expect(url).toMatch(/order_column|sort/);
@@ -328,17 +309,19 @@ test('sorting by Database column updates sort parameter', async () => {
     name: /Database/i,
   });
 
-  const initialCalls = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const initialCalls = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   await userEvent.click(databaseHeader);
 
   await waitFor(() => {
-    const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+    const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
     expect(calls.length).toBeGreaterThan(initialCalls);
   });
 
-  const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
-  const url = calls[calls.length - 1][0] as string;
+  const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
+  const url = calls[calls.length - 1].url as string;
   expect(url).toMatch(/order_column|sort/);
 });
 
@@ -354,28 +337,26 @@ test('sorting by Last modified column updates sort parameter', async () => {
     name: /Last modified/i,
   });
 
-  const initialCalls = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const initialCalls = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   await userEvent.click(modifiedHeader);
 
   await waitFor(() => {
-    const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+    const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
     expect(calls.length).toBeGreaterThan(initialCalls);
   });
 
-  const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
-  const url = calls[calls.length - 1][0] as string;
+  const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
+  const url = calls[calls.length - 1].url as string;
   expect(url).toMatch(/order_column|sort/);
 });
 
 test('export button triggers handleResourceExport with dataset ID', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -403,11 +384,7 @@ test('delete button opens modal with dataset details', async () => {
 
   setupDeleteMocks(dataset.id);
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -429,11 +406,10 @@ test('delete action successfully deletes dataset and refreshes list', async () =
   const datasetToDelete = mockDatasets[0];
   setupDeleteMocks(datasetToDelete.id);
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [datasetToDelete], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [datasetToDelete],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser, {
     addSuccessToast: mockAddSuccessToast,
@@ -455,7 +431,9 @@ test('delete action successfully deletes dataset and refreshes list', async () =
   await userEvent.type(confirmInput, 'DELETE');
 
   // Track API calls before confirm
-  const callsBefore = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const callsBefore = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   // Click confirm - find the danger button (last delete button in modal)
   const confirmButton = within(modal)
@@ -465,11 +443,11 @@ test('delete action successfully deletes dataset and refreshes list', async () =
 
   // Wait for delete API call
   await waitFor(() => {
-    const deleteCalls = fetchMock.calls(
+    const deleteCalls = fetchMock.callHistory.calls(
       `glob:*/api/v1/dataset/${datasetToDelete.id}`,
     );
     const hasDelete = deleteCalls.some(
-      call => (call[1] as RequestInit)?.method === 'DELETE',
+      call => (call.options as RequestInit)?.method === 'DELETE',
     );
     expect(hasDelete).toBe(true);
   });
@@ -482,9 +460,9 @@ test('delete action successfully deletes dataset and refreshes list', async () =
 
   // List refreshes
   await waitFor(() => {
-    expect(fetchMock.calls(API_ENDPOINTS.DATASETS).length).toBeGreaterThan(
-      callsBefore,
-    );
+    expect(
+      fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS).length,
+    ).toBeGreaterThan(callsBefore);
   });
 });
 
@@ -492,11 +470,7 @@ test('delete action cancel closes modal without deleting', async () => {
   const dataset = mockDatasets[0];
   setupDeleteMocks(dataset.id);
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -520,9 +494,11 @@ test('delete action cancel closes modal without deleting', async () => {
   });
 
   // No delete API call made (only related_objects GET was called)
-  const deleteCalls = fetchMock.calls(`glob:*/api/v1/dataset/${dataset.id}`);
+  const deleteCalls = fetchMock.callHistory.calls(
+    `glob:*/api/v1/dataset/${dataset.id}`,
+  );
   const hasDeleteMethod = deleteCalls.some(
-    call => (call[1] as RequestInit)?.method === 'DELETE',
+    call => (call.options as RequestInit)?.method === 'DELETE',
   );
   expect(hasDeleteMethod).toBe(false);
 
@@ -534,11 +510,7 @@ test('duplicate action successfully duplicates virtual dataset', async () => {
   const virtualDataset = mockDatasets[1]; // Virtual dataset (kind: 'virtual')
   setupDuplicateMocks();
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [virtualDataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [virtualDataset], count: 1 });
 
   renderDatasetList(mockAdminUser, {
     addSuccessToast: mockAddSuccessToast,
@@ -560,7 +532,9 @@ test('duplicate action successfully duplicates virtual dataset', async () => {
   await userEvent.type(input, 'Copy of Analytics');
 
   // Track API calls before submit
-  const callsBefore = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const callsBefore = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   // Submit
   const submitButton = within(modal).getByRole('button', {
@@ -570,7 +544,9 @@ test('duplicate action successfully duplicates virtual dataset', async () => {
 
   // Wait for duplicate API call and modal closes
   await waitFor(() => {
-    const dupCalls = fetchMock.calls(API_ENDPOINTS.DATASET_DUPLICATE);
+    const dupCalls = fetchMock.callHistory.calls(
+      API_ENDPOINTS.DATASET_DUPLICATE,
+    );
     expect(dupCalls.length).toBeGreaterThan(0);
     // Modal closes (duplicate success doesn't show toast, just closes modal)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -578,9 +554,9 @@ test('duplicate action successfully duplicates virtual dataset', async () => {
 
   // List refreshes
   await waitFor(() => {
-    expect(fetchMock.calls(API_ENDPOINTS.DATASETS).length).toBeGreaterThan(
-      callsBefore,
-    );
+    expect(
+      fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS).length,
+    ).toBeGreaterThan(callsBefore);
   });
 });
 
@@ -588,11 +564,10 @@ test('duplicate button visible only for virtual datasets', async () => {
   const physicalDataset = mockDatasets[0]; // kind: 'physical'
   const virtualDataset = mockDatasets[1]; // kind: 'virtual'
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [physicalDataset, virtualDataset], count: 2 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [physicalDataset, virtualDataset],
+    count: 2,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -648,11 +623,10 @@ test('bulk select enables checkboxes', async () => {
 }, 30000);
 
 test('selecting all datasets shows correct count in toolbar', async () => {
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: mockDatasets, count: mockDatasets.length },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: mockDatasets,
+    count: mockDatasets.length,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -688,11 +662,10 @@ test('selecting all datasets shows correct count in toolbar', async () => {
 }, 30000);
 
 test('bulk export triggers export with selected IDs', async () => {
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [mockDatasets[0]], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [mockDatasets[0]],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -731,11 +704,10 @@ test('bulk export triggers export with selected IDs', async () => {
 test('bulk delete opens confirmation modal', async () => {
   setupBulkDeleteMocks();
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [mockDatasets[0]], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [mockDatasets[0]],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -838,11 +810,10 @@ test('certified badge appears for certified datasets', async () => {
     }),
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [certifiedDataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [certifiedDataset],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -869,11 +840,10 @@ test('warning icon appears for datasets with warnings', async () => {
     }),
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [datasetWithWarning], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [datasetWithWarning],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -898,11 +868,10 @@ test('info tooltip appears for datasets with descriptions', async () => {
     description: 'Sales data from Q4 2024',
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [datasetWithDescription], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [datasetWithDescription],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -924,11 +893,7 @@ test('info tooltip appears for datasets with descriptions', async () => {
 test('dataset name links to Explore page', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -948,11 +913,10 @@ test('dataset name links to Explore page', async () => {
 test('physical dataset shows delete, export, and edit actions (no duplicate)', async () => {
   const physicalDataset = mockDatasets[0]; // kind: 'physical'
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [physicalDataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [physicalDataset],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -980,11 +944,7 @@ test('physical dataset shows delete, export, and edit actions (no duplicate)', a
 test('virtual dataset shows delete, export, edit, and duplicate actions', async () => {
   const virtualDataset = mockDatasets[1]; // kind: 'virtual'
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [virtualDataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [virtualDataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -1013,11 +973,7 @@ test('edit action is enabled for dataset owner', async () => {
     owners: [{ id: mockAdminUser.userId, username: 'admin' }],
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -1040,11 +996,7 @@ test('edit action is disabled for non-owner', async () => {
     owners: [{ id: 999, username: 'other_user' }], // Different user
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   // Use a non-admin user to test ownership check
   const regularUser = {
@@ -1073,11 +1025,7 @@ test('all action buttons are clickable and enabled for admin user', async () => 
     owners: [{ id: mockAdminUser.userId, username: 'admin' }],
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [virtualDataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [virtualDataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -1112,11 +1060,10 @@ test('all action buttons are clickable and enabled for admin user', async () => 
 });
 
 test('displays error when initial dataset fetch fails with 500', async () => {
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { status: 500, body: { message: 'Internal Server Error' } },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    status: 500,
+    body: { message: 'Internal Server Error' },
+  });
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: mockAddDangerToast,
@@ -1134,11 +1081,10 @@ test('displays error when initial dataset fetch fails with 500', async () => {
 });
 
 test('displays error when initial dataset fetch fails with 403 permission denied', async () => {
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { status: 403, body: { message: 'Access Denied' } },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    status: 403,
+    body: { message: 'Access Denied' },
+  });
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: mockAddDangerToast,
@@ -1150,7 +1096,7 @@ test('displays error when initial dataset fetch fails with 403 permission denied
   });
 
   // Verify toast message contains the 403-specific "Access Denied" text
-  const toastMessage = String(mockAddDangerToast.mock.calls[0][0]);
+  const toastMessage = String(mockAddDangerToast.mock.calls[0].url);
   expect(toastMessage).toContain('Access Denied');
 
   // No dataset names from mockDatasets should appear in the document
@@ -1402,20 +1348,22 @@ test('sort order persists after deleting a dataset', async () => {
   });
 
   // Record initial API calls count
-  const initialCalls = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const initialCalls = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   // Click Name header to sort
   await userEvent.click(nameHeader);
 
   // Wait for new API call with sort parameter
   await waitFor(() => {
-    const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+    const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
     expect(calls.length).toBeGreaterThan(initialCalls);
   });
 
   // Record the sort parameter from the API call after sorting
-  const callsAfterSort = fetchMock.calls(API_ENDPOINTS.DATASETS);
-  const sortedUrl = callsAfterSort[callsAfterSort.length - 1][0] as string;
+  const callsAfterSort = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
+  const sortedUrl = callsAfterSort[callsAfterSort.length - 1].url as string;
   expect(sortedUrl).toMatch(/order_column|sort/);
 
   // Delete a dataset - get delete button from first row only
@@ -1433,7 +1381,9 @@ test('sort order persists after deleting a dataset', async () => {
   await userEvent.type(confirmInput, 'DELETE');
 
   // Record call count before delete to track refetch
-  const callsBeforeDelete = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const callsBeforeDelete = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   const confirmButton = within(modal)
     .getAllByRole('button', { name: /^delete$/i })
@@ -1452,7 +1402,9 @@ test('sort order persists after deleting a dataset', async () => {
 
   // Wait for list refetch to complete (prevents async cleanup error)
   await waitFor(() => {
-    const currentCalls = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+    const currentCalls = fetchMock.callHistory.calls(
+      API_ENDPOINTS.DATASETS,
+    ).length;
     expect(currentCalls).toBeGreaterThan(callsBeforeDelete);
   });
 
@@ -1476,11 +1428,10 @@ test('sort order persists after deleting a dataset', async () => {
 // test. Component tests here focus on individual behaviors.
 
 test('bulk selection clears when filter changes', async () => {
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: mockDatasets, count: mockDatasets.length },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: mockDatasets,
+    count: mockDatasets.length,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -1528,7 +1479,9 @@ test('bulk selection clears when filter changes', async () => {
   });
 
   // Record API call count before filter
-  const beforeFilterCallCount = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const beforeFilterCallCount = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   // Wait for filter combobox to be ready before applying filter
   await screen.findByRole('combobox', { name: 'Type' });
@@ -1538,14 +1491,14 @@ test('bulk selection clears when filter changes', async () => {
 
   // Wait for filter API call to complete
   await waitFor(() => {
-    const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+    const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
     expect(calls.length).toBeGreaterThan(beforeFilterCallCount);
   });
 
   // Verify filter was applied by decoding URL payload
-  const urlAfterFilter = fetchMock
+  const urlAfterFilter = fetchMock.callHistory
     .calls(API_ENDPOINTS.DATASETS)
-    .at(-1)?.[0] as string;
+    .at(-1)?.url as string;
   const risonAfterFilter = new URL(
     urlAfterFilter,
     'http://localhost',
@@ -1578,19 +1531,22 @@ test('type filter API call includes correct filter parameter', async () => {
   await screen.findByRole('combobox', { name: 'Type' });
 
   // Snapshot call count before filter
-  const callsBeforeFilter = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const callsBeforeFilter = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   // Apply Type filter
   await selectOption('Virtual', 'Type');
 
   // Wait for filter API call to complete
   await waitFor(() => {
-    const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+    const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
     expect(calls.length).toBeGreaterThan(callsBeforeFilter);
   });
 
   // Verify the latest API call includes the Type filter
-  const url = fetchMock.calls(API_ENDPOINTS.DATASETS).at(-1)?.[0] as string;
+  const url = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS).at(-1)
+    ?.url as string;
   expect(url).toContain('filters');
 
   // searchParams.get() already URL-decodes, so pass directly to rison.decode
@@ -1622,21 +1578,23 @@ test('type filter persists after duplicating a dataset', async () => {
   await screen.findByRole('combobox', { name: 'Type' });
 
   // Snapshot call count before filter
-  const callsBeforeFilter = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+  const callsBeforeFilter = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASETS,
+  ).length;
 
   // Apply Type filter
   await selectOption('Virtual', 'Type');
 
   // Wait for filter API call to complete
   await waitFor(() => {
-    const calls = fetchMock.calls(API_ENDPOINTS.DATASETS);
+    const calls = fetchMock.callHistory.calls(API_ENDPOINTS.DATASETS);
     expect(calls.length).toBeGreaterThan(callsBeforeFilter);
   });
 
   // Verify filter is present by checking the latest API call
-  const urlAfterFilter = fetchMock
+  const urlAfterFilter = fetchMock.callHistory
     .calls(API_ENDPOINTS.DATASETS)
-    .at(-1)?.[0] as string;
+    .at(-1)?.url as string;
   const risonAfterFilter = new URL(
     urlAfterFilter,
     'http://localhost',
@@ -1654,7 +1612,7 @@ test('type filter persists after duplicating a dataset', async () => {
   );
 
   // Capture datasets API call count BEFORE any duplicate operations
-  const datasetsCallCountBeforeDuplicate = fetchMock.calls(
+  const datasetsCallCountBeforeDuplicate = fetchMock.callHistory.calls(
     API_ENDPOINTS.DATASETS,
   ).length;
 
@@ -1682,20 +1640,24 @@ test('type filter persists after duplicating a dataset', async () => {
 
   // Wait for duplicate API call to be made
   await waitFor(() => {
-    const duplicateCalls = fetchMock.calls(API_ENDPOINTS.DATASET_DUPLICATE);
+    const duplicateCalls = fetchMock.callHistory.calls(
+      API_ENDPOINTS.DATASET_DUPLICATE,
+    );
     expect(duplicateCalls.length).toBeGreaterThan(0);
   });
 
   // Wait for datasets refetch to occur (proves duplicate triggered a refresh)
   await waitFor(() => {
-    const datasetsCallCount = fetchMock.calls(API_ENDPOINTS.DATASETS).length;
+    const datasetsCallCount = fetchMock.callHistory.calls(
+      API_ENDPOINTS.DATASETS,
+    ).length;
     expect(datasetsCallCount).toBeGreaterThan(datasetsCallCountBeforeDuplicate);
   });
 
   // Verify Type filter persisted in the NEW datasets API call after duplication
-  const urlAfterDuplicate = fetchMock
+  const urlAfterDuplicate = fetchMock.callHistory
     .calls(API_ENDPOINTS.DATASETS)
-    .at(-1)?.[0] as string;
+    .at(-1)?.url as string;
   const risonAfterDuplicate = new URL(
     urlAfterDuplicate,
     'http://localhost',
@@ -1729,11 +1691,7 @@ test('edit action shows error toast when dataset fetch fails', async () => {
     ],
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [ownedDataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [ownedDataset], count: 1 });
 
   // Mock SupersetClient.get to fail for the specific dataset endpoint
   jest.spyOn(SupersetClient, 'get').mockImplementation(async request => {
@@ -1776,11 +1734,10 @@ test('bulk export error shows toast and clears loading state', async () => {
   // Mock handleResourceExport to throw an error
   mockHandleResourceExport.mockRejectedValueOnce(new Error('Export failed'));
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [mockDatasets[0]], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [mockDatasets[0]],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: mockAddDangerToast,
@@ -1836,17 +1793,15 @@ test('bulk export error shows toast and clears loading state', async () => {
 
 test('bulk delete error shows toast without refreshing list', async () => {
   // Mock bulk delete to fail
-  fetchMock.delete(
-    API_ENDPOINTS.DATASET_BULK_DELETE,
-    { status: 500, body: { message: 'Bulk delete failed' } },
-    { overwriteRoutes: true },
-  );
+  fetchMock.delete(API_ENDPOINTS.DATASET_BULK_DELETE, {
+    status: 500,
+    body: { message: 'Bulk delete failed' },
+  });
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [mockDatasets[0]], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [mockDatasets[0]],
+    count: 1,
+  });
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: mockAddDangerToast,
@@ -1919,11 +1874,10 @@ test('bulk select shows "N Selected (Virtual)" for virtual-only selection', asyn
   // Use only virtual datasets
   const virtualDatasets = mockDatasets.filter(d => d.kind === 'virtual');
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: virtualDatasets, count: virtualDatasets.length },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: virtualDatasets,
+    count: virtualDatasets.length,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -1966,11 +1920,10 @@ test('bulk select shows "N Selected (Physical)" for physical-only selection', as
   // Use only physical datasets
   const physicalDatasets = mockDatasets.filter(d => d.kind === 'physical');
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: physicalDatasets, count: physicalDatasets.length },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: physicalDatasets,
+    count: physicalDatasets.length,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -2017,11 +1970,10 @@ test('bulk select shows mixed count for virtual and physical selection', async (
     mockDatasets.find(d => d.kind === 'virtual')!,
   ];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: mixedDatasets, count: mixedDatasets.length },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: mixedDatasets,
+    count: mixedDatasets.length,
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -2081,20 +2033,12 @@ test('delete modal shows affected dashboards with overflow for >10 items', async
     title: `Dashboard ${i + 1}`,
   }));
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
-  fetchMock.get(
-    `glob:*/api/v1/dataset/${dataset.id}/related_objects*`,
-    {
-      charts: { count: 0, result: [] },
-      dashboards: { count: 15, result: manyDashboards },
-    },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(`glob:*/api/v1/dataset/${dataset.id}/related_objects*`, {
+    charts: { count: 0, result: [] },
+    dashboards: { count: 15, result: manyDashboards },
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -2126,20 +2070,12 @@ test('delete modal shows affected dashboards with overflow for >10 items', async
 test('delete modal hides affected dashboards section when count is zero', async () => {
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
-  fetchMock.get(
-    `glob:*/api/v1/dataset/${dataset.id}/related_objects*`,
-    {
-      charts: { count: 2, result: [{ id: 1, slice_name: 'Chart 1' }] },
-      dashboards: { count: 0, result: [] },
-    },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(`glob:*/api/v1/dataset/${dataset.id}/related_objects*`, {
+    charts: { count: 2, result: [{ id: 1, slice_name: 'Chart 1' }] },
+    dashboards: { count: 0, result: [] },
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -2172,20 +2108,12 @@ test('delete modal shows affected charts with overflow for >10 items', async () 
     slice_name: `Chart ${i + 1}`,
   }));
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
-  fetchMock.get(
-    `glob:*/api/v1/dataset/${dataset.id}/related_objects*`,
-    {
-      charts: { count: 12, result: manyCharts },
-      dashboards: { count: 0, result: [] },
-    },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(`glob:*/api/v1/dataset/${dataset.id}/related_objects*`, {
+    charts: { count: 12, result: manyCharts },
+    dashboards: { count: 0, result: [] },
+  });
 
   renderDatasetList(mockAdminUser);
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
@@ -1096,7 +1096,7 @@ test('displays error when initial dataset fetch fails with 403 permission denied
   });
 
   // Verify toast message contains the 403-specific "Access Denied" text
-  const toastMessage = String(mockAddDangerToast.mock.calls[0].url);
+  const toastMessage = String(mockAddDangerToast.mock.calls[0][0]);
   expect(toastMessage).toContain('Access Denied');
 
   // No dataset names from mockDatasets should appear in the document

--- a/superset-frontend/src/pages/DatasetList/DatasetList.permissions.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.permissions.test.tsx
@@ -237,11 +237,7 @@ test('action buttons respect user permissions', async () => {
 
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockAdminUser);
 
@@ -267,11 +263,7 @@ test('read-only user sees no delete or duplicate buttons in row', async () => {
 
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-
-  );
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockReadOnlyUser);
 
@@ -306,11 +298,9 @@ test('write user sees edit, delete, and export actions', async () => {
     owners: [{ id: mockWriteUser.userId, username: 'writeuser' }],
   };
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-
-  );
+  // Remove default route to ensure test-specific mock is used
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockWriteUser);
 
@@ -345,11 +335,9 @@ test('export-only user has no Actions column (no write/duplicate permissions)', 
 
   const dataset = mockDatasets[0];
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [dataset], count: 1 },
-
-  );
+  // Remove default route to ensure test-specific mock is used
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
 
   renderDatasetList(mockExportOnlyUser);
 
@@ -382,11 +370,12 @@ test('user with can_duplicate sees duplicate button only for virtual datasets', 
   const physicalDataset = mockDatasets[0]; // kind: 'physical'
   const virtualDataset = mockDatasets[1]; // kind: 'virtual'
 
-  fetchMock.get(
-    API_ENDPOINTS.DATASETS,
-    { result: [physicalDataset, virtualDataset], count: 2 },
-
-  );
+  // Remove default route to ensure test-specific mock is used
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(API_ENDPOINTS.DATASETS, {
+    result: [physicalDataset, virtualDataset],
+    count: 2,
+  });
 
   renderDatasetList(mockAdminUser);
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.permissions.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.permissions.test.tsx
@@ -20,7 +20,6 @@ import { act, screen, waitFor, within } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import {
   setupMocks,
-  setupApiPermissions,
   renderDatasetList,
   mockAdminUser,
   mockReadOnlyUser,
@@ -35,7 +34,7 @@ import {
 jest.setTimeout(30000);
 
 beforeEach(() => {
-  setupMocks();
+  // Default setup - tests that need different permissions will call setupMocks() again
   jest.clearAllMocks();
 });
 
@@ -58,7 +57,14 @@ afterEach(async () => {
 
 test('admin users see all UI elements', async () => {
   // Setup API with full admin permissions
-  setupApiPermissions(['can_read', 'can_write', 'can_export', 'can_duplicate']);
+  setupMocks({
+    [API_ENDPOINTS.DATASETS_INFO]: [
+      'can_read',
+      'can_write',
+      'can_export',
+      'can_duplicate',
+    ],
+  });
 
   renderDatasetList(mockAdminUser);
 
@@ -90,7 +96,7 @@ test('admin users see all UI elements', async () => {
 
 test('read-only users cannot see Actions column', async () => {
   // Setup API with read-only permissions
-  setupApiPermissions(['can_read']);
+  setupMocks({ [API_ENDPOINTS.DATASETS_INFO]: ['can_read'] });
 
   renderDatasetList(mockReadOnlyUser);
 
@@ -107,7 +113,7 @@ test('read-only users cannot see Actions column', async () => {
 
 test('read-only users cannot see bulk select button', async () => {
   // Setup API with read-only permissions
-  setupApiPermissions(['can_read']);
+  setupMocks({ [API_ENDPOINTS.DATASETS_INFO]: ['can_read'] });
 
   renderDatasetList(mockReadOnlyUser);
 
@@ -123,7 +129,7 @@ test('read-only users cannot see bulk select button', async () => {
 
 test('read-only users cannot see Create/Import buttons', async () => {
   // Setup API with read-only permissions
-  setupApiPermissions(['can_read']);
+  setupMocks({ [API_ENDPOINTS.DATASETS_INFO]: ['can_read'] });
 
   renderDatasetList(mockReadOnlyUser);
 
@@ -144,7 +150,9 @@ test('read-only users cannot see Create/Import buttons', async () => {
 
 test('write users see Actions column', async () => {
   // Setup API with write permissions
-  setupApiPermissions(['can_read', 'can_write', 'can_export']);
+  setupMocks({
+    [API_ENDPOINTS.DATASETS_INFO]: ['can_read', 'can_write', 'can_export'],
+  });
 
   renderDatasetList(mockWriteUser);
 
@@ -162,7 +170,9 @@ test('write users see Actions column', async () => {
 
 test('write users see bulk select button', async () => {
   // Setup API with write permissions
-  setupApiPermissions(['can_read', 'can_write', 'can_export']);
+  setupMocks({
+    [API_ENDPOINTS.DATASETS_INFO]: ['can_read', 'can_write', 'can_export'],
+  });
 
   renderDatasetList(mockWriteUser);
 
@@ -177,7 +187,9 @@ test('write users see bulk select button', async () => {
 
 test('write users see Create/Import buttons', async () => {
   // Setup API with write permissions
-  setupApiPermissions(['can_read', 'can_write', 'can_export']);
+  setupMocks({
+    [API_ENDPOINTS.DATASETS_INFO]: ['can_read', 'can_write', 'can_export'],
+  });
 
   renderDatasetList(mockWriteUser);
 
@@ -198,7 +210,7 @@ test('write users see Create/Import buttons', async () => {
 
 test('export-only users see bulk select (for export only)', async () => {
   // Setup API with export-only permissions
-  setupApiPermissions(['can_read', 'can_export']);
+  setupMocks({ [API_ENDPOINTS.DATASETS_INFO]: ['can_read', 'can_export'] });
 
   renderDatasetList(mockExportOnlyUser);
 
@@ -214,7 +226,7 @@ test('export-only users see bulk select (for export only)', async () => {
 
 test('export-only users cannot see Create/Import buttons', async () => {
   // Setup API with export-only permissions
-  setupApiPermissions(['can_read', 'can_export']);
+  setupMocks({ [API_ENDPOINTS.DATASETS_INFO]: ['can_read', 'can_export'] });
 
   renderDatasetList(mockExportOnlyUser);
 
@@ -233,11 +245,24 @@ test('export-only users cannot see Create/Import buttons', async () => {
 
 test('action buttons respect user permissions', async () => {
   // Setup API with full admin permissions
-  setupApiPermissions(['can_read', 'can_write', 'can_export', 'can_duplicate']);
+  setupMocks({
+    [API_ENDPOINTS.DATASETS_INFO]: [
+      'can_read',
+      'can_write',
+      'can_export',
+      'can_duplicate',
+    ],
+  });
 
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  // Override the default DATASETS route with test-specific data
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -259,11 +284,17 @@ test('action buttons respect user permissions', async () => {
 
 test('read-only user sees no delete or duplicate buttons in row', async () => {
   // Setup API with read-only permissions
-  setupApiPermissions(['can_read']);
+  setupMocks({ [API_ENDPOINTS.DATASETS_INFO]: ['can_read'] });
 
   const dataset = mockDatasets[0];
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  // Override the default DATASETS route with test-specific data
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockReadOnlyUser);
 
@@ -291,16 +322,22 @@ test('read-only user sees no delete or duplicate buttons in row', async () => {
 test('write user sees edit, delete, and export actions', async () => {
   // Setup API with write permissions (includes delete)
   // Note: can_write grants both edit and delete permissions in DatasetList
-  setupApiPermissions(['can_read', 'can_write', 'can_export']);
+  setupMocks({
+    [API_ENDPOINTS.DATASETS_INFO]: ['can_read', 'can_write', 'can_export'],
+  });
 
   const dataset = {
     ...mockDatasets[0],
     owners: [{ id: mockWriteUser.userId, username: 'writeuser' }],
   };
 
-  // Remove default route to ensure test-specific mock is used
+  // Override the default DATASETS route with test-specific data
   fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockWriteUser);
 
@@ -331,13 +368,17 @@ test('write user sees edit, delete, and export actions', async () => {
 test('export-only user has no Actions column (no write/duplicate permissions)', async () => {
   // Setup API with export-only permissions
   // Note: Export action alone doesn't render Actions column - it's in toolbar/bulk select
-  setupApiPermissions(['can_read', 'can_export']);
+  setupMocks({ [API_ENDPOINTS.DATASETS_INFO]: ['can_read', 'can_export'] });
 
   const dataset = mockDatasets[0];
 
-  // Remove default route to ensure test-specific mock is used
+  // Override the default DATASETS route with test-specific data
   fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockExportOnlyUser);
 
@@ -365,17 +406,21 @@ test('export-only user has no Actions column (no write/duplicate permissions)', 
 
 test('user with can_duplicate sees duplicate button only for virtual datasets', async () => {
   // Setup API with duplicate permission
-  setupApiPermissions(['can_read', 'can_duplicate']);
+  setupMocks({ [API_ENDPOINTS.DATASETS_INFO]: ['can_read', 'can_duplicate'] });
 
   const physicalDataset = mockDatasets[0]; // kind: 'physical'
   const virtualDataset = mockDatasets[1]; // kind: 'virtual'
 
-  // Remove default route to ensure test-specific mock is used
+  // Override the default DATASETS route with test-specific data
   fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [physicalDataset, virtualDataset],
-    count: 2,
-  });
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [physicalDataset, virtualDataset],
+      count: 2,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.permissions.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.permissions.test.tsx
@@ -51,8 +51,8 @@ afterEach(async () => {
   // Reset browser history to prevent query param leakage
   window.history.replaceState({}, '', '/');
 
-  fetchMock.resetHistory();
-  fetchMock.restore();
+  fetchMock.clearHistory();
+  fetchMock.removeRoutes();
   jest.restoreAllMocks();
 });
 
@@ -240,7 +240,7 @@ test('action buttons respect user permissions', async () => {
   fetchMock.get(
     API_ENDPOINTS.DATASETS,
     { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
+
   );
 
   renderDatasetList(mockAdminUser);
@@ -270,7 +270,7 @@ test('read-only user sees no delete or duplicate buttons in row', async () => {
   fetchMock.get(
     API_ENDPOINTS.DATASETS,
     { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
+
   );
 
   renderDatasetList(mockReadOnlyUser);
@@ -309,7 +309,7 @@ test('write user sees edit, delete, and export actions', async () => {
   fetchMock.get(
     API_ENDPOINTS.DATASETS,
     { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
+
   );
 
   renderDatasetList(mockWriteUser);
@@ -348,7 +348,7 @@ test('export-only user has no Actions column (no write/duplicate permissions)', 
   fetchMock.get(
     API_ENDPOINTS.DATASETS,
     { result: [dataset], count: 1 },
-    { overwriteRoutes: true },
+
   );
 
   renderDatasetList(mockExportOnlyUser);
@@ -385,7 +385,7 @@ test('user with can_duplicate sees duplicate button only for virtual datasets', 
   fetchMock.get(
     API_ENDPOINTS.DATASETS,
     { result: [physicalDataset, virtualDataset], count: 2 },
-    { overwriteRoutes: true },
+
   );
 
   renderDatasetList(mockAdminUser);

--- a/superset-frontend/src/pages/DatasetList/DatasetList.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.test.tsx
@@ -418,7 +418,7 @@ test('component requires explicit mocks for all API endpoints', async () => {
   expect(newInfoCalls.length).toBeGreaterThan(0);
 
   // Verify no unmatched calls (all endpoints were mocked)
-  const unmatchedCalls = fetchMock.callHistory.calls(false); // false = unmatched only
+  const unmatchedCalls = fetchMock.callHistory.calls('unmatched');
   expect(unmatchedCalls.length).toBe(0);
 });
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.test.tsx
@@ -213,10 +213,15 @@ test('handles datasets with missing fields and renders gracefully', async () => 
     sql: null,
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetWithMissingFields],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetWithMissingFields],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -239,7 +244,12 @@ test('handles datasets with missing fields and renders gracefully', async () => 
 });
 
 test('handles empty results (shows empty state)', async () => {
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [], count: 0 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [], count: 0 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -362,7 +372,10 @@ test('handles 500 error on initial load without crashing', async () => {
 test('handles 403 error on _info endpoint and disables create actions', async () => {
   const addDangerToast = jest.fn();
 
-  fetchMock.get(API_ENDPOINTS.DATASETS_INFO, mockApiError403, {});
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS_INFO);
+  fetchMock.get(API_ENDPOINTS.DATASETS_INFO, mockApiError403, {
+    name: API_ENDPOINTS.DATASETS_INFO,
+  });
 
   renderDatasetList(mockAdminUser, {
     addDangerToast,
@@ -382,9 +395,12 @@ test('handles 403 error on _info endpoint and disables create actions', async ()
 });
 
 test('handles network timeout without crashing', async () => {
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    throws: new Error('Network timeout'),
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { throws: new Error('Network timeout') },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser, {
     addDangerToast: jest.fn(),
@@ -442,10 +458,15 @@ test('renders datasets with certification data', async () => {
     }),
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [certifiedDataset],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [certifiedDataset],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -469,10 +490,15 @@ test('displays datasets with warning_markdown', async () => {
     }),
   };
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetWithWarning],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetWithWarning],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -490,10 +516,15 @@ test('displays datasets with warning_markdown', async () => {
 test('displays dataset with multiple owners', async () => {
   const datasetWithOwners = mockDatasets[1]; // Has 2 owners: Jane Smith, Bob Jones
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetWithOwners],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetWithOwners],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -511,10 +542,15 @@ test('displays dataset with multiple owners', async () => {
 test('displays ModifiedInfo with humanized date', async () => {
   const datasetWithModified = mockDatasets[0]; // changed_by_name: 'John Doe', changed_on: '1 day ago'
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, {
-    result: [datasetWithModified],
-    count: 1,
-  });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    {
+      result: [datasetWithModified],
+      count: 1,
+    },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 
@@ -533,7 +569,12 @@ test('displays ModifiedInfo with humanized date', async () => {
 test('dataset name links to Explore with correct explore_url', async () => {
   const dataset = mockDatasets[0]; // explore_url: '/explore/?datasource=1__table'
 
-  fetchMock.get(API_ENDPOINTS.DATASETS, { result: [dataset], count: 1 });
+  fetchMock.removeRoute(API_ENDPOINTS.DATASETS);
+  fetchMock.get(
+    API_ENDPOINTS.DATASETS,
+    { result: [dataset], count: 1 },
+    { name: API_ENDPOINTS.DATASETS },
+  );
 
   renderDatasetList(mockAdminUser);
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.testHelpers.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.testHelpers.tsx
@@ -449,10 +449,7 @@ export const setupDuplicateErrorMocks = (statusCode: number) => {
  * @throws If any unmocked endpoints were called or expected endpoints weren't called
  */
 export const assertOnlyExpectedCalls = (expectedEndpoints: string[]) => {
-  const allCalls = fetchMock.callHistory.calls();
-  const unmatchedCalls = allCalls.filter(
-    call => call.route?.config?.name === 'unmatched',
-  );
+  const unmatchedCalls = fetchMock.callHistory.calls('unmatched');
 
   if (unmatchedCalls.length > 0) {
     const unmatchedUrls = unmatchedCalls.map(call => call.url);


### PR DESCRIPTION
## Summary

Updates DatasetList test files to use the new fetch-mock v12 API, fixing TypeScript compilation errors.

#36681 added comprehensive RTL and integration tests for DatasetList using the fetch-mock v11 API. Subsequently, #36662 upgraded fetch-mock from v11.1.5 to v12.6.0, which introduced breaking API changes. This PR updates the DatasetList tests to use the new API.

## Changes

**API migrations (6 files, 318 insertions, 420 deletions):**

| Old API (v11) | New API (v12) |
|---------------|---------------|
| `fetchMock.reset()` | `fetchMock.removeRoutes()` |
| `fetchMock.resetHistory()` | `fetchMock.clearHistory()` |
| `fetchMock.restore()` | `fetchMock.removeRoutes()` |
| `fetchMock.calls(filter)` | `fetchMock.callHistory.calls(filter)` |
| `call[0]` (url) | `call.url` |
| `call[1]` (options) | `call.options` |
| `{ overwriteRoutes: true }` | removed (option no longer exists) |
| `<QueryParamProvider>` | `<QueryParamProvider adapter={ReactRouter5Adapter}>` |

**Files modified:**
- `DatasetList.testHelpers.tsx`
- `DatasetList.test.tsx`
- `DatasetList.behavior.test.tsx`
- `DatasetList.listview.test.tsx`
- `DatasetList.permissions.test.tsx`
- `DatasetList.integration.test.tsx`

## Test plan

- [x] `npm run build` passes (TypeScript compilation)
- [x] Pre-commit hooks pass (type-checking, prettier, eslint, oxlint)
- [ ] DatasetList tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)