### PR TITLE
feat(translations): make Radar chart label positions translatable

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -35,7 +35,7 @@ import {
   getStandardizedControls,
 } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA } from './types';
-import { LABEL_POSITION } from '../constants';
+import { LabelPositionEnum } from '../types';
 import { legendSection } from '../controls';
 
 const { labelType, labelPosition, numberFormat, showLabels, isCircle } =
@@ -71,6 +71,22 @@ const radarMetricMinValue: { name: string; config: ControlFormItemSpec } = {
     validators: [validateNumber],
   },
 };
+
+const getLabelPositionOptions = (): [LabelPositionEnum, string][] => [
+  [LabelPositionEnum.Top, t('Top')],
+  [LabelPositionEnum.Left, t('Left')],
+  [LabelPositionEnum.Right, t('Right')],
+  [LabelPositionEnum.Bottom, t('Bottom')],
+  [LabelPositionEnum.Inside, t('Inside')],
+  [LabelPositionEnum.InsideLeft, t('Inside left')],
+  [LabelPositionEnum.InsideRight, t('Inside right')],
+  [LabelPositionEnum.InsideTop, t('Inside top')],
+  [LabelPositionEnum.InsideBottom, t('Inside bottom')],
+  [LabelPositionEnum.InsideTopLeft, t('Inside top left')],
+  [LabelPositionEnum.InsideBottomLeft, t('Inside bottom left')],
+  [LabelPositionEnum.InsideTopRight, t('Inside top right')],
+  [LabelPositionEnum.InsideBottomRight, t('Inside bottom right')],
+];
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -136,7 +152,7 @@ const config: ControlPanelConfig = {
               freeForm: false,
               label: t('Label position'),
               renderTrigger: true,
-              choices: LABEL_POSITION,
+              choices: getLabelPositionOptions(),
               default: labelPosition,
               description: D3_FORMAT_DOCS,
             },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -21,7 +21,6 @@ import { t } from '@apache-superset/core';
 import { JsonValue, TimeGranularity } from '@superset-ui/core';
 import { ReactNode } from 'react';
 import {
-  LabelPositionEnum,
   LegendFormData,
   LegendOrientation,
   LegendType,
@@ -49,22 +48,6 @@ export const TIMESERIES_CONSTANTS = {
   // Min right padding (px) for horizontal bar charts to ensure value labels are fully visible
   horizontalBarLabelRightPadding: 70,
 };
-
-export const LABEL_POSITION: [LabelPositionEnum, string][] = [
-  [LabelPositionEnum.Top, 'Top'],
-  [LabelPositionEnum.Left, 'Left'],
-  [LabelPositionEnum.Right, 'Right'],
-  [LabelPositionEnum.Bottom, 'Bottom'],
-  [LabelPositionEnum.Inside, 'Inside'],
-  [LabelPositionEnum.InsideLeft, 'Inside left'],
-  [LabelPositionEnum.InsideRight, 'Inside right'],
-  [LabelPositionEnum.InsideTop, 'Inside top'],
-  [LabelPositionEnum.InsideBottom, 'Inside bottom'],
-  [LabelPositionEnum.InsideTopLeft, 'Inside top left'],
-  [LabelPositionEnum.InsideBottomLeft, 'Inside bottom left'],
-  [LabelPositionEnum.InsideTopRight, 'Inside top right'],
-  [LabelPositionEnum.InsideBottomRight, 'Inside bottom right'],
-];
 
 export enum OpacityEnum {
   Transparent = 0,


### PR DESCRIPTION
### SUMMARY

**Adopted from #33940 - Originally by @rusackas**

This PR adopts and applies the core feature from #33940: making label position options in the Radar chart translatable.

**Changes:**
- Wrap Radar chart label position strings with `t()` for translation support
- Move the `LABEL_POSITION` constant from `constants.ts` to a local `getLabelPositionOptions()` function in `controlPanel.tsx`
- Remove the unused `LabelPositionEnum` import from `constants.ts`

**Note about translations update:** The original PR (#33940) also included a batch update of all translation `.po/.pot` files. Per user guidance, the translation file conflicts should accept upstream/master versions, so this PR focuses only on the code changes that enable the new translatable strings. The translation files will be automatically updated during the next translation extraction cycle.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - No visual changes. The label position dropdown will display the same strings, but they will now be translatable.

### TESTING INSTRUCTIONS

1. Navigate to a Radar chart in Explore view
2. Open the "Chart Options" section
3. Find the "Label position" dropdown
4. Verify the dropdown still displays all label position options (Top, Left, Right, Bottom, Inside, Inside left, etc.)
5. If running with a non-English locale, verify the label positions are now translated

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #29479
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

Generated with [Claude Code](https://claude.com/claude-code)