### PR TITLE
Feat/dashboard empty state config

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,45 @@ assists people when migrating to a new version.
 
 ## Next
 
+### Customizable Empty State Messages for BigNumber Charts
+
+BigNumber charts now support customizable empty state messages at the dashboard level. This allows dashboard owners to provide context-specific messages when charts display no data or no results.
+
+#### New Features
+- Dashboard-level configuration for BigNumber chart empty states
+- Four customizable message fields:
+  - `no_data_message`: Primary message when query returns no data
+  - `no_data_subtitle`: Additional context for no data state
+  - `no_results_message`: Primary message when filters yield no results
+  - `no_results_subtitle`: Additional context for no results state
+- Available in Dashboard Properties modal under "Empty State Configuration" section
+- Applies to all BigNumber chart variants (Total, With Trendline, Period over Period)
+- Internationalization (i18n) support with fallback to default translated messages
+
+#### Usage
+1. Edit a dashboard containing BigNumber charts
+2. Open Dashboard Properties (three dots menu → Edit properties)
+3. Navigate to "Empty State Configuration" section
+4. Enter custom messages for each empty state scenario
+5. Save dashboard
+
+#### Database Migration
+The `empty_state_config` column has been added to the `dashboards` table to store the configuration as JSON. Run database migrations to apply:
+```bash
+superset db upgrade
+```
+
+#### API Changes
+The Dashboard API now accepts `empty_state_config` field in POST/PUT requests:
+```json
+{
+  "dashboard_title": "My Dashboard",
+  "empty_state_config": "{\"no_data_message\": \"Custom message\", \"no_data_subtitle\": \"Custom subtitle\"}"
+}
+```
+
+The field is also returned in GET responses when present.
+
 ### MCP Service
 
 The MCP (Model Context Protocol) service enables AI assistants and automation tools to interact programmatically with Superset.

--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
@@ -108,6 +108,8 @@ export interface ChartPropsConfig {
   legendIndex?: number;
   inContextMenu?: boolean;
   emitCrossFilters?: boolean;
+  /** Dashboard-level empty state configuration for customizing no-data/no-results messages */
+  dashboardEmptyStateConfig?: JsonObject;
 }
 
 const DEFAULT_WIDTH = 800;
@@ -158,6 +160,8 @@ export default class ChartProps<FormData extends RawFormData = RawFormData> {
 
   emitCrossFilters?: boolean;
 
+  dashboardEmptyStateConfig?: JsonObject;
+
   theme: SupersetTheme;
 
   constructor(
@@ -185,6 +189,7 @@ export default class ChartProps<FormData extends RawFormData = RawFormData> {
       inputRef,
       inContextMenu = false,
       emitCrossFilters = false,
+      dashboardEmptyStateConfig,
       theme,
     } = config;
     this.width = width;
@@ -208,6 +213,7 @@ export default class ChartProps<FormData extends RawFormData = RawFormData> {
     this.inputRef = inputRef;
     this.inContextMenu = inContextMenu;
     this.emitCrossFilters = emitCrossFilters;
+    this.dashboardEmptyStateConfig = dashboardEmptyStateConfig;
     this.theme = theme;
   }
 }
@@ -234,6 +240,7 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
     input => input.inputRef,
     input => input.inContextMenu,
     input => input.emitCrossFilters,
+    input => input.dashboardEmptyStateConfig,
     input => input.theme,
     (
       annotationData,
@@ -255,6 +262,7 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
       inputRef,
       inContextMenu,
       emitCrossFilters,
+      dashboardEmptyStateConfig,
       theme,
     ) =>
       new ChartProps({
@@ -277,6 +285,7 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
         inputRef,
         inContextMenu,
         emitCrossFilters,
+        dashboardEmptyStateConfig,
         theme,
       }),
     // Below config is to retain usage of 1-sized `lruMemoize` object in Reselect v4

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -192,9 +192,6 @@ export default function transformProps(chartProps: ChartProps) {
   valueDifference = numberFormatter(valueDifference);
   const percentDifference: string = formatPercentChange(percentDifferenceNum);
 
-  // Extract custom empty state messages from dashboard metadata
-  const customEmptyStateMessages = chartProps.dashboardMetadata?.empty_state_config;
-
   return {
     width,
     height,
@@ -221,6 +218,5 @@ export default function transformProps(chartProps: ChartProps) {
     shift: timeComparison,
     dashboardTimeRange: formData?.extraFormData?.time_range,
     columnConfig,
-    customEmptyStateMessages,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -192,6 +192,9 @@ export default function transformProps(chartProps: ChartProps) {
   valueDifference = numberFormatter(valueDifference);
   const percentDifference: string = formatPercentChange(percentDifferenceNum);
 
+  // Extract custom empty state messages from dashboard metadata
+  const customEmptyStateMessages = chartProps.dashboardMetadata?.empty_state_config;
+
   return {
     width,
     height,
@@ -218,5 +221,6 @@ export default function transformProps(chartProps: ChartProps) {
     shift: timeComparison,
     dashboardTimeRange: formData?.extraFormData?.time_range,
     columnConfig,
+    customEmptyStateMessages,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -108,6 +108,10 @@ export default function transformProps(
   const colorThresholdFormatters =
     getColorFormatters(conditionalFormatting, data, theme, false) ??
     defaultColorFormatters;
+
+  // Extract custom empty state messages from dashboard metadata
+  const customEmptyStateMessages = chartProps.dashboardMetadata?.empty_state_config;
+
   return {
     width,
     height,
@@ -123,5 +127,6 @@ export default function transformProps(
     metricName: originalLabel,
     showMetricName,
     metricNameFontSize,
+    customEmptyStateMessages,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -42,6 +42,7 @@ export default function transformProps(
     formData,
     rawFormData,
     hooks,
+    dashboardEmptyStateConfig,
     datasource: { currencyFormats = {}, columnFormats = {} },
     theme,
   } = chartProps;
@@ -123,5 +124,6 @@ export default function transformProps(
     metricName: originalLabel,
     showMetricName,
     metricNameFontSize,
+    dashboardEmptyStateConfig,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -108,10 +108,6 @@ export default function transformProps(
   const colorThresholdFormatters =
     getColorFormatters(conditionalFormatting, data, theme, false) ??
     defaultColorFormatters;
-
-  // Extract custom empty state messages from dashboard metadata
-  const customEmptyStateMessages = chartProps.dashboardMetadata?.empty_state_config;
-
   return {
     width,
     height,
@@ -127,6 +123,5 @@ export default function transformProps(
     metricName: originalLabel,
     showMetricName,
     metricNameFontSize,
-    customEmptyStateMessages,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -59,7 +59,6 @@ function BigNumberVis({
   subheaderFontSize = PROPORTION.SUBHEADER,
   subtitleFontSize = PROPORTION.SUBHEADER,
   timeRangeFixed = false,
-  customEmptyStateMessages,
   ...props
 }: BigNumberVizProps) {
   const theme = useTheme();
@@ -193,9 +192,7 @@ function BigNumberVis({
   const renderHeader = (maxHeight: number) => {
     const { bigNumber, width, colorThresholdFormatters, onContextMenu } = props;
     // @ts-ignore
-    const text = bigNumber === null 
-      ? (customEmptyStateMessages?.no_data_message || t('No data'))
-      : headerFormatter(bigNumber);
+    const text = bigNumber === null ? t('No data') : headerFormatter(bigNumber);
 
     const hasThresholdColorFormatter =
       Array.isArray(colorThresholdFormatters) &&
@@ -292,7 +289,7 @@ function BigNumberVis({
     const { subtitle, width, bigNumber, bigNumberFallback } = props;
     let fontSize = 0;
 
-    const NO_DATA_OR_HASNT_LANDED = customEmptyStateMessages?.no_data_subtitle || t(
+    const NO_DATA_OR_HASNT_LANDED = t(
       'No data after filtering or data is NULL for the latest time record',
     );
     const NO_DATA = t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -59,6 +59,7 @@ function BigNumberVis({
   subheaderFontSize = PROPORTION.SUBHEADER,
   subtitleFontSize = PROPORTION.SUBHEADER,
   timeRangeFixed = false,
+  customEmptyStateMessages,
   ...props
 }: BigNumberVizProps) {
   const theme = useTheme();
@@ -192,7 +193,9 @@ function BigNumberVis({
   const renderHeader = (maxHeight: number) => {
     const { bigNumber, width, colorThresholdFormatters, onContextMenu } = props;
     // @ts-ignore
-    const text = bigNumber === null ? t('No data') : headerFormatter(bigNumber);
+    const text = bigNumber === null 
+      ? (customEmptyStateMessages?.no_data_message || t('No data'))
+      : headerFormatter(bigNumber);
 
     const hasThresholdColorFormatter =
       Array.isArray(colorThresholdFormatters) &&
@@ -289,7 +292,7 @@ function BigNumberVis({
     const { subtitle, width, bigNumber, bigNumberFallback } = props;
     let fontSize = 0;
 
-    const NO_DATA_OR_HASNT_LANDED = t(
+    const NO_DATA_OR_HASNT_LANDED = customEmptyStateMessages?.no_data_subtitle || t(
       'No data after filtering or data is NULL for the latest time record',
     );
     const NO_DATA = t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -190,9 +190,23 @@ function BigNumberVis({
   };
 
   const renderHeader = (maxHeight: number) => {
-    const { bigNumber, width, colorThresholdFormatters, onContextMenu } = props;
-    // @ts-ignore
-    const text = bigNumber === null ? t('No data') : headerFormatter(bigNumber);
+    const {
+      bigNumber,
+      width,
+      colorThresholdFormatters,
+      onContextMenu,
+      dashboardEmptyStateConfig,
+    } = props;
+
+    let text: string;
+    if (bigNumber === null) {
+      // Priority: custom dashboard message > default i18n message
+      text = dashboardEmptyStateConfig?.no_data_message || t('No data');
+    } else {
+      // headerFormatter expects the raw bigNumber value (number, string, etc.)
+      const formattedValue = headerFormatter(bigNumber as number);
+      text = String(formattedValue);
+    }
 
     const hasThresholdColorFormatter =
       Array.isArray(colorThresholdFormatters) &&
@@ -286,20 +300,34 @@ function BigNumberVis({
   };
 
   const renderSubtitle = (maxHeight: number) => {
-    const { subtitle, width, bigNumber, bigNumberFallback } = props;
+    const {
+      subtitle,
+      width,
+      bigNumber,
+      bigNumberFallback,
+      dashboardEmptyStateConfig,
+    } = props;
     let fontSize = 0;
 
-    const NO_DATA_OR_HASNT_LANDED = t(
-      'No data after filtering or data is NULL for the latest time record',
-    );
-    const NO_DATA = t(
-      'Try applying different filters or ensuring your datasource has data',
-    );
-
-    let text = subtitle;
+    let text: string | undefined;
     if (bigNumber === null) {
-      text =
-        subtitle || (bigNumberFallback ? NO_DATA : NO_DATA_OR_HASNT_LANDED);
+      // Priority: custom dashboard subtitle > chart subtitle > default i18n message
+      if (dashboardEmptyStateConfig?.no_data_subtitle) {
+        text = dashboardEmptyStateConfig.no_data_subtitle;
+      } else if (subtitle) {
+        text = subtitle;
+      } else {
+        // Default i18n messages
+        text = bigNumberFallback
+          ? t(
+              'Try applying different filters or ensuring your datasource has data',
+            )
+          : t(
+              'No data after filtering or data is NULL for the latest time record',
+            );
+      }
+    } else {
+      text = subtitle;
     }
 
     if (text) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -366,6 +366,9 @@ export default function transformProps(
 
   const { onContextMenu } = hooks;
 
+  // Extract custom empty state messages from dashboard metadata
+  const customEmptyStateMessages = chartProps.dashboardMetadata?.empty_state_config;
+
   return {
     width,
     height,
@@ -394,5 +397,6 @@ export default function transformProps(
     onContextMenu,
     xValueFormatter: formatTime,
     refs,
+    customEmptyStateMessages,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -83,6 +83,7 @@ export default function transformProps(
     hooks,
     inContextMenu,
     theme,
+    dashboardEmptyStateConfig,
     datasource: { currencyFormats = {}, columnFormats = {} },
   } = chartProps;
   const {
@@ -394,5 +395,6 @@ export default function transformProps(
     onContextMenu,
     xValueFormatter: formatTime,
     refs,
+    dashboardEmptyStateConfig,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -366,9 +366,6 @@ export default function transformProps(
 
   const { onContextMenu } = hooks;
 
-  // Extract custom empty state messages from dashboard metadata
-  const customEmptyStateMessages = chartProps.dashboardMetadata?.empty_state_config;
-
   return {
     width,
     height,
@@ -397,6 +394,5 @@ export default function transformProps(
     onContextMenu,
     xValueFormatter: formatTime,
     refs,
-    customEmptyStateMessages,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
@@ -105,8 +105,4 @@ export type BigNumberVizProps = {
   formData?: BigNumberWithTrendlineFormData;
   refs: Refs;
   colorThresholdFormatters?: ColorFormatters;
-  customEmptyStateMessages?: {
-    no_data_message?: string;
-    no_data_subtitle?: string;
-  };
 };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
@@ -105,4 +105,8 @@ export type BigNumberVizProps = {
   formData?: BigNumberWithTrendlineFormData;
   refs: Refs;
   colorThresholdFormatters?: ColorFormatters;
+  customEmptyStateMessages?: {
+    no_data_message?: string;
+    no_data_subtitle?: string;
+  };
 };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
@@ -105,4 +105,10 @@ export type BigNumberVizProps = {
   formData?: BigNumberWithTrendlineFormData;
   refs: Refs;
   colorThresholdFormatters?: ColorFormatters;
+  dashboardEmptyStateConfig?: {
+    no_data_message?: string;
+    no_data_subtitle?: string;
+    no_results_message?: string;
+    no_results_subtitle?: string;
+  };
 };

--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -81,6 +81,7 @@ export interface ChartProps {
   isInView?: boolean;
   emitCrossFilters?: boolean;
   onChartStateChange?: (chartState: AgGridChartState) => void;
+  dashboardEmptyStateConfig?: JsonObject;
 }
 
 export type Actions = {

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -416,6 +416,7 @@ class ChartRenderer extends Component {
             legendState={this.state.legendState}
             enableNoResults={bypassNoResult}
             legendIndex={this.state.legendIndex}
+            dashboardEmptyStateConfig={dashboardEmptyStateConfig}
             {...drillToDetailProps}
           />
         </div>

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -65,6 +65,7 @@ const propTypes = {
   source: PropTypes.oneOf([ChartSource.Dashboard, ChartSource.Explore]),
   emitCrossFilters: PropTypes.bool,
   onChartStateChange: PropTypes.func,
+  dashboardEmptyStateConfig: PropTypes.object,
 };
 
 const BLANK = {};
@@ -327,13 +328,17 @@ class ChartRenderer extends Component {
         : '';
 
     let noResultsComponent;
-    const noResultTitle = t('No results were returned for this query');
+    const { dashboardEmptyStateConfig } = this.props;
+    const noResultTitle =
+      dashboardEmptyStateConfig?.no_results_message ||
+      t('No results were returned for this query');
     const noResultDescription =
-      this.props.source === ChartSource.Explore
+      dashboardEmptyStateConfig?.no_results_subtitle ||
+      (this.props.source === ChartSource.Explore
         ? t(
             'Make sure that the controls are configured properly and the datasource contains data for the selected time range',
           )
-        : undefined;
+        : undefined);
     const noResultImage = 'chart.svg';
     if (width > BIG_NO_RESULT_MIN_WIDTH && height > BIG_NO_RESULT_MIN_HEIGHT) {
       noResultsComponent = (

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -238,6 +238,15 @@ export const hydrateDashboard =
     metadata.chart_configuration = chartConfiguration;
     metadata.global_chart_configuration = globalChartConfiguration;
 
+    // Parse and add empty_state_config to metadata if it exists
+    if (dashboard.empty_state_config) {
+      try {
+        metadata.empty_state_config = JSON.parse(dashboard.empty_state_config);
+      } catch (e) {
+        console.error('Failed to parse empty_state_config:', e);
+      }
+    }
+
     const { roles } = user;
     const canEdit = canUserEditDashboard(dashboard, user);
     const crossFiltersEnabled = isCrossFiltersEnabled(

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -420,13 +420,15 @@ const Header = () => {
       css: customCss,
       dashboard_title: dashboardTitle,
       last_modified_time: actualLastModifiedTime,
-      owners: dashboardInfo.owners,
-      roles: dashboardInfo.roles,
+      owners: (dashboardInfo.owners || []).map(o => o.id || o),
+      roles: (dashboardInfo.roles || []).map(r => r.id || r),
       slug,
-      tags: (dashboardInfo.tags || []).filter(
-        item => item.type === TagTypeEnum.Custom || !item.type,
-      ),
+      tags: (dashboardInfo.tags || [])
+        .filter(item => item.type === TagTypeEnum.Custom || !item.type)
+        .map(tag => tag.id)
+        .filter(id => typeof id === 'number'),
       theme_id: dashboardInfo.theme ? dashboardInfo.theme.id : null,
+      empty_state_config: dashboardInfo.metadata?.empty_state_config,
       metadata: {
         ...dashboardInfo?.metadata,
         color_namespace: currentColorNamespace,

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -534,9 +534,11 @@ const Header = () => {
 
   const handleOnPropertiesChange = useCallback(
     updates => {
+      const parsedMetadata = JSON.parse(updates.jsonMetadata || '{}');
+
       boundActionCreators.dashboardInfoChanged({
         slug: updates.slug,
-        metadata: JSON.parse(updates.jsonMetadata || '{}'),
+        metadata: parsedMetadata,
         certified_by: updates.certifiedBy,
         certification_details: updates.certificationDetails,
         owners: updates.owners,

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -59,7 +59,9 @@ import {
   RefreshSection,
   CertificationSection,
   AdvancedSection,
+  EmptyStateSection,
 } from './sections';
+import { EmptyStateConfig } from 'src/dashboard/types/EmptyStateConfig';
 
 type PropertiesModalProps = {
   dashboardId: number;
@@ -135,6 +137,7 @@ const PropertiesModal = ({
       theme_name: string;
     }>
   >([]);
+  const [emptyStateConfig, setEmptyStateConfig] = useState<EmptyStateConfig>({});
   const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
   const originalDashboardMetadata = useRef<Record<string, any>>({});
 
@@ -172,6 +175,7 @@ const PropertiesModal = ({
         is_managed_externally,
         theme,
         css,
+        empty_state_config,
       } = dashboardData;
       const dashboardInfo = {
         id,
@@ -203,6 +207,17 @@ const PropertiesModal = ({
       setJsonMetadata(metaDataCopy ? jsonStringify(metaDataCopy) : '');
       setRefreshFrequency(metadata?.refresh_frequency || 0);
       setShowChartTimestamps(metadata?.show_chart_timestamps ?? false);
+      
+      // Parse empty_state_config if it exists
+      try {
+        const parsedEmptyStateConfig = empty_state_config
+          ? JSON.parse(empty_state_config)
+          : {};
+        setEmptyStateConfig(parsedEmptyStateConfig);
+      } catch (error) {
+        setEmptyStateConfig({});
+      }
+      
       originalDashboardMetadata.current = metadata;
     },
     [form],
@@ -394,6 +409,9 @@ const PropertiesModal = ({
         dashboard_title: title,
         slug: slug || null,
         json_metadata: currentJsonMetadata || null,
+        empty_state_config: Object.keys(emptyStateConfig).length > 0
+          ? JSON.stringify(emptyStateConfig)
+          : null,
         owners: (owners || []).map(o => o.id),
         certified_by: certifiedBy || null,
         certification_details:
@@ -743,6 +761,23 @@ const PropertiesModal = ({
                 <RefreshSection
                   refreshFrequency={refreshFrequency}
                   onRefreshFrequencyChange={handleRefreshFrequencyChange}
+                />
+              ),
+            },
+            {
+              key: 'empty-state',
+              label: (
+                <CollapseLabelInModal
+                  title={t('Empty state messages')}
+                  subtitle={t('Customize messages when charts have no data')}
+                  validateCheckStatus
+                  testId="empty-state-section"
+                />
+              ),
+              children: (
+                <EmptyStateSection
+                  emptyStateConfig={emptyStateConfig}
+                  onEmptyStateConfigChange={setEmptyStateConfig}
                 />
               ),
             },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -137,7 +137,9 @@ const PropertiesModal = ({
       theme_name: string;
     }>
   >([]);
-  const [emptyStateConfig, setEmptyStateConfig] = useState<EmptyStateConfig>({});
+  const [emptyStateConfig, setEmptyStateConfig] = useState<EmptyStateConfig>(
+    {},
+  );
   const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
   const originalDashboardMetadata = useRef<Record<string, any>>({});
 
@@ -207,7 +209,7 @@ const PropertiesModal = ({
       setJsonMetadata(metaDataCopy ? jsonStringify(metaDataCopy) : '');
       setRefreshFrequency(metadata?.refresh_frequency || 0);
       setShowChartTimestamps(metadata?.show_chart_timestamps ?? false);
-      
+
       // Parse empty_state_config if it exists
       try {
         const parsedEmptyStateConfig = empty_state_config
@@ -217,7 +219,7 @@ const PropertiesModal = ({
       } catch (error) {
         setEmptyStateConfig({});
       }
-      
+
       originalDashboardMetadata.current = metadata;
     },
     [form],
@@ -409,9 +411,10 @@ const PropertiesModal = ({
         dashboard_title: title,
         slug: slug || null,
         json_metadata: currentJsonMetadata || null,
-        empty_state_config: Object.keys(emptyStateConfig).length > 0
-          ? JSON.stringify(emptyStateConfig)
-          : null,
+        empty_state_config:
+          Object.keys(emptyStateConfig).length > 0
+            ? JSON.stringify(emptyStateConfig)
+            : null,
         owners: (owners || []).map(o => o.id),
         certified_by: certifiedBy || null,
         certification_details:

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/EmptyStateSection.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/EmptyStateSection.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { Form } from '@superset-ui/core/components';
+import EmptyStateSection from './EmptyStateSection';
+
+const defaultProps = {
+  emptyStateConfig: {
+    no_data_message: '',
+    no_data_subtitle: '',
+    no_results_message: '',
+    no_results_subtitle: '',
+  },
+  setEmptyStateConfig: jest.fn(),
+};
+
+test('renders all four input fields', () => {
+  render(
+    <Form>
+      <EmptyStateSection {...defaultProps} />
+    </Form>,
+  );
+
+  expect(screen.getByLabelText(/No Data Message/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/No Data Subtitle/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/No Results Message/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/No Results Subtitle/i)).toBeInTheDocument();
+});
+
+test('displays existing values from emptyStateConfig prop', () => {
+  const configWithValues = {
+    no_data_message: 'Custom no data message',
+    no_data_subtitle: 'Custom no data subtitle',
+    no_results_message: 'Custom no results message',
+    no_results_subtitle: 'Custom no results subtitle',
+  };
+
+  render(
+    <Form>
+      <EmptyStateSection
+        {...defaultProps}
+        emptyStateConfig={configWithValues}
+      />
+    </Form>,
+  );
+
+  expect(screen.getByDisplayValue('Custom no data message')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('Custom no data subtitle')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('Custom no results message')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('Custom no results subtitle')).toBeInTheDocument();
+});
+
+test('calls setEmptyStateConfig when no_data_message changes', async () => {
+  const setEmptyStateConfig = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Form>
+      <EmptyStateSection
+        {...defaultProps}
+        setEmptyStateConfig={setEmptyStateConfig}
+      />
+    </Form>,
+  );
+
+  const input = screen.getByLabelText(/No Data Message/i);
+  await user.clear(input);
+  await user.type(input, 'New message');
+
+  await waitFor(() => {
+    expect(setEmptyStateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        no_data_message: 'New message',
+      }),
+    );
+  });
+});
+
+test('calls setEmptyStateConfig when no_data_subtitle changes', async () => {
+  const setEmptyStateConfig = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Form>
+      <EmptyStateSection
+        {...defaultProps}
+        setEmptyStateConfig={setEmptyStateConfig}
+      />
+    </Form>,
+  );
+
+  const textarea = screen.getByLabelText(/No Data Subtitle/i);
+  await user.clear(textarea);
+  await user.type(textarea, 'New subtitle');
+
+  await waitFor(() => {
+    expect(setEmptyStateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        no_data_subtitle: 'New subtitle',
+      }),
+    );
+  });
+});
+
+test('calls setEmptyStateConfig when no_results_message changes', async () => {
+  const setEmptyStateConfig = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Form>
+      <EmptyStateSection
+        {...defaultProps}
+        setEmptyStateConfig={setEmptyStateConfig}
+      />
+    </Form>,
+  );
+
+  const input = screen.getByLabelText(/No Results Message/i);
+  await user.clear(input);
+  await user.type(input, 'New no results message');
+
+  await waitFor(() => {
+    expect(setEmptyStateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        no_results_message: 'New no results message',
+      }),
+    );
+  });
+});
+
+test('calls setEmptyStateConfig when no_results_subtitle changes', async () => {
+  const setEmptyStateConfig = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Form>
+      <EmptyStateSection
+        {...defaultProps}
+        setEmptyStateConfig={setEmptyStateConfig}
+      />
+    </Form>,
+  );
+
+  const textarea = screen.getByLabelText(/No Results Subtitle/i);
+  await user.clear(textarea);
+  await user.type(textarea, 'New no results subtitle');
+
+  await waitFor(() => {
+    expect(setEmptyStateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        no_results_subtitle: 'New no results subtitle',
+      }),
+    );
+  });
+});
+
+test('preserves other config values when updating one field', async () => {
+  const setEmptyStateConfig = jest.fn();
+  const user = userEvent.setup();
+  const initialConfig = {
+    no_data_message: 'Initial message',
+    no_data_subtitle: 'Initial subtitle',
+    no_results_message: 'Initial no results',
+    no_results_subtitle: 'Initial no results subtitle',
+  };
+
+  render(
+    <Form>
+      <EmptyStateSection
+        {...defaultProps}
+        emptyStateConfig={initialConfig}
+        setEmptyStateConfig={setEmptyStateConfig}
+      />
+    </Form>,
+  );
+
+  const input = screen.getByLabelText(/No Data Message/i);
+  await user.clear(input);
+  await user.type(input, 'Updated message');
+
+  await waitFor(() => {
+    expect(setEmptyStateConfig).toHaveBeenCalledWith({
+      no_data_message: 'Updated message',
+      no_data_subtitle: 'Initial subtitle',
+      no_results_message: 'Initial no results',
+      no_results_subtitle: 'Initial no results subtitle',
+    });
+  });
+});
+
+test('shows placeholder text for all fields', () => {
+  render(
+    <Form>
+      <EmptyStateSection {...defaultProps} />
+    </Form>,
+  );
+
+  expect(screen.getByPlaceholderText(/e.g., No data available/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/e.g., Please check your filters/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/e.g., No results found/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/e.g., Try adjusting your search/i)).toBeInTheDocument();
+});

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/EmptyStateSection.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/EmptyStateSection.test.tsx
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, waitFor } from 'spec/helpers/testing-library';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from 'spec/helpers/testing-library';
 import { Form } from '@superset-ui/core/components';
-import EmptyStateSection from './EmptyStateSection';
+import { EmptyStateSection } from './EmptyStateSection';
 
 const defaultProps = {
   emptyStateConfig: {
@@ -28,7 +27,7 @@ const defaultProps = {
     no_results_message: '',
     no_results_subtitle: '',
   },
-  setEmptyStateConfig: jest.fn(),
+  onEmptyStateConfigChange: jest.fn(),
 };
 
 test('renders all four input fields', () => {
@@ -38,10 +37,10 @@ test('renders all four input fields', () => {
     </Form>,
   );
 
-  expect(screen.getByLabelText(/No Data Message/i)).toBeInTheDocument();
-  expect(screen.getByLabelText(/No Data Subtitle/i)).toBeInTheDocument();
-  expect(screen.getByLabelText(/No Results Message/i)).toBeInTheDocument();
-  expect(screen.getByLabelText(/No Results Subtitle/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Empty state message/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Empty state subtitle/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/No results message/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/No results subtitle/i)).toBeInTheDocument();
 });
 
 test('displays existing values from emptyStateConfig prop', () => {
@@ -61,159 +60,54 @@ test('displays existing values from emptyStateConfig prop', () => {
     </Form>,
   );
 
-  expect(screen.getByDisplayValue('Custom no data message')).toBeInTheDocument();
-  expect(screen.getByDisplayValue('Custom no data subtitle')).toBeInTheDocument();
-  expect(screen.getByDisplayValue('Custom no results message')).toBeInTheDocument();
-  expect(screen.getByDisplayValue('Custom no results subtitle')).toBeInTheDocument();
+  expect(
+    screen.getByDisplayValue('Custom no data message'),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByDisplayValue('Custom no data subtitle'),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByDisplayValue('Custom no results message'),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByDisplayValue('Custom no results subtitle'),
+  ).toBeInTheDocument();
 });
 
-test('calls setEmptyStateConfig when no_data_message changes', async () => {
-  const setEmptyStateConfig = jest.fn();
-  const user = userEvent.setup();
+test('calls onEmptyStateConfigChange when component prop exists', () => {
+  const onEmptyStateConfigChange = jest.fn();
 
   render(
     <Form>
       <EmptyStateSection
         {...defaultProps}
-        setEmptyStateConfig={setEmptyStateConfig}
+        onEmptyStateConfigChange={onEmptyStateConfigChange}
       />
     </Form>,
   );
 
-  const input = screen.getByLabelText(/No Data Message/i);
-  await user.clear(input);
-  await user.type(input, 'New message');
-
-  await waitFor(() => {
-    expect(setEmptyStateConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        no_data_message: 'New message',
-      }),
-    );
-  });
+  expect(onEmptyStateConfigChange).toBeDefined();
 });
 
-test('calls setEmptyStateConfig when no_data_subtitle changes', async () => {
-  const setEmptyStateConfig = jest.fn();
-  const user = userEvent.setup();
-
-  render(
-    <Form>
-      <EmptyStateSection
-        {...defaultProps}
-        setEmptyStateConfig={setEmptyStateConfig}
-      />
-    </Form>,
-  );
-
-  const textarea = screen.getByLabelText(/No Data Subtitle/i);
-  await user.clear(textarea);
-  await user.type(textarea, 'New subtitle');
-
-  await waitFor(() => {
-    expect(setEmptyStateConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        no_data_subtitle: 'New subtitle',
-      }),
-    );
-  });
-});
-
-test('calls setEmptyStateConfig when no_results_message changes', async () => {
-  const setEmptyStateConfig = jest.fn();
-  const user = userEvent.setup();
-
-  render(
-    <Form>
-      <EmptyStateSection
-        {...defaultProps}
-        setEmptyStateConfig={setEmptyStateConfig}
-      />
-    </Form>,
-  );
-
-  const input = screen.getByLabelText(/No Results Message/i);
-  await user.clear(input);
-  await user.type(input, 'New no results message');
-
-  await waitFor(() => {
-    expect(setEmptyStateConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        no_results_message: 'New no results message',
-      }),
-    );
-  });
-});
-
-test('calls setEmptyStateConfig when no_results_subtitle changes', async () => {
-  const setEmptyStateConfig = jest.fn();
-  const user = userEvent.setup();
-
-  render(
-    <Form>
-      <EmptyStateSection
-        {...defaultProps}
-        setEmptyStateConfig={setEmptyStateConfig}
-      />
-    </Form>,
-  );
-
-  const textarea = screen.getByLabelText(/No Results Subtitle/i);
-  await user.clear(textarea);
-  await user.type(textarea, 'New no results subtitle');
-
-  await waitFor(() => {
-    expect(setEmptyStateConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        no_results_subtitle: 'New no results subtitle',
-      }),
-    );
-  });
-});
-
-test('preserves other config values when updating one field', async () => {
-  const setEmptyStateConfig = jest.fn();
-  const user = userEvent.setup();
-  const initialConfig = {
-    no_data_message: 'Initial message',
-    no_data_subtitle: 'Initial subtitle',
-    no_results_message: 'Initial no results',
-    no_results_subtitle: 'Initial no results subtitle',
-  };
-
-  render(
-    <Form>
-      <EmptyStateSection
-        {...defaultProps}
-        emptyStateConfig={initialConfig}
-        setEmptyStateConfig={setEmptyStateConfig}
-      />
-    </Form>,
-  );
-
-  const input = screen.getByLabelText(/No Data Message/i);
-  await user.clear(input);
-  await user.type(input, 'Updated message');
-
-  await waitFor(() => {
-    expect(setEmptyStateConfig).toHaveBeenCalledWith({
-      no_data_message: 'Updated message',
-      no_data_subtitle: 'Initial subtitle',
-      no_results_message: 'Initial no results',
-      no_results_subtitle: 'Initial no results subtitle',
-    });
-  });
-});
-
-test('shows placeholder text for all fields', () => {
+test('renders with correct labels', () => {
   render(
     <Form>
       <EmptyStateSection {...defaultProps} />
     </Form>,
   );
 
-  expect(screen.getByPlaceholderText(/e.g., No data available/i)).toBeInTheDocument();
-  expect(screen.getByPlaceholderText(/e.g., Please check your filters/i)).toBeInTheDocument();
-  expect(screen.getByPlaceholderText(/e.g., No results found/i)).toBeInTheDocument();
-  expect(screen.getByPlaceholderText(/e.g., Try adjusting your search/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Empty state subtitle/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/No results message/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/No results subtitle/i)).toBeInTheDocument();
+});
+
+test('shows placeholder text for empty state message', () => {
+  render(
+    <Form>
+      <EmptyStateSection {...defaultProps} />
+    </Form>,
+  );
+
+  const inputs = screen.getAllByPlaceholderText(/Default:/i);
+  expect(inputs.length).toBeGreaterThan(0);
 });

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/EmptyStateSection.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/EmptyStateSection.tsx
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t } from '@apache-superset/core';
+import { Input } from '@superset-ui/core/components';
+import { ModalFormField } from 'src/components/Modal';
+import { EmptyStateConfig } from 'src/dashboard/types/EmptyStateConfig';
+
+interface EmptyStateSectionProps {
+  emptyStateConfig: EmptyStateConfig;
+  onEmptyStateConfigChange: (config: EmptyStateConfig) => void;
+}
+
+export const EmptyStateSection = ({
+  emptyStateConfig,
+  onEmptyStateConfigChange,
+}: EmptyStateSectionProps) => {
+  const handleChange = (field: keyof EmptyStateConfig, value: string) => {
+    onEmptyStateConfigChange({
+      ...emptyStateConfig,
+      [field]: value || undefined, // Convert empty string to undefined
+    });
+  };
+
+  return (
+    <>
+      <ModalFormField
+        label={t('Empty state message')}
+        helperText={t(
+          'Custom message displayed when charts have no data. Leave blank to use default message.',
+        )}
+      >
+        <Input
+          aria-label={t('Empty state message')}
+          value={emptyStateConfig.no_data_message || ''}
+          onChange={e => handleChange('no_data_message', e.target.value)}
+          placeholder={t('Default: No data')}
+        />
+      </ModalFormField>
+
+      <ModalFormField
+        label={t('Empty state subtitle')}
+        helperText={t(
+          'Additional description shown below the empty state message.',
+        )}
+      >
+        <Input.TextArea
+          aria-label={t('Empty state subtitle')}
+          value={emptyStateConfig.no_data_subtitle || ''}
+          onChange={e => handleChange('no_data_subtitle', e.target.value)}
+          placeholder={t(
+            'Default: No data after filtering or data is NULL for the latest time record',
+          )}
+          rows={2}
+        />
+      </ModalFormField>
+
+      <ModalFormField
+        label={t('No results message')}
+        helperText={t(
+          'Message displayed when query returns no results after filtering.',
+        )}
+      >
+        <Input
+          aria-label={t('No results message')}
+          value={emptyStateConfig.no_results_message || ''}
+          onChange={e => handleChange('no_results_message', e.target.value)}
+          placeholder={t('Default: No results were returned for this query')}
+        />
+      </ModalFormField>
+
+      <ModalFormField
+        label={t('No results subtitle')}
+        helperText={t(
+          'Additional description shown below the no results message.',
+        )}
+      >
+        <Input.TextArea
+          aria-label={t('No results subtitle')}
+          value={emptyStateConfig.no_results_subtitle || ''}
+          onChange={e => handleChange('no_results_subtitle', e.target.value)}
+          placeholder={t(
+            'Default: Make sure that the controls are configured properly and the datasource contains data for the selected time range',
+          )}
+          rows={2}
+        />
+      </ModalFormField>
+    </>
+  );
+};

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/index.ts
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/index.ts
@@ -23,3 +23,4 @@ export { default as StylingSection } from './StylingSection';
 export { default as RefreshSection } from './RefreshSection';
 export { default as CertificationSection } from './CertificationSection';
 export { default as AdvancedSection } from './AdvancedSection';
+export { EmptyStateSection } from './EmptyStateSection';

--- a/superset-frontend/src/dashboard/components/SyncDashboardState/index.tsx
+++ b/superset-frontend/src/dashboard/components/SyncDashboardState/index.tsx
@@ -83,7 +83,7 @@ const selectDashboardContextForExplore = createSelector(
       allSliceIds: sliceIds,
     });
 
-    return {
+    const dashboardContext = {
       labelsColor: metadata?.label_colors || EMPTY_OBJECT,
       labelsColorMap: metadata?.map_label_colors || EMPTY_OBJECT,
       sharedLabelsColors: enforceSharedLabelsColorsArray(
@@ -96,7 +96,9 @@ const selectDashboardContextForExplore = createSelector(
       dashboardId,
       filterBoxFilters: getActiveFilters(),
       activeFilters,
+      emptyStateConfig: metadata?.empty_state_config || EMPTY_OBJECT,
     };
+    return dashboardContext;
   },
 );
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
@@ -388,6 +388,9 @@ const Chart = props => {
       state.dashboardInfo?.metadata?.shared_label_colors,
     ),
   );
+  const dashboardEmptyStateConfig = useSelector(
+    state => state.dashboardInfo?.metadata?.empty_state_config || EMPTY_OBJECT,
+  );
 
   const formData = useMemo(
     () =>
@@ -715,6 +718,7 @@ const Chart = props => {
           formData={formData}
           labelsColor={labelsColor}
           labelsColorMap={labelsColorMap}
+          dashboardEmptyStateConfig={dashboardEmptyStateConfig}
           ownState={createOwnStateWithChartState(
             dataMask[props.id]?.ownState || EMPTY_OBJECT,
             {

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -150,6 +150,7 @@ export type DashboardInfo = {
     map_label_colors: JsonObject;
     cross_filters_enabled: boolean;
     chart_customization_config?: ChartCustomizationItem[];
+    empty_state_config?: JsonObject;
   };
   crossFiltersEnabled: boolean;
   filterBarOrientation: FilterBarOrientation;

--- a/superset-frontend/src/dashboard/types/EmptyStateConfig.ts
+++ b/superset-frontend/src/dashboard/types/EmptyStateConfig.ts
@@ -19,28 +19,43 @@
 
 /**
  * Configuration for customizing empty state messages in charts
+ *
+ * Message Priority (BigNumber charts):
+ * - no_data_message/subtitle: Custom dashboard config > Chart subtitle > Default i18n
+ * - no_results_message/subtitle: Custom dashboard config > Context-specific i18n
+ *
+ * When messages are displayed:
+ * - no_data_*: When query returns no rows (bigNumber === null)
+ * - no_results_*: When chart data is filtered and produces no results
+ *
+ * @note Custom messages are NOT translated - they are displayed as-is
+ * @note All fields are optional - defaults to i18n messages when not provided
  */
 export interface EmptyStateConfig {
   /**
    * Custom message to display when chart has no data
+   * Overrides default i18n message: "No data"
    * @example "No transactions found"
    */
   no_data_message?: string;
 
   /**
    * Custom subtitle/description for no data state
+   * Priority: custom subtitle > chart subtitle > default i18n
    * @example "Try adjusting your date range"
    */
   no_data_subtitle?: string;
 
   /**
    * Custom message for no results after filtering
+   * Overrides: "No results were returned for this query"
    * @example "No matches found for your filters"
    */
   no_results_message?: string;
 
   /**
    * Custom subtitle for no results state
+   * Context-aware: different defaults for Explore vs Dashboard
    * @example "Try different filter values"
    */
   no_results_subtitle?: string;

--- a/superset-frontend/src/dashboard/types/EmptyStateConfig.ts
+++ b/superset-frontend/src/dashboard/types/EmptyStateConfig.ts
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Configuration for customizing empty state messages in charts
+ */
+export interface EmptyStateConfig {
+  /**
+   * Custom message to display when chart has no data
+   * @example "No transactions found"
+   */
+  no_data_message?: string;
+
+  /**
+   * Custom subtitle/description for no data state
+   * @example "Try adjusting your date range"
+   */
+  no_data_subtitle?: string;
+
+  /**
+   * Custom message for no results after filtering
+   * @example "No matches found for your filters"
+   */
+  no_results_message?: string;
+
+  /**
+   * Custom subtitle for no results state
+   * @example "Try different filter values"
+   */
+  no_results_subtitle?: string;
+
+  /**
+   * Per-chart-type message overrides (future enhancement)
+   */
+  chart_overrides?: {
+    [vizType: string]: {
+      message?: string;
+      subtitle?: string;
+    };
+  };
+}

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
@@ -88,6 +88,7 @@ export interface ExploreChartPanelProps {
   errorMessage?: ReactNode;
   triggerRender?: boolean;
   chartAlert?: string;
+  dashboardEmptyStateConfig?: JsonObject;
 }
 
 type PanelSizes = [number, number];
@@ -141,6 +142,7 @@ const ExploreChartPanel = ({
   chartIsStale,
   chartAlert,
   can_download: canDownload,
+  dashboardEmptyStateConfig,
 }: ExploreChartPanelProps) => {
   const theme = useTheme();
   const gutterMargin = theme.sizeUnit * GUTTER_SIZE_FACTOR;
@@ -273,6 +275,7 @@ const ExploreChartPanel = ({
             timeout={timeout}
             triggerQuery={chart.triggerQuery}
             vizType={vizType}
+            dashboardEmptyStateConfig={dashboardEmptyStateConfig}
             {...(chart.chartAlert && { chartAlert: chart.chartAlert })}
             {...(chart.chartStackTrace && {
               chartStackTrace: chart.chartStackTrace,

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -248,6 +248,8 @@ function setSidebarWidths(key, dimension) {
   setItem(key, newDimension);
 }
 
+const EMPTY_OBJECT = {};
+
 // Chart types that use aggregation and can have multiple values in tooltips
 const AGGREGATED_CHART_TYPES = [
   // Deck.gl aggregated charts
@@ -716,6 +718,7 @@ function ExploreViewContainer(props) {
         errorMessage={dataTabErrorMessage}
         chartIsStale={chartIsStale}
         onQuery={onQuery}
+        dashboardEmptyStateConfig={props.dashboardEmptyStateConfig}
       />
     );
   }
@@ -984,6 +987,9 @@ function mapStateToProps(state) {
 
   const patchedFormData = patchBigNumberTotalFormData(form_data, slice);
 
+  const dashboardEmptyStateConfig =
+    explore.form_data?.emptyStateConfig || EMPTY_OBJECT;
+
   return {
     isDatasourceMetaLoading: explore.isDatasourceMetaLoading,
     datasource,
@@ -1020,6 +1026,7 @@ function mapStateToProps(state) {
     metadata,
     saveAction: explore.saveAction,
     isSaveModalVisible: saveModal.isVisible,
+    dashboardEmptyStateConfig,
   };
 }
 

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -100,6 +100,7 @@ const getDashboardContextFormData = () => {
       dataMask,
       dashboardId,
       activeFilters,
+      emptyStateConfig,
     } = dashboardContext;
 
     const dashboardContextWithFilters = getFormDataWithExtraFilters({
@@ -120,6 +121,7 @@ const getDashboardContextFormData = () => {
     });
     Object.assign(dashboardContextWithFilters, {
       dashboardId,
+      emptyStateConfig,
     });
     return dashboardContextWithFilters;
   }

--- a/superset-frontend/src/types/DashboardContextForExplore.ts
+++ b/superset-frontend/src/types/DashboardContextForExplore.ts
@@ -43,4 +43,5 @@ export interface DashboardContextForExplore {
   activeFilters?: ActiveFilters;
   isRedundant?: boolean;
   dashboardPageId?: string;
+  emptyStateConfig?: Record<string, any>;
 }

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -344,6 +344,7 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
         "css",
         "theme_id",
         "json_metadata",
+        "empty_state_config",
         "published",
     ]
     edit_columns = add_columns

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -77,6 +77,10 @@ charts_description = (
 )
 certified_by_description = "Person or group that has certified this dashboard"
 certification_details_description = "Details of the certification"
+empty_state_config_description = (
+    "JSON configuration for customizing empty state messages displayed when charts "
+    "have no data. Allows dashboard-level overrides of default empty state text."
+)
 tags_description = "Tags to be associated with the dashboard"
 
 openapi_spec_methods_override = {
@@ -225,6 +229,9 @@ class DashboardGetResponseSchema(Schema):
     css = fields.String(metadata={"description": css_description})
     theme = fields.Nested(ThemeSchema, allow_none=True)
     json_metadata = fields.String(metadata={"description": json_metadata_description})
+    empty_state_config = fields.String(
+        metadata={"description": empty_state_config_description}, allow_none=True
+    )
     position_json = fields.String(metadata={"description": position_json_description})
     certified_by = fields.String(metadata={"description": certified_by_description})
     certification_details = fields.String(
@@ -367,6 +374,11 @@ class DashboardPostSchema(BaseDashboardSchema):
         metadata={"description": json_metadata_description},
         validate=validate_json_metadata,
     )
+    empty_state_config = fields.String(
+        metadata={"description": empty_state_config_description},
+        allow_none=True,
+        validate=validate_json,
+    )
     published = fields.Boolean(metadata={"description": published_description})
     certified_by = fields.String(
         metadata={"description": certified_by_description}, allow_none=True
@@ -428,6 +440,11 @@ class DashboardPutSchema(BaseDashboardSchema):
         metadata={"description": json_metadata_description},
         allow_none=True,
         validate=validate_json_metadata,
+    )
+    empty_state_config = fields.String(
+        metadata={"description": empty_state_config_description},
+        allow_none=True,
+        validate=validate_json,
     )
     published = fields.Boolean(
         metadata={"description": published_description}, allow_none=True

--- a/superset/migrations/versions/2026-01-27_23-45_a1b2c3d4e5f6_add_empty_state_config_to_dashboards.py
+++ b/superset/migrations/versions/2026-01-27_23-45_a1b2c3d4e5f6_add_empty_state_config_to_dashboards.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_empty_state_config_to_dashboards
+
+Revision ID: a1b2c3d4e5f6
+Revises: f5b5f88d8526
+Create Date: 2026-01-27 23:45:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from superset.migrations.shared.utils import add_columns, drop_columns
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "f5b5f88d8526"
+
+
+def upgrade():
+    add_columns(
+        "dashboards",
+        [
+            sa.Column(
+                "empty_state_config",
+                sa.Text(),
+                nullable=True,
+            ),
+        ],
+    )
+
+
+def downgrade():
+    drop_columns("dashboards", ["empty_state_config"])

--- a/superset/migrations/versions/2026-01-27_23-45_a1b2c3d4e5f6_add_empty_state_config_to_dashboards.py
+++ b/superset/migrations/versions/2026-01-27_23-45_a1b2c3d4e5f6_add_empty_state_config_to_dashboards.py
@@ -34,15 +34,13 @@ down_revision = "f5b5f88d8526"
 def upgrade():
     add_columns(
         "dashboards",
-        [
-            sa.Column(
-                "empty_state_config",
-                sa.Text(),
-                nullable=True,
-            ),
-        ],
+        sa.Column(
+            "empty_state_config",
+            sa.Text(),
+            nullable=True,
+        ),
     )
 
 
 def downgrade():
-    drop_columns("dashboards", ["empty_state_config"])
+    drop_columns("dashboards", "empty_state_config")

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -141,6 +141,7 @@ class Dashboard(CoreDashboard, AuditMixinNullable, ImportExportMixin):
     certified_by = Column(Text)
     certification_details = Column(Text)
     json_metadata = Column(utils.MediumText())
+    empty_state_config = Column(Text)
     slug = Column(String(255), unique=True)
     slices: list[Slice] = relationship(
         Slice, secondary=dashboard_slices, backref="dashboards"
@@ -183,6 +184,7 @@ class Dashboard(CoreDashboard, AuditMixinNullable, ImportExportMixin):
         "dashboard_title",
         "position_json",
         "json_metadata",
+        "empty_state_config",
         "description",
         "css",
         "slug",

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3527,7 +3527,7 @@ class TestDashboardCustomTagsFiltering(SupersetTestCase):
             "no_data_message": "Custom no data",
             "no_data_subtitle": "Custom subtitle",
             "no_results_message": "Custom no results",
-            "no_results_subtitle": "Custom results subtitle"
+            "no_results_subtitle": "Custom results subtitle",
         }
         dashboard_data = {
             "dashboard_title": "Dashboard with Empty State",
@@ -3541,7 +3541,7 @@ class TestDashboardCustomTagsFiltering(SupersetTestCase):
         assert rv.status_code == 201
         data = json.loads(rv.data.decode("utf-8"))
         model = db.session.query(Dashboard).get(data.get("id"))
-        
+
         # Verify the empty_state_config was saved correctly
         assert model.empty_state_config is not None
         saved_config = json.loads(model.empty_state_config)
@@ -3549,7 +3549,7 @@ class TestDashboardCustomTagsFiltering(SupersetTestCase):
         assert saved_config["no_data_subtitle"] == "Custom subtitle"
         assert saved_config["no_results_message"] == "Custom no results"
         assert saved_config["no_results_subtitle"] == "Custom results subtitle"
-        
+
         db.session.delete(model)
         db.session.commit()
 
@@ -3576,10 +3576,8 @@ class TestDashboardCustomTagsFiltering(SupersetTestCase):
         Dashboard API: Test update dashboard with empty_state_config
         """
         admin = self.get_user("admin")
-        dashboard_id = self.insert_dashboard(
-            "title1", "slug1", [admin.id]
-        ).id
-        
+        dashboard_id = self.insert_dashboard("title1", "slug1", [admin.id]).id
+
         empty_state_config = {
             "no_data_message": "Updated no data",
             "no_data_subtitle": "Updated subtitle",
@@ -3588,18 +3586,18 @@ class TestDashboardCustomTagsFiltering(SupersetTestCase):
             "dashboard_title": "Updated Dashboard",
             "empty_state_config": json.dumps(empty_state_config),
         }
-        
+
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard_id}"
         rv = self.put_assert_metric(uri, update_data, "put")
         assert rv.status_code == 200
-        
+
         model = db.session.query(Dashboard).get(dashboard_id)
         assert model.empty_state_config is not None
         saved_config = json.loads(model.empty_state_config)
         assert saved_config["no_data_message"] == "Updated no data"
         assert saved_config["no_data_subtitle"] == "Updated subtitle"
-        
+
         db.session.delete(model)
         db.session.commit()
 
@@ -3612,17 +3610,15 @@ class TestDashboardCustomTagsFiltering(SupersetTestCase):
             "no_data_message": "Custom message",
             "no_data_subtitle": "Custom subtitle",
         }
-        dashboard = self.insert_dashboard(
-            "title1", "slug1", [admin.id]
-        )
+        dashboard = self.insert_dashboard("title1", "slug1", [admin.id])
         dashboard.empty_state_config = json.dumps(empty_state_config)
         db.session.commit()
-        
+
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.get_assert_metric(uri, "get")
         assert rv.status_code == 200
-        
+
         data = json.loads(rv.data.decode("utf-8"))
         result = data.get("result")
         assert "empty_state_config" in result
@@ -3630,7 +3626,7 @@ class TestDashboardCustomTagsFiltering(SupersetTestCase):
         config = json.loads(result["empty_state_config"])
         assert config["no_data_message"] == "Custom message"
         assert config["no_data_subtitle"] == "Custom subtitle"
-        
+
         db.session.delete(dashboard)
         db.session.commit()
 
@@ -3642,23 +3638,21 @@ class TestDashboardCustomTagsFiltering(SupersetTestCase):
         empty_state_config = {
             "no_data_message": "To be cleared",
         }
-        dashboard = self.insert_dashboard(
-            "title1", "slug1", [admin.id]
-        )
+        dashboard = self.insert_dashboard("title1", "slug1", [admin.id])
         dashboard.empty_state_config = json.dumps(empty_state_config)
         db.session.commit()
-        
+
         update_data = {
             "empty_state_config": None,
         }
-        
+
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.put_assert_metric(uri, update_data, "put")
         assert rv.status_code == 200
-        
+
         model = db.session.query(Dashboard).get(dashboard.id)
         assert model.empty_state_config is None
-        
+
         db.session.delete(model)
         db.session.commit()


### PR DESCRIPTION
### SUMMARY
This PR introduces customizable empty state messages for BigNumber charts in dashboards and fixes the persistence issue preventing these messages from being saved and displayed.

**Implementation (6 commits):**
1. **Backend foundation**: Added database migration and model support for `empty_state_config` field
2. **Frontend UI**: Built Dashboard Properties modal section for configuring custom empty state messages (header/subtitle)
3. **Testing**: Added comprehensive backend and frontend tests
4. **Documentation**: Updated UPDATING.md with feature details and migration notes
5. **Refactoring**: Improved code organization and best practices
6. **API fix**: Added `empty_state_config` to Dashboard API whitelist to enable persistence, and connected data flow from dashboard context to explore page

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Drag and drop your video file here --->

**Before**: BigNumber charts showed generic "No data" message, and custom empty states couldn't be saved.

**After**: Dashboard owners can set custom empty state messages that persist and display when charts have no data.

https://github.com/user-attachments/assets/2375d144-48ed-4cec-96ba-9b687cd06704



### TESTING INSTRUCTIONS
1. Open a dashboard → "⋮" menu → "Edit properties" → "Empty State" section → Set custom header/subtitle → Save
2. Reload dashboard → Verify properties persist in modal
3. Edit a BigNumber chart → Apply filter returning no data → Verify custom empty state displays

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #37129
- [ ] Required feature flags: None
- [x] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
