### PR TITLE
fix(native-filters): Filters with select first value not restored correctly from url

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -151,7 +151,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const [col] = groupby;
   const [initialColtypeMap] = useState(coltypeMap);
   const [search, setSearch] = useState('');
-  const isChangedByUser = useRef(false);
   const prevDataRef = useRef(data);
   const [dataMask, dispatchDataMask] = useImmerReducer(reducer, {
     extraFormData: {},
@@ -273,8 +272,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       } else {
         updateDataMask(values);
       }
-
-      isChangedByUser.current = true;
     },
     [updateDataMask, formData.nativeFilterId, clearAllTrigger],
   );
@@ -400,14 +397,12 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
 
     // If data actually changed (e.g., due to parent filter), reset flag
     if (hasDataChanged) {
-      isChangedByUser.current = false;
       prevDataRef.current = data;
     }
   }, [data, col]);
 
   useEffect(() => {
     if (
-      isChangedByUser.current &&
       filterState.value?.every((value?: any) =>
         data.some(row => row[col] === value),
       )


### PR DESCRIPTION
### SUMMARY
When opening a dashboard using a saved native filter state (via URL containing native_filters_key or permalink), the parent filter restored correctly, but the dependent (cascading) child filter did not restore the saved value.

This PR removes an unnecessary condition which was preventing restoring the child filter value.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/c6d6d2d5-3759-423e-aa75-5f08c0c1e365


After:

https://github.com/user-attachments/assets/81848ef3-38b6-4d75-aa02-d0c74b789441


### TESTING INSTRUCTIONS
1. Create 2 native filters - Parent and Child
2. In Child filter, set `Values are dependent on other filters: Parent`, `Filter value is required` and `Select first filter value by default`
3. Set a value in Parent filter, wait for Child options to refresh and select some value other than the first one (selected by default)
4. Apply filters
5. Copy dashboard URL (or copy the permalink) and open it in another tab
6. Verify that both filter values have been correctly restored

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
