### PR TITLE
docs(dev_portal/test): remove refs of testing tools not used in project

### DIFF
--- a/docs/developer_portal/testing/overview.md
+++ b/docs/developer_portal/testing/overview.md
@@ -60,7 +60,6 @@ Superset embraces a testing pyramid approach:
 - **pytest**: Python testing framework with powerful fixtures and plugins
 - **SQLAlchemy Test Utilities**: Database testing and transaction management
 - **Flask Test Client**: API endpoint testing and request simulation
-- **Factory Boy**: Test data generation and model factories
 
 ## Best Practices
 
@@ -157,7 +156,6 @@ npm run test:coverage
 - **React Testing Library** - Component testing utilities
 - **Playwright** - End-to-end testing (replacing Cypress)
 - **Storybook** - Component development and testing
-- **MSW** - API mocking for testing
 
 ---
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
docs(dev_portal/test): remove refs of testing tools not used in project

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A very chore PR to remove references of tooling not used in Superset's backend testing. Or maybe @rusackas is doing some foreshadow? 👀 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
