### PR TITLE
fix(explore): update metric and column arrow state on datasource change

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourceItems.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourceItems.tsx
@@ -104,20 +104,20 @@ export const DatasourceItems = ({
       folders.filter(folder => folder.isCollapsed).map(folder => folder.id),
     ),
   );
-const didInitCollapsedState = useRef(false);
+  const didInitCollapsedState = useRef(false);
 
-useEffect(() => {
-  if (didInitCollapsedState.current) {
-    return;
-  }
-  setCollapsedFolderIds(
-    new Set(
-      folders.filter(folder => folder.isCollapsed).map(folder => folder.id),
-    ),
-  );
+  useEffect(() => {
+    if (didInitCollapsedState.current) {
+      return;
+    }
+    setCollapsedFolderIds(
+      new Set(
+        folders.filter(folder => folder.isCollapsed).map(folder => folder.id),
+      ),
+    );
 
-  didInitCollapsedState.current = true;
-}, [folders]);
+    didInitCollapsedState.current = true;
+  }, [folders]);
 
   const { flattenedItems, folderMap } = useMemo(
     () => flattenFolderStructure(folders, collapsedFolderIds),

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourceItems.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourceItems.tsx
@@ -105,6 +105,14 @@ export const DatasourceItems = ({
     ),
   );
 
+  useEffect(() => {
+    setCollapsedFolderIds(
+      new Set(
+        folders.filter(folder => folder.isCollapsed).map(folder => folder.id),
+      ),
+    );
+  }, [folders]);
+
   const { flattenedItems, folderMap } = useMemo(
     () => flattenFolderStructure(folders, collapsedFolderIds),
     [folders, collapsedFolderIds],

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourceItems.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourceItems.tsx
@@ -104,14 +104,20 @@ export const DatasourceItems = ({
       folders.filter(folder => folder.isCollapsed).map(folder => folder.id),
     ),
   );
+const didInitCollapsedState = useRef(false);
 
-  useEffect(() => {
-    setCollapsedFolderIds(
-      new Set(
-        folders.filter(folder => folder.isCollapsed).map(folder => folder.id),
-      ),
-    );
-  }, [folders]);
+useEffect(() => {
+  if (didInitCollapsedState.current) {
+    return;
+  }
+  setCollapsedFolderIds(
+    new Set(
+      folders.filter(folder => folder.isCollapsed).map(folder => folder.id),
+    ),
+  );
+
+  didInitCollapsedState.current = true;
+}, [folders]);
 
   const { flattenedItems, folderMap } = useMemo(
     () => flattenFolderStructure(folders, collapsedFolderIds),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

## Summary
Fixes #37444 an issue in the Explore datasource panel where the expand/collapse arrow
state for metrics and columns could become out of sync when the datasource
folders update.

This ensures the arrow state stays consistent with the underlying collapsed
state after datasource changes.

## Testing
- Verified locally in Explore view
- Confirmed metric and column arrows update correctly on datasource change

## After Fixing:
https://github.com/user-attachments/assets/d1644bc6-07c9-4b71-923c-48450e26c605


