### PR TITLE
fix(auth): gate legacy FAB password reset routes behind config flag

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -2097,7 +2097,7 @@ FAB_API_KEY_PREFIXES = ["sst_"]
 # When False (default), legacy FAB SSR password reset routes
 # (/superset/resetpassword, /superset/resetmypassword) are not registered.
 # Set to True to re-enable direct URL access to those views (e.g. during migration).
-ENABLE_LEGACY_FAB_PASSWORD_VIEWS = False
+ENABLE_LEGACY_FAB_PASSWORD_VIEWS: bool = False
 
 # The link to a page containing common errors and their resolutions
 # It will be appended at the bottom of sql_lab errors.

--- a/superset/config.py
+++ b/superset/config.py
@@ -2094,6 +2094,11 @@ FAB_ADD_SECURITY_PERMISSION_VIEWS_VIEW = False
 FAB_API_KEY_ENABLED = False
 FAB_API_KEY_PREFIXES = ["sst_"]
 
+# When False (default), legacy FAB SSR password reset routes
+# (/superset/resetpassword, /superset/resetmypassword) are not registered.
+# Set to True to re-enable direct URL access to those views (e.g. during migration).
+ENABLE_LEGACY_FAB_PASSWORD_VIEWS = False
+
 # The link to a page containing common errors and their resolutions
 # It will be appended at the bottom of sql_lab errors.
 TROUBLESHOOTING_LINK = ""

--- a/superset/config.py
+++ b/superset/config.py
@@ -2094,8 +2094,10 @@ FAB_ADD_SECURITY_PERMISSION_VIEWS_VIEW = False
 FAB_API_KEY_ENABLED = False
 FAB_API_KEY_PREFIXES = ["sst_"]
 
-# When False (default), legacy FAB SSR password reset routes
-# (/superset/resetpassword, /superset/resetmypassword) are not registered.
+# When False (default), the legacy FAB SSR admin password reset route
+# (/superset/resetpassword) is not registered. The self-service password reset
+# route (/superset/resetmypassword) is also skipped unless forced password
+# changes are enabled, since that flow still needs a reachable reset form.
 # Set to True to re-enable direct URL access to those views (e.g. during migration).
 ENABLE_LEGACY_FAB_PASSWORD_VIEWS: bool = False
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5124,7 +5124,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 "/roles",
                 "/users",
                 "/groups",
-                "registrations",
+                "/registrations",
             ]:
                 self.appbuilder.baseviews.remove(view)
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5044,7 +5044,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         ]
 
     def _skip_legacy_fab_password_view_registration(self) -> Callable[..., Any]:
-        original_add_view_no_menu = self.appbuilder.add_view_no_menu
+        original_add_view_no_menu: Callable[..., Any] = self.appbuilder.add_view_no_menu
 
         if current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
             return original_add_view_no_menu
@@ -5102,7 +5102,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         original_auth_rate_limited = current_app.config["AUTH_RATE_LIMITED"]
         current_app.config["AUTH_RATE_LIMITED"] = False
 
-        original_add_view_no_menu = self._skip_legacy_fab_password_view_registration()
+        original_add_view_no_menu: Callable[..., Any] = (
+            self._skip_legacy_fab_password_view_registration()
+        )
 
         try:
             super().register_views()
@@ -5116,7 +5118,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         # temporal change to remove the roles view from the security menu, after
         # migrating all views to frontend, we will set FAB_ADD_SECURITY_VIEWS = False
         for view in list(self.appbuilder.baseviews):
-            route_base = getattr(view, "route_base", None)
+            route_base: Optional[str] = getattr(view, "route_base", None)
             # Remove FAB security menu views (roles, users, groups, registrations)
             if isinstance(view, self.rolemodelview.__class__) and route_base in [
                 "/roles",

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5097,7 +5097,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 self.appbuilder.baseviews.remove(view)
                 continue
             # When legacy FAB password views are disabled, unregister and remove them
-            # so /superset/resetpassword and /superset/resetmypassword are not accessible.
+            # so legacy password reset routes are not directly accessible.
             if not current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
                 if isinstance(view, (ResetPasswordView, ResetMyPasswordView)):
                     blueprint = getattr(view, "blueprint", None)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5043,8 +5043,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             role.name for role in self.get_user_roles()
         ]
 
-    # temporal change to remove the roles view from the security menu,
-    # after migrating all views to frontend, we will set FAB_ADD_SECURITY_VIEWS = False
     def _skip_legacy_fab_password_view_registration(self) -> Callable[..., Any]:
         original_add_view_no_menu = self.appbuilder.add_view_no_menu
 
@@ -5056,14 +5054,15 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             ResetPasswordView,
         )
 
-        legacy_password_views = (ResetPasswordView, ResetMyPasswordView)
+        legacy_password_views: tuple[type[Any], ...] = (ResetPasswordView,)
+        if not current_app.config.get("ENABLE_FORCE_PASSWORD_CHANGE", False):
+            legacy_password_views = (*legacy_password_views, ResetMyPasswordView)
 
         def add_view_no_menu_without_legacy_password_views(
             baseview: Any, *args: Any, **kwargs: Any
         ) -> Any:
-            if (
-                isinstance(baseview, legacy_password_views)
-                or isinstance(baseview, type)
+            if isinstance(baseview, legacy_password_views) or (
+                isinstance(baseview, type)
                 and issubclass(baseview, legacy_password_views)
             ):
                 return baseview
@@ -5114,6 +5113,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 original_add_view_no_menu
             )
 
+        # temporal change to remove the roles view from the security menu, after
+        # migrating all views to frontend, we will set FAB_ADD_SECURITY_VIEWS = False
         for view in list(self.appbuilder.baseviews):
             route_base = getattr(view, "route_base", None)
             # Remove FAB security menu views (roles, users, groups, registrations)
@@ -5124,7 +5125,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 "registrations",
             ]:
                 self.appbuilder.baseviews.remove(view)
-                continue
 
         security_menu = next(
             (m for m in self.appbuilder.menu.get_list() if m.name == "Security"), None

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5097,8 +5097,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
             for view in list(self.appbuilder.baseviews):
                 if isinstance(view, (ResetPasswordView, ResetMyPasswordView)):
-                    if getattr(view, "blueprint", None) is not None:
-                        current_app.unregister_blueprint(view.blueprint)
+                    blueprint = getattr(view, "blueprint", None)
+                    if blueprint is not None and hasattr(
+                        current_app, "unregister_blueprint"
+                    ):
+                        current_app.unregister_blueprint(blueprint)
                     self.appbuilder.baseviews.remove(view)
 
         security_menu = next(

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5086,6 +5086,21 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             ) in ["/roles", "/users", "/groups", "registrations"]:
                 self.appbuilder.baseviews.remove(view)
 
+        # When legacy FAB password views are disabled, unregister their routes
+        # so direct URL access to /superset/resetpassword and /superset/resetmypassword
+        # is no longer possible (SPA handles password changes post-porting).
+        if not current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
+            from flask_appbuilder.security.views import (
+                ResetMyPasswordView,
+                ResetPasswordView,
+            )
+
+            for view in list(self.appbuilder.baseviews):
+                if isinstance(view, (ResetPasswordView, ResetMyPasswordView)):
+                    if getattr(view, "blueprint", None) is not None:
+                        current_app.unregister_blueprint(view.blueprint)
+                    self.appbuilder.baseviews.remove(view)
+
         security_menu = next(
             (m for m in self.appbuilder.menu.get_list() if m.name == "Security"), None
         )

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5080,22 +5080,25 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             # Restore original value even if an exception occurs
             current_app.config["AUTH_RATE_LIMITED"] = original_auth_rate_limited
 
+        from flask_appbuilder.security.views import (
+            ResetMyPasswordView,
+            ResetPasswordView,
+        )
+
         for view in list(self.appbuilder.baseviews):
-            if isinstance(view, self.rolemodelview.__class__) and getattr(
-                view, "route_base", None
-            ) in ["/roles", "/users", "/groups", "registrations"]:
+            route_base = getattr(view, "route_base", None)
+            # Remove FAB security menu views (roles, users, groups, registrations)
+            if isinstance(view, self.rolemodelview.__class__) and route_base in [
+                "/roles",
+                "/users",
+                "/groups",
+                "registrations",
+            ]:
                 self.appbuilder.baseviews.remove(view)
-
-        # When legacy FAB password views are disabled, unregister their routes
-        # so direct URL access to /superset/resetpassword and /superset/resetmypassword
-        # is no longer possible (SPA handles password changes post-porting).
-        if not current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
-            from flask_appbuilder.security.views import (
-                ResetMyPasswordView,
-                ResetPasswordView,
-            )
-
-            for view in list(self.appbuilder.baseviews):
+                continue
+            # When legacy FAB password views are disabled, unregister and remove them
+            # so /superset/resetpassword and /superset/resetmypassword are not accessible.
+            if not current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
                 if isinstance(view, (ResetPasswordView, ResetMyPasswordView)):
                     blueprint = getattr(view, "blueprint", None)
                     if blueprint is not None and hasattr(

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -5045,6 +5045,35 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
     # temporal change to remove the roles view from the security menu,
     # after migrating all views to frontend, we will set FAB_ADD_SECURITY_VIEWS = False
+    def _skip_legacy_fab_password_view_registration(self) -> Callable[..., Any]:
+        original_add_view_no_menu = self.appbuilder.add_view_no_menu
+
+        if current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
+            return original_add_view_no_menu
+
+        from flask_appbuilder.security.views import (
+            ResetMyPasswordView,
+            ResetPasswordView,
+        )
+
+        legacy_password_views = (ResetPasswordView, ResetMyPasswordView)
+
+        def add_view_no_menu_without_legacy_password_views(
+            baseview: Any, *args: Any, **kwargs: Any
+        ) -> Any:
+            if (
+                isinstance(baseview, legacy_password_views)
+                or isinstance(baseview, type)
+                and issubclass(baseview, legacy_password_views)
+            ):
+                return baseview
+            return original_add_view_no_menu(baseview, *args, **kwargs)
+
+        self.appbuilder.add_view_no_menu = (  # type: ignore[method-assign]
+            add_view_no_menu_without_legacy_password_views
+        )
+        return original_add_view_no_menu
+
     def register_views(self) -> None:
         from superset.views.auth import SupersetAuthView, SupersetRegisterUserView
 
@@ -5074,16 +5103,16 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         original_auth_rate_limited = current_app.config["AUTH_RATE_LIMITED"]
         current_app.config["AUTH_RATE_LIMITED"] = False
 
+        original_add_view_no_menu = self._skip_legacy_fab_password_view_registration()
+
         try:
             super().register_views()
         finally:
-            # Restore original value even if an exception occurs
+            # Restore original values even if an exception occurs
             current_app.config["AUTH_RATE_LIMITED"] = original_auth_rate_limited
-
-        from flask_appbuilder.security.views import (
-            ResetMyPasswordView,
-            ResetPasswordView,
-        )
+            self.appbuilder.add_view_no_menu = (  # type: ignore[method-assign]
+                original_add_view_no_menu
+            )
 
         for view in list(self.appbuilder.baseviews):
             route_base = getattr(view, "route_base", None)
@@ -5096,16 +5125,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             ]:
                 self.appbuilder.baseviews.remove(view)
                 continue
-            # When legacy FAB password views are disabled, unregister and remove them
-            # so legacy password reset routes are not directly accessible.
-            if not current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
-                if isinstance(view, (ResetPasswordView, ResetMyPasswordView)):
-                    blueprint = getattr(view, "blueprint", None)
-                    if blueprint is not None and hasattr(
-                        current_app, "unregister_blueprint"
-                    ):
-                        current_app.unregister_blueprint(blueprint)
-                    self.appbuilder.baseviews.remove(view)
 
         security_menu = next(
             (m for m in self.appbuilder.menu.get_list() if m.name == "Security"), None

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -137,6 +137,14 @@ class TestCore(SupersetTestCase):
         assert_admin_view_menus_in("Alpha", self.assertNotIn)
         assert_admin_view_menus_in("Gamma", self.assertNotIn)
 
+    def test_legacy_fab_password_views_are_not_registered(self):
+        from flask import current_app
+
+        endpoints = {rule.endpoint for rule in current_app.url_map.iter_rules()}
+
+        assert "ResetPasswordView.this_form_get" not in endpoints
+        assert "ResetMyPasswordView.this_form_get" not in endpoints
+
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_save_slice(self):
         self.login(ADMIN_USERNAME)

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -22,6 +22,7 @@ import html
 import logging
 import random
 import unittest
+from typing import Callable
 from unittest import mock
 from urllib.parse import parse_qs, quote, urlsplit
 
@@ -120,15 +121,18 @@ class TestCore(SupersetTestCase):
         resp = self.client.get("/slice/-1/")
         assert resp.status_code == 404
 
-    def test_admin_only_menu_views(self):
-        from flask import current_app
-
-        def assert_admin_view_menus_in(role_name, assert_func):
+    def test_admin_only_menu_views(self) -> None:
+        def assert_admin_view_menus_in(
+            role_name: str, assert_func: Callable[[str, list[str]], None]
+        ) -> None:
             role = security_manager.find_role(role_name)
             view_menus = [p.view_menu.name for p in role.permissions]
-            # ResetPasswordView only present when legacy FAB password views enabled
-            if current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
-                assert_func("ResetPasswordView", view_menus)
+            if role_name == "Admin" and current_app.config.get(
+                "ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False
+            ):
+                assert "ResetPasswordView" in view_menus
+            else:
+                assert "ResetPasswordView" not in view_menus
             assert_func("RoleRestAPI", view_menus)
             assert_func("Security", view_menus)
             assert_func("SQL Lab", view_menus)
@@ -137,13 +141,26 @@ class TestCore(SupersetTestCase):
         assert_admin_view_menus_in("Alpha", self.assertNotIn)
         assert_admin_view_menus_in("Gamma", self.assertNotIn)
 
-    def test_legacy_fab_password_views_are_not_registered(self):
-        from flask import current_app
+    def test_legacy_fab_password_views_are_not_registered(self) -> None:
+        endpoints: set[str] = {
+            rule.endpoint for rule in current_app.url_map.iter_rules()
+        }
+        legacy_password_views_enabled: bool = current_app.config.get(
+            "ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False
+        )
+        force_password_change_enabled: bool = current_app.config.get(
+            "ENABLE_FORCE_PASSWORD_CHANGE", False
+        )
 
-        endpoints = {rule.endpoint for rule in current_app.url_map.iter_rules()}
+        if legacy_password_views_enabled:
+            assert "ResetPasswordView.this_form_get" in endpoints
+        else:
+            assert "ResetPasswordView.this_form_get" not in endpoints
 
-        assert "ResetPasswordView.this_form_get" not in endpoints
-        assert "ResetMyPasswordView.this_form_get" not in endpoints
+        if legacy_password_views_enabled or force_password_change_enabled:
+            assert "ResetMyPasswordView.this_form_get" in endpoints
+        else:
+            assert "ResetMyPasswordView.this_form_get" not in endpoints
 
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_save_slice(self):

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -121,10 +121,14 @@ class TestCore(SupersetTestCase):
         assert resp.status_code == 404
 
     def test_admin_only_menu_views(self):
+        from flask import current_app
+
         def assert_admin_view_menus_in(role_name, assert_func):
             role = security_manager.find_role(role_name)
             view_menus = [p.view_menu.name for p in role.permissions]
-            assert_func("ResetPasswordView", view_menus)
+            # ResetPasswordView only present when legacy FAB password views enabled
+            if current_app.config.get("ENABLE_LEGACY_FAB_PASSWORD_VIEWS", False):
+                assert_func("ResetPasswordView", view_menus)
             assert_func("RoleRestAPI", view_menus)
             assert_func("Security", view_menus)
             assert_func("SQL Lab", view_menus)

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -3283,6 +3283,68 @@ def test_user_view_menu_names_for_guest_user_no_roles(
     mock_get_user_id.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "enable_legacy_password_views,enable_force_password_change,expected_registered",
+    [
+        (False, False, {"NonPasswordView"}),
+        (False, True, {"NonPasswordView", "ResetMyPasswordView"}),
+        (
+            True,
+            False,
+            {"NonPasswordView", "ResetMyPasswordView", "ResetPasswordView"},
+        ),
+    ],
+)
+def test_skip_legacy_fab_password_view_registration_keeps_forced_change_target(
+    app_context: None,
+    enable_legacy_password_views: bool,
+    enable_force_password_change: bool,
+    expected_registered: set[str],
+) -> None:
+    """Forced password changes require the self-service reset view."""
+    from flask import current_app
+    from flask_appbuilder.security.views import ResetMyPasswordView, ResetPasswordView
+
+    class NonPasswordView:
+        pass
+
+    registered: list[str] = []
+
+    def add_view_no_menu(baseview: type[Any], *args: Any, **kwargs: Any) -> type[Any]:
+        registered.append(baseview.__name__)
+        return baseview
+
+    fake_appbuilder = SimpleNamespace(add_view_no_menu=add_view_no_menu)
+    sm = SupersetSecurityManager.__new__(SupersetSecurityManager)
+    sm.appbuilder = fake_appbuilder
+
+    previous_config = {
+        "ENABLE_LEGACY_FAB_PASSWORD_VIEWS": current_app.config[
+            "ENABLE_LEGACY_FAB_PASSWORD_VIEWS"
+        ],
+        "ENABLE_FORCE_PASSWORD_CHANGE": current_app.config[
+            "ENABLE_FORCE_PASSWORD_CHANGE"
+        ],
+    }
+    current_app.config["ENABLE_LEGACY_FAB_PASSWORD_VIEWS"] = (
+        enable_legacy_password_views
+    )
+    current_app.config["ENABLE_FORCE_PASSWORD_CHANGE"] = enable_force_password_change
+
+    original_add_view_no_menu = fake_appbuilder.add_view_no_menu
+    try:
+        original_add_view_no_menu = sm._skip_legacy_fab_password_view_registration()
+
+        fake_appbuilder.add_view_no_menu(ResetPasswordView)
+        fake_appbuilder.add_view_no_menu(ResetMyPasswordView)
+        fake_appbuilder.add_view_no_menu(NonPasswordView)
+    finally:
+        current_app.config.update(previous_config)
+        fake_appbuilder.add_view_no_menu = original_add_view_no_menu
+
+    assert set(registered) == expected_registered
+
+
 def test_reset_password_self_service_clears_flag(
     mocker: MockerFixture,
     app_context: None,

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -20,7 +20,7 @@
 import json  # noqa: TID251
 import logging
 from types import SimpleNamespace
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -3331,7 +3331,7 @@ def test_skip_legacy_fab_password_view_registration_keeps_forced_change_target(
     )
     current_app.config["ENABLE_FORCE_PASSWORD_CHANGE"] = enable_force_password_change
 
-    original_add_view_no_menu = fake_appbuilder.add_view_no_menu
+    original_add_view_no_menu: Callable[..., Any] = fake_appbuilder.add_view_no_menu
     try:
         original_add_view_no_menu = sm._skip_legacy_fab_password_view_registration()
 


### PR DESCRIPTION
### Summary

After the frontend porting in Superset 6.0.0, most user-facing views were migrated to the React SPA and rendered via `render_app_template`. However, the legacy Flask-AppBuilder password reset views (`ResetPassword` and `ResetMyPassword`) remain directly accessible via URL and render using server-side templates.

This results in inconsistent behavior and exposes legacy SSR FAB views that were not intended to be accessible post-migration.

### What this PR does

- Prevents direct URL access to legacy FAB password reset views
- Aligns password-related routes with the post-6.0.0 SPA-based frontend architecture
- Ensures legacy SSR views are no longer rendered when accessed directly

### What this PR does not do

- Does not redesign password reset UX
- Does not migrate legacy FAB views to SPA
- Does not modify existing admin password reset behavior
- Does not introduce new authentication flows

### Rationale

This change addresses an unintended side effect of the FAB → SPA migration and keeps Superset’s frontend behavior consistent without expanding scope into broader authentication or UX changes.

### Related Issue

Fixes #37700