### PR TITLE
fix(translations): remove corrupted text from Spanish translation file

### DIFF
--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -11357,33 +11357,7 @@ msgid "Tree layout"
 msgstr "Diseño del árbol"
 
 msgid "Tree orientation"
-Findings (brief):
-
-- No git merge conflict markers found (no <<<<<<< / ======= / >>>>>>>).
-- PO header mismatch: "Language: en" — this is an Spanish file; set to "es".
-- Duplicate msgid entries with conflicting/empty translations:
-    - " at line %(line)d" — one entry has " en la línea %(line)d", another has an empty msgstr.
-    - "Dashboard cannot be copied due to invalid parameters." — appears multiple times with different/empty msgstr values.
-    - "%(subtitle)s\nThis may be triggered by:\n %(issue)s" — msgstr is empty in one occurrence.
-    - There are other repeated msgids with one occurrence left untranslated (examples: search for repeated msgid strings with one msgstr == "").
-- Empty translations (examples):
-    - msgid "%(subtitle)s\nThis may be triggered by:\n %(issue)s" → msgstr "".
-    - Several other msgid entries have msgstr "" (scan for msgstr "" occurrences).
-- Fuzzy entries present (e.g. entries annotated "#, fuzzy") — these need review and removal of the fuzzy flag after correction.
-- Typo in a translation: msgid "This action will permanently delete the user." → msgstr contains "uduario." (should be "usuario.").
-
-Recommended next steps:
-- Fix header Language to "es".
-- Remove/fix duplicate msgids: consolidate into a single entry and keep the correct translation.
-- Fill in missing msgstr values (or mark as untranslated intentionally).
-- Review and resolve fuzzy entries, then remove the "fuzzy" flag.
-- Fix obvious typos (e.g., "uduario" → "usuario").
-
-If you want, I can produce a patch that:
-- updates header Language to "es",
-- removes duplicate entries by keeping the first translated occurrence,
-- lists all msgids with empty msgstr for you to translate,
-or show exact locations (line ranges) for each problem. Which would you prefer?
+msgstr "Orientación del árbol"
 
 msgid "Treemap"
 msgstr "Diagrama de árbol"


### PR DESCRIPTION
## Summary

- Removes LLM analysis output that was accidentally committed to the Spanish `messages.po` file
- This garbage text was preventing the translation file from compiling with `pybabel compile`
- Adds the missing Spanish translation for "Tree orientation" → "Orientación del árbol"

## Before

The Spanish translation file contained ~27 lines of what appears to be LLM analysis output embedded directly in the .po file, causing compilation to fail with parse errors.

## After

File compiles successfully and all translation catalogs can be built.

## Testing Instructions

```bash
pybabel compile -d superset/translations -l es
```

Should complete without parse errors (placeholder warnings are pre-existing and unrelated).

## Additional Information

Discovered while working on PR #33940 - the translation compilation revealed this pre-existing corruption in the Spanish file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)