### PR TITLE
fix: Add .copy() to prevent SettingWithCopyWarning in histogram.py

### DIFF
--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -49,7 +49,7 @@ def histogram(
         groupby = []
 
     # drop empty values from the target column
-    df = df.dropna(subset=[column])
+    df = df.dropna(subset=[column]).copy()
     if df.empty:
         return df
 


### PR DESCRIPTION
Fixes #36530

The df.dropna() returns a view which causes a Pandas SettingWithCopyWarning when modifying the column. Adding .copy() ensures we're working with a copy of the DataFrame.