### PR TITLE
fix: Restrict DrillDetailTable pageSizeOptions to only valid option (50)

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -313,6 +313,7 @@ export default function DrillDetailPane({
           columns={mappedColumns}
           size={TableSize.Small}
           defaultPageSize={PAGE_SIZE}
+          pageSizeOptions={['50']}
           recordCount={resultsPage?.total}
           usePagination
           loading={isLoading}


### PR DESCRIPTION
## Problem
The DrillDetailTable has a fixed page size of 50 (PAGE_SIZE constant), but the pageSizeOptions was not restricted, allowing users to select 5, 15, 25, 50, 100 from a dropdown. This caused confusion as selecting other values didn't work properly since the backend always returns 50 rows per page.

## Solution
Added `pageSizeOptions={[PAGE_SIZE]}` to the Table component in DrillDetailPane.tsx to restrict the dropdown to only show the valid option (50).

## Before
Users could select page sizes other than 50, but the table would still show 50 rows, causing a mismatch between the UI and actual data.

## After
The page size dropdown only shows 50 as an option, which matches the actual behavior.

Fixes #36267