### PR TITLE
fix(mcp): Add database_name as valid filter column for list_datasets

### DIFF
--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -69,7 +69,7 @@ class DatasetDAO(BaseDAO[SqlaTable]):
         remaining_operators: list[ColumnOperator] = []
         for c in column_operators:
             if not isinstance(c, ColumnOperator):
-                continue
+                c = ColumnOperator.model_validate(c)
             if c.col == "database_name":
                 query = query.join(Database, SqlaTable.database_id == Database.id)
                 operator_enum = ColumnOperatorEnum(c.opr)

--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -22,9 +22,10 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Query
 
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
-from superset.daos.base import BaseDAO
+from superset.daos.base import BaseDAO, ColumnOperator, ColumnOperatorEnum
 from superset.extensions import db
 from superset.models.core import Database
 from superset.models.dashboard import Dashboard
@@ -35,8 +36,10 @@ from superset.views.base import DatasourceFilter
 
 logger = logging.getLogger(__name__)
 
-# Custom filterable fields for datasets
-DATASET_CUSTOM_FIELDS: dict[str, list[str]] = {}
+# Custom filterable fields for datasets (not direct model columns)
+DATASET_CUSTOM_FIELDS: dict[str, list[str]] = {
+    "database_name": ["eq", "like", "ilike"],
+}
 
 
 class DatasetDAO(BaseDAO[SqlaTable]):
@@ -48,6 +51,37 @@ class DatasetDAO(BaseDAO[SqlaTable]):
     """
 
     base_filter = DatasourceFilter
+
+    @classmethod
+    def apply_column_operators(
+        cls,
+        query: Query,
+        column_operators: list[ColumnOperator] | None = None,
+    ) -> Query:
+        """Override to handle database_name filter via join to Database table.
+
+        database_name lives on Database, not SqlaTable, so we intercept it
+        here, join to the Database table, and apply the filter there.
+        """
+        if not column_operators:
+            return query
+
+        remaining_operators: list[ColumnOperator] = []
+        for c in column_operators:
+            if not isinstance(c, ColumnOperator):
+                continue
+            if c.col == "database_name":
+                query = query.join(Database, SqlaTable.database_id == Database.id)
+                operator_enum = ColumnOperatorEnum(c.opr)
+                query = query.filter(
+                    operator_enum.apply(Database.database_name, c.value)
+                )
+            else:
+                remaining_operators.append(c)
+
+        if remaining_operators:
+            query = super().apply_column_operators(query, remaining_operators)
+        return query
 
     @staticmethod
     def get_database_by_id(database_id: int) -> Database | None:

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -54,6 +54,7 @@ class DatasetFilter(ColumnOperator):
     col: Literal[
         "table_name",
         "schema",
+        "database_name",
         "owner",
         "favorite",
     ] = Field(


### PR DESCRIPTION
### SUMMARY
Fixes `TypeError: encoding without a string argument` when the `list_datasets` MCP tool is called with `database_name` filters.

`database_name` was not in the `DatasetFilter.col` allowed Literal values, causing a Pydantic `ValidationError` when users try to filter datasets by database name. This is a reasonable filter since `database_name` appears in the response.

### BEFORE/AFTER SCREENSHOTS OR COVERAGE REPORT
N/A - backend only change

### TESTING INSTRUCTIONS
1. Call `list_datasets` MCP tool with filter: `{"filters": [{"col": "database_name", "opr": "ilike", "value": "%example%"}]}`
2. Should return matching datasets instead of TypeError

### ADDITIONAL INFORMATION

**Changes:**
- `superset/mcp_service/dataset/schemas.py` — Add `database_name` to `DatasetFilter.col` Literal
- `superset/daos/dataset.py` — Override `apply_column_operators` in `DatasetDAO` to intercept `database_name` filters and join to `Database` table; update `DATASET_CUSTOM_FIELDS` so `get_dataset_available_filters` reports it
- `tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py` — Add regression tests

**Root cause:** `database_name` lives on the `Database` model, not `SqlaTable`. The DAO override joins to the Database table and applies the filter on `Database.database_name`.