### PR TITLE
fix(pivot-table): rename Subtotal to Subvalue with aggregation function

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -718,7 +718,9 @@ export class TableRenderer extends Component {
               true,
             )}
           >
-            {t('Subtotal')}
+            {t('Subvalue (%(aggregatorName)s)', {
+              aggregatorName: t(this.props.aggregatorName),
+            })}
           </th>,
         );
       }
@@ -931,7 +933,9 @@ export class TableRenderer extends Component {
             true,
           )}
         >
-          {t('Subtotal')}
+          {t('Subvalue (%(aggregatorName)s)', {
+            aggregatorName: t(this.props.aggregatorName),
+          })}
         </th>
       ) : null;
 


### PR DESCRIPTION
## Summary

This PR renames 'Subtotal' to 'Subvalue' in Pivot Tables and includes the aggregation function name in the label.

## Changes

- Changed column subtotal label from 'Subtotal' to 'Subvalue (%(aggregatorName)s)'
- Changed row subtotal label from 'Subtotal' to 'Subvalue (%(aggregatorName)s)'

## Before
- Subtotal (for any aggregation function)

## After
- Subvalue (Sum)
- Subvalue (Average)
- Subvalue (Count)
- etc.

This change:
1. Renames 'Subtotal' to 'Subvalue' as requested
2. Makes the labeling consistent with how 'Total (Sum)' is displayed
3. Clarifies what aggregation function is being used for the subvalue

Closes #35089