### PR TITLE
fix(mcp): include x_axis column in query context for series charts with group_by

### DIFF
--- a/superset/mcp_service/chart/preview_utils.py
+++ b/superset/mcp_service/chart/preview_utils.py
@@ -70,7 +70,9 @@ def generate_preview_from_form_data(
         groupby_columns = form_data.get("groupby", [])
         raw_columns = form_data.get("columns", [])
 
-        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        columns = (
+            raw_columns.copy() if "columns" in form_data else groupby_columns.copy()
+        )
         if x_axis_config and isinstance(x_axis_config, str):
             if x_axis_config not in columns:
                 columns.insert(0, x_axis_config)

--- a/superset/mcp_service/chart/preview_utils.py
+++ b/superset/mcp_service/chart/preview_utils.py
@@ -39,8 +39,8 @@ logger = logging.getLogger(__name__)
 def _build_query_columns(form_data: Dict[str, Any]) -> list[str]:
     """Build query columns list from form_data, including both x_axis and groupby."""
     x_axis_config = form_data.get("x_axis")
-    groupby_columns: list[str] = form_data.get("groupby", [])
-    raw_columns: list[str] = form_data.get("columns", [])
+    groupby_columns: list[str] = form_data.get("groupby") or []
+    raw_columns: list[str] = form_data.get("columns") or []
 
     columns = raw_columns.copy() if "columns" in form_data else groupby_columns.copy()
     if x_axis_config and isinstance(x_axis_config, str):

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -606,6 +606,8 @@ class FilterConfig(BaseModel):
 
 # Actual chart types
 class TableChartConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     chart_type: Literal["table"] = Field(
         ..., description="Chart type (REQUIRED: must be 'table')"
     )
@@ -659,6 +661,8 @@ class TableChartConfig(BaseModel):
 
 
 class XYChartConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     chart_type: Literal["xy"] = Field(
         ...,
         description=(
@@ -692,7 +696,11 @@ class XYChartConfig(BaseModel):
         False,
         description="Stack bars/areas on top of each other instead of side-by-side",
     )
-    group_by: ColumnRef | None = Field(None, description="Column to group by")
+    group_by: ColumnRef | None = Field(
+        None,
+        description="Column to group by (creates series/breakdown). "
+        "Use this field for series grouping — do NOT use 'series'.",
+    )
     x_axis: AxisConfig | None = Field(None, description="X-axis configuration")
     y_axis: AxisConfig | None = Field(None, description="Y-axis configuration")
     legend: LegendConfig | None = Field(None, description="Legend configuration")

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -178,16 +178,16 @@ async def get_chart_data(  # noqa: C901
                     metrics = form_data.get("metrics", [])
                     groupby_columns = form_data.get("groupby", [])
 
-                # Build columns list: include both x_axis and groupby
+                # Build query columns list: include both x_axis and groupby
                 x_axis_config = form_data.get("x_axis")
-                columns = groupby_columns.copy()
+                query_columns = groupby_columns.copy()
                 if x_axis_config and isinstance(x_axis_config, str):
-                    if x_axis_config not in columns:
-                        columns.insert(0, x_axis_config)
+                    if x_axis_config not in query_columns:
+                        query_columns.insert(0, x_axis_config)
                 elif x_axis_config and isinstance(x_axis_config, dict):
                     col_name = x_axis_config.get("column_name")
-                    if col_name and col_name not in columns:
-                        columns.insert(0, col_name)
+                    if col_name and col_name not in query_columns:
+                        query_columns.insert(0, col_name)
 
                 query_context = factory.create(
                     datasource={
@@ -197,7 +197,7 @@ async def get_chart_data(  # noqa: C901
                     queries=[
                         {
                             "filters": form_data.get("filters", []),
-                            "columns": columns,
+                            "columns": query_columns,
                             "metrics": metrics,
                             "row_limit": row_limit,
                             "order_desc": True,

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -176,7 +176,7 @@ async def get_chart_data(  # noqa: C901
                 else:
                     # Standard charts use "metrics" (plural) and "groupby"
                     metrics = form_data.get("metrics", [])
-                    groupby_columns = form_data.get("groupby", [])
+                    groupby_columns = form_data.get("groupby") or []
 
                 # Build query columns list: include both x_axis and groupby
                 x_axis_config = form_data.get("x_axis")

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -178,6 +178,17 @@ async def get_chart_data(  # noqa: C901
                     metrics = form_data.get("metrics", [])
                     groupby_columns = form_data.get("groupby", [])
 
+                # Build columns list: include both x_axis and groupby
+                x_axis_config = form_data.get("x_axis")
+                columns = groupby_columns.copy()
+                if x_axis_config and isinstance(x_axis_config, str):
+                    if x_axis_config not in columns:
+                        columns.insert(0, x_axis_config)
+                elif x_axis_config and isinstance(x_axis_config, dict):
+                    col_name = x_axis_config.get("column_name")
+                    if col_name and col_name not in columns:
+                        columns.insert(0, col_name)
+
                 query_context = factory.create(
                     datasource={
                         "id": chart.datasource_id,
@@ -186,7 +197,7 @@ async def get_chart_data(  # noqa: C901
                     queries=[
                         {
                             "filters": form_data.get("filters", []),
-                            "columns": groupby_columns,
+                            "columns": columns,
                             "metrics": metrics,
                             "row_limit": row_limit,
                             "order_desc": True,

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -56,6 +56,22 @@ class ChartLike(Protocol):
     uuid: Any
 
 
+def _build_query_columns(form_data: Dict[str, Any]) -> list[str]:
+    """Build query columns list from form_data, including both x_axis and groupby."""
+    x_axis_config = form_data.get("x_axis")
+    groupby_columns: list[str] = form_data.get("groupby", [])
+
+    columns = groupby_columns.copy()
+    if x_axis_config and isinstance(x_axis_config, str):
+        if x_axis_config not in columns:
+            columns.insert(0, x_axis_config)
+    elif x_axis_config and isinstance(x_axis_config, dict):
+        col_name = x_axis_config.get("column_name")
+        if col_name and col_name not in columns:
+            columns.insert(0, col_name)
+    return columns
+
+
 class PreviewFormatStrategy:
     """Base class for preview format strategies."""
 
@@ -185,18 +201,7 @@ class TablePreviewStrategy(PreviewFormatStrategy):
                     error_type="InvalidChart",
                 )
 
-            # Build columns list: include both x_axis and groupby
-            x_axis_config = form_data.get("x_axis")
-            groupby_columns = form_data.get("groupby", [])
-
-            columns = groupby_columns.copy()
-            if x_axis_config and isinstance(x_axis_config, str):
-                if x_axis_config not in columns:
-                    columns.insert(0, x_axis_config)
-            elif x_axis_config and isinstance(x_axis_config, dict):
-                col_name = x_axis_config.get("column_name")
-                if col_name and col_name not in columns:
-                    columns.insert(0, col_name)
+            columns = _build_query_columns(form_data)
 
             factory = QueryContextFactory()
             query_context = factory.create(
@@ -293,17 +298,7 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
                 )
 
             # Build columns list: include both x_axis and groupby
-            x_axis_config = form_data.get("x_axis")
-            groupby_columns = form_data.get("groupby", [])
-
-            columns = groupby_columns.copy()
-            if x_axis_config and isinstance(x_axis_config, str):
-                if x_axis_config not in columns:
-                    columns.insert(0, x_axis_config)
-            elif x_axis_config and isinstance(x_axis_config, dict):
-                col_name = x_axis_config.get("column_name")
-                if col_name and col_name not in columns:
-                    columns.insert(0, col_name)
+            columns = _build_query_columns(form_data)
 
             # Create query context for data retrieval
             factory = QueryContextFactory()

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -185,6 +185,19 @@ class TablePreviewStrategy(PreviewFormatStrategy):
                     error_type="InvalidChart",
                 )
 
+            # Build columns list: include both x_axis and groupby
+            x_axis_config = form_data.get("x_axis")
+            groupby_columns = form_data.get("groupby", [])
+
+            columns = groupby_columns.copy()
+            if x_axis_config and isinstance(x_axis_config, str):
+                if x_axis_config not in columns:
+                    columns.insert(0, x_axis_config)
+            elif x_axis_config and isinstance(x_axis_config, dict):
+                col_name = x_axis_config.get("column_name")
+                if col_name and col_name not in columns:
+                    columns.insert(0, col_name)
+
             factory = QueryContextFactory()
             query_context = factory.create(
                 datasource={
@@ -194,7 +207,7 @@ class TablePreviewStrategy(PreviewFormatStrategy):
                 queries=[
                     {
                         "filters": form_data.get("filters", []),
-                        "columns": form_data.get("groupby", []),
+                        "columns": columns,
                         "metrics": form_data.get("metrics", []),
                         "row_limit": 20,
                         "order_desc": True,
@@ -279,6 +292,19 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
                     utils_json.loads(self.chart.params) if self.chart.params else {}
                 )
 
+            # Build columns list: include both x_axis and groupby
+            x_axis_config = form_data.get("x_axis")
+            groupby_columns = form_data.get("groupby", [])
+
+            columns = groupby_columns.copy()
+            if x_axis_config and isinstance(x_axis_config, str):
+                if x_axis_config not in columns:
+                    columns.insert(0, x_axis_config)
+            elif x_axis_config and isinstance(x_axis_config, dict):
+                col_name = x_axis_config.get("column_name")
+                if col_name and col_name not in columns:
+                    columns.insert(0, col_name)
+
             # Create query context for data retrieval
             factory = QueryContextFactory()
             query_context = factory.create(
@@ -289,7 +315,7 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
                 queries=[
                     {
                         "filters": form_data.get("filters", []),
-                        "columns": form_data.get("groupby", []),
+                        "columns": columns,
                         "metrics": form_data.get("metrics", []),
                         "row_limit": 1000,  # More data for visualization
                         "order_desc": True,

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -59,7 +59,7 @@ class ChartLike(Protocol):
 def _build_query_columns(form_data: Dict[str, Any]) -> list[str]:
     """Build query columns list from form_data, including both x_axis and groupby."""
     x_axis_config = form_data.get("x_axis")
-    groupby_columns: list[str] = form_data.get("groupby", [])
+    groupby_columns: list[str] = form_data.get("groupby") or []
 
     columns = groupby_columns.copy()
     if x_axis_config and isinstance(x_axis_config, str):

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -228,7 +228,7 @@ class TestXYChartConfig:
                 x=ColumnRef(name="territory"),
                 y=[ColumnRef(name="sales", aggregate="SUM")],
                 kind="bar",
-                series=ColumnRef(name="year"),  # type: ignore[call-arg]
+                series=ColumnRef(name="year"),
             )
 
     def test_group_by_accepted(self) -> None:
@@ -253,5 +253,5 @@ class TestTableChartConfigExtraFields:
             TableChartConfig(
                 chart_type="table",
                 columns=[ColumnRef(name="product")],
-                foo="bar",  # type: ignore[call-arg]
+                foo="bar",
             )

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -219,3 +219,39 @@ class TestXYChartConfig:
             kind="area",
         )
         assert config.kind == "area"
+
+    def test_unknown_fields_rejected(self) -> None:
+        """Test that unknown fields like 'series' are rejected."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            XYChartConfig(
+                chart_type="xy",
+                x=ColumnRef(name="territory"),
+                y=[ColumnRef(name="sales", aggregate="SUM")],
+                kind="bar",
+                series=ColumnRef(name="year"),  # type: ignore[call-arg]
+            )
+
+    def test_group_by_accepted(self) -> None:
+        """Test that group_by is the correct field for series grouping."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="territory"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            kind="bar",
+            group_by=ColumnRef(name="year"),
+        )
+        assert config.group_by is not None
+        assert config.group_by.name == "year"
+
+
+class TestTableChartConfigExtraFields:
+    """Test TableChartConfig rejects unknown fields."""
+
+    def test_unknown_fields_rejected(self) -> None:
+        """Test that unknown fields are rejected."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            TableChartConfig(
+                chart_type="table",
+                columns=[ColumnRef(name="product")],
+                foo="bar",  # type: ignore[call-arg]
+            )

--- a/tests/unit_tests/mcp_service/chart/test_preview_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_preview_utils.py
@@ -39,7 +39,9 @@ class TestPreviewUtilsColumnBuilding:
         groupby_columns = form_data.get("groupby", [])
         raw_columns = form_data.get("columns", [])
 
-        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        columns = (
+            raw_columns.copy() if "columns" in form_data else groupby_columns.copy()
+        )
         if x_axis_config and isinstance(x_axis_config, str):
             if x_axis_config not in columns:
                 columns.insert(0, x_axis_config)
@@ -61,7 +63,9 @@ class TestPreviewUtilsColumnBuilding:
         groupby_columns = form_data.get("groupby", [])
         raw_columns = form_data.get("columns", [])
 
-        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        columns = (
+            raw_columns.copy() if "columns" in form_data else groupby_columns.copy()
+        )
         if x_axis_config and isinstance(x_axis_config, str):
             if x_axis_config not in columns:
                 columns.insert(0, x_axis_config)
@@ -80,7 +84,9 @@ class TestPreviewUtilsColumnBuilding:
         groupby_columns = form_data.get("groupby", [])
         raw_columns = form_data.get("columns", [])
 
-        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        columns = (
+            raw_columns.copy() if "columns" in form_data else groupby_columns.copy()
+        )
         if x_axis_config and isinstance(x_axis_config, str):
             if x_axis_config not in columns:
                 columns.insert(0, x_axis_config)
@@ -102,7 +108,9 @@ class TestPreviewUtilsColumnBuilding:
         groupby_columns = form_data.get("groupby", [])
         raw_columns = form_data.get("columns", [])
 
-        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        columns = (
+            raw_columns.copy() if "columns" in form_data else groupby_columns.copy()
+        )
         if x_axis_config and isinstance(x_axis_config, str):
             if x_axis_config not in columns:
                 columns.insert(0, x_axis_config)
@@ -119,7 +127,9 @@ class TestPreviewUtilsColumnBuilding:
         groupby_columns = form_data.get("groupby", [])
         raw_columns = form_data.get("columns", [])
 
-        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        columns = (
+            raw_columns.copy() if "columns" in form_data else groupby_columns.copy()
+        )
         if x_axis_config and isinstance(x_axis_config, str):
             if x_axis_config not in columns:
                 columns.insert(0, x_axis_config)
@@ -138,7 +148,9 @@ class TestPreviewUtilsColumnBuilding:
         groupby_columns = form_data.get("groupby", [])
         raw_columns = form_data.get("columns", [])
 
-        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        columns = (
+            raw_columns.copy() if "columns" in form_data else groupby_columns.copy()
+        )
         if x_axis_config and isinstance(x_axis_config, str):
             if x_axis_config not in columns:
                 columns.insert(0, x_axis_config)

--- a/tests/unit_tests/mcp_service/chart/test_preview_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_preview_utils.py
@@ -1,0 +1,146 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for preview_utils query context column building.
+"""
+
+
+class TestPreviewUtilsColumnBuilding:
+    """Tests for x_axis + groupby column building in generate_preview_from_form_data.
+
+    The function must build the columns list from both x_axis and groupby for
+    XY charts, and fall back to form_data["columns"] for table charts.
+    """
+
+    def test_xy_chart_uses_x_axis_and_groupby(self):
+        """Test XY chart form_data builds columns from x_axis + groupby."""
+        form_data = {
+            "x_axis": "territory",
+            "groupby": ["year"],
+            "metrics": [{"label": "SUM(sales)"}],
+        }
+
+        x_axis_config = form_data.get("x_axis")
+        groupby_columns = form_data.get("groupby", [])
+        raw_columns = form_data.get("columns", [])
+
+        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+        elif x_axis_config and isinstance(x_axis_config, dict):
+            col_name = x_axis_config.get("column_name")
+            if col_name and col_name not in columns:
+                columns.insert(0, col_name)
+
+        assert columns == ["territory", "year"]
+
+    def test_table_chart_uses_columns_field(self):
+        """Test table chart form_data uses 'columns' field directly."""
+        form_data = {
+            "columns": ["name", "region", "sales"],
+            "metrics": [],
+        }
+
+        x_axis_config = form_data.get("x_axis")
+        groupby_columns = form_data.get("groupby", [])
+        raw_columns = form_data.get("columns", [])
+
+        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == ["name", "region", "sales"]
+
+    def test_xy_chart_x_axis_dict_format(self):
+        """Test XY chart with x_axis as dict (column_name key)."""
+        form_data = {
+            "x_axis": {"column_name": "order_date"},
+            "groupby": ["product_type"],
+            "metrics": [{"label": "SUM(revenue)"}],
+        }
+
+        x_axis_config = form_data.get("x_axis")
+        groupby_columns = form_data.get("groupby", [])
+        raw_columns = form_data.get("columns", [])
+
+        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+        elif x_axis_config and isinstance(x_axis_config, dict):
+            col_name = x_axis_config.get("column_name")
+            if col_name and col_name not in columns:
+                columns.insert(0, col_name)
+
+        assert columns == ["order_date", "product_type"]
+
+    def test_no_x_axis_no_columns_uses_groupby(self):
+        """Test fallback to groupby when no x_axis and no columns."""
+        form_data = {
+            "groupby": ["category"],
+            "metrics": [{"label": "COUNT(*)"}],
+        }
+
+        x_axis_config = form_data.get("x_axis")
+        groupby_columns = form_data.get("groupby", [])
+        raw_columns = form_data.get("columns", [])
+
+        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == ["category"]
+
+    def test_empty_form_data_returns_empty_columns(self):
+        """Test empty form_data returns empty columns list."""
+        form_data: dict = {
+            "metrics": [{"label": "COUNT(*)"}],
+        }
+
+        x_axis_config = form_data.get("x_axis")
+        groupby_columns = form_data.get("groupby", [])
+        raw_columns = form_data.get("columns", [])
+
+        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == []
+
+    def test_x_axis_not_duplicated_when_in_groupby(self):
+        """Test x_axis is not added if already present in groupby."""
+        form_data = {
+            "x_axis": "territory",
+            "groupby": ["territory", "year"],
+            "metrics": [{"label": "SUM(sales)"}],
+        }
+
+        x_axis_config = form_data.get("x_axis")
+        groupby_columns = form_data.get("groupby", [])
+        raw_columns = form_data.get("columns", [])
+
+        columns = raw_columns.copy() if raw_columns else groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == ["territory", "year"]

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -152,6 +152,115 @@ class TestBigNumberChartFallback:
         assert groupby_columns == []
 
 
+class TestXAxisInQueryContext:
+    """Tests for x_axis inclusion in fallback query context columns."""
+
+    def test_x_axis_string_included_in_columns(self):
+        """Test that x_axis (string format) is included alongside groupby columns."""
+        form_data = {
+            "x_axis": "territory",
+            "groupby": ["year"],
+            "metrics": [{"label": "SUM(sales)"}],
+            "viz_type": "echarts_timeseries_bar",
+        }
+
+        groupby_columns = form_data.get("groupby", [])
+        x_axis_config = form_data.get("x_axis")
+        columns = groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == ["territory", "year"]
+
+    def test_x_axis_dict_included_in_columns(self):
+        """Test that x_axis (dict format with column_name) is included."""
+        form_data = {
+            "x_axis": {"column_name": "territory"},
+            "groupby": ["year"],
+            "metrics": [{"label": "SUM(sales)"}],
+        }
+
+        groupby_columns = form_data.get("groupby", [])
+        x_axis_config = form_data.get("x_axis")
+        columns = groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+        elif x_axis_config and isinstance(x_axis_config, dict):
+            col_name = x_axis_config.get("column_name")
+            if col_name and col_name not in columns:
+                columns.insert(0, col_name)
+
+        assert columns == ["territory", "year"]
+
+    def test_no_x_axis_uses_groupby_only(self):
+        """Test that without x_axis, only groupby columns are used."""
+        form_data = {
+            "groupby": ["region", "category"],
+            "metrics": [{"label": "SUM(sales)"}],
+        }
+
+        groupby_columns = form_data.get("groupby", [])
+        x_axis_config = form_data.get("x_axis")
+        columns = groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == ["region", "category"]
+
+    def test_x_axis_not_duplicated_if_in_groupby(self):
+        """Test that x_axis is not duplicated if already in groupby list."""
+        form_data = {
+            "x_axis": "territory",
+            "groupby": ["territory", "year"],
+            "metrics": [{"label": "SUM(sales)"}],
+        }
+
+        groupby_columns = form_data.get("groupby", [])
+        x_axis_config = form_data.get("x_axis")
+        columns = groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == ["territory", "year"]
+
+    def test_x_axis_without_groupby(self):
+        """Test that x_axis works when there's no groupby."""
+        form_data = {
+            "x_axis": "date",
+            "metrics": [{"label": "SUM(sales)"}],
+        }
+
+        groupby_columns = form_data.get("groupby", [])
+        x_axis_config = form_data.get("x_axis")
+        columns = groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == ["date"]
+
+    def test_empty_groupby_with_x_axis(self):
+        """Test x_axis with explicitly empty groupby."""
+        form_data = {
+            "x_axis": "platform",
+            "groupby": [],
+            "metrics": [{"label": "SUM(global_sales)"}],
+        }
+
+        groupby_columns = form_data.get("groupby", [])
+        x_axis_config = form_data.get("x_axis")
+        columns = groupby_columns.copy()
+        if x_axis_config and isinstance(x_axis_config, str):
+            if x_axis_config not in columns:
+                columns.insert(0, x_axis_config)
+
+        assert columns == ["platform"]
+
+
 class TestGetChartDataRequestSchema:
     """Test the GetChartDataRequest schema validation."""
 


### PR DESCRIPTION
### SUMMARY

Two bugs in the MCP service prevented series charts with `group_by` from working:

**Bug 1: `XYChartConfig` silently ignored unknown fields.** LLMs frequently sent `"series"` instead of `"group_by"`, which was silently dropped by Pydantic (default behavior). The chart was created without any groupby dimension. Fixed by adding `extra="forbid"` to both `XYChartConfig` and `TableChartConfig`, so unknown fields like `series` now return a clear validation error that tells the LLM to use the correct field name (`group_by`).

**Bug 2: Query context omitted the `x_axis` column.** When building SQL queries for chart previews and data retrieval, only `groupby` columns were included in the query's `columns` list — the `x_axis` column was missing. This produced queries like `SELECT year, SUM(sales) FROM ... GROUP BY year` instead of `SELECT territory, year, SUM(sales) FROM ... GROUP BY territory, year`. Fixed in 4 locations:
- `TablePreviewStrategy` in `get_chart_preview.py`
- `VegaLitePreviewStrategy` in `get_chart_preview.py`
- Fallback query context in `get_chart_data.py`
- `generate_preview_from_form_data` in `preview_utils.py`

The fix follows the pattern already used by `ASCIIPreviewStrategy`, which correctly included both columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before (Bug 1):** LLM sends `"series": {"name": "year"}` → silently dropped, no groupby in form_data
```json
"form_data": {
    "viz_type": "echarts_timeseries_bar",
    "x_axis": "territory",
    "metrics": [{"label": "SUM(sales)"}]
}
```

**After (Bug 1):** LLM sends `"series"` → gets validation error → retries with `"group_by"` → works
```
Extra inputs are not permitted: series
```

**Before (Bug 2):** Query context missing x_axis column
```
year     | SUM(sales)
---------+-----------
2003     | 3,516,979
2004     | 4,724,163
```

**After (Bug 2):** Query context includes both x_axis and groupby
```
territory | year     | SUM(sales)
----------+----------+-----------
Japan     | 2,004    | 168,479.10
APAC      | 2,005    | 147,679.55
EMEA      | 2,003    | 1,660,000
...
12 rows × 3 columns
```

### TESTING INSTRUCTIONS

1. Start Superset with MCP service enabled
2. Use an MCP client to generate a bar chart with:
   - x-axis: `territory`
   - group_by: `year`
   - metric: `SUM(sales)`
3. Verify the chart preview shows all three columns (territory, year, SUM(sales))
4. Verify sending `"series"` instead of `"group_by"` returns a validation error
5. Run tests: `pytest tests/unit_tests/mcp_service/chart/ -v`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API