### PR TITLE
fix(docker): remove accidental command substitutions when building FE in dev mode

### DIFF
--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -28,11 +28,11 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     cd /app/superset-frontend
 
     if [ "$NPM_RUN_PRUNE" = "true" ]; then
-        echo "Running `npm run prune`"
+        echo "Running \"npm run prune\""
         npm run prune
     fi
 
-    echo "Running `npm install`"
+    echo "Running \"npm install\""
     npm install
 
     echo "Start webpack dev server"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

fix(docker): remove accidental command substitutions when building FE in dev mode

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #37662
Fixes accidental backticks which are used for command substitution in shell scripting. Plus, we don't have to run commands twice. Thanks to @jerry000lin for noticing this out!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
All checks to be green, especially the `docker-compose` sanity tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
