### PR TITLE
feat(semantic-layer): integrate semantic views with explore API

### DIFF
--- a/superset/commands/explore/parameters.py
+++ b/superset/commands/explore/parameters.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 
 @dataclass
 class CommandParameters:
     permalink_key: Optional[str]
     form_data_key: Optional[str]
-    datasource_id: Optional[int]
+    datasource_id: Optional[Union[int, str]]
     datasource_type: Optional[str]
     slice_id: Optional[int]

--- a/superset/daos/datasource.py
+++ b/superset/daos/datasource.py
@@ -28,6 +28,7 @@ from superset.daos.exceptions import (
     DatasourceValueIsIncorrect,
 )
 from superset.models.sql_lab import Query, SavedQuery
+from superset.semantic_layers.models import SemanticView
 from superset.utils.core import DatasourceType
 
 logger = logging.getLogger(__name__)
@@ -40,13 +41,14 @@ class DatasourceDAO(BaseDAO[Datasource]):
         DatasourceType.TABLE: SqlaTable,
         DatasourceType.QUERY: Query,
         DatasourceType.SAVEDQUERY: SavedQuery,
+        DatasourceType.SEMANTIC_VIEW: SemanticView,
     }
 
     @classmethod
     def get_datasource(
         cls,
         datasource_type: Union[DatasourceType, str],
-        database_id_or_uuid: int | str,
+        database_id_or_uuid: int | str | uuid.UUID,
     ) -> Datasource:
         if datasource_type not in cls.sources:
             raise DatasourceTypeNotSupportedError()

--- a/superset/explore/api.py
+++ b/superset/explore/api.py
@@ -109,7 +109,7 @@ class ExploreRestApi(BaseSupersetApi):
             params = CommandParameters(
                 permalink_key=request.args.get("permalink_key", type=str),
                 form_data_key=request.args.get("form_data_key", type=str),
-                datasource_id=request.args.get("datasource_id", type=int),
+                datasource_id=request.args.get("datasource_id"),
                 datasource_type=request.args.get("datasource_type", type=str),
                 slice_id=request.args.get("slice_id", type=int),
             )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is 3 of 4 stacked PRs to implement the backend functionality of semantic layers:

- https://github.com/apache/superset/pull/37646
- https://github.com/apache/superset/pull/37647
- https://github.com/apache/superset/pull/37648
- https://github.com/apache/superset/pull/37649

This one updates views and APIs to support semantic layer explorables:

- Adds UUID support for datasource IDs in views and utils
- Updates explore command to handle semantic views
- Extends datasource DAO to resolve semantic view UUIDs
- Updates explore API parameters for semantic layer support

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Tested end-to-end (all 4 PRs) with Snowflake.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:  https://github.com/apache/superset/issues/35003
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
