### PR TITLE
feat(ci): add GHA workflow to sync lockfiles for version bumping PRs in frontend's npm workspaces

### DIFF
--- a/.github/workflows/sync-lockfile-for-dependabot-prs-in-frontend-workspaces.yml
+++ b/.github/workflows/sync-lockfile-for-dependabot-prs-in-frontend-workspaces.yml
@@ -1,0 +1,38 @@
+name: "Sync lockfile for Dependabot PRs in frontend workspaces"
+
+on:
+  pull_request:
+    paths:
+      - 'superset-frontend/packages/**'
+      - 'superset-frontend/plugins/**'
+
+jobs:
+  sync-lockfile-for-npm-dependabot-prs:
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: './superset-frontend/.nvmrc'
+
+      - name: Sync lockfile
+        run: npm install
+
+      - name: Commit changes
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add .
+          # Only commit if there are actual change in lockfile
+          git diff-index --quiet HEAD || git commit -m "chore: sync lockfile"
+          git push
+        continue-on-error: true


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(ci): add GHA workflow to sync lockfiles for version bumping PRs in frontend's npm workspaces

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

During my usual maintenance PR review session, I couldn't help but noticing lots of Dependabot PRs that bumps version for deps in `superset-frontend/packages/*` or `superset-frontend/plugins/*` couldn't pass CI due to lack of lockfile sync in the root dir.

<img width="990" height="748" alt="image" src="https://github.com/user-attachments/assets/416d1a80-7b2b-4b46-b348-59f1f9e6e105" />
<img width="1113" height="456" alt="image" src="https://github.com/user-attachments/assets/8b880e61-0abe-4eae-bd02-3f539cd3d4fc" />


This PR is to rectify such flaw by running an additional `npm install` command for any PRs opened by Dependabot in described directories.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
This can only be tested after this PR got merged. If there are any issues, there'll be follow up PRs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
