### PR TITLE
chore(lint): enforce stricter eslint/oxlint rules

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -135,6 +135,7 @@ module.exports = {
     'icons',
     'i18n-strings',
     'react-prefer-function-component',
+    'react-you-might-not-need-an-effect',
     'prettier',
   ],
   rules: {
@@ -234,6 +235,11 @@ module.exports = {
     'jsx-a11y/click-events-have-key-events': 0,
     'jsx-a11y/mouse-events-have-key-events': 0,
     'jsx-a11y/no-static-element-interactions': 0,
+
+    // React effect best practices
+    'react-you-might-not-need-an-effect/no-empty-effect': 'error',
+    'react-you-might-not-need-an-effect/no-pass-live-state-to-parent': 'error',
+    'react-you-might-not-need-an-effect/no-initialize-state': 'error',
 
     // Lodash
     'lodash/import-scope': [2, 'member'],

--- a/superset-frontend/oxlint.json
+++ b/superset-frontend/oxlint.json
@@ -28,7 +28,8 @@
     // === Core ESLint rules ===
     // Error prevention
     "no-console": "warn",
-    "no-alert": "warn",
+    "no-alert": "error",
+    "constructor-super": "error",
     "no-debugger": "error",
     "no-unused-vars": "off",
     "no-undef": "error",
@@ -148,7 +149,8 @@
     ],
     "react/no-array-index-key": "off",
     "react/no-children-prop": "error",
-    "react/no-danger": "warn",
+    "react/no-danger": "error",
+    "react/forbid-foreign-prop-types": "error",
     "react/no-danger-with-children": "error",
     "react/no-deprecated": "error",
     "react/no-did-update-set-state": "error",
@@ -250,6 +252,7 @@
     ],
 
     // === Unicorn rules (bonus coverage) ===
+    "unicorn/no-invalid-remove-event-listener": "error",
     "unicorn/filename-case": "off",
     "unicorn/prevent-abbreviations": "off",
     "unicorn/no-null": "off",

--- a/superset-frontend/packages/superset-ui-core/src/models/ExtensibleFunction.ts
+++ b/superset-frontend/packages/superset-ui-core/src/models/ExtensibleFunction.ts
@@ -22,7 +22,8 @@
  */
 
 export default class ExtensibleFunction extends Function {
-  // @ts-expect-error
+  // @ts-expect-error - intentionally not calling super(), using setPrototypeOf pattern instead
+  // eslint-disable-next-line constructor-super
   constructor(fn: Function) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, no-constructor-return
     return Object.setPrototypeOf(fn, new.target.prototype);

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -106,6 +106,7 @@ describe('safeHtmlSpan', () => {
     expect(safeSpan).toEqual(
       <span
         className="safe-html-wrapper"
+        // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: htmlString }}
       />,
     );

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -167,6 +167,8 @@ export function safeHtmlSpan(possiblyHtmlString: string) {
     return (
       <span
         className="safe-html-wrapper"
+        // Safe: HTML is sanitized before rendering
+        // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: sanitizeHtml(possiblyHtmlString) }}
       />
     );

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/renderers/TextCellRenderer.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/renderers/TextCellRenderer.tsx
@@ -64,6 +64,8 @@ export const TextCellRenderer = (params: CellRendererProps) => {
       );
     }
     if (allowRenderHtml && isProbablyHTML(value)) {
+      // Safe: HTML is sanitized before rendering
+      // eslint-disable-next-line react/no-danger
       return <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(value) }} />;
     }
   }

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -1060,17 +1060,19 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           };
           if (html) {
             if (truncateLongCells) {
-              // eslint-disable-next-line react/no-danger
               return (
                 <StyledCell {...cellProps}>
                   <div
                     className="dt-truncate-cell"
                     style={columnWidth ? { width: columnWidth } : undefined}
+                    // Safe: HTML is sanitized via formatColumnValue
+                    // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={html}
                   />
                 </StyledCell>
               );
             }
+            // Safe: HTML is sanitized via formatColumnValue
             // eslint-disable-next-line react/no-danger
             return <StyledCell {...cellProps} dangerouslySetInnerHTML={html} />;
           }

--- a/superset-frontend/src/SqlLab/components/App/index.tsx
+++ b/superset-frontend/src/SqlLab/components/App/index.tsx
@@ -117,11 +117,15 @@ interface AppState {
 class App extends PureComponent<AppProps, AppState> {
   hasLoggedLocalStorageUsage: boolean;
 
+  private boundOnHashChanged: () => void;
+
   constructor(props: AppProps) {
     super(props);
     this.state = {
       hash: window.location.hash,
     };
+
+    this.boundOnHashChanged = this.onHashChanged.bind(this);
 
     this.showLocalStorageUsageWarning = throttle(
       this.showLocalStorageUsageWarning,
@@ -131,7 +135,7 @@ class App extends PureComponent<AppProps, AppState> {
   }
 
   componentDidMount() {
-    window.addEventListener('hashchange', this.onHashChanged.bind(this));
+    window.addEventListener('hashchange', this.boundOnHashChanged);
 
     // Horrible hack to disable side swipe navigation when in SQL Lab. Even though the
     // docs say setting this style on any div will prevent it, turns out it only works
@@ -165,7 +169,7 @@ class App extends PureComponent<AppProps, AppState> {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('hashchange', this.onHashChanged.bind(this));
+    window.removeEventListener('hashchange', this.boundOnHashChanged);
 
     // And now we need to reset the overscroll behavior back to the default.
     document.body.style.overscrollBehaviorX = 'auto';

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -102,6 +102,8 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
   );
 
   function renameTab() {
+    // TODO: Replace native prompt with a proper modal dialog
+    // eslint-disable-next-line no-alert
     const newTitle = prompt(t('Enter a new title for the tab'));
     if (newTitle) {
       actions.queryEditorSetTitle(qe, newTitle, qe.id);


### PR DESCRIPTION
### SUMMARY
Upgrade several lint rules from warn to error, reducing tech debt and enforcing better code practices. This PR cleans up the single violation of each rule in the codebase.

### Rules upgraded from warn → error

| Rule | Fix Applied |
|------|-------------|
| `constructor-super` | eslint-disable (intentional pattern in ExtensibleFunction) |
| `no-alert` | eslint-disable with TODO (SqlEditorTabHeader uses native prompt) |
| `react/no-danger` | eslint-disable with safety comments (all uses are sanitized) |
| `react/forbid-foreign-prop-types` | (no violations found) |
| `unicorn/no-invalid-remove-event-listener` | Fixed by storing bound function reference |

### New rules added (set to error)
- `react-you-might-not-need-an-effect/no-empty-effect`
- `react-you-might-not-need-an-effect/no-pass-live-state-to-parent`  
- `react-you-might-not-need-an-effect/no-initialize-state`

### Notable fix
**SqlLab App component**: The `removeEventListener` was using `.bind(this)` which creates a new function reference each time, meaning the listener was never actually removed. Fixed by storing the bound function in the constructor.

### BEFORE/AFTER SCREENSHOTS OR COVERAGE
N/A - lint configuration changes only

### TESTING INSTRUCTIONS
1. Run `npx oxlint -c oxlint.json` - should have no errors for upgraded rules
2. Run `npm run lint` - should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)