### PR TITLE
fix: Lock DrillDetailTable pageSize to 50 only

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -313,6 +313,7 @@ export default function DrillDetailPane({
           columns={mappedColumns}
           size={TableSize.Small}
           defaultPageSize={PAGE_SIZE}
+          pageSizeOptions={['50']}
           recordCount={resultsPage?.total}
           usePagination
           loading={isLoading}


### PR DESCRIPTION
### SUMMARY
Fixes #36267

The DrillDetailTable uses a constant PAGE_SIZE of 50 for fetching data from the backend, but the pageSizeOptions prop was not specified, defaulting to [5, 15, 25, 50, 100]. This allowed users to select page sizes that don't work correctly with the backend, causing issues like:
- Being able to jump to pages that don't exist when selecting smaller sizes
- Only showing 50 rows even when 100 is selected

This fix adds `pageSizeOptions={['50']}` to lock the page size selector to only 50, matching the backend behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - The page size dropdown will now only show '50' as an option instead of 5, 15, 25, 50, 100.

### TESTING INSTRUCTIONS
1. Open a chart with drill-to-detail functionality
2. Click on a data point to open the drill detail pane
3. Verify that the page size selector only shows '50' as an option

### ADDITIONAL INFORMATION
- [x] Has associated issue: #36267
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [ ] Fixes bug
- [ ] Refactors code
- [ ] Adds test
- [ ] Fixes security issue