### PR TITLE
feat(uploadDataModel): add DataPreviewModal for file upload preview and integrate driver.js for guided tours

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -82,6 +82,7 @@
         "dayjs": "^1.11.19",
         "dom-to-image-more": "^3.7.2",
         "dom-to-pdf": "^0.3.2",
+        "driver.js": "^1.4.0",
         "echarts": "^5.6.0",
         "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
         "fast-glob": "^3.3.2",
@@ -29377,6 +29378,11 @@
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew=="
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -164,6 +164,7 @@
     "dayjs": "^1.11.19",
     "dom-to-image-more": "^3.7.2",
     "dom-to-pdf": "^0.3.2",
+    "driver.js": "^1.4.0",
     "echarts": "^5.6.0",
     "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
     "fast-glob": "^3.3.2",

--- a/superset-frontend/src/features/databases/UploadDataModel/ColumnsPreview.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/ColumnsPreview.tsx
@@ -25,6 +25,7 @@ import { type TagType, TagsList } from 'src/components';
 interface ColumnsPreviewProps {
   columns: string[];
   maxColumnsToShow?: number;
+  fileTooLarge?: boolean;
 }
 
 export const StyledDivContainer = styled.div`
@@ -35,6 +36,7 @@ export const StyledDivContainer = styled.div`
 const ColumnsPreview: FC<ColumnsPreviewProps> = ({
   columns,
   maxColumnsToShow = 4,
+  fileTooLarge = false,
 }) => {
   const tags: TagType[] = columns.map(column => ({ name: column }));
 
@@ -42,7 +44,11 @@ const ColumnsPreview: FC<ColumnsPreviewProps> = ({
     <StyledDivContainer>
       <Typography.Text type="secondary">Columns:</Typography.Text>
       {columns.length === 0 ? (
-        <p className="help-block">{t('Upload file to preview columns')}</p>
+        <p className="help-block">
+          {fileTooLarge
+            ? t('Preview is not available for files larger than 5MB')
+            : t('Upload file to preview columns')}
+        </p>
       ) : (
         <TagsList tags={tags} maxTags={maxColumnsToShow} />
       )}

--- a/superset-frontend/src/features/databases/UploadDataModel/DataPreviewModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/DataPreviewModal.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  render,
+  screen,
+  waitFor,
+  userEvent,
+} from 'spec/helpers/testing-library';
+import { DataPreviewModal } from './DataPreviewModal';
+
+// Polyfill File.prototype.text for jsdom (not implemented)
+if (typeof File.prototype.text !== 'function') {
+  File.prototype.text = function (this: File) {
+    return new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result ?? ''));
+      reader.onerror = () => reject(reader.error ?? new Error('Read failed'));
+      reader.readAsText(this);
+    });
+  };
+}
+
+const defaultProps = {
+  show: true,
+  onHide: jest.fn(),
+  file: null,
+  type: 'csv' as const,
+};
+
+function createCSVFile(content: string): File {
+  return new File([content], 'test.csv', { type: 'text/csv' });
+}
+
+test('renders modal with Data preview title when show is true', () => {
+  render(<DataPreviewModal {...defaultProps} />);
+
+  expect(screen.getByText('Data preview')).toBeInTheDocument();
+});
+
+test('shows no data to preview when file is null', async () => {
+  render(<DataPreviewModal {...defaultProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByText('No data to preview')).toBeInTheDocument();
+  });
+});
+
+test('parses CSV and displays data in table', async () => {
+  const csvContent = 'name,age,city\nAlice,30,NYC\nBob,25,Boston';
+  const file = createCSVFile(csvContent);
+
+  render(<DataPreviewModal {...defaultProps} file={file} type="csv" />);
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole('columnheader', { name: 'name' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'age' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'city' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Alice' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '30' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'NYC' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Bob' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '25' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Boston' })).toBeInTheDocument();
+  });
+});
+
+test('uses custom delimiter for CSV parsing', async () => {
+  const csvContent = 'name;age;city\nAlice;30;NYC';
+  const file = createCSVFile(csvContent);
+
+  render(
+    <DataPreviewModal {...defaultProps} file={file} type="csv" delimiter=";" />,
+  );
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole('columnheader', { name: 'name' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Alice' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '30' })).toBeInTheDocument();
+  });
+});
+
+test('shows error for columnar type', async () => {
+  const file = createCSVFile('col1\nval1');
+
+  render(<DataPreviewModal {...defaultProps} file={file} type="columnar" />);
+
+  await waitFor(() => {
+    expect(
+      screen.getByText('Data preview is not available for Parquet files.'),
+    ).toBeInTheDocument();
+  });
+});
+
+test('shows No data to preview for empty CSV', async () => {
+  const file = createCSVFile('');
+
+  render(<DataPreviewModal {...defaultProps} file={file} type="csv" />);
+
+  await waitFor(() => {
+    expect(screen.getByText('No data to preview')).toBeInTheDocument();
+  });
+});
+
+test('shows Loading while parsing', async () => {
+  const file = createCSVFile('a,b\n1,2');
+  const textSpy = jest.spyOn(File.prototype, 'text');
+  textSpy.mockImplementation(
+    () => new Promise(resolve => setTimeout(() => resolve('a,b\n1,2'), 100)),
+  );
+
+  render(<DataPreviewModal {...defaultProps} file={file} type="csv" />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  textSpy.mockRestore();
+});
+
+test('calls onHide when modal close button is clicked', async () => {
+  const onHide = jest.fn();
+  render(
+    <DataPreviewModal
+      {...defaultProps}
+      onHide={onHide}
+      file={createCSVFile('a,b\n1,2')}
+      type="csv"
+    />,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByRole('cell', { name: '1' })).toBeInTheDocument();
+  });
+
+  const closeButton = screen.getByTestId('close-modal-btn');
+  await userEvent.click(closeButton);
+
+  expect(onHide).toHaveBeenCalledTimes(1);
+});
+
+test('shows error message when CSV parse fails', async () => {
+  const file = new File(['invalid'], 'test.csv', { type: 'text/csv' });
+  const textSpy = jest.spyOn(File.prototype, 'text');
+  textSpy.mockRejectedValueOnce(new Error('Read failed'));
+
+  render(<DataPreviewModal {...defaultProps} file={file} type="csv" />);
+
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Read failed|Failed to parse file/),
+    ).toBeInTheDocument();
+  });
+
+  textSpy.mockRestore();
+});

--- a/superset-frontend/src/features/databases/UploadDataModel/DataPreviewModal.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/DataPreviewModal.tsx
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { FunctionComponent, useEffect, useState } from 'react';
+import { t } from '@apache-superset/core';
+import { Modal, Table, TableSize } from '@superset-ui/core/components';
+import type { ColumnsType } from 'antd/es/table';
+import type { UploadType } from './uploadDataModalTour';
+
+const PREVIEW_ROW_LIMIT = 100;
+
+interface DataPreviewModalProps {
+  show: boolean;
+  onHide: () => void;
+  file: File | null;
+  type: UploadType;
+  delimiter?: string;
+  sheetName?: string;
+}
+
+async function parseCSV(
+  file: File,
+  delimiter: string,
+): Promise<{ columns: string[]; data: Record<string, string>[] }> {
+  const text = await file.text();
+  const lines = text.split(/\r?\n/).filter(line => line.trim().length > 0);
+  if (lines.length === 0) {
+    return { columns: [], data: [] };
+  }
+  const headerLine = lines[0];
+  const columns = headerLine
+    .split(delimiter)
+    .map((c, i) => c.trim() || `col_${i}`);
+  const dataRows = lines.slice(1, PREVIEW_ROW_LIMIT + 1);
+  const data = dataRows.map(row => {
+    const values = row.split(delimiter);
+    const obj: Record<string, string> = {};
+    columns.forEach((col, i) => {
+      obj[col] = values[i]?.trim() ?? '';
+    });
+    return obj;
+  });
+  return { columns, data };
+}
+
+async function parseExcel(
+  file: File,
+  sheetName?: string,
+): Promise<{ columns: string[]; data: Record<string, string>[] }> {
+  const XLSX = (await import(/* webpackChunkName: "xlsx" */ 'xlsx')).default;
+  const arrayBuffer = await file.arrayBuffer();
+  const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+  const sheet = sheetName
+    ? workbook.Sheets[sheetName]
+    : workbook.Sheets[workbook.SheetNames[0]];
+  if (!sheet) {
+    return { columns: [], data: [] };
+  }
+  const jsonData = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
+    header: 1,
+    defval: '',
+  }) as unknown[][];
+  if (jsonData.length === 0) {
+    return { columns: [], data: [] };
+  }
+  const headerRow = jsonData[0] as (string | number)[];
+  const columns = headerRow.map((c, i) => String(c ?? '').trim() || `col_${i}`);
+  const dataRows = jsonData.slice(1, PREVIEW_ROW_LIMIT + 1) as (
+    | string
+    | number
+  )[][];
+  const data = dataRows.map(row => {
+    const obj: Record<string, string> = {};
+    columns.forEach((col, i) => {
+      obj[col] = String(row[i] ?? '');
+    });
+    return obj;
+  });
+  return { columns, data };
+}
+
+export const DataPreviewModal: FunctionComponent<DataPreviewModalProps> = ({
+  show,
+  onHide,
+  file,
+  type,
+  delimiter = ',',
+  sheetName,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [columns, setColumns] = useState<string[]>([]);
+  const [data, setData] = useState<Record<string, string>[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!show || !file) {
+      setColumns([]);
+      setData([]);
+      setError(null);
+      return;
+    }
+    if (type === 'columnar') {
+      setError(t('Data preview is not available for Parquet files.'));
+      setColumns([]);
+      setData([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    const parse =
+      type === 'csv' ? parseCSV(file, delimiter) : parseExcel(file, sheetName);
+    parse
+      .then(({ columns: cols, data: parsedData }) => {
+        setColumns(cols);
+        setData(parsedData);
+      })
+      .catch(err => {
+        setError(err?.message || t('Failed to parse file'));
+        setColumns([]);
+        setData([]);
+      })
+      .finally(() => setLoading(false));
+  }, [show, file, type, delimiter, sheetName]);
+
+  const tableColumns: ColumnsType<Record<string, string>> = columns.map(
+    (col, idx) => ({
+      title: col,
+      dataIndex: col,
+      key: `col_${idx}_${col}`,
+      ellipsis: true,
+      width: 150,
+    }),
+  );
+
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      title={t('Data preview')}
+      hideFooter
+      width="90vw"
+      responsive
+      centered
+    >
+      {loading && (
+        <div style={{ padding: 24, textAlign: 'center' }}>
+          {t('Loading...')}
+        </div>
+      )}
+      {error && !loading && (
+        <div style={{ padding: 24, color: 'var(--ant-color-error)' }}>
+          {error}
+        </div>
+      )}
+      {!loading && !error && columns.length > 0 && (
+        <Table
+          columns={tableColumns}
+          data={data}
+          rowKey={(_, idx) => `row_${idx}`}
+          size={TableSize.Small}
+          defaultPageSize={20}
+        />
+      )}
+      {!loading && !error && columns.length === 0 && (
+        <div style={{ padding: 24, color: 'var(--ant-color-text-secondary)' }}>
+          {t('No data to preview')}
+        </div>
+      )}
+    </Modal>
+  );
+};

--- a/superset-frontend/src/features/databases/UploadDataModel/styles.ts
+++ b/superset-frontend/src/features/databases/UploadDataModel/styles.ts
@@ -21,6 +21,53 @@ import { css, styled, SupersetTheme } from '@apache-superset/core/ui';
 
 const MODAL_BODY_HEIGHT = 180.5;
 
+export const StyledFileDropzone = styled.div`
+  ${({ theme }) => css`
+    .ant-upload-drag {
+      border-radius: ${theme.borderRadius}px;
+      border: 2px dashed ${theme.colorPrimaryBorder};
+      background: ${theme.colorPrimaryBg};
+      padding: ${theme.sizeUnit * 5}px ${theme.sizeUnit * 4}px;
+      transition:
+        border-color 0.2s ease,
+        background-color 0.2s ease;
+    }
+
+    .ant-upload-drag:hover {
+      border-color: ${theme.colorPrimary};
+      background: ${theme.colorPrimaryBgHover};
+    }
+
+    .ant-upload-drag-icon {
+      margin-bottom: ${theme.sizeUnit * 2}px;
+    }
+
+    .ant-upload-drag-icon .anticon {
+      font-size: ${theme.sizeUnit * 8}px;
+      color: ${theme.colorPrimary};
+    }
+
+    .ant-upload-text {
+      font-size: ${theme.fontSize}px;
+      color: ${theme.colorTextHeading};
+      margin-bottom: ${theme.sizeUnit}px;
+    }
+
+    .ant-upload-hint {
+      font-size: ${theme.fontSizeSM}px;
+      color: ${theme.colorTextDescription};
+    }
+
+    .ant-upload-drag .ant-upload-btn {
+      padding: 0;
+    }
+
+    .ant-upload-list {
+      margin-top: ${theme.sizeUnit * 2}px;
+    }
+  `}
+`;
+
 export const StyledFormItem = styled(FormItem)`
   ${({ theme }) => css`
     flex: 1;

--- a/superset-frontend/src/features/databases/UploadDataModel/uploadDataModalTour.test.ts
+++ b/superset-frontend/src/features/databases/UploadDataModel/uploadDataModalTour.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { startUploadDataModalTour } from './uploadDataModalTour';
+
+const mockDrive = jest.fn();
+const mockDriver = jest.fn<{ drive: jest.Mock }, [Record<string, unknown>]>(
+  () => ({
+    drive: mockDrive,
+  }),
+);
+
+jest.mock('driver.js', () => ({
+  driver: (config: Record<string, unknown>) => mockDriver(config),
+}));
+
+// Suppress CSS import in tests
+jest.mock('driver.js/dist/driver.css', () => ({}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function getDriverConfig(): Record<string, unknown> {
+  expect(mockDriver).toHaveBeenCalled();
+  const call = mockDriver.mock.calls[0] as unknown[];
+  return call[0] as Record<string, unknown>;
+}
+
+test('startUploadDataModalTour calls driver with correct config for CSV', () => {
+  startUploadDataModalTour('csv');
+
+  expect(mockDriver).toHaveBeenCalledTimes(1);
+  const config = getDriverConfig();
+  expect(config.animate).toBe(false);
+  expect(config.showProgress).toBe(true);
+  expect(config.showButtons).toEqual(['next', 'previous', 'close']);
+  const steps = config.steps as Array<{ element: string }>;
+  expect(steps).toHaveLength(5);
+  expect(steps[0].element).toBe(
+    '[data-tour="upload-modal-csv"] [data-tour="upload-file-dropzone-csv"]',
+  );
+  expect(steps[4].element).toBe(
+    '[data-tour="upload-modal-csv"] [data-tour="upload-submit-button-csv"]',
+  );
+  expect(mockDrive).toHaveBeenCalledTimes(1);
+});
+
+test('startUploadDataModalTour calls driver with correct selectors for Excel', () => {
+  startUploadDataModalTour('excel');
+
+  const config = getDriverConfig();
+  const steps = config.steps as Array<{ element: string }>;
+  expect(steps[0].element).toBe(
+    '[data-tour="upload-modal-excel"] [data-tour="upload-file-dropzone-excel"]',
+  );
+  expect(steps[4].element).toBe(
+    '[data-tour="upload-modal-excel"] [data-tour="upload-submit-button-excel"]',
+  );
+});
+
+test('startUploadDataModalTour calls driver with correct selectors for columnar', () => {
+  startUploadDataModalTour('columnar');
+
+  const config = getDriverConfig();
+  const steps = config.steps as Array<{ element: string }>;
+  expect(steps[0].element).toBe(
+    '[data-tour="upload-modal-columnar"] [data-tour="upload-file-dropzone-columnar"]',
+  );
+  expect(steps[4].element).toBe(
+    '[data-tour="upload-modal-columnar"] [data-tour="upload-submit-button-columnar"]',
+  );
+});
+
+test('startUploadDataModalTour steps have expected popover structure', () => {
+  startUploadDataModalTour('csv');
+
+  const config = getDriverConfig();
+  const expectedTitles = [
+    'Upload your file',
+    'Preview columns',
+    'Select database',
+    'Table name',
+    'Upload',
+  ];
+  const steps = config.steps as Array<{
+    popover: { title: string; description?: string };
+  }>;
+  steps.forEach((step, idx) => {
+    expect(step.popover).toBeDefined();
+    expect(step.popover.title).toBe(expectedTitles[idx]);
+    expect(step.popover.description).toBeDefined();
+    expect(typeof step.popover.description).toBe('string');
+  });
+});
+
+test('startUploadDataModalTour includes all five tour steps with correct element targets', () => {
+  startUploadDataModalTour('csv');
+
+  const config = getDriverConfig();
+  const expectedTargets = [
+    'upload-file-dropzone-csv',
+    'upload-preview-csv',
+    'upload-database-csv',
+    'upload-table-name-csv',
+    'upload-submit-button-csv',
+  ];
+  const steps = config.steps as Array<{ element: string }>;
+  steps.forEach((step, idx) => {
+    expect(step.element).toContain(expectedTargets[idx]);
+  });
+});

--- a/superset-frontend/src/features/databases/UploadDataModel/uploadDataModalTour.ts
+++ b/superset-frontend/src/features/databases/UploadDataModel/uploadDataModalTour.ts
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { driver, type DriveStep } from 'driver.js';
+import 'driver.js/dist/driver.css';
+import { t } from '@apache-superset/core';
+
+export type UploadType = 'csv' | 'excel' | 'columnar';
+
+function getTourSteps(type: UploadType): DriveStep[] {
+  const scope = `[data-tour="upload-modal-${type}"]`;
+  return [
+    {
+      element: `${scope} [data-tour="upload-file-dropzone-${type}"]`,
+      popover: {
+        title: t('Upload your file'),
+        description: t(
+          'Drag and drop your file here or click Select to browse. Supported formats: CSV, Excel, or Columnar (Parquet).',
+        ),
+        side: 'bottom',
+        align: 'start',
+      },
+    },
+    {
+      element: `${scope} [data-tour="upload-preview-${type}"]`,
+      popover: {
+        title: t('Preview columns'),
+        description: t(
+          'Toggle to preview the columns from your uploaded file. The column names will appear here once a file is selected.',
+        ),
+        side: 'bottom',
+        align: 'start',
+      },
+    },
+    {
+      element: `${scope} [data-tour="upload-database-${type}"]`,
+      popover: {
+        title: t('Select database'),
+        description: t(
+          'Choose the database where you want to store the uploaded data.',
+        ),
+        side: 'bottom',
+        align: 'start',
+      },
+    },
+    {
+      element: `${scope} [data-tour="upload-table-name-${type}"]`,
+      popover: {
+        title: t('Table name'),
+        description: t(
+          'Enter a name for the new table that will be created from your uploaded file.',
+        ),
+        side: 'bottom',
+        align: 'start',
+      },
+    },
+    {
+      element: `${scope} [data-tour="upload-submit-button-${type}"]`,
+      popover: {
+        title: t('Upload'),
+        description: t(
+          'Click Upload to import your data. Make sure you have selected a file, database, and entered a table name.',
+        ),
+        side: 'top',
+        align: 'center',
+      },
+    },
+  ];
+}
+
+export function startUploadDataModalTour(type: UploadType): void {
+  const driverObj = driver({
+    animate: false,
+    showProgress: true,
+    showButtons: ['next', 'previous', 'close'],
+    progressText: t('{{current}} of {{total}}'),
+    nextBtnText: t('Next'),
+    prevBtnText: t('Previous'),
+    doneBtnText: t('Done'),
+    steps: getTourSteps(type),
+  });
+
+  driverObj.drive();
+}


### PR DESCRIPTION
### SUMMARY
Improve file uploader UI and UX

Added the following:
- **Onboarding tour**: 5-step driver.js tour (file drop zone → preview → database → table name → Upload) with type-specific data-tour IDs (csv, excel, columnar).
- **Tour trigger**: “?” icon next to the modal title starts the tour.
- **Data preview**: “Preview data” button for CSV/Excel opens a modal with client-side parsing (no Parquet preview).
- **5MB preview limit**: For files > 5MB:
  - Disables “Preview data”.
  - Skips column metadata API calls.
  - Shows “Preview is not available for files larger than 5MB” in the columns section.
- Fixed “Uploading a file is required” after selecting a file (correct validation via fileListRef).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### AFTER
https://github.com/user-attachments/assets/7f70315e-c3ff-43ad-b6f0-9b496e53d0f8

### TESTING INSTRUCTIONS
1. Go to "+" icon.
2. Click on Upload CSV or Excel to database.
3. For the Tour, click on the "?" icon.
4. To add a new file drag and drop it into the section for uploading files.
5. To preview the data, click on the "Preview data" button.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
