### PR TITLE
fix(componentParent): Newly created tabs don't show up in Scoping tab

### DIFF
--- a/superset-frontend/src/dashboard/reducers/dashboardLayout.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardLayout.test.ts
@@ -422,14 +422,17 @@ describe('dashboardLayout reducer', () => {
       [DASHBOARD_GRID_ID]: {
         id: DASHBOARD_GRID_ID,
         children: ['child', 'child2'],
+        parents: [DASHBOARD_ROOT_ID],
       },
       child: {
         id: 'child',
         children: [],
+        parents: [DASHBOARD_ROOT_ID, DASHBOARD_GRID_ID],
       },
       child2: {
         id: 'child2',
         children: [],
+        parents: [DASHBOARD_ROOT_ID, DASHBOARD_GRID_ID],
       },
     });
   });
@@ -465,6 +468,112 @@ describe('dashboardLayout reducer', () => {
     const newId = result[DASHBOARD_GRID_ID].children[1];
     expect(result[DASHBOARD_GRID_ID].children).toHaveLength(2);
     expect(result[newId].type).toBe(ROW_TYPE);
+  });
+
+  test('should update parents array when creating top-level tabs', () => {
+    const layout = {
+      [DASHBOARD_ROOT_ID]: {
+        id: DASHBOARD_ROOT_ID,
+        type: DASHBOARD_ROOT_TYPE,
+        children: [DASHBOARD_GRID_ID],
+        parents: [],
+      },
+      [DASHBOARD_GRID_ID]: {
+        id: DASHBOARD_GRID_ID,
+        type: DASHBOARD_GRID_TYPE,
+        children: ['row1'],
+        parents: [DASHBOARD_ROOT_ID],
+      },
+      row1: {
+        id: 'row1',
+        type: ROW_TYPE,
+        children: ['chart1'],
+        parents: [DASHBOARD_ROOT_ID, DASHBOARD_GRID_ID],
+      },
+      chart1: {
+        id: 'chart1',
+        type: CHART_TYPE,
+        children: [],
+        parents: [DASHBOARD_ROOT_ID, DASHBOARD_GRID_ID, 'row1'],
+      },
+    };
+
+    const dropResult = {
+      source: { id: NEW_COMPONENTS_SOURCE_ID, type: '' },
+      destination: {
+        id: DASHBOARD_ROOT_ID,
+        type: DASHBOARD_ROOT_TYPE,
+        index: 0,
+      },
+      dragging: { id: NEW_TABS_ID, type: TABS_TYPE },
+    };
+
+    const result = testReducer(layout, {
+      type: CREATE_TOP_LEVEL_TABS,
+      payload: { dropResult },
+    });
+
+    const tabsComponent = Object.values(result).find(
+      component => component.type === TABS_TYPE,
+    )!;
+
+    const tabComponent = Object.values(result).find(
+      component => component.type === TAB_TYPE,
+    )!;
+
+    // Verify parents are updated for moved components
+    expect(result.row1.parents).toContain(tabComponent.id);
+    expect(result.chart1.parents).toContain(tabComponent.id);
+  });
+
+  test('should update parents array when moving a component', () => {
+    const layout = {
+      [DASHBOARD_ROOT_ID]: {
+        id: DASHBOARD_ROOT_ID,
+        type: DASHBOARD_ROOT_TYPE,
+        children: [DASHBOARD_GRID_ID],
+        parents: [],
+      },
+      [DASHBOARD_GRID_ID]: {
+        id: DASHBOARD_GRID_ID,
+        type: DASHBOARD_GRID_TYPE,
+        children: ['row1', 'row2'],
+        parents: [DASHBOARD_ROOT_ID],
+      },
+      row1: {
+        id: 'row1',
+        type: ROW_TYPE,
+        children: ['chart1'],
+        parents: [DASHBOARD_ROOT_ID, DASHBOARD_GRID_ID],
+      },
+      row2: {
+        id: 'row2',
+        type: ROW_TYPE,
+        children: [],
+        parents: [DASHBOARD_ROOT_ID, DASHBOARD_GRID_ID],
+      },
+      chart1: {
+        id: 'chart1',
+        type: CHART_TYPE,
+        children: [],
+        parents: [DASHBOARD_ROOT_ID, DASHBOARD_GRID_ID, 'row1'],
+      },
+    };
+
+    const dropResult = {
+      source: { id: 'row1', type: ROW_TYPE, index: 0 },
+      destination: { id: 'row2', type: ROW_TYPE, index: 0 },
+      dragging: { id: 'chart1', type: CHART_TYPE },
+    };
+
+    const result = testReducer(layout, {
+      type: MOVE_COMPONENT,
+      payload: { dropResult },
+    });
+
+    // Chart should now have row2 as parent instead of row1
+    expect(result.chart1.parents).toContain('row2');
+    expect(result.chart1.parents).not.toContain('row1');
   });
 
   test('recursivelyDeleteChildren should be error proof with bad inputs', () => {

--- a/superset-frontend/src/dashboard/reducers/dashboardLayout.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardLayout.test.ts
@@ -513,10 +513,6 @@ describe('dashboardLayout reducer', () => {
       payload: { dropResult },
     });
 
-    const tabsComponent = Object.values(result).find(
-      component => component.type === TABS_TYPE,
-    )!;
-
     const tabComponent = Object.values(result).find(
       component => component.type === TAB_TYPE,
     )!;

--- a/superset-frontend/src/dashboard/reducers/dashboardLayout.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardLayout.ts
@@ -368,7 +368,17 @@ export default function layoutReducer(
 ): DashboardLayout {
   if (action.type in actionHandlers) {
     const handler = actionHandlers[action.type];
-    return handler(state, action);
+    const nextState = handler(state, action);
+
+    // Update parents list after any layout change
+    if (nextState !== state && nextState[DASHBOARD_ROOT_ID]) {
+      updateComponentParentsList({
+        currentComponent: nextState[DASHBOARD_ROOT_ID],
+        layout: nextState,
+      });
+    }
+
+    return nextState;
   }
 
   return state;


### PR DESCRIPTION
### SUMMARY

When users create tabs or move components in dashboard edit mode, the `parents` array on layout items was not being updated. The `parents` array tracks the ancestry chain of each component (e.g., a chart inside a tab would have `parents: ["ROOT_ID", "TABS_ID", "TAB_ID"]`).

The `updateComponentParentsList` function that rebuilds these arrays was only called when **saving** the dashboard (via `saveDashboardRequest`). This meant:

1. User creates tabs → visual layout updates correctly
2. User opens filter editor → scoping tree reads stale `parents` arrays
3. Scoping tree shows incorrect hierarchy (charts not under tabs)
4. User refreshes page → saved data loads with correct `parents` → works correctly

### Solution

Call `updateComponentParentsList` in the main `layoutReducer` function after any layout action that modifies the state. This ensures `parents` arrays are always up-to-date immediately after any layout change.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

https://github.com/user-attachments/assets/60c0d464-d8ed-4f72-9f8b-c24fdb604aa1

#### AFTER

https://github.com/user-attachments/assets/4efe6d7a-6f25-40d6-b788-567e8bc43bbe



### TESTING INSTRUCTIONS
1. Created a new dashboard with charts
2. Edited dashboard and created tabs
3. Moved charts into tabs
4. Opened filter editor → Scoping tab
5. Verified tree shows correct tab hierarchy immediately (without refresh)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
