### PR TITLE
fix: allow comma typing in D3 format for Table chart

### DIFF
--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/constants.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/constants.tsx
@@ -58,6 +58,7 @@ const d3NumberFormat: ControlFormItemSpec<'Select'> = {
   creatable: true,
   minWidth: '14em',
   debounceDelay: 500,
+  commaChoosesOption: false,
 };
 
 const d3TimeFormat: ControlFormItemSpec<'Select'> = {
@@ -72,6 +73,7 @@ const d3TimeFormat: ControlFormItemSpec<'Select'> = {
   creatable: true,
   minWidth: '10em',
   debounceDelay: 500,
+  commaChoosesOption: false,
 };
 
 const fractionDigits: ControlFormItemSpec<'Slider'> = {

--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -49,7 +49,7 @@ def histogram(
         groupby = []
 
     # drop empty values from the target column
-    df = df.dropna(subset=[column])
+    df = df.dropna(subset=[column]).copy()
     if df.empty:
         return df
 


### PR DESCRIPTION
Add commaChoosesOption: false to d3NumberFormat and d3TimeFormat controls in ColumnConfigControl to prevent comma from triggering option selection.

Fixes #37038