### PR TITLE
fix(frontend): clean up console warnings and deprecations

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
@@ -227,8 +227,15 @@ const CustomModal = ({
   draggableConfig,
   destroyOnHidden,
   openerRef,
+  bodyStyle,
+  styles: stylesProp,
   ...rest
 }: ModalProps) => {
+  // Convert deprecated bodyStyle to styles.body
+  const styles = useMemo(
+    () => (bodyStyle ? { ...stylesProp, body: bodyStyle } : stylesProp),
+    [bodyStyle, stylesProp],
+  );
   const draggableRef = useRef<HTMLDivElement>(null);
   const [bounds, setBounds] = useState<DraggableBounds>();
   const [dragDisabled, setDragDisabled] = useState<boolean>(true);
@@ -361,6 +368,7 @@ const CustomModal = ({
       draggable={draggable}
       resizable={resizable}
       destroyOnHidden={destroyOnHidden}
+      styles={styles}
       {...rest}
     >
       {children}

--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/types.ts
@@ -51,7 +51,9 @@ export interface ModalProps {
   destroyOnHidden?: boolean;
   maskClosable?: boolean;
   zIndex?: number;
+  /** @deprecated Use styles.body instead */
   bodyStyle?: CSSProperties;
+  styles?: { body?: CSSProperties; [key: string]: CSSProperties | undefined };
   openerRef?: React.RefObject<HTMLElement>;
 }
 

--- a/superset-frontend/packages/superset-ui-core/src/components/PageHeaderWithActions/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/PageHeaderWithActions/index.tsx
@@ -155,19 +155,21 @@ export const PageHeaderWithActions = ({
               popupRender={() => additionalActionsMenu}
               {...menuDropdownProps}
             >
-              <Button
-                css={menuTriggerStyles}
-                buttonStyle="tertiary"
-                aria-label={t('Menu actions trigger')}
-                tooltip={tooltipProps?.text}
-                placement={tooltipProps?.placement}
-                data-test="actions-trigger"
-              >
-                <Icons.EllipsisOutlined
-                  iconColor={theme.colorPrimary}
-                  iconSize="l"
-                />
-              </Button>
+              <span>
+                <Button
+                  css={menuTriggerStyles}
+                  buttonStyle="tertiary"
+                  aria-label={t('Menu actions trigger')}
+                  tooltip={tooltipProps?.text}
+                  placement={tooltipProps?.placement}
+                  data-test="actions-trigger"
+                >
+                  <Icons.EllipsisOutlined
+                    iconColor={theme.colorPrimary}
+                    iconSize="l"
+                  />
+                </Button>
+              </span>
             </Dropdown>
           )}
         </div>

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -179,7 +179,13 @@ function Echart(
       }
       if (!divRef.current) return;
       if (!chartRef.current) {
-        chartRef.current = init(divRef.current, null, { locale });
+        // Pass width and height to init to avoid "Can't get DOM width or height" warning
+        // since the DOM element may not have its dimensions yet when init is called
+        chartRef.current = init(divRef.current, null, {
+          locale,
+          width,
+          height,
+        });
       }
       // did mount
       handleSizeChange({ width, height });

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -808,7 +808,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           th {
             border-right: 1px solid ${theme.colorSplit};
           }
-          th:first-child {
+          th:first-of-type {
             border-left: none;
           }
           th:last-child {

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.tsx
@@ -194,13 +194,14 @@ class TabbedSqlEditors extends PureComponent<TabbedSqlEditorsProps> {
               : t('New tab (Ctrl + t)')
           }
         >
-          <Icons.PlusCircleOutlined
-            iconSize="s"
+          <span
             css={css`
+              display: inline-flex;
               vertical-align: middle;
             `}
-            data-test="add-tab-icon"
-          />
+          >
+            <Icons.PlusCircleOutlined iconSize="s" data-test="add-tab-icon" />
+          </span>
         </Tooltip>
       </StyledTab>
     );
@@ -241,13 +242,14 @@ class TabbedSqlEditors extends PureComponent<TabbedSqlEditorsProps> {
                 : t('New tab (Ctrl + t)')
             }
           >
-            <Icons.PlusOutlined
-              iconSize="l"
+            <span
               css={css`
+                display: inline-flex;
                 vertical-align: middle;
               `}
-              data-test="add-tab-icon"
-            />
+            >
+              <Icons.PlusOutlined iconSize="l" data-test="add-tab-icon" />
+            </span>
           </Tooltip>
         }
         items={tabItems}

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.tsx
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import type { QueryEditor, SqlLabRootState } from 'src/SqlLab/types';
 import { t } from '@apache-superset/core/translation';
 import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
-import { styled, css } from '@apache-superset/core/theme';
+import { styled } from '@apache-superset/core/theme';
 import { Logger } from 'src/logger/LogUtils';
 import { EmptyState, Tooltip } from '@superset-ui/core/components';
 import { detectOS } from 'src/utils/common';
@@ -87,6 +87,11 @@ const StyledTab = styled.span`
 const TabTitle = styled.span`
   margin-right: ${({ theme }) => theme.sizeUnit * 2}px;
   text-transform: none;
+`;
+
+const AddTabIconWrapper = styled.span`
+  display: inline-flex;
+  vertical-align: middle;
 `;
 
 // Get the user's OS
@@ -194,14 +199,9 @@ class TabbedSqlEditors extends PureComponent<TabbedSqlEditorsProps> {
               : t('New tab (Ctrl + t)')
           }
         >
-          <span
-            css={css`
-              display: inline-flex;
-              vertical-align: middle;
-            `}
-          >
+          <AddTabIconWrapper>
             <Icons.PlusCircleOutlined iconSize="s" data-test="add-tab-icon" />
-          </span>
+          </AddTabIconWrapper>
         </Tooltip>
       </StyledTab>
     );
@@ -242,14 +242,9 @@ class TabbedSqlEditors extends PureComponent<TabbedSqlEditorsProps> {
                 : t('New tab (Ctrl + t)')
             }
           >
-            <span
-              css={css`
-                display: inline-flex;
-                vertical-align: middle;
-              `}
-            >
+            <AddTabIconWrapper>
               <Icons.PlusOutlined iconSize="l" data-test="add-tab-icon" />
-            </span>
+            </AddTabIconWrapper>
           </Tooltip>
         }
         items={tabItems}

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -139,9 +139,11 @@ const LabelStyle = styled.div`
   }
 `;
 
-const SelectButton = styled(Button)<{ empty: boolean }>`
-  color: ${({ theme, empty }) =>
-    empty ? theme.colorTextPlaceholder : theme.colorTextBase};
+const SelectButton = styled(Button, {
+  shouldForwardProp: prop => prop !== '$empty',
+})<{ $empty: boolean }>`
+  color: ${({ theme, $empty }) =>
+    $empty ? theme.colorTextPlaceholder : theme.colorTextBase};
 `;
 
 export const SelectLabel = ({
@@ -410,7 +412,7 @@ export function DatabaseSelector({
             buttonStyle="tertiary"
             disabled={sqlLabModeConfig.disabled}
             loading={sqlLabModeConfig.loading}
-            empty={!sqlLabModeConfig.displayValue}
+            $empty={!sqlLabModeConfig.displayValue}
           >
             {displayValue}
           </SelectButton>

--- a/superset-frontend/src/components/ListView/ActionsBar.tsx
+++ b/superset-frontend/src/components/ListView/ActionsBar.tsx
@@ -68,7 +68,7 @@ export function ActionsBar({ actions }: ActionsBarProps) {
         const IconComponent = Icons[icon as IconNameType];
         return (
           <ActionButton
-            key={tooltip ? undefined : index}
+            key={rest.label ?? index}
             icon={<IconComponent iconSize="l" />}
             tooltip={tooltip}
             {...rest}

--- a/superset-frontend/src/components/ListView/Filters/Select.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Select.tsx
@@ -39,7 +39,7 @@ interface SelectFilterProps extends BaseFilter {
   paginate?: boolean;
   selects: Filter['selects'];
   loading?: boolean;
-  dropdownStyle?: React.CSSProperties;
+  popupStyle?: React.CSSProperties;
 }
 
 function SelectFilter(
@@ -52,7 +52,7 @@ function SelectFilter(
     optionFilterProps,
     selects = [],
     loading = false,
-    dropdownStyle,
+    popupStyle,
   }: SelectFilterProps,
   ref: RefObject<FilterHandler>,
 ) {
@@ -120,7 +120,7 @@ function SelectFilter(
           options={fetchAndFormatSelects}
           optionFilterProps={optionFilterProps}
           placeholder={placeholder}
-          dropdownStyle={dropdownStyle}
+          styles={popupStyle ? { popup: { root: popupStyle } } : undefined}
           showSearch
           value={selectedOption}
         />
@@ -134,7 +134,7 @@ function SelectFilter(
           onClear={onClear}
           options={selects}
           placeholder={placeholder}
-          dropdownStyle={dropdownStyle}
+          styles={popupStyle ? { popup: { root: popupStyle } } : undefined}
           showSearch
           value={selectedOption}
           loading={loading}

--- a/superset-frontend/src/components/ListView/Filters/Select.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Select.tsx
@@ -39,7 +39,7 @@ interface SelectFilterProps extends BaseFilter {
   paginate?: boolean;
   selects: Filter['selects'];
   loading?: boolean;
-  popupStyle?: React.CSSProperties;
+  dropdownStyle?: React.CSSProperties;
 }
 
 function SelectFilter(
@@ -52,7 +52,7 @@ function SelectFilter(
     optionFilterProps,
     selects = [],
     loading = false,
-    popupStyle,
+    dropdownStyle,
   }: SelectFilterProps,
   ref: RefObject<FilterHandler>,
 ) {
@@ -120,7 +120,7 @@ function SelectFilter(
           options={fetchAndFormatSelects}
           optionFilterProps={optionFilterProps}
           placeholder={placeholder}
-          styles={popupStyle ? { popup: { root: popupStyle } } : undefined}
+          dropdownStyle={dropdownStyle}
           showSearch
           value={selectedOption}
         />
@@ -134,7 +134,7 @@ function SelectFilter(
           onClear={onClear}
           options={selects}
           placeholder={placeholder}
-          styles={popupStyle ? { popup: { root: popupStyle } } : undefined}
+          dropdownStyle={dropdownStyle}
           showSearch
           value={selectedOption}
           loading={loading}

--- a/superset-frontend/src/components/ListView/Filters/index.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.tsx
@@ -81,7 +81,7 @@ function UIFilters(
             dateFilterValueType,
             min,
             max,
-            dropdownStyle,
+            popupStyle,
             autoComplete,
             inputName,
           },
@@ -114,7 +114,7 @@ function UIFilters(
                 paginate={paginate}
                 selects={selects}
                 loading={loading ?? false}
-                dropdownStyle={dropdownStyle}
+                popupStyle={popupStyle}
               />
             );
           }

--- a/superset-frontend/src/components/ListView/Filters/index.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.tsx
@@ -114,7 +114,7 @@ function UIFilters(
                 paginate={paginate}
                 selects={selects}
                 loading={loading ?? false}
-                popupStyle={popupStyle}
+                dropdownStyle={popupStyle}
               />
             );
           }

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -66,7 +66,7 @@ export interface ListViewFilter {
   dateFilterValueType?: 'unix' | 'iso';
   min?: number;
   max?: number;
-  dropdownStyle?: React.CSSProperties;
+  popupStyle?: React.CSSProperties;
   autoComplete?: string;
   inputName?: string;
 }

--- a/superset-frontend/src/components/Modal/StandardModal.tsx
+++ b/superset-frontend/src/components/Modal/StandardModal.tsx
@@ -76,7 +76,7 @@ const StyledModal = styled(Modal)`
   .ant-collapse {
     border: none;
 
-    > .ant-collapse-item:first-child {
+    > .ant-collapse-item:first-of-type {
       border-top: none;
     }
 

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -252,7 +252,7 @@ const DashboardContentWrapper = styled.div`
         width: 100%;
       }
 
-      & > .empty-droptarget:first-child:not(.empty-droptarget--full) {
+      & > .empty-droptarget:first-of-type:not(.empty-droptarget--full) {
         height: ${theme.sizeUnit * 4}px;
         top: 0;
       }
@@ -298,7 +298,7 @@ const StyledDashboardContent = styled.div<{
     `}
 
       /* this is the ParentSize wrapper */
-    & > div:first-child {
+    & > div:first-of-type {
         height: 100% !important;
       }
     }

--- a/superset-frontend/src/dashboard/components/DashboardGrid.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardGrid.tsx
@@ -102,7 +102,7 @@ const GridContent = styled.div<{ editMode?: boolean }>`
       }
     }
 
-    & > .empty-droptarget:first-child {
+    & > .empty-droptarget:first-of-type {
       height: ${theme.sizeUnit * 4}px;
       margin-top: ${theme.sizeUnit * -4}px;
     }

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -144,7 +144,7 @@ type SliceHeaderControlsPropsWithRouter = SliceHeaderControlsProps &
   RouteComponentProps;
 
 const dropdownIconsStyles = css`
-  &&.anticon > .anticon:first-child {
+  &&.anticon > .anticon:first-of-type {
     margin-right: 0;
     vertical-align: 0;
   }

--- a/superset-frontend/src/dashboard/components/gridComponents/Column/Column.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column/Column.tsx
@@ -116,7 +116,7 @@ const ColumnStyles = styled.div<{ editMode: boolean }>`
         width: 100%;
         height: 100%;
       }
-      &:not(:first-child):not(.droptarget-edge) {
+      &:not(:first-of-type):not(.droptarget-edge) {
         width: 100%;
         min-height: ${theme.sizeUnit * 4}px;
       }

--- a/superset-frontend/src/dashboard/components/gridComponents/Column/Column.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column/Column.tsx
@@ -104,11 +104,11 @@ const ColumnStyles = styled.div<{ editMode: boolean }>`
         z-index: ${EMPTY_CONTAINER_Z_INDEX};
         width: 100%;
         height: ${theme.sizeUnit * 4}px;
-        &:first-child {
+        &:first-of-type {
           inset-block-start: 0;
         }
       }
-      &:first-child:not(.droptarget-edge) {
+      &:first-of-type:not(.droptarget-edge) {
         position: absolute;
         top: 0;
         left: 0;

--- a/superset-frontend/src/dashboard/components/gridComponents/Row/Row.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row/Row.tsx
@@ -100,7 +100,7 @@ const GridRow = styled.div<{ editMode: boolean }>`
         &:not(:last-child) {
           width: ${theme.sizeUnit * 4}px;
         }
-        &:first-child:not(.droptarget-side) {
+        &:first-of-type:not(.droptarget-side) {
           z-index: ${EMPTY_CONTAINER_Z_INDEX};
           position: absolute;
           width: 100%;
@@ -111,7 +111,7 @@ const GridRow = styled.div<{ editMode: boolean }>`
         z-index: ${EMPTY_CONTAINER_Z_INDEX};
         position: absolute;
         width: ${theme.sizeUnit * 4}px;
-        &:first-child {
+        &:first-of-type {
           inset-inline-start: 0;
         }
       }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
@@ -45,7 +45,7 @@ const HorizontalDivider = ({ title, description }: FilterDividerProps) => {
         border-left: 1px solid ${theme.colorSplit};
         padding-left: ${4 * theme.sizeUnit}px;
 
-        .filter-item-wrapper:first-child & {
+        .filter-item-wrapper:first-of-type & {
           border-left: none;
           padding-left: 0;
         }

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.tsx
@@ -130,7 +130,7 @@ interface AnnotationLayerState {
 const AUTOMATIC_COLOR = '';
 
 const NotFoundContentWrapper = styled.div`
-  && > div:first-child {
+  && > div:first-of-type {
     padding-left: 0;
     padding-right: 0;
   }

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
@@ -257,7 +257,7 @@ class AnnotationLayerControl extends PureComponent<Props, PopoverState> {
             )}
             title={t('Add annotation layer')}
             open={this.state.popoverVisible[addLayerPopoverKey]}
-            destroyTooltipOnHide
+            destroyOnHidden
             onOpenChange={visible =>
               this.handleVisibleChange(visible, addLayerPopoverKey)
             }

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
@@ -157,7 +157,7 @@ const ConditionalFormattingControl = ({
               onChange={(newConfig: ConditionalFormattingConfig) =>
                 onEdit(newConfig, index)
               }
-              destroyTooltipOnHide
+              destroyOnHidden
               extraColorChoices={extraColorChoices}
               allColumns={allColumns}
             >
@@ -174,7 +174,7 @@ const ConditionalFormattingControl = ({
           title={t('Add new formatter')}
           columns={columnOptions}
           onChange={onSave}
-          destroyTooltipOnHide
+          destroyOnHidden
           extraColorChoices={extraColorChoices}
           allColumns={allColumns}
         >

--- a/superset-frontend/src/explore/components/controls/ContourControl/ContourPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/ContourControl/ContourPopoverTrigger.tsx
@@ -50,7 +50,7 @@ const ContourPopoverTrigger = ({
       defaultOpen={visible}
       open={visible}
       onOpenChange={setVisibility}
-      destroyTooltipOnHide
+      destroyOnHidden
     >
       {props.children}
     </ControlPopover>

--- a/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.test.tsx
@@ -134,7 +134,7 @@ test('Should place popover at the bottom', async () => {
 test('Should close popover on escape press', async () => {
   setupTest({
     ...createProps(),
-    destroyTooltipOnHide: true,
+    destroyOnHidden: true,
   });
 
   expect(screen.getByTestId('control-popover')).toBeInTheDocument();
@@ -165,7 +165,7 @@ test('Should close popover on escape press', async () => {
 test('Controlled mode', async () => {
   const baseProps = {
     ...createProps(),
-    destroyTooltipOnHide: true,
+    destroyOnHidden: true,
     open: false,
   };
 

--- a/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
@@ -52,7 +52,7 @@ const ControlPopover: FC<PopoverProps> = ({
   getPopupContainer,
   getVisibilityRatio = getElementVisibilityRatio,
   open: visibleProp,
-  destroyTooltipOnHide = false,
+  destroyOnHidden = false,
   placement: initialPlacement = 'right',
   ...props
 }) => {
@@ -200,7 +200,7 @@ const ControlPopover: FC<PopoverProps> = ({
       placement={placement}
       onOpenChange={handleOnVisibleChange}
       getPopupContainer={handleGetPopupContainer}
-      destroyTooltipOnHide={destroyTooltipOnHide}
+      destroyOnHidden={destroyOnHidden}
       afterOpenChange={handleAfterOpenChange}
     />
   );

--- a/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.tsx
+++ b/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.tsx
@@ -41,7 +41,7 @@ const CurrencyControlContainer = styled.div`
     display: flex;
     align-items: center;
 
-    & > :first-child {
+    & > :first-of-type {
       margin-right: ${theme.sizeUnit * 4}px;
       min-width: 0;
       flex: 1;
@@ -162,7 +162,7 @@ export const CurrencyControl = ({
       <ControlHeader {...props} />
       <CurrencyControlContainer
         css={css`
-          & > :first-child {
+          & > :first-of-type {
             ${symbolSelectAdditionalStyles};
           }
           & > :nth-child(2) {

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -360,7 +360,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       open={show}
       onOpenChange={toggleOverlay}
       overlayStyle={{ width: '600px' }}
-      destroyTooltipOnHide
+      destroyOnHidden
       getPopupContainer={nodeTrigger =>
         isOverflowingFilterBar
           ? (nodeTrigger.parentNode as HTMLElement)

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -199,7 +199,7 @@ const ColumnSelectPopoverTriggerInner = ({
         open={visible}
         onOpenChange={handleTogglePopover}
         title={popoverTitle}
-        destroyTooltipOnHide
+        destroyOnHidden
       >
         {children}
       </ControlPopover>

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -357,6 +357,7 @@ const DndFilterSelect = (props: DndFilterSelectProps) => {
     () =>
       values.map((adhocFilter: AdhocFilter, index: number) => (
         <DndAdhocFilterOption
+          key={adhocFilter.filterOptionName ?? index}
           index={index}
           adhocFilter={adhocFilter}
           options={options}

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterPopoverTrigger/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterPopoverTrigger/index.tsx
@@ -109,7 +109,7 @@ class AdhocFilterPopoverTrigger extends PureComponent<
         defaultOpen={visible}
         open={visible}
         onOpenChange={togglePopover}
-        destroyTooltipOnHide
+        destroyOnHidden
       >
         {this.props.children}
       </ControlPopover>

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -272,7 +272,7 @@ class AdhocMetricPopoverTrigger extends PureComponent<
           open={visible}
           onOpenChange={togglePopover}
           title={popoverTitle}
-          destroyTooltipOnHide
+          destroyOnHidden
         >
           {this.props.children}
         </ControlPopover>

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -100,7 +100,7 @@ const StyledNotificationMethod = styled.div`
       margin-left: ${theme.sizeUnit * 4}px;
     }
 
-    .ghost-button:first-child[style*='none'] + .ghost-button {
+    .ghost-button:first-of-type[style*='none'] + .ghost-button {
       margin-left: 0px; /* Remove margin when the first button is hidden */
     }
   `}

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -1160,7 +1160,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         getPopupContainer={triggerNode =>
           triggerNode.parentElement || document.body
         }
-        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        styles={{ popup: { root: { maxHeight: 400, overflow: 'auto' } } }}
       />
       <Alert
         showIcon

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -1160,7 +1160,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         getPopupContainer={triggerNode =>
           triggerNode.parentElement || document.body
         }
-        styles={{ popup: { root: { maxHeight: 400, overflow: 'auto' } } }}
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
       />
       <Alert
         showIcon

--- a/superset-frontend/src/features/home/ActivityTable.tsx
+++ b/superset-frontend/src/features/home/ActivityTable.tsx
@@ -126,19 +126,23 @@ export default function ActivityTable({
   const [editedCards, setEditedCards] = useState<ActivityData[]>();
   const [isFetchingEditedCards, setIsFetchingEditedCards] = useState(false);
 
-  const getEditedCards = () => {
-    setIsFetchingEditedCards(true);
-    getEditedObjects(user.userId).then(r => {
-      setEditedCards([...r.editedChart, ...r.editedDash]);
-      setIsFetchingEditedCards(false);
-    });
-  };
-
   useEffect(() => {
+    let isMounted = true;
+
     if (activeChild === TableTab.Edited) {
-      getEditedCards();
+      setIsFetchingEditedCards(true);
+      getEditedObjects(user.userId).then(r => {
+        if (isMounted) {
+          setEditedCards([...r.editedChart, ...r.editedDash]);
+          setIsFetchingEditedCards(false);
+        }
+      });
     }
-  }, [activeChild]);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [activeChild, user.userId]);
 
   const tabs = [
     {

--- a/superset-frontend/src/features/home/ActivityTable.tsx
+++ b/superset-frontend/src/features/home/ActivityTable.tsx
@@ -132,10 +132,14 @@ export default function ActivityTable({
     if (activeChild === TableTab.Edited) {
       setIsFetchingEditedCards(true);
       getEditedObjects(user.userId).then(r => {
-        if (isMounted) {
-          setEditedCards([...r.editedChart, ...r.editedDash]);
-          setIsFetchingEditedCards(false);
-        }
+        if (!isMounted) return;
+        // `getEditedObjects` swallows errors via `.catch(err => err)` and
+        // returns the raw error object, which has no `editedChart` /
+        // `editedDash` arrays. Guard against that so spreading can't throw.
+        const editedChart = Array.isArray(r?.editedChart) ? r.editedChart : [];
+        const editedDash = Array.isArray(r?.editedDash) ? r.editedDash : [];
+        setEditedCards([...editedChart, ...editedDash]);
+        setIsFetchingEditedCards(false);
       });
     }
 

--- a/superset-frontend/src/features/home/ActivityTable.tsx
+++ b/superset-frontend/src/features/home/ActivityTable.tsx
@@ -141,6 +141,7 @@ export default function ActivityTable({
 
     return () => {
       isMounted = false;
+      setIsFetchingEditedCards(false);
     };
   }, [activeChild, user.userId]);
 

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -28,7 +28,7 @@ import {
 } from '@apache-superset/core/theme';
 import cx from 'classnames';
 import { debounce } from 'lodash';
-import { Menu, MenuMode, MainNav } from '@superset-ui/core/components/Menu';
+import { Menu, MenuMode } from '@superset-ui/core/components/Menu';
 import {
   Button,
   Tooltip,
@@ -166,8 +166,6 @@ export interface SubMenuProps {
   backgroundColor?: string;
 }
 
-const { SubMenu } = MainNav;
-
 const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
   const [showMenu, setMenu] = useState<MenuMode>('horizontal');
   const [navRightStyle, setNavRightStyle] = useState('nav-right');
@@ -183,7 +181,10 @@ const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
   }
 
   useEffect(() => {
+    let isMounted = true;
+
     function handleResize() {
+      if (!isMounted) return;
       if (window.innerWidth <= 767) setMenu('inline');
       else setMenu('horizontal');
 
@@ -192,7 +193,6 @@ const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
         props.buttons.length >= 3 &&
         window.innerWidth >= 795
       ) {
-        // eslint-disable-next-line no-unused-expressions
         setNavRightStyle('nav-right');
       } else if (
         props.buttons &&
@@ -205,7 +205,11 @@ const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
     handleResize();
     const resize = debounce(handleResize, 10);
     window.addEventListener('resize', resize);
-    return () => window.removeEventListener('resize', resize);
+    return () => {
+      isMounted = false;
+      resize.cancel();
+      window.removeEventListener('resize', resize);
+    };
   }, [props.buttons]);
 
   return (
@@ -254,52 +258,60 @@ const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
           })}
         />
         <div className={navRightStyle}>
-          <Menu mode="horizontal" triggerSubMenuAction="click" disabledOverflow>
-            {props.dropDownLinks?.map((link, i) => (
-              <SubMenu
-                css={css`
-                  [data-icon='caret-down'] {
-                    color: ${theme.colorIcon};
-                    font-size: ${theme.fontSizeXS}px;
-                    margin-left: ${theme.sizeUnit}px;
-                  }
-                `}
-                key={i}
-                title={link.label}
-                icon={<Icons.CaretDownOutlined />}
-                popupOffset={[10, 20]}
-                className="dropdown-menu-links"
-              >
-                {link.childs?.map(item => {
-                  if (typeof item === 'object') {
-                    return item.disable ? (
-                      <MainNav.Item
-                        key={item.label}
-                        css={styledDisabled}
-                        disabled
-                      >
-                        <Tooltip
-                          placement="top"
-                          title={t(
-                            "Enable 'Allow file uploads to database' in any database's settings",
-                          )}
-                        >
-                          {item.label}
-                        </Tooltip>
-                      </MainNav.Item>
-                    ) : (
-                      <MainNav.Item key={item.label}>
-                        <Typography.Link href={item.url} onClick={item.onClick}>
-                          {item.label}
-                        </Typography.Link>
-                      </MainNav.Item>
-                    );
-                  }
-                  return null;
-                })}
-              </SubMenu>
-            ))}
-          </Menu>
+          <Menu
+            mode="horizontal"
+            triggerSubMenuAction="click"
+            disabledOverflow
+            css={css`
+              [data-icon='caret-down'] {
+                color: ${theme.colorIcon};
+                font-size: ${theme.fontSizeXS}px;
+                margin-left: ${theme.sizeUnit}px;
+              }
+            `}
+            items={props.dropDownLinks?.map((link, i) => ({
+              key: `dropdown-${i}`,
+              label: link.label,
+              icon: <Icons.CaretDownOutlined />,
+              popupOffset: [10, 20],
+              className: 'dropdown-menu-links',
+              children: link.childs
+                ?.filter(
+                  (item): item is Exclude<typeof item, string> =>
+                    typeof item === 'object',
+                )
+                .map(item =>
+                  item.disable
+                    ? {
+                        key: item.label,
+                        disabled: true,
+                        label: (
+                          <Tooltip
+                            placement="top"
+                            title={t(
+                              "Enable 'Allow file uploads to database' in any database's settings",
+                            )}
+                          >
+                            <span css={styledDisabled(theme)}>
+                              {item.label}
+                            </span>
+                          </Tooltip>
+                        ),
+                      }
+                    : {
+                        key: item.label,
+                        label: (
+                          <Typography.Link
+                            href={item.url}
+                            onClick={item.onClick}
+                          >
+                            {item.label}
+                          </Typography.Link>
+                        ),
+                      },
+                ),
+            }))}
+          />
           {props.buttons?.map((btn, i) => (
             <Button
               key={i}

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
@@ -50,7 +50,7 @@ const StyledDropdownItemWithIcon = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  > *:first-child {
+  > *:first-of-type {
     margin-right: ${({ theme }) => theme.sizeUnit}px;
   }
 `;

--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -107,7 +107,7 @@ const StyledHeaderWithIcon = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  > *:first-child {
+  > *:first-of-type {
     margin-right: ${({ theme }) => theme.sizeUnit}px;
   }
 `;

--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -498,7 +498,7 @@ function AlertList({
         ),
         optionFilterProps: OWNER_OPTION_FILTER_PROPS,
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       {
         Header: t('Status'),
@@ -540,7 +540,7 @@ function AlertList({
           user,
         ),
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
     ],
     [],

--- a/superset-frontend/src/pages/AnnotationLayerList/index.tsx
+++ b/superset-frontend/src/pages/AnnotationLayerList/index.tsx
@@ -277,7 +277,7 @@ function AnnotationLayersList({
           user,
         ),
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
     ],
     [],

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -666,7 +666,7 @@ function ChartList(props: ChartListProps) {
         unfilteredLabel: t('All'),
         fetchSelects: createFetchDatasets,
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       ...(isFeatureEnabled(FeatureFlag.TaggingSystem) && canReadTag
         ? [
@@ -702,7 +702,7 @@ function ChartList(props: ChartListProps) {
         ),
         optionFilterProps: OWNER_OPTION_FILTER_PROPS,
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       {
         Header: t('Dashboard'),
@@ -713,7 +713,7 @@ function ChartList(props: ChartListProps) {
         unfilteredLabel: t('All'),
         fetchSelects: fetchDashboards,
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       ...(userId ? [favoritesFilter] : []),
       {
@@ -748,7 +748,7 @@ function ChartList(props: ChartListProps) {
           props.user,
         ),
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
     ] as ListViewFilters;
     return filtersList;

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -605,7 +605,7 @@ function DashboardList(props: DashboardListProps) {
         ),
         optionFilterProps: OWNER_OPTION_FILTER_PROPS,
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       ...(user?.userId ? [favoritesFilter] : []),
       {
@@ -640,7 +640,7 @@ function DashboardList(props: DashboardListProps) {
           user,
         ),
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
     ] as ListViewFilters;
     return filtersList;

--- a/superset-frontend/src/pages/DatabaseList/index.tsx
+++ b/superset-frontend/src/pages/DatabaseList/index.tsx
@@ -656,7 +656,7 @@ function DatabaseList({
           user,
         ),
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
     ],
     [user],

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -570,7 +570,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           ),
         ),
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       {
         Header: t('Schema'),
@@ -587,7 +587,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           ),
         ),
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       {
         Header: t('Owner'),
@@ -608,7 +608,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         ),
         optionFilterProps: OWNER_OPTION_FILTER_PROPS,
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       {
         Header: t('Certified'),
@@ -642,7 +642,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           user,
         ),
         paginate: true,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
     ],
     [user],

--- a/superset-frontend/src/pages/GroupsList/index.tsx
+++ b/superset-frontend/src/pages/GroupsList/index.tsx
@@ -327,7 +327,7 @@ function GroupsList({ user }: GroupsListProps) {
           value: role.id,
         })),
         loading: loadingState.roles,
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       {
         Header: t('Users'),
@@ -338,7 +338,7 @@ function GroupsList({ user }: GroupsListProps) {
         unfilteredLabel: t('All'),
         fetchSelects: async (filterValue, page, pageSize) =>
           fetchUserOptions(filterValue, page, pageSize, addDangerToast),
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
     ],
     [loadingState.roles, roles],

--- a/superset-frontend/src/pages/RolesList/index.tsx
+++ b/superset-frontend/src/pages/RolesList/index.tsx
@@ -283,7 +283,7 @@ function RolesList({ addDangerToast, addSuccessToast, user }: RolesListProps) {
         unfilteredLabel: t('All'),
         fetchSelects: async (filterValue, page, pageSize) =>
           fetchPermissionOptions(filterValue, page, pageSize, addDangerToast),
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       {
         Header: t('Groups'),
@@ -294,7 +294,7 @@ function RolesList({ addDangerToast, addSuccessToast, user }: RolesListProps) {
         unfilteredLabel: t('All'),
         fetchSelects: async (filterValue, page, pageSize) =>
           fetchGroupOptions(filterValue, page, pageSize, addDangerToast),
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
     ],
     [addDangerToast],

--- a/superset-frontend/src/pages/RolesList/index.tsx
+++ b/superset-frontend/src/pages/RolesList/index.tsx
@@ -272,7 +272,7 @@ function RolesList({ addDangerToast, addSuccessToast, user }: RolesListProps) {
         unfilteredLabel: t('All'),
         fetchSelects: async (filterValue, page, pageSize) =>
           fetchUserOptions(filterValue, page, pageSize, addDangerToast),
-        dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
+        popupStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },
       {
         Header: t('Permissions'),


### PR DESCRIPTION
### SUMMARY

This PR addresses numerous console warnings that appear during development, improving the developer experience and reducing noise in the browser console.

**Fixes include:**

1. **Ant Design deprecation warnings:**
   - `destroyTooltipOnHide` → `destroyOnHidden` (Tooltip/Popover)
   - Menu `children` → `items` prop pattern
   - Modal `bodyStyle` → `styles.body`

2. **React warnings:**
   - Missing `key` props in list renders (ActionsBar, DndFilterSelect)
   - Memory leak warnings from async operations in unmounted components (ActivityTable, SubMenu)
   - Ref forwarding issues with Emotion's css prop (wrapped elements in `<span>`)

3. **Emotion CSS warnings:**
   - `:first-child` → `:first-of-type` for SSR safety (13 files)

4. **ECharts warning:**
   - Pass `width`/`height` to `init()` to prevent "Can't get DOM width or height" warning

5. **DOM attribute warnings:**
   - Use `shouldForwardProp` to prevent `$empty` prop from leaking to DOM (DatabaseSelector)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Console output changes only

### TESTING INSTRUCTIONS

1. Start the dev server (`npm run dev`)
2. Navigate to various pages: `/welcome`, `/dashboard/list`, `/explore`, `/sqllab`, `/roles`
3. Open browser DevTools console
4. Verify reduced console warnings compared to master branch

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)