### PR TITLE
feat(api): return uuid in POST response for dataset, chart, and dashboard

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -365,7 +365,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             return self.response_400(message=error.messages)
         try:
             new_model = CreateChartCommand(item).run()
-            return self.response(201, id=new_model.id, result=item)
+            return self.response(201, id=new_model.id, result=item, uuid=new_model.uuid)
         except DashboardsForbiddenError as ex:
             return self.response(ex.status, message=ex.message)
         except ChartInvalidError as ex:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -754,7 +754,7 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
             return self.response_400(message=error.messages)
         try:
             new_model = CreateDashboardCommand(item).run()
-            return self.response(201, id=new_model.id, result=item)
+            return self.response(201, id=new_model.id, result=item, uuid=new_model.uuid)
         except DashboardInvalidError as ex:
             return self.response_422(message=ex.normalized_messages())
         except DashboardCreateFailedError as ex:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -357,7 +357,13 @@ class DatasetRestApi(BaseSupersetModelRestApi):
 
         try:
             new_model = CreateDatasetCommand(item).run()
-            return self.response(201, id=new_model.id, result=item, data=new_model.data)
+            return self.response(
+                201,
+                id=new_model.id,
+                result=item,
+                data=new_model.data,
+                uuid=new_model.uuid,
+            )
         except DatasetInvalidError as ex:
             return self.response_422(message=ex.normalized_messages())
         except DatasetCreateFailedError as ex:

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -556,6 +556,9 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         assert rv.status_code == 201
         data = json.loads(rv.data.decode("utf-8"))
         model = db.session.query(Slice).get(data.get("id"))
+        # uuid should be returned in the response
+        assert "uuid" in data
+        assert str(model.uuid) == str(data["uuid"])
         db.session.delete(model)
         db.session.commit()
 

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1746,6 +1746,9 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         assert rv.status_code == 201
         data = json.loads(rv.data.decode("utf-8"))
         model = db.session.query(Dashboard).get(data.get("id"))
+        # uuid should be returned in the response
+        assert "uuid" in data
+        assert str(model.uuid) == str(data["uuid"])
         db.session.delete(model)
         db.session.commit()
 

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -725,6 +725,9 @@ class TestDatasetApi(SupersetTestCase):
         assert model.database_id == table_data["database"]
         # normalize_columns should default to False
         assert model.normalize_columns is False
+        # uuid should be returned in the response
+        assert "uuid" in data
+        assert str(model.uuid) == str(data["uuid"])
 
         # Assert that columns were created
         columns = (


### PR DESCRIPTION
### SUMMARY

The auto-generated uuid was missing from the POST creation response for datasets, charts, and dashboards, making it impossible for API consumers to reference newly created resources by UUID without a subsequent GET request.

The database endpoint already returns uuid in its POST response (via `item["uuid"] = new_model.uuid`). This change brings the other three resource types in line with that precedent by adding `uuid=new_model.uuid` to the `self.response()` call in each endpoint.

This is needed for programmatic workflows such as cross-environment dashboard imports that use `dataset_mapping` and `database_mapping` parameters, which require UUIDs to map resources across instances.

Closes #15456 (Issue was already marked as closed due to inactivity)


### TESTING INSTRUCTIONS
For each of these following endpoints ensure uuid field exist in the response:

- POST /api/v1/dataset/ -- Create a dataset
<img width="923" height="567" alt="Screenshot 2026-02-09 at 16 57 44" src="https://github.com/user-attachments/assets/598ba024-c0d2-4b40-b1e9-3bfc627053ca" />


- POST /api/v1/chart/ -- Create a chart
<img width="935" height="615" alt="Screenshot 2026-02-09 at 16 58 05" src="https://github.com/user-attachments/assets/9aecdb74-9a1d-46df-97a1-80bc55f32b58" />


- POST /api/v1/dashboard/ -- Create a dashboard
<img width="914" height="545" alt="Screenshot 2026-02-09 at 16 58 51" src="https://github.com/user-attachments/assets/3659e316-85aa-443e-91e4-00cd838591f9" />


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
