### PR TITLE
fix(docs): make page size selector work in database table

### DIFF
--- a/docs/src/components/databases/DatabaseIndex.tsx
+++ b/docs/src/components/databases/DatabaseIndex.tsx
@@ -579,7 +579,7 @@ const DatabaseIndex: React.FC<DatabaseIndexProps> = ({ data }) => {
         columns={columns}
         rowKey={(record) => record.isCompatible ? `${record.compatibleWith}-${record.name}` : record.name}
         pagination={{
-          pageSize: 20,
+          defaultPageSize: 20,
           showSizeChanger: true,
           showTotal: (total) => `${total} databases`,
         }}


### PR DESCRIPTION
## Summary

The page limit select dropdown in the database overview table wasn't working. Users could click the dropdown and select a different page size (e.g., 50 or 100), but the table would immediately reset back to showing 20 items.

**Root cause:** The pagination config used `pageSize: 20` as a static prop, which always overrides antd's internal pagination state.

**Fix:** Changed to `defaultPageSize: 20`, which sets the initial value but allows the Table component to manage state internally when users change it.

## Test plan

1. Go to the database overview page in the docs
2. Scroll down to the database table
3. Click the page size dropdown (shows "20 / page" by default)
4. Select a different size (e.g., "50 / page")
5. Verify the table now shows 50 items and the selection persists

🤖 Generated with [Claude Code](https://claude.ai/code)