### PR TITLE
fix(gtf): set dedup_key on atomic sql

### DIFF
--- a/docs/developer_portal/extensions/tasks.md
+++ b/docs/developer_portal/extensions/tasks.md
@@ -50,7 +50,7 @@ When GTF is considered stable, it will replace legacy Celery tasks for built-in 
 ### Define a Task
 
 ```python
-from superset_core.api.types import task, get_context
+from superset_core.api.tasks import task, get_context
 
 @task
 def process_data(dataset_id: int) -> None:
@@ -245,7 +245,7 @@ Always implement an abort handler for long-running tasks. This allows users to c
 Set a timeout to automatically abort tasks that run too long:
 
 ```python
-from superset_core.api.types import task, get_context, TaskOptions
+from superset_core.api.tasks import task, get_context, TaskOptions
 
 # Set default timeout in decorator
 @task(timeout=300)  # 5 minutes
@@ -299,7 +299,7 @@ Timeouts require an abort handler to be effective. Without one, the timeout trig
 Use `task_key` to prevent duplicate task execution:
 
 ```python
-from superset_core.api.types import TaskOptions
+from superset_core.api.tasks import TaskOptions
 
 # Without key - creates new task each time (random UUID)
 task1 = my_task.schedule(x=1)
@@ -331,7 +331,7 @@ print(task2.status)  # "success" (terminal status)
 ## Task Scopes
 
 ```python
-from superset_core.api.types import task, TaskScope
+from superset_core.api.tasks import task, TaskScope
 
 @task  # Private by default
 def private_task(): ...

--- a/superset-core/src/superset_core/api/tasks.py
+++ b/superset-core/src/superset_core/api/tasks.py
@@ -259,7 +259,7 @@ def task(
         is discarded; only side effects and context updates matter.
 
     Example:
-        from superset_core.api.types import task, get_context, TaskScope
+        from superset_core.api.tasks import task, get_context, TaskScope
 
         # Private task (default scope)
         @task

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -112,9 +112,6 @@ class TaskManager:
     _completion_channel_prefix: str = "gtf:complete:"
     _initialized: bool = False
 
-    # Backward compatibility alias - prefer importing from superset.tasks.constants
-    TERMINAL_STATES = TERMINAL_STATES
-
     @classmethod
     def init_app(cls, app: Flask) -> None:
         """
@@ -271,7 +268,7 @@ class TaskManager:
         if not task:
             raise ValueError(f"Task {task_uuid} not found")
 
-        if task.status in cls.TERMINAL_STATES:
+        if task.status in TERMINAL_STATES:
             return task
 
         logger.debug(
@@ -342,13 +339,13 @@ class TaskManager:
                         message.get("data"),
                     )
                     task = get_task()
-                    if task and task.status in cls.TERMINAL_STATES:
+                    if task and task.status in TERMINAL_STATES:
                         return task
 
                 # Also check database periodically in case we missed the message
                 # (e.g., task completed before we subscribed)
                 task = get_task()
-                if task and task.status in cls.TERMINAL_STATES:
+                if task and task.status in TERMINAL_STATES:
                     logger.debug(
                         "Task %s completed (detected via db check): status=%s",
                         task_uuid,
@@ -384,7 +381,7 @@ class TaskManager:
             if not task:
                 raise ValueError(f"Task {task_uuid} not found")
 
-            if task.status in cls.TERMINAL_STATES:
+            if task.status in TERMINAL_STATES:
                 logger.debug(
                     "Task %s completed (detected via polling): status=%s",
                     task_uuid,

--- a/superset/tasks/schemas.py
+++ b/superset/tasks/schemas.py
@@ -25,6 +25,9 @@ get_delete_ids_schema = {"type": "array", "items": {"type": "string"}}
 # Field descriptions
 uuid_description = "The unique identifier (UUID) of the task"
 task_key_description = "The task identifier used for deduplication"
+dedup_key_description = (
+    "The hashed deduplication key used internally for task deduplication"
+)
 task_type_description = (
     "The type of task (e.g., 'sql_execution', 'thumbnail_generation')"
 )
@@ -74,6 +77,7 @@ class TaskResponseSchema(Schema):
     id = fields.Int(metadata={"description": "Internal task ID"})
     uuid = fields.UUID(metadata={"description": uuid_description})
     task_key = fields.String(metadata={"description": task_key_description})
+    dedup_key = fields.String(metadata={"description": dedup_key_description})
     task_type = fields.String(metadata={"description": task_type_description})
     task_name = fields.String(
         metadata={"description": task_name_description}, allow_none=True

--- a/tests/integration_tests/tasks/test_sync_join_wait.py
+++ b/tests/integration_tests/tasks/test_sync_join_wait.py
@@ -68,21 +68,6 @@ def test_submit_task_distinguishes_new_vs_existing(
         db.session.commit()
 
 
-def test_terminal_states_recognized_correctly(app_context) -> None:
-    """
-    Test that TaskManager.TERMINAL_STATES contains the expected values.
-    """
-    assert TaskStatus.SUCCESS.value in TaskManager.TERMINAL_STATES
-    assert TaskStatus.FAILURE.value in TaskManager.TERMINAL_STATES
-    assert TaskStatus.ABORTED.value in TaskManager.TERMINAL_STATES
-    assert TaskStatus.TIMED_OUT.value in TaskManager.TERMINAL_STATES
-
-    # Non-terminal states should not be in the set
-    assert TaskStatus.PENDING.value not in TaskManager.TERMINAL_STATES
-    assert TaskStatus.IN_PROGRESS.value not in TaskManager.TERMINAL_STATES
-    assert TaskStatus.ABORTING.value not in TaskManager.TERMINAL_STATES
-
-
 def test_wait_for_completion_timeout(app_context, login_as, get_user) -> None:
     """
     Test that wait_for_completion raises TimeoutError on timeout.

--- a/tests/unit_tests/daos/test_tasks.py
+++ b/tests/unit_tests/daos/test_tasks.py
@@ -495,9 +495,9 @@ def test_conditional_status_update_terminal_state_updates_dedup_key(
     # Verify dedup_key was updated
     session_with_task.refresh(task)
     assert task.status == terminal_state.value
-    assert (
-        task.dedup_key == expected_finished_key
-    ), f"dedup_key not updated for {terminal_state.value}"
-    assert (
-        task.dedup_key != original_dedup_key
-    ), f"dedup_key should have changed for {terminal_state.value}"
+    assert task.dedup_key == expected_finished_key, (
+        f"dedup_key not updated for {terminal_state.value}"
+    )
+    assert task.dedup_key != original_dedup_key, (
+        f"dedup_key should have changed for {terminal_state.value}"
+    )

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -455,8 +455,3 @@ class TestTaskManagerCompletion:
                 timeout=5.0,
                 poll_interval=0.1,
             )
-
-    def test_terminal_states_constant(self):
-        """Test TERMINAL_STATES contains expected values"""
-        expected = {"success", "failure", "aborted", "timed_out"}
-        assert TaskManager.TERMINAL_STATES == expected


### PR DESCRIPTION
### SUMMARY
A few fixes to the initial GTF implementation in #36368 :
- Atomic SQL wasn't updating `dedup_key`, making completed tasks blocking. This fixes the issue, adds unit tests and adds `dedup_key` to the task schema for easier debugging.
- Fixes some typos in the docs.
- Some general slop cleanup.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
