### PR TITLE
fix(histogram): prevent SettingWithCopyWarning in pandas histogram postprocessing

### DIFF
--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -48,6 +48,9 @@ def histogram(
     if groupby is None:
         groupby = []
 
+    # Create an explicit copy to avoid SettingWithCopyWarning
+    df = df.copy()
+
     # drop empty values from the target column
     df = df.dropna(subset=[column])
     if df.empty:


### PR DESCRIPTION
## Problem
The histogram pandas postprocessing function was throwing a SettingWithCopyWarning in Superset 6.0.0rc4 logs when modifying DataFrame column values after dropping NA values.

## Solution
Add an explicit `df.copy()` at the beginning of the function to ensure we're working with a copy of the DataFrame, preventing the SettingWithCopyWarning.

## Changes
- Added explicit copy of DataFrame before modifications

Fixes #36530