### PR TITLE
feat: lineage and usage visualization

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -88,8 +88,26 @@ import {
 } from '../../FoldersEditor/constants';
 import { validateFolders } from '../../FoldersEditor/folderValidation';
 import FoldersEditor from '../../FoldersEditor';
+import { useDatasetLineage } from 'src/hooks/apiResources';
+import { LineageView } from 'src/features/lineage';
 
 const extensionsRegistry = getExtensionsRegistry();
+
+// Functional wrapper component for lineage tab (needed because hooks can't be used in class components)
+function DatasetLineageTab({ datasourceId }) {
+  const lineageResource = useDatasetLineage(datasourceId);
+
+  // Show loading state if datasourceId is not available
+  if (!datasourceId) {
+    return <Loading />;
+  }
+
+  return <LineageView lineageResource={lineageResource} entityType="dataset" />;
+}
+
+DatasetLineageTab.propTypes = {
+  datasourceId: PropTypes.number,
+};
 
 const DatasourceContainer = styled.div`
   .change-warning {
@@ -217,6 +235,7 @@ const TABS_KEYS = {
   COLUMNS: 'COLUMNS',
   CALCULATED_COLUMNS: 'CALCULATED_COLUMNS',
   USAGE: 'USAGE',
+  LINEAGE: 'LINEAGE',
   FOLDERS: 'FOLDERS',
   SETTINGS: 'SETTINGS',
   SPATIAL: 'SPATIAL',
@@ -2065,6 +2084,15 @@ class DatasourceEditor extends PureComponent {
                     onFetchCharts={this.fetchUsageData}
                     addDangerToast={this.props.addDangerToast}
                   />
+                </StyledTableTabWrapper>
+              ),
+            },
+            {
+              key: TABS_KEYS.LINEAGE,
+              label: t('Lineage'),
+              children: (
+                <StyledTableTabWrapper>
+                  <DatasetLineageTab datasourceId={datasource.id} />
                 </StyledTableTabWrapper>
               ),
             },

--- a/superset-frontend/src/dashboard/components/Header/useHeaderActionsDropdownMenu.tsx
+++ b/superset-frontend/src/dashboard/components/Header/useHeaderActionsDropdownMenu.tsx
@@ -35,6 +35,7 @@ import { getActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { MenuKeys, RootState } from 'src/dashboard/types';
 import { HeaderDropdownProps } from 'src/dashboard/components/Header/types';
+import { LineageModal } from 'src/features/lineage';
 
 export const useHeaderActionsMenu = ({
   customCss,
@@ -217,6 +218,24 @@ export const useHeaderActionsMenu = ({
         key: MenuKeys.EditProperties,
         label: t('Edit properties'),
       });
+
+      // View lineage
+      if (dashboardId) {
+        menuItems.push(
+          createModalMenuItem(
+            MenuKeys.ViewLineage,
+            <LineageModal
+              entityType="dashboard"
+              entityId={dashboardId}
+              triggerNode={
+                <div data-test="view-lineage-menu-item">
+                  {t('View lineage')}
+                </div>
+              }
+            />,
+          ),
+        );
+      }
     }
 
     // Divider

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -310,4 +310,5 @@ export enum MenuKeys {
   ManageEmailReports = 'manage_email_reports',
   ExportPivotXlsx = 'export_pivot_xlsx',
   EmbedCode = 'embed_code',
+  ViewLineage = 'view_lineage',
 }

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -49,6 +49,7 @@ import { useStreamingExport } from 'src/components/StreamingExportModal';
 import ViewQueryModal from '../controls/ViewQueryModal';
 import EmbedCodeContent from '../EmbedCodeContent';
 import { useDashboardsMenuItems } from './DashboardsSubMenu';
+import { LineageModal } from 'src/features/lineage';
 
 export const SEARCH_THRESHOLD = 10;
 
@@ -79,6 +80,7 @@ const MENU_KEYS = {
   EDIT_REPORT: 'edit_report',
   DELETE_REPORT: 'delete_report',
   VIEW_QUERY: 'view_query',
+  VIEW_LINEAGE: 'view_lineage',
   RUN_IN_SQL_LAB: 'run_in_sql_lab',
 };
 
@@ -858,6 +860,23 @@ export const useExploreAdditionalActionsMenu = (
       ),
       onClick: () => setIsDropdownVisible(false),
     });
+
+    // View lineage
+    if (slice?.slice_id) {
+      menuItems.push({
+        key: MENU_KEYS.VIEW_LINEAGE,
+        label: (
+          <LineageModal
+            entityType="chart"
+            entityId={slice.slice_id}
+            triggerNode={
+              <div data-test="view-lineage-menu-item">{t('View lineage')}</div>
+            }
+          />
+        ),
+        onClick: () => setIsDropdownVisible(false),
+      });
+    }
 
     // Run in SQL Lab
     if (datasource) {

--- a/superset-frontend/src/features/charts/ChartCard.tsx
+++ b/superset-frontend/src/features/charts/ChartCard.tsx
@@ -34,6 +34,7 @@ import Chart from 'src/types/Chart';
 import { FacePile } from 'src/components';
 import { handleChartDelete, CardStyles } from 'src/views/CRUD/utils';
 import { assetUrl } from 'src/utils/assetUrl';
+import { LineageModal } from 'src/features/lineage';
 
 interface ChartCardProps {
   chart: Chart;
@@ -72,6 +73,7 @@ export default function ChartCard({
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
+  const canRead = hasPerm('can_read');
   const menuItems: MenuItem[] = [];
 
   if (canEdit) {
@@ -92,6 +94,29 @@ export default function ChartCard({
           />{' '}
           {t('Edit')}
         </div>
+      ),
+    });
+  }
+
+  if (canRead) {
+    menuItems.push({
+      key: 'lineage',
+      label: (
+        <LineageModal
+          entityType="chart"
+          entityId={chart.id}
+          triggerNode={
+            <div>
+              <Icons.ShareAltOutlined
+                iconSize="l"
+                css={css`
+                  vertical-align: text-top;
+                `}
+              />{' '}
+              {t('View Lineage')}
+            </div>
+          }
+        />
       ),
     });
   }
@@ -162,54 +187,59 @@ export default function ChartCard({
   }
 
   return (
-    <CardStyles
-      onClick={() => {
-        if (!bulkSelectEnabled && chart.url) {
-          history.push(chart.url);
-        }
-      }}
-    >
-      <ListViewCard
-        loading={loading}
-        title={chart.slice_name}
-        certifiedBy={chart.certified_by}
-        certificationDetails={chart.certification_details}
-        cover={
-          !isFeatureEnabled(FeatureFlag.Thumbnails) || !showThumbnails ? (
-            <></>
-          ) : null
-        }
-        url={bulkSelectEnabled ? undefined : chart.url}
-        imgURL={chart.thumbnail_url || ''}
-        imgFallbackURL={assetUrl(
-          '/static/assets/images/chart-card-fallback.svg',
-        )}
-        description={t('Modified %s', chart.changed_on_delta_humanized)}
-        coverLeft={<FacePile users={chart.owners || []} />}
-        coverRight={<Label>{chart.datasource_name_text}</Label>}
-        linkComponent={Link}
-        actions={
-          <ListViewCard.Actions
-            onClick={e => {
-              e.stopPropagation();
-              e.preventDefault();
-            }}
-          >
-            {userId && (
-              <FaveStar
-                itemId={chart.id}
-                saveFaveStar={saveFavoriteStatus}
-                isStarred={favoriteStatus}
-              />
-            )}
-            <Dropdown menu={{ items: menuItems }} trigger={['click', 'hover']}>
-              <Button buttonSize="xsmall" type="link" buttonStyle="link">
-                <Icons.MoreOutlined iconSize="xl" />
-              </Button>
-            </Dropdown>
-          </ListViewCard.Actions>
-        }
-      />
-    </CardStyles>
+    <>
+      <CardStyles
+        onClick={() => {
+          if (!bulkSelectEnabled && chart.url) {
+            history.push(chart.url);
+          }
+        }}
+      >
+        <ListViewCard
+          loading={loading}
+          title={chart.slice_name}
+          certifiedBy={chart.certified_by}
+          certificationDetails={chart.certification_details}
+          cover={
+            !isFeatureEnabled(FeatureFlag.Thumbnails) || !showThumbnails ? (
+              <></>
+            ) : null
+          }
+          url={bulkSelectEnabled ? undefined : chart.url}
+          imgURL={chart.thumbnail_url || ''}
+          imgFallbackURL={assetUrl(
+            '/static/assets/images/chart-card-fallback.svg',
+          )}
+          description={t('Modified %s', chart.changed_on_delta_humanized)}
+          coverLeft={<FacePile users={chart.owners || []} />}
+          coverRight={<Label>{chart.datasource_name_text}</Label>}
+          linkComponent={Link}
+          actions={
+            <ListViewCard.Actions
+              onClick={e => {
+                e.stopPropagation();
+                e.preventDefault();
+              }}
+            >
+              {userId && (
+                <FaveStar
+                  itemId={chart.id}
+                  saveFaveStar={saveFavoriteStatus}
+                  isStarred={favoriteStatus}
+                />
+              )}
+              <Dropdown
+                menu={{ items: menuItems }}
+                trigger={['click', 'hover']}
+              >
+                <Button buttonSize="xsmall" type="link" buttonStyle="link">
+                  <Icons.MoreOutlined iconSize="xl" />
+                </Button>
+              </Dropdown>
+            </ListViewCard.Actions>
+          }
+        />
+      </CardStyles>
+    </>
   );
 }

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -37,6 +37,7 @@ import { Icons } from '@superset-ui/core/components/Icons';
 import { Dashboard } from 'src/views/CRUD/types';
 import { assetUrl } from 'src/utils/assetUrl';
 import { FacePile } from 'src/components';
+import { LineageModal } from 'src/features/lineage';
 
 interface DashboardCardProps {
   isChart?: boolean;
@@ -69,6 +70,7 @@ function DashboardCard({
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
+  const canRead = hasPerm('can_read');
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
   const [fetchingThumbnail, setFetchingThumbnail] = useState<boolean>(false);
 
@@ -98,6 +100,23 @@ function DashboardCard({
   }, [dashboard, thumbnailUrl]);
 
   const menuItems: MenuItem[] = [];
+
+  if (canRead) {
+    menuItems.push({
+      key: 'lineage',
+      label: (
+        <LineageModal
+          entityType="dashboard"
+          entityId={dashboard.id}
+          triggerNode={
+            <div data-test="dashboard-card-option-lineage-button">
+              <Icons.ShareAltOutlined iconSize="l" /> {t('View Lineage')}
+            </div>
+          }
+        />
+      ),
+    });
+  }
 
   if (canEdit && openDashboardEditModal) {
     menuItems.push({
@@ -151,55 +170,60 @@ function DashboardCard({
   }
 
   return (
-    <CardStyles
-      onClick={() => {
-        if (!bulkSelectEnabled) {
-          history.push(dashboard.url);
-        }
-      }}
-    >
-      <ListViewCard
-        loading={dashboard.loading || false}
-        title={dashboard.dashboard_title}
-        certifiedBy={dashboard.certified_by}
-        certificationDetails={dashboard.certification_details}
-        titleRight={<PublishedLabel isPublished={dashboard.published} />}
-        cover={
-          !isFeatureEnabled(FeatureFlag.Thumbnails) || !showThumbnails ? (
-            <></>
-          ) : null
-        }
-        url={bulkSelectEnabled ? undefined : dashboard.url}
-        linkComponent={Link}
-        imgURL={thumbnailUrl}
-        imgFallbackURL={assetUrl(
-          '/static/assets/images/dashboard-card-fallback.svg',
-        )}
-        description={t('Modified %s', dashboard.changed_on_delta_humanized)}
-        coverLeft={<FacePile users={dashboard.owners || []} />}
-        actions={
-          <ListViewCard.Actions
-            onClick={e => {
-              e.stopPropagation();
-              e.preventDefault();
-            }}
-          >
-            {userId && (
-              <FaveStar
-                itemId={dashboard.id}
-                saveFaveStar={saveFavoriteStatus}
-                isStarred={favoriteStatus}
-              />
-            )}
-            <Dropdown menu={{ items: menuItems }} trigger={['hover', 'click']}>
-              <Button buttonSize="xsmall" buttonStyle="link">
-                <Icons.MoreOutlined iconSize="xl" />
-              </Button>
-            </Dropdown>
-          </ListViewCard.Actions>
-        }
-      />
-    </CardStyles>
+    <>
+      <CardStyles
+        onClick={() => {
+          if (!bulkSelectEnabled) {
+            history.push(dashboard.url);
+          }
+        }}
+      >
+        <ListViewCard
+          loading={dashboard.loading || false}
+          title={dashboard.dashboard_title}
+          certifiedBy={dashboard.certified_by}
+          certificationDetails={dashboard.certification_details}
+          titleRight={<PublishedLabel isPublished={dashboard.published} />}
+          cover={
+            !isFeatureEnabled(FeatureFlag.Thumbnails) || !showThumbnails ? (
+              <></>
+            ) : null
+          }
+          url={bulkSelectEnabled ? undefined : dashboard.url}
+          linkComponent={Link}
+          imgURL={thumbnailUrl}
+          imgFallbackURL={assetUrl(
+            '/static/assets/images/dashboard-card-fallback.svg',
+          )}
+          description={t('Modified %s', dashboard.changed_on_delta_humanized)}
+          coverLeft={<FacePile users={dashboard.owners || []} />}
+          actions={
+            <ListViewCard.Actions
+              onClick={e => {
+                e.stopPropagation();
+                e.preventDefault();
+              }}
+            >
+              {userId && (
+                <FaveStar
+                  itemId={dashboard.id}
+                  saveFaveStar={saveFavoriteStatus}
+                  isStarred={favoriteStatus}
+                />
+              )}
+              <Dropdown
+                menu={{ items: menuItems }}
+                trigger={['hover', 'click']}
+              >
+                <Button buttonSize="xsmall" buttonStyle="link">
+                  <Icons.MoreOutlined iconSize="xl" />
+                </Button>
+              </Dropdown>
+            </ListViewCard.Actions>
+          }
+        />
+      </CardStyles>
+    </>
   );
 }
 

--- a/superset-frontend/src/features/datasets/AddDataset/EditDataset/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/EditDataset/index.tsx
@@ -21,6 +21,8 @@ import { styled } from '@apache-superset/core/ui';
 import useGetDatasetRelatedCounts from 'src/features/datasets/hooks/useGetDatasetRelatedCounts';
 import { Badge } from '@superset-ui/core/components';
 import Tabs from '@superset-ui/core/components/Tabs';
+import { useDatasetLineage } from 'src/hooks/apiResources';
+import { LineageView } from 'src/features/lineage';
 
 const StyledTabs = styled(Tabs)`
   ${({ theme }) => `
@@ -51,16 +53,19 @@ const TRANSLATIONS = {
   USAGE_TEXT: t('Usage'),
   COLUMNS_TEXT: t('Columns'),
   METRICS_TEXT: t('Metrics'),
+  LINEAGE_TEXT: t('Lineage'),
 };
 
 const TABS_KEYS = {
   COLUMNS: 'COLUMNS',
   METRICS: 'METRICS',
   USAGE: 'USAGE',
+  LINEAGE: 'LINEAGE',
 };
 
 const EditPage = ({ id }: EditPageProps) => {
   const { usageCount } = useGetDatasetRelatedCounts(id);
+  const lineageResource = useDatasetLineage(id);
 
   const usageTab = (
     <TabStyles>
@@ -84,6 +89,13 @@ const EditPage = ({ id }: EditPageProps) => {
       key: TABS_KEYS.USAGE,
       label: usageTab,
       children: null,
+    },
+    {
+      key: TABS_KEYS.LINEAGE,
+      label: TRANSLATIONS.LINEAGE_TEXT,
+      children: (
+        <LineageView lineageResource={lineageResource} entityType="dataset" />
+      ),
     },
   ];
 

--- a/superset-frontend/src/features/lineage/LineageModal.tsx
+++ b/superset-frontend/src/features/lineage/LineageModal.tsx
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { FC, ReactNode } from 'react';
+import { t } from '@apache-superset/core';
+import { ModalTrigger } from '@superset-ui/core/components';
+import {
+  useChartLineage,
+  useDashboardLineage,
+  useDatasetLineage,
+} from 'src/hooks/apiResources';
+import LineageView from './LineageView';
+
+export interface LineageModalProps {
+  entityType: 'dataset' | 'chart' | 'dashboard';
+  entityId: string | number;
+  triggerNode: ReactNode;
+}
+
+const LineageModal: FC<LineageModalProps> = ({
+  entityType,
+  entityId,
+  triggerNode,
+}) => {
+  const datasetLineage = useDatasetLineage(
+    entityType === 'dataset' ? entityId : '',
+  );
+  const chartLineage = useChartLineage(entityType === 'chart' ? entityId : '');
+  const dashboardLineage = useDashboardLineage(
+    entityType === 'dashboard' ? entityId : '',
+  );
+
+  const lineageResource =
+    entityType === 'dataset'
+      ? datasetLineage
+      : entityType === 'chart'
+        ? chartLineage
+        : dashboardLineage;
+
+  const title =
+    entityType === 'dataset'
+      ? t('Dataset Lineage')
+      : entityType === 'chart'
+        ? t('Chart Lineage')
+        : t('Dashboard Lineage');
+
+  return (
+    <ModalTrigger
+      triggerNode={triggerNode}
+      modalTitle={title}
+      modalBody={
+        <LineageView
+          lineageResource={lineageResource}
+          entityType={entityType}
+        />
+      }
+      width="800px"
+      responsive
+      destroyOnHidden
+    />
+  );
+};
+
+export default LineageModal;

--- a/superset-frontend/src/features/lineage/LineageModal.tsx
+++ b/superset-frontend/src/features/lineage/LineageModal.tsx
@@ -69,7 +69,7 @@ const LineageModal: FC<LineageModalProps> = ({
           entityType={entityType}
         />
       }
-      width="800px"
+      width="850px"
       responsive
       destroyOnHidden
     />

--- a/superset-frontend/src/features/lineage/LineageView.tsx
+++ b/superset-frontend/src/features/lineage/LineageView.tsx
@@ -1,0 +1,233 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { FC, useMemo } from 'react';
+import { t, useTheme } from '@apache-superset/core/ui';
+import { Empty, Loading } from '@superset-ui/core/components';
+import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
+import type { Resource } from 'src/hooks/apiResources/apiResources';
+import type {
+  DatasetLineage,
+  ChartLineage,
+  DashboardLineage,
+  ChartEntity,
+  DashboardEntity,
+} from 'src/hooks/apiResources/lineage';
+import Echart from '../../../plugins/plugin-chart-echarts/src/components/Echart';
+import type { EChartsCoreOption } from 'echarts/core';
+
+type LineageViewProps = {
+  lineageResource:
+    | Resource<DatasetLineage>
+    | Resource<ChartLineage>
+    | Resource<DashboardLineage>;
+  entityType: 'dataset' | 'chart' | 'dashboard';
+};
+
+const LineageView: FC<LineageViewProps> = ({ lineageResource, entityType }) => {
+  const theme = useTheme();
+
+  const echartOptions: EChartsCoreOption | null = useMemo(() => {
+    if (
+      lineageResource.status !== ResourceStatus.Complete ||
+      !lineageResource.result
+    ) {
+      return null;
+    }
+
+    const data = lineageResource.result;
+    const nodes: { name: string; itemStyle?: { color: string } }[] = [];
+    const links: { source: string; target: string; value: number }[] = [];
+    const nodeSet = new Set<string>();
+
+    // Helper to add a node
+    const addNode = (name: string, color: string) => {
+      if (!nodeSet.has(name)) {
+        nodeSet.add(name);
+        nodes.push({
+          name,
+          itemStyle: { color },
+        });
+      }
+    };
+
+    // Helper to add a link
+    const addLink = (source: string, target: string) => {
+      links.push({ source, target, value: 1 });
+    };
+
+    // Build nodes and links based on entity type
+    if (entityType === 'dataset' && 'dataset' in data) {
+      const { dataset, upstream, downstream } = data as DatasetLineage;
+
+      // Add current dataset node (center)
+      addNode(dataset.name, theme.colorPrimary);
+
+      // Add upstream database
+      if (upstream?.database) {
+        addNode(upstream.database.database_name, theme.colorInfo);
+        addLink(upstream.database.database_name, dataset.name);
+      }
+
+      // Add downstream charts
+      const chartMap = new Map<number, ChartEntity>();
+      if (downstream?.charts?.result) {
+        downstream.charts.result.forEach((chart: ChartEntity) => {
+          chartMap.set(chart.id, chart);
+          addNode(chart.slice_name, theme.colorSuccess);
+          addLink(dataset.name, chart.slice_name);
+        });
+      }
+
+      // Add downstream dashboards and link to their specific charts
+      if (downstream?.dashboards?.result) {
+        downstream.dashboards.result.forEach((dashboard: DashboardEntity) => {
+          addNode(dashboard.title, theme.colorWarning);
+
+          // Link from charts to dashboards using chart_ids
+          if (dashboard.chart_ids && dashboard.chart_ids.length > 0) {
+            dashboard.chart_ids.forEach(chartId => {
+              const chart = chartMap.get(chartId);
+              if (chart) {
+                addLink(chart.slice_name, dashboard.title);
+              }
+            });
+          }
+        });
+      }
+    } else if (entityType === 'chart' && 'chart' in data) {
+      const { chart, upstream, downstream } = data as ChartLineage;
+
+      // Add current chart node (center)
+      addNode(chart.slice_name, theme.colorPrimary);
+
+      // Add upstream dataset
+      if (upstream?.dataset) {
+        addNode(upstream.dataset.name, theme.colorInfo);
+        addLink(upstream.dataset.name, chart.slice_name);
+
+        // Add upstream database
+        if (upstream.database) {
+          addNode(upstream.database.database_name, theme.colorWarning);
+          addLink(upstream.database.database_name, upstream.dataset.name);
+        }
+      }
+
+      // Add downstream dashboards
+      if (downstream?.dashboards?.result) {
+        downstream.dashboards.result.forEach((dashboard: DashboardEntity) => {
+          addNode(dashboard.title, theme.colorSuccess);
+          addLink(chart.slice_name, dashboard.title);
+        });
+      }
+    } else if (entityType === 'dashboard' && 'dashboard' in data) {
+      const { dashboard, upstream } = data as DashboardLineage;
+
+      // Add current dashboard node (right)
+      addNode(dashboard.title, theme.colorPrimary);
+
+      // Create a map of chart id to chart for easy lookup
+      const chartMap = new Map<number, ChartEntity>();
+      if (upstream?.charts?.result) {
+        upstream.charts.result.forEach((chart: ChartEntity) => {
+          chartMap.set(chart.id, chart);
+          addNode(chart.slice_name, theme.colorInfo);
+          addLink(chart.slice_name, dashboard.title);
+        });
+      }
+
+      // Create a map of dataset id to dataset for easy lookup
+      const datasetMap = new Map<number, any>();
+      if (upstream?.datasets?.result) {
+        upstream.datasets.result.forEach(dataset => {
+          datasetMap.set(dataset.id, dataset);
+          addNode(dataset.name, theme.colorSuccess);
+
+          // Link datasets to their specific charts using chart_ids
+          if (dataset.chart_ids && dataset.chart_ids.length > 0) {
+            dataset.chart_ids.forEach(chartId => {
+              const chart = chartMap.get(chartId);
+              if (chart) {
+                addLink(dataset.name, chart.slice_name);
+              }
+            });
+          }
+        });
+      }
+
+      // Add upstream databases and link to their specific datasets
+      if (upstream?.databases?.result) {
+        upstream.databases.result.forEach(database => {
+          addNode(database.database_name, theme.colorWarning);
+
+          // Link databases to datasets that belong to them using database_id
+          if (upstream.datasets?.result) {
+            upstream.datasets.result.forEach(dataset => {
+              if (dataset.database_id === database.id) {
+                addLink(database.database_name, dataset.name);
+              }
+            });
+          }
+        });
+      }
+    }
+
+    return {
+      series: {
+        animation: false,
+        data: nodes,
+        lineStyle: {
+          color: 'source',
+        },
+        links,
+        type: 'sankey',
+      },
+      tooltip: {
+        trigger: 'item',
+        triggerOn: 'mousemove',
+      },
+    };
+  }, [lineageResource, entityType, theme]);
+
+  if (lineageResource.status === ResourceStatus.Loading) {
+    return <Loading />;
+  }
+
+  if (
+    lineageResource.status === ResourceStatus.Error ||
+    !lineageResource.result
+  ) {
+    return <Empty description={t('Failed to load lineage data')} />;
+  }
+
+  if (!echartOptions) {
+    return <Empty description={t('No lineage data available')} />;
+  }
+
+  return (
+    <Echart
+      refs={{}}
+      height={600}
+      width={800}
+      echartOptions={echartOptions}
+      vizType="sankey"
+    />
+  );
+};
+
+export default LineageView;

--- a/superset-frontend/src/features/lineage/LineageView.tsx
+++ b/superset-frontend/src/features/lineage/LineageView.tsx
@@ -16,9 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC, useMemo } from 'react';
+import { FC, useMemo, useState, useCallback } from 'react';
 import { t, useTheme, styled } from '@apache-superset/core/ui';
 import { Empty, Loading } from '@superset-ui/core/components';
+import { Button } from '@superset-ui/core/components';
 import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
 import type { Resource } from 'src/hooks/apiResources/apiResources';
 import type {
@@ -27,6 +28,8 @@ import type {
   DashboardLineage,
   ChartEntity,
   DashboardEntity,
+  DatasetEntity,
+  DatabaseEntity,
 } from 'src/hooks/apiResources/lineage';
 import Echart from '../../../plugins/plugin-chart-echarts/src/components/Echart';
 import type { EChartsCoreOption } from 'echarts/core';
@@ -68,6 +71,77 @@ const LegendItem = styled.div<{ color: string }>`
   `}
 `;
 
+const DetailsPanel = styled.div`
+  ${({ theme }) => `
+    padding: ${theme.sizeUnit * 4}px;
+    background-color: ${theme.colorBgLayout};
+    border-top: 1px solid ${theme.colorBorder};
+    min-height: 120px;
+  `}
+`;
+
+const DetailsPanelHeader = styled.div`
+  ${({ theme }) => `
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: ${theme.sizeUnit * 3}px;
+  `}
+`;
+
+const DetailsPanelActions = styled.div`
+  ${({ theme }) => `
+    display: flex;
+    gap: ${theme.sizeUnit * 2}px;
+  `}
+`;
+
+const DetailsPanelTitle = styled.h4`
+  ${({ theme }) => `
+    margin: 0;
+    font-size: ${theme.fontSizeLG}px;
+    font-weight: ${theme.fontWeightStrong};
+    color: ${theme.colorText};
+  `}
+`;
+
+const DetailsPanelContent = styled.div`
+  ${({ theme }) => `
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.sizeUnit * 2}px;
+  `}
+`;
+
+const DetailRow = styled.div`
+  ${({ theme }) => `
+    display: flex;
+    gap: ${theme.sizeUnit * 2}px;
+    font-size: ${theme.fontSizeSM}px;
+    color: ${theme.colorText};
+  `}
+`;
+
+const DetailLabel = styled.span`
+  ${({ theme }) => `
+    font-weight: ${theme.fontWeightStrong};
+    min-width: 100px;
+  `}
+`;
+
+const DetailValue = styled.span`
+  ${({ theme }) => `
+    color: ${theme.colorTextSecondary};
+  `}
+`;
+
+type NodeDetails = {
+  name: string;
+  type: 'database' | 'dataset' | 'chart' | 'dashboard';
+  id?: number;
+  additionalInfo?: Record<string, any>;
+};
+
 type LineageViewProps = {
   lineageResource:
     | Resource<DatasetLineage>
@@ -78,6 +152,204 @@ type LineageViewProps = {
 
 const LineageView: FC<LineageViewProps> = ({ lineageResource, entityType }) => {
   const theme = useTheme();
+  const [selectedNode, setSelectedNode] = useState<NodeDetails | null>(null);
+
+  // Create a mapping of node names to their details
+  const nodeDetailsMap = useMemo(() => {
+    if (
+      lineageResource.status !== ResourceStatus.Complete ||
+      !lineageResource.result
+    ) {
+      return new Map<string, NodeDetails>();
+    }
+
+    const data = lineageResource.result;
+    const map = new Map<string, NodeDetails>();
+
+    if (entityType === 'dataset' && 'dataset' in data) {
+      const { dataset, upstream, downstream } = data as DatasetLineage;
+
+      // Add current dataset
+      map.set(dataset.name, {
+        name: dataset.name,
+        type: 'dataset',
+        id: dataset.id,
+        additionalInfo: {
+          schema: dataset.schema,
+          table_name: dataset.table_name,
+          database_name: dataset.database_name,
+        },
+      });
+
+      // Add upstream database
+      if (upstream?.database) {
+        map.set(upstream.database.database_name, {
+          name: upstream.database.database_name,
+          type: 'database',
+          id: upstream.database.id,
+        });
+      }
+
+      // Add downstream charts
+      if (downstream?.charts?.result) {
+        downstream.charts.result.forEach((chart: ChartEntity) => {
+          map.set(chart.slice_name, {
+            name: chart.slice_name,
+            type: 'chart',
+            id: chart.id,
+            additionalInfo: {
+              viz_type: chart.viz_type,
+            },
+          });
+        });
+      }
+
+      // Add downstream dashboards
+      if (downstream?.dashboards?.result) {
+        downstream.dashboards.result.forEach((dashboard: DashboardEntity) => {
+          map.set(dashboard.title, {
+            name: dashboard.title,
+            type: 'dashboard',
+            id: dashboard.id,
+            additionalInfo: {
+              slug: dashboard.slug,
+            },
+          });
+        });
+      }
+    } else if (entityType === 'chart' && 'chart' in data) {
+      const { chart, upstream, downstream } = data as ChartLineage;
+
+      // Add current chart
+      map.set(chart.slice_name, {
+        name: chart.slice_name,
+        type: 'chart',
+        id: chart.id,
+        additionalInfo: {
+          viz_type: chart.viz_type,
+        },
+      });
+
+      // Add upstream dataset
+      if (upstream?.dataset) {
+        map.set(upstream.dataset.name, {
+          name: upstream.dataset.name,
+          type: 'dataset',
+          id: upstream.dataset.id,
+          additionalInfo: {
+            schema: upstream.dataset.schema,
+            table_name: upstream.dataset.table_name,
+          },
+        });
+      }
+
+      // Add upstream database
+      if (upstream?.database) {
+        map.set(upstream.database.database_name, {
+          name: upstream.database.database_name,
+          type: 'database',
+          id: upstream.database.id,
+        });
+      }
+
+      // Add downstream dashboards
+      if (downstream?.dashboards?.result) {
+        downstream.dashboards.result.forEach((dashboard: DashboardEntity) => {
+          map.set(dashboard.title, {
+            name: dashboard.title,
+            type: 'dashboard',
+            id: dashboard.id,
+            additionalInfo: {
+              slug: dashboard.slug,
+            },
+          });
+        });
+      }
+    } else if (entityType === 'dashboard' && 'dashboard' in data) {
+      const { dashboard, upstream } = data as DashboardLineage;
+
+      // Add current dashboard
+      map.set(dashboard.title, {
+        name: dashboard.title,
+        type: 'dashboard',
+        id: dashboard.id,
+        additionalInfo: {
+          slug: dashboard.slug,
+        },
+      });
+
+      // First pass: detect duplicate chart names
+      const chartNameCounts = new Map<string, number>();
+      if (upstream?.charts?.result) {
+        upstream.charts.result.forEach((chart: ChartEntity) => {
+          const count = chartNameCounts.get(chart.slice_name) || 0;
+          chartNameCounts.set(chart.slice_name, count + 1);
+        });
+      }
+
+      // Add upstream charts
+      if (upstream?.charts?.result) {
+        upstream.charts.result.forEach((chart: ChartEntity) => {
+          // Only append ID if there are duplicate names
+          const hasDuplicate = (chartNameCounts.get(chart.slice_name) || 0) > 1;
+          const chartNodeName = hasDuplicate
+            ? `${chart.slice_name} (#${chart.id})`
+            : chart.slice_name;
+          map.set(chartNodeName, {
+            name: chart.slice_name,
+            type: 'chart',
+            id: chart.id,
+            additionalInfo: {
+              viz_type: chart.viz_type,
+            },
+          });
+        });
+      }
+
+      // Add upstream datasets
+      if (upstream?.datasets?.result) {
+        upstream.datasets.result.forEach((dataset: DatasetEntity) => {
+          map.set(dataset.name, {
+            name: dataset.name,
+            type: 'dataset',
+            id: dataset.id,
+            additionalInfo: {
+              schema: dataset.schema,
+              table_name: dataset.table_name,
+            },
+          });
+        });
+      }
+
+      // Add upstream databases
+      if (upstream?.databases?.result) {
+        upstream.databases.result.forEach((database: DatabaseEntity) => {
+          map.set(database.database_name, {
+            name: database.database_name,
+            type: 'database',
+            id: database.id,
+          });
+        });
+      }
+    }
+
+    return map;
+  }, [lineageResource, entityType]);
+
+  // Handle node click
+  const handleNodeClick = useCallback((params: any) => {
+    if (params.dataType === 'node') {
+      const nodeName = params.name;
+      const nodeDetails = nodeDetailsMap.get(nodeName);
+      if (nodeDetails) {
+        setSelectedNode(nodeDetails);
+      }
+    }
+    // Always stop event propagation to prevent tooltip issues
+    if (params.event) {
+      params.event.stop();
+    }
+  }, [nodeDetailsMap]);
 
   const echartOptions: EChartsCoreOption | null = useMemo(() => {
     if (
@@ -189,14 +461,30 @@ const LineageView: FC<LineageViewProps> = ({ lineageResource, entityType }) => {
       // Add current dashboard node (right) - label inside
       addNode(dashboard.title, theme.colorPrimary, 'inside');
 
+      // First pass: detect duplicate chart names
+      const chartNameCounts = new Map<string, number>();
+      if (upstream?.charts?.result) {
+        upstream.charts.result.forEach((chart: ChartEntity) => {
+          const count = chartNameCounts.get(chart.slice_name) || 0;
+          chartNameCounts.set(chart.slice_name, count + 1);
+        });
+      }
+
       // Create a map of chart id to chart for easy lookup
       const chartMap = new Map<number, ChartEntity>();
+      const chartNodeNames = new Map<number, string>(); // Map chart ID to its node name
       if (upstream?.charts?.result) {
         upstream.charts.result.forEach((chart: ChartEntity) => {
           chartMap.set(chart.id, chart);
+          // Only append ID if there are duplicate names
+          const hasDuplicate = (chartNameCounts.get(chart.slice_name) || 0) > 1;
+          const chartNodeName = hasDuplicate
+            ? `${chart.slice_name} (#${chart.id})`
+            : chart.slice_name;
+          chartNodeNames.set(chart.id, chartNodeName);
           // Charts are upstream - label on left
-          addNode(chart.slice_name, theme.colorInfo, 'left');
-          addLink(chart.slice_name, dashboard.title);
+          addNode(chartNodeName, theme.colorInfo, 'left');
+          addLink(chartNodeName, dashboard.title);
         });
       }
 
@@ -207,15 +495,18 @@ const LineageView: FC<LineageViewProps> = ({ lineageResource, entityType }) => {
           datasetMap.set(dataset.id, dataset);
           // Datasets are upstream - label on left
           addNode(dataset.name, theme.colorSuccess, 'left');
+        });
+      }
 
-          // Link datasets to their specific charts using chart_ids
-          if (dataset.chart_ids && dataset.chart_ids.length > 0) {
-            dataset.chart_ids.forEach(chartId => {
-              const chart = chartMap.get(chartId);
-              if (chart) {
-                addLink(dataset.name, chart.slice_name);
-              }
-            });
+      // Link charts to their specific datasets using dataset_id from each chart
+      if (upstream?.charts?.result) {
+        upstream.charts.result.forEach((chart: ChartEntity) => {
+          if (chart.dataset_id) {
+            const dataset = datasetMap.get(chart.dataset_id);
+            const chartNodeName = chartNodeNames.get(chart.id);
+            if (dataset && chartNodeName) {
+              addLink(dataset.name, chartNodeName);
+            }
           }
         });
       }
@@ -249,8 +540,7 @@ const LineageView: FC<LineageViewProps> = ({ lineageResource, entityType }) => {
         type: 'sankey',
       },
       tooltip: {
-        trigger: 'item',
-        triggerOn: 'mousemove',
+        show: false,
       },
     };
   }, [lineageResource, entityType, theme]);
@@ -297,6 +587,20 @@ const LineageView: FC<LineageViewProps> = ({ lineageResource, entityType }) => {
     return <Empty description={t('No lineage data available')} />;
   }
 
+  // Helper function to get the URL for an entity
+  const getEntityUrl = (nodeDetails: NodeDetails): string => {
+    switch (nodeDetails.type) {
+      case 'dashboard':
+        return `/superset/dashboard/${nodeDetails.id}/`;
+      case 'chart':
+        return `/explore/?slice_id=${nodeDetails.id}`;
+      case 'dataset':
+        return `/dataset/${nodeDetails.id}`;
+      default:
+        return '#';
+    }
+  };
+
   return (
     <LineageContainer>
       <Legend>
@@ -308,11 +612,64 @@ const LineageView: FC<LineageViewProps> = ({ lineageResource, entityType }) => {
       </Legend>
       <Echart
         refs={{}}
-        height={600}
+        height={selectedNode ? 450 : 600}
         width={800}
         echartOptions={echartOptions}
         vizType="sankey"
+        eventHandlers={{
+          click: handleNodeClick,
+        }}
       />
+      {selectedNode && (
+        <DetailsPanel>
+          <DetailsPanelHeader>
+            <DetailsPanelTitle>
+              {selectedNode.type.charAt(0).toUpperCase() + selectedNode.type.slice(1)} Details
+            </DetailsPanelTitle>
+            <DetailsPanelActions>
+              {(selectedNode.type === 'dashboard' || selectedNode.type === 'chart') && (
+                <Button
+                  buttonStyle="primary"
+                  buttonSize="small"
+                  onClick={() => {
+                    window.location.href = getEntityUrl(selectedNode);
+                  }}
+                >
+                  {t('Open')} {selectedNode.type.charAt(0).toUpperCase() + selectedNode.type.slice(1)}
+                </Button>
+              )}
+              <Button
+                buttonStyle="tertiary"
+                buttonSize="small"
+                onClick={() => setSelectedNode(null)}
+              >
+                {t('Close')}
+              </Button>
+            </DetailsPanelActions>
+          </DetailsPanelHeader>
+          <DetailsPanelContent>
+            <DetailRow>
+              <DetailLabel>{t('Name')}:</DetailLabel>
+              <DetailValue>{selectedNode.name}</DetailValue>
+            </DetailRow>
+            {selectedNode.id && (
+              <DetailRow>
+                <DetailLabel>{t('ID')}:</DetailLabel>
+                <DetailValue>{selectedNode.id}</DetailValue>
+              </DetailRow>
+            )}
+            {selectedNode.additionalInfo &&
+              Object.entries(selectedNode.additionalInfo).map(([key, value]) => (
+                <DetailRow key={key}>
+                  <DetailLabel>
+                    {key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, ' ')}:
+                  </DetailLabel>
+                  <DetailValue>{String(value)}</DetailValue>
+                </DetailRow>
+              ))}
+          </DetailsPanelContent>
+        </DetailsPanel>
+      )}
     </LineageContainer>
   );
 };

--- a/superset-frontend/src/features/lineage/index.ts
+++ b/superset-frontend/src/features/lineage/index.ts
@@ -16,20 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export { skipToken } from '@reduxjs/toolkit/query/react';
-export {
-  useApiResourceFullBody,
-  useApiV1Resource,
-  useTransformedResource,
-} from './apiResources';
 
-// A central catalog of API Resource hooks.
-// Add new API hooks here, organized under
-// different files for different resource types.
-export * from './catalogs';
-export * from './charts';
-export * from './dashboards';
-export * from './lineage';
-export * from './tables';
-export * from './schemas';
-export * from './queryValidations';
+export { default as LineageView } from './LineageView';
+export { default as LineageModal } from './LineageModal';

--- a/superset-frontend/src/hooks/apiResources/lineage.ts
+++ b/superset-frontend/src/hooks/apiResources/lineage.ts
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useApiV1Resource } from './apiResources';
+
+// Database entity type
+export type DatabaseEntity = {
+  id: number;
+  database_name: string;
+  backend: string;
+};
+
+// Dataset entity type
+export type DatasetEntity = {
+  id: number;
+  name: string;
+  schema: string | null;
+  table_name: string;
+  database_id: number;
+  database_name: string;
+  chart_ids?: number[];
+};
+
+// Chart entity type
+export type ChartEntity = {
+  id: number;
+  slice_name: string;
+  viz_type: string;
+  dashboard_ids?: number[];
+  dataset_id?: number;
+};
+
+// Dashboard entity type
+export type DashboardEntity = {
+  id: number;
+  title: string;
+  slug: string;
+  chart_ids?: number[];
+};
+
+// Dataset lineage response type
+export type DatasetLineage = {
+  dataset: DatasetEntity;
+  upstream: {
+    database: DatabaseEntity;
+  };
+  downstream: {
+    charts: {
+      count: number;
+      result: ChartEntity[];
+    };
+    dashboards: {
+      count: number;
+      result: DashboardEntity[];
+    };
+  };
+};
+
+// Chart lineage response type
+export type ChartLineage = {
+  chart: ChartEntity & {
+    datasource_id: number;
+    datasource_type: string;
+  };
+  upstream: {
+    dataset: DatasetEntity;
+    database: DatabaseEntity;
+  };
+  downstream: {
+    dashboards: {
+      count: number;
+      result: DashboardEntity[];
+    };
+  };
+};
+
+// Dashboard lineage response type
+export type DashboardLineage = {
+  dashboard: DashboardEntity & {
+    published: boolean;
+  };
+  upstream: {
+    charts: {
+      count: number;
+      result: ChartEntity[];
+    };
+    datasets: {
+      count: number;
+      result: DatasetEntity[];
+    };
+    databases: {
+      count: number;
+      result: DatabaseEntity[];
+    };
+  };
+  downstream: null;
+};
+
+/**
+ * Hook to fetch lineage data for a dataset
+ * @param idOrUuid Dataset ID or UUID
+ */
+export const useDatasetLineage = (idOrUuid: string | number) =>
+  useApiV1Resource<DatasetLineage>(`/api/v1/dataset/${idOrUuid}/lineage`);
+
+/**
+ * Hook to fetch lineage data for a chart
+ * @param idOrUuid Chart ID or UUID
+ */
+export const useChartLineage = (idOrUuid: string | number) =>
+  useApiV1Resource<ChartLineage>(`/api/v1/chart/${idOrUuid}/lineage`);
+
+/**
+ * Hook to fetch lineage data for a dashboard
+ * @param idOrSlug Dashboard ID or slug
+ */
+export const useDashboardLineage = (idOrSlug: string | number) =>
+  useApiV1Resource<DashboardLineage>(`/api/v1/dashboard/${idOrSlug}/lineage`);

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -402,12 +402,12 @@ class ChartRestApi(BaseSupersetModelRestApi):
             },
         }
 
-        return self.response(
-            200,
-            chart=chart_info,
-            upstream=upstream,
-            downstream=downstream,
-        )
+        result = {
+            "chart": chart_info,
+            "upstream": upstream,
+            "downstream": downstream,
+        }
+        return self.response(200, result=result)
 
     @expose("/", methods=("POST",))
     @protect()

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1704,6 +1704,53 @@ class ChartGetResponseSchema(Schema):
     datasource_uuid = fields.UUID(attribute="table.uuid")
 
 
+class ChartLineageChartSchema(Schema):
+    id = fields.Integer()
+    slice_name = fields.String()
+    viz_type = fields.String()
+
+
+class ChartLineageDatasetSchema(Schema):
+    id = fields.Integer()
+    name = fields.String()
+    database_id = fields.Integer()
+    database_name = fields.String()
+    schema = fields.String(allow_none=True)
+    table_name = fields.String()
+
+
+class ChartLineageDatabaseSchema(Schema):
+    id = fields.Integer()
+    database_name = fields.String()
+    backend = fields.String()
+
+
+class ChartLineageDashboardSchema(Schema):
+    id = fields.Integer()
+    title = fields.String()
+    slug = fields.String()
+
+
+class ChartLineageUpstreamSchema(Schema):
+    dataset = fields.Nested(ChartLineageDatasetSchema, allow_none=True)
+    database = fields.Nested(ChartLineageDatabaseSchema, allow_none=True)
+
+
+class ChartLineageDownstreamDashboardsSchema(Schema):
+    count = fields.Integer()
+    result = fields.List(fields.Nested(ChartLineageDashboardSchema))
+
+
+class ChartLineageDownstreamSchema(Schema):
+    dashboards = fields.Nested(ChartLineageDownstreamDashboardsSchema)
+
+
+class ChartLineageResponseSchema(Schema):
+    chart = fields.Nested(ChartLineageChartSchema)
+    upstream = fields.Nested(ChartLineageUpstreamSchema)
+    downstream = fields.Nested(ChartLineageDownstreamSchema)
+
+
 CHART_SCHEMAS = (
     ChartCacheWarmUpRequestSchema,
     ChartCacheWarmUpResponseSchema,
@@ -1730,4 +1777,5 @@ CHART_SCHEMAS = (
     ChartGetResponseSchema,
     ChartCacheScreenshotResponseSchema,
     GetFavStarIdsSchema,
+    ChartLineageResponseSchema,
 )

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -174,6 +174,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "put_filters": "write",
     "put_colors": "write",
     "sync_permissions": "write",
+    "lineage": "read",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -593,12 +593,12 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
             },
         }
 
-        return self.response(
-            200,
-            dashboard=dashboard_info,
-            upstream=upstream,
-            downstream=None,
-        )
+        result = {
+            "dashboard": dashboard_info,
+            "upstream": upstream,
+            "downstream": None,
+        }
+        return self.response(200, result=result)
 
     @expose("/<id_or_slug>/datasets", methods=("GET",))
     @protect()

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -557,3 +557,60 @@ class CacheScreenshotSchema(Schema):
         fields.List(fields.Str(), validate=lambda x: len(x) == 2), required=False
     )
     permalinkKey = fields.Str(required=False)  # noqa: N815
+
+
+class DashboardLineageDashboardSchema(Schema):
+    id = fields.Integer()
+    title = fields.String()
+    slug = fields.String()
+    published = fields.Boolean()
+
+
+class DashboardLineageChartSchema(Schema):
+    id = fields.Integer()
+    slice_name = fields.String()
+    viz_type = fields.String()
+    dataset_id = fields.Integer()
+
+
+class DashboardLineageDatasetSchema(Schema):
+    id = fields.Integer()
+    name = fields.String()
+    database_id = fields.Integer()
+    database_name = fields.String()
+    schema = fields.String(allow_none=True)
+    table_name = fields.String()
+    chart_ids = fields.List(fields.Integer())
+
+
+class DashboardLineageDatabaseSchema(Schema):
+    id = fields.Integer()
+    database_name = fields.String()
+    backend = fields.String()
+
+
+class DashboardLineageUpstreamChartsSchema(Schema):
+    count = fields.Integer()
+    result = fields.List(fields.Nested(DashboardLineageChartSchema))
+
+
+class DashboardLineageUpstreamDatasetsSchema(Schema):
+    count = fields.Integer()
+    result = fields.List(fields.Nested(DashboardLineageDatasetSchema))
+
+
+class DashboardLineageUpstreamDatabasesSchema(Schema):
+    count = fields.Integer()
+    result = fields.List(fields.Nested(DashboardLineageDatabaseSchema))
+
+
+class DashboardLineageUpstreamSchema(Schema):
+    charts = fields.Nested(DashboardLineageUpstreamChartsSchema)
+    datasets = fields.Nested(DashboardLineageUpstreamDatasetsSchema)
+    databases = fields.Nested(DashboardLineageUpstreamDatabasesSchema)
+
+
+class DashboardLineageResponseSchema(Schema):
+    dashboard = fields.Nested(DashboardLineageDashboardSchema)
+    upstream = fields.Nested(DashboardLineageUpstreamSchema)
+    downstream = fields.Field(allow_none=True)

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -897,9 +897,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             "id": dataset.id,
             "name": dataset.name,
             "database_id": dataset.database_id,
-            "database_name": dataset.database.database_name
-            if dataset.database
-            else None,
+            "database_name": (
+                dataset.database.database_name if dataset.database else None
+            ),
             "schema": dataset.schema,
             "table_name": dataset.table_name,
         }

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -959,12 +959,12 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             },
         }
 
-        return self.response(
-            200,
-            dataset=dataset_info,
-            upstream=upstream,
-            downstream=downstream,
-        )
+        result = {
+            "dataset": dataset_info,
+            "upstream": upstream,
+            "downstream": downstream,
+        }
+        return self.response(200, result=result)
 
     @expose("/", methods=("DELETE",))
     @protect()

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -234,6 +234,60 @@ class DatasetRelatedObjectsResponse(Schema):
     dashboards = fields.Nested(DatasetRelatedDashboards)
 
 
+class DatasetLineageDatasetSchema(Schema):
+    id = fields.Integer()
+    name = fields.String()
+    database_id = fields.Integer()
+    database_name = fields.String()
+    schema = fields.String(allow_none=True)
+    table_name = fields.String()
+
+
+class DatasetLineageDatabaseSchema(Schema):
+    id = fields.Integer()
+    database_name = fields.String()
+    backend = fields.String()
+
+
+class DatasetLineageChartSchema(Schema):
+    id = fields.Integer()
+    slice_name = fields.String()
+    viz_type = fields.String()
+    dashboard_ids = fields.List(fields.Integer())
+
+
+class DatasetLineageDashboardSchema(Schema):
+    id = fields.Integer()
+    title = fields.String()
+    slug = fields.String()
+    chart_ids = fields.List(fields.Integer())
+
+
+class DatasetLineageUpstreamSchema(Schema):
+    database = fields.Nested(DatasetLineageDatabaseSchema, allow_none=True)
+
+
+class DatasetLineageDownstreamChartsSchema(Schema):
+    count = fields.Integer()
+    result = fields.List(fields.Nested(DatasetLineageChartSchema))
+
+
+class DatasetLineageDownstreamDashboardsSchema(Schema):
+    count = fields.Integer()
+    result = fields.List(fields.Nested(DatasetLineageDashboardSchema))
+
+
+class DatasetLineageDownstreamSchema(Schema):
+    charts = fields.Nested(DatasetLineageDownstreamChartsSchema)
+    dashboards = fields.Nested(DatasetLineageDownstreamDashboardsSchema)
+
+
+class DatasetLineageResponseSchema(Schema):
+    dataset = fields.Nested(DatasetLineageDatasetSchema)
+    upstream = fields.Nested(DatasetLineageUpstreamSchema)
+    downstream = fields.Nested(DatasetLineageDownstreamSchema)
+
+
 class ImportV1ColumnSchema(Schema):
     # pylint: disable=unused-argument
     @pre_load

--- a/tests/integration_tests/fixtures/lineage.py
+++ b/tests/integration_tests/fixtures/lineage.py
@@ -1,0 +1,266 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+from superset import db
+from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
+from superset.utils.database import get_example_database
+from tests.integration_tests.dashboard_utils import create_table_metadata
+
+
+@pytest.fixture
+def lineage_test_data(app_context, load_birth_names_data):
+    """
+    Base fixture that creates a simple lineage structure and returns
+    the created entities (database, dataset, charts, dashboard).
+    """
+    database = get_example_database()
+
+    # Create dataset
+    dataset = create_table_metadata(
+        table_name="lineage_test_dataset",
+        database=database,
+    )
+    db.session.add(dataset)
+    db.session.flush()
+
+    # Create charts
+    chart1 = Slice(
+        slice_name="Lineage Test Chart 1",
+        viz_type="table",
+        datasource_id=dataset.id,
+        datasource_type="table",
+        params="{}",
+    )
+    chart2 = Slice(
+        slice_name="Lineage Test Chart 2",
+        viz_type="pie",
+        datasource_id=dataset.id,
+        datasource_type="table",
+        params="{}",
+    )
+    db.session.add(chart1)
+    db.session.add(chart2)
+    db.session.flush()
+
+    # Create dashboard with charts
+    dashboard = Dashboard(
+        dashboard_title="Lineage Test Dashboard",
+        slug="lineage-test-dashboard",
+        slices=[chart1, chart2],
+        published=True,
+    )
+    db.session.add(dashboard)
+    db.session.commit()
+
+    # Return the created entities
+    result = {
+        "database": database,
+        "dataset": dataset,
+        "charts": [chart1, chart2],
+        "dashboard": dashboard,
+    }
+
+    yield result
+
+    # Cleanup
+    db.session.delete(dashboard)
+    db.session.delete(chart1)
+    db.session.delete(chart2)
+    for col in dataset.columns + dataset.metrics:
+        db.session.delete(col)
+    db.session.delete(dataset)
+    db.session.commit()
+
+
+@pytest.fixture(autouse=False)
+def inject_expected_dataset_lineage(request, lineage_test_data):
+    """
+    Injects dataset lineage data into test class instance.
+    """
+    dataset = lineage_test_data["dataset"]
+    database = lineage_test_data["database"]
+    charts = lineage_test_data["charts"]
+    dashboard = lineage_test_data["dashboard"]
+
+    request.instance.dataset_lineage = {
+        "dataset_id": dataset.id,
+        "expected": {
+            "dataset": {
+                "id": dataset.id,
+                "name": dataset.name,
+                "schema": dataset.schema,
+                "table_name": dataset.table_name,
+                "database_id": database.id,
+                "database_name": database.database_name,
+            },
+            "upstream": {
+                "database": {
+                    "id": database.id,
+                    "database_name": database.database_name,
+                    "backend": database.backend,
+                }
+            },
+            "downstream": {
+                "charts": {
+                    "count": 2,
+                    "result": [
+                        {
+                            "id": charts[0].id,
+                            "slice_name": charts[0].slice_name,
+                            "viz_type": charts[0].viz_type,
+                            "dashboard_ids": [dashboard.id],
+                        },
+                        {
+                            "id": charts[1].id,
+                            "slice_name": charts[1].slice_name,
+                            "viz_type": charts[1].viz_type,
+                            "dashboard_ids": [dashboard.id],
+                        },
+                    ],
+                },
+                "dashboards": {
+                    "count": 1,
+                    "result": [
+                        {
+                            "id": dashboard.id,
+                            "title": dashboard.dashboard_title,
+                            "slug": dashboard.slug,
+                            "chart_ids": sorted([charts[0].id, charts[1].id]),
+                        }
+                    ],
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(autouse=False)
+def inject_expected_chart_lineage(request, lineage_test_data):
+    """
+    Injects chart lineage data into test class instance.
+    """
+    dataset = lineage_test_data["dataset"]
+    database = lineage_test_data["database"]
+    chart = lineage_test_data["charts"][0]  # Use first chart
+    dashboard = lineage_test_data["dashboard"]
+
+    request.instance.chart_lineage = {
+        "chart_id": chart.id,
+        "expected": {
+            "chart": {
+                "id": chart.id,
+                "slice_name": chart.slice_name,
+                "viz_type": chart.viz_type,
+            },
+            "upstream": {
+                "dataset": {
+                    "id": dataset.id,
+                    "name": dataset.name,
+                    "schema": dataset.schema,
+                    "table_name": dataset.table_name,
+                    "database_id": database.id,
+                    "database_name": database.database_name,
+                },
+                "database": {
+                    "id": database.id,
+                    "database_name": database.database_name,
+                    "backend": database.backend,
+                },
+            },
+            "downstream": {
+                "dashboards": {
+                    "count": 1,
+                    "result": [
+                        {
+                            "id": dashboard.id,
+                            "title": dashboard.dashboard_title,
+                            "slug": dashboard.slug,
+                        }
+                    ],
+                }
+            },
+        },
+    }
+
+
+@pytest.fixture(autouse=False)
+def inject_expected_dashboard_lineage(request, lineage_test_data):
+    """
+    Injects dashboard lineage data into test class instance.
+    """
+    dataset = lineage_test_data["dataset"]
+    database = lineage_test_data["database"]
+    charts = lineage_test_data["charts"]
+    dashboard = lineage_test_data["dashboard"]
+
+    request.instance.dashboard_lineage = {
+        "dashboard_id": dashboard.id,
+        "expected": {
+            "dashboard": {
+                "id": dashboard.id,
+                "title": dashboard.dashboard_title,
+                "slug": dashboard.slug,
+                "published": dashboard.published,
+            },
+            "upstream": {
+                "charts": {
+                    "count": 2,
+                    "result": [
+                        {
+                            "id": charts[0].id,
+                            "slice_name": charts[0].slice_name,
+                            "viz_type": charts[0].viz_type,
+                            "dataset_id": dataset.id,
+                        },
+                        {
+                            "id": charts[1].id,
+                            "slice_name": charts[1].slice_name,
+                            "viz_type": charts[1].viz_type,
+                            "dataset_id": dataset.id,
+                        },
+                    ],
+                },
+                "datasets": {
+                    "count": 1,
+                    "result": [
+                        {
+                            "id": dataset.id,
+                            "name": dataset.name,
+                            "schema": dataset.schema,
+                            "table_name": dataset.table_name,
+                            "database_id": database.id,
+                            "database_name": database.database_name,
+                            "chart_ids": sorted([charts[0].id, charts[1].id]),
+                        }
+                    ],
+                },
+                "databases": {
+                    "count": 1,
+                    "result": [
+                        {
+                            "id": database.id,
+                            "database_name": database.database_name,
+                            "backend": database.backend,
+                        }
+                    ],
+                },
+            },
+            "downstream": None,
+        },
+    }


### PR DESCRIPTION
### SUMMARY

This PR introduces a comprehensive lineage visualization feature that allows users to explore data relationships across datasets, charts, and dashboards using interactive Sankey diagrams.

**Three Lineage Perspectives:**

1. **Dataset Lineage**: Shows upstream database and downstream charts/dashboards that use the dataset
2. **Chart Lineage**: Displays the complete data pipeline from database → dataset → chart → dashboards
3. **Dashboard Lineage**: Reveals all upstream databases, datasets, and charts feeding into a dashboard

**Implementation:**

- **Backend**: Three new REST API endpoints (`/api/v1/lineage/{dataset|chart|dashboard}/<id>`) with proper permissions and comprehensive unit tests
- **Frontend**: LineageView component with ECharts Sankey chart, API hooks, and LineageModal for reusable display across the application

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


https://github.com/user-attachments/assets/8b7941bb-fde9-48b9-a348-02ee9b152ed3



### TESTING INSTRUCTIONS

**View Dataset Lineage:**
1. Navigate to **Data → Datasets**
2. Click on any dataset to open the edit dialog
3. Click the **Lineage** tab
4. Verify you see a Sankey diagram showing the database, dataset, and all charts/dashboards using it
5. Click on any node in the diagram and verify details appear at the bottom
6. Click **Close** to dismiss the details panel

**View Chart Lineage:**
1. Navigate to **Charts**
2. Click the three-dot menu (⋮) on any chart card
3. Select **View Lineage**
4. Verify the modal shows the data flow: database → dataset → chart → dashboards
5. Click on the chart node and click **Open Chart** to verify navigation works
6. Alternatively, open any chart in Explore view, click the header menu (⋮), and select **View Lineage**

**View Dashboard Lineage:**
1. Navigate to **Dashboards**
2. In dashboard edit mode, click the three-dot menu (⋮) on any dashboard card
3. Select **View Lineage**
4. Verify the diagram shows all databases, datasets, and charts feeding into the dashboard
5. Click on a dashboard node and click **Open Dashboard** to verify navigation
6. Alternatively, open any dashboard, click the header menu (⋮), and select **View Lineage**

**Test Interactive Features:**
- Click different nodes and verify the details panel updates with correct information
- Verify database and dataset nodes show only a **Close** button
- Verify chart and dashboard nodes show both **Open** and **Close** buttons
- Verify the legend at the top matches the node colors in the diagram

### ADDITIONAL INFORMATION
- [x] Changes UI
- [x] Introduces new feature or API
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration
- [ ] Removes existing feature or API