### PR TITLE
chore(lint): add jest/expect-expect rule for test assertions

### DIFF
--- a/superset-frontend/oxlint.json
+++ b/superset-frontend/oxlint.json
@@ -262,7 +262,19 @@
     // === Jest rules ===
     "jest/consistent-test-it": ["error", { "fn": "test" }],
     "jest/no-focused-tests": "error",
-    "jest/no-disabled-tests": "error"
+    "jest/no-disabled-tests": "error",
+    "jest/expect-expect": [
+      "error",
+      {
+        "assertFunctionNames": [
+          "expect",
+          "expect*",
+          "runTimezoneTest",
+          "compareURI",
+          "test*WithInitialValues"
+        ]
+      }
+    ]
   },
   "ignorePatterns": [
     "packages/generator-superset/**/*",

--- a/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/ModalTrigger.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/ModalTrigger.test.tsx
@@ -61,7 +61,7 @@ test('should render a tooltip on hover', async () => {
   render(<ModalTrigger {...tooltipProps} />);
 
   await userEvent.hover(screen.getByRole('button'));
-  await screen.findByRole('tooltip');
+  expect(await screen.findByRole('tooltip')).toBeInTheDocument();
 });
 
 test('should not render a modal before click', () => {

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/ChartDataProvider.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/ChartDataProvider.test.tsx
@@ -231,7 +231,7 @@ describe('ChartDataProvider', () => {
       mockLoadDatasource.mockImplementation(() => new Promise(() => {}));
 
       setup();
-      await screen.findByRole('status');
+      expect(await screen.findByRole('status')).toBeInTheDocument();
     });
 
     test('shows payload when loaded', async () => {

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
@@ -276,7 +276,7 @@ describe('SuperChart', () => {
   };
 
   // Update the resize observer trigger to ensure it's called after component mount
-  /* oxlint-disable-next-line jest/no-disabled-tests */
+  /* oxlint-disable-next-line jest/no-disabled-tests, jest/expect-expect -- skipped test */
   test.skip('works when width and height are percent', async () => {
     const { container } = render(
       <SuperChart

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.ts
@@ -575,7 +575,10 @@ describe('sqlLabReducer', () => {
       expect(newState.queries.def).toBe(completedQuery);
     });
     test('should refresh queries when polling returns empty', () => {
+      const prevQueries = newState.queries;
       newState = sqlLabReducer(newState, actions.refreshQueries({}));
+      // Empty refresh should preserve existing queries
+      expect(newState.queries).toBe(prevQueries);
     });
     test('should set state to fetching when sync query succeeds without results', () => {
       const syncQuery = {

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.tsx
@@ -281,6 +281,9 @@ test('should handle markdown errors gracefully', async () => {
 
     await new Promise(resolve => setTimeout(resolve, 100));
   });
+
+  // Verify component still renders after error events
+  expect(screen.getByTestId('dashboard-markdown-editor')).toBeInTheDocument();
 });
 
 test('should resize editor when width changes', async () => {
@@ -307,6 +310,11 @@ test('should resize editor when width changes', async () => {
 
     await new Promise(resolve => setTimeout(resolve, 100));
   });
+
+  // Verify component still renders after resize
+  expect(
+    screen.getByTestId('dashboard-component-chart-holder'),
+  ).toBeInTheDocument();
 });
 
 test('should update content when undo/redo changes occur', async () => {

--- a/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
@@ -412,8 +412,10 @@ describe('UploadDataModal - Database and Schema Population', () => {
     await userEvent.click(selectDatabase);
     await userEvent.click(screen.getByText('database2'));
     await userEvent.click(selectSchema);
-    await waitFor(() => screen.getAllByText('schema1'));
-    await waitFor(() => screen.getAllByText('schema2'));
+    await waitFor(() => {
+      expect(screen.getAllByText('schema1')).not.toHaveLength(0);
+      expect(screen.getAllByText('schema2')).not.toHaveLength(0);
+    });
   }, 60000);
 });
 

--- a/superset-frontend/src/pages/AnnotationLayerList/AnnotationLayerList.test.tsx
+++ b/superset-frontend/src/pages/AnnotationLayerList/AnnotationLayerList.test.tsx
@@ -205,6 +205,6 @@ describe('AnnotationLayersList', () => {
     fireEvent.click(bulkSelectButton);
 
     // Wait for bulk select mode to be enabled
-    await screen.findByText('0 Selected');
+    expect(await screen.findByText('0 Selected')).toBeInTheDocument();
   }, 30000);
 });

--- a/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
+++ b/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
@@ -260,7 +260,7 @@ test('handles special characters in dataset name from URL parameter', async () =
 
   await renderComponent();
 
-  await screen.findByText('flightsÆ test');
+  expect(await screen.findByText('flightsÆ test')).toBeInTheDocument();
 
   Object.defineProperty(window, 'location', {
     value: originalLocation,
@@ -294,7 +294,7 @@ test('pre-selects the dataset from URL parameter and shows it in dropdown', asyn
 
   await renderComponent();
 
-  await screen.findByText('flights');
+  expect(await screen.findByText('flights')).toBeInTheDocument();
 
   Object.defineProperty(window, 'location', {
     value: originalLocation,

--- a/superset-frontend/src/pages/CssTemplateList/CssTemplateList.test.tsx
+++ b/superset-frontend/src/pages/CssTemplateList/CssTemplateList.test.tsx
@@ -196,6 +196,6 @@ describe('CssTemplatesList', () => {
     fireEvent.click(bulkSelectButton);
 
     // Wait for bulk select mode to be enabled
-    await screen.findByText('0 Selected');
+    expect(await screen.findByText('0 Selected')).toBeInTheDocument();
   }, 30000);
 });


### PR DESCRIPTION
## SUMMARY

Add the `jest/expect-expect` rule to enforce that all Jest test blocks contain explicit assertions. This rule helps ensure tests actually verify behavior rather than just running code without checking results.

### Rule Configuration

The rule is added to `oxlint.json` with:
- Error level enforcement
- Custom `assertFunctionNames` to recognize project-specific assertion helper functions:
  - `expect*` (glob pattern matching all expect-prefixed helpers like `expectDrillToDetailEnabled`, `expectElementsVisible`)
  - `runTimezoneTest` (time comparison test helper)
  - `compareURI` (explore utils test helper)
  - `test*WithInitialValues` (truncation hook test helper)

### Tests Fixed

Fixed 11 tests that had implicit or missing assertions by adding explicit `expect()` calls:

| File | Issue | Fix |
|------|-------|-----|
| `ModalTrigger.test.tsx` | `findByRole('tooltip')` implicit | Added `expect(...).toBeInTheDocument()` |
| `ChartDataProvider.test.tsx` | `findByRole('status')` implicit | Added explicit assertion |
| `SuperChart.test.tsx` | Skipped test still flagged | Added eslint-disable comment |
| `Markdown.test.tsx` (x2) | Missing assertions | Added assertions for error handling and resize |
| `UploadDataModal.test.tsx` | `waitFor` without expect | Added assertions inside waitFor |
| `AnnotationLayerList.test.tsx` | `findByText` implicit | Added explicit assertion |
| `CssTemplateList.test.tsx` | `findByText` implicit | Added explicit assertion |
| `ChartCreation.test.tsx` (x2) | `findByText` implicit | Added explicit assertions |
| `sqlLab.test.ts` | No assertion at all | Added assertion verifying empty refresh behavior |

## BEFORE/AFTER

Before:
```typescript
test('should render a tooltip on hover', async () => {
  render(<ModalTrigger {...tooltipProps} />);
  await userEvent.hover(screen.getByRole('button'));
  await screen.findByRole('tooltip');  // implicit assertion - will throw if not found
});
```

After:
```typescript
test('should render a tooltip on hover', async () => {
  render(<ModalTrigger {...tooltipProps} />);
  await userEvent.hover(screen.getByRole('button'));
  expect(await screen.findByRole('tooltip')).toBeInTheDocument();  // explicit assertion
});
```

## TESTING INSTRUCTIONS

These are lint rule changes. CI will verify all linting passes.

## ADDITIONAL INFORMATION

- Part of ongoing lint cleanup effort (batch 4)
- Related PRs: #37883, #37884, #37885
- The rule recognizes Cypress tests are excluded via `ignorePatterns` in oxlint.json

🤖 Generated with [Claude Code](https://claude.ai/code)