### PR TITLE
fix(chart): prevent x-axis date labels from disappearing when rotated

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -606,14 +606,16 @@ export default function transformProps(
     nameGap: convertInteger(xAxisTitleMargin),
     nameLocation: 'middle',
     axisLabel: {
-      hideOverlap: true,
+      // When rotation is applied on time axes, hideOverlap can
+      // aggressively hide the last label. Rotated labels already
+      // have less overlap, so disabling hideOverlap is safe.
+      // At 0° rotation, keep hideOverlap to prevent long labels
+      // from overlapping each other.
+      hideOverlap:
+        !(xAxisType === AxisType.Time && xAxisLabelRotation !== 0),
       formatter: xAxisFormatter,
       rotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,
-      ...(xAxisType === AxisType.Time && {
-        showMaxLabel: true,
-        alignMaxLabel: 'right',
-      }),
     },
     minorTick: { show: minorTicks },
     minInterval:
@@ -658,6 +660,22 @@ export default function transformProps(
     nameGap: convertInteger(yAxisTitleMargin),
     nameLocation: yAxisTitlePosition === 'Left' ? 'middle' : 'end',
   };
+
+  // Increase right padding for rotated time axis labels to prevent
+  // the last label from being clipped at the chart boundary.
+  if (
+    xAxisType === AxisType.Time &&
+    xAxisLabelRotation !== 0 &&
+    !isHorizontal
+  ) {
+    padding.right = Math.max(
+      padding.right || 0,
+      TIMESERIES_CONSTANTS.gridOffsetRight +
+        Math.ceil(
+          Math.abs(Math.sin((xAxisLabelRotation * Math.PI) / 180)) * 80,
+        ),
+    );
+  }
 
   if (isHorizontal) {
     [xAxis, yAxis] = [yAxis, xAxis];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -610,12 +610,20 @@ export default function transformProps(
       // aggressively hide the last label. Rotated labels already
       // have less overlap, so disabling hideOverlap is safe.
       // At 0° rotation, keep hideOverlap to prevent long labels
-      // from overlapping each other.
-      hideOverlap:
-        !(xAxisType === AxisType.Time && xAxisLabelRotation !== 0),
+      // from overlapping each other, with showMaxLabel to ensure
+      // the last data point label stays visible (#37181).
+      hideOverlap: !(xAxisType === AxisType.Time && xAxisLabelRotation !== 0),
       formatter: xAxisFormatter,
       rotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,
+      // Force last label on non-rotated time axes to prevent
+      // hideOverlap from hiding it. Skipped when rotated to
+      // avoid phantom labels at the axis boundary.
+      ...(xAxisType === AxisType.Time &&
+        xAxisLabelRotation === 0 && {
+          showMaxLabel: true,
+          alignMaxLabel: 'right',
+        }),
     },
     minorTick: { show: minorTicks },
     minInterval:

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -227,47 +227,98 @@ describe('transformNegativeLabelsPosition', () => {
   });
 });
 
-test('should configure time axis labels to show max label for last month visibility', () => {
-  const formData = {
-    colorScheme: 'bnbColors',
-    datasource: '3__table',
-    granularity_sqla: 'ds',
-    metric: 'sum__num',
-    viz_type: 'my_viz',
-  };
-  const queriesData = [
-    {
-      data: [
-        { sum__num: 100, __timestamp: new Date('2026-01-01').getTime() },
-        { sum__num: 200, __timestamp: new Date('2026-02-01').getTime() },
-        { sum__num: 300, __timestamp: new Date('2026-03-01').getTime() },
-        { sum__num: 400, __timestamp: new Date('2026-04-01').getTime() },
-        { sum__num: 500, __timestamp: new Date('2026-05-01').getTime() },
-      ],
-      colnames: ['sum__num', '__timestamp'],
-      coltypes: [GenericDataType.Numeric, GenericDataType.Temporal],
+function buildTimeseriesChartProps(
+  overrides: Record<string, unknown> = {},
+): EchartsTimeseriesChartProps {
+  return new ChartProps({
+    formData: {
+      colorScheme: 'bnbColors',
+      datasource: '3__table',
+      granularity_sqla: 'ds',
+      metric: 'sum__num',
+      viz_type: 'my_viz',
+      ...overrides,
     },
-  ];
-  const chartProps = new ChartProps({
-    formData,
     width: 800,
     height: 600,
-    queriesData,
+    queriesData: [
+      {
+        data: [
+          { sum__num: 100, __timestamp: new Date('2026-01-01').getTime() },
+          { sum__num: 200, __timestamp: new Date('2026-04-01').getTime() },
+          { sum__num: 300, __timestamp: new Date('2026-07-01').getTime() },
+          { sum__num: 400, __timestamp: new Date('2026-10-01').getTime() },
+          { sum__num: 500, __timestamp: new Date('2026-12-01').getTime() },
+        ],
+        colnames: ['sum__num', '__timestamp'],
+        coltypes: [GenericDataType.Numeric, GenericDataType.Temporal],
+      },
+    ],
     theme: supersetTheme,
-  });
+  }) as unknown as EchartsTimeseriesChartProps;
+}
 
+test('x-axis dates do not overlap when horizontal (rotation 0°)', () => {
+  const result = transformProps(buildTimeseriesChartProps());
+  const { axisLabel } = result.echartOptions.xAxis as Record<string, any>;
+
+  expect(axisLabel.hideOverlap).toBe(true);
+  expect(axisLabel.showMaxLabel).toBeUndefined();
+  expect(axisLabel.alignMaxLabel).toBeUndefined();
+});
+
+test('last x-axis date is visible and not cut off when rotated -45°', () => {
+  const lastDataPointTimestamp = new Date('2026-12-01').getTime();
   const result = transformProps(
-    chartProps as unknown as EchartsTimeseriesChartProps,
-  );
-
-  expect(result.echartOptions.xAxis).toEqual(
-    expect.objectContaining({
-      axisLabel: expect.objectContaining({
-        showMaxLabel: true,
-        alignMaxLabel: 'right',
-      }),
+    buildTimeseriesChartProps({
+      xAxisLabelRotation: -45,
+      x_axis_time_format: '%d-%m-%Y %H:%M:%S',
     }),
   );
+  const { xAxis, grid } = result.echartOptions as Record<string, any>;
+  const { axisLabel } = xAxis;
+
+  // The formatter renders the last data point's date as a full string
+  const lastDateLabel = axisLabel.formatter(lastDataPointTimestamp);
+  expect(lastDateLabel).toMatch(/01-12-2026/);
+  expect(lastDateLabel).not.toBe('');
+
+  // Labels are not aggressively hidden so the last date stays visible
+  expect(axisLabel.hideOverlap).toBe(false);
+  expect(axisLabel.rotate).toBe(-45);
+  // No phantom label at a position that doesn't correspond to any bar
+  expect(axisLabel.showMaxLabel).toBeUndefined();
+  // Enough right padding so the last rotated label is not clipped
+  expect(grid.right).toBeGreaterThan(TIMESERIES_CONSTANTS.gridOffsetRight);
+});
+
+test('last x-axis date is visible and not cut off when rotated 45°', () => {
+  const lastDataPointTimestamp = new Date('2026-12-01').getTime();
+  const result = transformProps(
+    buildTimeseriesChartProps({
+      xAxisLabelRotation: 45,
+      x_axis_time_format: '%d-%m-%Y %H:%M:%S',
+    }),
+  );
+  const { xAxis, grid } = result.echartOptions as Record<string, any>;
+
+  const lastDateLabel = xAxis.axisLabel.formatter(lastDataPointTimestamp);
+  expect(lastDateLabel).toMatch(/01-12-2026/);
+  expect(lastDateLabel).not.toBe('');
+
+  expect(xAxis.axisLabel.hideOverlap).toBe(false);
+  expect(xAxis.axisLabel.rotate).toBe(45);
+  expect(grid.right).toBeGreaterThan(TIMESERIES_CONSTANTS.gridOffsetRight);
+});
+
+test('no phantom date label appears at the axis boundary', () => {
+  const result = transformProps(
+    buildTimeseriesChartProps({ xAxisLabelRotation: -45 }),
+  );
+  const { axisLabel } = result.echartOptions.xAxis as Record<string, any>;
+
+  expect(axisLabel.showMaxLabel).toBeUndefined();
+  expect(axisLabel.showMinLabel).toBeUndefined();
 });
 
 function setupGetChartPaddingMock(): jest.SpyInstance {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using a bar chart with a verbose date format (e.g. `%d-%m-%Y %H:%M:%S`) and a rotated x-axis (e.g. -45°), the last date label either disappeared entirely or was truncated at the chart boundary. In some cases a phantom date label appeared at the axis edge that did not correspond to any data point.

The root cause was a combination of three issues in the ECharts timeseries axis configuration. First, `hideOverlap: true` was set unconditionally for all time axes. ECharts overlap detection is known to conflict with forced label visibility, causing it to aggressively hide labels — including the last one — when rotated long date strings produce large bounding boxes. Second, `showMaxLabel: true` and alignMaxLabel: 'right' were being applied to force the last label to render, but showMaxLabel displays a label at the axis boundary rather than at the last data point, creating a phantom date with no corresponding bar. Third, the default right grid padding (20px) was insufficient for long rotated labels, leading to clipping.

This PR replaces all three workarounds with a simpler approach: `hideOverlap` is now conditionally disabled only when label rotation is applied on time axes, since rotated labels naturally have less overlap and the time axis already manages tick density via its `interval` setting. The `showMaxLabel` and `alignMaxLabel` overrides are removed entirely, eliminating phantom labels. Finally, dynamic right padding is added proportional to the rotation angle to prevent clipping of the last label.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
- Before

https://github.com/user-attachments/assets/c713eccb-1c86-4373-a3b7-c5eff16df90d



- After

https://github.com/user-attachments/assets/ef558e70-e600-4233-809e-8965ab0f34e6




- Before
<img width="1769" height="953" alt="before-45" src="https://github.com/user-attachments/assets/fed89ee6-975a-4c26-bcbf-4f8e56db15d4" />


- After


<img width="1763" height="953" alt="after-45" src="https://github.com/user-attachments/assets/2d9599e7-f152-4df9-ab48-044f0f0a875a" />





### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a bar chart with a temporal x-axis
2. Set x-axis time format to %d-%m-%Y %H:%M:%S
3. Set "Rotate x axis label" to -45
4. Verify the last date label is fully visible and not truncated
5. Verify no extra date label appears at the axis boundary without a corresponding bar
6. Change rotation back to 0 and verify long date labels do not overlap each other
7. Test with 45 rotation as well

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
