### PR TITLE
fix: Allow comma typing in D3 format for Table chart

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -573,6 +573,7 @@ export type ControlFormItemSpec<T extends ControlType = ControlType> = {
       creatable?: boolean;
       minWidth?: number | string;
       validators?: ControlFormValueValidator<string>[];
+      tokenSeparators?: string[];
     }
   : T extends 'RadioButtonControl'
     ? {

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/constants.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/constants.tsx
@@ -58,6 +58,7 @@ const d3NumberFormat: ControlFormItemSpec<'Select'> = {
   creatable: true,
   minWidth: '14em',
   debounceDelay: 500,
+  tokenSeparators: [],
 };
 
 const d3TimeFormat: ControlFormItemSpec<'Select'> = {
@@ -72,6 +73,7 @@ const d3TimeFormat: ControlFormItemSpec<'Select'> = {
   creatable: true,
   minWidth: '10em',
   debounceDelay: 500,
+  tokenSeparators: [],
 };
 
 const fractionDigits: ControlFormItemSpec<'Slider'> = {


### PR DESCRIPTION
Fixes #37038

The Select component's default TOKEN_SEPARATORS includes comma, which causes commas to be treated as token separators instead of part of the D3 format string. This prevented users from typing formats like ',.2f' in the D3 format input.