### PR TITLE
fix: Vertical lines in the middle of Treemap categories

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -173,8 +173,6 @@ export default function transformProps(
   const treeData = treeBuilder(data, groupbyLabels, metricLabel);
   const labelProps = {
     color: theme.colorText,
-    borderColor: theme.colorBgBase,
-    borderWidth: 1,
   };
   const traverse = (treeNodes: TreeNode[], path: string[]) =>
     treeNodes.map(treeNode => {


### PR DESCRIPTION

### SUMMARY
Due to unnecessary borders around labels, Treemap charts had vertical lines in the middle of each section/category.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1718" height="864" alt="image" src="https://github.com/user-attachments/assets/10c0635f-c82d-4e5a-a1b1-6bcaf139b4bc" />

After:
<img width="1728" height="856" alt="image" src="https://github.com/user-attachments/assets/ac05f26b-b4fe-4e20-a00b-0da16108825a" />


### TESTING INSTRUCTIONS
Open a treemap chart, verify there are no vertical lines in the middle of sections.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
