### PR TITLE
fix(ssh): add auto-detection support for Paramiko private key types

### DIFF
--- a/tests/unit_tests/extensions/ssh_test.py
+++ b/tests/unit_tests/extensions/ssh_test.py
@@ -14,11 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from io import StringIO
 from unittest.mock import Mock
 
+import pytest
 import sshtunnel
+from paramiko import ECDSAKey, Ed25519Key, RSAKey
 
-from superset.extensions.ssh import SSHManagerFactory
+from superset.extensions.ssh import _load_private_key, SSHManagerFactory
 
 
 def test_ssh_tunnel_timeout_setting() -> None:
@@ -34,3 +37,103 @@ def test_ssh_tunnel_timeout_setting() -> None:
     factory.init_app(app)
     assert sshtunnel.TUNNEL_TIMEOUT == 123.0
     assert sshtunnel.SSH_TIMEOUT == 321.0
+
+
+def test_load_private_key_rsa() -> None:
+    """Test loading RSA private key (backward compatibility)."""
+    # Generate a test RSA key
+    rsa_key = RSAKey.generate(bits=2048)
+    key_file = StringIO()
+    rsa_key.write_private_key(key_file)
+    key_str = key_file.getvalue()
+
+    # Load the key using auto-detection
+    loaded_key = _load_private_key(key_str)
+
+    # Verify it's an RSA key and matches
+    assert isinstance(loaded_key, RSAKey)
+    assert loaded_key.get_base64() == rsa_key.get_base64()
+
+
+def test_load_private_key_ed25519() -> None:
+    """Test loading Ed25519 private key (new functionality)."""
+    # Generate a test Ed25519 key using cryptography library
+    # Ed25519Key doesn't have a direct generate() method, so we use from_private_key
+    # with a newly generated key from the underlying cryptography library
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    private_key_crypto = ed25519.Ed25519PrivateKey.generate()
+    from cryptography.hazmat.primitives import serialization
+
+    pem = private_key_crypto.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.OpenSSH,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_str = pem.decode("utf-8")
+
+    # Load the key using auto-detection
+    loaded_key = _load_private_key(key_str)
+
+    # Verify it's an Ed25519 key
+    assert isinstance(loaded_key, Ed25519Key)
+
+
+def test_load_private_key_ecdsa() -> None:
+    """Test loading ECDSA private key."""
+    # Generate a test ECDSA key (256-bit curve)
+    ecdsa_key = ECDSAKey.generate()
+    key_file = StringIO()
+    ecdsa_key.write_private_key(key_file)
+    key_str = key_file.getvalue()
+
+    # Load the key using auto-detection
+    loaded_key = _load_private_key(key_str)
+
+    # Verify it's an ECDSA key and matches
+    assert isinstance(loaded_key, ECDSAKey)
+    assert loaded_key.get_base64() == ecdsa_key.get_base64()
+
+
+def test_load_private_key_with_password() -> None:
+    """Test loading password-protected private key."""
+    # Generate an RSA key and save with password
+    rsa_key = RSAKey.generate(bits=2048)
+    key_file = StringIO()
+    password = "test_password_123"
+    rsa_key.write_private_key(key_file, password=password)
+    key_str = key_file.getvalue()
+
+    # Load the key with correct password
+    loaded_key = _load_private_key(key_str, password)
+    assert isinstance(loaded_key, RSAKey)
+    assert loaded_key.get_base64() == rsa_key.get_base64()
+
+    # Verify loading fails with wrong password
+    with pytest.raises(ValueError, match="Failed to load private key"):
+        _load_private_key(key_str, "wrong_password")
+
+    # Verify loading fails without password
+    with pytest.raises(ValueError, match="Failed to load private key"):
+        _load_private_key(key_str)
+
+
+def test_load_private_key_invalid() -> None:
+    """Test that invalid keys fail cleanly with descriptive error."""
+    invalid_key = "not a valid private key"
+
+    with pytest.raises(ValueError) as exc_info:
+        _load_private_key(invalid_key)
+
+    error_msg = str(exc_info.value)
+    # Error message should mention all attempted key types
+    assert "Failed to load private key" in error_msg
+    assert "RSAKey" in error_msg
+    assert "Ed25519Key" in error_msg
+    assert "ECDSAKey" in error_msg
+
+
+def test_load_private_key_empty() -> None:
+    """Test that empty key string fails cleanly."""
+    with pytest.raises(ValueError, match="Failed to load private key"):
+        _load_private_key("")


### PR DESCRIPTION
This PR fixes SSH tunnel authentication failures when using modern private key formats supported by Paramiko (e.g. ED25519).

The existing implementation assumed RSA keys during private key loading, which caused valid non-RSA keys to fail during SSH tunnel initialization. Since Paramiko already supports multiple key formats, this change updates Superset to safely leverage those capabilities through automatic key type detection.

The implementation is intentionally minimal, scoped only to SSH key loading, and preserves the existing authentication flow and validation behavior. No configuration, schema, or connection model changes are introduced.

RSA-based tunnels remain fully supported, ensuring complete backward compatibility while improving support for modern SSH key standards.