### PR TITLE
fix(db): prevent long database error messages from overflowing UI

### DIFF
--- a/superset-frontend/src/components/MessageToasts/Toast.tsx
+++ b/superset-frontend/src/components/MessageToasts/Toast.tsx
@@ -26,14 +26,24 @@ import { ToastType, ToastMeta } from './types';
 const ToastContainer = styled.div`
   ${({ theme }) => css`
     display: flex;
-    justify-content: space-between; // Changed from center to space-between
-    align-items: center;
+    align-items: flex-start;
+    gap: ${theme.sizeUnit * 2}px;
 
     // Content container for icon and text
     .toast__content {
       display: flex;
-      align-items: center;
-      flex: 1; // Take available space
+      align-items: flex-start;
+      gap: ${theme.sizeUnit * 2}px;
+
+      flex: 1;
+
+      max-height: 60vh;
+      overflow-y: auto;
+
+      padding-right: ${theme.sizeUnit * 2}px;
+
+      scrollbar-width: thin;
+      scrollbar-color: ${theme.colorTextLightSolid} ${theme.colorBgSpotlight};
     }
 
     .anticon {

--- a/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
@@ -47,10 +47,17 @@ const StyledToastPresenter = styled.div<VisualProps>(
     overscroll-behavior: contain;
     overflow-x: hidden;
     scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
 
-    &:hover {
-      scrollbar-color: rgba(255, 255, 255, 0.4) transparent;
+    scrollbar-color:
+      color-mix(in srgb, ${theme.colorText}, transparent 75%)
+      transparent;
+
+    &:hover,
+    &:focus-within,
+    &:active {
+      scrollbar-color:
+        color-mix(in srgb, ${theme.colorText}, transparent 60%)
+        transparent;
     }
 
     /* Chromium / WebKit */
@@ -63,18 +70,23 @@ const StyledToastPresenter = styled.div<VisualProps>(
     }
 
     &::-webkit-scrollbar-thumb {
-      background-color: rgba(255, 255, 255, 0.25);
+      background-color: color-mix(
+        in srgb,
+        ${theme.colorText},
+        transparent 75%
+      );
       border-radius: 6px;
-      opacity: 0;
-      transition: opacity 0.2s ease;
+      transition: background-color 0.2s ease;
     }
 
-    &:hover::-webkit-scrollbar-thumb {
-      opacity: 1;
-    }
-
+    &:hover::-webkit-scrollbar-thumb,
+    &:focus-within::-webkit-scrollbar-thumb,
     &:active::-webkit-scrollbar-thumb {
-      opacity: 1;
+      background-color: color-mix(
+        in srgb,
+        ${theme.colorText},
+        transparent 60%
+      );
     }
 
     .toast {
@@ -106,7 +118,7 @@ const StyledToastPresenter = styled.div<VisualProps>(
     }
 
     .toast > button {
-      color: ${theme.colorTextLightSolid};
+      color: ${theme.colorText};
       opacity: 1;
     }
 

--- a/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
@@ -33,9 +33,49 @@ const StyledToastPresenter = styled.div<VisualProps>(
     ${position === 'bottom' ? 'bottom' : 'top'}: 0px;
     right: 0px;
     margin-right: 50px;
-    margin-bottom: 50px;
+    margin-block: 50px;
     z-index: ${theme.zIndexPopupBase + 1};
     word-break: break-word;
+
+    height: calc(100vh - 100px);
+
+    display: flex;
+    flex-direction: ${position === 'bottom' ? 'column-reverse' : 'column'};
+    align-items: stretch;
+    gap: ${theme.sizeUnit * 2}px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    overflow-x: hidden;
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+
+    &:hover {
+      scrollbar-color: rgba(255, 255, 255, 0.4) transparent;
+    }
+
+    /* Chromium / WebKit */
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: rgba(255, 255, 255, 0.25);
+      border-radius: 6px;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    &:hover::-webkit-scrollbar-thumb {
+      opacity: 1;
+    }
+
+    &:active::-webkit-scrollbar-thumb {
+      opacity: 1;
+    }
 
     .toast {
       padding: ${theme.sizeUnit * 4}px;
@@ -44,6 +84,9 @@ const StyledToastPresenter = styled.div<VisualProps>(
       border-radius: ${theme.borderRadius}px;
       box-shadow: ${theme.boxShadow};
       color: ${theme.colorTextLightSolid};
+      display: flex;
+      align-items: flex-start;
+      max-height: 70vh;
       opacity: 0;
       position: relative;
       transform: translateY(-100%);


### PR DESCRIPTION
### SUMMARY
This PR fixes a UI issue where very long database error messages overflow the container and become difficult to read or copy.

The problem commonly occurs during database validation or metadata migrations (e.g. SQLite → PostgreSQL), where error output can be verbose.
The change ensures long error messages are rendered in a scrollable, readable way without truncation, improving usability while debugging database issues.

This is a frontend-only change and does not affect backend behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE
<img width="1917" height="1086" alt="Screenshot from 2026-02-05 17-12-14" src="https://github.com/user-attachments/assets/1dce87c0-838d-4407-a889-69ebf7a8bc63" />
AFTER
<img width="1917" height="1086" alt="Screenshot from 2026-02-05 17-14-25" src="https://github.com/user-attachments/assets/f1d180f3-16e0-4568-bdfe-687d580fcd94" />


### TESTING INSTRUCTIONS
Configure or migrate a Superset metadata database in a way that produces a long database error message (e.g. schema mismatch during SQLite → PostgreSQL migration)

1. Ensure a schema mismatch exists (for example, a foreign key constraint where column types differ, such as string vs uint)
2. Verify that the error message:
3. Does not overflow the UI
4. Remains fully readable
5. Can be selected and copied in full

### ADDITIONAL INFORMATION
- [x] Has associated issue: #37707
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
