### PR TITLE
chore(deps): Upgrade sqlglot from 27.15.2 to 28.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dependencies = [
     "slack_sdk>=3.19.0, <4",
     "sqlalchemy>=1.4, <2",
     "sqlalchemy-utils>=0.38.3, <0.39",
-    "sqlglot>=27.15.2, <28",
+    "sqlglot>=28.10.0, <29",
     # newer pandas needs 0.9+
     "tabulate>=0.9.0, <1.0",
     "typing-extensions>=4, <5",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -404,7 +404,7 @@ sqlalchemy-utils==0.38.3
     #   apache-superset (pyproject.toml)
     #   apache-superset-core
     #   flask-appbuilder
-sqlglot==27.15.2
+sqlglot==28.10.0
     # via
     #   apache-superset (pyproject.toml)
     #   apache-superset-core

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -996,7 +996,7 @@ sqlalchemy-utils==0.38.3
     #   apache-superset
     #   apache-superset-core
     #   flask-appbuilder
-sqlglot==27.15.2
+sqlglot==28.10.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/superset-core/pyproject.toml
+++ b/superset-core/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pydantic>=2.8.0",
     "sqlalchemy>=1.4.0,<2.0",
     "sqlalchemy-utils>=0.38.0",
-    "sqlglot>=27.15.2, <28",
+    "sqlglot>=28.10.0, <29",
     "typing-extensions>=4.0.0",
 ]
 

--- a/superset/sql/dialects/pinot.py
+++ b/superset/sql/dialects/pinot.py
@@ -144,6 +144,8 @@ class Pinot(MySQL):
                 e.args.get("expression"),
                 e.args.get("variant"),
             ),
+            # Preserve Pinot's YEAROFWEEK (sqlglot normalizes to YEAR_OF_WEEK)
+            exp.YearOfWeek: lambda self, e: self.func("YEAROFWEEK", e.this),
         }
         # Remove DATE_TRUNC transformation - Pinot supports standard SQL DATE_TRUNC
         TRANSFORMS.pop(exp.DateTrunc, None)

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -271,7 +271,7 @@ class RLSAsSubqueryTransformer(RLSTransformer):
                 this=exp.Select(
                     expressions=[exp.Star()],
                     where=exp.Where(this=predicate),
-                    **{"from": exp.From(this=node.copy())},
+                    from_=exp.From(this=node.copy()),
                 ),
                 alias=alias,
             )
@@ -816,7 +816,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
                 limit=exp.Limit(
                     expression=exp.Literal(this=str(limit), is_string=False)
                 ),
-                **{"from": exp.From(this=exp.Subquery(this=self._parsed.copy()))},
+                from_=exp.From(this=exp.Subquery(this=self._parsed.copy())),
             )
         else:  # method == LimitMethod.FETCH_MANY
             pass
@@ -827,7 +827,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
 
         :return: True if the statement has a CTE at the top level.
         """
-        return "with" in self._parsed.args
+        return "with_" in self._parsed.args
 
     def as_cte(self, alias: str = "__cte") -> SQLStatement:
         """
@@ -840,8 +840,8 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         :param alias: The alias to use for the CTE.
         :return: A new SQLStatement with the CTE.
         """
-        existing_ctes = self._parsed.args["with"].expressions if self.has_cte() else []
-        self._parsed.args["with"] = None
+        existing_ctes = self._parsed.args["with_"].expressions if self.has_cte() else []
+        self._parsed.args["with_"] = None
         new_cte = exp.CTE(
             this=self._parsed.copy(),
             alias=exp.TableAlias(this=exp.Identifier(this=alias)),

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -827,7 +827,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
 
         :return: True if the statement has a CTE at the top level.
         """
-        return "with_" in self._parsed.args
+        return bool(self._parsed.args.get("with_"))
 
     def as_cte(self, alias: str = "__cte") -> SQLStatement:
         """

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1867,6 +1867,23 @@ def test_as_cte(sql: str, engine: str, expected: str) -> None:
     assert SQLStatement(sql, engine).as_cte().format() == expected
 
 
+def test_as_cte_called_twice() -> None:
+    """
+    Test that calling as_cte() multiple times on the same instance works.
+
+    Regression test for a bug where as_cte() sets self._parsed.args["with_"] = None
+    after extracting CTEs, but has_cte() only checked if the key existed, not if
+    the value was truthy. This caused an AttributeError on subsequent as_cte() calls.
+    """
+    sql = "WITH cte AS (SELECT 1) SELECT * FROM cte"
+    stmt = SQLStatement(sql, "postgresql")
+
+    assert stmt.has_cte() is True
+    stmt.as_cte()
+    assert stmt.has_cte() is False
+    stmt.as_cte()
+
+
 @pytest.mark.parametrize(
     "sql, rules, expected",
     [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Upgrades sqlglot from `>=27.15.2, <28` to `>=28.10.0, <29`.

**Why this change is needed:**
- sqlglot v28 includes many bug fixes, improved type annotations, and better dialect support
- Keeps Superset current with upstream improvements in SQL parsing and transpilation

**Changelog review:**

Reviewed all breaking changes from v27.15.2 to v28.10.0 in the [sqlglot changelog](https://github.com/tobymao/sqlglot/blob/main/CHANGELOG.md). The vast majority are additive changes (new function type annotations, transpilation improvements) that don't affect Superset. The only breaking changes impacting Superset were the arg name renames detailed below.

**Breaking changes addressed:**

sqlglot v28 renamed Python reserved keywords used as expression argument names:
- `from` → `from_`
- `with` → `with_`

This required updates in `superset/sql/parse.py`:
- `exp.Select(..., **{"from": ...})` → `exp.Select(..., from_=...)`
- `"with" in self._parsed.args` → `"with_" in self._parsed.args`
- `args["with"]` → `args["with_"]`

Additionally, sqlglot v28 added a `YearOfWeek` expression class that normalizes `YEAROFWEEK` to `YEAR_OF_WEEK`. Added a generator transform in the Pinot dialect to preserve Pinot's expected function name.

### TESTING INSTRUCTIONS

1. Run the SQL unit tests:
   ```bash
   pytest tests/unit_tests/sql/ -v
   ```
   Expected: All 986 tests pass

2. Verify RLS (Row Level Security) functionality works correctly:
   ```bash
   pytest tests/unit_tests/sql/parse_tests.py::test_rls_subquery_transformer -v
   pytest tests/unit_tests/sql/parse_tests.py::test_rls_predicate_transformer -v
   ```

3. Verify CTE handling:
   ```bash
   pytest tests/unit_tests/sql/parse_tests.py::test_has_cte -v
   pytest tests/unit_tests/sql/parse_tests.py::test_as_cte -v
   ```

4. Verify Pinot dialect:
   ```bash
   pytest tests/unit_tests/sql/dialects/pinot_tests.py -v
   ```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
