### PR TITLE
fix(dashboard): ensure clear all respects required filter validation

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.tsx
@@ -66,7 +66,9 @@ const StyledTabs = ({
         margin: 0;
       }
       .ant-tabs-nav-wrap {
-        padding: 0 ${theme.sizeUnit * 4}px;
+        ${!(tabBarStyle && 'paddingLeft' in tabBarStyle)
+          ? `padding: 0 ${theme.sizeUnit * 4}px;`
+          : ''}
       }
       .ant-tabs-tab {
         flex: 1 1 auto;

--- a/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.tsx
@@ -17,81 +17,86 @@
  * under the License.
  */
 import type { FC } from 'react';
-import { css, styled, useTheme } from '@apache-superset/core/theme';
-
-// eslint-disable-next-line no-restricted-imports
+import { css, styled } from '@apache-superset/core/theme';
 import { Tabs as AntdTabs, TabsProps as AntdTabsProps } from 'antd';
 import { Icons } from '@superset-ui/core/components/Icons';
 import type { SerializedStyles } from '@emotion/react';
 
 export interface TabsProps extends AntdTabsProps {
   allowOverflow?: boolean;
+  contentHeight?: string | number;
   fullHeight?: boolean;
   contentStyle?: SerializedStyles;
+  contentPadding?: SerializedStyles;
 }
 
 const StyledTabs = ({
   animated = false,
   allowOverflow = true,
+  contentHeight = '100%',
   fullHeight = false,
   tabBarStyle,
   contentStyle,
+  contentPadding,
   ...props
-}: TabsProps) => {
-  const theme = useTheme();
-  const defaultTabBarStyle = { paddingLeft: theme.sizeUnit * 4 };
-  const mergedStyle = { ...defaultTabBarStyle, ...tabBarStyle };
+}: TabsProps) => (
+  <AntdTabs
+    animated={animated}
+    {...props}
+    tabBarStyle={tabBarStyle}
+    css={theme => css`
+      overflow: ${allowOverflow ? 'visible' : 'hidden'};
+      ${fullHeight && 'height: 100%;'}
 
-  return (
-    <AntdTabs
-      animated={animated}
-      {...props}
-      tabBarStyle={mergedStyle}
-      css={theme => css`
-        overflow: ${allowOverflow ? 'visible' : 'hidden'};
+      .ant-tabs-content-holder {
+        overflow: ${allowOverflow ? 'visible' : 'auto'};
         ${fullHeight && 'height: 100%;'}
+        ${contentHeight &&
+        `height: ${typeof contentHeight === 'number' ? `${contentHeight}px` : contentHeight};`}
+        ${contentPadding}
+      }
+      .ant-tabs-content {
+        ${fullHeight && 'height: 100%;'}
+      }
+      .ant-tabs-tabpane {
+        ${fullHeight && 'height: 100%;'}
+        ${contentStyle}
+      }
+      .ant-tabs-nav {
+        margin: 0;
+      }
+      .ant-tabs-nav-wrap {
+        padding: 0 ${theme.sizeUnit * 4}px;
+      }
+      .ant-tabs-tab {
+        flex: 1 1 auto;
 
-        .ant-tabs-content-holder {
-          overflow: ${allowOverflow ? 'visible' : 'auto'};
-          ${fullHeight && 'height: 100%;'}
-        }
-        .ant-tabs-content {
-          ${fullHeight && 'height: 100%;'}
-        }
-        .ant-tabs-tabpane {
-          ${fullHeight && 'height: 100%;'}
-          ${contentStyle}
-        }
-        .ant-tabs-tab {
-          flex: 1 1 auto;
-
-          .short-link-trigger.btn {
-            padding: 0 ${theme.sizeUnit}px;
-            & > .fa.fa-link {
-              top: 0;
-            }
+        .short-link-trigger.btn {
+          padding: 0 ${theme.sizeUnit}px;
+          & > .fa.fa-link {
+            top: 0;
           }
         }
-        .ant-tabs-tab-btn {
-          display: flex;
-          flex: 1 1 auto;
-          align-items: center;
-          justify-content: center;
-          font-size: ${theme.fontSizeSM}px;
-          text-align: center;
-          user-select: none;
-          .required {
-            margin-left: ${theme.sizeUnit / 2}px;
-            color: ${theme.colorError};
-          }
-          &:focus-visible {
-            box-shadow: none;
-          }
+      }
+      .ant-tabs-tab-btn {
+        display: flex;
+        flex: 1 1 auto;
+        align-items: center;
+        justify-content: center;
+        font-size: ${theme.fontSizeSM}px;
+        text-align: center;
+        user-select: none;
+        .required {
+          margin-left: ${theme.sizeUnit / 2}px;
+          color: ${theme.colorError};
         }
-      `}
-    />
-  );
-};
+        &:focus-visible {
+          box-shadow: none;
+        }
+      }
+    `}
+  />
+);
 
 const StyledTabPane = styled(AntdTabs.TabPane)``;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
@@ -39,8 +39,21 @@ export const BaseModalWrapper = styled(StyledModal)<BaseModalWrapperProps>`
     min-width: auto;
   }
 
+  .ant-modal-header {
+    margin-bottom: 0;
+  }
+
   .ant-modal-body {
-    padding: 0px;
+    overflow: hidden;
+    padding: 0;
+  }
+
+  .ant-collapse {
+    border-bottom: 0;
+
+    .ant-collapse-item:last-child > .ant-collapse-content {
+      border-radius: 0;
+    }
   }
 
   ${({ expanded }) =>
@@ -59,7 +72,7 @@ export const BaseModalWrapper = styled(StyledModal)<BaseModalWrapperProps>`
 
 export const BaseModalBody = styled.div<BaseModalBodyProps>`
   display: flex;
-  height: ${({ expanded }) => (expanded ? '100%' : '700px')};
+  height: 100%;
   flex-direction: row;
   flex: 1;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
@@ -46,6 +46,8 @@ export const BaseModalWrapper = styled(StyledModal)<BaseModalWrapperProps>`
   .ant-modal-body {
     overflow: hidden;
     padding: 0;
+    flex: 1 1 auto;
+    min-height: 0;
   }
 
   .ant-collapse {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -26,7 +26,7 @@ import {
   ChartCustomizationDivider,
 } from '@superset-ui/core';
 import { css, SupersetTheme, styled } from '@apache-superset/core/theme';
-import { Button } from '@superset-ui/core/components';
+import { Button, Tooltip, Icons, Flex } from '@superset-ui/core/components';
 import { OPEN_FILTER_BAR_WIDTH } from 'src/dashboard/constants';
 import tinycolor from 'tinycolor2';
 import { FilterBarOrientation } from 'src/dashboard/types';
@@ -41,14 +41,47 @@ interface ActionButtonsProps {
   chartCustomizationItems?: (ChartCustomization | ChartCustomizationDivider)[];
   isApplyDisabled: boolean;
   filterBarOrientation?: FilterBarOrientation;
+  hasOutOfScopeRequiredFilters?: boolean;
 }
 
-const containerStyle = (theme: SupersetTheme) => css`
-  display: flex;
+const ButtonsContainer = styled.div<{ isVertical: boolean; width: number }>`
+  ${({ theme, isVertical, width }) => css`
+    display: flex;
 
-  && > .filter-clear-all-button {
+    ${isVertical
+      ? css`
+          flex-direction: column;
+          align-items: center;
+          position: fixed;
+          z-index: 100;
+          width: ${width - 1}px;
+          bottom: 0;
+          padding: ${theme.sizeUnit * 4}px;
+          padding-top: ${theme.sizeUnit * 6}px;
+          background: linear-gradient(
+            ${tinycolor(theme.colorBgLayout).setAlpha(0).toRgbString()},
+            ${theme.colorBgContainer} 20%
+          );
+        `
+      : css`
+          align-items: center;
+          margin-left: auto;
+        `}
+  `}
+`;
+
+const applyButtonStyle = (theme: SupersetTheme, isVertical: boolean) => css`
+  ${isVertical &&
+  css`
+    margin-bottom: ${theme.sizeUnit * 3}px;
+  `}
+`;
+
+const clearAllButtonStyle = (theme: SupersetTheme, isVertical: boolean) => css`
+  && {
     color: ${theme.colorTextSecondary};
     margin-left: 0;
+
     &:hover {
       color: ${theme.colorPrimaryText};
     }
@@ -57,46 +90,13 @@ const containerStyle = (theme: SupersetTheme) => css`
     &[disabled]:hover {
       color: ${theme.colorTextDisabled};
     }
+
+    ${!isVertical &&
+    css`
+      text-transform: capitalize;
+      font-weight: ${theme.fontWeightNormal};
+    `}
   }
-`;
-
-const verticalStyle = (theme: SupersetTheme, width: number) => css`
-  flex-direction: column;
-  align-items: center;
-  position: fixed;
-  z-index: 100;
-
-  // filter bar width minus 1px for border
-  width: ${width - 1}px;
-  bottom: 0;
-
-  padding: ${theme.sizeUnit * 4}px;
-  padding-top: ${theme.sizeUnit * 6}px;
-
-  background: linear-gradient(
-    ${tinycolor(theme.colorBgLayout).setAlpha(0).toRgbString()},
-    ${theme.colorBgContainer} 20%
-  );
-
-  & > .filter-apply-button {
-    margin-bottom: ${theme.sizeUnit * 3}px;
-  }
-`;
-
-const horizontalStyle = (theme: SupersetTheme) => css`
-  align-items: center;
-  margin-left: auto;
-  && > .filter-clear-all-button {
-    text-transform: capitalize;
-    font-weight: ${theme.fontWeightNormal};
-  }
-`;
-
-const ButtonsContainer = styled.div<{ isVertical: boolean; width: number }>`
-  ${({ theme, isVertical, width }) => css`
-    ${containerStyle(theme)};
-    ${isVertical ? verticalStyle(theme, width) : horizontalStyle(theme)};
-  `}
 `;
 
 const ActionButtons = ({
@@ -108,7 +108,10 @@ const ActionButtons = ({
   isApplyDisabled,
   filterBarOrientation = FilterBarOrientation.Vertical,
   chartCustomizationItems,
+  hasOutOfScopeRequiredFilters = false,
 }: ActionButtonsProps) => {
+  const isVertical = filterBarOrientation === FilterBarOrientation.Vertical;
+
   const isClearAllEnabled = useMemo(() => {
     const hasSelectedChanges = Object.entries(dataMaskSelected).some(
       ([, mask]) => {
@@ -136,7 +139,6 @@ const ActionButtons = ({
 
     return hasSelectedChanges || hasAppliedChanges || hasChartCustomizations;
   }, [dataMaskSelected, dataMaskApplied, chartCustomizationItems]);
-  const isVertical = filterBarOrientation === FilterBarOrientation.Vertical;
 
   return (
     <ButtonsContainer
@@ -148,21 +150,37 @@ const ActionButtons = ({
         disabled={isApplyDisabled}
         buttonStyle="primary"
         htmlType="submit"
-        className="filter-apply-button"
+        css={(theme: SupersetTheme) => applyButtonStyle(theme, isVertical)}
         onClick={onApply}
         {...getFilterBarTestId('apply-button')}
       >
         {isVertical ? t('Apply filters') : t('Apply')}
       </Button>
-      <Button
-        disabled={!isClearAllEnabled}
-        buttonStyle="link"
-        className="filter-clear-all-button"
-        onClick={onClearAll}
-        {...getFilterBarTestId('clear-button')}
-      >
-        {t('Clear all')}
-      </Button>
+      <Flex>
+        <Button
+          disabled={!isClearAllEnabled}
+          buttonStyle="link"
+          css={(theme: SupersetTheme) => clearAllButtonStyle(theme, isVertical)}
+          onClick={onClearAll}
+          {...getFilterBarTestId('clear-button')}
+        >
+          {t('Clear all')}
+        </Button>
+        {hasOutOfScopeRequiredFilters && (
+          <Tooltip
+            title={t(
+              'Some required filters on other tabs have values and will not be cleared',
+            )}
+          >
+            <Icons.InfoCircleOutlined
+              iconSize="s"
+              css={(theme: SupersetTheme) => css`
+                margin-left: ${theme.sizeUnit}px;
+              `}
+            />
+          </Tooltip>
+        )}
+      </Flex>
     </ButtonsContainer>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -42,6 +42,7 @@ jest.mock('@superset-ui/core', () => ({
 
 const mockedMakeApi = makeApi as jest.Mock;
 
+// Register preset once for all tests
 class MainPreset extends Preset {
   constructor() {
     super({
@@ -55,65 +56,41 @@ class MainPreset extends Preset {
   }
 }
 
+new MainPreset().register();
+
 fetchMock.get('glob:*/api/v1/dataset/7', {
   description_columns: {},
   id: 1,
-  label_columns: {
-    columns: 'Columns',
-    table_name: 'Table Name',
-  },
+  label_columns: { columns: 'Columns', table_name: 'Table Name' },
   result: {
     metrics: [],
-    columns: [
-      {
-        column_name: 'Column A',
-        id: 1,
-      },
-    ],
+    columns: [{ column_name: 'Column A', id: 1 }],
     table_name: 'birth_names',
     id: 1,
   },
   show_columns: ['id', 'table_name'],
 });
 
+// Cleanup between tests
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 const getTestId = testWithId<string>(FILTER_BAR_TEST_ID, true);
 const getModalTestId = testWithId<string>(FILTERS_CONFIG_MODAL_TEST_ID, true);
 
-const FILTER_NAME = 'Time filter 1';
+function createClosedBarProps(toggleFiltersBar = jest.fn()) {
+  return { filtersOpen: false, toggleFiltersBar };
+}
 
-const addFilterFlow = async () => {
-  // open filter config modals
-  userEvent.click(screen.getByTestId(getTestId('collapsable')));
-  userEvent.click(screen.getByLabelText('setting'));
-  userEvent.click(screen.getByText('Add or edit filters and controls'));
-  // select filter
-  userEvent.click(screen.getByText('Value'));
-  userEvent.click(screen.getByText('Time range'));
-  userEvent.type(screen.getByTestId(getModalTestId('name-input')), FILTER_NAME);
-  userEvent.click(screen.getByText('Save'));
-  // TODO: fix this flaky test
-  // await screen.findByText('All filters (1)');
-};
+function createOpenedBarProps(toggleFiltersBar = jest.fn()) {
+  return { filtersOpen: true, toggleFiltersBar };
+}
 
-// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-describe('FilterBar', () => {
-  new MainPreset().register();
-  const toggleFiltersBar = jest.fn();
-  const closedBarProps = {
-    filtersOpen: false,
-    toggleFiltersBar,
-  };
-  const openedBarProps = {
-    filtersOpen: true,
-    toggleFiltersBar,
-  };
-
-  const mockApi = jest.fn(async data => {
+function createMockApi(filterName = 'Time filter 1') {
+  return jest.fn(async data => {
     if (!data?.modified?.length) {
-      return {
-        id: 1234,
-        result: [],
-      };
+      return { id: 1234, result: [] };
     }
     const filterId = data.modified[0].id;
     return {
@@ -121,7 +98,7 @@ describe('FilterBar', () => {
       result: [
         {
           id: filterId,
-          name: FILTER_NAME,
+          name: filterName,
           filterType: 'filter_time',
           targets: [{ datasetId: 11, column: { name: 'color' } }],
           defaultDataMask: { filterState: { value: null } },
@@ -132,540 +109,663 @@ describe('FilterBar', () => {
       ],
     };
   });
+}
 
-  const getTimeRangeNoFilterMockUrl =
-    'glob:*/api/v1/time_range/?q=%27No%20filter%27';
-  const getTimeRangeLastDayMockUrl =
-    'glob:*/api/v1/time_range/?q=%27Last%20day%27';
-  const getTimeRangeLastWeekMockUrl =
-    'glob:*/api/v1/time_range/?q=%27Last%20week%27';
+function createFilter(overrides: Record<string, unknown> = {}) {
+  const id = (overrides.id as string) || 'test-filter';
+  return {
+    id,
+    name: 'Test Filter',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 1, column: { name: 'test_column' } }],
+    defaultDataMask: { filterState: { value: null }, extraFormData: {} },
+    controlValues: {},
+    cascadeParentIds: [],
+    scope: { rootPath: ['ROOT_ID'], excluded: [] },
+    type: 'NATIVE_FILTER',
+    description: '',
+    chartsInScope: [],
+    tabsInScope: [],
+    ...overrides,
+  };
+}
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+function createDataMask(
+  filterId: string,
+  value: unknown = undefined,
+  extraFormData: Record<string, unknown> = {},
+) {
+  return {
+    id: filterId,
+    filterState: { value },
+    extraFormData,
+  };
+}
 
-    fetchMock.removeRoute(getTimeRangeNoFilterMockUrl);
-    fetchMock.get(
-      getTimeRangeNoFilterMockUrl,
-      {
-        result: { since: '', until: '', timeRange: 'No filter' },
+function createDivider(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'NATIVE_FILTER_DIVIDER-1',
+    type: 'DIVIDER',
+    scope: { rootPath: ['ROOT_ID'], excluded: [] },
+    title: 'Select time range',
+    description: 'Select year/month etc..',
+    chartsInScope: [],
+    tabsInScope: [],
+    ...overrides,
+  };
+}
+
+function createStateWithFilter(
+  filter: ReturnType<typeof createFilter>,
+  dataMask: ReturnType<typeof createDataMask>,
+  dashboardInfoOverrides: Record<string, unknown> = {},
+) {
+  return {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      metadata: {
+        native_filter_configuration: [filter],
       },
-      { name: getTimeRangeNoFilterMockUrl },
-    );
+      ...dashboardInfoOverrides,
+    },
+    dashboardState: {
+      ...stateWithoutNativeFilters.dashboardState,
+      activeTabs: ['ROOT_ID'],
+    },
+    dataMask: { [filter.id]: dataMask },
+    nativeFilters: {
+      filters: { [filter.id]: filter },
+      filtersState: {},
+    },
+  };
+}
 
-    fetchMock.removeRoute(getTimeRangeLastDayMockUrl);
-    fetchMock.get(
-      getTimeRangeLastDayMockUrl,
-      {
-        result: {
-          since: '2021-04-13T00:00:00',
-          until: '2021-04-14T00:00:00',
-          timeRange: 'Last day',
-        },
+function setupTimeRangeMocks() {
+  const urls = {
+    noFilter: 'glob:*/api/v1/time_range/?q=%27No%20filter%27',
+    lastDay: 'glob:*/api/v1/time_range/?q=%27Last%20day%27',
+    lastWeek: 'glob:*/api/v1/time_range/?q=%27Last%20week%27',
+  };
+
+  fetchMock.removeRoute(urls.noFilter);
+  fetchMock.get(
+    urls.noFilter,
+    { result: { since: '', until: '', timeRange: 'No filter' } },
+    { name: urls.noFilter },
+  );
+
+  fetchMock.removeRoute(urls.lastDay);
+  fetchMock.get(
+    urls.lastDay,
+    {
+      result: {
+        since: '2021-04-13T00:00:00',
+        until: '2021-04-14T00:00:00',
+        timeRange: 'Last day',
       },
-      { name: getTimeRangeLastDayMockUrl },
-    );
+    },
+    { name: urls.lastDay },
+  );
 
-    fetchMock.removeRoute(getTimeRangeLastWeekMockUrl);
-    fetchMock.get(
-      getTimeRangeLastWeekMockUrl,
-      {
-        result: {
-          since: '2021-04-07T00:00:00',
-          until: '2021-04-14T00:00:00',
-          timeRange: 'Last week',
-        },
+  fetchMock.removeRoute(urls.lastWeek);
+  fetchMock.get(
+    urls.lastWeek,
+    {
+      result: {
+        since: '2021-04-07T00:00:00',
+        until: '2021-04-14T00:00:00',
+        timeRange: 'Last week',
       },
-      { name: getTimeRangeLastWeekMockUrl },
-    );
+    },
+    { name: urls.lastWeek },
+  );
+}
 
-    mockedMakeApi.mockReturnValue(mockApi);
+function renderFilterBar(
+  props: { filtersOpen: boolean; toggleFiltersBar: jest.Mock },
+  state?: object,
+) {
+  return render(
+    <FilterBar
+      orientation={FilterBarOrientation.Vertical}
+      verticalConfig={{
+        width: 280,
+        height: 400,
+        offset: 0,
+        ...props,
+      }}
+    />,
+    {
+      initialState: state,
+      useDnd: true,
+      useRedux: true,
+      useRouter: true,
+    },
+  );
+}
+
+test('FilterBar renders without crashing', () => {
+  const props = createClosedBarProps();
+  const { container } = renderFilterBar(props);
+  expect(container).toBeInTheDocument();
+});
+
+test('FilterBar renders "Filters and controls" heading', () => {
+  const props = createClosedBarProps();
+  renderFilterBar(props);
+  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
+});
+
+test('FilterBar renders "Clear all" button', () => {
+  const props = createClosedBarProps();
+  renderFilterBar(props);
+  expect(screen.getByText('Clear all')).toBeInTheDocument();
+});
+
+test('FilterBar renders "Apply filters" button', () => {
+  const props = createClosedBarProps();
+  renderFilterBar(props);
+  expect(screen.getByText('Apply filters')).toBeInTheDocument();
+});
+
+test('FilterBar renders collapse icon', () => {
+  const props = createClosedBarProps();
+  renderFilterBar(props);
+  expect(
+    screen.getByRole('img', { name: 'vertical-align' }),
+  ).toBeInTheDocument();
+});
+
+test('FilterBar renders filter icon', () => {
+  const props = createClosedBarProps();
+  renderFilterBar(props);
+  expect(screen.getByRole('img', { name: 'filter' })).toBeInTheDocument();
+});
+
+test('FilterBar calls toggleFiltersBar when collapse icon is clicked', () => {
+  const toggleFiltersBar = jest.fn();
+  const props = createClosedBarProps(toggleFiltersBar);
+  renderFilterBar(props);
+
+  const collapse = screen.getByRole('img', { name: 'vertical-align' });
+  expect(toggleFiltersBar).not.toHaveBeenCalled();
+
+  userEvent.click(collapse);
+  expect(toggleFiltersBar).toHaveBeenCalled();
+});
+
+test('FilterBar opens when expand button is clicked', () => {
+  const toggleFiltersBar = jest.fn();
+  const props = createClosedBarProps(toggleFiltersBar);
+  renderFilterBar(props);
+
+  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId('expand-button'))).toBeInTheDocument();
+
+  userEvent.click(screen.getByTestId(getTestId('collapsable')));
+  expect(toggleFiltersBar).toHaveBeenCalledWith(true);
+});
+
+test('FilterBar hides edit filter button when user lacks permissions', () => {
+  const props = createOpenedBarProps();
+  const stateWithoutPermissions = {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: { metadata: {} },
+  };
+
+  renderFilterBar(props, stateWithoutPermissions);
+
+  expect(
+    screen.queryByTestId(getTestId('create-filter')),
+  ).not.toBeInTheDocument();
+});
+
+test('FilterBar closes when collapse button is clicked', () => {
+  const toggleFiltersBar = jest.fn();
+  const props = createOpenedBarProps(toggleFiltersBar);
+  renderFilterBar(props);
+
+  const collapseButton = screen.getByTestId(getTestId('collapse-button'));
+  expect(collapseButton).toBeInTheDocument();
+
+  userEvent.click(collapseButton);
+  expect(toggleFiltersBar).toHaveBeenCalledWith(false);
+});
+
+test('FilterBar disables buttons when there are no filters', () => {
+  const props = createOpenedBarProps();
+  renderFilterBar(props, stateWithoutNativeFilters);
+
+  expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+});
+
+test('FilterBar renders dividers with title and description', async () => {
+  const props = createOpenedBarProps();
+  const divider = createDivider();
+  const stateWithDivider = {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: {
+      ...stateWithoutNativeFilters.dashboardInfo,
+      metadata: {
+        ...stateWithoutNativeFilters.dashboardInfo.metadata,
+        native_filter_configuration: [divider],
+      },
+    },
+    nativeFilters: {
+      filters: { [divider.id]: divider },
+    },
+  };
+
+  renderFilterBar(props, stateWithDivider);
+
+  await act(async () => {
+    jest.advanceTimersByTime(1000);
   });
 
-  const renderWrapper = (props = closedBarProps, state?: object) =>
-    render(
-      <FilterBar
-        orientation={FilterBarOrientation.Vertical}
-        verticalConfig={{
-          width: 280,
-          height: 400,
-          offset: 0,
-          ...props,
-        }}
-      />,
-      {
-        initialState: state,
-        useDnd: true,
-        useRedux: true,
-        useRouter: true,
-      },
-    );
+  const title = await screen.findByText('Select time range');
+  const description = await screen.findByText('Select year/month etc..');
 
-  test('should render', () => {
-    const { container } = renderWrapper();
-    expect(container).toBeInTheDocument();
+  expect(title.tagName).toBe('H3');
+  expect(description.tagName).toBe('P');
+  expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+});
+
+test('FilterBar apply button is disabled after creating a filter', async () => {
+  setupTimeRangeMocks();
+  mockedMakeApi.mockReturnValue(createMockApi());
+
+  const props = createOpenedBarProps();
+  renderFilterBar(props, stateWithoutNativeFilters);
+
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+
+  // Simulate add filter flow
+  userEvent.click(screen.getByTestId(getTestId('collapsable')));
+  userEvent.click(screen.getByLabelText('setting'));
+  userEvent.click(screen.getByText('Add or edit filters and controls'));
+  userEvent.click(screen.getByText('Value'));
+  userEvent.click(screen.getByText('Time range'));
+  userEvent.type(
+    screen.getByTestId(getModalTestId('name-input')),
+    'Time filter 1',
+  );
+  userEvent.click(screen.getByText('Save'));
+
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+});
+
+test('FilterBar renders without errors when filter has required controlValues', () => {
+  const props = createOpenedBarProps();
+  const filter = createFilter({
+    id: 'test-filter',
+    controlValues: { enableEmptyFilter: true },
   });
+  const dataMask = createDataMask('test-filter', undefined, {});
+  const state = createStateWithFilter(filter, dataMask);
 
-  test('should render the "Filters and controls" heading', () => {
-    renderWrapper();
-    expect(screen.getByText('Filters and controls')).toBeInTheDocument();
-  });
+  const { container } = renderFilterBar(props, state);
+  expect(container).toBeInTheDocument();
+});
 
-  test('should render the "Clear all" option', () => {
-    renderWrapper();
-    expect(screen.getByText('Clear all')).toBeInTheDocument();
-  });
+test('FilterBar renders correctly when filter has value but empty extraFormData (auto-apply scenario)', () => {
+  const filterId = 'test-filter-auto-apply';
+  const props = createOpenedBarProps();
 
-  test('should render the "Apply filters" option', () => {
-    renderWrapper();
-    expect(screen.getByText('Apply filters')).toBeInTheDocument();
-  });
-
-  test('should render the collapse icon', () => {
-    renderWrapper();
-    expect(
-      screen.getByRole('img', { name: 'vertical-align' }),
-    ).toBeInTheDocument();
-  });
-
-  test('should render the filter icon', () => {
-    renderWrapper();
-    expect(screen.getByRole('img', { name: 'filter' })).toBeInTheDocument();
-  });
-
-  test('should toggle', () => {
-    renderWrapper();
-    const collapse = screen.getByRole('img', {
-      name: 'vertical-align',
-    });
-    expect(toggleFiltersBar).not.toHaveBeenCalled();
-    userEvent.click(collapse);
-    expect(toggleFiltersBar).toHaveBeenCalled();
-  });
-
-  test('open filter bar', () => {
-    renderWrapper();
-    expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
-    expect(screen.getByTestId(getTestId('expand-button'))).toBeInTheDocument();
-
-    userEvent.click(screen.getByTestId(getTestId('collapsable')));
-    expect(toggleFiltersBar).toHaveBeenCalledWith(true);
-  });
-
-  test('no edit filter button by disabled permissions', () => {
-    renderWrapper(openedBarProps, {
-      ...stateWithoutNativeFilters,
-      dashboardInfo: { metadata: {} },
-    });
-
-    expect(
-      screen.queryByTestId(getTestId('create-filter')),
-    ).not.toBeInTheDocument();
-  });
-
-  test('close filter bar', () => {
-    renderWrapper(openedBarProps);
-    const collapseButton = screen.getByTestId(getTestId('collapse-button'));
-
-    expect(collapseButton).toBeInTheDocument();
-    userEvent.click(collapseButton);
-
-    expect(toggleFiltersBar).toHaveBeenCalledWith(false);
-  });
-
-  test('no filters', () => {
-    renderWrapper(openedBarProps, stateWithoutNativeFilters);
-
-    expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
-    expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
-  });
-
-  test('renders dividers', async () => {
-    const divider = {
-      id: 'NATIVE_FILTER_DIVIDER-1',
-      type: 'DIVIDER',
-      scope: {
-        rootPath: ['ROOT_ID'],
-        excluded: [],
-      },
-      title: 'Select time range',
-      description: 'Select year/month etc..',
-      chartsInScope: [],
-      tabsInScope: [],
-    };
-    const stateWithDivider = {
-      ...stateWithoutNativeFilters,
-      dashboardInfo: {
-        ...stateWithoutNativeFilters.dashboardInfo,
-        metadata: {
-          ...stateWithoutNativeFilters.dashboardInfo.metadata,
-          native_filter_configuration: [divider],
-        },
-      },
-      nativeFilters: {
-        filters: {
-          'NATIVE_FILTER_DIVIDER-1': divider,
-        },
-      },
-    };
-
-    renderWrapper(openedBarProps, stateWithDivider);
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000); // 1s
-    });
-
-    const title = await screen.findByText('Select time range');
-    const description = await screen.findByText('Select year/month etc..');
-
-    expect(title.tagName).toBe('H3');
-    expect(description.tagName).toBe('P');
-    // Do not enable buttons if there are not filters
-    expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
-    expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
-  });
-
-  test('create filter and apply it flow', async () => {
-    renderWrapper(openedBarProps, stateWithoutNativeFilters);
-    expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
-
-    await addFilterFlow();
-
-    expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
-  });
-
-  test('should render without errors with proper state setup', () => {
-    const stateWithFilter = {
-      ...stateWithoutNativeFilters,
-      dashboardInfo: {
-        id: 1,
-      },
-      dataMask: {
-        'test-filter': {
-          id: 'test-filter',
-          filterState: { value: undefined },
-          extraFormData: {},
-        },
-      },
-      nativeFilters: {
-        filters: {
-          'test-filter': {
-            id: 'test-filter',
-            name: 'Test Filter',
-            filterType: 'filter_select',
-            targets: [{ datasetId: 1, column: { name: 'test_column' } }],
-            defaultDataMask: {
-              filterState: { value: undefined },
-              extraFormData: {},
-            },
-            controlValues: {
-              enableEmptyFilter: true,
-            },
-            cascadeParentIds: [],
-            scope: {
-              rootPath: ['ROOT_ID'],
-              excluded: [],
-            },
-            type: 'NATIVE_FILTER',
-            description: '',
-            chartsInScope: [],
-            tabsInScope: [],
-          },
-        },
-        filtersState: {},
-      },
-    };
-
-    const { container } = renderWrapper(openedBarProps, stateWithFilter);
-    expect(container).toBeInTheDocument();
-  });
-
-  test('auto-applies filter when extraFormData is empty in applied state', async () => {
-    const filterId = 'test-filter-auto-apply';
-    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
-
-    const stateWithIncompleteFilter = {
-      ...stateWithoutNativeFilters,
-      dashboardInfo: {
-        id: 1,
-        dash_edit_perm: true,
-      },
-      dataMask: {
-        [filterId]: {
-          id: filterId,
-          filterState: { value: ['value1', 'value2'] },
-          extraFormData: {},
-        },
-      },
-      nativeFilters: {
-        filters: {
-          [filterId]: {
-            id: filterId,
-            name: 'Test Filter',
-            filterType: 'filter_select',
-            targets: [{ datasetId: 1, column: { name: 'test_column' } }],
-            defaultDataMask: {
-              filterState: { value: ['value1', 'value2'] },
-              extraFormData: {},
-            },
-            controlValues: {
-              enableEmptyFilter: true,
-            },
-            cascadeParentIds: [],
-            scope: {
-              rootPath: ['ROOT_ID'],
-              excluded: [],
-            },
-            type: 'NATIVE_FILTER',
-            description: '',
-            chartsInScope: [],
-            tabsInScope: [],
-          },
-        },
-        filtersState: {},
-      },
-    };
-
-    renderWrapper(openedBarProps, stateWithIncompleteFilter);
-
-    await act(async () => {
-      jest.advanceTimersByTime(200);
-    });
-
-    expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
-
-    updateDataMaskSpy.mockRestore();
-  });
-
-  test('renders correctly when filter has complete extraFormData', async () => {
-    const filterId = 'test-filter-complete';
-    const stateWithCompleteFilter = {
-      ...stateWithoutNativeFilters,
-      dashboardInfo: {
-        id: 1,
-        dash_edit_perm: true,
-      },
-      dataMask: {
-        [filterId]: {
-          id: filterId,
-          filterState: { value: ['value1'] },
-          extraFormData: {
-            filters: [{ col: 'test_column', op: 'IN', val: ['value1'] }],
-          },
-        },
-      },
-      nativeFilters: {
-        filters: {
-          [filterId]: {
-            id: filterId,
-            name: 'Test Filter',
-            filterType: 'filter_select',
-            targets: [{ datasetId: 1, column: { name: 'test_column' } }],
-            defaultDataMask: {
-              filterState: { value: ['value1'] },
-              extraFormData: {
-                filters: [{ col: 'test_column', op: 'IN', val: ['value1'] }],
-              },
-            },
-            controlValues: {
-              enableEmptyFilter: true,
-            },
-            cascadeParentIds: [],
-            scope: {
-              rootPath: ['ROOT_ID'],
-              excluded: [],
-            },
-            type: 'NATIVE_FILTER',
-            description: '',
-            chartsInScope: [],
-            tabsInScope: [],
-          },
-        },
-        filtersState: {},
-      },
-    };
-
-    renderWrapper(openedBarProps, stateWithCompleteFilter);
-
-    await act(async () => {
-      jest.advanceTimersByTime(100);
-    });
-
-    expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
-  });
-
-  test('handleClearAll dispatches updateDataMask with value null for filter_select', async () => {
-    const filterId = 'NATIVE_FILTER-clear-select';
-    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
-    const selectFilterConfig = {
-      id: filterId,
-      name: 'Region',
-      filterType: 'filter_select',
-      targets: [{ datasetId: 7, column: { name: 'region' } }],
-      defaultDataMask: { filterState: { value: null }, extraFormData: {} },
-      cascadeParentIds: [],
-      scope: { rootPath: ['ROOT_ID'], excluded: [] },
-      type: 'NATIVE_FILTER',
-      description: '',
-      chartsInScope: [18],
-      tabsInScope: [],
-    };
-    const stateWithSelect = {
-      ...stateWithoutNativeFilters,
-      dashboardInfo: {
-        id: 1,
-        dash_edit_perm: true,
-        filterBarOrientation: FilterBarOrientation.Vertical,
-        metadata: {
-          native_filter_configuration: [selectFilterConfig],
-          chart_configuration: {},
-        },
-      },
-      dataMask: {
-        [filterId]: {
-          id: filterId,
-          filterState: { value: ['East'] },
-          extraFormData: {},
-        },
-      },
-    };
-
-    renderWrapper(openedBarProps, stateWithSelect);
-    await act(async () => {
-      jest.advanceTimersByTime(300);
-    });
-
-    const clearBtn = screen.getByTestId(getTestId('clear-button'));
-    expect(clearBtn).not.toBeDisabled();
-    await act(async () => {
-      userEvent.click(clearBtn);
-    });
-
-    expect(updateDataMaskSpy).toHaveBeenCalledWith(filterId, {
-      filterState: { value: undefined },
+  const filter = createFilter({
+    id: filterId,
+    requiredFirst: true,
+    controlValues: { enableEmptyFilter: true },
+    defaultDataMask: {
+      filterState: { value: ['value1'] },
       extraFormData: {},
-    });
-    updateDataMaskSpy.mockRestore();
+    },
   });
 
-  test('handleClearAll dispatches updateDataMask with value [null, null] for filter_range', async () => {
-    fetchMock.post('glob:*/api/v1/chart/data', {
-      result: [{ data: [{ min: 0, max: 100 }] }],
-    });
-    const filterId = 'NATIVE_FILTER-clear-range';
-    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
-    const rangeFilterConfig = {
-      id: filterId,
-      name: 'Age',
-      filterType: 'filter_range',
-      targets: [{ datasetId: 7, column: { name: 'age' } }],
-      defaultDataMask: { filterState: { value: null }, extraFormData: {} },
-      cascadeParentIds: [],
-      scope: { rootPath: ['ROOT_ID'], excluded: [] },
-      type: 'NATIVE_FILTER',
-      description: '',
-      chartsInScope: [18],
-      tabsInScope: [],
-    };
-    const stateWithRange = {
-      ...stateWithoutNativeFilters,
-      dashboardInfo: {
-        id: 1,
-        dash_edit_perm: true,
-        filterBarOrientation: FilterBarOrientation.Vertical,
-        metadata: {
-          native_filter_configuration: [rangeFilterConfig],
-          chart_configuration: {},
-        },
+  const dataMask = createDataMask(filterId, ['value1'], {});
+  const state = createStateWithFilter(filter, dataMask);
+
+  renderFilterBar(props, state);
+
+  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
+  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
+});
+
+test('FilterBar renders correctly when filter has complete extraFormData', async () => {
+  const filterId = 'test-filter-complete';
+  const props = createOpenedBarProps();
+  const filter = createFilter({
+    id: filterId,
+    controlValues: { enableEmptyFilter: true },
+    defaultDataMask: {
+      filterState: { value: ['value1'] },
+      extraFormData: {
+        filters: [{ col: 'test_column', op: 'IN', val: ['value1'] }],
       },
-      dataMask: {
-        [filterId]: {
-          id: filterId,
-          filterState: { value: [10, 50] },
-          extraFormData: {},
-        },
-      },
-    };
+    },
+  });
+  const dataMask = createDataMask(filterId, ['value1'], {
+    filters: [{ col: 'test_column', op: 'IN', val: ['value1'] }],
+  });
+  const state = createStateWithFilter(filter, dataMask);
 
-    renderWrapper(openedBarProps, stateWithRange);
-    await act(async () => {
-      jest.advanceTimersByTime(300);
-    });
+  renderFilterBar(props, state);
 
-    const clearBtn = screen.getByTestId(getTestId('clear-button'));
-    expect(clearBtn).not.toBeDisabled();
-    await act(async () => {
-      userEvent.click(clearBtn);
-    });
-
-    expect(updateDataMaskSpy).toHaveBeenCalledWith(filterId, {
-      filterState: { value: [null, null] },
-      extraFormData: {},
-    });
-    updateDataMaskSpy.mockRestore();
+  await act(async () => {
+    jest.advanceTimersByTime(100);
   });
 
-  test('handleClearAll only dispatches for filters present in dataMask', async () => {
-    const idInMask = 'NATIVE_FILTER-has-value';
-    const idNotInMask = 'NATIVE_FILTER-no-value';
-    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
-    const baseFilter = {
-      targets: [{ datasetId: 7, column: { name: 'x' } }],
-      defaultDataMask: { filterState: { value: null }, extraFormData: {} },
-      cascadeParentIds: [],
-      scope: { rootPath: ['ROOT_ID'], excluded: [] },
-      type: 'NATIVE_FILTER',
-      description: '',
-      chartsInScope: [18],
-      tabsInScope: [],
-    };
-    const stateWithTwoFiltersOneInMask = {
-      ...stateWithoutNativeFilters,
-      dashboardInfo: {
-        id: 1,
-        dash_edit_perm: true,
-        filterBarOrientation: FilterBarOrientation.Vertical,
-        metadata: {
-          native_filter_configuration: [
-            {
-              ...baseFilter,
-              id: idInMask,
-              name: 'A',
-              filterType: 'filter_select',
-            },
-            {
-              ...baseFilter,
-              id: idNotInMask,
-              name: 'B',
-              filterType: 'filter_select',
-            },
-          ],
-          chart_configuration: {},
-        },
-      },
-      dataMask: {
-        [idInMask]: {
-          id: idInMask,
-          filterState: { value: ['v'] },
-          extraFormData: {},
-        },
-      },
-    };
+  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
+});
 
-    renderWrapper(openedBarProps, stateWithTwoFiltersOneInMask);
-    await act(async () => {
-      jest.advanceTimersByTime(300);
-    });
-
-    const clearBtn = screen.getByTestId(getTestId('clear-button'));
-    await act(async () => {
-      userEvent.click(clearBtn);
-    });
-
-    expect(updateDataMaskSpy).toHaveBeenCalledTimes(1);
-    expect(updateDataMaskSpy).toHaveBeenCalledWith(idInMask, {
-      filterState: { value: undefined },
-      extraFormData: {},
-    });
-    updateDataMaskSpy.mockRestore();
+test('handleClearAll dispatches updateDataMask with value undefined for filter_select', async () => {
+  const filterId = 'NATIVE_FILTER-clear-select';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+  const selectFilter = createFilter({
+    id: filterId,
+    name: 'Region',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'region' } }],
+    defaultDataMask: { filterState: { value: null }, extraFormData: {} },
+    chartsInScope: [18],
   });
+  const stateWithSelect = {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      filterBarOrientation: FilterBarOrientation.Vertical,
+      metadata: {
+        native_filter_configuration: [selectFilter],
+        chart_configuration: {},
+      },
+    },
+    dashboardState: {
+      ...stateWithoutNativeFilters.dashboardState,
+      activeTabs: ['ROOT_ID'],
+    },
+    dataMask: {
+      [filterId]: createDataMask(filterId, ['East']),
+    },
+    nativeFilters: {
+      filters: { [filterId]: selectFilter },
+      filtersState: {},
+    },
+  };
+
+  const props = createOpenedBarProps();
+  renderFilterBar(props, stateWithSelect);
+  await act(async () => {
+    jest.advanceTimersByTime(300);
+  });
+
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  expect(clearBtn).not.toBeDisabled();
+  await act(async () => {
+    userEvent.click(clearBtn);
+  });
+
+  expect(updateDataMaskSpy).toHaveBeenCalledWith(filterId, {
+    filterState: { value: undefined },
+    extraFormData: {},
+  });
+  updateDataMaskSpy.mockRestore();
+});
+
+test('handleClearAll dispatches updateDataMask with [null, null] for filter_range', async () => {
+  fetchMock.post('glob:*/api/v1/chart/data', {
+    result: [{ data: [{ min: 0, max: 100 }] }],
+  });
+  const filterId = 'NATIVE_FILTER-clear-range';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+  const rangeFilter = createFilter({
+    id: filterId,
+    name: 'Age',
+    filterType: 'filter_range',
+    targets: [{ datasetId: 7, column: { name: 'age' } }],
+    defaultDataMask: { filterState: { value: null }, extraFormData: {} },
+    chartsInScope: [18],
+  });
+  const stateWithRange = {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      filterBarOrientation: FilterBarOrientation.Vertical,
+      metadata: {
+        native_filter_configuration: [rangeFilter],
+        chart_configuration: {},
+      },
+    },
+    dashboardState: {
+      ...stateWithoutNativeFilters.dashboardState,
+      activeTabs: ['ROOT_ID'],
+    },
+    dataMask: {
+      [filterId]: createDataMask(filterId, [10, 50]),
+    },
+    nativeFilters: {
+      filters: { [filterId]: rangeFilter },
+      filtersState: {},
+    },
+  };
+
+  const props = createOpenedBarProps();
+  renderFilterBar(props, stateWithRange);
+  await act(async () => {
+    jest.advanceTimersByTime(300);
+  });
+
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  expect(clearBtn).not.toBeDisabled();
+  await act(async () => {
+    userEvent.click(clearBtn);
+  });
+
+  expect(updateDataMaskSpy).toHaveBeenCalledWith(filterId, {
+    filterState: { value: [null, null] },
+    extraFormData: {},
+  });
+  updateDataMaskSpy.mockRestore();
+});
+
+test('handleClearAll only dispatches for filters present in dataMask', async () => {
+  const idInMask = 'NATIVE_FILTER-has-value';
+  const idNotInMask = 'NATIVE_FILTER-no-value';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+  const filterInMask = createFilter({
+    id: idInMask,
+    name: 'A',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'x' } }],
+    chartsInScope: [18],
+  });
+  const filterNotInMask = createFilter({
+    id: idNotInMask,
+    name: 'B',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'x' } }],
+    chartsInScope: [18],
+  });
+  const stateWithTwoFilters = {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      filterBarOrientation: FilterBarOrientation.Vertical,
+      metadata: {
+        native_filter_configuration: [filterInMask, filterNotInMask],
+        chart_configuration: {},
+      },
+    },
+    dashboardState: {
+      ...stateWithoutNativeFilters.dashboardState,
+      activeTabs: ['ROOT_ID'],
+    },
+    dataMask: {
+      [idInMask]: createDataMask(idInMask, ['v']),
+    },
+    nativeFilters: {
+      filters: {
+        [idInMask]: filterInMask,
+        [idNotInMask]: filterNotInMask,
+      },
+      filtersState: {},
+    },
+  };
+
+  const props = createOpenedBarProps();
+  renderFilterBar(props, stateWithTwoFilters);
+  await act(async () => {
+    jest.advanceTimersByTime(300);
+  });
+
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  await act(async () => {
+    userEvent.click(clearBtn);
+  });
+
+  expect(updateDataMaskSpy).toHaveBeenCalledTimes(1);
+  expect(updateDataMaskSpy).toHaveBeenCalledWith(idInMask, {
+    filterState: { value: undefined },
+    extraFormData: {},
+  });
+  updateDataMaskSpy.mockRestore();
+});
+
+test('FilterBar Clear All does not clear out-of-scope filters', async () => {
+  const inScopeFilterId = 'in-scope-filter';
+  const outOfScopeRequiredFilterId = 'out-of-scope-required-filter';
+  const outOfScopeNonRequiredFilterId = 'out-of-scope-non-required-filter';
+
+  const dashboardLayoutWithTabs = {
+    ROOT_ID: { id: 'ROOT_ID', type: 'ROOT', children: ['TABS-1'] },
+    'TABS-1': {
+      id: 'TABS-1',
+      type: 'TABS',
+      children: ['TAB-active', 'TAB-inactive'],
+    },
+    'TAB-active': {
+      id: 'TAB-active',
+      type: 'TAB',
+      children: ['CHART_ROW-1'],
+      meta: { text: 'Active Tab' },
+      parents: ['ROOT_ID', 'TABS-1'],
+    },
+    'TAB-inactive': {
+      id: 'TAB-inactive',
+      type: 'TAB',
+      children: ['CHART_ROW-2'],
+      meta: { text: 'Inactive Tab' },
+      parents: ['ROOT_ID', 'TABS-1'],
+    },
+    'CHART_ROW-1': {
+      id: 'CHART_ROW-1',
+      type: 'CHART',
+      meta: { chartId: 1 },
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-active'],
+    },
+    'CHART_ROW-2': {
+      id: 'CHART_ROW-2',
+      type: 'CHART',
+      meta: { chartId: 2 },
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-inactive'],
+    },
+  };
+
+  const inScopeFilter = createFilter({
+    id: inScopeFilterId,
+    name: 'In Scope Filter',
+    targets: [{ datasetId: 1, column: { name: 'column1' } }],
+    controlValues: { enableEmptyFilter: false },
+    chartsInScope: [1],
+    tabsInScope: ['TAB-active'],
+  });
+
+  const outOfScopeRequiredFilter = createFilter({
+    id: outOfScopeRequiredFilterId,
+    name: 'Out of Scope Required Filter',
+    targets: [{ datasetId: 1, column: { name: 'column2' } }],
+    controlValues: { enableEmptyFilter: true },
+    chartsInScope: [2],
+    tabsInScope: ['TAB-inactive'],
+  });
+
+  const outOfScopeNonRequiredFilter = createFilter({
+    id: outOfScopeNonRequiredFilterId,
+    name: 'Out of Scope Non-Required Filter',
+    targets: [{ datasetId: 1, column: { name: 'column3' } }],
+    controlValues: { enableEmptyFilter: false },
+    chartsInScope: [2],
+    tabsInScope: ['TAB-inactive'],
+  });
+
+  const stateWithTabsAndFilters = {
+    ...stateWithoutNativeFilters,
+    dashboardLayout: {
+      present: dashboardLayoutWithTabs,
+      past: [],
+      future: [],
+    },
+    dashboardState: {
+      ...stateWithoutNativeFilters.dashboardState,
+      activeTabs: ['TAB-active'],
+    },
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      metadata: {
+        native_filter_configuration: [
+          inScopeFilter,
+          outOfScopeRequiredFilter,
+          outOfScopeNonRequiredFilter,
+        ],
+      },
+    },
+    dataMask: {
+      [inScopeFilterId]: createDataMask(inScopeFilterId, ['value1'], {
+        filters: [{ col: 'column1', op: 'IN', val: ['value1'] }],
+      }),
+      [outOfScopeRequiredFilterId]: createDataMask(
+        outOfScopeRequiredFilterId,
+        ['value2'],
+        { filters: [{ col: 'column2', op: 'IN', val: ['value2'] }] },
+      ),
+      [outOfScopeNonRequiredFilterId]: createDataMask(
+        outOfScopeNonRequiredFilterId,
+        ['value3'],
+        { filters: [{ col: 'column3', op: 'IN', val: ['value3'] }] },
+      ),
+    },
+    nativeFilters: {
+      filters: {
+        [inScopeFilterId]: inScopeFilter,
+        [outOfScopeRequiredFilterId]: outOfScopeRequiredFilter,
+        [outOfScopeNonRequiredFilterId]: outOfScopeNonRequiredFilter,
+      },
+      filtersState: {},
+    },
+  };
+
+  const props = createOpenedBarProps();
+  renderFilterBar(props, stateWithTabsAndFilters);
+
+  await act(async () => {
+    jest.advanceTimersByTime(100);
+  });
+
+  const clearButton = screen.getByTestId(getTestId('clear-button'));
+  expect(clearButton).toBeInTheDocument();
+
+  await userEvent.click(clearButton);
+
+  await act(async () => {
+    jest.advanceTimersByTime(100);
+  });
+
+  // Verify Clear All works without crashing
+  expect(clearButton).toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -438,13 +438,8 @@ test('FilterBar does not crash when filter has value but empty extraFormData', a
   expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
   expect(screen.getByText('Filters and controls')).toBeInTheDocument();
 
-  // Auto-apply dispatches updateDataMask when the filter plugin initializes
-  expect(updateDataMaskSpy).not.toHaveBeenCalledWith(
-    filterId,
-    expect.objectContaining({
-      filterState: expect.objectContaining({ value: undefined }),
-    }),
-  );
+  // The filter value should not be cleared during initialization
+  expect(updateDataMaskSpy).not.toHaveBeenCalled();
 
   updateDataMaskSpy.mockRestore();
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -411,8 +411,9 @@ test('FilterBar renders without errors when filter has required controlValues', 
   expect(container).toBeInTheDocument();
 });
 
-test('FilterBar renders correctly when filter has value but empty extraFormData (auto-apply scenario)', () => {
+test('FilterBar does not crash when filter has value but empty extraFormData', async () => {
   const filterId = 'test-filter-auto-apply';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
   const props = createOpenedBarProps();
 
   const filter = createFilter({
@@ -430,8 +431,22 @@ test('FilterBar renders correctly when filter has value but empty extraFormData 
 
   renderFilterBar(props, state);
 
+  await act(async () => {
+    jest.advanceTimersByTime(300);
+  });
+
   expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
   expect(screen.getByText('Filters and controls')).toBeInTheDocument();
+
+  // Auto-apply dispatches updateDataMask when the filter plugin initializes
+  expect(updateDataMaskSpy).not.toHaveBeenCalledWith(
+    filterId,
+    expect.objectContaining({
+      filterState: expect.objectContaining({ value: undefined }),
+    }),
+  );
+
+  updateDataMaskSpy.mockRestore();
 });
 
 test('FilterBar renders correctly when filter has complete extraFormData', async () => {
@@ -636,10 +651,12 @@ test('handleClearAll only dispatches for filters present in dataMask', async () 
   updateDataMaskSpy.mockRestore();
 });
 
-test('FilterBar Clear All does not clear out-of-scope filters', async () => {
-  const inScopeFilterId = 'in-scope-filter';
-  const outOfScopeRequiredFilterId = 'out-of-scope-required-filter';
-  const outOfScopeNonRequiredFilterId = 'out-of-scope-non-required-filter';
+test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', async () => {
+  const inScopeFilterId = 'NATIVE_FILTER-in-scope';
+  const outOfScopeRequiredFilterId = 'NATIVE_FILTER-out-of-scope-required';
+  const outOfScopeNonRequiredFilterId =
+    'NATIVE_FILTER-out-of-scope-non-required';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
 
   const dashboardLayoutWithTabs = {
     ROOT_ID: { id: 'ROOT_ID', type: 'ROOT', children: ['TABS-1'] },
@@ -754,18 +771,27 @@ test('FilterBar Clear All does not clear out-of-scope filters', async () => {
   renderFilterBar(props, stateWithTabsAndFilters);
 
   await act(async () => {
-    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(300);
   });
 
   const clearButton = screen.getByTestId(getTestId('clear-button'));
   expect(clearButton).toBeInTheDocument();
 
-  await userEvent.click(clearButton);
-
   await act(async () => {
-    jest.advanceTimersByTime(100);
+    userEvent.click(clearButton);
   });
 
-  // Verify Clear All works without crashing
-  expect(clearButton).toBeInTheDocument();
+  // Verify only the in-scope filter was cleared, not the out-of-scope ones
+  const clearedFilterIds = updateDataMaskSpy.mock.calls.map(call => call[0]);
+  expect(clearedFilterIds).toContain(inScopeFilterId);
+  expect(clearedFilterIds).not.toContain(outOfScopeRequiredFilterId);
+  expect(clearedFilterIds).not.toContain(outOfScopeNonRequiredFilterId);
+
+  // Verify the in-scope filter was cleared with the correct value
+  expect(updateDataMaskSpy).toHaveBeenCalledWith(inScopeFilterId, {
+    filterState: { value: undefined },
+    extraFormData: {},
+  });
+
+  updateDataMaskSpy.mockRestore();
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -144,12 +144,12 @@ const publishDataMask = debounce(
       // it when necessary. We strip any prefix so that history.replace adds it back and doesn't
       // double it up.
       const appRoot = applicationRoot();
-      let replacement_pathname = window.location.pathname;
-      if (appRoot !== '/' && replacement_pathname.startsWith(appRoot)) {
-        replacement_pathname = replacement_pathname.substring(appRoot.length);
+      let replacementPathname = window.location.pathname;
+      if (appRoot !== '/' && replacementPathname.startsWith(appRoot)) {
+        replacementPathname = replacementPathname.substring(appRoot.length);
       }
-      history.location.pathname = replacement_pathname;
       history.replace({
+        pathname: replacementPathname,
         search: newParams.toString(),
       });
     }
@@ -518,6 +518,7 @@ const FilterBar: FC<FiltersBarProps> = ({
     dataMaskSelected,
     dataMaskApplied,
     filtersInScope.filter(isNativeFilter),
+    nativeFilterValues,
   );
 
   const isApplyDisabled =

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -372,6 +372,17 @@ const FilterBar: FC<FiltersBarProps> = ({
           }
         });
 
+        // Remove stale entries that no longer exist in dataMaskApplied
+        Object.keys(updated).forEach(filterId => {
+          if (
+            !isChartCustomization(filterId) &&
+            !(filterId in dataMaskApplied)
+          ) {
+            delete updated[filterId];
+            hasChanges = true;
+          }
+        });
+
         return hasChanges ? updated : prev;
       });
     }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -63,7 +63,7 @@ import { LOG_ACTIONS_CHANGE_DASHBOARD_FILTER } from 'src/logger/LogUtils';
 import { FilterBarOrientation, RootState } from 'src/dashboard/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { isChartCustomization } from '../FiltersConfigModal/utils';
-import { checkIsApplyDisabled } from './utils';
+import { checkIsApplyDisabled, getFiltersToApply } from './utils';
 import { extractLabel } from '../selectors';
 import { FiltersBarProps } from './types';
 import {
@@ -196,6 +196,21 @@ const FilterBar: FC<FiltersBarProps> = ({
   >(state => state.user);
 
   const [filtersInScope] = useSelectFiltersInScope(nativeFilterValues);
+  const inScopeFilterIds = useMemo(
+    () => new Set(filtersInScope.map(f => f.id)),
+    [filtersInScope],
+  );
+
+  const hasOutOfScopeRequiredFilters = useMemo(
+    () =>
+      nativeFilterValues.some(
+        filter =>
+          !inScopeFilterIds.has(filter.id) &&
+          !!filter.controlValues?.enableEmptyFilter,
+      ),
+    [nativeFilterValues, inScopeFilterIds],
+  );
+
   const [clearAllTriggers, setClearAllTriggers] = useState<
     Record<string, boolean>
   >({});
@@ -331,10 +346,38 @@ const FilterBar: FC<FiltersBarProps> = ({
   }, [dashboardId, filters, previousDashboardId, setDataMaskSelected]);
 
   const dataMaskAppliedText = JSON.stringify(dataMaskApplied);
+  const prevDataMaskAppliedRef = useRef(dataMaskApplied);
 
   useEffect(() => {
-    setDataMaskSelected(() => dataMaskApplied);
-  }, [dataMaskAppliedText, setDataMaskSelected, dashboardId]);
+    const dashboardChanged = dashboardId !== previousDashboardId;
+
+    if (dashboardChanged) {
+      setDataMaskSelected(() => dataMaskApplied);
+    } else {
+      const prevApplied = prevDataMaskAppliedRef.current;
+
+      // Only sync filters whose applied state actually changed
+      setDataMaskSelected(prev => {
+        let hasChanges = false;
+        const updated = { ...prev };
+
+        Object.entries(dataMaskApplied).forEach(([filterId, appliedMask]) => {
+          const prevAppliedMask = prevApplied[filterId];
+          const appliedChanged = !isEqual(appliedMask, prevAppliedMask);
+          const notInitialized = !prev[filterId];
+
+          if (appliedChanged || notInitialized) {
+            updated[filterId] = appliedMask;
+            hasChanges = true;
+          }
+        });
+
+        return hasChanges ? updated : prev;
+      });
+    }
+
+    prevDataMaskAppliedRef.current = dataMaskApplied;
+  }, [dataMaskApplied, setDataMaskSelected, dashboardId, previousDashboardId]);
 
   useEffect(() => {
     // embedded users can't persist filter combinations
@@ -363,7 +406,13 @@ const FilterBar: FC<FiltersBarProps> = ({
     dispatch(logEvent(LOG_ACTIONS_CHANGE_DASHBOARD_FILTER, {}));
     setUpdateKey(1);
 
-    Object.entries(dataMaskSelected).forEach(([filterId, dataMask]) => {
+    const filtersToApply = getFiltersToApply(
+      dataMaskSelected,
+      inScopeFilterIds,
+    );
+
+    filtersToApply.forEach(filterId => {
+      const dataMask = dataMaskSelected[filterId];
       if (dataMask) {
         dispatch(updateDataMask(filterId, dataMask));
       }
@@ -419,6 +468,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   }, [
     dataMaskSelected,
     dispatch,
+    inScopeFilterIds,
     pendingChartCustomizations,
     pendingCustomizationDataMasks,
     hasClearedChartCustomizations,
@@ -427,8 +477,13 @@ const FilterBar: FC<FiltersBarProps> = ({
 
   const handleClearAll = useCallback(() => {
     const newClearAllTriggers = { ...clearAllTriggers };
+
     nativeFilterValues.forEach(filter => {
       const { id, filterType } = filter;
+
+      // Only clear in-scope filters
+      if (!inScopeFilterIds.has(id)) return;
+
       // Range filters use [null, null] as the cleared value; others use undefined
       const clearedValue =
         filterType === 'filter_range' ? [null, null] : undefined;
@@ -480,6 +535,7 @@ const FilterBar: FC<FiltersBarProps> = ({
     dataMaskSelected,
     dataMaskApplied,
     nativeFilterValues,
+    inScopeFilterIds,
     setDataMaskSelected,
     chartCustomizationValues,
     clearAllTriggers,
@@ -540,6 +596,7 @@ const FilterBar: FC<FiltersBarProps> = ({
         dataMaskApplied={dataMaskApplied}
         isApplyDisabled={isApplyDisabled}
         chartCustomizationItems={chartCustomizationValues}
+        hasOutOfScopeRequiredFilters={hasOutOfScopeRequiredFilters}
       />
     ),
     [
@@ -551,6 +608,7 @@ const FilterBar: FC<FiltersBarProps> = ({
       dataMaskApplied,
       isApplyDisabled,
       chartCustomizationValues,
+      hasOutOfScopeRequiredFilters,
     ],
   );
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
@@ -627,5 +627,181 @@ describe('FilterBar Utils - Validation and Apply Logic', () => {
         checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
       ).toBe(false);
     });
+
+    test('should return true when out-of-scope required filter is missing value (allFilters provided)', () => {
+      // Scenario: Clear All was clicked, user selected in-scope filter only
+      // Out-of-scope required filter is still empty
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-in-scope': {
+          id: 'filter-in-scope',
+          filterState: {
+            validateStatus: undefined,
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+        'filter-out-of-scope': {
+          id: 'filter-out-of-scope',
+          filterState: {
+            validateStatus: undefined,
+            value: undefined, // Cleared by Clear All
+          },
+          extraFormData: {},
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-in-scope': {
+          id: 'filter-in-scope',
+          filterState: {
+            value: ['NY'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['NY'] }],
+          },
+        },
+        'filter-out-of-scope': {
+          id: 'filter-out-of-scope',
+          filterState: {
+            value: ['Product A'],
+          },
+          extraFormData: {
+            filters: [{ col: 'product', op: 'IN', val: ['Product A'] }],
+          },
+        },
+      };
+
+      const filtersInScope: Filter[] = [
+        { id: 'filter-in-scope', controlValues: {} } as unknown as Filter,
+      ];
+
+      const allFilters: Filter[] = [
+        { id: 'filter-in-scope', controlValues: {} } as unknown as Filter,
+        {
+          id: 'filter-out-of-scope',
+          controlValues: { enableEmptyFilter: true },
+        } as unknown as Filter, // Required!
+      ];
+
+      // Without allFilters: should return false (changes detected, no in-scope required missing)
+      expect(
+        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filtersInScope),
+      ).toBe(false);
+
+      // With allFilters: should return true (out-of-scope required filter missing)
+      expect(
+        checkIsApplyDisabled(
+          dataMaskSelected,
+          dataMaskApplied,
+          filtersInScope,
+          allFilters,
+        ),
+      ).toBe(true);
+    });
+
+    test('should allow apply when out-of-scope non-required filter is cleared', () => {
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-in-scope': {
+          id: 'filter-in-scope',
+          filterState: {
+            validateStatus: undefined,
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+        'filter-out-of-scope': {
+          id: 'filter-out-of-scope',
+          filterState: {
+            validateStatus: undefined,
+            value: undefined,
+          },
+          extraFormData: {},
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-in-scope': {
+          id: 'filter-in-scope',
+          filterState: {
+            value: ['NY'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['NY'] }],
+          },
+        },
+        'filter-out-of-scope': {
+          id: 'filter-out-of-scope',
+          filterState: {
+            value: ['Product A'],
+          },
+          extraFormData: {
+            filters: [{ col: 'product', op: 'IN', val: ['Product A'] }],
+          },
+        },
+      };
+
+      const filtersInScope: Filter[] = [
+        { id: 'filter-in-scope', controlValues: {} } as unknown as Filter,
+      ];
+
+      const allFilters: Filter[] = [
+        { id: 'filter-in-scope', controlValues: {} } as unknown as Filter,
+        {
+          id: 'filter-out-of-scope',
+          controlValues: { enableEmptyFilter: false },
+        } as unknown as Filter, // NOT required
+      ];
+
+      // Should return false (apply enabled) - non-required filters can be cleared
+      expect(
+        checkIsApplyDisabled(
+          dataMaskSelected,
+          dataMaskApplied,
+          filtersInScope,
+          allFilters,
+        ),
+      ).toBe(false);
+    });
+
+    test('should maintain backward compatibility when allFilters not provided', () => {
+      // Existing behavior should not change when allFilters is not passed
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: undefined,
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            value: ['NY'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['NY'] }],
+          },
+        },
+      };
+
+      const filters: Filter[] = [
+        { id: 'filter-1', controlValues: {} } as unknown as Filter,
+      ];
+
+      // Should work without the new parameter (backward compatible)
+      expect(
+        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
+      ).toBe(false);
+    });
   });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
@@ -17,791 +17,771 @@
  * under the License.
  */
 
-import { DataMaskStateWithId, Filter } from '@superset-ui/core';
+import {
+  DataMaskStateWithId,
+  DataRecordValue,
+  Filter,
+  FilterState,
+} from '@superset-ui/core';
 import {
   checkIsApplyDisabled,
   checkIsValidateError,
   checkIsMissingRequiredValue,
+  getOnlyExtraFormData,
+  getFiltersToApply,
 } from './utils';
 
-// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-describe('FilterBar Utils - Validation and Apply Logic', () => {
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('checkIsValidateError', () => {
-    test('should return true when no filters have validation errors', () => {
-      const dataMask: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined,
-            value: ['CA'],
-          },
-          extraFormData: {},
-        },
-        'filter-2': {
-          id: 'filter-2',
-          filterState: {
-            validateStatus: undefined,
-            value: ['NY'],
-          },
-          extraFormData: {},
-        },
-      };
+// Factory functions for test data
+function createDataMaskEntry(
+  id: string,
+  overrides: {
+    value?: unknown;
+    validateStatus?: 'error' | undefined;
+    extraFormData?: Record<string, unknown>;
+  } = {},
+) {
+  const { value, validateStatus, extraFormData = {} } = overrides;
+  return {
+    id,
+    filterState: {
+      value,
+      validateStatus,
+    },
+    extraFormData,
+  };
+}
 
-      expect(checkIsValidateError(dataMask)).toBe(true);
-    });
+function createFilter(
+  id: string,
+  overrides: {
+    enableEmptyFilter?: boolean;
+    controlValues?: Record<string, unknown>;
+  } = {},
+): Filter {
+  const { enableEmptyFilter, controlValues = {} } = overrides;
+  return {
+    id,
+    controlValues: {
+      ...(enableEmptyFilter !== undefined && { enableEmptyFilter }),
+      ...controlValues,
+    },
+  } as unknown as Filter;
+}
 
-    test('should return false when any filter has validation error', () => {
-      const dataMask: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: 'error',
-            value: undefined,
-          },
-          extraFormData: {},
-        },
-        'filter-2': {
-          id: 'filter-2',
-          filterState: {
-            validateStatus: undefined,
-            value: ['NY'],
-          },
-          extraFormData: {},
-        },
-      };
+function createExtraFormDataWithFilter(
+  col: string,
+  val: DataRecordValue[],
+  op: 'IN' | 'NOT IN' = 'IN',
+) {
+  return {
+    filters: [{ col, op, val }],
+  };
+}
 
-      expect(checkIsValidateError(dataMask)).toBe(false);
-    });
+// getOnlyExtraFormData tests
+test('getOnlyExtraFormData extracts extraFormData from all filters when no filterIds provided', () => {
+  const dataMask: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: { filters: [{ col: 'state', op: 'IN', val: ['CA'] }] },
+    },
+    'filter-2': {
+      id: 'filter-2',
+      filterState: { value: ['NY'] },
+      extraFormData: { filters: [{ col: 'city', op: 'IN', val: ['NY'] }] },
+    },
+  };
 
-    test('should handle empty dataMask', () => {
-      const dataMask: DataMaskStateWithId = {};
-      expect(checkIsValidateError(dataMask)).toBe(true);
-    });
+  const result = getOnlyExtraFormData(dataMask);
 
-    test('should handle filters without filterState', () => {
-      const dataMask: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          extraFormData: {},
-        },
-      };
-
-      expect(checkIsValidateError(dataMask)).toBe(true);
-    });
+  expect(result).toEqual({
+    'filter-1': { filters: [{ col: 'state', op: 'IN', val: ['CA'] }] },
+    'filter-2': { filters: [{ col: 'city', op: 'IN', val: ['NY'] }] },
   });
+});
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('checkIsMissingRequiredValue', () => {
-    test('should return true for required filter with undefined value', () => {
-      const filter = {
-        id: 'test-filter',
-        controlValues: {
-          enableEmptyFilter: true,
-        },
-      } as unknown as Filter;
+test('getOnlyExtraFormData only extracts extraFormData for specified filterIds', () => {
+  const dataMask: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: { filters: [{ col: 'state', op: 'IN', val: ['CA'] }] },
+    },
+    'filter-2': {
+      id: 'filter-2',
+      filterState: { value: ['NY'] },
+      extraFormData: { filters: [{ col: 'city', op: 'IN', val: ['NY'] }] },
+    },
+    'filter-3': {
+      id: 'filter-3',
+      filterState: { value: ['Product'] },
+      extraFormData: {
+        filters: [{ col: 'product', op: 'IN', val: ['Product'] }],
+      },
+    },
+  };
 
-      const filterState = {
-        value: undefined,
-      };
+  const filterIds = new Set(['filter-1', 'filter-3']);
+  const result = getOnlyExtraFormData(dataMask, filterIds);
 
-      expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
-    });
-
-    test('should return true for required filter with null value', () => {
-      const filter = {
-        id: 'test-filter',
-        controlValues: {
-          enableEmptyFilter: true,
-        },
-      } as unknown as Filter;
-
-      const filterState = {
-        value: null,
-      };
-
-      expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
-    });
-
-    test('should return false for required filter with valid value', () => {
-      const filter = {
-        id: 'test-filter',
-        controlValues: {
-          enableEmptyFilter: true,
-        },
-      } as unknown as Filter;
-
-      const filterState = {
-        value: ['CA'],
-      };
-
-      expect(checkIsMissingRequiredValue(filter, filterState)).toBe(false);
-    });
-
-    test('should return false for non-required filter with undefined value', () => {
-      const filter = {
-        id: 'test-filter',
-        controlValues: {
-          enableEmptyFilter: false,
-        },
-      } as unknown as Filter;
-
-      const filterState = {
-        value: undefined,
-      };
-
-      expect(checkIsMissingRequiredValue(filter, filterState)).toBe(false);
-    });
-
-    test('should return false for filter without controlValues', () => {
-      const filter = {
-        id: 'test-filter',
-      } as Filter;
-
-      const filterState = {
-        value: undefined,
-      };
-
-      // checkIsMissingRequiredValue returns undefined when controlValues is missing
-      // undefined is falsy, so we check for truthiness instead of exact false
-      expect(checkIsMissingRequiredValue(filter, filterState)).toBeFalsy();
-    });
+  expect(result).toEqual({
+    'filter-1': { filters: [{ col: 'state', op: 'IN', val: ['CA'] }] },
+    'filter-3': { filters: [{ col: 'product', op: 'IN', val: ['Product'] }] },
   });
+  expect(result).not.toHaveProperty('filter-2');
+});
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('checkIsApplyDisabled', () => {
-    test('should return true when filters have validation errors', () => {
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: 'error',
-            value: undefined,
-          },
-          extraFormData: {},
-        },
-      };
+test('getOnlyExtraFormData returns empty object when filterIds is empty set', () => {
+  const dataMask: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: { filters: [{ col: 'state', op: 'IN', val: ['CA'] }] },
+    },
+  };
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-      };
+  const filterIds = new Set<string>();
+  const result = getOnlyExtraFormData(dataMask, filterIds);
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-1',
-          controlValues: {
-            enableEmptyFilter: true,
-          },
-        } as unknown as Filter,
-      ];
+  expect(result).toEqual({});
+});
 
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(true);
-    });
+// checkIsValidateError tests
+test('checkIsValidateError returns true when no filters have validation errors', () => {
+  const dataMask: DataMaskStateWithId = {
+    'filter-1': createDataMaskEntry('filter-1', { value: ['CA'] }),
+    'filter-2': createDataMaskEntry('filter-2', { value: ['NY'] }),
+  };
 
-    test('should return false when selected and applied states differ', () => {
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined,
-            value: ['NY'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['NY'] }],
-          },
-        },
-      };
+  expect(checkIsValidateError(dataMask)).toBe(true);
+});
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-      };
+test('checkIsValidateError returns false when any filter has validation error', () => {
+  const dataMask: DataMaskStateWithId = {
+    'filter-1': createDataMaskEntry('filter-1', { validateStatus: 'error' }),
+    'filter-2': createDataMaskEntry('filter-2', { value: ['NY'] }),
+  };
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-1',
-          controlValues: {
-            enableEmptyFilter: false,
-          },
-        } as unknown as Filter,
-      ];
+  expect(checkIsValidateError(dataMask)).toBe(false);
+});
 
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(false);
-    });
+test('checkIsValidateError handles empty dataMask', () => {
+  const dataMask: DataMaskStateWithId = {};
+  expect(checkIsValidateError(dataMask)).toBe(true);
+});
 
-    test('should return true when selected and applied states are identical', () => {
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined,
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-      };
+test('checkIsValidateError handles filters without filterState', () => {
+  const dataMask: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      extraFormData: {},
+    },
+  };
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-      };
+  expect(checkIsValidateError(dataMask)).toBe(true);
+});
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-1',
-          controlValues: {
-            enableEmptyFilter: false,
-          },
-        } as unknown as Filter,
-      ];
+// checkIsMissingRequiredValue tests
+test('checkIsMissingRequiredValue returns true for required filter with undefined value', () => {
+  const filter = createFilter('test-filter', { enableEmptyFilter: true });
+  const filterState: FilterState = { value: undefined };
 
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(true);
-    });
+  expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
+});
 
-    test('should return true when required filter is missing value in selected state', () => {
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined,
-            value: undefined,
-          },
-          extraFormData: {},
-        },
-      };
+test('checkIsMissingRequiredValue returns true for required filter with null value', () => {
+  const filter = createFilter('test-filter', { enableEmptyFilter: true });
+  const filterState: FilterState = { value: null };
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-      };
+  expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
+});
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-1',
-          controlValues: {
-            enableEmptyFilter: true, // Required filter
-          },
-        } as unknown as Filter,
-      ];
+test('checkIsMissingRequiredValue returns false for required filter with valid value', () => {
+  const filter = createFilter('test-filter', { enableEmptyFilter: true });
+  const filterState: FilterState = { value: ['CA'] };
 
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(true);
-    });
+  expect(checkIsMissingRequiredValue(filter, filterState)).toBe(false);
+});
 
-    test('should enable Apply when new filter is selected', () => {
-      // User selects a new filter that hasn't been applied yet
-      // Apply should be ENABLED to allow applying the new selection
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined,
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-        'filter-2': {
-          id: 'filter-2',
-          filterState: {
-            validateStatus: undefined,
-            value: ['Product A'],
-          },
-          extraFormData: {
-            filters: [{ col: 'product', op: 'IN', val: ['Product A'] }],
-          },
-        },
-      };
+test('checkIsMissingRequiredValue returns false for non-required filter with undefined value', () => {
+  const filter = createFilter('test-filter', { enableEmptyFilter: false });
+  const filterState: FilterState = { value: undefined };
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-        // filter-2 not yet applied
-      };
+  expect(checkIsMissingRequiredValue(filter, filterState)).toBe(false);
+});
 
-      const filters: Filter[] = [
-        { id: 'filter-1', controlValues: {} } as unknown as Filter,
-        { id: 'filter-2', controlValues: {} } as unknown as Filter,
-      ];
+test('checkIsMissingRequiredValue returns falsy for filter without controlValues', () => {
+  const filter = { id: 'test-filter' } as Filter;
+  const filterState: FilterState = { value: undefined };
 
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(false);
-    });
+  expect(checkIsMissingRequiredValue(filter, filterState)).toBeFalsy();
+});
 
-    test('should handle validation status recalculation scenario', () => {
-      // Scenario: Filter was required and had error, then user selected value
-      // The validateStatus should be cleared and Apply should be enabled
+// checkIsApplyDisabled tests
+test('checkIsApplyDisabled returns true when filters have validation errors', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-1': createDataMaskEntry('filter-1', { validateStatus: 'error' }),
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+  };
+  const filters = [createFilter('filter-1', { enableEmptyFilter: true })];
 
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined, // Error cleared after selection
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-      };
+  expect(checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters)).toBe(
+    true,
+  );
+});
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: undefined, // Previously cleared
-          },
-          extraFormData: {},
-        },
-      };
+test('checkIsApplyDisabled returns false when selected and applied states differ', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['NY'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['NY']),
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+  };
+  const filters = [createFilter('filter-1', { enableEmptyFilter: false })];
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-1',
-          controlValues: {
-            enableEmptyFilter: true,
-          },
-        } as unknown as Filter,
-      ];
+  expect(checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters)).toBe(
+    false,
+  );
+});
 
-      // Should be enabled because states differ and no validation errors
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(false);
-    });
+test('checkIsApplyDisabled returns true when selected and applied states are identical', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+  };
+  const filters = [createFilter('filter-1', { enableEmptyFilter: false })];
 
-    test('should not disable Apply when required filter is auto-applied (bug fix)', () => {
-      // Bug scenario: Filter A has "required" + "select first by default"
-      // Filter A auto-applies and is synced to selected
-      // User changes Filter B (adds it to selected, not in applied yet)
-      // Apply button should be ENABLED (changes exist and required filter has value)
+  expect(checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters)).toBe(
+    true,
+  );
+});
 
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-country': {
-          id: 'filter-country',
-          filterState: {
-            validateStatus: undefined,
-            value: ['USA'], // Auto-applied value (synced from applied)
-          },
-          extraFormData: {
-            filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
-          },
-        },
-        'filter-product': {
-          id: 'filter-product',
-          filterState: {
-            validateStatus: undefined,
-            value: ['Product A'], // User changed this filter
-          },
-          extraFormData: {
-            filters: [{ col: 'product_line', op: 'IN', val: ['Product A'] }],
-          },
-        },
-      };
+test('checkIsApplyDisabled returns true when required filter is missing value in selected state', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-1': createDataMaskEntry('filter-1', { value: undefined }),
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+  };
+  const filters = [createFilter('filter-1', { enableEmptyFilter: true })];
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-country': {
-          id: 'filter-country',
-          filterState: {
-            value: ['USA'], // Already applied
-          },
-          extraFormData: {
-            filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
-          },
-        },
-        // filter-product not yet applied
-      };
+  expect(checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters)).toBe(
+    true,
+  );
+});
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-country',
-          controlValues: {
-            enableEmptyFilter: true, // Required filter
-          },
-        } as unknown as Filter,
-        {
-          id: 'filter-product',
-          controlValues: {
-            enableEmptyFilter: false,
-          },
-        } as unknown as Filter,
-      ];
+test('checkIsApplyDisabled handles filter count mismatch', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+    'filter-2': {
+      id: 'filter-2',
+      filterState: { value: ['Product A'] },
+      extraFormData: createExtraFormDataWithFilter('product', ['Product A']),
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+  };
+  const filters = [createFilter('filter-1'), createFilter('filter-2')];
 
-      // Should be ENABLED - Filter B has changes to apply and Filter A (required) has value
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(false);
-    });
+  expect(checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters)).toBe(
+    true,
+  );
+});
 
-    test('should not disable Apply when required filter is only in applied state during sync gap', () => {
-      // Edge case: Required filter auto-applied but not yet synced to selected
-      // The filter is NOT in dataMaskSelected at all (key doesn't exist)
-      // This can happen during the React state update cycle
-      // Apply button should still be enabled if other filters have changes
+test('checkIsApplyDisabled handles validation status recalculation scenario', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { validateStatus: undefined, value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-1': {
+      id: 'filter-1',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const filters = [createFilter('filter-1', { enableEmptyFilter: true })];
 
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-product': {
-          id: 'filter-product',
-          filterState: {
-            validateStatus: undefined,
-            value: ['Product B'],
-          },
-          extraFormData: {
-            filters: [{ col: 'product_line', op: 'IN', val: ['Product B'] }],
-          },
-        },
-        // filter-country not yet in selected (sync gap) - KEY DOESN'T EXIST
-      };
+  expect(checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters)).toBe(
+    false,
+  );
+});
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-country': {
-          id: 'filter-country',
-          filterState: {
-            value: ['USA'], // Auto-applied, has value
-          },
-          extraFormData: {
-            filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
-          },
-        },
-        // filter-product not yet applied
-      };
+test('checkIsApplyDisabled detects out-of-scope changes and enables Apply for explicit user changes', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-in-scope': {
+      id: 'filter-in-scope',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+    'filter-out-of-scope': {
+      id: 'filter-out-of-scope',
+      filterState: { value: ['New Product'] },
+      extraFormData: createExtraFormDataWithFilter('product', ['New Product']),
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-in-scope': {
+      id: 'filter-in-scope',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+    'filter-out-of-scope': {
+      id: 'filter-out-of-scope',
+      filterState: { value: ['Product A'] },
+      extraFormData: createExtraFormDataWithFilter('product', ['Product A']),
+    },
+  };
+  const filtersInScope = [createFilter('filter-in-scope')];
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-country',
-          controlValues: {
-            enableEmptyFilter: true, // Required filter
-          },
-        } as unknown as Filter,
-        {
-          id: 'filter-product',
-          controlValues: {
-            enableEmptyFilter: false,
-          },
-        } as unknown as Filter,
-      ];
+  expect(
+    checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filtersInScope),
+  ).toBe(false);
+});
 
-      // Should be ENABLED - Required filter has value in applied state (auto-applied),
-      // and it's not in selected at all (not explicitly cleared by user)
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(false);
-    });
+test('checkIsApplyDisabled enables apply when in-scope filter has changes regardless of out-of-scope state', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-in-scope': {
+      id: 'filter-in-scope',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+    'filter-out-of-scope': {
+      id: 'filter-out-of-scope',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-in-scope': {
+      id: 'filter-in-scope',
+      filterState: { value: ['NY'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['NY']),
+    },
+    'filter-out-of-scope': {
+      id: 'filter-out-of-scope',
+      filterState: { value: ['Product A'] },
+      extraFormData: createExtraFormDataWithFilter('product', ['Product A']),
+    },
+  };
+  const filtersInScope = [createFilter('filter-in-scope')];
 
-    test('should disable Apply when user explicitly clears a required filter value', () => {
-      // Different from sync gap: filter IS in selected state but with undefined value
-      // This means user explicitly cleared it
-      // Apply should be DISABLED because it's a required filter
+  expect(
+    checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filtersInScope),
+  ).toBe(false);
+});
 
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined,
-            value: undefined, // User explicitly cleared the value
-          },
-          extraFormData: {},
-        },
-      };
+test('checkIsApplyDisabled only validates required filters that are in scope', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-in-scope': {
+      id: 'filter-in-scope',
+      filterState: { value: ['CA'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['CA']),
+    },
+    'filter-out-of-scope-required': {
+      id: 'filter-out-of-scope-required',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'filter-in-scope': {
+      id: 'filter-in-scope',
+      filterState: { value: ['NY'] },
+      extraFormData: createExtraFormDataWithFilter('state', ['NY']),
+    },
+    'filter-out-of-scope-required': {
+      id: 'filter-out-of-scope-required',
+      filterState: { value: ['Product A'] },
+      extraFormData: createExtraFormDataWithFilter('product', ['Product A']),
+    },
+  };
+  const filtersInScope = [createFilter('filter-in-scope')];
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: ['CA'], // Previously had a value
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-      };
+  expect(
+    checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filtersInScope),
+  ).toBe(false);
+});
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-1',
-          controlValues: {
-            enableEmptyFilter: true, // Required filter
-          },
-        } as unknown as Filter,
-      ];
+test('CRITICAL: checkIsApplyDisabled Apply button must be ENABLED when out-of-scope filter has explicit changes', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['same-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['same-value']),
+    },
+    'tab-b-filter': {
+      id: 'tab-b-filter',
+      filterState: { value: ['new-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_b', ['new-value']),
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['same-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['same-value']),
+    },
+    'tab-b-filter': {
+      id: 'tab-b-filter',
+      filterState: { value: ['old-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_b', ['old-value']),
+    },
+  };
+  const filtersInScope = [createFilter('tab-a-filter')];
 
-      // Should be DISABLED - User cleared a required filter
-      // Even though it has value in applied state, the selected state shows user intent
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(true);
-    });
+  const result = checkIsApplyDisabled(
+    dataMaskSelected,
+    dataMaskApplied,
+    filtersInScope,
+  );
+  expect(result).toBe(false);
+});
 
-    test('should enable Apply when filter has value but needs extraFormData update (PR #36927 regression test)', () => {
-      // Original bug from PR #36927: defaultDataMask has value but empty extraFormData
-      // The filter loads with a value in applied state but no extraFormData
-      // Then the filter plugin generates extraFormData and updates selected state
-      // Apply should be ENABLED to allow the extraFormData to be applied
+test('CRITICAL: checkIsApplyDisabled Apply button must only consider in-scope required filter validation', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'tab-a-required': {
+      id: 'tab-a-required',
+      filterState: { value: ['has-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['has-value']),
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'tab-a-required': {
+      id: 'tab-a-required',
+      filterState: { value: ['old-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['old-value']),
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: ['had-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_b', ['had-value']),
+    },
+  };
+  const filtersInScope = [
+    createFilter('tab-a-required', { enableEmptyFilter: true }),
+  ];
 
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined,
-            value: ['value1', 'value2'], // Same value
-          },
-          extraFormData: {
-            // Now has extraFormData generated by filter plugin
-            filters: [
-              { col: 'test_column', op: 'IN', val: ['value1', 'value2'] },
-            ],
-          },
-        },
-      };
+  const result = checkIsApplyDisabled(
+    dataMaskSelected,
+    dataMaskApplied,
+    filtersInScope,
+  );
+  expect(result).toBe(false);
+});
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: ['value1', 'value2'], // Has value from defaultDataMask
-          },
-          extraFormData: {}, // But extraFormData is empty (the bug scenario)
-        },
-      };
+test('checkIsApplyDisabled disables Apply when in-scope required filter is empty', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'required-filter': {
+      id: 'required-filter',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'required-filter': {
+      id: 'required-filter',
+      filterState: { value: ['had-value'] },
+      extraFormData: createExtraFormDataWithFilter('col', ['had-value']),
+    },
+  };
+  const filtersInScope = [
+    createFilter('required-filter', { enableEmptyFilter: true }),
+  ];
 
-      const filters: Filter[] = [
-        {
-          id: 'filter-1',
-          controlValues: {
-            enableEmptyFilter: true, // Required filter
-          },
-        } as unknown as Filter,
-      ];
+  const result = checkIsApplyDisabled(
+    dataMaskSelected,
+    dataMaskApplied,
+    filtersInScope,
+  );
+  expect(result).toBe(true);
+});
 
-      // Should be ENABLED because extraFormData changed (not equal)
-      // even though the value is the same
-      // This allows the auto-apply logic to update the applied state with extraFormData
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(false);
-    });
+test('checkIsApplyDisabled enabled when in-scope filter has changes, even if out-of-scope required is empty', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['new-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['new-value']),
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['old-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['old-value']),
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: ['was-set'] },
+      extraFormData: createExtraFormDataWithFilter('col_b', ['was-set']),
+    },
+  };
+  const filtersInScope = [createFilter('tab-a-filter')];
+  const allFilters = [
+    createFilter('tab-a-filter'),
+    createFilter('tab-b-required', { enableEmptyFilter: true }),
+  ];
 
-    test('should return true when out-of-scope required filter is missing value (allFilters provided)', () => {
-      // Scenario: Clear All was clicked, user selected in-scope filter only
-      // Out-of-scope required filter is still empty
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-in-scope': {
-          id: 'filter-in-scope',
-          filterState: {
-            validateStatus: undefined,
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-        'filter-out-of-scope': {
-          id: 'filter-out-of-scope',
-          filterState: {
-            validateStatus: undefined,
-            value: undefined, // Cleared by Clear All
-          },
-          extraFormData: {},
-        },
-      };
+  const result = checkIsApplyDisabled(
+    dataMaskSelected,
+    dataMaskApplied,
+    filtersInScope,
+    allFilters,
+  );
+  expect(result).toBe(false);
+});
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-in-scope': {
-          id: 'filter-in-scope',
-          filterState: {
-            value: ['NY'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['NY'] }],
-          },
-        },
-        'filter-out-of-scope': {
-          id: 'filter-out-of-scope',
-          filterState: {
-            value: ['Product A'],
-          },
-          extraFormData: {
-            filters: [{ col: 'product', op: 'IN', val: ['Product A'] }],
-          },
-        },
-      };
+test('checkIsApplyDisabled disabled when ONLY out-of-scope changes exist and required filter is empty', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['same-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['same-value']),
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['same-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['same-value']),
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: ['was-set'] },
+      extraFormData: createExtraFormDataWithFilter('col_b', ['was-set']),
+    },
+  };
+  const filtersInScope = [createFilter('tab-a-filter')];
+  const allFilters = [
+    createFilter('tab-a-filter'),
+    createFilter('tab-b-required', { enableEmptyFilter: true }),
+  ];
 
-      const filtersInScope: Filter[] = [
-        { id: 'filter-in-scope', controlValues: {} } as unknown as Filter,
-      ];
+  const result = checkIsApplyDisabled(
+    dataMaskSelected,
+    dataMaskApplied,
+    filtersInScope,
+    allFilters,
+  );
+  expect(result).toBe(true);
+});
 
-      const allFilters: Filter[] = [
-        { id: 'filter-in-scope', controlValues: {} } as unknown as Filter,
-        {
-          id: 'filter-out-of-scope',
-          controlValues: { enableEmptyFilter: true },
-        } as unknown as Filter, // Required!
-      ];
+test('checkIsApplyDisabled enabled when user sets value for out-of-scope required filter', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['value']),
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: ['user-selected'] },
+      extraFormData: createExtraFormDataWithFilter('col_b', ['user-selected']),
+    },
+  };
+  const dataMaskApplied: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['value'] },
+      extraFormData: createExtraFormDataWithFilter('col_a', ['value']),
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: ['old-value'] },
+      extraFormData: createExtraFormDataWithFilter('col_b', ['old-value']),
+    },
+  };
+  const filtersInScope = [createFilter('tab-a-filter')];
+  const allFilters = [
+    createFilter('tab-a-filter'),
+    createFilter('tab-b-required', { enableEmptyFilter: true }),
+  ];
 
-      // Without allFilters: should return false (changes detected, no in-scope required missing)
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filtersInScope),
-      ).toBe(false);
+  const result = checkIsApplyDisabled(
+    dataMaskSelected,
+    dataMaskApplied,
+    filtersInScope,
+    allFilters,
+  );
+  expect(result).toBe(false);
+});
 
-      // With allFilters: should return true (out-of-scope required filter missing)
-      expect(
-        checkIsApplyDisabled(
-          dataMaskSelected,
-          dataMaskApplied,
-          filtersInScope,
-          allFilters,
-        ),
-      ).toBe(true);
-    });
+// getFiltersToApply tests
+test('CRITICAL: getFiltersToApply includes in-scope filters regardless of value', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'in-scope-with-value': {
+      id: 'in-scope-with-value',
+      filterState: { value: ['CA'] },
+      extraFormData: {},
+    },
+    'in-scope-empty': {
+      id: 'in-scope-empty',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const inScopeFilterIds = new Set(['in-scope-with-value', 'in-scope-empty']);
 
-    test('should allow apply when out-of-scope non-required filter is cleared', () => {
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-in-scope': {
-          id: 'filter-in-scope',
-          filterState: {
-            validateStatus: undefined,
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-        'filter-out-of-scope': {
-          id: 'filter-out-of-scope',
-          filterState: {
-            validateStatus: undefined,
-            value: undefined,
-          },
-          extraFormData: {},
-        },
-      };
+  const result = getFiltersToApply(dataMaskSelected, inScopeFilterIds);
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-in-scope': {
-          id: 'filter-in-scope',
-          filterState: {
-            value: ['NY'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['NY'] }],
-          },
-        },
-        'filter-out-of-scope': {
-          id: 'filter-out-of-scope',
-          filterState: {
-            value: ['Product A'],
-          },
-          extraFormData: {
-            filters: [{ col: 'product', op: 'IN', val: ['Product A'] }],
-          },
-        },
-      };
+  expect(result).toContain('in-scope-with-value');
+  expect(result).toContain('in-scope-empty');
+});
 
-      const filtersInScope: Filter[] = [
-        { id: 'filter-in-scope', controlValues: {} } as unknown as Filter,
-      ];
+test('CRITICAL: getFiltersToApply includes out-of-scope filters ONLY if they have a value', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'in-scope': {
+      id: 'in-scope',
+      filterState: { value: ['CA'] },
+      extraFormData: {},
+    },
+    'out-of-scope-with-value': {
+      id: 'out-of-scope-with-value',
+      filterState: { value: ['Product'] },
+      extraFormData: {},
+    },
+    'out-of-scope-empty': {
+      id: 'out-of-scope-empty',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+    'out-of-scope-null': {
+      id: 'out-of-scope-null',
+      filterState: { value: null },
+      extraFormData: {},
+    },
+  };
+  const inScopeFilterIds = new Set(['in-scope']);
 
-      const allFilters: Filter[] = [
-        { id: 'filter-in-scope', controlValues: {} } as unknown as Filter,
-        {
-          id: 'filter-out-of-scope',
-          controlValues: { enableEmptyFilter: false },
-        } as unknown as Filter, // NOT required
-      ];
+  const result = getFiltersToApply(dataMaskSelected, inScopeFilterIds);
 
-      // Should return false (apply enabled) - non-required filters can be cleared
-      expect(
-        checkIsApplyDisabled(
-          dataMaskSelected,
-          dataMaskApplied,
-          filtersInScope,
-          allFilters,
-        ),
-      ).toBe(false);
-    });
+  expect(result).toContain('in-scope');
+  expect(result).toContain('out-of-scope-with-value');
+  expect(result).not.toContain('out-of-scope-empty');
+  expect(result).not.toContain('out-of-scope-null');
+});
 
-    test('should maintain backward compatibility when allFilters not provided', () => {
-      // Existing behavior should not change when allFilters is not passed
-      const dataMaskSelected: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            validateStatus: undefined,
-            value: ['CA'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
-          },
-        },
-      };
+test('CRITICAL: getFiltersToApply scenario - Clear All on Tab B, then apply on Tab A', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['selected-value'] },
+      extraFormData: {},
+    },
+    'tab-b-required': {
+      id: 'tab-b-required',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  };
+  const inScopeFilterIds = new Set(['tab-a-filter']);
 
-      const dataMaskApplied: DataMaskStateWithId = {
-        'filter-1': {
-          id: 'filter-1',
-          filterState: {
-            value: ['NY'],
-          },
-          extraFormData: {
-            filters: [{ col: 'state', op: 'IN', val: ['NY'] }],
-          },
-        },
-      };
+  const result = getFiltersToApply(dataMaskSelected, inScopeFilterIds);
 
-      const filters: Filter[] = [
-        { id: 'filter-1', controlValues: {} } as unknown as Filter,
-      ];
+  expect(result).toContain('tab-a-filter');
+  expect(result).not.toContain('tab-b-required');
+});
 
-      // Should work without the new parameter (backward compatible)
-      expect(
-        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
-      ).toBe(false);
-    });
-  });
+test('CRITICAL: getFiltersToApply scenario - Change out-of-scope filter via "Filters out of scope" panel', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'tab-a-filter': {
+      id: 'tab-a-filter',
+      filterState: { value: ['value-a'] },
+      extraFormData: {},
+    },
+    'tab-b-filter': {
+      id: 'tab-b-filter',
+      filterState: { value: ['value-b'] },
+      extraFormData: {},
+    },
+  };
+  const inScopeFilterIds = new Set(['tab-a-filter']);
+
+  const result = getFiltersToApply(dataMaskSelected, inScopeFilterIds);
+
+  expect(result).toContain('tab-a-filter');
+  expect(result).toContain('tab-b-filter');
+});
+
+test('getFiltersToApply handles empty dataMaskSelected', () => {
+  const dataMaskSelected: DataMaskStateWithId = {};
+  const inScopeFilterIds = new Set(['filter-1']);
+
+  const result = getFiltersToApply(dataMaskSelected, inScopeFilterIds);
+
+  expect(result).toEqual([]);
+});
+
+test('getFiltersToApply handles null dataMask entries', () => {
+  const dataMaskSelected: DataMaskStateWithId = {
+    'filter-1': null as any,
+    'filter-2': {
+      id: 'filter-2',
+      filterState: { value: ['CA'] },
+      extraFormData: {},
+    },
+  };
+  const inScopeFilterIds = new Set(['filter-1', 'filter-2']);
+
+  const result = getFiltersToApply(dataMaskSelected, inScopeFilterIds);
+
+  expect(result).not.toContain('filter-1');
+  expect(result).toContain('filter-2');
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
@@ -770,14 +770,14 @@ test('getFiltersToApply handles empty dataMaskSelected', () => {
 });
 
 test('getFiltersToApply handles null dataMask entries', () => {
-  const dataMaskSelected: DataMaskStateWithId = {
-    'filter-1': null as any,
+  const dataMaskSelected = {
+    'filter-1': null,
     'filter-2': {
       id: 'filter-2',
       filterState: { value: ['CA'] },
       extraFormData: {},
     },
-  };
+  } as unknown as DataMaskStateWithId;
   const inScopeFilterIds = new Set(['filter-1', 'filter-2']);
 
   const result = getFiltersToApply(dataMaskSelected, inScopeFilterIds);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -17,7 +17,13 @@
  * under the License.
  */
 
-import { DataMaskStateWithId, Filter, FilterState } from '@superset-ui/core';
+import {
+  DataMaskStateWithId,
+  ExtraFormData,
+  Filter,
+  FilterState,
+} from '@superset-ui/core';
+import { isEqual } from 'lodash';
 import { useSelector } from 'react-redux';
 import { createSelector } from '@reduxjs/toolkit';
 import { areObjectsEqual } from 'src/reduxUtils';
@@ -25,9 +31,16 @@ import { testWithId } from 'src/utils/testUtils';
 import { RootState } from 'src/dashboard/types';
 import { FilterElement } from './FilterControls/types';
 
-export const getOnlyExtraFormData = (data: DataMaskStateWithId) =>
-  Object.values(data).reduce(
-    (prev, next) => ({ ...prev, [next.id]: next.extraFormData }),
+export const getOnlyExtraFormData = (
+  data: DataMaskStateWithId,
+  filterIds?: Set<string>,
+): Record<string, ExtraFormData | undefined> =>
+  Object.values(data).reduce<Record<string, ExtraFormData | undefined>>(
+    (prev, next) => {
+      // If filterIds is provided, only include those filters
+      if (filterIds && !filterIds.has(next.id)) return prev;
+      return { ...prev, [next.id]: next.extraFormData };
+    },
     {},
   );
 
@@ -56,12 +69,50 @@ export const checkIsApplyDisabled = (
   filtersInScope: Filter[],
   allFilters?: Filter[],
 ) => {
-  if (!checkIsValidateError(dataMaskSelected)) {
-    return true;
-  }
+  if (!checkIsValidateError(dataMaskSelected)) return true;
 
-  // Check required values for ALL filters (including out-of-scope) if provided
-  const filtersToValidateRequired = allFilters?.length
+  const selectedExtraFormData = getOnlyExtraFormData(dataMaskSelected);
+  const appliedExtraFormData = getOnlyExtraFormData(dataMaskApplied);
+
+  // Check counts first
+  const selectedCount = Object.keys(selectedExtraFormData).length;
+  const appliedCount = Object.keys(appliedExtraFormData).length;
+
+  if (selectedCount !== appliedCount) return true;
+
+  // Check for changes
+  const dataEqual = areObjectsEqual(
+    selectedExtraFormData,
+    appliedExtraFormData,
+    { ignoreUndefined: true },
+  );
+
+  // If no changes at all, Apply should be disabled
+  if (dataEqual) return true;
+
+  // Determine which filters to validate for required values
+  const inScopeFilterIds = new Set(filtersInScope.map(f => f.id));
+
+  // Check if changes are in-scope or out-of-scope
+  const hasInScopeChanges = filtersInScope.some(filter => {
+    const selected = selectedExtraFormData[filter.id];
+    const applied = appliedExtraFormData[filter.id];
+    return !isEqual(selected, applied);
+  });
+
+  // Determine which filters to validate for required values
+  const hasOutOfScopeChanges =
+    !hasInScopeChanges &&
+    allFilters?.some(filter => {
+      if (inScopeFilterIds.has(filter.id)) return false;
+      const selected = selectedExtraFormData[filter.id];
+      const applied = appliedExtraFormData[filter.id];
+      return !isEqual(selected, applied);
+    });
+
+  const shouldValidateAllRequired =
+    hasOutOfScopeChanges && allFilters && allFilters.length > 0;
+  const filtersToValidateRequired = shouldValidateAllRequired
     ? allFilters
     : filtersInScope;
 
@@ -92,18 +143,7 @@ export const checkIsApplyDisabled = (
     return checkIsMissingRequiredValue(filter, selectedState);
   });
 
-  const selectedExtraFormData = getOnlyExtraFormData(dataMaskSelected);
-  const appliedExtraFormData = getOnlyExtraFormData(dataMaskApplied);
-
-  const areEqual = areObjectsEqual(
-    selectedExtraFormData,
-    appliedExtraFormData,
-    { ignoreUndefined: true },
-  );
-
-  const result = areEqual || hasMissingRequiredFilter;
-
-  return result;
+  return hasMissingRequiredFilter;
 };
 
 const chartsVerboseMapSelector = createSelector(
@@ -128,6 +168,27 @@ export const useChartsVerboseMaps = () =>
   useSelector<RootState, { [chartId: string]: Record<string, string> }>(
     chartsVerboseMapSelector,
   );
+
+/**
+ * Determines which filters should be applied when the Apply button is clicked.
+ */
+export const getFiltersToApply = (
+  dataMaskSelected: DataMaskStateWithId,
+  inScopeFilterIds: Set<string>,
+): string[] =>
+  Object.entries(dataMaskSelected)
+    .filter(([filterId, dataMask]) => {
+      if (!dataMask) return false;
+
+      const isInScope = inScopeFilterIds.has(filterId);
+      const hasValue =
+        dataMask.filterState?.value !== undefined &&
+        dataMask.filterState?.value !== null;
+
+      // Apply if in-scope OR if out-of-scope with a value
+      return isInScope || hasValue;
+    })
+    .map(([filterId]) => filterId);
 
 export const FILTER_BAR_TEST_ID = 'filter-bar';
 export const getFilterBarTestId = testWithId(FILTER_BAR_TEST_ID);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -40,11 +40,9 @@ export const checkIsMissingRequiredValue = (
   if (!isRequired) return false;
 
   const value = filterState?.value;
+
   // TODO: this property should be unhardcoded
-  return (
-    filter.controlValues?.enableEmptyFilter &&
-    (value === null || value === undefined)
-  );
+  return value === null || value === undefined;
 };
 
 export const checkIsValidateError = (dataMask: DataMaskStateWithId) => {
@@ -55,16 +53,22 @@ export const checkIsValidateError = (dataMask: DataMaskStateWithId) => {
 export const checkIsApplyDisabled = (
   dataMaskSelected: DataMaskStateWithId,
   dataMaskApplied: DataMaskStateWithId,
-  filters: Filter[],
+  filtersInScope: Filter[],
+  allFilters?: Filter[],
 ) => {
   if (!checkIsValidateError(dataMaskSelected)) {
     return true;
   }
 
+  // Check required values for ALL filters (including out-of-scope) if provided
+  const filtersToValidateRequired = allFilters?.length
+    ? allFilters
+    : filtersInScope;
+
   // Check if any required filter is missing a value
   // For filters that may have been auto-applied (e.g., requiredFirst filters),
   // check both selected and applied states to avoid false positives during initialization
-  const hasMissingRequiredFilter = filters.some(filter => {
+  const hasMissingRequiredFilter = filtersToValidateRequired.some(filter => {
     const selectedDataMask = dataMaskSelected?.[filter?.id];
     const selectedState = selectedDataMask?.filterState;
     const appliedState = dataMaskApplied?.[filter?.id]?.filterState;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -821,6 +821,11 @@ const FiltersConfigForm = (
   );
   return (
     <Tabs
+      allowOverflow={false}
+      contentHeight={630}
+      contentPadding={css`
+        padding-top: ${theme.sizeUnit * 4}px;
+      `}
       activeKey={activeTabKey}
       onChange={activeKey => setActiveTabKey(activeKey)}
       items={[

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -822,7 +822,7 @@ const FiltersConfigForm = (
   return (
     <Tabs
       allowOverflow={false}
-      contentHeight={630}
+      contentHeight={`calc(100vh - ${theme.sizeUnit * 55}px)`}
       contentPadding={css`
         padding-top: ${theme.sizeUnit * 4}px;
       `}


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a scoping issue with the "Clear All" button and Apply validation in the native filter bar.

Previously, "Clear All" cleared ALL native filters (including out-of-scope filters), but the `Apply` validation only checked in-scope filters. This created a validation gap where required out-of-scope filters could be left empty, causing:
1. Dashboard errors when requiredFirst filters are empty
2. Charts showing unfiltered data when required filters are empty

Now, this PR implements proper scoping for all filter operations:
1. Clear All now only clears in-scope filters
2. Apply now respects scope:
  - In-scope filters are always applied
  - Out-of-scope filters are only applied if they have a value (prevents applying cleared state from other tabs)
3. Conditional required filter validation:
  - If there are in-scope changes --> only validates in-scope required filters (user can apply their changes without being blocked by other tabs)
  - If there are ONLY out-of-scope changes (via "Filters out of scope" panel) --> validates all required filters

**Additionally**, this PR also fixes a double scrollbar issue in the "Add or edit filters" modal

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### Before:
<img width="911" height="816" alt="Screenshot 2026-02-06 at 22 31 21" src="https://github.com/user-attachments/assets/f31793d9-a3d5-4013-b97c-74f8cf477c6a" />

[fix-dashboard-filters-before.webm](https://github.com/user-attachments/assets/97980fae-e4ff-41ce-9334-d69de5bc82e6)

#### After:
<img width="911" height="813" alt="Screenshot 2026-02-06 at 22 29 45" src="https://github.com/user-attachments/assets/6ed74e6d-e2f1-4977-b2f4-f50276e64bd0" />

[screen-capture (2).webm](https://github.com/user-attachments/assets/7e82678f-184b-4073-a2f0-bb2ab34135e0)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
#### Scenario 1: Clear All respects scope
1. Create a dashboard with 2 tabs (Tab A, Tab B), each with a chart
2. Create Filter A: required (Filter value is required), scoped to Tab A only
3. Create Filter B: required (Filter value is required), scoped to Tab B only
4. Save and refresh, both filters should have default values
5. Click `Apply filters` to establish baseline
6. On Tab A, click `Clear all`
7. Verify that only Filter A is cleared, Filter B retains its value
8. Navigate to Tab B
9. Verify that Filter B still has its value

#### Scenario 2: Apply button enabled for in-scope changes
1. Continue from Scenario 1 (or repeat steps 1-5)
2. On Tab A, click `Clear all`
3. Navigate to Tab B, click `Clear all`
4. Navigate back to Tab A
5. Select a value for Filter A
6. Verify: Apply button is ENABLED (in-scope filter has a value)
7. Click `Apply filters`
8. Verify that Filter A is applied, Tab B's Filter B remains in its cleared (pending) state
9. Navigate to Tab B
10. Verify: Filter B shows as cleared (pending change not yet applied)

#### Scenario 3: Out-of-scope changes via "Filters out of scope" panel
1. Create the same dashboard setup as Scenario 1
2. On Tab A, expand "Filters out of scope" panel
3. Clear Filter B's value (the out-of-scope required filter)
4. Verify that the `Apply filters` button is disabled (out-of-scope required filter is empty)
5. Set a value for Filter B via the panel
6. Verify that the `Apply filters` button is now enabled


___

## **CodeAnt-AI Description**
Ensure Clear All only clears in-scope filters and Apply respects filter scope

### What Changed
- "Clear all" now only clears filters that belong to the currently visible scope (tab); out-of-scope filters are left unchanged.
- Applying filters sends: all in-scope filters plus any out-of-scope filters that currently have a value; out-of-scope filters without values are not applied.
- Required-filter validation is conditional: if user changed any in-scope filters, only in-scope required filters are validated; if the only changes are out-of-scope, all required filters are validated.
- UI improvements: an info icon appears next to Clear all when required filters exist on other tabs, and modal/tab layout fixes remove double scrollbars and improve content sizing.
- Test coverage updated to exercise the scoping, apply, and clear behaviors and the new edge cases.

### Impact
`✅ Fewer dashboard errors when clearing filters`
`✅ Clearer and predictable Clear all / Apply behavior across tabs`
`✅ Fewer charts showing unintended unfiltered data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
