### PR TITLE
feat(mcp): add event_logger instrumentation to MCP tools

### DIFF
--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -288,7 +288,9 @@ async def generate_chart(  # noqa: C901
 
                     # Ensure chart was created successfully before committing
                     if not chart or not chart.id:
-                        raise Exception("Chart creation failed - no chart ID returned")
+                        raise RuntimeError(
+                            "Chart creation failed - no chart ID returned"
+                        )
 
                 await ctx.info(
                     "Chart created successfully: chart_id=%s, chart_name=%s"
@@ -440,7 +442,8 @@ async def generate_chart(  # noqa: C901
                                 else:
                                     # Skip for non-numeric dataset IDs
                                     logger.warning(
-                                        "Cannot generate preview for non-numeric "
+                                        "Cannot generate preview for"
+                                        " non-numeric dataset IDs"
                                     )
                                     continue
 

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -25,6 +25,7 @@ from urllib.parse import parse_qs, urlparse
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.extensions import event_logger
 from superset.mcp_service.auth import has_dataset_access
 from superset.mcp_service.chart.chart_utils import (
     analyze_chart_capabilities,
@@ -132,23 +133,24 @@ async def generate_chart(  # noqa: C901
         await ctx.debug(
             "Validating chart request: dataset_id=%s" % (request.dataset_id,)
         )
-        from superset.mcp_service.chart.validation import ValidationPipeline
+        with event_logger.log_context(action="mcp.generate_chart.validation"):
+            from superset.mcp_service.chart.validation import ValidationPipeline
 
-        validation_result = ValidationPipeline.validate_request_with_warnings(
-            request.model_dump()
-        )
+            validation_result = ValidationPipeline.validate_request_with_warnings(
+                request.model_dump()
+            )
 
-        if validation_result.is_valid and validation_result.request is not None:
-            # Use the validated request going forward
-            request = validation_result.request
+            if validation_result.is_valid and validation_result.request is not None:
+                # Use the validated request going forward
+                request = validation_result.request
 
-        # Capture runtime warnings (informational, not blocking)
-        if validation_result.warnings:
-            runtime_warnings = validation_result.warnings.get("warnings", [])
-            if runtime_warnings:
-                await ctx.info(
-                    "Runtime suggestions: %s" % ("; ".join(runtime_warnings[:3]),)
-                )
+            # Capture runtime warnings (informational, not blocking)
+            if validation_result.warnings:
+                runtime_warnings = validation_result.warnings.get("warnings", [])
+                if runtime_warnings:
+                    await ctx.info(
+                        "Runtime suggestions: %s" % ("; ".join(runtime_warnings[:3]),)
+                    )
 
         if not validation_result.is_valid:
             execution_time = int((time.time() - start_time) * 1000)
@@ -197,35 +199,38 @@ async def generate_chart(  # noqa: C901
             from superset.daos.dataset import DatasetDAO
 
             await ctx.debug("Looking up dataset: dataset_id=%s" % (request.dataset_id,))
-            dataset = None
-            if isinstance(request.dataset_id, int) or (
-                isinstance(request.dataset_id, str) and request.dataset_id.isdigit()
-            ):
-                dataset_id = (
-                    int(request.dataset_id)
-                    if isinstance(request.dataset_id, str)
-                    else request.dataset_id
-                )
-                dataset = DatasetDAO.find_by_id(dataset_id)
-                # SECURITY FIX: Also validate permissions for numeric ID access
-                if dataset and not has_dataset_access(dataset):
-                    logger.warning(
-                        "User %s attempted to access dataset %s without permission",
-                        ctx.user.username if hasattr(ctx, "user") else "unknown",
-                        dataset_id,
+            with event_logger.log_context(action="mcp.generate_chart.dataset_lookup"):
+                dataset = None
+                if isinstance(request.dataset_id, int) or (
+                    isinstance(request.dataset_id, str) and request.dataset_id.isdigit()
+                ):
+                    dataset_id = (
+                        int(request.dataset_id)
+                        if isinstance(request.dataset_id, str)
+                        else request.dataset_id
                     )
-                    dataset = None  # Treat as not found
-            else:
-                # SECURITY FIX: Try UUID lookup with permission validation
-                dataset = DatasetDAO.find_by_id(request.dataset_id, id_column="uuid")
-                # Validate permissions for UUID-based access
-                if dataset and not has_dataset_access(dataset):
-                    logger.warning(
-                        "User %s attempted access dataset %s via UUID",
-                        ctx.user.username if hasattr(ctx, "user") else "unknown",
-                        request.dataset_id,
+                    dataset = DatasetDAO.find_by_id(dataset_id)
+                    # SECURITY FIX: Also validate permissions for numeric ID access
+                    if dataset and not has_dataset_access(dataset):
+                        logger.warning(
+                            "User %s attempted to access dataset %s without permission",
+                            ctx.user.username if hasattr(ctx, "user") else "unknown",
+                            dataset_id,
+                        )
+                        dataset = None  # Treat as not found
+                else:
+                    # SECURITY FIX: Try UUID lookup with permission validation
+                    dataset = DatasetDAO.find_by_id(
+                        request.dataset_id, id_column="uuid"
                     )
-                    dataset = None  # Treat as not found
+                    # Validate permissions for UUID-based access
+                    if dataset and not has_dataset_access(dataset):
+                        logger.warning(
+                            "User %s attempted access dataset %s via UUID",
+                            ctx.user.username if hasattr(ctx, "user") else "unknown",
+                            request.dataset_id,
+                        )
+                        dataset = None  # Treat as not found
 
             if not dataset:
                 await ctx.error(
@@ -267,22 +272,23 @@ async def generate_chart(  # noqa: C901
                 )
 
             try:
-                command = CreateChartCommand(
-                    {
-                        "slice_name": chart_name,
-                        "viz_type": form_data["viz_type"],
-                        "datasource_id": dataset.id,
-                        "datasource_type": "table",
-                        "params": json.dumps(form_data),
-                    }
-                )
+                with event_logger.log_context(action="mcp.generate_chart.db_write"):
+                    command = CreateChartCommand(
+                        {
+                            "slice_name": chart_name,
+                            "viz_type": form_data["viz_type"],
+                            "datasource_id": dataset.id,
+                            "datasource_type": "table",
+                            "params": json.dumps(form_data),
+                        }
+                    )
 
-                chart = command.run()
-                chart_id = chart.id
+                    chart = command.run()
+                    chart_id = chart.id
 
-                # Ensure chart was created successfully before committing
-                if not chart or not chart.id:
-                    raise Exception("Chart creation failed - no chart ID returned")
+                    # Ensure chart was created successfully before committing
+                    if not chart or not chart.id:
+                        raise Exception("Chart creation failed - no chart ID returned")
 
                 await ctx.info(
                     "Chart created successfully: chart_id=%s, chart_name=%s"
@@ -301,35 +307,39 @@ async def generate_chart(  # noqa: C901
 
             # Generate form_data_key for saved charts (needed for chatbot rendering)
             try:
-                from superset.commands.explore.form_data.parameters import (
-                    CommandParameters,
-                )
-                from superset.mcp_service.commands.create_form_data import (
-                    MCPCreateFormDataCommand,
-                )
-                from superset.utils.core import DatasourceType
+                with event_logger.log_context(
+                    action="mcp.generate_chart.form_data_cache"
+                ):
+                    from superset.commands.explore.form_data.parameters import (
+                        CommandParameters,
+                    )
+                    from superset.mcp_service.commands.create_form_data import (
+                        MCPCreateFormDataCommand,
+                    )
+                    from superset.utils.core import DatasourceType
 
-                # Add datasource to form_data for the cache
-                form_data_with_datasource = {
-                    **form_data,
-                    "datasource": f"{dataset.id}__table",
-                }
+                    # Add datasource to form_data for the cache
+                    form_data_with_datasource = {
+                        **form_data,
+                        "datasource": f"{dataset.id}__table",
+                    }
 
-                cmd_params = CommandParameters(
-                    datasource_type=DatasourceType.TABLE,
-                    datasource_id=dataset.id,
-                    chart_id=chart.id,
-                    tab_id=None,
-                    form_data=json.dumps(form_data_with_datasource),
-                )
-                form_data_key = MCPCreateFormDataCommand(cmd_params).run()
-                await ctx.debug(
-                    "Generated form_data_key for saved chart: form_data_key=%s"
-                    % (form_data_key,)
-                )
+                    cmd_params = CommandParameters(
+                        datasource_type=DatasourceType.TABLE,
+                        datasource_id=dataset.id,
+                        chart_id=chart.id,
+                        tab_id=None,
+                        form_data=json.dumps(form_data_with_datasource),
+                    )
+                    form_data_key = MCPCreateFormDataCommand(cmd_params).run()
+                    await ctx.debug(
+                        "Generated form_data_key for saved chart: "
+                        "form_data_key=%s" % (form_data_key,)
+                    )
             except Exception as fdk_error:
                 logger.warning(
-                    "Failed to generate form_data_key for saved chart: %s", fdk_error
+                    "Failed to generate form_data_key for saved chart: %s",
+                    fdk_error,
                 )
                 await ctx.warning(
                     "Failed to generate form_data_key: error=%s" % (str(fdk_error),)
@@ -383,60 +393,65 @@ async def generate_chart(  # noqa: C901
                 "Generating previews: formats=%s" % (str(request.preview_formats),)
             )
             try:
-                for format_type in request.preview_formats:
-                    await ctx.debug(
-                        "Processing preview format: format=%s" % (format_type,)
-                    )
-
-                    if chart_id:
-                        # For saved charts, use the existing preview generation
-                        from superset.mcp_service.chart.tool.get_chart_preview import (
-                            _get_chart_preview_internal,
-                            GetChartPreviewRequest,
+                with event_logger.log_context(action="mcp.generate_chart.preview"):
+                    for format_type in request.preview_formats:
+                        await ctx.debug(
+                            "Processing preview format: format=%s" % (format_type,)
                         )
 
-                        preview_request = GetChartPreviewRequest(
-                            identifier=str(chart_id), format=format_type
-                        )
-                        preview_result = await _get_chart_preview_internal(
-                            preview_request, ctx
-                        )
-
-                        if hasattr(preview_result, "content"):
-                            previews[format_type] = preview_result.content
-                    else:
-                        # For preview-only mode (save_chart=false)
-                        # Note: Screenshot-based URL previews are not supported.
-                        # Use the explore_url to view the chart interactively.
-                        if format_type in ["ascii", "table", "vega_lite"]:
-                            # Generate preview from form data without saved chart
-                            from superset.mcp_service.chart.preview_utils import (
-                                generate_preview_from_form_data,
+                        if chart_id:
+                            # For saved charts, use the existing preview
+                            from superset.mcp_service.chart.tool.get_chart_preview import (  # noqa: E501
+                                _get_chart_preview_internal,
+                                GetChartPreviewRequest,
                             )
 
-                            # Convert dataset_id to int only if it's numeric
-                            if (
-                                isinstance(request.dataset_id, str)
-                                and request.dataset_id.isdigit()
-                            ):
-                                dataset_id_for_preview = int(request.dataset_id)
-                            elif isinstance(request.dataset_id, int):
-                                dataset_id_for_preview = request.dataset_id
-                            else:
-                                # Skip preview generation for non-numeric dataset IDs
-                                logger.warning(
-                                    "Cannot generate preview for non-numeric "
+                            preview_request = GetChartPreviewRequest(
+                                identifier=str(chart_id), format=format_type
+                            )
+                            preview_result = await _get_chart_preview_internal(
+                                preview_request, ctx
+                            )
+
+                            if hasattr(preview_result, "content"):
+                                previews[format_type] = preview_result.content
+                        else:
+                            # For preview-only mode (save_chart=false)
+                            # Note: Screenshot-based URL previews are not
+                            # supported. Use explore_url to view interactively.
+                            if format_type in [
+                                "ascii",
+                                "table",
+                                "vega_lite",
+                            ]:
+                                # Generate preview from form data
+                                from superset.mcp_service.chart.preview_utils import (
+                                    generate_preview_from_form_data,
                                 )
-                                continue
 
-                            preview_result = generate_preview_from_form_data(
-                                form_data=form_data,
-                                dataset_id=dataset_id_for_preview,
-                                preview_format=format_type,
-                            )
+                                # Convert dataset_id to int only if numeric
+                                if (
+                                    isinstance(request.dataset_id, str)
+                                    and request.dataset_id.isdigit()
+                                ):
+                                    dataset_id_for_preview = int(request.dataset_id)
+                                elif isinstance(request.dataset_id, int):
+                                    dataset_id_for_preview = request.dataset_id
+                                else:
+                                    # Skip for non-numeric dataset IDs
+                                    logger.warning(
+                                        "Cannot generate preview for non-numeric "
+                                    )
+                                    continue
 
-                            if not hasattr(preview_result, "error"):
-                                previews[format_type] = preview_result
+                                preview_result = generate_preview_from_form_data(
+                                    form_data=form_data,
+                                    dataset_id=dataset_id_for_preview,
+                                    preview_format=format_type,
+                                )
+
+                                if not hasattr(preview_result, "error"):
+                                    previews[format_type] = preview_result
 
             except Exception as e:
                 # Log warning but don't fail the entire request

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Protocol
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.extensions import event_logger
 from superset.mcp_service.chart.schemas import (
     AccessibilityMetadata,
     ASCIIPreview,
@@ -1807,65 +1808,71 @@ async def _get_chart_preview_internal(  # noqa: C901
         from superset.daos.chart import ChartDAO
 
         # Find the chart
-        chart: Any = None
-        if isinstance(request.identifier, int) or (
-            isinstance(request.identifier, str) and request.identifier.isdigit()
-        ):
-            chart_id = (
-                int(request.identifier)
-                if isinstance(request.identifier, str)
-                else request.identifier
-            )
-            await ctx.debug(
-                "Performing ID-based chart lookup: chart_id=%s" % (chart_id,)
-            )
-            chart = ChartDAO.find_by_id(chart_id)
-        else:
-            await ctx.debug(
-                "Performing UUID-based chart lookup: uuid=%s" % (request.identifier,)
-            )
-            # Try UUID lookup using DAO flexible method
-            chart = ChartDAO.find_by_id(request.identifier, id_column="uuid")
-
-            # If not found and looks like a form_data_key, try to create transient chart
-            if (
-                not chart
-                and isinstance(request.identifier, str)
-                and len(request.identifier) > 8
+        with event_logger.log_context(action="mcp.get_chart_preview.chart_lookup"):
+            chart: Any = None
+            if isinstance(request.identifier, int) or (
+                isinstance(request.identifier, str) and request.identifier.isdigit()
             ):
-                # This might be a form_data_key, try to get form data from cache
-                from superset.commands.explore.form_data.get import GetFormDataCommand
-                from superset.commands.explore.form_data.parameters import (
-                    CommandParameters,
+                chart_id = (
+                    int(request.identifier)
+                    if isinstance(request.identifier, str)
+                    else request.identifier
                 )
+                await ctx.debug(
+                    "Performing ID-based chart lookup: chart_id=%s" % (chart_id,)
+                )
+                chart = ChartDAO.find_by_id(chart_id)
+            else:
+                await ctx.debug(
+                    "Performing UUID-based chart lookup: uuid=%s"
+                    % (request.identifier,)
+                )
+                # Try UUID lookup using DAO flexible method
+                chart = ChartDAO.find_by_id(request.identifier, id_column="uuid")
 
-                try:
-                    cmd_params = CommandParameters(key=request.identifier)
-                    cmd = GetFormDataCommand(cmd_params)
-                    form_data_json = cmd.run()
-                    if form_data_json:
-                        from superset.utils import json as utils_json
-
-                        form_data = utils_json.loads(form_data_json)
-
-                        # Create a transient chart object from form data
-                        class TransientChart:
-                            def __init__(self, form_data: Dict[str, Any]):
-                                self.id = None
-                                self.slice_name = "Unsaved Chart Preview"
-                                self.viz_type = form_data.get("viz_type", "table")
-                                self.datasource_id = None
-                                self.datasource_type = "table"
-                                self.params = utils_json.dumps(form_data)
-                                self.form_data = form_data
-                                self.uuid = None
-
-                        chart = TransientChart(form_data)
-                except Exception as e:
-                    # Form data key not found or invalid
-                    logger.debug(
-                        "Failed to get form data for key %s: %s", request.identifier, e
+                # If not found and looks like a form_data_key, try transient
+                if (
+                    not chart
+                    and isinstance(request.identifier, str)
+                    and len(request.identifier) > 8
+                ):
+                    # This might be a form_data_key
+                    from superset.commands.explore.form_data.get import (
+                        GetFormDataCommand,
                     )
+                    from superset.commands.explore.form_data.parameters import (
+                        CommandParameters,
+                    )
+
+                    try:
+                        cmd_params = CommandParameters(key=request.identifier)
+                        cmd = GetFormDataCommand(cmd_params)
+                        form_data_json = cmd.run()
+                        if form_data_json:
+                            from superset.utils import json as utils_json
+
+                            form_data = utils_json.loads(form_data_json)
+
+                            # Create a transient chart object from form data
+                            class TransientChart:
+                                def __init__(self, form_data: Dict[str, Any]):
+                                    self.id = None
+                                    self.slice_name = "Unsaved Chart Preview"
+                                    self.viz_type = form_data.get("viz_type", "table")
+                                    self.datasource_id = None
+                                    self.datasource_type = "table"
+                                    self.params = utils_json.dumps(form_data)
+                                    self.form_data = form_data
+                                    self.uuid = None
+
+                            chart = TransientChart(form_data)
+                    except Exception as e:
+                        # Form data key not found or invalid
+                        logger.debug(
+                            "Failed to get form data for key %s: %s",
+                            request.identifier,
+                            e,
+                        )
 
         if not chart:
             await ctx.error("Chart not found: identifier=%s" % (request.identifier,))
@@ -1911,8 +1918,11 @@ async def _get_chart_preview_internal(  # noqa: C901
         )
 
         # Handle different preview formats using strategy pattern
-        preview_generator = PreviewFormatGenerator(chart, request)
-        content = preview_generator.generate()
+        with event_logger.log_context(
+            action="mcp.get_chart_preview.preview_generation"
+        ):
+            preview_generator = PreviewFormatGenerator(chart, request)
+            content = preview_generator.generate()
 
         if isinstance(content, ChartError):
             await ctx.error(
@@ -1930,18 +1940,19 @@ async def _get_chart_preview_internal(  # noqa: C901
         await ctx.report_progress(3, 3, "Building response")
 
         # Create performance and accessibility metadata
-        execution_time = int((time.time() - start_time) * 1000)
-        performance = PerformanceMetadata(
-            query_duration_ms=execution_time,
-            cache_status="miss",
-            optimization_suggestions=[],
-        )
+        with event_logger.log_context(action="mcp.get_chart_preview.metadata"):
+            execution_time = int((time.time() - start_time) * 1000)
+            performance = PerformanceMetadata(
+                query_duration_ms=execution_time,
+                cache_status="miss",
+                optimization_suggestions=[],
+            )
 
-        accessibility = AccessibilityMetadata(
-            color_blind_safe=True,
-            alt_text=f"Preview of {chart.slice_name or f'Chart {chart.id}'}",
-            high_contrast_available=False,
-        )
+            accessibility = AccessibilityMetadata(
+                color_blind_safe=True,
+                alt_text=f"Preview of {chart.slice_name or f'Chart {chart.id}'}",
+                high_contrast_available=False,
+            )
 
         await ctx.debug(
             "Preview generation completed: execution_time_ms=%s, content_type=%s"

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1866,7 +1866,7 @@ async def _get_chart_preview_internal(  # noqa: C901
                                     self.uuid = None
 
                             chart = TransientChart(form_data)
-                    except Exception as e:
+                    except (ValueError, KeyError, AttributeError, TypeError) as e:
                         # Form data key not found or invalid
                         logger.debug(
                             "Failed to get form data for key %s: %s",

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.extensions import event_logger
 from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
     DashboardError,
@@ -59,16 +60,17 @@ async def get_dashboard_info(
     try:
         from superset.daos.dashboard import DashboardDAO
 
-        tool = ModelGetInfoCore(
-            dao_class=DashboardDAO,
-            output_schema=DashboardInfo,
-            error_schema=DashboardError,
-            serializer=dashboard_serializer,
-            supports_slug=True,  # Dashboards support slugs
-            logger=logger,
-        )
+        with event_logger.log_context(action="mcp.get_dashboard_info.lookup"):
+            tool = ModelGetInfoCore(
+                dao_class=DashboardDAO,
+                output_schema=DashboardInfo,
+                error_schema=DashboardError,
+                serializer=dashboard_serializer,
+                supports_slug=True,  # Dashboards support slugs
+                logger=logger,
+            )
 
-        result = tool.run_tool(request.identifier)
+            result = tool.run_tool(request.identifier)
 
         if isinstance(result, DashboardInfo):
             await ctx.info(

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.extensions import event_logger
 from superset.mcp_service.dataset.schemas import (
     DatasetError,
     DatasetInfo,
@@ -83,16 +84,17 @@ async def get_dataset_info(
     try:
         from superset.daos.dataset import DatasetDAO
 
-        tool = ModelGetInfoCore(
-            dao_class=DatasetDAO,
-            output_schema=DatasetInfo,
-            error_schema=DatasetError,
-            serializer=serialize_dataset_object,
-            supports_slug=False,  # Datasets don't have slugs
-            logger=logger,
-        )
+        with event_logger.log_context(action="mcp.get_dataset_info.lookup"):
+            tool = ModelGetInfoCore(
+                dao_class=DatasetDAO,
+                output_schema=DatasetInfo,
+                error_schema=DatasetError,
+                serializer=serialize_dataset_object,
+                supports_slug=False,  # Datasets don't have slugs
+                logger=logger,
+            )
 
-        result = tool.run_tool(request.identifier)
+            result = tool.run_tool(request.identifier)
 
         if isinstance(result, DatasetInfo):
             await ctx.info(

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -93,14 +93,16 @@ class LoggingMiddleware(Middleware):
     event logger. This matches the core audit log system (Action Log UI,
     logs table, custom loggers). Also attempts to log dashboard_id, chart_id
     (slice_id), and dataset_id if present in tool params.
+
+    Tool calls are handled in on_call_tool() which wraps execution to capture
+    duration_ms. Non-tool messages (resource reads, prompts, etc.) are handled
+    in on_message().
     """
 
-    async def on_message(
-        self,
-        context: MiddlewareContext,
-        call_next: Callable[[MiddlewareContext], Awaitable[Any]],
-    ) -> Any:
-        # Extract agent_id and user_id
+    def _extract_context_info(
+        self, context: MiddlewareContext
+    ) -> tuple[Any, Any, Any, Any, Any, Any]:
+        """Extract agent_id, user_id, and entity IDs from context."""
         agent_id = None
         user_id = None
         dashboard_id = None
@@ -115,16 +117,76 @@ class LoggingMiddleware(Middleware):
             user_id = get_user_id()
         except Exception:
             user_id = None
-        # Try to extract IDs from params
         if isinstance(params, dict):
             dashboard_id = params.get("dashboard_id")
-            # Chart ID may be under 'chart_id' or 'slice_id'
             slice_id = params.get("chart_id") or params.get("slice_id")
             dataset_id = params.get("dataset_id")
-        # Log to Superset's event logger (DB, Action Log UI, or custom)
+        return agent_id, user_id, dashboard_id, slice_id, dataset_id, params
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext,
+        call_next: Callable[[MiddlewareContext], Awaitable[Any]],
+    ) -> Any:
+        """Log tool calls with duration tracking."""
+        agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
+            self._extract_context_info(context)
+        )
+        tool_name = getattr(context.message, "name", None)
+
+        start_time = time.time()
+        success = False
+        try:
+            result = await call_next(context)
+            success = True
+            return result
+        finally:
+            duration_ms = int((time.time() - start_time) * 1000)
+            event_logger.log(
+                user_id=user_id,
+                action="mcp_tool_call",
+                dashboard_id=dashboard_id,
+                duration_ms=duration_ms,
+                slice_id=slice_id,
+                referrer=None,
+                curated_payload={
+                    "tool": tool_name,
+                    "agent_id": agent_id,
+                    "params": params,
+                    "method": context.method,
+                    "dashboard_id": dashboard_id,
+                    "slice_id": slice_id,
+                    "dataset_id": dataset_id,
+                    "success": success,
+                },
+            )
+            logger.info(
+                "MCP tool call: tool=%s, agent_id=%s, user_id=%s, method=%s, "
+                "dashboard_id=%s, slice_id=%s, dataset_id=%s, duration_ms=%s, "
+                "success=%s",
+                tool_name,
+                agent_id,
+                user_id,
+                context.method,
+                dashboard_id,
+                slice_id,
+                dataset_id,
+                duration_ms,
+                success,
+            )
+
+    async def on_message(
+        self,
+        context: MiddlewareContext,
+        call_next: Callable[[MiddlewareContext], Awaitable[Any]],
+    ) -> Any:
+        """Log non-tool messages (resource reads, prompts, etc.)."""
+        agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
+            self._extract_context_info(context)
+        )
         event_logger.log(
             user_id=user_id,
-            action="mcp_tool_call",
+            action="mcp_message",
             dashboard_id=dashboard_id,
             duration_ms=None,
             slice_id=slice_id,
@@ -139,17 +201,12 @@ class LoggingMiddleware(Middleware):
                 "dataset_id": dataset_id,
             },
         )
-        # (Optional) also log to standard logger for debugging
         logger.info(
-            "MCP tool call: tool=%s, agent_id=%s, user_id=%s, method=%s, "
-            "dashboard_id=%s, slice_id=%s, dataset_id=%s",
+            "MCP message: tool=%s, agent_id=%s, user_id=%s, method=%s",
             getattr(context.message, "name", None),
             agent_id,
             user_id,
             context.method,
-            dashboard_id,
-            slice_id,
-            dataset_id,
         )
         return await call_next(context)
 

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -115,7 +115,7 @@ class LoggingMiddleware(Middleware):
             agent_id = getattr(context.session, "agent_id", None)
         try:
             user_id = get_user_id()
-        except Exception:
+        except (RuntimeError, AttributeError):
             user_id = None
         if isinstance(params, dict):
             dashboard_id = params.get("dashboard_id")

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -27,6 +27,7 @@ from urllib.parse import urlencode
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.extensions import event_logger
 from superset.mcp_service.sql_lab.schemas import (
     OpenSqlLabRequest,
     SqlLabResponse,
@@ -48,8 +49,9 @@ def open_sql_lab_with_context(
     try:
         from superset.daos.database import DatabaseDAO
 
-        # Validate database exists and is accessible
-        database = DatabaseDAO.find_by_id(request.database_connection_id)
+        with event_logger.log_context(action="mcp.open_sql_lab.db_validation"):
+            # Validate database exists and is accessible
+            database = DatabaseDAO.find_by_id(request.database_connection_id)
         if not database:
             return SqlLabResponse(
                 url="",

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -25,6 +25,7 @@ import logging
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.extensions import event_logger
 from superset.mcp_service.mcp_core import InstanceInfoCore
 from superset.mcp_service.system.schemas import (
     GetSupersetInstanceInfoRequest,
@@ -98,7 +99,8 @@ def get_instance_info(
         }
 
         # Run the configurable core
-        return _instance_info_core.run_tool()
+        with event_logger.log_context(action="mcp.get_instance_info.metrics"):
+            return _instance_info_core.run_tool()
 
     except Exception as e:
         error_msg = f"Unexpected error in instance info: {str(e)}"

--- a/superset/mcp_service/system/tool/get_schema.py
+++ b/superset/mcp_service/system/tool/get_schema.py
@@ -29,6 +29,7 @@ from typing import Callable, Literal
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.extensions import event_logger
 from superset.mcp_service.common.schema_discovery import (
     CHART_DEFAULT_COLUMNS,
     CHART_SEARCH_COLUMNS,
@@ -154,8 +155,9 @@ async def get_schema(request: GetSchemaRequest, ctx: Context) -> GetSchemaRespon
         )
 
     # Create core instance and run (columns extracted dynamically)
-    core = factory()
-    schema_info = core.run_tool()
+    with event_logger.log_context(action="mcp.get_schema.discovery"):
+        core = factory()
+        schema_info = core.run_tool()
 
     await ctx.debug(
         f"Schema for {request.model_type}: "

--- a/superset/mcp_service/system/tool/health_check.py
+++ b/superset/mcp_service/system/tool/health_check.py
@@ -24,6 +24,7 @@ import platform
 from flask import current_app
 from superset_core.mcp import tool
 
+from superset.extensions import event_logger
 from superset.mcp_service.system.schemas import HealthCheckResponse
 from superset.utils.version import get_version_metadata
 
@@ -64,9 +65,10 @@ async def health_check() -> HealthCheckResponse:
     service_name = f"{app_name} MCP Service"
 
     try:
-        # Get version from Superset version metadata
-        version_metadata = get_version_metadata()
-        version = version_metadata.get("version_string", "unknown")
+        with event_logger.log_context(action="mcp.health_check.status"):
+            # Get version from Superset version metadata
+            version_metadata = get_version_metadata()
+            version = version_metadata.get("version_string", "unknown")
 
         response = HealthCheckResponse(
             status="healthy",

--- a/tests/unit_tests/extensions/test_types.py
+++ b/tests/unit_tests/extensions/test_types.py
@@ -67,10 +67,13 @@ def test_extension_config_full():
                     "views": {
                         "sqllab": {
                             "panels": [
-                                {"id": "query_insights.main", "name": "Query Insights"}
-                            ],
-                        },
-                    },
+                                {
+                                    "id": "query_insights.main",
+                                    "name": "Query Insights",
+                                }
+                            ]
+                        }
+                    }
                 },
                 "moduleFederation": {"exposes": ["./index"]},
             },

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -1,0 +1,206 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for LoggingMiddleware on_call_tool() and on_message() methods.
+
+Tests verify that:
+- on_call_tool() captures duration_ms and success status
+- on_message() logs non-tool messages without duration
+- _extract_context_info() extracts entity IDs from params
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from superset.mcp_service.middleware import LoggingMiddleware
+
+
+def _make_context(
+    method: str = "tools/call",
+    name: str = "list_charts",
+    params: dict | None = None,
+    metadata: dict | None = None,
+):
+    """Create a mock MiddlewareContext."""
+    ctx = MagicMock()
+    ctx.method = method
+    message = MagicMock()
+    message.name = name
+    message.params = params or {}
+    ctx.message = message
+    if metadata is not None:
+        ctx.metadata = metadata
+    else:
+        ctx.metadata = None
+    ctx.session = None
+    return ctx
+
+
+class TestLoggingMiddlewareOnCallTool:
+    """Tests for LoggingMiddleware.on_call_tool()."""
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
+    @pytest.mark.asyncio
+    async def test_on_call_tool_logs_duration_and_success(
+        self, mock_get_user_id, mock_event_logger
+    ):
+        """on_call_tool records duration_ms and success=True on normal return."""
+        middleware = LoggingMiddleware()
+        ctx = _make_context(name="list_charts")
+        call_next = AsyncMock(return_value="tool_result")
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result == "tool_result"
+        call_next.assert_awaited_once_with(ctx)
+
+        # Verify event_logger.log was called with duration_ms and success
+        mock_event_logger.log.assert_called_once()
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["action"] == "mcp_tool_call"
+        assert call_kwargs["user_id"] == 42
+        assert isinstance(call_kwargs["duration_ms"], int)
+        assert call_kwargs["duration_ms"] >= 0
+        assert call_kwargs["curated_payload"]["success"] is True
+        assert call_kwargs["curated_payload"]["tool"] == "list_charts"
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
+    @pytest.mark.asyncio
+    async def test_on_call_tool_logs_failure_on_exception(
+        self, mock_get_user_id, mock_event_logger
+    ):
+        """on_call_tool records success=False when tool raises."""
+        middleware = LoggingMiddleware()
+        ctx = _make_context(name="execute_sql")
+        call_next = AsyncMock(side_effect=ValueError("boom"))
+
+        with pytest.raises(ValueError, match="boom"):
+            await middleware.on_call_tool(ctx, call_next)
+
+        # Verify event_logger.log was still called (in the finally block)
+        mock_event_logger.log.assert_called_once()
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["curated_payload"]["success"] is False
+        assert call_kwargs["duration_ms"] >= 0
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
+    @pytest.mark.asyncio
+    async def test_on_call_tool_extracts_entity_ids(
+        self, mock_get_user_id, mock_event_logger
+    ):
+        """on_call_tool extracts dashboard_id, chart_id, dataset_id from params."""
+        middleware = LoggingMiddleware()
+        ctx = _make_context(
+            name="get_chart_info",
+            params={
+                "dashboard_id": 10,
+                "chart_id": 20,
+                "dataset_id": 30,
+            },
+        )
+        call_next = AsyncMock(return_value="ok")
+
+        await middleware.on_call_tool(ctx, call_next)
+
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["dashboard_id"] == 10
+        assert call_kwargs["slice_id"] == 20
+        assert call_kwargs["curated_payload"]["dataset_id"] == 30
+
+
+class TestLoggingMiddlewareOnMessage:
+    """Tests for LoggingMiddleware.on_message()."""
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=1)
+    @pytest.mark.asyncio
+    async def test_on_message_logs_without_duration(
+        self, mock_get_user_id, mock_event_logger
+    ):
+        """on_message logs with action=mcp_message and duration_ms=None."""
+        middleware = LoggingMiddleware()
+        ctx = _make_context(method="resources/read", name="instance/metadata")
+        call_next = AsyncMock(return_value="resource_data")
+
+        result = await middleware.on_message(ctx, call_next)
+
+        assert result == "resource_data"
+        call_next.assert_awaited_once_with(ctx)
+
+        mock_event_logger.log.assert_called_once()
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["action"] == "mcp_message"
+        assert call_kwargs["duration_ms"] is None
+        # on_message should NOT have success field
+        assert "success" not in call_kwargs["curated_payload"]
+
+
+class TestExtractContextInfo:
+    """Tests for LoggingMiddleware._extract_context_info()."""
+
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=99)
+    def test_extract_with_metadata_agent_id(self, mock_get_user_id):
+        """Extracts agent_id from context.metadata."""
+        middleware = LoggingMiddleware()
+        ctx = _make_context(metadata={"agent_id": "agent-123"})
+
+        agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
+            middleware._extract_context_info(ctx)
+        )
+
+        assert agent_id == "agent-123"
+        assert user_id == 99
+
+    @patch(
+        "superset.mcp_service.middleware.get_user_id",
+        side_effect=RuntimeError("no context"),
+    )
+    def test_extract_handles_missing_user(self, mock_get_user_id):
+        """Gracefully handles missing user context."""
+        middleware = LoggingMiddleware()
+        ctx = _make_context()
+
+        agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
+            middleware._extract_context_info(ctx)
+        )
+
+        assert user_id is None
+
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=1)
+    def test_extract_slice_id_from_chart_id(self, mock_get_user_id):
+        """Extracts slice_id from chart_id param (alias)."""
+        middleware = LoggingMiddleware()
+        ctx = _make_context(params={"chart_id": 55})
+
+        _, _, _, slice_id, _, _ = middleware._extract_context_info(ctx)
+
+        assert slice_id == 55
+
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=1)
+    def test_extract_slice_id_from_slice_id(self, mock_get_user_id):
+        """Extracts slice_id from slice_id param (fallback)."""
+        middleware = LoggingMiddleware()
+        ctx = _make_context(params={"slice_id": 66})
+
+        _, _, _, slice_id, _, _ = middleware._extract_context_info(ctx)
+
+        assert slice_id == 66

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -172,7 +172,7 @@ class TestExtractContextInfo:
 
     @patch(
         "superset.mcp_service.middleware.get_user_id",
-        side_effect=RuntimeError("no context"),
+        side_effect=RuntimeError("no Flask request context"),
     )
     def test_extract_handles_missing_user(self, mock_get_user_id):
         """Gracefully handles missing user context."""

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -24,6 +24,7 @@ Tests verify that:
 - _extract_context_info() extracts entity IDs from params
 """
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,8 +35,8 @@ from superset.mcp_service.middleware import LoggingMiddleware
 def _make_context(
     method: str = "tools/call",
     name: str = "list_charts",
-    params: dict | None = None,
-    metadata: dict | None = None,
+    params: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
 ):
     """Create a mock MiddlewareContext."""
     ctx = MagicMock()


### PR DESCRIPTION
### SUMMARY

Adds two layers of observability instrumentation to MCP tool calls, matching the patterns used across Superset's REST API endpoints:

**Layer 1 — Middleware duration tracking for ALL tool calls:**
- Restructured `LoggingMiddleware` to use `on_call_tool()` (wraps execution) instead of only `on_message()` (fires before execution)
- Tool calls now record `duration_ms` (was `None`) and `success` status in the audit log
- `on_message()` retained for non-tool traffic (resource reads, prompts)

**Layer 2 — Sub-operation timing inside 7 complex tools:**
- Added `event_logger.log_context(action="mcp.<tool>.<phase>")` blocks that automatically measure duration and write `Log` rows
- **generate_chart**: validation, dataset_lookup, db_write, form_data_cache, preview (5 phases)
- **get_chart_data**: chart_lookup, query_execution, format_conversion (3 phases)
- **get_chart_preview**: chart_lookup, preview_generation, metadata (3 phases)
- **execute_sql**: db_validation, query_execution, response_conversion (3 phases)
- **generate_dashboard**: chart_validation, layout, db_write (3 phases)
- **update_chart**: chart_lookup, db_write, preview (3 phases)
- **add_chart_to_existing_dashboard**: validation, layout, db_write (3 phases)

12 simpler tools (list_*, get_*_info, get_schema, health_check, etc.) get automatic duration tracking from the middleware layer without per-tool changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — observability-only change, no UI impact.

### TESTING INSTRUCTIONS
1. Start the MCP service
2. Call any MCP tool (e.g., `list_charts`, `generate_chart`)
3. Check the Superset `logs` table for `mcp_tool_call` action entries — they should now have `duration_ms` populated and `success` in the curated payload
4. For complex tools, check for sub-operation log entries like `mcp.generate_chart.validation`, `mcp.execute_sql.query_execution`, etc.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API