### PR TITLE
feat(extensions): Enhances SQL Lab API

### DIFF
--- a/superset-frontend/packages/superset-core/src/api/editors.ts
+++ b/superset-frontend/packages/superset-core/src/api/editors.ts
@@ -18,12 +18,19 @@
  */
 
 /**
- * @fileoverview Editors API for Superset extension editor contributions.
+ * @fileoverview Editors API for Superset text editor integration.
  *
- * This module defines the interfaces and types for editor contributions to the
- * Superset platform. Extensions can register custom text editor implementations
- * (e.g., Monaco, CodeMirror) through the extension manifest, replacing the
- * default Ace editor for specific languages.
+ * This module defines the interfaces and types for working with text editors
+ * in Superset. It provides:
+ *
+ * - `EditorHandle`: Imperative API for programmatically controlling editors
+ *   (get/set content, cursor position, selections, annotations, completions)
+ * - `EditorProps`: Props contract for editor React components
+ * - `CompletionProvider`: Interface for registering custom autocomplete providers
+ * - Registration functions for custom editor implementations
+ *
+ * The API is editor-agnostic, supporting Ace, Monaco, CodeMirror, or any
+ * compliant implementation.
  */
 
 import { ForwardRefExoticComponent, RefAttributes } from 'react';
@@ -36,69 +43,111 @@ export type { EditorContribution, EditorLanguage };
 
 /**
  * Represents a position in the editor (line and column).
+ * Both line and column are zero-based indices.
+ *
+ * @example
+ * // Position at the start of line 5, column 10
+ * const pos: Position = { line: 4, column: 9 };
  */
 export interface Position {
-  /** Zero-based line number */
+  /** Zero-based line number (first line is 0) */
   line: number;
-  /** Zero-based column number */
+  /** Zero-based column number (first column is 0) */
   column: number;
 }
 
 /**
- * Represents a range in the editor with start and end positions.
+ * Represents a contiguous range in the editor defined by start and end positions.
+ * The range is inclusive of the start position and exclusive of the end position.
  */
 export interface Range {
-  /** Start position of the range */
+  /** Start position of the range (inclusive) */
   start: Position;
-  /** End position of the range */
+  /** End position of the range (exclusive) */
   end: Position;
 }
 
 /**
- * Represents a selection in the editor.
+ * Represents a selection in the editor, extending Range with direction information.
+ * A selection is a highlighted range of text that can be manipulated.
  */
 export interface Selection extends Range {
-  /** Direction of the selection */
+  /**
+   * Direction of the selection.
+   * - 'ltr': Selection was made left-to-right (anchor at start, cursor at end)
+   * - 'rtl': Selection was made right-to-left (anchor at end, cursor at start)
+   */
   direction?: 'ltr' | 'rtl';
 }
 
 /**
- * Annotation severity levels for editor markers.
+ * Severity levels for editor annotations.
+ * Determines the visual style and icon used to display the annotation.
  */
 export type AnnotationSeverity = 'error' | 'warning' | 'info';
 
 /**
- * Represents an annotation (marker/diagnostic) in the editor.
+ * Represents a diagnostic annotation displayed in the editor.
+ * Annotations are used to highlight issues like syntax errors, linting warnings,
+ * or informational messages at specific locations in the code.
+ *
+ * @example
+ * const annotation: EditorAnnotation = {
+ *   line: 5,
+ *   column: 10,
+ *   message: 'Unknown column "user_id"',
+ *   severity: 'error',
+ *   source: 'sql-validator',
+ * };
  */
 export interface EditorAnnotation {
-  /** Zero-based line number */
+  /** Zero-based line number where the annotation appears */
   line: number;
-  /** Zero-based column number (optional) */
+  /** Zero-based column number for precise positioning (optional) */
   column?: number;
-  /** Annotation message to display */
+  /** Human-readable message describing the issue or information */
   message: string;
-  /** Severity level of the annotation */
+  /** Severity determines visual styling (red for error, yellow for warning, blue for info) */
   severity: AnnotationSeverity;
-  /** Optional source of the annotation (e.g., "linter", "typescript") */
+  /** Identifies what produced this annotation (e.g., "linter", "sql-validator") */
   source?: string;
 }
 
 /**
- * Represents a keyboard shortcut binding.
+ * Defines a keyboard shortcut that triggers a custom action in the editor.
+ * Hotkeys allow binding key combinations to functions that manipulate
+ * the editor or perform other actions.
+ *
+ * @example
+ * const runQueryHotkey: EditorHotkey = {
+ *   name: 'runQuery',
+ *   key: 'Ctrl+Enter',
+ *   description: 'Execute the current query',
+ *   exec: (handle) => {
+ *     const sql = handle.getValue();
+ *     executeQuery(sql);
+ *   },
+ * };
  */
 export interface EditorHotkey {
-  /** Unique name for the hotkey command */
+  /** Unique identifier for this hotkey command */
   name: string;
-  /** Key binding string (e.g., "Ctrl+Enter", "Alt+Enter") */
+  /**
+   * Key combination string. Format varies by editor but typically uses:
+   * - Modifiers: Ctrl, Alt, Shift, Meta (Cmd on Mac)
+   * - Separator: + (e.g., "Ctrl+Enter", "Ctrl+Shift+F")
+   */
   key: string;
-  /** Description of what the hotkey does */
+  /** Human-readable description shown in keyboard shortcut help */
   description?: string;
-  /** Function to execute when the hotkey is triggered */
+  /** Callback invoked when the hotkey is pressed, receives the editor handle */
   exec: (handle: EditorHandle) => void;
 }
 
 /**
- * Completion item kinds for autocompletion.
+ * Categories for completion items, determining the icon displayed.
+ * Includes standard programming concepts plus SQL-specific types
+ * (table, column, schema, catalog, database).
  */
 export type CompletionItemKind =
   | 'text'
@@ -132,53 +181,87 @@ export type CompletionItemKind =
   | 'database';
 
 /**
- * Represents a completion item for autocompletion.
+ * Represents a single item in the autocompletion dropdown.
+ * Completion items are suggestions shown to users as they type,
+ * allowing quick insertion of code snippets, keywords, or identifiers.
+ *
+ * @example
+ * const tableCompletion: CompletionItem = {
+ *   label: 'users',
+ *   insertText: 'users',
+ *   kind: 'table',
+ *   detail: 'public schema',
+ *   documentation: 'User accounts table with profile information',
+ * };
  */
 export interface CompletionItem {
-  /** Display label for the completion item */
+  /** Text displayed in the completion dropdown */
   label: string;
-  /** Text to insert when the item is selected */
+  /** Text inserted into the editor when this item is selected */
   insertText: string;
-  /** Kind of completion item for icon display */
+  /** Category of completion, determines the icon shown (e.g., table, column, function) */
   kind: CompletionItemKind;
-  /** Optional documentation to show in the completion popup */
+  /** Extended description shown in a details pane or tooltip */
   documentation?: string;
-  /** Optional detail text to show alongside the label */
+  /** Short additional info displayed next to the label (e.g., type, schema) */
   detail?: string;
-  /** Sorting priority (higher numbers appear first) */
+  /** String used for sorting; items are sorted lexicographically by this value */
   sortText?: string;
-  /** Text used for filtering completions */
+  /** String used for filtering; if omitted, label is used for matching user input */
   filterText?: string;
 }
 
 /**
- * Context provided to completion providers.
+ * Context information passed to completion providers when requesting suggestions.
+ * Contains details about how completion was triggered and the current environment.
  */
 export interface CompletionContext {
-  /** Character that triggered the completion (if any) */
+  /** The character that triggered automatic completion (e.g., '.', ' '), if applicable */
   triggerCharacter?: string;
-  /** How the completion was triggered */
+  /**
+   * How the completion was triggered:
+   * - 'invoke': User explicitly requested completion (e.g., Ctrl+Space)
+   * - 'automatic': Triggered automatically by typing a trigger character
+   */
   triggerKind: 'invoke' | 'automatic';
-  /** Language of the editor */
+  /** The language mode of the editor (e.g., 'sql', 'json') */
   language: EditorLanguage;
-  /** Generic metadata passed from the host (e.g., SQL Lab can pass database context) */
+  /** Host-provided context (e.g., database ID, schema name for SQL completions) */
   metadata?: Record<string, unknown>;
 }
 
 /**
- * Provider interface for dynamic completions.
+ * Interface for providing dynamic autocompletion suggestions.
+ * Providers are invoked when the user triggers completion, allowing
+ * context-aware suggestions based on cursor position and editor content.
+ *
+ * @example
+ * const tableCompletionProvider: CompletionProvider = {
+ *   id: 'sql-tables',
+ *   triggerCharacters: [' ', '.'],
+ *   provideCompletions: async (content, position, context) => {
+ *     const dbId = context.metadata?.databaseId;
+ *     const tables = await fetchTables(dbId);
+ *     return tables.map(t => ({
+ *       label: t.name,
+ *       insertText: t.name,
+ *       kind: 'table',
+ *     }));
+ *   },
+ * };
  */
 export interface CompletionProvider {
-  /** Unique identifier for this provider */
+  /** Unique identifier for this provider, used for debugging and deduplication */
   id: string;
-  /** Trigger characters that invoke this provider (e.g., '.', ' ') */
+  /** Characters that trigger this provider automatically when typed (e.g., '.', ' ') */
   triggerCharacters?: string[];
   /**
-   * Provide completions at the given position.
-   * @param content The editor content
-   * @param position The cursor position
-   * @param context Completion context with trigger info and metadata
-   * @returns Array of completion items or a promise that resolves to them
+   * Generate completion suggestions for the current cursor position.
+   *
+   * @param content Full text content of the editor
+   * @param position Current cursor position where completion was triggered
+   * @param context Additional context about the trigger and environment
+   * @returns Array of completion items, or a Promise resolving to them for async providers
    */
   provideCompletions(
     content: string,
@@ -188,98 +271,186 @@ export interface CompletionProvider {
 }
 
 /**
- * A keyword for editor autocomplete.
- * This is a generic format that editor implementations convert to their native format.
+ * Represents a static keyword for basic autocomplete.
+ * Keywords are simpler than CompletionItems and are used for static lists
+ * of suggestions (e.g., SQL keywords, table names) that don't require
+ * dynamic computation.
+ *
+ * Editor implementations convert these to their native completion format.
+ *
+ * @example
+ * const sqlKeywords: EditorKeyword[] = [
+ *   { name: 'SELECT', meta: 'keyword', score: 100 },
+ *   { name: 'FROM', meta: 'keyword', score: 100 },
+ *   { name: 'users', value: 'users', meta: 'table', score: 50 },
+ * ];
  */
 export interface EditorKeyword {
-  /** Display name of the keyword */
+  /** Display name shown in the completion dropdown */
   name: string;
-  /** Value to insert when selected (defaults to name if not provided) */
+  /** Text to insert when selected; defaults to name if not provided */
   value?: string;
-  /** Category/type of the keyword (e.g., "column", "table", "function") */
+  /** Category label shown alongside the name (e.g., "column", "table", "function") */
   meta?: string;
-  /** Optional score for sorting (higher = more relevant) */
+  /** Sorting priority; higher scores appear first in the completion list */
   score?: number;
 }
 
 /**
- * Props that all editor implementations must accept.
+ * Props accepted by all editor component implementations.
+ * This interface defines the contract between Superset and editor components,
+ * ensuring consistent behavior regardless of the underlying editor library.
  */
 export interface EditorProps {
-  /** Instance identifier */
+  /** Unique identifier for this editor instance */
   id: string;
-  /** Controlled value */
+  /** Current editor content (controlled component pattern) */
   value: string;
-  /** Content change handler */
+  /** Called when the editor content changes */
   onChange: (value: string) => void;
-  /** Blur handler */
+  /** Called when the editor loses focus, with the current value */
   onBlur?: (value: string) => void;
-  /** Cursor position change handler */
+  /** Called when the cursor position changes */
   onCursorPositionChange?: (pos: Position) => void;
-  /** Selection change handler */
+  /** Called when the selection(s) change */
   onSelectionChange?: (sel: Selection[]) => void;
-  /** Language mode for syntax highlighting */
+  /** Language mode for syntax highlighting and language features */
   language: EditorLanguage;
-  /** Whether the editor is read-only */
+  /** When true, prevents editing (view-only mode) */
   readOnly?: boolean;
-  /** Tab size in spaces */
+  /** Number of spaces per tab character */
   tabSize?: number;
-  /** Whether to show line numbers */
+  /** Whether to display line numbers in the gutter */
   lineNumbers?: boolean;
-  /** Whether to enable word wrap */
+  /** Whether long lines should wrap to the next visual line */
   wordWrap?: boolean;
-  /** Linting/error annotations */
+  /** Diagnostic annotations to display (errors, warnings, info) */
   annotations?: EditorAnnotation[];
-  /** Keyboard shortcuts */
+  /** Custom keyboard shortcuts */
   hotkeys?: EditorHotkey[];
-  /** Static keywords for autocomplete */
+  /** Static keywords for basic autocomplete */
   keywords?: EditorKeyword[];
-  /** CSS height (e.g., "100%", "500px") */
+  /** CSS height value (e.g., "100%", "500px", "calc(100vh - 200px)") */
   height?: string;
-  /** CSS width (e.g., "100%", "800px") */
+  /** CSS width value (e.g., "100%", "800px") */
   width?: string;
-  /** Callback when editor is ready with imperative handle */
+  /** Called when the editor is fully initialized, providing the imperative handle */
   onReady?: (handle: EditorHandle) => void;
-  /** Host-specific context (e.g., database info from SQL Lab) */
+  /** Contextual data passed to completion providers (e.g., database ID, schema) */
   metadata?: Record<string, unknown>;
-  /** Theme object for styling the editor */
+  /** Theme object for styling the editor to match Superset's appearance */
   theme?: SupersetTheme;
 }
 
 /**
  * Imperative API for controlling the editor programmatically.
+ *
+ * This handle provides a unified interface for interacting with text editors
+ * regardless of the underlying implementation (Ace, Monaco, CodeMirror, etc.).
+ * It can be used by any part of Superset that needs to manipulate editor content,
+ * read selections, or register custom behaviors.
  */
 export interface EditorHandle {
-  /** Focus the editor */
-  focus(): void;
-  /** Get the current editor content */
-  getValue(): string;
-  /** Set the editor content */
-  setValue(value: string): void;
-  /** Get the current cursor position */
-  getCursorPosition(): Position;
-  /** Move the cursor to a specific position */
-  moveCursorToPosition(position: Position): void;
-  /** Get all selections in the editor */
-  getSelections(): Selection[];
-  /** Set the selection range */
-  setSelection(selection: Range): void;
-  /** Get the selected text */
-  getSelectedText(): string;
-  /** Insert text at the current cursor position */
-  insertText(text: string): void;
-  /** Execute a named editor command */
-  executeCommand(commandName: string): void;
-  /** Scroll to a specific line */
-  scrollToLine(line: number): void;
-  /** Set annotations (replaces existing) */
-  setAnnotations(annotations: EditorAnnotation[]): void;
-  /** Clear all annotations */
-  clearAnnotations(): void;
   /**
-   * Register a completion provider for dynamic suggestions.
+   * Moves keyboard focus to the editor.
+   * Useful after programmatic operations to return user focus to the editing area.
+   */
+  focus(): void;
+
+  /**
+   * Returns the complete text content of the editor.
+   * @returns The full editor content as a string
+   */
+  getValue(): string;
+
+  /**
+   * Replaces the entire editor content with the provided value.
+   * This will clear any existing content and reset the undo history in most editors.
+   * @param value The new content to set
+   */
+  setValue(value: string): void;
+
+  /**
+   * Returns the current cursor position in the editor.
+   * @returns Position object with zero-based line and column numbers
+   */
+  getCursorPosition(): Position;
+
+  /**
+   * Moves the cursor to the specified position.
+   * @param position Target position with zero-based line and column numbers
+   */
+  moveCursorToPosition(position: Position): void;
+
+  /**
+   * Returns all active selections in the editor.
+   * Most editors support multiple selections (e.g., via Ctrl+click).
+   * Each selection includes start/end positions and optional direction.
+   * @returns Array of Selection objects, empty array if no selections
+   */
+  getSelections(): Selection[];
+
+  /**
+   * Sets the selection to the specified range.
+   * This replaces any existing selections with a single new selection.
+   * @param selection Range to select, with start and end positions
+   */
+  setSelection(selection: Range): void;
+
+  /**
+   * Returns the text within the current selection.
+   * If multiple selections exist, behavior depends on the editor implementation
+   * (typically returns the primary/first selection's text).
+   * @returns The selected text, or empty string if no selection
+   */
+  getSelectedText(): string;
+
+  /**
+   * Inserts text at the current cursor position.
+   * If text is selected, the selection is replaced with the inserted text.
+   * @param text The text to insert
+   */
+  insertText(text: string): void;
+  /**
+   * Execute a named editor command.
+   *
+   * Note: Command names are editor-specific. For example:
+   * - Ace: 'centerselection', 'gotoline', 'fold', 'unfold'
+   * - Monaco: 'editor.action.formatDocument', 'editor.action.commentLine'
+   *
+   * Callers using this method should be aware of which editor is active
+   * or handle cases where the command may not exist.
+   *
+   * @param commandName The editor-specific command name to execute
+   */
+  executeCommand(commandName: string): void;
+  /**
+   * Scrolls the editor viewport to bring the specified line into view.
+   * The exact positioning (top, center, bottom) depends on the editor implementation.
+   * @param line Zero-based line number to scroll to
+   */
+  scrollToLine(line: number): void;
+
+  /**
+   * Sets diagnostic annotations (errors, warnings, info markers) in the editor.
+   * This replaces any previously set annotations.
+   * Annotations appear as markers in the gutter and/or inline decorations.
+   * @param annotations Array of annotations to display
+   */
+  setAnnotations(annotations: EditorAnnotation[]): void;
+
+  /**
+   * Removes all annotations from the editor.
+   * Equivalent to calling setAnnotations([]).
+   */
+  clearAnnotations(): void;
+
+  /**
+   * Registers a provider for dynamic autocompletion suggestions.
+   * The provider will be invoked when completion is triggered (manually or automatically).
+   * Multiple providers can be registered; their results are merged.
    * @param provider The completion provider to register
-   * @returns A Disposable to unregister the provider
+   * @returns A Disposable that removes the provider when disposed
    */
   registerCompletionProvider(provider: CompletionProvider): Disposable;
 }

--- a/superset-frontend/packages/superset-core/src/api/sqlLab.ts
+++ b/superset-frontend/packages/superset-core/src/api/sqlLab.ts
@@ -30,44 +30,14 @@
  */
 
 import { Event, Database, SupersetError, Column } from './core';
+import { EditorHandle } from './editors';
 
 /**
- * Represents an SQL editor instance within a SQL Lab tab.
- * Contains the editor content and associated database connection information.
+ * Provides imperative control over the code editor component.
+ * Allows extensions to manipulate text content, cursor position,
+ * selections, annotations, and register completion providers.
  */
-export interface Editor {
-  /**
-   * The SQL content of the editor.
-   * This represents the current text in the SQL editor.
-   */
-  content: string;
-
-  /**
-   * The database identifier associated with the editor.
-   * This determines which database the queries will be executed against.
-   */
-  databaseId: number;
-
-  /**
-   * The catalog name associated with the editor.
-   * Can be null if no specific catalog is selected.
-   */
-  catalog: string | null;
-
-  /**
-   * The schema name associated with the editor.
-   * Defines the database schema context for the editor.
-   */
-  schema: string;
-
-  /**
-   * The table name associated with the editor.
-   * Can be null if no specific table is selected.
-   *
-   * @todo Revisit if we actually need the table property
-   */
-  table: string | null;
-}
+export interface Editor extends EditorHandle {}
 
 /**
  * Represents a panel within a SQL Lab tab.
@@ -99,10 +69,40 @@ export interface Tab {
   title: string;
 
   /**
-   * The SQL editor instance associated with this tab.
-   * Contains the editor content and database connection settings.
+   * The database identifier for this tab's query context.
+   * This determines which database the queries will be executed against.
    */
-  editor: Editor;
+  databaseId: number;
+
+  /**
+   * The catalog name for this tab's query context.
+   * Can be null if no specific catalog is selected (for multi-catalog databases like Trino).
+   */
+  catalog: string | null;
+
+  /**
+   * The schema name for this tab's query context.
+   * Can be null if no schema is selected.
+   */
+  schema: string | null;
+
+  /**
+   * Gets the code editor instance for this tab.
+   * Returns a Promise that resolves when the editor is ready.
+   * The returned editor is a proxy that always delegates to the current
+   * editor implementation, even if the editor is swapped (e.g., Ace to Monaco).
+   *
+   * @returns Promise that resolves to the Editor instance
+   *
+   * @example
+   * ```typescript
+   * const tab = sqlLab.getCurrentTab();
+   * const editor = await tab.getEditor();
+   * editor.setValue("SELECT * FROM users");
+   * editor.focus();
+   * ```
+   */
+  getEditor(): Promise<Editor>;
 
   /**
    * The panels associated with the tab.
@@ -262,7 +262,11 @@ export declare const getActivePanel: () => Panel;
  * const tab = getCurrentTab();
  * if (tab) {
  *   console.log(`Active tab: ${tab.title}`);
- *   console.log(`Database ID: ${tab.editor.databaseId}`);
+ *   console.log(`Database ID: ${tab.databaseId}, Schema: ${tab.schema}`);
+ *
+ *   // Direct editor manipulation
+ *   tab.editor.setValue("SELECT * FROM users");
+ *   tab.editor.focus();
  * }
  * ```
  */
@@ -327,8 +331,8 @@ export declare const onDidChangeTabTitle: Event<string>;
  * @example
  * ```typescript
  * onDidQueryRun.event((query) => {
- *   console.log('Query started on database:', query.tab.editor.databaseId);
- *   console.log('Query content:', query.tab.editor.content);
+ *   console.log('Query started on database:', query.tab.databaseId);
+ *   console.log('Query SQL:', query.tab.editor.getValue());
  * });
  * ```
  */
@@ -341,7 +345,7 @@ export declare const onDidQueryRun: Event<QueryContext>;
  * @example
  * ```typescript
  * onDidQueryStop.event((query) => {
- *   console.log('Query stopped for database:', query.tab.editor.databaseId);
+ *   console.log('Query stopped for database:', query.tab.databaseId);
  * });
  * ```
  */
@@ -444,3 +448,193 @@ export declare const onDidCloseTab: Event<Tab>;
  * ```
  */
 export declare const onDidChangeActiveTab: Event<Tab>;
+
+/**
+ * Event fired when a new tab is created in SQL Lab.
+ * Provides the newly created tab object as the event payload.
+ *
+ * @example
+ * ```typescript
+ * onDidCreateTab.event((tab) => {
+ *   console.log('New tab created:', tab.title);
+ *   // Initialize extension state for new tab
+ * });
+ * ```
+ */
+export declare const onDidCreateTab: Event<Tab>;
+
+/**
+ * Tab/Editor Management APIs
+ *
+ * These APIs allow extensions to create, close, and manage SQL Lab tabs.
+ */
+
+/**
+ * Options for creating a new SQL Lab tab.
+ */
+export interface CreateTabOptions {
+  /**
+   * Initial SQL content for the editor.
+   */
+  sql?: string;
+
+  /**
+   * Display title for the tab.
+   * If not provided, defaults to "Untitled Query N".
+   */
+  title?: string;
+
+  /**
+   * Database ID to connect to.
+   * If not provided, inherits from the active tab or uses default.
+   */
+  databaseId?: number;
+
+  /**
+   * Catalog name (for multi-catalog databases like Trino).
+   */
+  catalog?: string | null;
+
+  /**
+   * Schema name for the query context.
+   */
+  schema?: string;
+}
+
+/**
+ * Creates a new query editor tab in SQL Lab.
+ *
+ * @param options Optional configuration for the new tab
+ * @returns The newly created tab object
+ *
+ * @example
+ * ```typescript
+ * // Create a tab with default settings
+ * const tab = await createTab();
+ *
+ * // Create a tab with specific SQL and database
+ * const tab = await createTab({
+ *   sql: "SELECT * FROM users LIMIT 10",
+ *   title: "User Query",
+ *   databaseId: 1,
+ *   schema: "public"
+ * });
+ * ```
+ */
+export declare function createTab(options?: CreateTabOptions): Promise<Tab>;
+
+/**
+ * Closes a specific tab in SQL Lab.
+ *
+ * @param tabId The ID of the tab to close
+ * @returns Promise that resolves when the tab is closed
+ *
+ * @example
+ * ```typescript
+ * const tabs = getTabs();
+ * if (tabs.length > 1) {
+ *   await closeTab(tabs[0].id);
+ * }
+ * ```
+ */
+export declare function closeTab(tabId: string): Promise<void>;
+
+/**
+ * Switches to a specific tab in SQL Lab.
+ *
+ * @param tabId The ID of the tab to activate
+ * @returns Promise that resolves when the tab is activated
+ *
+ * @example
+ * ```typescript
+ * const tabs = getTabs();
+ * const targetTab = tabs.find(t => t.title === "My Query");
+ * if (targetTab) {
+ *   await setActiveTab(targetTab.id);
+ * }
+ * ```
+ */
+export declare function setActiveTab(tabId: string): Promise<void>;
+
+/**
+ * Query Execution APIs
+ *
+ * These APIs allow extensions to execute and control SQL queries.
+ */
+
+/**
+ * Executes the SQL query in the current tab.
+ *
+ * @returns Promise that resolves with the query client ID
+ *
+ * @example
+ * ```typescript
+ * const queryId = await runQuery();
+ * ```
+ */
+export declare function runQuery(): Promise<string>;
+
+/**
+ * Stops a running query.
+ *
+ * @param queryId The client ID of the query to stop
+ * @returns Promise that resolves when the stop request is sent
+ *
+ * @example
+ * ```typescript
+ * const queryId = await runQuery();
+ * // Later, if needed:
+ * await stopQuery(queryId);
+ * ```
+ */
+export declare function stopQuery(queryId: string): Promise<void>;
+
+/**
+ * Tab Context APIs
+ *
+ * These APIs manage tab-level query context and settings.
+ * Text manipulation is handled directly via Editor (e.g., tab.editor.setValue(sql)).
+ */
+
+/**
+ * Sets the database for the current tab.
+ *
+ * @param databaseId The ID of the database to set
+ * @returns Promise that resolves when the database is updated
+ *
+ * @example
+ * ```typescript
+ * const databases = getDatabases();
+ * const prodDb = databases.find(d => d.database_name === "production");
+ * if (prodDb) {
+ *   await setDatabase(prodDb.id);
+ * }
+ * ```
+ */
+export declare function setDatabase(databaseId: number): Promise<void>;
+
+/**
+ * Sets the catalog for the current tab.
+ *
+ * @param catalog The catalog name to set, or null to clear
+ * @returns Promise that resolves when the catalog is updated
+ *
+ * @example
+ * ```typescript
+ * await setCatalog("hive_metastore");
+ * ```
+ */
+export declare function setCatalog(catalog: string | null): Promise<void>;
+
+/**
+ * Sets the schema for the current tab.
+ *
+ * @param schema The schema name to set, or null to clear
+ * @returns Promise that resolves when the schema is updated
+ *
+ * @example
+ * ```typescript
+ * await setSchema("public");
+ * ```
+ */
+export declare function setSchema(schema: string | null): Promise<void>;

--- a/superset-frontend/packages/superset-core/src/api/sqlLab.ts
+++ b/superset-frontend/packages/superset-core/src/api/sqlLab.ts
@@ -264,9 +264,10 @@ export declare const getActivePanel: () => Panel;
  *   console.log(`Active tab: ${tab.title}`);
  *   console.log(`Database ID: ${tab.databaseId}, Schema: ${tab.schema}`);
  *
- *   // Direct editor manipulation
- *   tab.editor.setValue("SELECT * FROM users");
- *   tab.editor.focus();
+ *   // Editor manipulation via async getEditor()
+ *   const editor = await tab.getEditor();
+ *   editor.setValue("SELECT * FROM users");
+ *   editor.focus();
  * }
  * ```
  */
@@ -330,9 +331,10 @@ export declare const onDidChangeTabTitle: Event<string>;
  *
  * @example
  * ```typescript
- * onDidQueryRun.event((query) => {
+ * onDidQueryRun.event(async (query) => {
  *   console.log('Query started on database:', query.tab.databaseId);
- *   console.log('Query SQL:', query.tab.editor.getValue());
+ *   const editor = await query.tab.getEditor();
+ *   console.log('Query SQL:', editor.getValue());
  * });
  * ```
  */
@@ -498,7 +500,7 @@ export interface CreateTabOptions {
   /**
    * Schema name for the query context.
    */
-  schema?: string;
+  schema?: string | null;
 }
 
 /**

--- a/superset-frontend/packages/superset-core/src/api/sqlLab.ts
+++ b/superset-frontend/packages/superset-core/src/api/sqlLab.ts
@@ -590,7 +590,7 @@ export interface QueryOptions {
    * Template parameters for Jinja templating.
    * Merged with existing template parameters from the editor.
    */
-  templateParams?: Record<string, unknown>;
+  templateParameters?: Record<string, unknown>;
 
   /**
    * Create Table/View As Select options.

--- a/superset-frontend/packages/superset-core/src/api/sqlLab.ts
+++ b/superset-frontend/packages/superset-core/src/api/sqlLab.ts
@@ -565,31 +565,91 @@ export declare function setActiveTab(tabId: string): Promise<void>;
  */
 
 /**
- * Executes the SQL query in the current tab.
- *
- * @returns Promise that resolves with the query client ID
- *
- * @example
- * ```typescript
- * const queryId = await runQuery();
- * ```
+ * Options for executing a SQL query.
  */
-export declare function runQuery(): Promise<string>;
+export interface QueryOptions {
+  /**
+   * SQL to execute without modifying editor content.
+   * If not provided, uses the current editor content.
+   */
+  sql?: string;
+
+  /**
+   * Run only the selected text in the editor.
+   * Ignored if `sql` option is provided.
+   */
+  selectedOnly?: boolean;
+
+  /**
+   * Override the query row limit.
+   * If not provided, uses the tab's configured limit.
+   */
+  limit?: number;
+
+  /**
+   * Template parameters for Jinja templating.
+   * Merged with existing template parameters from the editor.
+   */
+  templateParams?: Record<string, unknown>;
+
+  /**
+   * Create Table/View As Select options.
+   * When provided, query results are stored in a new table instead of returned directly.
+   */
+  ctas?: {
+    /**
+     * Whether to create a TABLE or VIEW.
+     */
+    method: 'TABLE' | 'VIEW';
+
+    /**
+     * Name of the table or view to create.
+     */
+    tableName: string;
+  };
+}
 
 /**
- * Stops a running query.
+ * Executes a SQL query in the current tab.
  *
- * @param queryId The client ID of the query to stop
- * @returns Promise that resolves when the stop request is sent
+ * @param options Optional query execution options
+ * @returns Promise that resolves with the query ID
  *
  * @example
  * ```typescript
- * const queryId = await runQuery();
- * // Later, if needed:
- * await stopQuery(queryId);
+ * // Execute the current editor content
+ * const queryId = await executeQuery();
+ *
+ * // Execute custom SQL without modifying the editor
+ * const queryId = await executeQuery({
+ *   sql: "SELECT * FROM users LIMIT 10"
+ * });
+ *
+ * // Execute only selected text
+ * const queryId = await executeQuery({ selectedOnly: true });
+ *
+ * // Create a table from query results
+ * const queryId = await executeQuery({
+ *   ctas: { method: 'TABLE', tableName: 'my_results' }
+ * });
  * ```
  */
-export declare function stopQuery(queryId: string): Promise<void>;
+export declare function executeQuery(options?: QueryOptions): Promise<string>;
+
+/**
+ * Cancels a running query.
+ *
+ * @param queryId The client ID of the query to cancel
+ * @returns Promise that resolves when the cancellation request is sent
+ *
+ * @example
+ * ```typescript
+ * const queryId = await executeQuery();
+ * // Later, if needed:
+ * await cancelQuery(queryId);
+ * ```
+ */
+export declare function cancelQuery(queryId: string): Promise<void>;
 
 /**
  * Tab Context APIs

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
@@ -29,6 +29,10 @@ import type { KeyboardShortcut } from 'src/SqlLab/components/KeyboardShortcutBut
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 import { SqlLabRootState, type CursorPosition } from 'src/SqlLab/types';
 import { EditorHost } from 'src/core/editors';
+import {
+  registerEditorHandle,
+  unregisterEditorHandle,
+} from 'src/core/sqlLab';
 import { useAnnotations } from './useAnnotations';
 import { useKeywords } from './useKeywords';
 
@@ -253,13 +257,23 @@ const EditorWrapper = ({
   const handleEditorReady = useCallback(
     (handle: EditorHandle) => {
       editorHandleRef.current = handle;
+      // Register handle for SQL Lab API access
+      registerEditorHandle(queryEditorId, handle);
       // Set initial cursor position
       const { row, column } = cursorPosition;
       handle.moveCursorToPosition({ line: row, column });
       handle.focus();
       handle.scrollToLine(row);
     },
-    [cursorPosition],
+    [cursorPosition, queryEditorId],
+  );
+
+  // Unregister editor handle on unmount
+  useEffect(
+    () => () => {
+      unregisterEditorHandle(queryEditorId);
+    },
+    [queryEditorId],
   );
 
   const { data: annotations } = useAnnotations({

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/index.tsx
@@ -29,10 +29,7 @@ import type { KeyboardShortcut } from 'src/SqlLab/components/KeyboardShortcutBut
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 import { SqlLabRootState, type CursorPosition } from 'src/SqlLab/types';
 import { EditorHost } from 'src/core/editors';
-import {
-  registerEditorHandle,
-  unregisterEditorHandle,
-} from 'src/core/sqlLab';
+import { registerEditorHandle, unregisterEditorHandle } from 'src/core/sqlLab';
 import { useAnnotations } from './useAnnotations';
 import { useKeywords } from './useKeywords';
 

--- a/superset-frontend/src/core/sqlLab/index.ts
+++ b/superset-frontend/src/core/sqlLab/index.ts
@@ -18,6 +18,7 @@
  */
 import { sqlLab as sqlLabApi } from '@apache-superset/core';
 import {
+  ADD_QUERY_EDITOR,
   QUERY_FAILED,
   QUERY_SUCCESS,
   QUERY_EDITOR_SETDB,
@@ -26,21 +27,28 @@ import {
   REMOVE_QUERY_EDITOR,
   SET_ACTIVE_QUERY_EDITOR,
   SET_ACTIVE_SOUTHPANE_TAB,
+  addQueryEditor,
   querySuccess,
   startQuery,
   START_QUERY,
-  stopQuery,
+  stopQuery as stopQueryAction,
   STOP_QUERY,
   createQueryFailedAction,
+  setActiveQueryEditor,
+  queryEditorSetDb,
+  queryEditorSetCatalog,
+  queryEditorSetSchema,
+  runQueryFromSqlEditor,
+  postStopQuery,
 } from 'src/SqlLab/actions/sqlLab';
 import { RootState, store } from 'src/views/store';
 import { AnyListenerPredicate } from '@reduxjs/toolkit';
-import type { SqlLabRootState } from 'src/SqlLab/types';
+import type { QueryEditor, SqlLabRootState } from 'src/SqlLab/types';
+import { newQueryTabName } from 'src/SqlLab/utils/newQueryTabName';
 import { Database, Disposable } from '../models';
 import { createActionListener } from '../utils';
 import {
   Panel,
-  Editor,
   Tab,
   QueryContext,
   QueryResultContext,
@@ -70,39 +78,117 @@ const findQueryEditor = (editorId: string) => {
   return editor;
 };
 
-const createTab = (
+/**
+ * Registry for editor handles. Editor components register their handles here
+ * when they mount, allowing the SQL Lab API to access them.
+ */
+const editorHandleRegistry = new Map<string, sqlLabApi.Editor>();
+
+/**
+ * Pending promises waiting for editor handles to be registered.
+ */
+const pendingEditorPromises = new Map<
+  string,
+  Array<(handle: sqlLabApi.Editor) => void>
+>();
+
+/**
+ * Registers an editor handle for a tab. Called by EditorWrapper when it mounts.
+ * Resolves any pending promises waiting for this editor.
+ */
+export const registerEditorHandle = (
+  tabId: string,
+  handle: sqlLabApi.Editor,
+): void => {
+  editorHandleRegistry.set(tabId, handle);
+
+  // Resolve any pending promises waiting for this editor
+  const pending = pendingEditorPromises.get(tabId);
+  if (pending) {
+    pending.forEach(resolve => resolve(handle));
+    pendingEditorPromises.delete(tabId);
+  }
+};
+
+/**
+ * Unregisters an editor handle for a tab. Called when EditorWrapper unmounts.
+ */
+export const unregisterEditorHandle = (tabId: string): void => {
+  editorHandleRegistry.delete(tabId);
+};
+
+/**
+ * Creates a Proxy that always delegates to the current editor handle in the registry.
+ * This handles editor hot-swapping (e.g., Ace to Monaco).
+ */
+const createEditorProxy = (tabId: string): sqlLabApi.Editor =>
+  new Proxy({} as sqlLabApi.Editor, {
+    get(_, prop: keyof sqlLabApi.Editor) {
+      const handle = editorHandleRegistry.get(tabId);
+      if (!handle) {
+        throw new Error(`Editor handle not found for tab ${tabId}`);
+      }
+      const value = handle[prop];
+      return typeof value === 'function' ? value.bind(handle) : value;
+    },
+  });
+
+/**
+ * Gets the editor for a tab, waiting for it to be registered if necessary.
+ * Returns a Proxy that always delegates to the current handle.
+ */
+const getEditorAsync = (tabId: string): Promise<sqlLabApi.Editor> => {
+  const existingHandle = editorHandleRegistry.get(tabId);
+  if (existingHandle) {
+    // Editor already registered, return proxy immediately
+    return Promise.resolve(createEditorProxy(tabId));
+  }
+
+  // Wait for the editor to be registered
+  return new Promise(resolve => {
+    const pending = pendingEditorPromises.get(tabId) ?? [];
+    pending.push(() => resolve(createEditorProxy(tabId)));
+    pendingEditorPromises.set(tabId, pending);
+  });
+};
+
+const makeTab = (
   id: string,
   name: string,
-  sql: string,
   dbId: number,
-  catalog?: string,
-  schema?: string,
-  table?: any,
-) => {
-  const editor = new Editor(sql, dbId, catalog, schema, table);
+  catalog?: string | null,
+  schema?: string | null,
+): Tab => {
   const panels: Panel[] = []; // TODO: Populate panels
-  return new Tab(id, name, editor, panels);
+  return new Tab(
+    id,
+    name,
+    dbId,
+    catalog ?? null,
+    schema ?? null,
+    () => getEditorAsync(id),
+    panels,
+  );
 };
 
 const getTab = (id: string): Tab | undefined => {
   const queryEditor = findQueryEditor(id);
-  if (queryEditor && queryEditor.dbId !== undefined) {
-    const { name, sql, dbId, catalog, schema } = queryEditor;
-    return createTab(
-      id,
-      name,
-      sql,
-      dbId,
-      catalog ?? undefined,
-      schema ?? undefined,
-      undefined,
-    );
+  if (queryEditor?.dbId !== undefined) {
+    const { name, dbId, catalog, schema } = queryEditor;
+    return makeTab(id, name, dbId, catalog, schema);
   }
   return undefined;
 };
 
-function extractBaseData(action: any): {
+type QueryAction =
+  | ReturnType<typeof startQuery>
+  | ReturnType<typeof stopQueryAction>
+  | ReturnType<typeof querySuccess>
+  | ReturnType<typeof createQueryFailedAction>;
+
+function extractBaseData(action: QueryAction): {
   baseParams: [string, Tab, boolean, number];
+  sql: string;
   options: {
     ctasMethod?: string;
     tempTable?: string;
@@ -127,13 +213,20 @@ function extractBaseData(action: any): {
     queryLimit,
   } = query;
 
-  const tab = createTab(sqlEditorId, tabName, sql, dbId, catalog, schema);
+  const tab = makeTab(
+    sqlEditorId ?? '',
+    tabName ?? '',
+    dbId ?? 0,
+    catalog,
+    schema,
+  );
 
   return {
     baseParams: [id, tab, runAsync ?? false, startDttm ?? 0],
+    sql,
     options: {
       ctasMethod,
-      tempTable,
+      tempTable: tempTable ?? undefined,
       templateParams,
       requestedLimit: queryLimit,
     },
@@ -141,7 +234,7 @@ function extractBaseData(action: any): {
 }
 
 function createQueryContext(
-  action: ReturnType<typeof startQuery> | ReturnType<typeof stopQuery>,
+  action: ReturnType<typeof startQuery> | ReturnType<typeof stopQueryAction>,
 ): QueryContext {
   const { baseParams, options } = extractBaseData(action);
   return new QueryContext(...baseParams, options);
@@ -150,9 +243,7 @@ function createQueryContext(
 function createQueryResultContext(
   action: ReturnType<typeof querySuccess>,
 ): QueryResultContext {
-  const { baseParams, options } = extractBaseData(action);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_, tab] = baseParams;
+  const { baseParams, sql, options } = extractBaseData(action);
   const { results } = action;
   const { query_id: queryId, columns, data, query } = results;
   const {
@@ -173,7 +264,7 @@ function createQueryResultContext(
   return new QueryResultContext(
     ...baseParams,
     queryId ?? 0,
-    executedSql ?? tab.editor.content,
+    executedSql ?? sql,
     mappedColumns,
     data,
     endDttm ?? 0,
@@ -305,7 +396,7 @@ const onDidQueryStop: typeof sqlLabApi.onDidQueryStop = (
   createActionListener(
     predicate(STOP_QUERY),
     listener,
-    (action: ReturnType<typeof stopQuery>) => createQueryContext(action),
+    (action: ReturnType<typeof stopQueryAction>) => createQueryContext(action),
     thisArgs,
   );
 
@@ -340,10 +431,10 @@ const onDidCloseTab: typeof sqlLabApi.onDidCloseTab = (
   thisArgs?: any,
 ): Disposable =>
   createActionListener(
-    predicate(REMOVE_QUERY_EDITOR),
+    globalPredicate(REMOVE_QUERY_EDITOR),
     listener,
     (action: { type: string; queryEditor: { id: string } }) =>
-      getTab(action.queryEditor.id)!,
+      getTab(action.queryEditor.id),
     thisArgs,
   );
 
@@ -352,10 +443,10 @@ const onDidChangeActiveTab: typeof sqlLabApi.onDidChangeActiveTab = (
   thisArgs?: any,
 ): Disposable =>
   createActionListener(
-    predicate(SET_ACTIVE_QUERY_EDITOR),
+    globalPredicate(SET_ACTIVE_QUERY_EDITOR),
     listener,
     (action: { type: string; queryEditor: { id: string } }) =>
-      getTab(action.queryEditor.id)!,
+      getTab(action.queryEditor.id),
     thisArgs,
   );
 
@@ -392,10 +483,166 @@ const onDidChangeTabTitle: typeof sqlLabApi.onDidChangeTabTitle = (
     thisArgs,
   );
 
+/**
+ * Event fired when a new tab is created.
+ */
+const onDidCreateTab: typeof sqlLabApi.onDidCreateTab = (
+  listener: (tab: sqlLabApi.Tab) => void,
+  thisArgs?: any,
+): Disposable =>
+  createActionListener(
+    globalPredicate(ADD_QUERY_EDITOR),
+    listener,
+    (action: { type: string; queryEditor: QueryEditor }) =>
+      makeTab(
+        action.queryEditor.id!,
+        action.queryEditor.name ?? '',
+        action.queryEditor.dbId ?? 0,
+        action.queryEditor.catalog,
+        action.queryEditor.schema ?? undefined,
+      ),
+    thisArgs,
+  );
+
+/**
+ * Tab/Editor Management APIs
+ */
+
+const createTab: typeof sqlLabApi.createTab = async (
+  options?: sqlLabApi.CreateTabOptions,
+) => {
+  const {
+    sqlLab: { queryEditors, tabHistory, unsavedQueryEditor, databases },
+    common,
+  } = store.getState() as SqlLabRootState;
+
+  const activeQueryEditor = queryEditors.find(
+    (qe: QueryEditor) => qe.id === tabHistory[tabHistory.length - 1],
+  );
+  const dbIds = Object.values(databases).map(db => db.id);
+  const defaultDbId = common?.conf?.SQLLAB_DEFAULT_DBID;
+  const firstDbId = dbIds.length > 0 ? Math.min(...dbIds) : undefined;
+
+  // Inherit from active tab or use defaults
+  const inheritedValues = {
+    ...queryEditors[0],
+    ...activeQueryEditor,
+    ...(unsavedQueryEditor?.id === activeQueryEditor?.id && unsavedQueryEditor),
+  } as Partial<QueryEditor>;
+
+  // Generate default name if no title provided
+  const name =
+    options?.title ??
+    newQueryTabName(
+      queryEditors?.map((qe: QueryEditor) => ({
+        ...qe,
+        ...(qe.id === unsavedQueryEditor?.id && unsavedQueryEditor),
+      })) || [],
+    );
+
+  const newQueryEditor: Partial<QueryEditor> = {
+    dbId:
+      options?.databaseId ?? inheritedValues.dbId ?? defaultDbId ?? firstDbId,
+    catalog: options?.catalog ?? inheritedValues.catalog,
+    schema: options?.schema ?? inheritedValues.schema,
+    sql: options?.sql ?? 'SELECT ...',
+    queryLimit:
+      inheritedValues.queryLimit ?? common?.conf?.DEFAULT_SQLLAB_LIMIT,
+    autorun: false,
+    name,
+  };
+
+  store.dispatch(addQueryEditor(newQueryEditor) as any);
+
+  // Get the newly created tab
+  const updatedState = store.getState() as SqlLabRootState;
+  const newTab =
+    updatedState.sqlLab.queryEditors[
+      updatedState.sqlLab.queryEditors.length - 1
+    ];
+
+  return makeTab(
+    newTab.id,
+    newTab.name ?? '',
+    newTab.dbId ?? 0,
+    newTab.catalog,
+    newTab.schema ?? undefined,
+  );
+};
+
+const closeTab: typeof sqlLabApi.closeTab = async (tabId: string) => {
+  const queryEditor = findQueryEditor(tabId);
+  if (queryEditor) {
+    store.dispatch({ type: REMOVE_QUERY_EDITOR, queryEditor });
+  }
+};
+
+const setActiveTab: typeof sqlLabApi.setActiveTab = async (tabId: string) => {
+  const queryEditor = findQueryEditor(tabId);
+  if (queryEditor) {
+    store.dispatch(setActiveQueryEditor(queryEditor as QueryEditor));
+  }
+};
+
+const runQuery: typeof sqlLabApi.runQuery = async () => {
+  const state = store.getState() as SqlLabRootState;
+  const editorId = activeEditorId();
+  const queryEditor = findQueryEditor(editorId);
+
+  if (!queryEditor) {
+    throw new Error('No active query editor');
+  }
+
+  const { databases, unsavedQueryEditor } = state.sqlLab;
+  const qe = {
+    ...queryEditor,
+    ...(queryEditor.id === unsavedQueryEditor?.id && unsavedQueryEditor),
+  } as QueryEditor;
+
+  const database = qe.dbId ? databases[qe.dbId] : null;
+  const defaultLimit = state.common?.conf?.DEFAULT_SQLLAB_LIMIT ?? 1000;
+
+  store.dispatch(runQueryFromSqlEditor(database, qe, defaultLimit) as any);
+
+  return qe.id;
+};
+
+const stopQuery: typeof sqlLabApi.stopQuery = async (queryId: string) => {
+  const state = store.getState() as SqlLabRootState;
+  const query = state.sqlLab.queries[queryId];
+
+  if (query) {
+    store.dispatch(postStopQuery(query as any) as any);
+  }
+};
+
+const setDatabase: typeof sqlLabApi.setDatabase = async (
+  databaseId: number,
+) => {
+  const queryEditor = findQueryEditor(activeEditorId());
+  if (queryEditor) {
+    store.dispatch(queryEditorSetDb(queryEditor, databaseId));
+  }
+};
+
+const setCatalog: typeof sqlLabApi.setCatalog = async (
+  catalog: string | null,
+) => {
+  const queryEditor = findQueryEditor(activeEditorId());
+  store.dispatch(queryEditorSetCatalog(queryEditor ?? null, catalog));
+};
+
+const setSchema: typeof sqlLabApi.setSchema = async (schema: string | null) => {
+  const queryEditor = findQueryEditor(activeEditorId());
+  store.dispatch(queryEditorSetSchema(queryEditor ?? null, schema));
+};
+
 export const sqlLab: typeof sqlLabApi = {
   CTASMethod,
   getActivePanel,
   getCurrentTab,
+  getDatabases,
+  getTabs,
   onDidChangeEditorDatabase,
   onDidChangeEditorSchema,
   onDidChangeActivePanel,
@@ -404,10 +651,17 @@ export const sqlLab: typeof sqlLabApi = {
   onDidQueryStop,
   onDidQueryFail,
   onDidQuerySuccess,
-  getDatabases,
-  getTabs,
   onDidCloseTab,
   onDidChangeActiveTab,
+  onDidCreateTab,
+  createTab,
+  closeTab,
+  setActiveTab,
+  runQuery,
+  stopQuery,
+  setDatabase,
+  setCatalog,
+  setSchema,
 };
 
 // Export all models

--- a/superset-frontend/src/core/sqlLab/index.ts
+++ b/superset-frontend/src/core/sqlLab/index.ts
@@ -433,8 +433,15 @@ const onDidCloseTab: typeof sqlLabApi.onDidCloseTab = (
   createActionListener(
     globalPredicate(REMOVE_QUERY_EDITOR),
     listener,
-    (action: { type: string; queryEditor: { id: string } }) =>
-      getTab(action.queryEditor.id),
+    (action: { type: string; queryEditor: QueryEditor }) =>
+      // Construct tab from action data since the tab has already been removed from state
+      makeTab(
+        action.queryEditor.id,
+        action.queryEditor.name ?? '',
+        action.queryEditor.dbId ?? 0,
+        action.queryEditor.catalog,
+        action.queryEditor.schema,
+      ),
     thisArgs,
   );
 

--- a/superset-frontend/src/core/sqlLab/models.ts
+++ b/superset-frontend/src/core/sqlLab/models.ts
@@ -28,47 +28,41 @@ export class Panel implements sqlLabType.Panel {
   }
 }
 
-export class Editor implements sqlLabType.Editor {
-  content: string;
-
-  databaseId: number;
-
-  schema: string;
-
-  // TODO: Check later if we'll use objects instead of strings.
-  catalog: string | null;
-
-  table: string | null;
-
-  constructor(
-    content: string,
-    databaseId: number,
-    catalog: string | null = null,
-    schema = '',
-    table: string | null = null,
-  ) {
-    this.content = content;
-    this.databaseId = databaseId;
-    this.catalog = catalog;
-    this.schema = schema;
-    this.table = table;
-  }
-}
-
 export class Tab implements sqlLabType.Tab {
   id: string;
 
   title: string;
 
-  editor: Editor;
+  databaseId: number;
+
+  catalog: string | null;
+
+  schema: string | null;
 
   panels: Panel[];
 
-  constructor(id: string, title: string, editor: Editor, panels: Panel[] = []) {
+  private editorGetter: () => Promise<sqlLabType.Editor>;
+
+  constructor(
+    id: string,
+    title: string,
+    databaseId: number,
+    catalog: string | null = null,
+    schema: string | null = null,
+    editorGetter: () => Promise<sqlLabType.Editor>,
+    panels: Panel[] = [],
+  ) {
     this.id = id;
     this.title = title;
-    this.editor = editor;
+    this.databaseId = databaseId;
+    this.catalog = catalog;
+    this.schema = schema;
+    this.editorGetter = editorGetter;
     this.panels = panels;
+  }
+
+  getEditor(): Promise<sqlLabType.Editor> {
+    return this.editorGetter();
   }
 }
 
@@ -87,8 +81,6 @@ export class QueryContext implements sqlLabType.QueryContext {
   clientId: string;
 
   ctas: sqlLabType.CTAS | null;
-
-  editor: Editor;
 
   requestedLimit: number | null;
 
@@ -116,7 +108,6 @@ export class QueryContext implements sqlLabType.QueryContext {
   ) {
     this.clientId = clientId;
     this.tab = tab;
-    this.editor = tab.editor;
     this.runAsync = runAsync;
     this.startDttm = startDttm;
     this.requestedLimit = options.requestedLimit ?? null;

--- a/superset-frontend/src/core/utils.ts
+++ b/superset-frontend/src/core/utils.ts
@@ -24,7 +24,7 @@ import { AnyListenerPredicate } from '@reduxjs/toolkit';
 export function createActionListener<V, S>(
   predicate: AnyListenerPredicate<S>,
   listener: (v: V) => void,
-  valueParser: (action: AnyAction, state: RootState) => V,
+  valueParser: (action: AnyAction, state: RootState) => V | null | undefined,
   thisArgs?: any,
 ): core.Disposable {
   const boundListener = thisArgs ? listener.bind(thisArgs) : listener;
@@ -33,7 +33,11 @@ export function createActionListener<V, S>(
     predicate,
     effect: (action: AnyAction) => {
       const state = store.getState();
-      boundListener(valueParser(action, state));
+      const value = valueParser(action, state);
+      // Skip calling listener if valueParser returns null/undefined
+      if (value != null) {
+        boundListener(value);
+      }
     },
   });
 

--- a/superset-frontend/src/core/utils.ts
+++ b/superset-frontend/src/core/utils.ts
@@ -21,8 +21,8 @@ import { AnyAction } from 'redux';
 import { listenerMiddleware, RootState, store } from 'src/views/store';
 import { AnyListenerPredicate } from '@reduxjs/toolkit';
 
-export function createActionListener<V, S>(
-  predicate: AnyListenerPredicate<S>,
+export function createActionListener<V>(
+  predicate: AnyListenerPredicate<RootState>,
   listener: (v: V) => void,
   valueParser: (action: AnyAction, state: RootState) => V | null | undefined,
   thisArgs?: any,


### PR DESCRIPTION
## Summary

This PR extends the SQL Lab API with new capabilities for tab management, query execution, and editor manipulation.

## New APIs

### Editor Access (now available via `Tab.getEditor()`)
- **`Tab.getEditor()`** - Async method to get the editor handle
- **`Editor.getValue()`** - Get the current SQL content
- **`Editor.setValue(sql)`** - Replace the editor content
- **`Editor.insertText(text)`** - Insert text at cursor position
- **`Editor.focus()`** - Focus the editor
- **`Editor.getCursorPosition()`** - Get current cursor position
- **`Editor.getSelections()`** - Get current selections
- **`Editor.setAnnotations(annotations)`** - Set error/warning markers
- **`Editor.registerCompletionProvider(provider)`** - Register custom autocomplete

### Tab Management
- **`createTab(options?)`** - Create a new query editor tab with optional SQL, title, database, catalog, and schema
- **`closeTab(tabId)`** - Close a specific tab
- **`setActiveTab(tabId)`** - Switch to a specific tab
- **`onDidCreateTab`** - Event fired when a new tab is created

### Query Execution
- **`executeQuery(options?)`** - Execute the SQL query in the current tab
- **`cancelQuery(queryId)`** - Cancel a running query

### Tab Context
- **`setDatabase(databaseId)`** - Set the database for the current tab
- **`setCatalog(catalog)`** - Set the catalog for the current tab
- **`setSchema(schema)`** - Set the schema for the current tab
- **`Tab.databaseId`**, **`Tab.catalog`**, **`Tab.schema`** - Direct access to tab context

## API Changes

### Tab Interface
```typescript
// Before
interface Tab {
  id: string;
  title: string;
  editor: Editor;  // sync property with content, databaseId, catalog, schema
  panels: Panel[];
}

// After
interface Tab {
  id: string;
  title: string;
  databaseId: number;
  catalog: string | null;
  schema: string | null;
  getEditor(): Promise<Editor>;  // async method returning EditorHandle
  panels: Panel[];
}
```

### Editor Interface
```typescript
// Before
interface Editor {
  content: string;
  databaseId: number;
  catalog: string | null;
  schema: string;
  table: string | null;
}

// After - extends EditorHandle with full editor manipulation
interface Editor extends EditorHandle {
  // Inherited: getValue(), setValue(), insertText(), focus(),
  // getCursorPosition(), getSelections(), setAnnotations(), etc.
}
```

### Migration Example
```typescript
// Before
const tab = sqlLab.getCurrentTab();
const sql = tab.editor.content;
const dbId = tab.editor.databaseId;

// After
const tab = sqlLab.getCurrentTab();
const editor = await tab.getEditor();
const sql = editor.getValue();
const dbId = tab.databaseId;
```

## Documentation

Improved JSDoc documentation for the Editor API in `packages/superset-core/src/api/editors.ts`:

- **EditorHandle** - Comprehensive documentation for all methods including behavior details, edge cases, and parameter descriptions
- **Position, Range, Selection** - Added examples and clarified zero-based indexing
- **EditorAnnotation** - Added example and severity color explanations
- **EditorHotkey** - Documented key combination format with example
- **CompletionProvider** - Added example showing async table completion
- **executeCommand()** - Noted that command names are editor-specific (Ace vs Monaco)

## Test Plan

- Create new tabs via `createTab()` with various options
- Verify default tab naming "Untitled Query N"
- Close and switch tabs via API
- Execute and stop queries via API
- Change database/catalog/schema via API
- Access editor via `getEditor()` and manipulate content

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
