### PR TITLE
fix(sqllab): Skip progress bar on no data

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/Results.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/Results.tsx
@@ -83,25 +83,27 @@ const Results: FC<Props> = ({
     !latestQuery.resultsKey &&
     !latestQuery.results;
 
+  if (hasNoStoredResults) {
+    return (
+      <Alert
+        type="info"
+        message={t('No stored results found, you need to re-run your query')}
+      />
+    );
+  }
+
   return (
     <>
       <QueryStatusBar key={latestQueryId} query={latestQuery} />
-      {hasNoStoredResults ? (
-        <Alert
-          type="info"
-          message={t('No stored results found, you need to re-run your query')}
-        />
-      ) : (
-        <ResultSet
-          search
-          queryId={latestQuery.id}
-          database={databases[latestQuery.dbId]}
-          displayLimit={displayLimit}
-          defaultQueryLimit={defaultQueryLimit}
-          showSql
-          showSqlInline
-        />
-      )}
+      <ResultSet
+        search
+        queryId={latestQuery.id}
+        database={databases[latestQuery.dbId]}
+        displayLimit={displayLimit}
+        defaultQueryLimit={defaultQueryLimit}
+        showSql
+        showSqlInline
+      />
     </>
   );
 };

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -572,6 +572,28 @@ describe('sqlLabReducer', () => {
     test('should refresh queries when polling returns empty', () => {
       newState = sqlLabReducer(newState, actions.refreshQueries({}));
     });
+    test('should set state to fetching when sync query succeeds without results', () => {
+      const syncQuery = {
+        ...query,
+        id: 'sync-query',
+        state: QueryState.Pending,
+        runAsync: false,
+        results: null,
+      };
+      newState = sqlLabReducer(
+        {
+          ...newState,
+          queries: { 'sync-query': syncQuery },
+        },
+        actions.refreshQueries({
+          'sync-query': {
+            ...syncQuery,
+            state: QueryState.Success,
+          },
+        }),
+      );
+      expect(newState.queries['sync-query'].state).toBe(QueryState.Fetching);
+    });
   });
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('CLEAR_INACTIVE_QUERIES', () => {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.ts
@@ -760,6 +760,13 @@ export default function sqlLabReducer(
                   : currentState,
             };
             if (
+              newQueries[id].state === QueryState.Success &&
+              newQueries[id].runAsync === false &&
+              !newQueries[id].results
+            ) {
+              newQueries[id].state = QueryState.Fetching;
+            }
+            if (
               shallowEqual(
                 omit(newQueries[id], ['extra']),
                 omit(state.queries[id], ['extra']),


### PR DESCRIPTION
### SUMMARY
There is an issue where the query progress bar and the "no data" state are displayed together, which can cause confusion. This occurs because, in sync mode, when a query is executed, the batch query/updated_since is triggered at the moment the query results are being parsed. As a result, the query state changes to "success" before the results are actually populated.
This commit modifies the process so that, just like in async mode, the state changes to "fetching" during this period. This prevents misunderstanding by displaying the correct status until the results are available.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="1154" height="833" alt="Screenshot 2026-02-03 at 8 19 04 PM" src="https://github.com/user-attachments/assets/32dbfb42-55e5-447a-be51-d69fe204519d" />

After:

<img width="1187" height="1182" alt="Screenshot 2026-02-03 at 8 18 16 PM" src="https://github.com/user-attachments/assets/0644d098-c10f-4a6e-86a8-8164f5f66262" />

### TESTING INSTRUCTIONS
specs are added

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
