### PR TITLE
fix: Fix SettingWithCopyWarning in histogram.py and allow typing comma in D3 format

### DIFF
--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -49,7 +49,7 @@ def histogram(
         groupby = []
 
     # drop empty values from the target column
-    df = df.dropna(subset=[column])
+    df = df.dropna(subset=[column]).copy()
     if df.empty:
         return df
 


### PR DESCRIPTION
This PR contains two fixes:

## Fix 1: SettingWithCopyWarning in histogram.py
Add .copy() after dropna() to avoid pandas SettingWithCopyWarning. This ensures we're working with a copy of the DataFrame before modifying.

Fixes #36530

## Fix 2: Allow typing comma in D3 format for Table chart
The Select component uses TOKEN_SEPARATORS which includes comma by default. This prevents users from typing commas in D3 format strings for table charts.

Add tokenSeparators prop to ControlFormItemSpec and set it to empty array for d3NumberFormat and d3TimeFormat controls to disable token separation.

Fixes #37038