### PR TITLE
feat(ci): only bump patch version for Storybook-related deps until React 18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,9 @@ updates:
     ignore:
       # TODO: remove below entries until React >= 18.0.0
       - dependency-name: "storybook"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "@storybook*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "eslint-plugin-storybook"
       # remark-gfm v4+ requires react-markdown v9+, which needs React 18
       - dependency-name: "remark-gfm"
@@ -24,6 +26,14 @@ updates:
       # See https://github.com/apache/superset/pull/37384#issuecomment-3793991389
       # TODO: remove the plugin once Lodash usage has been migrated to a more readily tree-shakeable alternative
       - dependency-name: "@swc/plugin-transform-imports"
+    groups:
+      storybook:
+        applies-to: version-updates
+        patterns:
+          - "@storybook*"
+          - "storybook"
+        update-types:
+          - "patch"
     directory: "/superset-frontend/"
     schedule:
       interval: "daily"
@@ -358,8 +368,15 @@ updates:
     directory: "/superset-frontend/packages/superset-ui-demo/"
     ignore:
       # TODO: remove below entries until React >= 18.0.0
-      - dependency-name: "@storybook/*"
-      - dependency-name: "@storybook/react"
+      - dependency-name: "@storybook*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    groups:
+      storybook:
+        applies-to: version-updates
+        patterns:
+          - "@storybook*"
+        update-types:
+          - "patch"
     schedule:
       interval: "daily"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,10 @@ updates:
 
   - package-ecosystem: "npm"
     ignore:
-      # not until React >= 18.0.0
+      # TODO: remove below entries until React >= 18.0.0
       - dependency-name: "storybook"
       - dependency-name: "@storybook*"
+      - dependency-name: "eslint-plugin-storybook"
       # remark-gfm v4+ requires react-markdown v9+, which needs React 18
       - dependency-name: "remark-gfm"
       - dependency-name: "react-markdown"
@@ -355,6 +356,10 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/superset-frontend/packages/superset-ui-demo/"
+    ignore:
+      # TODO: remove below entries until React >= 18.0.0
+      - dependency-name: "@storybook/*"
+      - dependency-name: "@storybook/react"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(ci): only bump patch version for Storybook-related deps until React 18

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Configure Dependabot to only bump patch version for Storybook-related deps, preventing PRs that are 100% non-upgradeable like these following items:
- https://github.com/apache/superset/pull/37735
- https://github.com/apache/superset/pull/37724

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
