### PR TITLE
fix(native-filters): align refresh icon with default value field

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -171,7 +171,7 @@ export const StyledLabel = styled.span`
 const DefaultValueContainer = styled.div`
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-start;
 `;
 
 const StyledAsterisk = styled.span`
@@ -1676,6 +1676,8 @@ const FiltersConfigForm = (
                                             css={css`
                                               margin-left: ${theme.sizeUnit *
                                               2}px;
+                                              margin-top: ${theme.sizeUnit *
+                                              1.5}px;
                                             `}
                                             onClick={() => refreshHandler(true)}
                                           />


### PR DESCRIPTION
### SUMMARY
The SyncOutlined refresh icon in the filter config form's "Default Value" row was vertically misaligned when a validation error message appeared below the field. The `DefaultValueContainer` used `align-items: center`, which centered the icon relative to the combined height of the field + error message, pushing it below the field line.

Changed `align-items` from `center` to `flex-start` so the icon stays anchored at field level, and added `margin-top` to vertically center it with the 32px input.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!-- Before: icon drops below the field when validation error shows -->
<!-- After: icon stays aligned with the input field, error flows below -->

- Before
<img width="1041" height="998" alt="Screenshot 2026-02-09 132445" src="https://github.com/user-attachments/assets/69e09169-a74c-4d69-911d-dea0b7156b34" />

- After
<img width="1005" height="947" alt="Screenshot 2026-02-09 132324" src="https://github.com/user-attachments/assets/65166d6e-d816-4ce6-9a10-d82f61f19a14" />

- Before
<img width="1023" height="942" alt="Screenshot 2026-02-09 132451" src="https://github.com/user-attachments/assets/ab6dfdc0-f59b-4bda-8f06-3c547e56d4c3" />

- After
<img width="1073" height="907" alt="Screenshot 2026-02-09 132334" src="https://github.com/user-attachments/assets/3a45a5be-421f-4780-b9da-3988d10cff74" />


### TESTING INSTRUCTIONS
1. Go to a dashboard → Edit → Filters
2. Select or create a filter with a dataset
3. Check "Filter has default value"
4. Leave the default value empty so the validation error "Value is required" appears
5. Verify the sync (refresh) icon stays aligned with the select field, not centered with field + error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
