### PR TITLE
fix(scatter): Fix ad-hoc metric for pointsize

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
@@ -518,3 +518,32 @@ test('Scatter buildQuery should add adhoc metric radius to existing saved metric
   expect(query.metrics).toContainEqual(radiusAdhocMetric);
   expect(query.metrics).toHaveLength(3);
 });
+
+test('Scatter buildQuery should handle legacy string format for point_radius_fixed', () => {
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    point_radius_fixed: 'COUNT(*)',
+  };
+
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  // Legacy string format should be treated as a metric
+  expect(query.metrics).toContain('COUNT(*)');
+  expect(query.orderby).toEqual([['COUNT(*)', false]]);
+});
+
+test('Scatter buildQuery should deduplicate legacy string metric with existing metrics', () => {
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    metrics: ['COUNT(*)', 'SUM(value)'],
+    point_radius_fixed: 'COUNT(*)',
+  };
+
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  // Should not duplicate COUNT(*)
+  expect(query.metrics).toEqual(['COUNT(*)', 'SUM(value)']);
+  expect(query.metrics).toHaveLength(2);
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -19,6 +19,8 @@
 import {
   buildQueryContext,
   ensureIsArray,
+  getMetricLabel,
+  QueryFormMetric,
   QueryFormOrderBy,
   SqlaFormData,
   QueryFormColumn,
@@ -31,16 +33,15 @@ import {
 } from '../spatialUtils';
 import {
   addJsColumnsToColumns,
-  processMetricsArray,
   addTooltipColumnsToQuery,
 } from '../buildQueryUtils';
-import { isMetricValue, extractMetricKey } from '../utils/metricUtils';
+import { isMetricValue } from '../utils/metricUtils';
 
 export interface DeckScatterFormData
   extends Omit<SpatialFormData, 'color_picker'>, SqlaFormData {
   point_radius_fixed?: {
     type?: 'fix' | 'metric';
-    value?: string | number;
+    value?: QueryFormMetric;
   };
   multiplier?: number;
   point_unit?: string;
@@ -82,26 +83,29 @@ export default function buildQuery(formData: DeckScatterFormData) {
 
       // Only add metric if point_radius_fixed is a metric type
       const isMetric = isMetricValue(point_radius_fixed);
-      const metricValue = isMetric
-        ? extractMetricKey(point_radius_fixed?.value)
-        : null;
+      // Preserve full metric value (string for saved metrics, object for adhoc)
+      const metricValue = isMetric ? point_radius_fixed?.value : null;
 
       // Preserve existing metrics and only add radius metric if it's metric-based
       const existingMetrics = baseQueryObject.metrics || [];
-      const radiusMetrics = processMetricsArray(
-        metricValue ? [metricValue] : [],
+      // Deduplicate metrics using getMetricLabel for comparison
+      const existingLabels = new Set(
+        existingMetrics.map(m => getMetricLabel(m)),
       );
-      // Deduplicate metrics to avoid adding the same metric twice
-      const metricsSet = new Set([...existingMetrics, ...radiusMetrics]);
-      const metrics = Array.from(metricsSet);
+      const metrics =
+        metricValue && !existingLabels.has(getMetricLabel(metricValue))
+          ? [...existingMetrics, metricValue]
+          : [...existingMetrics];
+
       const filters = addSpatialNullFilters(
         spatial,
         ensureIsArray(baseQueryObject.filters || []),
       );
 
+      // orderby needs string label, not the full metric object
       const orderby =
         isMetric && metricValue
-          ? ([[metricValue, false]] as QueryFormOrderBy[])
+          ? ([[getMetricLabel(metricValue), false]] as QueryFormOrderBy[])
           : (baseQueryObject.orderby as QueryFormOrderBy[]) || [];
 
       return [

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -86,20 +86,15 @@ export default function buildQuery(formData: DeckScatterFormData) {
 
       // Only add metric if point_radius_fixed is a metric type
       const isMetric = isMetricValue(point_radius_fixed);
-      // Extract metric value, handling both legacy string format and object format
-      let metricValue: QueryFormMetric | null = null;
-      if (isMetric) {
-        if (typeof point_radius_fixed === 'string') {
-          // Legacy string format: treat the string itself as the metric
-          metricValue = point_radius_fixed;
-        } else if (
-          point_radius_fixed?.value !== undefined &&
-          typeof point_radius_fixed.value !== 'number'
-        ) {
-          // Metric object format: use the metric value (string or adhoc metric object)
-          metricValue = point_radius_fixed.value as QueryFormMetric;
-        }
-      }
+      // Extract metric value: legacy string format or object with metric value
+      const rawValue =
+        typeof point_radius_fixed === 'string'
+          ? point_radius_fixed
+          : point_radius_fixed?.value;
+      const metricValue: QueryFormMetric | null =
+        isMetric && rawValue !== undefined && typeof rawValue !== 'number'
+          ? (rawValue as QueryFormMetric)
+          : null;
 
       // Preserve existing metrics and only add radius metric if it's metric-based
       const existingMetrics = baseQueryObject.metrics || [];
@@ -110,7 +105,7 @@ export default function buildQuery(formData: DeckScatterFormData) {
       const metrics: QueryFormMetric[] =
         metricValue && !existingLabels.has(getMetricLabel(metricValue))
           ? [...existingMetrics, metricValue]
-          : [...existingMetrics];
+          : existingMetrics;
 
       const filters = addSpatialNullFilters(
         spatial,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -41,7 +41,7 @@ export interface DeckScatterFormData
   extends Omit<SpatialFormData, 'color_picker'>, SqlaFormData {
   point_radius_fixed?: {
     type?: 'fix' | 'metric';
-    value?: QueryFormMetric;
+    value?: QueryFormMetric | number;
   };
   multiplier?: number;
   point_unit?: string;
@@ -83,8 +83,11 @@ export default function buildQuery(formData: DeckScatterFormData) {
 
       // Only add metric if point_radius_fixed is a metric type
       const isMetric = isMetricValue(point_radius_fixed);
-      // Preserve full metric value (string for saved metrics, object for adhoc)
-      const metricValue = isMetric ? point_radius_fixed?.value : null;
+      // When type is 'metric', value is QueryFormMetric (string or adhoc object)
+      const metricValue: QueryFormMetric | null =
+        isMetric && point_radius_fixed?.value !== undefined
+          ? (point_radius_fixed.value as QueryFormMetric)
+          : null;
 
       // Preserve existing metrics and only add radius metric if it's metric-based
       const existingMetrics = baseQueryObject.metrics || [];
@@ -92,7 +95,7 @@ export default function buildQuery(formData: DeckScatterFormData) {
       const existingLabels = new Set(
         existingMetrics.map(m => getMetricLabel(m)),
       );
-      const metrics =
+      const metrics: QueryFormMetric[] =
         metricValue && !existingLabels.has(getMetricLabel(metricValue))
           ? [...existingMetrics, metricValue]
           : [...existingMetrics];

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/buildQueryUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/buildQueryUtils.ts
@@ -92,10 +92,6 @@ export function addColumnsIfNotExists(
   return result;
 }
 
-export function processMetricsArray(metrics: (string | undefined)[]): string[] {
-  return metrics.filter((metric): metric is string => Boolean(metric));
-}
-
 export function extractTooltipColumns(tooltipContents?: unknown[]): string[] {
   if (!Array.isArray(tooltipContents) || !tooltipContents.length) {
     return [];


### PR DESCRIPTION
### SUMMARY

When creating a deck.gl Scatterplot chart, it's possible to choose between a fixed point size, or a dynamic one (calculated with a metric). The metric popover allows you to either select an existing metric from the dataset, or create a new one via custom SQL. Charts using a custom SQL metric are showing errors.

#### Root Cause

This is a regression from a previous [fix](https://github.com/apache/superset/pull/36890/changes) that addressed fixed point size not working. That fix introduced `extractMetricKey()` which converts adhoc metric objects to plain strings, losing the `expressionType` property that the backend needs to identify custom SQL metrics.

**What happens:**

1. User creates a custom SQL metric like `count(*) * 1.1`
2. The UI correctly stores it as an object with `expressionType: "SQL"` and `sqlExpression`
3. `extractMetricKey()` strips it down to just the string `"count(*) * 1.1"`
4. Backend receives the string, can't identify it as an adhoc metric (missing `expressionType`), and it's not a saved metric either
5. Error: "Metric does not exist"

#### Fix

Modified `buildQuery.ts` to preserve the full metric object instead of extracting only the label string. Used `getMetricLabel()` only where a string representation is actually needed (for the `orderby` clause).

#### Alternative Considered

**Fix `extractMetricKey()` to optionally return full objects** - This would be a more "correct" fix at the utility level, but touches shared code used by other components, increasing risk of unintended side effects. The minimal fix in `buildQuery.ts` is safer and achieves the same result.

#### Tests Added

5 new tests to prevent future regressions:

- Adhoc SQL metrics (`count(*) * 1.1`)
- Adhoc SIMPLE metrics (`AVG(column)`)
- Deduplication of adhoc metrics
- Fixed type with string values
- Undefined metric values

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

https://github.com/user-attachments/assets/c083ee24-6155-4596-bece-2e5ab85df286

#### AFTER

https://github.com/user-attachments/assets/39a29df0-5ac1-42bb-9f75-381087ded902



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
