### PR TITLE
fix(DrillDetailPane): restrict pageSizeOptions to only valid PAGE_SIZE

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -313,6 +313,7 @@ export default function DrillDetailPane({
           columns={mappedColumns}
           size={TableSize.Small}
           defaultPageSize={PAGE_SIZE}
+          pageSizeOptions={[PAGE_SIZE]}
           recordCount={resultsPage?.total}
           usePagination
           loading={isLoading}


### PR DESCRIPTION
### Bug description

The DrillDetailTable's pageSize is hardcoded to 50, but the pageSizeOptions defaults to [5, 15, 25, 50, 100]. This causes issues where users can select page sizes that don't work properly.

### Fix

Set pageSizeOptions={[PAGE_SIZE]} to only allow the valid page size of 50.

### Issue

Fixes #36267