### PR TITLE
feat: Rename 'Subtotal' to 'Subvalue' in Pivot Tables

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -718,7 +718,7 @@ export class TableRenderer extends Component {
               true,
             )}
           >
-            {t('Subtotal')}
+            {t('Subvalue')}
           </th>,
         );
       }
@@ -931,7 +931,7 @@ export class TableRenderer extends Component {
             true,
           )}
         >
-          {t('Subtotal')}
+          {t('Subvalue')}
         </th>
       ) : null;
 


### PR DESCRIPTION
### SUMMARY
Fixes #35089

Pivot Table offers the possibility to show aggregated values by group. For example, when showing total sum of sales, the sub-group aggregations are labeled 'Subtotal'. However, when using other aggregation functions like Average, the label 'Subtotal' is misleading since it's not a sum.

This PR changes the user-facing label from 'Subtotal' to 'Subvalue' to be more accurate regardless of the aggregation function used.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Text label change from 'Subtotal' to 'Subvalue'

### TESTING INSTRUCTIONS
1. Create a Pivot Table chart with subtotals enabled
2. Verify that the subtotal rows/columns now show 'Subvalue' instead of 'Subtotal'

### ADDITIONAL INFORMATION
- [x] Has associated issue: #35089
- [ ] Required feature flags
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [ ] Fixes bug
- [ ] Refactors code
- [ ] Adds test