### PR TITLE
chore(tagging system): set TAGGING_SYSTEM feature flag to True

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,7 +24,7 @@ assists people when migrating to a new version.
 
 ## Next
 
-### Feature Flag Changed
+### Feature Flags Changed
 
 - The default value of **TAGGING_SYSTEM** was flipped from `False` to `True`([37852](https://github.com/apache/superset/pull/37852)).
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,10 @@ assists people when migrating to a new version.
 
 ## Next
 
+### Feature Flag Changed
+
+- The default value of **TAGGING_SYSTEM** was flipped from `False` to `True`([37852](https://github.com/apache/superset/pull/37852)).
+
 ### Signal Cache Backend
 
 A new `SIGNAL_CACHE_CONFIG` configuration provides a unified Redis-based backend for real-time coordination features in Superset. This backend enables:

--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -74,12 +74,6 @@
         "default": false,
         "lifecycle": "development",
         "description": "Enable Table V2 time comparison feature"
-      },
-      {
-        "name": "TAGGING_SYSTEM",
-        "default": false,
-        "lifecycle": "development",
-        "description": "Enables the tagging system for organizing assets"
       }
     ],
     "testing": [
@@ -195,6 +189,12 @@
         "lifecycle": "testing",
         "description": "Allow users to enable SSH tunneling when creating a DB connection. DB engine must support SSH Tunnels.",
         "docs": "https://superset.apache.org/docs/configuration/setup-ssh-tunneling"
+      },
+      {
+        "name": "TAGGING_SYSTEM",
+        "default": true,
+        "lifecycle": "testing",
+        "description": "Enables the tagging system for organizing assets"
       },
       {
         "name": "USE_ANALOGOUS_COLORS",

--- a/superset/config.py
+++ b/superset/config.py
@@ -581,9 +581,6 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # Enable Table V2 time comparison feature
     # @lifecycle: development
     "TABLE_V2_TIME_COMPARISON_ENABLED": False,
-    # Enables the tagging system for organizing assets
-    # @lifecycle: development
-    "TAGGING_SYSTEM": False,
     # =================================================================
     # IN TESTING
     # =================================================================
@@ -668,6 +665,9 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # Use analogous colors in charts
     # @lifecycle: testing
     "USE_ANALOGOUS_COLORS": False,
+    # Enables the tagging system for organizing assets
+    # @lifecycle: testing
+    "TAGGING_SYSTEM": True,
     # =================================================================
     # STABLE - PATH TO DEPRECATION
     # =================================================================


### PR DESCRIPTION
Also mark its lifecycle as "testing" instead of "development".

### SUMMARY
Discussed at January 2026 Superset Town Hall. From those meeting notes:

> Q: [SF] Should we flip the TAGGING_SYSTEM feature flag to true for the next major release? See unresolved discussion at[ https://github.com/apache/superset/pull/32318](https://github.com/apache/superset/pull/32318)
> 
> A: Might want to keep it as a configuration, but probably? Sure!

We didn't discuss marking it as "testing" but that seems more accurate to me than "in development" as development seems largely to have stabilized.