### PR TITLE
fix(explore): Don't show unsaved changes modal on new charts

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -248,6 +248,147 @@ describe('ExploreChartHeader', () => {
     );
   });
 
+  test('does not show unsaved changes for new charts on initial load', async () => {
+    const props = createProps({
+      slice: null,
+      chart: {
+        ...createProps().chart,
+        sliceFormData: null,
+      },
+      formData: {
+        viz_type: VizType.Histogram,
+        datasource: '49__table',
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    expect(
+      await screen.findByText(/add the name of the chart/i),
+    ).toBeInTheDocument();
+
+    expect(useUnsavedChangesPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasUnsavedChanges: false,
+      }),
+    );
+  });
+
+  test('shows unsaved changes for new charts when user makes changes', async () => {
+    const initialFormData = {
+      viz_type: VizType.Histogram,
+      datasource: '49__table',
+      metrics: ['count'],
+    };
+
+    const modifiedFormData = {
+      ...initialFormData,
+      metrics: ['count', 'sum'],
+    };
+
+    const props = createProps({
+      slice: null,
+      chart: {
+        ...createProps().chart,
+        sliceFormData: null,
+      },
+      formData: initialFormData,
+    });
+
+    const { rerender } = render(<ExploreHeader {...props} />, {
+      useRedux: true,
+    });
+
+    // Initial render should not have unsaved changes
+    expect(useUnsavedChangesPrompt).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        hasUnsavedChanges: false,
+      }),
+    );
+
+    // Simulate user making changes
+    const modifiedProps = {
+      ...props,
+      formData: modifiedFormData,
+    };
+
+    rerender(<ExploreHeader {...modifiedProps} />, { useRedux: true });
+
+    await waitFor(() => {
+      expect(useUnsavedChangesPrompt).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          hasUnsavedChanges: true,
+        }),
+      );
+    });
+  });
+
+  test('shows unsaved changes for existing charts when form data differs from saved', async () => {
+    const savedFormData = {
+      viz_type: VizType.Histogram,
+      datasource: '49__table',
+      metrics: ['count'],
+    };
+
+    const currentFormData = {
+      ...savedFormData,
+      metrics: ['sum'],
+    };
+
+    const props = createProps({
+      formData: currentFormData,
+      chart: {
+        ...createProps().chart,
+        sliceFormData: savedFormData,
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    expect(useUnsavedChangesPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasUnsavedChanges: true,
+      }),
+    );
+  });
+
+  test('does not show unsaved changes for existing charts when form data matches saved', async () => {
+    const baseFormData = {
+      viz_type: VizType.Histogram,
+      datasource: '49__table',
+      slice_id: 318,
+      url_params: {},
+      granularity_sqla: 'time_start',
+      time_range: 'No filter',
+      all_columns_x: ['age'],
+      adhoc_filters: [],
+      row_limit: 10000,
+      groupby: null,
+      color_scheme: 'supersetColors',
+      label_colors: {},
+      link_length: '25',
+      x_axis_label: 'age',
+      y_axis_label: 'count',
+    };
+
+    const props = createProps({
+      formData: baseFormData,
+      sliceName: 'Age distribution of respondents',
+      chart: {
+        ...createProps().chart,
+        sliceFormData: { ...baseFormData },
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    expect(useUnsavedChangesPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasUnsavedChanges: false,
+      }),
+    );
+  });
+
   test('Save chart', async () => {
     const setSaveChartModalVisibilitySpy = jest.spyOn(
       saveModalActions,

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -251,6 +251,7 @@ describe('ExploreChartHeader', () => {
   test('does not show unsaved changes for new charts on initial load', async () => {
     const props = createProps({
       slice: null,
+      sliceName: '',
       chart: {
         ...createProps().chart,
         sliceFormData: null,
@@ -288,6 +289,7 @@ describe('ExploreChartHeader', () => {
 
     const props = createProps({
       slice: null,
+      sliceName: '',
       chart: {
         ...createProps().chart,
         sliceFormData: null,
@@ -312,7 +314,7 @@ describe('ExploreChartHeader', () => {
       formData: modifiedFormData,
     };
 
-    rerender(<ExploreHeader {...modifiedProps} />, { useRedux: true });
+    rerender(<ExploreHeader {...modifiedProps} />);
 
     await waitFor(() => {
       expect(useUnsavedChangesPrompt).toHaveBeenLastCalledWith(

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -250,7 +250,9 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     triggerManualSave,
   } = useUnsavedChangesPrompt({
     hasUnsavedChanges,
-    onSave: () => dispatch(setSaveChartModalVisibility(true)),
+    onSave: () => {
+      dispatch(setSaveChartModalVisibility(true));
+    },
     isSaveModalVisible,
     manualSaveOnUnsavedChanges: true,
   });

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -240,13 +240,6 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     [originalFormData, currentFormData],
   );
 
-  useEffect(() => {
-    console.log('slice:', slice);
-    console.log('sliceFormData:', sliceFormData);
-    console.log('formDiffs:', formDiffs);
-    console.log('hasUnsavedChanges:', Object.keys(formDiffs).length > 0);
-  }, [slice, sliceFormData, formDiffs]);
-
   const hasUnsavedChanges = Object.keys(formDiffs).length > 0;
 
   const {

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -212,13 +212,23 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
   const metadataBar = useExploreMetadataBar(metadata, slice ?? null);
   const oldSliceName = slice?.slice_name;
 
+  // Capture initial form data for new charts
+  const [initialFormDataForNewChart] = useState(() =>
+    !slice ? { ...formData, chartTitle: oldSliceName } : null,
+  );
+
   const originalFormData = useMemo(() => {
+    // For new charts (no slice), use the captured initial formData
+    if (!slice && initialFormDataForNewChart) {
+      return initialFormDataForNewChart;
+    }
+    // For existing charts, use the saved sliceFormData if available
     if (!sliceFormData) return {};
     return {
       ...sliceFormData,
       chartTitle: oldSliceName,
     };
-  }, [sliceFormData, oldSliceName]);
+  }, [sliceFormData, oldSliceName, slice, initialFormDataForNewChart]);
 
   const currentFormData = useMemo(
     () => ({ ...formData, chartTitle: sliceName }),
@@ -230,6 +240,15 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     [originalFormData, currentFormData],
   );
 
+  useEffect(() => {
+    console.log('slice:', slice);
+    console.log('sliceFormData:', sliceFormData);
+    console.log('formDiffs:', formDiffs);
+    console.log('hasUnsavedChanges:', Object.keys(formDiffs).length > 0);
+  }, [slice, sliceFormData, formDiffs]);
+
+  const hasUnsavedChanges = Object.keys(formDiffs).length > 0;
+
   const {
     showModal: showUnsavedChangesModal,
     setShowModal: setShowUnsavedChangesModal,
@@ -237,10 +256,8 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     handleSaveAndCloseModal,
     triggerManualSave,
   } = useUnsavedChangesPrompt({
-    hasUnsavedChanges: Object.keys(formDiffs).length > 0,
-    onSave: () => {
-      dispatch(setSaveChartModalVisibility(true));
-    },
+    hasUnsavedChanges,
+    onSave: () => dispatch(setSaveChartModalVisibility(true)),
     isSaveModalVisible,
     manualSaveOnUnsavedChanges: true,
   });

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -240,8 +240,6 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     [originalFormData, currentFormData],
   );
 
-  const hasUnsavedChanges = Object.keys(formDiffs).length > 0;
-
   const {
     showModal: showUnsavedChangesModal,
     setShowModal: setShowUnsavedChangesModal,
@@ -249,7 +247,7 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     handleSaveAndCloseModal,
     triggerManualSave,
   } = useUnsavedChangesPrompt({
-    hasUnsavedChanges,
+    hasUnsavedChanges: Object.keys(formDiffs).length > 0,
     onSave: () => {
       dispatch(setSaveChartModalVisibility(true));
     },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a bug/nuisance that when going to another page from an unmodified and new chart triggering unsaved changes modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

https://github.com/user-attachments/assets/e41d0390-0c0d-4f9f-88f6-513f95a6e055

After:


https://github.com/user-attachments/assets/0b25c2da-952f-4f57-b5cc-708bbfb68884



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a chart
2. Leave chart page without making any changes
3. Unsaved changes modal should not pop up unless there are actual unsaved changes.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
