### PR TITLE
fix: resolve SettingWithCopyWarning in histogram post-processing

### DIFF
--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -49,7 +49,7 @@ def histogram(
         groupby = []
 
     # drop empty values from the target column
-    df = df.dropna(subset=[column])
+    df = df.dropna(subset=[column]).copy()
     if df.empty:
         return df
 


### PR DESCRIPTION
## Problem
When loading a dashboard with a Histogram chart or editing one directly, a Pandas SettingWithCopyWarning appears in the logs:


## Solution
Added an explicit DataFrame copy after dropna() to ensure we're modifying an actual DataFrame rather than a view/slice.

## Changes
- Added df = df.copy() after dropna() in histogram.py

Fixes #36530