### PR TITLE
feat: dashboard activity feed

### DIFF
--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -84,6 +84,12 @@
     ],
     "testing": [
       {
+        "name": "ADMIN_ACTIVITY_FEED",
+        "default": true,
+        "lifecycle": "testing",
+        "description": "Enables admin-wide activity feed panel on the welcome page."
+      },
+      {
         "name": "ALERT_REPORTS",
         "default": false,
         "lifecycle": "testing",
@@ -230,6 +236,13 @@
         "default": true,
         "lifecycle": "stable",
         "description": "Enables CSS Templates in Settings menu and dashboard forms",
+        "category": "runtime_config"
+      },
+      {
+        "name": "DASHBOARD_ACTIVITY_FEED",
+        "default": true,
+        "lifecycle": "stable",
+        "description": "Enables dashboard-level activity feed in dashboard header and API.",
         "category": "runtime_config"
       },
       {

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -22,6 +22,7 @@ import { logging as logger } from '@apache-superset/core';
 // check into source control. We're hardcoding the supported flags for now.
 export enum FeatureFlag {
   // PLEASE KEEP THE LIST SORTED ALPHABETICALLY
+  AdminActivityFeed = 'ADMIN_ACTIVITY_FEED',
   AlertsAttachReports = 'ALERTS_ATTACH_REPORTS',
   AlertReports = 'ALERT_REPORTS',
   AlertReportTabs = 'ALERT_REPORT_TABS',
@@ -33,6 +34,7 @@ export enum FeatureFlag {
   ChartPluginsExperimental = 'CHART_PLUGINS_EXPERIMENTAL',
   ConfirmDashboardDiff = 'CONFIRM_DASHBOARD_DIFF',
   CssTemplates = 'CSS_TEMPLATES',
+  DashboardActivityFeed = 'DASHBOARD_ACTIVITY_FEED',
   DashboardVirtualization = 'DASHBOARD_VIRTUALIZATION',
   DashboardVirtualizationDeferData = 'DASHBOARD_VIRTUALIZATION_DEFER_DATA',
   DashboardRbac = 'DASHBOARD_RBAC',

--- a/superset-frontend/src/dashboard/components/ActivityFeed/ActivityFeedDrawer.tsx
+++ b/superset-frontend/src/dashboard/components/ActivityFeed/ActivityFeedDrawer.tsx
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { styled, t } from '@apache-superset/core/ui';
+import {
+  Button,
+  Drawer,
+  Select,
+  Tooltip,
+  Typography,
+} from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
+
+import { fetchDashboardActivity } from './api';
+import ActivityTimeline from './ActivityTimeline';
+import { ActionTypeFilter, ActivityItem, ActivitySummary } from './types';
+
+const Controls = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.sizeUnit * 2}px;
+  margin-bottom: ${({ theme }) => theme.sizeUnit * 4}px;
+  align-items: center;
+`;
+
+const Summary = styled.div`
+  margin-bottom: ${({ theme }) => theme.sizeUnit * 3}px;
+  color: ${({ theme }) => theme.colorTextDescription};
+`;
+
+interface ActivityFeedDrawerProps {
+  dashboardId: number;
+  open: boolean;
+  summary: ActivitySummary | null;
+  onClose: () => void;
+}
+
+export default function ActivityFeedDrawer({
+  dashboardId,
+  open,
+  summary,
+  onClose,
+}: ActivityFeedDrawerProps) {
+  const [activities, setActivities] = useState<ActivityItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [actionType, setActionType] = useState<ActionTypeFilter>('all');
+  const [days, setDays] = useState(30);
+
+  const loadActivity = useCallback(
+    async ({
+      reset = false,
+      pageToLoad = 0,
+    }: {
+      reset?: boolean;
+      pageToLoad?: number;
+    }) => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetchDashboardActivity(dashboardId, {
+          page: pageToLoad,
+          pageSize: 25,
+          actionType,
+          days,
+        });
+
+        setActivities(prev =>
+          reset ? response.activities : [...prev, ...response.activities],
+        );
+        setHasMore(response.has_more ?? (pageToLoad + 1) * 25 < response.count);
+        setPage(pageToLoad);
+      } catch {
+        setError(t('Failed to load dashboard activity'));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [actionType, dashboardId, days],
+  );
+
+  useEffect(() => {
+    if (open) {
+      loadActivity({ reset: true, pageToLoad: 0 });
+    }
+  }, [open, actionType, days, loadActivity]);
+
+  const handleLoadMore = useCallback(() => {
+    if (loading) {
+      return;
+    }
+    const nextPage = page + 1;
+    loadActivity({ pageToLoad: nextPage });
+  }, [loadActivity, loading, page]);
+
+  const actionOptions = useMemo(
+    () => [
+      { label: t('All activity'), value: 'all' },
+      { label: t('Views'), value: 'view' },
+      { label: t('Edits'), value: 'edit' },
+      { label: t('Exports'), value: 'export' },
+      { label: t('Chart interactions'), value: 'chart_interaction' },
+    ],
+    [],
+  );
+
+  const dayOptions = useMemo(
+    () => [
+      { label: t('7 days'), value: 7 },
+      { label: t('30 days'), value: 30 },
+      { label: t('90 days'), value: 90 },
+    ],
+    [],
+  );
+
+  return (
+    <Drawer
+      title={t('Dashboard activity')}
+      placement="right"
+      width={460}
+      open={open}
+      onClose={onClose}
+      extra={
+        <Tooltip title={t('Refresh activity')}>
+          <Button
+            buttonStyle="secondary"
+            onClick={() => loadActivity({ reset: true, pageToLoad: 0 })}
+            loading={loading}
+            aria-label={t('Refresh activity')}
+          >
+            <Icons.ReloadOutlined iconSize="m" />
+          </Button>
+        </Tooltip>
+      }
+    >
+      {summary && (
+        <Summary data-test="dashboard-activity-summary">
+          <Typography.Text>
+            {t(
+              '%s views today, %s unique viewers in %s days',
+              summary.views_today,
+              summary.unique_viewers,
+              summary.period_days,
+            )}
+          </Typography.Text>
+        </Summary>
+      )}
+      <Controls>
+        <Select
+          value={actionType}
+          onChange={(value: ActionTypeFilter) => setActionType(value)}
+          options={actionOptions}
+          ariaLabel={t('Activity type')}
+          style={{ minWidth: 190 }}
+        />
+        <Select
+          value={days}
+          onChange={(value: number) => setDays(value)}
+          options={dayOptions}
+          ariaLabel={t('Time range')}
+          style={{ minWidth: 130 }}
+        />
+      </Controls>
+
+      <ActivityTimeline
+        activities={activities}
+        loading={loading}
+        hasMore={hasMore}
+        error={error}
+        onRetry={() => loadActivity({ reset: true, pageToLoad: 0 })}
+        onLoadMore={handleLoadMore}
+      />
+    </Drawer>
+  );
+}

--- a/superset-frontend/src/dashboard/components/ActivityFeed/ActivityItem.tsx
+++ b/superset-frontend/src/dashboard/components/ActivityFeed/ActivityItem.tsx
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { css, styled, t, useTheme } from '@apache-superset/core/ui';
+import { Tooltip } from '@superset-ui/core/components';
+import { extendedDayjs } from '@superset-ui/core/utils/dates';
+import { Icons } from '@superset-ui/core/components/Icons';
+
+import { ActivityItem as ActivityItemType } from './types';
+
+const Row = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: ${({ theme }) => theme.sizeUnit * 2}px;
+  padding: ${({ theme }) => theme.sizeUnit * 3}px;
+  border-bottom: 1px solid ${({ theme }) => theme.colorBorder};
+`;
+
+const IconWrapper = styled.div`
+  width: ${({ theme }) => theme.sizeUnit * 8}px;
+  height: ${({ theme }) => theme.sizeUnit * 8}px;
+  border-radius: ${({ theme }) => theme.borderRadius}px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const Content = styled.div`
+  min-width: 0;
+`;
+
+const Action = styled.div`
+  color: ${({ theme }) => theme.colorText};
+`;
+
+const UserName = styled.span`
+  font-weight: ${({ theme }) => theme.fontWeightStrong};
+`;
+
+const Timestamp = styled.div`
+  color: ${({ theme }) => theme.colorTextDescription};
+  margin-top: ${({ theme }) => theme.sizeUnit}px;
+`;
+
+function getActionIcon(category: ActivityItemType['action_category']) {
+  switch (category) {
+    case 'view':
+      return Icons.EyeOutlined;
+    case 'edit':
+      return Icons.EditOutlined;
+    case 'export':
+      return Icons.DownloadOutlined;
+    case 'chart_interaction':
+      return Icons.SyncOutlined;
+    default:
+      return Icons.UserOutlined;
+  }
+}
+
+function getCategoryColors(
+  category: ActivityItemType['action_category'],
+  theme: ReturnType<typeof useTheme>,
+) {
+  switch (category) {
+    case 'view':
+      return { bg: theme.colorInfoBg, fg: theme.colorInfo };
+    case 'edit':
+      return { bg: theme.colorWarningBg, fg: theme.colorWarning };
+    case 'export':
+      return { bg: theme.colorSuccessBg, fg: theme.colorSuccess };
+    case 'chart_interaction':
+      return { bg: theme.colorPrimaryBg, fg: theme.colorPrimary };
+    default:
+      return { bg: theme.colorFillSecondary, fg: theme.colorTextDescription };
+  }
+}
+
+function getDisplayUserName(item: ActivityItemType): string {
+  const firstName = item.user.first_name?.trim();
+  const lastName = item.user.last_name?.trim();
+  const fullName = [firstName, lastName].filter(Boolean).join(' ');
+  return fullName || item.user.username || t('Anonymous');
+}
+
+interface ActivityItemProps {
+  item: ActivityItemType;
+}
+
+export default function ActivityItem({ item }: ActivityItemProps) {
+  const theme = useTheme();
+  const Icon = getActionIcon(item.action_category);
+  const colorTokens = getCategoryColors(item.action_category, theme);
+
+  const displayName = getDisplayUserName(item);
+  const relativeTime = extendedDayjs(item.timestamp).fromNow();
+  const fullTime = extendedDayjs(item.timestamp).format('YYYY-MM-DD HH:mm:ss');
+  const firstSeen = extendedDayjs(item.first_seen).format('YYYY-MM-DD HH:mm:ss');
+  const lastSeen = extendedDayjs(item.last_seen).format('YYYY-MM-DD HH:mm:ss');
+  const displayAction =
+    item.event_count > 1
+      ? t('%s (%s times)', item.action_display, item.event_count)
+      : item.action_display;
+  const tooltipContent =
+    item.event_count > 1
+      ? t('Latest: %s | First: %s', lastSeen, firstSeen)
+      : fullTime;
+
+  return (
+    <Row data-test="dashboard-activity-item">
+      <IconWrapper
+        css={css`
+          background: ${colorTokens.bg};
+          color: ${colorTokens.fg};
+        `}
+      >
+        <Icon iconSize="m" />
+      </IconWrapper>
+      <Content>
+        <Action>
+          <UserName>{displayName}</UserName> {displayAction}
+        </Action>
+        <Tooltip title={tooltipContent}>
+          <Timestamp>{relativeTime}</Timestamp>
+        </Tooltip>
+      </Content>
+    </Row>
+  );
+}

--- a/superset-frontend/src/dashboard/components/ActivityFeed/ActivityTimeline.tsx
+++ b/superset-frontend/src/dashboard/components/ActivityFeed/ActivityTimeline.tsx
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { styled, t } from '@apache-superset/core/ui';
+import { Button, Empty, Loading } from '@superset-ui/core/components';
+
+import ActivityItem from './ActivityItem';
+import { ActivityItem as ActivityItemType } from './types';
+
+const TimelineContainer = styled.div`
+  border: 1px solid ${({ theme }) => theme.colorBorder};
+  border-radius: ${({ theme }) => theme.borderRadius}px;
+  overflow: hidden;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: ${({ theme }) => theme.sizeUnit * 3}px;
+`;
+
+const EmptyWrap = styled.div`
+  padding: ${({ theme }) => theme.sizeUnit * 6}px;
+`;
+
+interface ActivityTimelineProps {
+  activities: ActivityItemType[];
+  loading: boolean;
+  hasMore: boolean;
+  error: string | null;
+  onRetry: () => void;
+  onLoadMore: () => void;
+}
+
+export default function ActivityTimeline({
+  activities,
+  loading,
+  hasMore,
+  error,
+  onRetry,
+  onLoadMore,
+}: ActivityTimelineProps) {
+  if (loading && activities.length === 0) {
+    return <Loading />;
+  }
+
+  if (error && activities.length === 0) {
+    return (
+      <EmptyWrap>
+        <Empty
+          description={error}
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          data-test="dashboard-activity-empty-error"
+        >
+          <Button onClick={onRetry} buttonStyle="secondary">
+            {t('Retry')}
+          </Button>
+        </Empty>
+      </EmptyWrap>
+    );
+  }
+
+  if (activities.length === 0) {
+    return (
+      <EmptyWrap>
+        <Empty
+          description={t('No activity found')}
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          data-test="dashboard-activity-empty"
+        />
+      </EmptyWrap>
+    );
+  }
+
+  return (
+    <TimelineContainer>
+      {activities.map(item => (
+        <ActivityItem key={item.id} item={item} />
+      ))}
+      {(hasMore || loading) && (
+        <Actions>
+          <Button
+            loading={loading}
+            onClick={onLoadMore}
+            buttonStyle="secondary"
+            disabled={loading}
+          >
+            {hasMore ? t('Load more') : t('Loading...')}
+          </Button>
+        </Actions>
+      )}
+    </TimelineContainer>
+  );
+}

--- a/superset-frontend/src/dashboard/components/ActivityFeed/api.test.ts
+++ b/superset-frontend/src/dashboard/components/ActivityFeed/api.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+
+import {
+  fetchDashboardActivity,
+  fetchDashboardActivitySummary,
+} from './api';
+
+afterEach(() => {
+  fetchMock.clearHistory().removeRoutes();
+});
+
+test('fetchDashboardActivity passes filters and returns result payload', async () => {
+  fetchMock.get('glob:*/api/v1/dashboard/12/activity/*', {
+    result: {
+      activities: [],
+      count: 0,
+      page: 0,
+      page_size: 25,
+    },
+  });
+
+  const result = await fetchDashboardActivity(12, {
+    actionType: 'view',
+    days: 7,
+    page: 2,
+    pageSize: 10,
+  });
+
+  expect(result.count).toBe(0);
+
+  const call = fetchMock.callHistory.lastCall();
+  expect(call?.url).toContain('/api/v1/dashboard/12/activity/');
+  expect(call?.url).toContain('action_type=view');
+  expect(call?.url).toContain('days=7');
+  expect(call?.url).toContain('page=2');
+  expect(call?.url).toContain('page_size=10');
+});
+
+test('fetchDashboardActivitySummary calls summary endpoint', async () => {
+  fetchMock.get('glob:*/api/v1/dashboard/45/activity/summary/*', {
+    result: {
+      total_views: 2,
+      unique_viewers: 1,
+      views_today: 1,
+      recent_editors: ['admin'],
+      period_days: 30,
+    },
+  });
+
+  const result = await fetchDashboardActivitySummary(45, 30);
+
+  expect(result.views_today).toBe(1);
+  const call = fetchMock.callHistory.lastCall();
+  expect(call?.url).toContain('/api/v1/dashboard/45/activity/summary/');
+});

--- a/superset-frontend/src/dashboard/components/ActivityFeed/api.ts
+++ b/superset-frontend/src/dashboard/components/ActivityFeed/api.ts
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SupersetClient } from '@superset-ui/core';
+
+import {
+  ActionTypeFilter,
+  ActivityFeedResponse,
+  ActivitySummary,
+} from './types';
+
+export async function fetchDashboardActivity(
+  dashboardId: number,
+  options: {
+    page?: number;
+    pageSize?: number;
+    actionType?: ActionTypeFilter;
+    days?: number;
+  } = {},
+): Promise<ActivityFeedResponse> {
+  const { page = 0, pageSize = 25, actionType = 'all', days = 30 } = options;
+
+  const response = await SupersetClient.get({
+    endpoint: `/api/v1/dashboard/${dashboardId}/activity/`,
+    searchParams: {
+      page,
+      page_size: pageSize,
+      action_type: actionType,
+      days,
+    },
+  });
+
+  return response.json.result as ActivityFeedResponse;
+}
+
+export async function fetchDashboardActivitySummary(
+  dashboardId: number,
+  days = 30,
+): Promise<ActivitySummary> {
+  const response = await SupersetClient.get({
+    endpoint: `/api/v1/dashboard/${dashboardId}/activity/summary/`,
+    searchParams: { days },
+  });
+
+  return response.json.result as ActivitySummary;
+}

--- a/superset-frontend/src/dashboard/components/ActivityFeed/index.tsx
+++ b/superset-frontend/src/dashboard/components/ActivityFeed/index.tsx
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { t } from '@apache-superset/core/ui';
+import { Button, Tooltip } from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
+
+import { fetchDashboardActivitySummary } from './api';
+import ActivityFeedDrawer from './ActivityFeedDrawer';
+import { ActivitySummary } from './types';
+
+interface ActivityFeedProps {
+  dashboardId: number;
+}
+
+export default function ActivityFeed({ dashboardId }: ActivityFeedProps) {
+  const [open, setOpen] = useState(false);
+  const [summary, setSummary] = useState<ActivitySummary | null>(null);
+  const [loadingSummary, setLoadingSummary] = useState(false);
+
+  const loadSummary = useCallback(async () => {
+    setLoadingSummary(true);
+    try {
+      const data = await fetchDashboardActivitySummary(dashboardId);
+      setSummary(data);
+    } catch {
+      setSummary(null);
+    } finally {
+      setLoadingSummary(false);
+    }
+  }, [dashboardId]);
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  const summaryLabel = summary
+    ? t('%s views today', summary.views_today)
+    : t('Activity');
+
+  return (
+    <>
+      <Tooltip title={summaryLabel}>
+        <Button
+          buttonStyle="secondary"
+          onClick={() => setOpen(true)}
+          loading={loadingSummary}
+          data-test="dashboard-activity-button"
+          aria-label={summaryLabel}
+        >
+          <Icons.HistoryOutlined iconSize="m" />
+          {summaryLabel}
+        </Button>
+      </Tooltip>
+      <ActivityFeedDrawer
+        dashboardId={dashboardId}
+        open={open}
+        summary={summary}
+        onClose={() => {
+          setOpen(false);
+          loadSummary();
+        }}
+      />
+    </>
+  );
+}

--- a/superset-frontend/src/dashboard/components/ActivityFeed/types.ts
+++ b/superset-frontend/src/dashboard/components/ActivityFeed/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type ActionTypeFilter =
+  | 'all'
+  | 'view'
+  | 'edit'
+  | 'export'
+  | 'chart_interaction';
+
+export interface ActivityUser {
+  id: number | null;
+  username: string;
+  first_name?: string | null;
+  last_name?: string | null;
+}
+
+export interface ActivityItem {
+  id: number;
+  action: string;
+  action_category: 'view' | 'edit' | 'export' | 'chart_interaction' | 'other';
+  action_display: string;
+  user: ActivityUser;
+  timestamp: string;
+  first_seen: string;
+  last_seen: string;
+  event_count: number;
+  duration_ms?: number | null;
+  details?: Record<string, unknown> | null;
+}
+
+export interface ActivityFeedResponse {
+  activities: ActivityItem[];
+  count: number;
+  has_more?: boolean;
+  page: number;
+  page_size: number;
+}
+
+export interface ActivitySummary {
+  total_views: number;
+  unique_viewers: number;
+  views_today: number;
+  recent_editors: string[];
+  period_days: number;
+}

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -62,6 +62,7 @@ import { PageHeaderWithActions } from '@superset-ui/core/components/PageHeaderWi
 import { useUnsavedChangesPrompt } from 'src/hooks/useUnsavedChangesPrompt';
 import DashboardEmbedModal from '../EmbeddedModal';
 import OverwriteConfirm from '../OverwriteConfirm';
+import ActivityFeed from '../ActivityFeed';
 import {
   addDangerToast,
   addSuccessToast,
@@ -715,6 +716,10 @@ const Header = () => {
         ) : (
           <div css={actionButtonsStyle}>
             {NavExtension && <NavExtension />}
+            {!isEmbedded &&
+              isFeatureEnabled(FeatureFlag.DashboardActivityFeed) && (
+                <ActivityFeed dashboardId={dashboardInfo.id} />
+              )}
             {userCanEdit && (
               <Button
                 buttonStyle="secondary"

--- a/superset-frontend/src/features/home/AdminActivityPanel.test.tsx
+++ b/superset-frontend/src/features/home/AdminActivityPanel.test.tsx
@@ -56,7 +56,7 @@ test('renders admin activity items', async () => {
     page_size: 20,
   });
 
-  render(<AdminActivityPanel showThumbnails={false} />, {
+  render(<AdminActivityPanel />, {
     useRedux: true,
     useRouter: true,
   });
@@ -68,12 +68,14 @@ test('renders admin activity items', async () => {
 test('hides panel on unauthorized response', async () => {
   fetchMock.get(adminActivityEndpoint, 403);
 
-  render(<AdminActivityPanel showThumbnails={false} />, {
+  render(<AdminActivityPanel />, {
     useRedux: true,
     useRouter: true,
   });
 
   await waitFor(() => {
-    expect(screen.queryByLabelText('Admin activity type')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Admin activity type'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/features/home/AdminActivityPanel.test.tsx
+++ b/superset-frontend/src/features/home/AdminActivityPanel.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+
+import AdminActivityPanel from './AdminActivityPanel';
+
+const adminActivityEndpoint = 'glob:*/api/v1/log/admin_activity/*';
+
+afterEach(() => {
+  fetchMock.clearHistory().removeRoutes();
+});
+
+test('renders admin activity items', async () => {
+  fetchMock.get(adminActivityEndpoint, {
+    result: [
+      {
+        id: 1,
+        actor: {
+          id: 1,
+          username: 'admin',
+          first_name: 'Superset',
+          last_name: 'Admin',
+        },
+        action: 'Viewed dashboard',
+        action_category: 'view',
+        object_type: 'dashboard',
+        object_id: 11,
+        object_title: 'Revenue Dashboard',
+        object_url: '/superset/dashboard/11/',
+        timestamp: '2026-01-01T00:00:00',
+        first_seen: '2026-01-01T00:00:00',
+        last_seen: '2026-01-01T00:00:00',
+        event_count: 2,
+      },
+    ],
+    count: 1,
+    page: 0,
+    page_size: 20,
+  });
+
+  render(<AdminActivityPanel showThumbnails={false} />, {
+    useRedux: true,
+    useRouter: true,
+  });
+
+  expect(await screen.findByText('Revenue Dashboard')).toBeInTheDocument();
+  expect(screen.getByText(/Viewed dashboard/)).toBeInTheDocument();
+});
+
+test('hides panel on unauthorized response', async () => {
+  fetchMock.get(adminActivityEndpoint, 403);
+
+  render(<AdminActivityPanel showThumbnails={false} />, {
+    useRedux: true,
+    useRouter: true,
+  });
+
+  await waitFor(() => {
+    expect(screen.queryByLabelText('Admin activity type')).not.toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/features/home/AdminActivityPanel.tsx
+++ b/superset-frontend/src/features/home/AdminActivityPanel.tsx
@@ -1,0 +1,231 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { t } from '@apache-superset/core';
+import { styled } from '@apache-superset/core/ui';
+import { getClientErrorObject } from '@superset-ui/core';
+import {
+  Button,
+  Empty,
+  ListViewCard,
+  Loading,
+  Select,
+} from '@superset-ui/core/components';
+import { extendedDayjs } from '@superset-ui/core/utils/dates';
+import { Icons } from '@superset-ui/core/components/Icons';
+
+import { CardContainer, CardStyles } from 'src/views/CRUD/utils';
+import {
+  AdminActionFilter,
+  fetchAdminActivity,
+  AdminActivityResponse,
+} from './adminActivityApi';
+import { AdminActivityItem } from './types';
+
+const Controls = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.sizeUnit * 2}px;
+  margin-bottom: ${({ theme }) => theme.sizeUnit * 4}px;
+  align-items: center;
+`;
+
+const LoadMore = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: ${({ theme }) => theme.sizeUnit * 4}px;
+`;
+
+function getActorName(item: AdminActivityItem): string {
+  const firstName = item.actor.first_name?.trim();
+  const lastName = item.actor.last_name?.trim();
+  const fullName = [firstName, lastName].filter(Boolean).join(' ');
+  return fullName || item.actor.username || t('Anonymous');
+}
+
+function getDescription(item: AdminActivityItem): string {
+  const relativeTime = extendedDayjs(item.timestamp).fromNow();
+  const countSuffix =
+    item.event_count > 1 ? t(' (%s times)', item.event_count) : '';
+  return t('%s · %s%s · %s', getActorName(item), item.action, countSuffix, relativeTime);
+}
+
+interface AdminActivityPanelProps {
+  showThumbnails: boolean;
+}
+
+export default function AdminActivityPanel({
+  showThumbnails,
+}: AdminActivityPanelProps) {
+  const [items, setItems] = useState<AdminActivityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [canAccess, setCanAccess] = useState(true);
+  const [page, setPage] = useState(0);
+  const [count, setCount] = useState(0);
+  const [actionType, setActionType] = useState<AdminActionFilter>('all');
+  const [days, setDays] = useState(7);
+
+  const hasMore = items.length < count;
+
+  const load = useCallback(
+    async (nextPage = 0, reset = false) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response: AdminActivityResponse = await fetchAdminActivity({
+          page: nextPage,
+          pageSize: 20,
+          days,
+          actionType,
+          coalesce: true,
+        });
+
+        setCanAccess(true);
+        setItems(prev => (reset ? response.result : [...prev, ...response.result]));
+        setCount(response.count);
+        setPage(nextPage);
+      } catch (caught) {
+        const errorObject = await getClientErrorObject(caught);
+        if (errorObject.status === 403) {
+          setCanAccess(false);
+        } else {
+          setError(t('Failed to load admin activity'));
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [actionType, days],
+  );
+
+  useEffect(() => {
+    load(0, true);
+  }, [load]);
+
+  const actionOptions = useMemo(
+    () => [
+      { label: t('All activity'), value: 'all' },
+      { label: t('Views'), value: 'view' },
+      { label: t('Edits'), value: 'edit' },
+      { label: t('Exports'), value: 'export' },
+    ],
+    [],
+  );
+
+  const dayOptions = useMemo(
+    () => [
+      { label: t('7 days'), value: 7 },
+      { label: t('30 days'), value: 30 },
+      { label: t('90 days'), value: 90 },
+    ],
+    [],
+  );
+
+  if (!canAccess) {
+    return null;
+  }
+
+  if (loading && items.length === 0) {
+    return <Loading />;
+  }
+
+  if (error && items.length === 0) {
+    return (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description={error}
+        data-test="admin-activity-error"
+      />
+    );
+  }
+
+  return (
+    <>
+      <Controls>
+        <Select
+          value={actionType}
+          onChange={(value: AdminActionFilter) => {
+            setActionType(value);
+          }}
+          options={actionOptions}
+          ariaLabel={t('Admin activity type')}
+          style={{ minWidth: 190 }}
+        />
+        <Select
+          value={days}
+          onChange={(value: number) => {
+            setDays(value);
+          }}
+          options={dayOptions}
+          ariaLabel={t('Admin activity time range')}
+          style={{ minWidth: 130 }}
+        />
+        <Button
+          buttonStyle="secondary"
+          onClick={() => load(0, true)}
+          loading={loading}
+          aria-label={t('Refresh admin activity')}
+        >
+          <Icons.ReloadOutlined iconSize="m" />
+        </Button>
+      </Controls>
+
+      {items.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={t('No admin activity found')}
+          data-test="admin-activity-empty"
+        />
+      ) : (
+        <CardContainer showThumbnails={showThumbnails}>
+          {items.map(item => (
+            <CardStyles key={`${item.id}-${item.timestamp}`}>
+              <ListViewCard
+                cover={<></>}
+                title={item.object_title || t('[Untitled]')}
+                description={getDescription(item)}
+                avatar={
+                  item.object_type === 'dashboard' ? (
+                    <Icons.DashboardOutlined />
+                  ) : (
+                    <Icons.BarChartOutlined />
+                  )
+                }
+                url={item.object_url || undefined}
+              />
+            </CardStyles>
+          ))}
+        </CardContainer>
+      )}
+
+      {hasMore && (
+        <LoadMore>
+          <Button
+            buttonStyle="secondary"
+            onClick={() => load(page + 1, false)}
+            loading={loading}
+            disabled={loading}
+          >
+            {t('Load more')}
+          </Button>
+        </LoadMore>
+      )}
+    </>
+  );
+}

--- a/superset-frontend/src/features/home/AdminActivityPanel.tsx
+++ b/superset-frontend/src/features/home/AdminActivityPanel.tsx
@@ -30,7 +30,7 @@ import {
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 import { Icons } from '@superset-ui/core/components/Icons';
 
-import { CardContainer, CardStyles } from 'src/views/CRUD/utils';
+import { CardStyles } from 'src/views/CRUD/utils';
 import {
   AdminActionFilter,
   fetchAdminActivity,
@@ -51,6 +51,18 @@ const LoadMore = styled.div`
   margin-top: ${({ theme }) => theme.sizeUnit * 4}px;
 `;
 
+export const CardContainer = styled.div`
+  ${({ theme }) => `
+    overflow: hidden;
+    display: grid;
+    justify-content: center;
+    grid-gap: ${theme.sizeUnit * 12}px ${theme.sizeUnit * 4}px;
+    grid-template-columns: repeat(auto-fit, 300px);
+    margin-top: ${theme.sizeUnit * -6}px;
+    padding: ${`${theme.sizeUnit * 8 + 1}px ${theme.sizeUnit * 20}px`};
+  `}
+`;
+
 function getActorName(item: AdminActivityItem): string {
   const firstName = item.actor.first_name?.trim();
   const lastName = item.actor.last_name?.trim();
@@ -62,16 +74,16 @@ function getDescription(item: AdminActivityItem): string {
   const relativeTime = extendedDayjs(item.timestamp).fromNow();
   const countSuffix =
     item.event_count > 1 ? t(' (%s times)', item.event_count) : '';
-  return t('%s · %s%s · %s', getActorName(item), item.action, countSuffix, relativeTime);
+  return t(
+    '%s · %s%s · %s',
+    getActorName(item),
+    item.action,
+    countSuffix,
+    relativeTime,
+  );
 }
 
-interface AdminActivityPanelProps {
-  showThumbnails: boolean;
-}
-
-export default function AdminActivityPanel({
-  showThumbnails,
-}: AdminActivityPanelProps) {
+export default function AdminActivityPanel() {
   const [items, setItems] = useState<AdminActivityItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -97,12 +109,14 @@ export default function AdminActivityPanel({
         });
 
         setCanAccess(true);
-        setItems(prev => (reset ? response.result : [...prev, ...response.result]));
+        setItems(prev =>
+          reset ? response.result : [...prev, ...response.result],
+        );
         setCount(response.count);
         setPage(nextPage);
       } catch (caught) {
         const errorObject = await getClientErrorObject(caught);
-        if (errorObject.status === 403) {
+        if (errorObject.statusText === '403') {
           setCanAccess(false);
         } else {
           setError(t('Failed to load admin activity'));
@@ -165,7 +179,7 @@ export default function AdminActivityPanel({
           }}
           options={actionOptions}
           ariaLabel={t('Admin activity type')}
-          style={{ minWidth: 190 }}
+          css={{ minWidth: 190 }}
         />
         <Select
           value={days}
@@ -174,7 +188,7 @@ export default function AdminActivityPanel({
           }}
           options={dayOptions}
           ariaLabel={t('Admin activity time range')}
-          style={{ minWidth: 130 }}
+          css={{ minWidth: 130 }}
         />
         <Button
           buttonStyle="secondary"
@@ -193,7 +207,7 @@ export default function AdminActivityPanel({
           data-test="admin-activity-empty"
         />
       ) : (
-        <CardContainer showThumbnails={showThumbnails}>
+        <CardContainer>
           {items.map(item => (
             <CardStyles key={`${item.id}-${item.timestamp}`}>
               <ListViewCard

--- a/superset-frontend/src/features/home/adminActivityApi.ts
+++ b/superset-frontend/src/features/home/adminActivityApi.ts
@@ -45,14 +45,14 @@ export async function fetchAdminActivity(options: {
     coalesce = true,
   } = options;
 
-  const action_types =
+  const actionTypes =
     actionType === 'all' ? ['view', 'edit', 'export'] : [actionType];
 
   const q = rison.encode({
     page,
     page_size: pageSize,
     days,
-    action_types,
+    action_types: actionTypes,
     coalesce,
   });
 

--- a/superset-frontend/src/features/home/adminActivityApi.ts
+++ b/superset-frontend/src/features/home/adminActivityApi.ts
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SupersetClient } from '@superset-ui/core';
+import rison from 'rison';
+
+import { AdminActivityItem } from './types';
+
+export type AdminActionFilter = 'all' | 'view' | 'edit' | 'export';
+
+export interface AdminActivityResponse {
+  result: AdminActivityItem[];
+  count: number;
+  page: number;
+  page_size: number;
+}
+
+export async function fetchAdminActivity(options: {
+  page?: number;
+  pageSize?: number;
+  days?: number;
+  actionType?: AdminActionFilter;
+  coalesce?: boolean;
+}): Promise<AdminActivityResponse> {
+  const {
+    page = 0,
+    pageSize = 20,
+    days = 7,
+    actionType = 'all',
+    coalesce = true,
+  } = options;
+
+  const action_types =
+    actionType === 'all' ? ['view', 'edit', 'export'] : [actionType];
+
+  const q = rison.encode({
+    page,
+    page_size: pageSize,
+    days,
+    action_types,
+    coalesce,
+  });
+
+  const response = await SupersetClient.get({
+    endpoint: `/api/v1/log/admin_activity/?q=${q}`,
+  });
+
+  return response.json as AdminActivityResponse;
+}

--- a/superset-frontend/src/features/home/types.ts
+++ b/superset-frontend/src/features/home/types.ts
@@ -67,3 +67,25 @@ export interface RecentActivity {
   time: number;
   time_delta_humanized?: string;
 }
+
+export interface AdminActivityActor {
+  id: number | null;
+  username: string;
+  first_name: string | null;
+  last_name: string | null;
+}
+
+export interface AdminActivityItem {
+  id: number;
+  actor: AdminActivityActor;
+  action: string;
+  action_category: string;
+  object_type: string | null;
+  object_id: number | null;
+  object_title: string | null;
+  object_url: string | null;
+  timestamp: string;
+  event_count: number;
+  first_seen: string;
+  last_seen: string;
+}

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -52,6 +52,7 @@ import SubMenu, { SubMenuProps } from 'src/features/home/SubMenu';
 import { userHasPermission } from 'src/dashboard/util/permissionUtils';
 import { WelcomePageLastTab } from 'src/features/home/types';
 import ActivityTable from 'src/features/home/ActivityTable';
+import AdminActivityPanel from 'src/features/home/AdminActivityPanel';
 import ChartTable from 'src/features/home/ChartTable';
 import SavedQueries from 'src/features/home/SavedQueries';
 import DashboardTable from 'src/features/home/DashboardTable';
@@ -156,6 +157,9 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   const userKey = dangerouslyGetItemDoNotUse(id, null);
   let defaultChecked = false;
   const isThumbnailsEnabled = isFeatureEnabled(FeatureFlag.Thumbnails);
+  const isAdminActivityEnabled = isFeatureEnabled(
+    FeatureFlag.AdminActivityFeed,
+  );
   if (isThumbnailsEnabled) {
     defaultChecked =
       userKey?.thumbnails === undefined ? true : userKey?.thumbnails;
@@ -360,6 +364,17 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
               onChange={handleCollapse}
               ghost
               items={[
+                ...(isAdminActivityEnabled
+                  ? [
+                      {
+                        key: 'admin-activity',
+                        label: t('Activity Feed'),
+                        children: (
+                          <AdminActivityPanel showThumbnails={checked} />
+                        ),
+                      },
+                    ]
+                  : []),
                 {
                   key: 'recents',
                   label: t('Recents'),

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -369,9 +369,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
                       {
                         key: 'admin-activity',
                         label: t('Activity Feed'),
-                        children: (
-                          <AdminActivityPanel showThumbnails={checked} />
-                        ),
+                        children: <AdminActivityPanel />,
                       },
                     ]
                   : []),

--- a/superset/config.py
+++ b/superset/config.py
@@ -590,6 +590,9 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # These features are finished but currently being tested.
     # They are usable, but may still contain some bugs.
     # -----------------------------------------------------------------
+    # Enables admin-wide activity feed panel on the welcome page.
+    # @lifecycle: testing
+    "ADMIN_ACTIVITY_FEED": True,
     # Enables filter functionality in Alerts and Reports
     # @lifecycle: testing
     "ALERT_REPORTS_FILTER": False,
@@ -703,6 +706,10 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # @category: runtime_config
     # @docs: https://superset.apache.org/docs/using-superset/creating-your-first-dashboard
     "DASHBOARD_RBAC": False,
+    # Enables dashboard-level activity feed in dashboard header and API.
+    # @lifecycle: stable
+    # @category: runtime_config
+    "DASHBOARD_ACTIVITY_FEED": True,
     # Supports simultaneous data and dashboard virtualization for backend performance
     # @lifecycle: stable
     # @category: runtime_config

--- a/superset/daos/log.py
+++ b/superset/daos/log.py
@@ -14,11 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime, timedelta
+import re
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import humanize
-from sqlalchemy import and_, or_
+from flask_appbuilder.security.sqla.models import User
+from sqlalchemy import and_, desc, or_
 from sqlalchemy.sql import functions as func
 
 from superset import db
@@ -26,11 +28,61 @@ from superset.daos.base import BaseDAO
 from superset.models.core import Log
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
+from superset.utils import json
 from superset.utils.core import get_user_id
 from superset.utils.dates import datetime_to_epoch
 
+COALESCE_WINDOW = timedelta(minutes=5)
+VALID_ADMIN_ACTIVITY_TYPES = {"view", "edit", "export", "chart_interaction"}
+
+ADMIN_ACTION_CATEGORIES: dict[str, set[str]] = {
+    "view": {
+        "dashboard",
+        "mount_dashboard",
+        "DashboardRestApi.get",
+        "DashboardRestApi.get_list",
+    },
+    "edit": {
+        "DashboardRestApi.put",
+        "DashboardRestApi.post",
+        "DashboardRestApi.delete",
+        "force_refresh_dashboard",
+    },
+    "export": {
+        "DashboardRestApi.export",
+        "export_csv_dashboard_chart",
+    },
+    "chart_interaction": {
+        "explore_json",
+        "ChartRestApi.data",
+        "mount_explorer",
+    },
+}
+
+ADMIN_ACTION_DISPLAY = {
+    "dashboard": "Viewed dashboard",
+    "mount_dashboard": "Viewed dashboard",
+    "DashboardRestApi.get": "Viewed dashboard",
+    "DashboardRestApi.get_list": "Listed dashboards",
+    "DashboardRestApi.put": "Updated dashboard",
+    "DashboardRestApi.post": "Created dashboard",
+    "DashboardRestApi.delete": "Deleted dashboard",
+    "DashboardRestApi.export": "Exported dashboard",
+    "export_csv_dashboard_chart": "Exported chart CSV",
+    "force_refresh_dashboard": "Refreshed dashboard",
+    "explore_json": "Loaded chart data",
+    "ChartRestApi.data": "Loaded chart data",
+    "mount_explorer": "Opened chart",
+}
+
 
 class LogDAO(BaseDAO[Log]):
+    @staticmethod
+    def _serialize_datetime(value: datetime) -> str:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat()
+
     @staticmethod
     def get_recent_activity(
         actions: list[str],
@@ -147,3 +199,233 @@ class LogDAO(BaseDAO[Log]):
                 }
             )
         return payload
+
+    @staticmethod
+    def get_admin_activity(
+        action_types: list[str],
+        page: int,
+        page_size: int,
+        days: int,
+        coalesce: bool,
+    ) -> tuple[list[dict[str, Any]], int]:
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        rows = (
+            db.session.query(Log, User, Dashboard, Slice)
+            .outerjoin(User, Log.user_id == User.id)
+            .outerjoin(Dashboard, Dashboard.id == Log.dashboard_id)
+            .outerjoin(Slice, Slice.id == Log.slice_id)
+            .filter(Log.dttm >= cutoff)
+            .order_by(desc(Log.dttm), desc(Log.id))
+            .all()
+        )
+
+        filtered_types = set(action_types).intersection(VALID_ADMIN_ACTIVITY_TYPES)
+        if not filtered_types:
+            filtered_types = {"view", "edit", "export"}
+
+        events: list[dict[str, Any]] = []
+        dashboard_cache: dict[int, Dashboard | None] = {}
+        chart_cache: dict[int, Slice | None] = {}
+
+        for log, user, dashboard, slice_obj in rows:
+            effective_action = LogDAO._effective_action(log.action, log.json)
+            category = LogDAO._categorize_action(effective_action)
+            if category not in filtered_types:
+                continue
+
+            payload = LogDAO._parse_payload(log.json)
+            resolved_dashboard_id, resolved_slice_id = LogDAO._resolve_object_ids(
+                log.dashboard_id,
+                log.slice_id,
+                payload,
+            )
+
+            if dashboard is None and resolved_dashboard_id is not None:
+                if resolved_dashboard_id not in dashboard_cache:
+                    dashboard_cache[resolved_dashboard_id] = db.session.get(
+                        Dashboard,
+                        resolved_dashboard_id,
+                    )
+                dashboard = dashboard_cache[resolved_dashboard_id]
+
+            if slice_obj is None and resolved_slice_id is not None:
+                if resolved_slice_id not in chart_cache:
+                    chart_cache[resolved_slice_id] = db.session.get(
+                        Slice,
+                        resolved_slice_id,
+                    )
+                slice_obj = chart_cache[resolved_slice_id]
+
+            object_type: str | None = None
+            object_id: int | None = None
+            object_title: str | None = None
+            object_url: str | None = None
+
+            if dashboard is not None:
+                object_type = "dashboard"
+                object_id = resolved_dashboard_id or dashboard.id
+                object_title = dashboard.dashboard_title
+                object_url = Dashboard.get_url(dashboard.id, dashboard.slug)
+            elif slice_obj is not None:
+                object_type = "chart"
+                object_id = resolved_slice_id or slice_obj.id
+                object_title = slice_obj.slice_name
+                object_url = Slice.build_explore_url(slice_obj.id)
+
+            if object_title in (None, ""):
+                object_title = "<untitled>"
+
+            timestamp = log.dttm or datetime.utcnow()
+            serialized_timestamp = LogDAO._serialize_datetime(timestamp)
+            action_display = LogDAO._get_action_display(effective_action, category)
+            events.append(
+                {
+                    "id": log.id,
+                    "actor": {
+                        "id": log.user_id,
+                        "username": user.username if user else "Anonymous",
+                        "first_name": user.first_name if user else None,
+                        "last_name": user.last_name if user else None,
+                    },
+                    "action": action_display,
+                    "action_category": category,
+                    "object_type": object_type,
+                    "object_id": object_id,
+                    "object_title": object_title,
+                    "object_url": object_url,
+                    "timestamp": serialized_timestamp,
+                    "first_seen": serialized_timestamp,
+                    "last_seen": serialized_timestamp,
+                    "event_count": 1,
+                    "_timestamp": timestamp,
+                    "_coalesce_key": (
+                        log.user_id,
+                        category,
+                        action_display,
+                        object_type,
+                        object_id,
+                    ),
+                }
+            )
+
+        grouped = LogDAO._coalesce_admin_activity(events) if coalesce else events
+        total = len(grouped)
+        start = page * page_size
+        end = start + page_size
+
+        payload = [
+            {
+                key: value
+                for key, value in event.items()
+                if key not in {"_timestamp", "_coalesce_key"}
+            }
+            for event in grouped[start:end]
+        ]
+        return payload, total
+
+    @staticmethod
+    def _coalesce_admin_activity(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        grouped: list[dict[str, Any]] = []
+        for event in events:
+            if not grouped:
+                grouped.append(event)
+                continue
+
+            current = grouped[-1]
+            same_key = current["_coalesce_key"] == event["_coalesce_key"]
+            within_window = (
+                current["_timestamp"] - event["_timestamp"]
+            ) <= COALESCE_WINDOW
+            if same_key and within_window:
+                current["event_count"] += 1
+                current["first_seen"] = event["timestamp"]
+                continue
+
+            grouped.append(event)
+        return grouped
+
+    @staticmethod
+    def _effective_action(action: str | None, payload: str | None) -> str:
+        if action == "log" and payload:
+            try:
+                parsed = json.loads(payload)
+                if isinstance(parsed, dict):
+                    event_name = parsed.get("event_name")
+                    if isinstance(event_name, str) and event_name:
+                        return event_name
+            except (TypeError, ValueError):
+                return action or "unknown"
+        return action or "unknown"
+
+    @staticmethod
+    def _categorize_action(action: str) -> str:
+        for category, actions in ADMIN_ACTION_CATEGORIES.items():
+            if action in actions:
+                return category
+        if LogDAO._is_export_action(action):
+            return "export"
+        return "other"
+
+    @staticmethod
+    def _is_export_action(action: str) -> bool:
+        lowered = action.lower()
+        return (
+            action.startswith("export_")
+            or ".export" in action
+            or "download" in lowered
+            or lowered.endswith("_csv")
+            or lowered.endswith("_xlsx")
+        )
+
+    @staticmethod
+    def _get_action_display(action: str, category: str) -> str:
+        if action in ADMIN_ACTION_DISPLAY:
+            return ADMIN_ACTION_DISPLAY[action]
+        if normalized := action.replace("_", " ").replace(".", " ").strip():
+            return normalized.capitalize()
+        return category.replace("_", " ").capitalize()
+
+    @staticmethod
+    def _parse_payload(payload: str | None) -> dict[str, Any] | None:
+        if not payload:
+            return None
+        try:
+            parsed = json.loads(payload)
+            return parsed if isinstance(parsed, dict) else None
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _to_int(value: Any) -> int | None:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+        return None
+
+    @staticmethod
+    def _resolve_object_ids(
+        dashboard_id: int | None,
+        slice_id: int | None,
+        payload: dict[str, Any] | None,
+    ) -> tuple[int | None, int | None]:
+        resolved_dashboard_id = dashboard_id
+        resolved_slice_id = slice_id
+
+        if payload:
+            if resolved_dashboard_id is None:
+                resolved_dashboard_id = LogDAO._to_int(
+                    payload.get("dashboard_id")
+                ) or LogDAO._to_int(payload.get("source_id"))
+            if resolved_slice_id is None:
+                resolved_slice_id = LogDAO._to_int(payload.get("slice_id"))
+            if resolved_dashboard_id is None and isinstance(payload.get("rison"), list):
+                for value in payload["rison"]:
+                    resolved_dashboard_id = LogDAO._to_int(value)
+                    if resolved_dashboard_id is not None:
+                        break
+            if resolved_dashboard_id is None and isinstance(payload.get("q"), str):
+                if match := re.search(r"\d+", payload["q"]):
+                    resolved_dashboard_id = int(match.group(0))
+
+        return resolved_dashboard_id, resolved_slice_id

--- a/superset/dashboards/activity/__init__.py
+++ b/superset/dashboards/activity/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/dashboards/activity/commands/__init__.py
+++ b/superset/dashboards/activity/commands/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/dashboards/activity/commands/get_activity.py
+++ b/superset/dashboards/activity/commands/get_activity.py
@@ -1,0 +1,460 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from flask_appbuilder.security.sqla.models import User
+from sqlalchemy import and_, desc, or_
+
+from superset import db
+from superset.commands.base import BaseCommand
+from superset.dashboards.activity.schemas import VALID_ACTIVITY_ACTION_TYPES
+from superset.models.core import Log
+from superset.utils import json
+
+COALESCE_WINDOW = timedelta(minutes=5)
+EXPORT_ACTIONS = {
+    "DashboardRestApi.export",
+    "export_csv_dashboard_chart",
+}
+
+ACTION_CATEGORIES: dict[str, list[str]] = {
+    "view": [
+        "dashboard",
+        "mount_dashboard",
+        "DashboardRestApi.get",
+        "DashboardRestApi.get_list",
+    ],
+    "edit": [
+        "DashboardRestApi.put",
+        "DashboardRestApi.post",
+        "DashboardRestApi.delete",
+        "force_refresh_dashboard",
+    ],
+    "export": [
+        "DashboardRestApi.export",
+        "export_csv_dashboard_chart",
+    ],
+    "chart_interaction": [
+        "explore_json",
+        "ChartRestApi.data",
+        "mount_explorer",
+        "load_chart",
+        "execute_sql",
+        "load_into_dataframe",
+        "ChartDataRestApi.data",
+        "ChartDataRestApi.json_dumps",
+        "_get_data_response",
+        "QueryObject.post_processing",
+        "render_chart",
+    ],
+}
+
+ACTION_DISPLAY_NAMES = {
+    "dashboard": "Viewed dashboard",
+    "mount_dashboard": "Viewed dashboard",
+    "DashboardRestApi.get": "Viewed dashboard",
+    "DashboardRestApi.get_list": "Listed dashboards",
+    "DashboardRestApi.put": "Updated dashboard",
+    "DashboardRestApi.post": "Created dashboard",
+    "DashboardRestApi.delete": "Deleted dashboard",
+    "DashboardRestApi.export": "Exported dashboard",
+    "export_csv_dashboard_chart": "Exported chart CSV",
+    "force_refresh_dashboard": "Refreshed dashboard",
+    "explore_json": "Loaded chart data",
+    "ChartRestApi.data": "Loaded chart data",
+    "mount_explorer": "Opened chart",
+    "load_chart": "Loaded chart",
+    "execute_sql": "Executed SQL",
+    "load_into_dataframe": "Loaded into dataframe",
+    "ChartDataRestApi.data": "Loaded chart data",
+    "ChartDataRestApi.json_dumps": "Serialized chart data",
+    "_get_data_response": "Received chart data response",
+    "QueryObject.post_processing": "Post-processed query results",
+    "render_chart": "Rendered chart",
+}
+
+DETAIL_KEYS = (
+    "slice_name",
+    "slice_id",
+    "viz_type",
+    "datasource_name",
+    "dashboard_id",
+)
+
+
+@dataclass
+class ActivityItem:
+    id: int
+    action: str
+    action_category: str
+    action_display: str
+    user_id: int | None
+    username: str
+    user_first_name: str | None
+    user_last_name: str | None
+    timestamp: datetime
+    first_seen: datetime
+    last_seen: datetime
+    event_count: int
+    dashboard_id: int | None
+    slice_id: int | None
+    duration_ms: float | None
+    details: dict[str, Any] | None
+
+    @staticmethod
+    def _serialize_datetime(value: datetime) -> str:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "action": self.action,
+            "action_category": self.action_category,
+            "action_display": self.action_display,
+            "user": {
+                "id": self.user_id,
+                "username": self.username,
+                "first_name": self.user_first_name,
+                "last_name": self.user_last_name,
+            },
+            "timestamp": self._serialize_datetime(self.timestamp),
+            "first_seen": self._serialize_datetime(self.first_seen),
+            "last_seen": self._serialize_datetime(self.last_seen),
+            "event_count": self.event_count,
+            "duration_ms": self.duration_ms,
+            "details": self.details,
+        }
+
+
+class GetDashboardActivityCommand(BaseCommand):
+    def __init__(
+        self,
+        dashboard_id: int,
+        page: int = 0,
+        page_size: int = 25,
+        action_type: str = "all",
+        days: int = 30,
+        summary_only: bool = False,
+    ):
+        self.dashboard_id = dashboard_id
+        self.page = page
+        self.page_size = page_size
+        self.action_type = action_type
+        self.days = days
+        self.summary_only = summary_only
+
+    def run(self) -> dict[str, Any]:
+        self.validate()
+        if self.summary_only:
+            return self._get_summary()
+        return self._get_activity_feed()
+
+    def validate(self) -> None:
+        if self.page < 0:
+            raise ValueError("`page` must be >= 0")
+        if self.page_size < 1 or self.page_size > 100:
+            raise ValueError("`page_size` must be between 1 and 100")
+        if self.days < 1 or self.days > 365:
+            raise ValueError("`days` must be between 1 and 365")
+        if self.action_type not in VALID_ACTIVITY_ACTION_TYPES:
+            raise ValueError("`action_type` has an invalid value")
+
+    def _get_base_query(self) -> Any:
+        cutoff = datetime.utcnow() - timedelta(days=self.days)
+        return (
+            db.session.query(Log, User)
+            .outerjoin(User, Log.user_id == User.id)
+            .filter(
+                and_(
+                    Log.dttm >= cutoff,
+                    or_(
+                        Log.dashboard_id == self.dashboard_id,
+                        Log.action == "DashboardRestApi.export",
+                        and_(
+                            Log.action == "log",
+                            Log.json.ilike('%"event_name": "export%'),
+                        ),
+                    ),
+                )
+            )
+            .order_by(desc(Log.dttm), desc(Log.id))
+        )
+
+    def _get_base_rows(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[tuple[Log, User | None]]:
+        query = self._get_base_query()
+        if offset:
+            query = query.offset(offset)
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
+
+    def _get_activity_feed(self) -> dict[str, Any]:
+        start = self.page * self.page_size
+        end = start + self.page_size
+        chunk_size = max(self.page_size * 5, 100)
+        row_offset = 0
+        grouped: list[ActivityItem] = []
+        has_more = False
+
+        while True:
+            rows = self._get_base_rows(limit=chunk_size, offset=row_offset)
+            if not rows:
+                break
+
+            normalized = self._build_activity_items(rows)
+            grouped = self._coalesce_activity_items([*grouped, *normalized])
+            row_offset += len(rows)
+
+            if len(grouped) > end:
+                has_more = True
+                break
+
+            if len(rows) < chunk_size:
+                break
+
+        visible = grouped[start:end]
+        total = end + 1 if has_more else len(grouped)
+        activities = [item.to_dict() for item in visible]
+
+        return {
+            "activities": activities,
+            "count": total,
+            "has_more": has_more,
+            "page": self.page,
+            "page_size": self.page_size,
+        }
+
+    def _get_summary(self) -> dict[str, Any]:
+        normalized = self._build_activity_items(
+            self._get_base_rows(),
+            apply_action_filter=False,
+            include_chart_interaction=True,
+        )
+        view_events = [event for event in normalized if event.action_category == "view"]
+
+        total_views = len(view_events)
+        unique_viewers = len(
+            {event.user_id for event in view_events if event.user_id is not None}
+        )
+
+        today = datetime.utcnow().date()
+        views_today = len(
+            [event for event in view_events if event.timestamp.date() == today]
+        )
+
+        editors: list[str] = []
+        seen_editors: set[str] = set()
+        for event in normalized:
+            if event.action_category != "edit":
+                continue
+            if not event.username or event.username in seen_editors:
+                continue
+            seen_editors.add(event.username)
+            editors.append(event.username)
+            if len(editors) == 5:
+                break
+
+        return {
+            "total_views": total_views,
+            "unique_viewers": unique_viewers,
+            "views_today": views_today,
+            "recent_editors": editors,
+            "period_days": self.days,
+        }
+
+    def _build_activity_items(
+        self,
+        rows: list[tuple[Log, User | None]],
+        apply_action_filter: bool = True,
+        include_chart_interaction: bool = False,
+    ) -> list[ActivityItem]:
+        items: list[ActivityItem] = []
+
+        for log, user in rows:
+            timestamp = log.dttm or datetime.utcnow()
+            payload = self._parse_payload(log.json)
+            resolved_dashboard_id = self._resolve_dashboard_id(log, payload)
+            if resolved_dashboard_id != self.dashboard_id:
+                continue
+            effective_action = self._effective_action(log.action, payload)
+            action_category = self._categorize_action(effective_action)
+
+            if apply_action_filter:
+                if self.action_type == "all":
+                    if (
+                        not include_chart_interaction
+                        and action_category == "chart_interaction"
+                    ):
+                        continue
+                elif action_category != self.action_type:
+                    continue
+
+            details = self._extract_details(payload)
+            if log.slice_id is not None and details.get("slice_id") is None:
+                details["slice_id"] = log.slice_id
+            if details.get("dashboard_id") is None:
+                details["dashboard_id"] = resolved_dashboard_id
+
+            items.append(
+                ActivityItem(
+                    id=log.id,
+                    action=effective_action,
+                    action_category=action_category,
+                    action_display=self._get_action_display(
+                        effective_action, action_category
+                    ),
+                    user_id=log.user_id,
+                    username=user.username if user else "Anonymous",
+                    user_first_name=user.first_name if user else None,
+                    user_last_name=user.last_name if user else None,
+                    timestamp=timestamp,
+                    first_seen=timestamp,
+                    last_seen=timestamp,
+                    event_count=1,
+                    dashboard_id=resolved_dashboard_id,
+                    slice_id=log.slice_id,
+                    duration_ms=float(log.duration_ms)
+                    if log.duration_ms is not None
+                    else None,
+                    details=details or None,
+                )
+            )
+
+        return items
+
+    @staticmethod
+    def _resolve_dashboard_id(log: Log, payload: dict[str, Any] | None) -> int | None:
+        if log.dashboard_id is not None:
+            return log.dashboard_id
+        if not payload:
+            return None
+
+        for key in ("dashboard_id", "source_id"):
+            if dashboard_id := GetDashboardActivityCommand._as_int(payload.get(key)):
+                return dashboard_id
+
+        rison_values = payload.get("rison")
+        if isinstance(rison_values, list):
+            for value in rison_values:
+                if dashboard_id := GetDashboardActivityCommand._as_int(value):
+                    return dashboard_id
+
+        q_value = payload.get("q")
+        if isinstance(q_value, str):
+            if match := re.search(r"\d+", q_value):
+                return int(match.group(0))
+
+        return None
+
+    @staticmethod
+    def _as_int(value: Any) -> int | None:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+        return None
+
+    def _coalesce_activity_items(self, items: list[ActivityItem]) -> list[ActivityItem]:
+        grouped: list[ActivityItem] = []
+        for item in items:
+            if grouped and self._should_coalesce(grouped[-1], item):
+                grouped[-1].event_count += 1
+                grouped[-1].first_seen = item.timestamp
+            else:
+                grouped.append(item)
+        return grouped
+
+    @staticmethod
+    def _should_coalesce(current: ActivityItem, incoming: ActivityItem) -> bool:
+        if current.user_id != incoming.user_id:
+            return False
+        if current.action_category != incoming.action_category:
+            return False
+        if current.action_display != incoming.action_display:
+            return False
+        if current.dashboard_id != incoming.dashboard_id:
+            return False
+        if current.slice_id != incoming.slice_id:
+            return False
+
+        return (current.first_seen - incoming.timestamp) <= COALESCE_WINDOW
+
+    @staticmethod
+    def _effective_action(action: str | None, payload: dict[str, Any] | None) -> str:
+        if action == "log" and payload:
+            event_name = payload.get("event_name")
+            if isinstance(event_name, str) and event_name:
+                return event_name
+        return action or "unknown"
+
+    @staticmethod
+    def _categorize_action(action: str) -> str:
+        for category, actions in ACTION_CATEGORIES.items():
+            if action in actions:
+                return category
+        if GetDashboardActivityCommand._is_export_action(action):
+            return "export"
+        return "other"
+
+    @staticmethod
+    def _is_export_action(action: str) -> bool:
+        lowered = action.lower()
+        return (
+            action in EXPORT_ACTIONS
+            or action.startswith("export_")
+            or ".export" in action
+            or "download" in lowered
+            or lowered.endswith("_csv")
+            or lowered.endswith("_xlsx")
+        )
+
+    @staticmethod
+    def _get_action_display(action: str, category: str) -> str:
+        if action in ACTION_DISPLAY_NAMES:
+            return ACTION_DISPLAY_NAMES[action]
+        # Keep unknown actions understandable in UI instead of showing generic "other".
+        if normalized := action.replace("_", " ").replace(".", " ").strip():
+            return normalized.capitalize()
+        return category.replace("_", " ").capitalize()
+
+    @staticmethod
+    def _parse_payload(payload: str | None) -> dict[str, Any] | None:
+        if not payload:
+            return None
+        try:
+            parsed = json.loads(payload)
+            return parsed if isinstance(parsed, dict) else None
+        except Exception:  # pylint: disable=broad-exception-caught
+            return None
+
+    @staticmethod
+    def _extract_details(payload: dict[str, Any] | None) -> dict[str, Any]:
+        if not payload:
+            return {}
+        return {key: payload[key] for key in DETAIL_KEYS if key in payload}

--- a/superset/dashboards/activity/schemas.py
+++ b/superset/dashboards/activity/schemas.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from marshmallow import fields, Schema, validate
+
+VALID_ACTIVITY_ACTION_TYPES = ("view", "edit", "export", "chart_interaction", "all")
+
+
+class DashboardActivityQuerySchema(Schema):
+    page = fields.Integer(load_default=0, validate=validate.Range(min=0))
+    page_size = fields.Integer(
+        load_default=25,
+        validate=validate.Range(min=1, max=100),
+    )
+    action_type = fields.String(
+        load_default="all",
+        validate=validate.OneOf(VALID_ACTIVITY_ACTION_TYPES),
+    )
+    days = fields.Integer(load_default=30, validate=validate.Range(min=1, max=365))
+
+
+class ActivityUserSchema(Schema):
+    id = fields.Integer(allow_none=True)
+    username = fields.String()
+    first_name = fields.String(allow_none=True)
+    last_name = fields.String(allow_none=True)
+
+
+class ActivityItemSchema(Schema):
+    id = fields.Integer()
+    action = fields.String()
+    action_category = fields.String()
+    action_display = fields.String()
+    user = fields.Nested(ActivityUserSchema)
+    timestamp = fields.DateTime()
+    first_seen = fields.DateTime()
+    last_seen = fields.DateTime()
+    event_count = fields.Integer()
+    duration_ms = fields.Float(allow_none=True)
+    details = fields.Dict(allow_none=True)
+
+
+class DashboardActivityResponseSchema(Schema):
+    activities = fields.List(fields.Nested(ActivityItemSchema))
+    count = fields.Integer()
+    has_more = fields.Boolean()
+    page = fields.Integer()
+    page_size = fields.Integer()
+
+
+class DashboardActivitySummarySchema(Schema):
+    total_views = fields.Integer()
+    unique_viewers = fields.Integer()
+    views_today = fields.Integer()
+    recent_editors = fields.List(fields.String())
+    period_days = fields.Integer()

--- a/superset/migrations/versions/2026-02-05_10-00_b3b6d8d2c6a1_add_logs_dashboard_dttm_index.py
+++ b/superset/migrations/versions/2026-02-05_10-00_b3b6d8d2c6a1_add_logs_dashboard_dttm_index.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add logs dashboard_id+dttm index
+
+Revision ID: b3b6d8d2c6a1
+Revises: 9787190b3d89
+Create Date: 2026-02-05 10:00:00.000000
+
+"""
+
+from alembic import op
+
+from superset.migrations.shared.utils import create_index, drop_index
+
+# revision identifiers, used by Alembic.
+revision = "b3b6d8d2c6a1"
+down_revision = "9787190b3d89"
+
+
+def upgrade():
+    create_index(
+        table_name="logs",
+        index_name=op.f("ix_logs_dashboard_id_dttm"),
+        columns=["dashboard_id", "dttm"],
+        unique=False,
+    )
+
+
+def downgrade():
+    drop_index(
+        table_name="logs",
+        index_name=op.f("ix_logs_dashboard_id_dttm"),
+    )

--- a/superset/static/service-worker.js
+++ b/superset/static/service-worker.js
@@ -1,27 +1,1471 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+/*
+ * ATTENTION: An "eval-source-map" devtool has been used.
+ * This devtool is neither made for production nor for readable output files.
+ * It uses "eval()" calls to create a separate source file with attached SourceMaps in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with "devtool: false".
+ * If you are looking for production-ready output files, see mode: "production" (https://webpack.js.org/configuration/mode/).
  */
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
 
-// Minimal service worker for PWA file handling support
-self.addEventListener('install', event => {
-  event.waitUntil(self.skipWaiting());
-});
+/***/ "./src/service-worker.ts"
+/*!*******************************!*\
+  !*** ./src/service-worker.ts ***!
+  \*******************************/
+() {
 
-self.addEventListener('activate', event => {
-  event.waitUntil(self.clients.claim());
-});
+eval("{/**\n * Licensed to the Apache Software Foundation (ASF) under one\n * or more contributor license agreements.  See the NOTICE file\n * distributed with this work for additional information\n * regarding copyright ownership.  The ASF licenses this file\n * to you under the Apache License, Version 2.0 (the\n * \"License\"); you may not use this file except in compliance\n * with the License.  You may obtain a copy of the License at\n *\n *   http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing,\n * software distributed under the License is distributed on an\n * \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n * KIND, either express or implied.  See the License for the\n * specific language governing permissions and limitations\n * under the License.\n */ // Service Worker types (declared locally to avoid polluting global scope)\nself.addEventListener('install', (event)=>{\n    event.waitUntil(self.skipWaiting());\n});\nself.addEventListener('activate', (event)=>{\n    event.waitUntil(self.clients.claim());\n});\n\n//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9zcmMvc2VydmljZS13b3JrZXIudHMiLCJtYXBwaW5ncyI6IkFBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBaUJBO0FBWUE7QUFDQTtBQUNBO0FBRUE7QUFDQTtBQUNBO0FBRUEiLCJzb3VyY2VzIjpbIndlYnBhY2s6Ly9zdXBlcnNldC8uL3NyYy9zZXJ2aWNlLXdvcmtlci50cz83ZjU4Il0sInNvdXJjZXNDb250ZW50IjpbIi8qKlxuICogTGljZW5zZWQgdG8gdGhlIEFwYWNoZSBTb2Z0d2FyZSBGb3VuZGF0aW9uIChBU0YpIHVuZGVyIG9uZVxuICogb3IgbW9yZSBjb250cmlidXRvciBsaWNlbnNlIGFncmVlbWVudHMuICBTZWUgdGhlIE5PVElDRSBmaWxlXG4gKiBkaXN0cmlidXRlZCB3aXRoIHRoaXMgd29yayBmb3IgYWRkaXRpb25hbCBpbmZvcm1hdGlvblxuICogcmVnYXJkaW5nIGNvcHlyaWdodCBvd25lcnNoaXAuICBUaGUgQVNGIGxpY2Vuc2VzIHRoaXMgZmlsZVxuICogdG8geW91IHVuZGVyIHRoZSBBcGFjaGUgTGljZW5zZSwgVmVyc2lvbiAyLjAgKHRoZVxuICogXCJMaWNlbnNlXCIpOyB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlXG4gKiB3aXRoIHRoZSBMaWNlbnNlLiAgWW91IG1heSBvYnRhaW4gYSBjb3B5IG9mIHRoZSBMaWNlbnNlIGF0XG4gKlxuICogICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvTElDRU5TRS0yLjBcbiAqXG4gKiBVbmxlc3MgcmVxdWlyZWQgYnkgYXBwbGljYWJsZSBsYXcgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsXG4gKiBzb2Z0d2FyZSBkaXN0cmlidXRlZCB1bmRlciB0aGUgTGljZW5zZSBpcyBkaXN0cmlidXRlZCBvbiBhblxuICogXCJBUyBJU1wiIEJBU0lTLCBXSVRIT1VUIFdBUlJBTlRJRVMgT1IgQ09ORElUSU9OUyBPRiBBTllcbiAqIEtJTkQsIGVpdGhlciBleHByZXNzIG9yIGltcGxpZWQuICBTZWUgdGhlIExpY2Vuc2UgZm9yIHRoZVxuICogc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZCBsaW1pdGF0aW9uc1xuICogdW5kZXIgdGhlIExpY2Vuc2UuXG4gKi9cblxuLy8gU2VydmljZSBXb3JrZXIgdHlwZXMgKGRlY2xhcmVkIGxvY2FsbHkgdG8gYXZvaWQgcG9sbHV0aW5nIGdsb2JhbCBzY29wZSlcbmRlY2xhcmUgY29uc3Qgc2VsZjoge1xuICBza2lwV2FpdGluZygpOiBQcm9taXNlPHZvaWQ+O1xuICBjbGllbnRzOiB7IGNsYWltKCk6IFByb21pc2U8dm9pZD4gfTtcbiAgYWRkRXZlbnRMaXN0ZW5lcihcbiAgICB0eXBlOiAnaW5zdGFsbCcgfCAnYWN0aXZhdGUnLFxuICAgIGxpc3RlbmVyOiAoZXZlbnQ6IHsgd2FpdFVudGlsKHByb21pc2U6IFByb21pc2U8dW5rbm93bj4pOiB2b2lkIH0pID0+IHZvaWQsXG4gICk6IHZvaWQ7XG59O1xuXG5zZWxmLmFkZEV2ZW50TGlzdGVuZXIoJ2luc3RhbGwnLCBldmVudCA9PiB7XG4gIGV2ZW50LndhaXRVbnRpbChzZWxmLnNraXBXYWl0aW5nKCkpO1xufSk7XG5cbnNlbGYuYWRkRXZlbnRMaXN0ZW5lcignYWN0aXZhdGUnLCBldmVudCA9PiB7XG4gIGV2ZW50LndhaXRVbnRpbChzZWxmLmNsaWVudHMuY2xhaW0oKSk7XG59KTtcblxuZXhwb3J0IHt9O1xuIl0sIm5hbWVzIjpbXSwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./src/service-worker.ts\n\n}");
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Check if module exists (development only)
+/******/ 		if (__webpack_modules__[moduleId] === undefined) {
+/******/ 			var e = new Error("Cannot find module '" + moduleId + "'");
+/******/ 			e.code = 'MODULE_NOT_FOUND';
+/******/ 			throw e;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			id: moduleId,
+/******/ 			loaded: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var execOptions = { id: moduleId, module: module, factory: __webpack_modules__[moduleId], require: __webpack_require__ };
+/******/ 		__webpack_require__.i.forEach(function(handler) { handler(execOptions); });
+/******/ 		module = execOptions.module;
+/******/ 		execOptions.factory.call(module.exports, module, module.exports, execOptions.require);
+/******/ 	
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = __webpack_modules__;
+/******/ 	
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = __webpack_module_cache__;
+/******/ 	
+/******/ 	// expose the module execution interceptor
+/******/ 	__webpack_require__.i = [];
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/chunk loaded */
+/******/ 	(() => {
+/******/ 		var deferred = [];
+/******/ 		__webpack_require__.O = (result, chunkIds, fn, priority) => {
+/******/ 			if(chunkIds) {
+/******/ 				priority = priority || 0;
+/******/ 				for(var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--) deferred[i] = deferred[i - 1];
+/******/ 				deferred[i] = [chunkIds, fn, priority];
+/******/ 				return;
+/******/ 			}
+/******/ 			var notFulfilled = Infinity;
+/******/ 			for (var i = 0; i < deferred.length; i++) {
+/******/ 				var [chunkIds, fn, priority] = deferred[i];
+/******/ 				var fulfilled = true;
+/******/ 				for (var j = 0; j < chunkIds.length; j++) {
+/******/ 					if ((priority & 1 === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
+/******/ 						chunkIds.splice(j--, 1);
+/******/ 					} else {
+/******/ 						fulfilled = false;
+/******/ 						if(priority < notFulfilled) notFulfilled = priority;
+/******/ 					}
+/******/ 				}
+/******/ 				if(fulfilled) {
+/******/ 					deferred.splice(i--, 1)
+/******/ 					var r = fn();
+/******/ 					if (r !== undefined) result = r;
+/******/ 				}
+/******/ 			}
+/******/ 			return result;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	(() => {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = (module) => {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				() => (module['default']) :
+/******/ 				() => (module);
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/create fake namespace object */
+/******/ 	(() => {
+/******/ 		var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
+/******/ 		var leafPrototypes;
+/******/ 		// create a fake namespace object
+/******/ 		// mode & 1: value is a module id, require it
+/******/ 		// mode & 2: merge all properties of value into the ns
+/******/ 		// mode & 4: return value when already ns object
+/******/ 		// mode & 16: return value when it's Promise-like
+/******/ 		// mode & 8|1: behave like require
+/******/ 		__webpack_require__.t = function(value, mode) {
+/******/ 			if(mode & 1) value = this(value);
+/******/ 			if(mode & 8) return value;
+/******/ 			if(typeof value === 'object' && value) {
+/******/ 				if((mode & 4) && value.__esModule) return value;
+/******/ 				if((mode & 16) && typeof value.then === 'function') return value;
+/******/ 			}
+/******/ 			var ns = Object.create(null);
+/******/ 			__webpack_require__.r(ns);
+/******/ 			var def = {};
+/******/ 			leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
+/******/ 			for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
+/******/ 				Object.getOwnPropertyNames(current).forEach((key) => (def[key] = () => (value[key])));
+/******/ 			}
+/******/ 			def['default'] = () => (value);
+/******/ 			__webpack_require__.d(ns, def);
+/******/ 			return ns;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/get javascript update chunk filename */
+/******/ 	(() => {
+/******/ 		// This function allow to reference all chunks
+/******/ 		__webpack_require__.hu = (chunkId) => {
+/******/ 			// return url for filenames based on template
+/******/ 			return "" + chunkId + "." + __webpack_require__.h() + ".hot-update.js";
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/get update manifest filename */
+/******/ 	(() => {
+/******/ 		__webpack_require__.hmrF = () => ("service-worker." + __webpack_require__.h() + ".hot-update.json");
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/getFullHash */
+/******/ 	(() => {
+/******/ 		__webpack_require__.h = () => ("9a5c0ca85f3f00cf481e")
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/harmony module decorator */
+/******/ 	(() => {
+/******/ 		__webpack_require__.hmd = (module) => {
+/******/ 			module = Object.create(module);
+/******/ 			if (!module.children) module.children = [];
+/******/ 			Object.defineProperty(module, 'exports', {
+/******/ 				enumerable: true,
+/******/ 				set: () => {
+/******/ 					throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
+/******/ 				}
+/******/ 			});
+/******/ 			return module;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/load script */
+/******/ 	(() => {
+/******/ 		var inProgress = {};
+/******/ 		var dataWebpackPrefix = "superset:";
+/******/ 		// loadScript function to load a script via script tag
+/******/ 		__webpack_require__.l = (url, done, key, chunkId) => {
+/******/ 			if(inProgress[url]) { inProgress[url].push(done); return; }
+/******/ 			var script, needAttach;
+/******/ 			if(key !== undefined) {
+/******/ 				var scripts = document.getElementsByTagName("script");
+/******/ 				for(var i = 0; i < scripts.length; i++) {
+/******/ 					var s = scripts[i];
+/******/ 					if(s.getAttribute("src") == url || s.getAttribute("data-webpack") == dataWebpackPrefix + key) { script = s; break; }
+/******/ 				}
+/******/ 			}
+/******/ 			if(!script) {
+/******/ 				needAttach = true;
+/******/ 				script = document.createElement('script');
+/******/ 		
+/******/ 				script.charset = 'utf-8';
+/******/ 				if (__webpack_require__.nc) {
+/******/ 					script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 				}
+/******/ 				script.setAttribute("data-webpack", dataWebpackPrefix + key);
+/******/ 		
+/******/ 				script.src = url;
+/******/ 			}
+/******/ 			inProgress[url] = [done];
+/******/ 			var onScriptComplete = (prev, event) => {
+/******/ 				// avoid mem leaks in IE.
+/******/ 				script.onerror = script.onload = null;
+/******/ 				clearTimeout(timeout);
+/******/ 				var doneFns = inProgress[url];
+/******/ 				delete inProgress[url];
+/******/ 				script.parentNode && script.parentNode.removeChild(script);
+/******/ 				doneFns && doneFns.forEach((fn) => (fn(event)));
+/******/ 				if(prev) return prev(event);
+/******/ 			}
+/******/ 			var timeout = setTimeout(onScriptComplete.bind(null, undefined, { type: 'timeout', target: script }), 120000);
+/******/ 			script.onerror = onScriptComplete.bind(null, script.onerror);
+/******/ 			script.onload = onScriptComplete.bind(null, script.onload);
+/******/ 			needAttach && document.head.appendChild(script);
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/node module decorator */
+/******/ 	(() => {
+/******/ 		__webpack_require__.nmd = (module) => {
+/******/ 			module.paths = [];
+/******/ 			if (!module.children) module.children = [];
+/******/ 			return module;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/sharing */
+/******/ 	(() => {
+/******/ 		__webpack_require__.S = {};
+/******/ 		var initPromises = {};
+/******/ 		var initTokens = {};
+/******/ 		__webpack_require__.I = (name, initScope) => {
+/******/ 			if(!initScope) initScope = [];
+/******/ 			// handling circular init calls
+/******/ 			var initToken = initTokens[name];
+/******/ 			if(!initToken) initToken = initTokens[name] = {};
+/******/ 			if(initScope.indexOf(initToken) >= 0) return;
+/******/ 			initScope.push(initToken);
+/******/ 			// only runs once
+/******/ 			if(initPromises[name]) return initPromises[name];
+/******/ 			// creates a new share scope if needed
+/******/ 			if(!__webpack_require__.o(__webpack_require__.S, name)) __webpack_require__.S[name] = {};
+/******/ 			// runs all init snippets from all modules reachable
+/******/ 			var scope = __webpack_require__.S[name];
+/******/ 			var warn = (msg) => {
+/******/ 				if (typeof console !== "undefined" && console.warn) console.warn(msg);
+/******/ 			};
+/******/ 			var uniqueName = "superset";
+/******/ 			var register = (name, version, factory, eager) => {
+/******/ 				var versions = scope[name] = scope[name] || {};
+/******/ 				var activeVersion = versions[version];
+/******/ 				if(!activeVersion || (!activeVersion.loaded && (!eager != !activeVersion.eager ? eager : uniqueName > activeVersion.from))) versions[version] = { get: factory, from: uniqueName, eager: !!eager };
+/******/ 			};
+/******/ 			var initExternal = (id) => {
+/******/ 				var handleError = (err) => (warn("Initialization of sharing external failed: " + err));
+/******/ 				try {
+/******/ 					var module = __webpack_require__(id);
+/******/ 					if(!module) return;
+/******/ 					var initFn = (module) => (module && module.init && module.init(__webpack_require__.S[name], initScope))
+/******/ 					if(module.then) return promises.push(module.then(initFn, handleError));
+/******/ 					var initResult = initFn(module);
+/******/ 					if(initResult && initResult.then) return promises.push(initResult['catch'](handleError));
+/******/ 				} catch(err) { handleError(err); }
+/******/ 			}
+/******/ 			var promises = [];
+/******/ 			switch(name) {
+/******/ 				case "default": {
+/******/ 					register("antd", "5.27.6", () => (() => (__webpack_require__(/*! ./node_modules/antd/es/index.js */ "./node_modules/antd/es/index.js"))), 1);
+/******/ 					register("react-dom", "17.0.2", () => (() => (__webpack_require__(/*! ./node_modules/react-dom/index.js */ "./node_modules/react-dom/index.js"))), 1);
+/******/ 					register("react", "17.0.2", () => (() => (__webpack_require__(/*! ./node_modules/react/index.js */ "./node_modules/react/index.js"))), 1);
+/******/ 				}
+/******/ 				break;
+/******/ 			}
+/******/ 			if(!promises.length) return initPromises[name] = 1;
+/******/ 			return initPromises[name] = Promise.all(promises).then(() => (initPromises[name] = 1));
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hot module replacement */
+/******/ 	(() => {
+/******/ 		var currentModuleData = {};
+/******/ 		var installedModules = __webpack_require__.c;
+/******/ 		
+/******/ 		// module and require creation
+/******/ 		var currentChildModule;
+/******/ 		var currentParents = [];
+/******/ 		
+/******/ 		// status
+/******/ 		var registeredStatusHandlers = [];
+/******/ 		var currentStatus = "idle";
+/******/ 		
+/******/ 		// while downloading
+/******/ 		var blockingPromises = 0;
+/******/ 		var blockingPromisesWaiting = [];
+/******/ 		
+/******/ 		// The update info
+/******/ 		var currentUpdateApplyHandlers;
+/******/ 		var queuedInvalidatedModules;
+/******/ 		
+/******/ 		__webpack_require__.hmrD = currentModuleData;
+/******/ 		
+/******/ 		__webpack_require__.i.push(function (options) {
+/******/ 			var module = options.module;
+/******/ 			var require = createRequire(options.require, options.id);
+/******/ 			module.hot = createModuleHotObject(options.id, module);
+/******/ 			module.parents = currentParents;
+/******/ 			module.children = [];
+/******/ 			currentParents = [];
+/******/ 			options.require = require;
+/******/ 		});
+/******/ 		
+/******/ 		__webpack_require__.hmrC = {};
+/******/ 		__webpack_require__.hmrI = {};
+/******/ 		
+/******/ 		function createRequire(require, moduleId) {
+/******/ 			var me = installedModules[moduleId];
+/******/ 			if (!me) return require;
+/******/ 			var fn = function (request) {
+/******/ 				if (me.hot.active) {
+/******/ 					if (installedModules[request]) {
+/******/ 						var parents = installedModules[request].parents;
+/******/ 						if (parents.indexOf(moduleId) === -1) {
+/******/ 							parents.push(moduleId);
+/******/ 						}
+/******/ 					} else {
+/******/ 						currentParents = [moduleId];
+/******/ 						currentChildModule = request;
+/******/ 					}
+/******/ 					if (me.children.indexOf(request) === -1) {
+/******/ 						me.children.push(request);
+/******/ 					}
+/******/ 				} else {
+/******/ 					console.warn(
+/******/ 						"[HMR] unexpected require(" +
+/******/ 							request +
+/******/ 							") from disposed module " +
+/******/ 							moduleId
+/******/ 					);
+/******/ 					currentParents = [];
+/******/ 				}
+/******/ 				return require(request);
+/******/ 			};
+/******/ 			var createPropertyDescriptor = function (name) {
+/******/ 				return {
+/******/ 					configurable: true,
+/******/ 					enumerable: true,
+/******/ 					get: function () {
+/******/ 						return require[name];
+/******/ 					},
+/******/ 					set: function (value) {
+/******/ 						require[name] = value;
+/******/ 					}
+/******/ 				};
+/******/ 			};
+/******/ 			for (var name in require) {
+/******/ 				if (Object.prototype.hasOwnProperty.call(require, name) && name !== "e") {
+/******/ 					Object.defineProperty(fn, name, createPropertyDescriptor(name));
+/******/ 				}
+/******/ 			}
+/******/ 			fn.e = function (chunkId, fetchPriority) {
+/******/ 				return trackBlockingPromise(require.e(chunkId, fetchPriority));
+/******/ 			};
+/******/ 			return fn;
+/******/ 		}
+/******/ 		
+/******/ 		function createModuleHotObject(moduleId, me) {
+/******/ 			var _main = currentChildModule !== moduleId;
+/******/ 			var hot = {
+/******/ 				// private stuff
+/******/ 				_acceptedDependencies: {},
+/******/ 				_acceptedErrorHandlers: {},
+/******/ 				_declinedDependencies: {},
+/******/ 				_selfAccepted: false,
+/******/ 				_selfDeclined: false,
+/******/ 				_selfInvalidated: false,
+/******/ 				_disposeHandlers: [],
+/******/ 				_main: _main,
+/******/ 				_requireSelf: function () {
+/******/ 					currentParents = me.parents.slice();
+/******/ 					currentChildModule = _main ? undefined : moduleId;
+/******/ 					__webpack_require__(moduleId);
+/******/ 				},
+/******/ 		
+/******/ 				// Module API
+/******/ 				active: true,
+/******/ 				accept: function (dep, callback, errorHandler) {
+/******/ 					if (dep === undefined) hot._selfAccepted = true;
+/******/ 					else if (typeof dep === "function") hot._selfAccepted = dep;
+/******/ 					else if (typeof dep === "object" && dep !== null) {
+/******/ 						for (var i = 0; i < dep.length; i++) {
+/******/ 							hot._acceptedDependencies[dep[i]] = callback || function () {};
+/******/ 							hot._acceptedErrorHandlers[dep[i]] = errorHandler;
+/******/ 						}
+/******/ 					} else {
+/******/ 						hot._acceptedDependencies[dep] = callback || function () {};
+/******/ 						hot._acceptedErrorHandlers[dep] = errorHandler;
+/******/ 					}
+/******/ 				},
+/******/ 				decline: function (dep) {
+/******/ 					if (dep === undefined) hot._selfDeclined = true;
+/******/ 					else if (typeof dep === "object" && dep !== null)
+/******/ 						for (var i = 0; i < dep.length; i++)
+/******/ 							hot._declinedDependencies[dep[i]] = true;
+/******/ 					else hot._declinedDependencies[dep] = true;
+/******/ 				},
+/******/ 				dispose: function (callback) {
+/******/ 					hot._disposeHandlers.push(callback);
+/******/ 				},
+/******/ 				addDisposeHandler: function (callback) {
+/******/ 					hot._disposeHandlers.push(callback);
+/******/ 				},
+/******/ 				removeDisposeHandler: function (callback) {
+/******/ 					var idx = hot._disposeHandlers.indexOf(callback);
+/******/ 					if (idx >= 0) hot._disposeHandlers.splice(idx, 1);
+/******/ 				},
+/******/ 				invalidate: function () {
+/******/ 					this._selfInvalidated = true;
+/******/ 					switch (currentStatus) {
+/******/ 						case "idle":
+/******/ 							currentUpdateApplyHandlers = [];
+/******/ 							Object.keys(__webpack_require__.hmrI).forEach(function (key) {
+/******/ 								__webpack_require__.hmrI[key](
+/******/ 									moduleId,
+/******/ 									currentUpdateApplyHandlers
+/******/ 								);
+/******/ 							});
+/******/ 							setStatus("ready");
+/******/ 							break;
+/******/ 						case "ready":
+/******/ 							Object.keys(__webpack_require__.hmrI).forEach(function (key) {
+/******/ 								__webpack_require__.hmrI[key](
+/******/ 									moduleId,
+/******/ 									currentUpdateApplyHandlers
+/******/ 								);
+/******/ 							});
+/******/ 							break;
+/******/ 						case "prepare":
+/******/ 						case "check":
+/******/ 						case "dispose":
+/******/ 						case "apply":
+/******/ 							(queuedInvalidatedModules = queuedInvalidatedModules || []).push(
+/******/ 								moduleId
+/******/ 							);
+/******/ 							break;
+/******/ 						default:
+/******/ 							// ignore requests in error states
+/******/ 							break;
+/******/ 					}
+/******/ 				},
+/******/ 		
+/******/ 				// Management API
+/******/ 				check: hotCheck,
+/******/ 				apply: hotApply,
+/******/ 				status: function (l) {
+/******/ 					if (!l) return currentStatus;
+/******/ 					registeredStatusHandlers.push(l);
+/******/ 				},
+/******/ 				addStatusHandler: function (l) {
+/******/ 					registeredStatusHandlers.push(l);
+/******/ 				},
+/******/ 				removeStatusHandler: function (l) {
+/******/ 					var idx = registeredStatusHandlers.indexOf(l);
+/******/ 					if (idx >= 0) registeredStatusHandlers.splice(idx, 1);
+/******/ 				},
+/******/ 		
+/******/ 				// inherit from previous dispose call
+/******/ 				data: currentModuleData[moduleId]
+/******/ 			};
+/******/ 			currentChildModule = undefined;
+/******/ 			return hot;
+/******/ 		}
+/******/ 		
+/******/ 		function setStatus(newStatus) {
+/******/ 			currentStatus = newStatus;
+/******/ 			var results = [];
+/******/ 		
+/******/ 			for (var i = 0; i < registeredStatusHandlers.length; i++)
+/******/ 				results[i] = registeredStatusHandlers[i].call(null, newStatus);
+/******/ 		
+/******/ 			return Promise.all(results).then(function () {});
+/******/ 		}
+/******/ 		
+/******/ 		function unblock() {
+/******/ 			if (--blockingPromises === 0) {
+/******/ 				setStatus("ready").then(function () {
+/******/ 					if (blockingPromises === 0) {
+/******/ 						var list = blockingPromisesWaiting;
+/******/ 						blockingPromisesWaiting = [];
+/******/ 						for (var i = 0; i < list.length; i++) {
+/******/ 							list[i]();
+/******/ 						}
+/******/ 					}
+/******/ 				});
+/******/ 			}
+/******/ 		}
+/******/ 		
+/******/ 		function trackBlockingPromise(promise) {
+/******/ 			switch (currentStatus) {
+/******/ 				case "ready":
+/******/ 					setStatus("prepare");
+/******/ 				/* fallthrough */
+/******/ 				case "prepare":
+/******/ 					blockingPromises++;
+/******/ 					promise.then(unblock, unblock);
+/******/ 					return promise;
+/******/ 				default:
+/******/ 					return promise;
+/******/ 			}
+/******/ 		}
+/******/ 		
+/******/ 		function waitForBlockingPromises(fn) {
+/******/ 			if (blockingPromises === 0) return fn();
+/******/ 			return new Promise(function (resolve) {
+/******/ 				blockingPromisesWaiting.push(function () {
+/******/ 					resolve(fn());
+/******/ 				});
+/******/ 			});
+/******/ 		}
+/******/ 		
+/******/ 		function hotCheck(applyOnUpdate) {
+/******/ 			if (currentStatus !== "idle") {
+/******/ 				throw new Error("check() is only allowed in idle status");
+/******/ 			}
+/******/ 			return setStatus("check")
+/******/ 				.then(__webpack_require__.hmrM)
+/******/ 				.then(function (update) {
+/******/ 					if (!update) {
+/******/ 						return setStatus(applyInvalidatedModules() ? "ready" : "idle").then(
+/******/ 							function () {
+/******/ 								return null;
+/******/ 							}
+/******/ 						);
+/******/ 					}
+/******/ 		
+/******/ 					return setStatus("prepare").then(function () {
+/******/ 						var updatedModules = [];
+/******/ 						currentUpdateApplyHandlers = [];
+/******/ 		
+/******/ 						return Promise.all(
+/******/ 							Object.keys(__webpack_require__.hmrC).reduce(function (
+/******/ 								promises,
+/******/ 								key
+/******/ 							) {
+/******/ 								__webpack_require__.hmrC[key](
+/******/ 									update.c,
+/******/ 									update.r,
+/******/ 									update.m,
+/******/ 									promises,
+/******/ 									currentUpdateApplyHandlers,
+/******/ 									updatedModules,
+/******/ 									update.css
+/******/ 								);
+/******/ 								return promises;
+/******/ 							}, [])
+/******/ 						).then(function () {
+/******/ 							return waitForBlockingPromises(function () {
+/******/ 								if (applyOnUpdate) {
+/******/ 									return internalApply(applyOnUpdate);
+/******/ 								}
+/******/ 								return setStatus("ready").then(function () {
+/******/ 									return updatedModules;
+/******/ 								});
+/******/ 							});
+/******/ 						});
+/******/ 					});
+/******/ 				});
+/******/ 		}
+/******/ 		
+/******/ 		function hotApply(options) {
+/******/ 			if (currentStatus !== "ready") {
+/******/ 				return Promise.resolve().then(function () {
+/******/ 					throw new Error(
+/******/ 						"apply() is only allowed in ready status (state: " +
+/******/ 							currentStatus +
+/******/ 							")"
+/******/ 					);
+/******/ 				});
+/******/ 			}
+/******/ 			return internalApply(options);
+/******/ 		}
+/******/ 		
+/******/ 		function internalApply(options) {
+/******/ 			options = options || {};
+/******/ 		
+/******/ 			applyInvalidatedModules();
+/******/ 		
+/******/ 			var results = currentUpdateApplyHandlers.map(function (handler) {
+/******/ 				return handler(options);
+/******/ 			});
+/******/ 			currentUpdateApplyHandlers = undefined;
+/******/ 		
+/******/ 			var errors = results
+/******/ 				.map(function (r) {
+/******/ 					return r.error;
+/******/ 				})
+/******/ 				.filter(Boolean);
+/******/ 		
+/******/ 			if (errors.length > 0) {
+/******/ 				return setStatus("abort").then(function () {
+/******/ 					throw errors[0];
+/******/ 				});
+/******/ 			}
+/******/ 		
+/******/ 			// Now in "dispose" phase
+/******/ 			var disposePromise = setStatus("dispose");
+/******/ 		
+/******/ 			results.forEach(function (result) {
+/******/ 				if (result.dispose) result.dispose();
+/******/ 			});
+/******/ 		
+/******/ 			// Now in "apply" phase
+/******/ 			var applyPromise = setStatus("apply");
+/******/ 		
+/******/ 			var error;
+/******/ 			var reportError = function (err) {
+/******/ 				if (!error) error = err;
+/******/ 			};
+/******/ 		
+/******/ 			var outdatedModules = [];
+/******/ 		
+/******/ 			var onAccepted = function () {
+/******/ 				return Promise.all([disposePromise, applyPromise]).then(function () {
+/******/ 					// handle errors in accept handlers and self accepted module load
+/******/ 					if (error) {
+/******/ 						return setStatus("fail").then(function () {
+/******/ 							throw error;
+/******/ 						});
+/******/ 					}
+/******/ 		
+/******/ 					if (queuedInvalidatedModules) {
+/******/ 						return internalApply(options).then(function (list) {
+/******/ 							outdatedModules.forEach(function (moduleId) {
+/******/ 								if (list.indexOf(moduleId) < 0) list.push(moduleId);
+/******/ 							});
+/******/ 							return list;
+/******/ 						});
+/******/ 					}
+/******/ 		
+/******/ 					return setStatus("idle").then(function () {
+/******/ 						return outdatedModules;
+/******/ 					});
+/******/ 				});
+/******/ 			};
+/******/ 		
+/******/ 			return Promise.all(
+/******/ 				results
+/******/ 					.filter(function (result) {
+/******/ 						return result.apply;
+/******/ 					})
+/******/ 					.map(function (result) {
+/******/ 						return result.apply(reportError);
+/******/ 					})
+/******/ 			)
+/******/ 				.then(function (applyResults) {
+/******/ 					applyResults.forEach(function (modules) {
+/******/ 						if (modules) {
+/******/ 							for (var i = 0; i < modules.length; i++) {
+/******/ 								outdatedModules.push(modules[i]);
+/******/ 							}
+/******/ 						}
+/******/ 					});
+/******/ 				})
+/******/ 				.then(onAccepted);
+/******/ 		}
+/******/ 		
+/******/ 		function applyInvalidatedModules() {
+/******/ 			if (queuedInvalidatedModules) {
+/******/ 				if (!currentUpdateApplyHandlers) currentUpdateApplyHandlers = [];
+/******/ 				Object.keys(__webpack_require__.hmrI).forEach(function (key) {
+/******/ 					queuedInvalidatedModules.forEach(function (moduleId) {
+/******/ 						__webpack_require__.hmrI[key](
+/******/ 							moduleId,
+/******/ 							currentUpdateApplyHandlers
+/******/ 						);
+/******/ 					});
+/******/ 				});
+/******/ 				queuedInvalidatedModules = undefined;
+/******/ 				return true;
+/******/ 			}
+/******/ 		}
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/publicPath */
+/******/ 	(() => {
+/******/ 		__webpack_require__.p = "/static/assets/";
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/react refresh */
+/******/ 	(() => {
+/******/ 		const setup = (moduleId) => {
+/******/ 			const refresh = {
+/******/ 				moduleId: moduleId,
+/******/ 				register: (type, id) => {
+/******/ 					const typeId = moduleId + ' ' + id;
+/******/ 					refresh.runtime.register(type, typeId);
+/******/ 				},
+/******/ 				signature: () => (refresh.runtime.createSignatureFunctionForTransform()),
+/******/ 				runtime: {
+/******/ 					createSignatureFunctionForTransform: () => ((type) => (type)),
+/******/ 					register: x => {}
+/******/ 				},
+/******/ 			};
+/******/ 			return refresh;
+/******/ 		};
+/******/ 		
+/******/ 		__webpack_require__.i.push((options) => {
+/******/ 			const originalFactory = options.factory;
+/******/ 			options.factory = function(moduleObject, moduleExports, webpackRequire) {
+/******/ 				const hotRequire = (request) => (webpackRequire(request));
+/******/ 				const createPropertyDescriptor = (name) => {
+/******/ 					return {
+/******/ 						configurable: true,
+/******/ 						enumerable: true,
+/******/ 						get: () => (webpackRequire[name]),
+/******/ 						set: (value) => {
+/******/ 							webpackRequire[name] = value;
+/******/ 						},
+/******/ 					};
+/******/ 				};
+/******/ 				for (const name in webpackRequire) {
+/******/ 					if (name === "$Refresh$") continue;
+/******/ 					if (Object.prototype.hasOwnProperty.call(webpackRequire, name)) {
+/******/ 						Object.defineProperty(hotRequire, name, createPropertyDescriptor(name));
+/******/ 					}
+/******/ 				}
+/******/ 				hotRequire.$Refresh$ = setup(options.id);
+/******/ 				originalFactory.call(this, moduleObject, moduleExports, hotRequire);
+/******/ 			};
+/******/ 		});
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/consumes */
+/******/ 	(() => {
+/******/ 		var parseVersion = (str) => {
+/******/ 			// see webpack/lib/util/semver.js for original code
+/******/ 			var p=p=>{return p.split(".").map(p=>{return+p==p?+p:p})},n=/^([^-+]+)?(?:-([^+]+))?(?:\+(.+))?$/.exec(str),r=n[1]?p(n[1]):[];return n[2]&&(r.length++,r.push.apply(r,p(n[2]))),n[3]&&(r.push([]),r.push.apply(r,p(n[3]))),r;
+/******/ 		}
+/******/ 		var versionLt = (a, b) => {
+/******/ 			// see webpack/lib/util/semver.js for original code
+/******/ 			a=parseVersion(a),b=parseVersion(b);for(var r=0;;){if(r>=a.length)return r<b.length&&"u"!=(typeof b[r])[0];var e=a[r],n=(typeof e)[0];if(r>=b.length)return"u"==n;var t=b[r],f=(typeof t)[0];if(n!=f)return"o"==n&&"n"==f||("s"==f||"u"==n);if("o"!=n&&"u"!=n&&e!=t)return e<t;r++}
+/******/ 		}
+/******/ 		var rangeToString = (range) => {
+/******/ 			// see webpack/lib/util/semver.js for original code
+/******/ 			var r=range[0],n="";if(1===range.length)return"*";if(r+.5){n+=0==r?">=":-1==r?"<":1==r?"^":2==r?"~":r>0?"=":"!=";for(var e=1,a=1;a<range.length;a++){e--,n+="u"==(typeof(t=range[a]))[0]?"-":(e>0?".":"")+(e=2,t)}return n}var g=[];for(a=1;a<range.length;a++){var t=range[a];g.push(0===t?"not("+o()+")":1===t?"("+o()+" || "+o()+")":2===t?g.pop()+" "+g.pop():rangeToString(t))}return o();function o(){return g.pop().replace(/^\((.+)\)$/,"$1")}
+/******/ 		}
+/******/ 		var satisfy = (range, version) => {
+/******/ 			// see webpack/lib/util/semver.js for original code
+/******/ 			if(0 in range){version=parseVersion(version);var e=range[0],r=e<0;r&&(e=-e-1);for(var n=0,i=1,a=!0;;i++,n++){var f,s,g=i<range.length?(typeof range[i])[0]:"";if(n>=version.length||"o"==(s=(typeof(f=version[n]))[0]))return!a||("u"==g?i>e&&!r:""==g!=r);if("u"==s){if(!a||"u"!=g)return!1}else if(a)if(g==s)if(i<=e){if(f!=range[i])return!1}else{if(r?f>range[i]:f<range[i])return!1;f!=range[i]&&(a=!1)}else if("s"!=g&&"n"!=g){if(r||i<=e)return!1;a=!1,i--}else{if(i<=e||s<g!=r)return!1;a=!1}else"s"!=g&&"n"!=g&&(a=!1,i--)}}var t=[],o=t.pop.bind(t);for(n=1;n<range.length;n++){var u=range[n];t.push(1==u?o()|o():2==u?o()&o():u?satisfy(u,version):!o())}return!!o();
+/******/ 		}
+/******/ 		var exists = (scope, key) => {
+/******/ 			return scope && __webpack_require__.o(scope, key);
+/******/ 		}
+/******/ 		var get = (entry) => {
+/******/ 			entry.loaded = 1;
+/******/ 			return entry.get()
+/******/ 		};
+/******/ 		var eagerOnly = (versions) => {
+/******/ 			return Object.keys(versions).reduce((filtered, version) => {
+/******/ 					if (versions[version].eager) {
+/******/ 						filtered[version] = versions[version];
+/******/ 					}
+/******/ 					return filtered;
+/******/ 			}, {});
+/******/ 		};
+/******/ 		var findLatestVersion = (scope, key, eager) => {
+/******/ 			var versions = eager ? eagerOnly(scope[key]) : scope[key];
+/******/ 			var key = Object.keys(versions).reduce((a, b) => {
+/******/ 				return !a || versionLt(a, b) ? b : a;
+/******/ 			}, 0);
+/******/ 			return key && versions[key];
+/******/ 		};
+/******/ 		var findSatisfyingVersion = (scope, key, requiredVersion, eager) => {
+/******/ 			var versions = eager ? eagerOnly(scope[key]) : scope[key];
+/******/ 			var key = Object.keys(versions).reduce((a, b) => {
+/******/ 				if (!satisfy(requiredVersion, b)) return a;
+/******/ 				return !a || versionLt(a, b) ? b : a;
+/******/ 			}, 0);
+/******/ 			return key && versions[key]
+/******/ 		};
+/******/ 		var findSingletonVersionKey = (scope, key, eager) => {
+/******/ 			var versions = eager ? eagerOnly(scope[key]) : scope[key];
+/******/ 			return Object.keys(versions).reduce((a, b) => {
+/******/ 				return !a || (!versions[a].loaded && versionLt(a, b)) ? b : a;
+/******/ 			}, 0);
+/******/ 		};
+/******/ 		var getInvalidSingletonVersionMessage = (scope, key, version, requiredVersion) => {
+/******/ 			return "Unsatisfied version " + version + " from " + (version && scope[key][version].from) + " of shared singleton module " + key + " (required " + rangeToString(requiredVersion) + ")"
+/******/ 		};
+/******/ 		var getInvalidVersionMessage = (scope, scopeName, key, requiredVersion, eager) => {
+/******/ 			var versions = scope[key];
+/******/ 			return "No satisfying version (" + rangeToString(requiredVersion) + ")" + (eager ? " for eager consumption" : "") + " of shared module " + key + " found in shared scope " + scopeName + ".\n" +
+/******/ 				"Available versions: " + Object.keys(versions).map((key) => {
+/******/ 				return key + " from " + versions[key].from;
+/******/ 			}).join(", ");
+/******/ 		};
+/******/ 		var fail = (msg) => {
+/******/ 			throw new Error(msg);
+/******/ 		}
+/******/ 		var failAsNotExist = (scopeName, key) => {
+/******/ 			return fail("Shared module " + key + " doesn't exist in shared scope " + scopeName);
+/******/ 		}
+/******/ 		var warn = /*#__PURE__*/ (msg) => {
+/******/ 			if (typeof console !== "undefined" && console.warn) console.warn(msg);
+/******/ 		};
+/******/ 		var init = (fn) => (function(scopeName, key, eager, c, d) {
+/******/ 			var promise = __webpack_require__.I(scopeName);
+/******/ 			if (promise && promise.then && !eager) {
+/******/ 				return promise.then(fn.bind(fn, scopeName, __webpack_require__.S[scopeName], key, false, c, d));
+/******/ 			}
+/******/ 			return fn(scopeName, __webpack_require__.S[scopeName], key, eager, c, d);
+/******/ 		});
+/******/ 		
+/******/ 		var useFallback = (scopeName, key, fallback) => {
+/******/ 			return fallback ? fallback() : failAsNotExist(scopeName, key);
+/******/ 		}
+/******/ 		var load = /*#__PURE__*/ init((scopeName, scope, key, eager, fallback) => {
+/******/ 			if (!exists(scope, key)) return useFallback(scopeName, key, fallback);
+/******/ 			return get(findLatestVersion(scope, key, eager));
+/******/ 		});
+/******/ 		var loadVersion = /*#__PURE__*/ init((scopeName, scope, key, eager, requiredVersion, fallback) => {
+/******/ 			if (!exists(scope, key)) return useFallback(scopeName, key, fallback);
+/******/ 			var satisfyingVersion = findSatisfyingVersion(scope, key, requiredVersion, eager);
+/******/ 			if (satisfyingVersion) return get(satisfyingVersion);
+/******/ 			warn(getInvalidVersionMessage(scope, scopeName, key, requiredVersion, eager))
+/******/ 			return get(findLatestVersion(scope, key, eager));
+/******/ 		});
+/******/ 		var loadStrictVersion = /*#__PURE__*/ init((scopeName, scope, key, eager, requiredVersion, fallback) => {
+/******/ 			if (!exists(scope, key)) return useFallback(scopeName, key, fallback);
+/******/ 			var satisfyingVersion = findSatisfyingVersion(scope, key, requiredVersion, eager);
+/******/ 			if (satisfyingVersion) return get(satisfyingVersion);
+/******/ 			if (fallback) return fallback();
+/******/ 			fail(getInvalidVersionMessage(scope, scopeName, key, requiredVersion, eager));
+/******/ 		});
+/******/ 		var loadSingleton = /*#__PURE__*/ init((scopeName, scope, key, eager, fallback) => {
+/******/ 			if (!exists(scope, key)) return useFallback(scopeName, key, fallback);
+/******/ 			var version = findSingletonVersionKey(scope, key, eager);
+/******/ 			return get(scope[key][version]);
+/******/ 		});
+/******/ 		var loadSingletonVersion = /*#__PURE__*/ init((scopeName, scope, key, eager, requiredVersion, fallback) => {
+/******/ 			if (!exists(scope, key)) return useFallback(scopeName, key, fallback);
+/******/ 			var version = findSingletonVersionKey(scope, key, eager);
+/******/ 			if (!satisfy(requiredVersion, version)) {
+/******/ 				warn(getInvalidSingletonVersionMessage(scope, key, version, requiredVersion));
+/******/ 			}
+/******/ 			return get(scope[key][version]);
+/******/ 		});
+/******/ 		var loadStrictSingletonVersion = /*#__PURE__*/ init((scopeName, scope, key, eager, requiredVersion, fallback) => {
+/******/ 			if (!exists(scope, key)) return useFallback(scopeName, key, fallback);
+/******/ 			var version = findSingletonVersionKey(scope, key, eager);
+/******/ 			if (!satisfy(requiredVersion, version)) {
+/******/ 				fail(getInvalidSingletonVersionMessage(scope, key, version, requiredVersion));
+/******/ 			}
+/******/ 			return get(scope[key][version]);
+/******/ 		});
+/******/ 		var installedModules = {};
+/******/ 		var moduleToHandlerMapping = {
+/******/ 			"webpack/sharing/consume/default/react-dom/react-dom": () => (loadSingletonVersion("default", "react-dom", true, [1,17,0,2], () => (() => (__webpack_require__(/*! react-dom */ "./node_modules/react-dom/index.js"))))),
+/******/ 			"webpack/sharing/consume/default/react/react": () => (loadSingletonVersion("default", "react", true, [1,17,0,2], () => (() => (__webpack_require__(/*! react */ "./node_modules/react/index.js")))))
+/******/ 		};
+/******/ 		var initialConsumes = ["webpack/sharing/consume/default/react-dom/react-dom","webpack/sharing/consume/default/react/react"];
+/******/ 		initialConsumes.forEach((id) => {
+/******/ 			__webpack_require__.m[id] = (module) => {
+/******/ 				// Handle case when module is used sync
+/******/ 				installedModules[id] = 0;
+/******/ 				delete __webpack_require__.c[id];
+/******/ 				var factory = moduleToHandlerMapping[id]();
+/******/ 				if(typeof factory !== "function") throw new Error("Shared module is not available for eager consumption: " + id);
+/******/ 				module.exports = factory();
+/******/ 			}
+/******/ 		});
+/******/ 		// no chunk loading of consumes
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/jsonp chunk loading */
+/******/ 	(() => {
+/******/ 		// no baseURI
+/******/ 		
+/******/ 		// object to store loaded and loading chunks
+/******/ 		// undefined = chunk not loaded, null = chunk preloaded/prefetched
+/******/ 		// [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
+/******/ 		var installedChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {
+/******/ 			"service-worker": 0,
+/******/ 			"webpack_sharing_consume_default_react-dom_react-dom-webpack_sharing_consume_default_react_rea-153fef": 0
+/******/ 		};
+/******/ 		
+/******/ 		// no chunk on demand loading
+/******/ 		
+/******/ 		// no prefetching
+/******/ 		
+/******/ 		// no preloaded
+/******/ 		
+/******/ 		var currentUpdatedModulesList;
+/******/ 		var waitingUpdateResolves = {};
+/******/ 		function loadUpdateChunk(chunkId, updatedModulesList) {
+/******/ 			currentUpdatedModulesList = updatedModulesList;
+/******/ 			return new Promise((resolve, reject) => {
+/******/ 				waitingUpdateResolves[chunkId] = resolve;
+/******/ 				// start update chunk loading
+/******/ 				var url = __webpack_require__.p + __webpack_require__.hu(chunkId);
+/******/ 				// create error before stack unwound to get useful stacktrace later
+/******/ 				var error = new Error();
+/******/ 				var loadingEnded = (event) => {
+/******/ 					if(waitingUpdateResolves[chunkId]) {
+/******/ 						waitingUpdateResolves[chunkId] = undefined
+/******/ 						var errorType = event && (event.type === 'load' ? 'missing' : event.type);
+/******/ 						var realSrc = event && event.target && event.target.src;
+/******/ 						error.message = 'Loading hot update chunk ' + chunkId + ' failed.\n(' + errorType + ': ' + realSrc + ')';
+/******/ 						error.name = 'ChunkLoadError';
+/******/ 						error.type = errorType;
+/******/ 						error.request = realSrc;
+/******/ 						reject(error);
+/******/ 					}
+/******/ 				};
+/******/ 				__webpack_require__.l(url, loadingEnded);
+/******/ 			});
+/******/ 		}
+/******/ 		
+/******/ 		globalThis["webpackHotUpdatesuperset"] = (chunkId, moreModules, runtime) => {
+/******/ 			for(var moduleId in moreModules) {
+/******/ 				if(__webpack_require__.o(moreModules, moduleId)) {
+/******/ 					currentUpdate[moduleId] = moreModules[moduleId];
+/******/ 					if(currentUpdatedModulesList) currentUpdatedModulesList.push(moduleId);
+/******/ 				}
+/******/ 			}
+/******/ 			if(runtime) currentUpdateRuntime.push(runtime);
+/******/ 			if(waitingUpdateResolves[chunkId]) {
+/******/ 				waitingUpdateResolves[chunkId]();
+/******/ 				waitingUpdateResolves[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		
+/******/ 		var currentUpdateChunks;
+/******/ 		var currentUpdate;
+/******/ 		var currentUpdateRemovedChunks;
+/******/ 		var currentUpdateRuntime;
+/******/ 		function applyHandler(options) {
+/******/ 			if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
+/******/ 			currentUpdateChunks = undefined;
+/******/ 			function getAffectedModuleEffects(updateModuleId) {
+/******/ 				var outdatedModules = [updateModuleId];
+/******/ 				var outdatedDependencies = {};
+/******/ 		
+/******/ 				var queue = outdatedModules.map(function (id) {
+/******/ 					return {
+/******/ 						chain: [id],
+/******/ 						id: id
+/******/ 					};
+/******/ 				});
+/******/ 				while (queue.length > 0) {
+/******/ 					var queueItem = queue.pop();
+/******/ 					var moduleId = queueItem.id;
+/******/ 					var chain = queueItem.chain;
+/******/ 					var module = __webpack_require__.c[moduleId];
+/******/ 					if (
+/******/ 						!module ||
+/******/ 						(module.hot._selfAccepted && !module.hot._selfInvalidated)
+/******/ 					)
+/******/ 						continue;
+/******/ 					if (module.hot._selfDeclined) {
+/******/ 						return {
+/******/ 							type: "self-declined",
+/******/ 							chain: chain,
+/******/ 							moduleId: moduleId
+/******/ 						};
+/******/ 					}
+/******/ 					if (module.hot._main) {
+/******/ 						return {
+/******/ 							type: "unaccepted",
+/******/ 							chain: chain,
+/******/ 							moduleId: moduleId
+/******/ 						};
+/******/ 					}
+/******/ 					for (var i = 0; i < module.parents.length; i++) {
+/******/ 						var parentId = module.parents[i];
+/******/ 						var parent = __webpack_require__.c[parentId];
+/******/ 						if (!parent) continue;
+/******/ 						if (parent.hot._declinedDependencies[moduleId]) {
+/******/ 							return {
+/******/ 								type: "declined",
+/******/ 								chain: chain.concat([parentId]),
+/******/ 								moduleId: moduleId,
+/******/ 								parentId: parentId
+/******/ 							};
+/******/ 						}
+/******/ 						if (outdatedModules.indexOf(parentId) !== -1) continue;
+/******/ 						if (parent.hot._acceptedDependencies[moduleId]) {
+/******/ 							if (!outdatedDependencies[parentId])
+/******/ 								outdatedDependencies[parentId] = [];
+/******/ 							addAllToSet(outdatedDependencies[parentId], [moduleId]);
+/******/ 							continue;
+/******/ 						}
+/******/ 						delete outdatedDependencies[parentId];
+/******/ 						outdatedModules.push(parentId);
+/******/ 						queue.push({
+/******/ 							chain: chain.concat([parentId]),
+/******/ 							id: parentId
+/******/ 						});
+/******/ 					}
+/******/ 				}
+/******/ 		
+/******/ 				return {
+/******/ 					type: "accepted",
+/******/ 					moduleId: updateModuleId,
+/******/ 					outdatedModules: outdatedModules,
+/******/ 					outdatedDependencies: outdatedDependencies
+/******/ 				};
+/******/ 			}
+/******/ 		
+/******/ 			function addAllToSet(a, b) {
+/******/ 				for (var i = 0; i < b.length; i++) {
+/******/ 					var item = b[i];
+/******/ 					if (a.indexOf(item) === -1) a.push(item);
+/******/ 				}
+/******/ 			}
+/******/ 		
+/******/ 			// at begin all updates modules are outdated
+/******/ 			// the "outdated" status can propagate to parents if they don't accept the children
+/******/ 			var outdatedDependencies = {};
+/******/ 			var outdatedModules = [];
+/******/ 			var appliedUpdate = {};
+/******/ 		
+/******/ 			var warnUnexpectedRequire = function warnUnexpectedRequire(module) {
+/******/ 				console.warn(
+/******/ 					"[HMR] unexpected require(" + module.id + ") to disposed module"
+/******/ 				);
+/******/ 			};
+/******/ 		
+/******/ 			for (var moduleId in currentUpdate) {
+/******/ 				if (__webpack_require__.o(currentUpdate, moduleId)) {
+/******/ 					var newModuleFactory = currentUpdate[moduleId];
+/******/ 					var result = newModuleFactory
+/******/ 						? getAffectedModuleEffects(moduleId)
+/******/ 						: {
+/******/ 								type: "disposed",
+/******/ 								moduleId: moduleId
+/******/ 							};
+/******/ 					/** @type {Error|false} */
+/******/ 					var abortError = false;
+/******/ 					var doApply = false;
+/******/ 					var doDispose = false;
+/******/ 					var chainInfo = "";
+/******/ 					if (result.chain) {
+/******/ 						chainInfo = "\nUpdate propagation: " + result.chain.join(" -> ");
+/******/ 					}
+/******/ 					switch (result.type) {
+/******/ 						case "self-declined":
+/******/ 							if (options.onDeclined) options.onDeclined(result);
+/******/ 							if (!options.ignoreDeclined)
+/******/ 								abortError = new Error(
+/******/ 									"Aborted because of self decline: " +
+/******/ 										result.moduleId +
+/******/ 										chainInfo
+/******/ 								);
+/******/ 							break;
+/******/ 						case "declined":
+/******/ 							if (options.onDeclined) options.onDeclined(result);
+/******/ 							if (!options.ignoreDeclined)
+/******/ 								abortError = new Error(
+/******/ 									"Aborted because of declined dependency: " +
+/******/ 										result.moduleId +
+/******/ 										" in " +
+/******/ 										result.parentId +
+/******/ 										chainInfo
+/******/ 								);
+/******/ 							break;
+/******/ 						case "unaccepted":
+/******/ 							if (options.onUnaccepted) options.onUnaccepted(result);
+/******/ 							if (!options.ignoreUnaccepted)
+/******/ 								abortError = new Error(
+/******/ 									"Aborted because " + moduleId + " is not accepted" + chainInfo
+/******/ 								);
+/******/ 							break;
+/******/ 						case "accepted":
+/******/ 							if (options.onAccepted) options.onAccepted(result);
+/******/ 							doApply = true;
+/******/ 							break;
+/******/ 						case "disposed":
+/******/ 							if (options.onDisposed) options.onDisposed(result);
+/******/ 							doDispose = true;
+/******/ 							break;
+/******/ 						default:
+/******/ 							throw new Error("Unexception type " + result.type);
+/******/ 					}
+/******/ 					if (abortError) {
+/******/ 						return {
+/******/ 							error: abortError
+/******/ 						};
+/******/ 					}
+/******/ 					if (doApply) {
+/******/ 						appliedUpdate[moduleId] = newModuleFactory;
+/******/ 						addAllToSet(outdatedModules, result.outdatedModules);
+/******/ 						for (moduleId in result.outdatedDependencies) {
+/******/ 							if (__webpack_require__.o(result.outdatedDependencies, moduleId)) {
+/******/ 								if (!outdatedDependencies[moduleId])
+/******/ 									outdatedDependencies[moduleId] = [];
+/******/ 								addAllToSet(
+/******/ 									outdatedDependencies[moduleId],
+/******/ 									result.outdatedDependencies[moduleId]
+/******/ 								);
+/******/ 							}
+/******/ 						}
+/******/ 					}
+/******/ 					if (doDispose) {
+/******/ 						addAllToSet(outdatedModules, [result.moduleId]);
+/******/ 						appliedUpdate[moduleId] = warnUnexpectedRequire;
+/******/ 					}
+/******/ 				}
+/******/ 			}
+/******/ 			currentUpdate = undefined;
+/******/ 		
+/******/ 			// Store self accepted outdated modules to require them later by the module system
+/******/ 			var outdatedSelfAcceptedModules = [];
+/******/ 			for (var j = 0; j < outdatedModules.length; j++) {
+/******/ 				var outdatedModuleId = outdatedModules[j];
+/******/ 				var module = __webpack_require__.c[outdatedModuleId];
+/******/ 				if (
+/******/ 					module &&
+/******/ 					(module.hot._selfAccepted || module.hot._main) &&
+/******/ 					// removed self-accepted modules should not be required
+/******/ 					appliedUpdate[outdatedModuleId] !== warnUnexpectedRequire &&
+/******/ 					// when called invalidate self-accepting is not possible
+/******/ 					!module.hot._selfInvalidated
+/******/ 				) {
+/******/ 					outdatedSelfAcceptedModules.push({
+/******/ 						module: outdatedModuleId,
+/******/ 						require: module.hot._requireSelf,
+/******/ 						errorHandler: module.hot._selfAccepted
+/******/ 					});
+/******/ 				}
+/******/ 			}
+/******/ 		
+/******/ 			var moduleOutdatedDependencies;
+/******/ 		
+/******/ 			return {
+/******/ 				dispose: function () {
+/******/ 					currentUpdateRemovedChunks.forEach(function (chunkId) {
+/******/ 						delete installedChunks[chunkId];
+/******/ 					});
+/******/ 					currentUpdateRemovedChunks = undefined;
+/******/ 		
+/******/ 					var idx;
+/******/ 					var queue = outdatedModules.slice();
+/******/ 					while (queue.length > 0) {
+/******/ 						var moduleId = queue.pop();
+/******/ 						var module = __webpack_require__.c[moduleId];
+/******/ 						if (!module) continue;
+/******/ 		
+/******/ 						var data = {};
+/******/ 		
+/******/ 						// Call dispose handlers
+/******/ 						var disposeHandlers = module.hot._disposeHandlers;
+/******/ 						for (j = 0; j < disposeHandlers.length; j++) {
+/******/ 							disposeHandlers[j].call(null, data);
+/******/ 						}
+/******/ 						__webpack_require__.hmrD[moduleId] = data;
+/******/ 		
+/******/ 						// disable module (this disables requires from this module)
+/******/ 						module.hot.active = false;
+/******/ 		
+/******/ 						// remove module from cache
+/******/ 						delete __webpack_require__.c[moduleId];
+/******/ 		
+/******/ 						// when disposing there is no need to call dispose handler
+/******/ 						delete outdatedDependencies[moduleId];
+/******/ 		
+/******/ 						// remove "parents" references from all children
+/******/ 						for (j = 0; j < module.children.length; j++) {
+/******/ 							var child = __webpack_require__.c[module.children[j]];
+/******/ 							if (!child) continue;
+/******/ 							idx = child.parents.indexOf(moduleId);
+/******/ 							if (idx >= 0) {
+/******/ 								child.parents.splice(idx, 1);
+/******/ 							}
+/******/ 						}
+/******/ 					}
+/******/ 		
+/******/ 					// remove outdated dependency from module children
+/******/ 					var dependency;
+/******/ 					for (var outdatedModuleId in outdatedDependencies) {
+/******/ 						if (__webpack_require__.o(outdatedDependencies, outdatedModuleId)) {
+/******/ 							module = __webpack_require__.c[outdatedModuleId];
+/******/ 							if (module) {
+/******/ 								moduleOutdatedDependencies =
+/******/ 									outdatedDependencies[outdatedModuleId];
+/******/ 								for (j = 0; j < moduleOutdatedDependencies.length; j++) {
+/******/ 									dependency = moduleOutdatedDependencies[j];
+/******/ 									idx = module.children.indexOf(dependency);
+/******/ 									if (idx >= 0) module.children.splice(idx, 1);
+/******/ 								}
+/******/ 							}
+/******/ 						}
+/******/ 					}
+/******/ 				},
+/******/ 				apply: function (reportError) {
+/******/ 					var acceptPromises = [];
+/******/ 					// insert new code
+/******/ 					for (var updateModuleId in appliedUpdate) {
+/******/ 						if (__webpack_require__.o(appliedUpdate, updateModuleId)) {
+/******/ 							__webpack_require__.m[updateModuleId] = appliedUpdate[updateModuleId];
+/******/ 						}
+/******/ 					}
+/******/ 		
+/******/ 					// run new runtime modules
+/******/ 					for (var i = 0; i < currentUpdateRuntime.length; i++) {
+/******/ 						currentUpdateRuntime[i](__webpack_require__);
+/******/ 					}
+/******/ 		
+/******/ 					// call accept handlers
+/******/ 					for (var outdatedModuleId in outdatedDependencies) {
+/******/ 						if (__webpack_require__.o(outdatedDependencies, outdatedModuleId)) {
+/******/ 							var module = __webpack_require__.c[outdatedModuleId];
+/******/ 							if (module) {
+/******/ 								moduleOutdatedDependencies =
+/******/ 									outdatedDependencies[outdatedModuleId];
+/******/ 								var callbacks = [];
+/******/ 								var errorHandlers = [];
+/******/ 								var dependenciesForCallbacks = [];
+/******/ 								for (var j = 0; j < moduleOutdatedDependencies.length; j++) {
+/******/ 									var dependency = moduleOutdatedDependencies[j];
+/******/ 									var acceptCallback =
+/******/ 										module.hot._acceptedDependencies[dependency];
+/******/ 									var errorHandler =
+/******/ 										module.hot._acceptedErrorHandlers[dependency];
+/******/ 									if (acceptCallback) {
+/******/ 										if (callbacks.indexOf(acceptCallback) !== -1) continue;
+/******/ 										callbacks.push(acceptCallback);
+/******/ 										errorHandlers.push(errorHandler);
+/******/ 										dependenciesForCallbacks.push(dependency);
+/******/ 									}
+/******/ 								}
+/******/ 								for (var k = 0; k < callbacks.length; k++) {
+/******/ 									var result;
+/******/ 									try {
+/******/ 										result = callbacks[k].call(null, moduleOutdatedDependencies);
+/******/ 									} catch (err) {
+/******/ 										if (typeof errorHandlers[k] === "function") {
+/******/ 											try {
+/******/ 												errorHandlers[k](err, {
+/******/ 													moduleId: outdatedModuleId,
+/******/ 													dependencyId: dependenciesForCallbacks[k]
+/******/ 												});
+/******/ 											} catch (err2) {
+/******/ 												if (options.onErrored) {
+/******/ 													options.onErrored({
+/******/ 														type: "accept-error-handler-errored",
+/******/ 														moduleId: outdatedModuleId,
+/******/ 														dependencyId: dependenciesForCallbacks[k],
+/******/ 														error: err2,
+/******/ 														originalError: err
+/******/ 													});
+/******/ 												}
+/******/ 												if (!options.ignoreErrored) {
+/******/ 													reportError(err2);
+/******/ 													reportError(err);
+/******/ 												}
+/******/ 											}
+/******/ 										} else {
+/******/ 											if (options.onErrored) {
+/******/ 												options.onErrored({
+/******/ 													type: "accept-errored",
+/******/ 													moduleId: outdatedModuleId,
+/******/ 													dependencyId: dependenciesForCallbacks[k],
+/******/ 													error: err
+/******/ 												});
+/******/ 											}
+/******/ 											if (!options.ignoreErrored) {
+/******/ 												reportError(err);
+/******/ 											}
+/******/ 										}
+/******/ 									}
+/******/ 									if (result && typeof result.then === "function") {
+/******/ 										acceptPromises.push(result);
+/******/ 									}
+/******/ 								}
+/******/ 							}
+/******/ 						}
+/******/ 					}
+/******/ 		
+/******/ 					var onAccepted = function () {
+/******/ 						// Load self accepted modules
+/******/ 						for (var o = 0; o < outdatedSelfAcceptedModules.length; o++) {
+/******/ 							var item = outdatedSelfAcceptedModules[o];
+/******/ 							var moduleId = item.module;
+/******/ 							try {
+/******/ 								item.require(moduleId);
+/******/ 							} catch (err) {
+/******/ 								if (typeof item.errorHandler === "function") {
+/******/ 									try {
+/******/ 										item.errorHandler(err, {
+/******/ 											moduleId: moduleId,
+/******/ 											module: __webpack_require__.c[moduleId]
+/******/ 										});
+/******/ 									} catch (err1) {
+/******/ 										if (options.onErrored) {
+/******/ 											options.onErrored({
+/******/ 												type: "self-accept-error-handler-errored",
+/******/ 												moduleId: moduleId,
+/******/ 												error: err1,
+/******/ 												originalError: err
+/******/ 											});
+/******/ 										}
+/******/ 										if (!options.ignoreErrored) {
+/******/ 											reportError(err1);
+/******/ 											reportError(err);
+/******/ 										}
+/******/ 									}
+/******/ 								} else {
+/******/ 									if (options.onErrored) {
+/******/ 										options.onErrored({
+/******/ 											type: "self-accept-errored",
+/******/ 											moduleId: moduleId,
+/******/ 											error: err
+/******/ 										});
+/******/ 									}
+/******/ 									if (!options.ignoreErrored) {
+/******/ 										reportError(err);
+/******/ 									}
+/******/ 								}
+/******/ 							}
+/******/ 						}
+/******/ 					};
+/******/ 		
+/******/ 					return Promise.all(acceptPromises)
+/******/ 						.then(onAccepted)
+/******/ 						.then(function () {
+/******/ 							return outdatedModules;
+/******/ 						});
+/******/ 				}
+/******/ 			};
+/******/ 		}
+/******/ 		__webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
+/******/ 			if (!currentUpdate) {
+/******/ 				currentUpdate = {};
+/******/ 				currentUpdateRuntime = [];
+/******/ 				currentUpdateRemovedChunks = [];
+/******/ 				applyHandlers.push(applyHandler);
+/******/ 			}
+/******/ 			if (!__webpack_require__.o(currentUpdate, moduleId)) {
+/******/ 				currentUpdate[moduleId] = __webpack_require__.m[moduleId];
+/******/ 			}
+/******/ 		};
+/******/ 		__webpack_require__.hmrC.jsonp = function (
+/******/ 			chunkIds,
+/******/ 			removedChunks,
+/******/ 			removedModules,
+/******/ 			promises,
+/******/ 			applyHandlers,
+/******/ 			updatedModulesList
+/******/ 		) {
+/******/ 			applyHandlers.push(applyHandler);
+/******/ 			currentUpdateChunks = {};
+/******/ 			currentUpdateRemovedChunks = removedChunks;
+/******/ 			currentUpdate = removedModules.reduce(function (obj, key) {
+/******/ 				obj[key] = false;
+/******/ 				return obj;
+/******/ 			}, {});
+/******/ 			currentUpdateRuntime = [];
+/******/ 			chunkIds.forEach(function (chunkId) {
+/******/ 				if (
+/******/ 					__webpack_require__.o(installedChunks, chunkId) &&
+/******/ 					installedChunks[chunkId] !== undefined
+/******/ 				) {
+/******/ 					promises.push(loadUpdateChunk(chunkId, updatedModulesList));
+/******/ 					currentUpdateChunks[chunkId] = true;
+/******/ 				} else {
+/******/ 					currentUpdateChunks[chunkId] = false;
+/******/ 				}
+/******/ 			});
+/******/ 			if (__webpack_require__.f) {
+/******/ 				__webpack_require__.f.jsonpHmr = function (chunkId, promises) {
+/******/ 					if (
+/******/ 						currentUpdateChunks &&
+/******/ 						__webpack_require__.o(currentUpdateChunks, chunkId) &&
+/******/ 						!currentUpdateChunks[chunkId]
+/******/ 					) {
+/******/ 						promises.push(loadUpdateChunk(chunkId));
+/******/ 						currentUpdateChunks[chunkId] = true;
+/******/ 					}
+/******/ 				};
+/******/ 			}
+/******/ 		};
+/******/ 		
+/******/ 		__webpack_require__.hmrM = () => {
+/******/ 			if (typeof fetch === "undefined") throw new Error("No browser support: need fetch API");
+/******/ 			return fetch(__webpack_require__.p + __webpack_require__.hmrF()).then((response) => {
+/******/ 				if(response.status === 404) return; // no update available
+/******/ 				if(!response.ok) throw new Error("Failed to fetch update manifest " + response.statusText);
+/******/ 				return response.json();
+/******/ 			});
+/******/ 		};
+/******/ 		
+/******/ 		__webpack_require__.O.j = (chunkId) => (installedChunks[chunkId] === 0);
+/******/ 		
+/******/ 		// install a JSONP callback for chunk loading
+/******/ 		var webpackJsonpCallback = (parentChunkLoadingFunction, data) => {
+/******/ 			var [chunkIds, moreModules, runtime] = data;
+/******/ 			// add "moreModules" to the modules object,
+/******/ 			// then flag all "chunkIds" as loaded and fire callback
+/******/ 			var moduleId, chunkId, i = 0;
+/******/ 			if(chunkIds.some((id) => (installedChunks[id] !== 0))) {
+/******/ 				for(moduleId in moreModules) {
+/******/ 					if(__webpack_require__.o(moreModules, moduleId)) {
+/******/ 						__webpack_require__.m[moduleId] = moreModules[moduleId];
+/******/ 					}
+/******/ 				}
+/******/ 				if(runtime) var result = runtime(__webpack_require__);
+/******/ 			}
+/******/ 			if(parentChunkLoadingFunction) parentChunkLoadingFunction(data);
+/******/ 			for(;i < chunkIds.length; i++) {
+/******/ 				chunkId = chunkIds[i];
+/******/ 				if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
+/******/ 					installedChunks[chunkId][0]();
+/******/ 				}
+/******/ 				installedChunks[chunkId] = 0;
+/******/ 			}
+/******/ 			return __webpack_require__.O(result);
+/******/ 		}
+/******/ 		
+/******/ 		var chunkLoadingGlobal = globalThis["webpackChunksuperset"] = globalThis["webpackChunksuperset"] || [];
+/******/ 		chunkLoadingGlobal.forEach(webpackJsonpCallback.bind(null, 0));
+/******/ 		chunkLoadingGlobal.push = webpackJsonpCallback.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+/******/ 	})();
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// module cache are used so entry inlining is disabled
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	__webpack_require__.O(undefined, ["vendors","vendors-node_modules_rc-component_color-picker_es_index_js-node_modules_rc-component_mutate-o-484854","webpack_sharing_consume_default_react-dom_react-dom-webpack_sharing_consume_default_react_rea-153fef"], () => (__webpack_require__("./node_modules/@pmmmwh/react-refresh-webpack-plugin/client/ReactRefreshEntry.js")))
+/******/ 	__webpack_require__.O(undefined, ["vendors","vendors-node_modules_rc-component_color-picker_es_index_js-node_modules_rc-component_mutate-o-484854","webpack_sharing_consume_default_react-dom_react-dom-webpack_sharing_consume_default_react_rea-153fef"], () => (__webpack_require__("./node_modules/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&port=0&pathname=%2Fws&logging=info&overlay=%7B%22errors%22%3Atrue%2C%22warnings%22%3Afalse%2C%22runtimeErrors%22%3A%22error%2520%253D%253E%2520%21%252FResizeObserver%252F.test%28error.message%29%22%7D&reconnect=10&hot=only&live-reload=false")))
+/******/ 	__webpack_require__.O(undefined, ["vendors","vendors-node_modules_rc-component_color-picker_es_index_js-node_modules_rc-component_mutate-o-484854","webpack_sharing_consume_default_react-dom_react-dom-webpack_sharing_consume_default_react_rea-153fef"], () => (__webpack_require__("./node_modules/webpack/hot/only-dev-server.js")))
+/******/ 	__webpack_require__.O(undefined, ["vendors","vendors-node_modules_rc-component_color-picker_es_index_js-node_modules_rc-component_mutate-o-484854","webpack_sharing_consume_default_react-dom_react-dom-webpack_sharing_consume_default_react_rea-153fef"], () => (__webpack_require__("./node_modules/@pmmmwh/react-refresh-webpack-plugin/client/ErrorOverlayEntry.js")))
+/******/ 	var __webpack_exports__ = __webpack_require__.O(undefined, ["vendors","vendors-node_modules_rc-component_color-picker_es_index_js-node_modules_rc-component_mutate-o-484854","webpack_sharing_consume_default_react-dom_react-dom-webpack_sharing_consume_default_react_rea-153fef"], () => (__webpack_require__("./src/service-worker.ts")))
+/******/ 	__webpack_exports__ = __webpack_require__.O(__webpack_exports__);
+/******/ 	
+/******/ })()
+;

--- a/superset/views/log/schemas.py
+++ b/superset/views/log/schemas.py
@@ -26,6 +26,17 @@ get_recent_activity_schema = {
     },
 }
 
+get_admin_activity_schema = {
+    "type": "object",
+    "properties": {
+        "page": {"type": "number"},
+        "page_size": {"type": "number"},
+        "days": {"type": "number"},
+        "action_types": {"type": "array", "items": {"type": "string"}},
+        "coalesce": {"type": "boolean"},
+    },
+}
+
 openapi_spec_methods_override = {
     "get": {"get": {"summary": "Get a log detail information"}},
     "get_list": {
@@ -64,3 +75,35 @@ class RecentActivityResponseSchema(Schema):
         fields.Nested(RecentActivitySchema),
         metadata={"description": "A list of recent activity objects"},
     )
+
+
+class AdminActivityActorSchema(Schema):
+    id = fields.Integer(allow_none=True)
+    username = fields.String()
+    first_name = fields.String(allow_none=True)
+    last_name = fields.String(allow_none=True)
+
+
+class AdminActivityItemSchema(Schema):
+    id = fields.Integer()
+    actor = fields.Nested(AdminActivityActorSchema)
+    action = fields.String()
+    action_category = fields.String()
+    object_type = fields.String(allow_none=True)
+    object_id = fields.Integer(allow_none=True)
+    object_title = fields.String(allow_none=True)
+    object_url = fields.String(allow_none=True)
+    timestamp = fields.DateTime()
+    event_count = fields.Integer()
+    first_seen = fields.DateTime()
+    last_seen = fields.DateTime()
+
+
+class AdminActivityResponseSchema(Schema):
+    result = fields.List(
+        fields.Nested(AdminActivityItemSchema),
+        metadata={"description": "A list of admin activity objects"},
+    )
+    count = fields.Integer()
+    page = fields.Integer()
+    page_size = fields.Integer()

--- a/tests/integration_tests/dashboards/activity_api_tests.py
+++ b/tests/integration_tests/dashboards/activity_api_tests.py
@@ -1,0 +1,411 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import datetime, timedelta
+
+from flask_appbuilder.security.sqla.models import User
+
+from superset import db
+from superset.models.core import Log
+from superset.utils import json
+from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.conftest import with_feature_flags
+from tests.integration_tests.constants import ADMIN_USERNAME
+
+
+class TestDashboardActivityApi(SupersetTestCase):
+    def insert_log(
+        self,
+        *,
+        action: str,
+        user: User,
+        dashboard_id: int | None = None,
+        dttm: datetime | None = None,
+        payload: str | None = None,
+    ) -> Log:
+        log = Log(
+            action=action,
+            user=user,
+            dashboard_id=dashboard_id,
+            json=payload or '{"slice_name": "Sales by Country", "viz_type": "line"}',
+            dttm=dttm or datetime.utcnow(),
+        )
+        db.session.add(log)
+        db.session.commit()
+        return log
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=False)
+    def test_activity_requires_feature_flag(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-flag",
+            "activity-flag",
+            [admin_user.id],
+        )
+
+        response = self.client.get(f"/api/v1/dashboard/{dashboard.id}/activity/")
+        assert response.status_code == 404
+
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-main",
+            "activity-main",
+            [admin_user.id],
+        )
+
+        view_log = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+        )
+        chart_log = self.insert_log(
+            action="explore_json",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            dttm=datetime.utcnow() - timedelta(minutes=2),
+        )
+
+        response = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/"
+            "?action_type=view&page=0&page_size=10&days=30",
+            "activity",
+        )
+        assert response.status_code == 200
+        payload = json.loads(response.data.decode("utf-8"))["result"]
+        assert payload["count"] == 1
+        assert payload["activities"][0]["id"] == view_log.id
+        assert payload["activities"][0]["action_category"] == "view"
+
+        db.session.delete(view_log)
+        db.session.delete(chart_log)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity_normalizes_log_event_name(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-normalization",
+            "activity-normalization",
+            [admin_user.id],
+        )
+
+        log_event = self.insert_log(
+            action="log",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            payload='{"event_name": "mount_dashboard"}',
+        )
+
+        response = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/?action_type=view&page=0&page_size=10&days=30",
+            "activity",
+        )
+        assert response.status_code == 200
+        activity = json.loads(response.data.decode("utf-8"))["result"]["activities"][0]
+        assert activity["id"] == log_event.id
+        assert activity["action"] == "mount_dashboard"
+        assert activity["action_display"] == "Viewed dashboard"
+
+        db.session.delete(log_event)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity_empty(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-empty",
+            "activity-empty",
+            [admin_user.id],
+        )
+
+        response = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/"
+            "?action_type=all&page=0&page_size=10&days=30",
+            "activity",
+        )
+        assert response.status_code == 200
+        payload = json.loads(response.data.decode("utf-8"))["result"]
+        assert payload["count"] == 0
+        assert payload["activities"] == []
+
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity_pagination(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-pagination",
+            "activity-pagination",
+            [admin_user.id],
+        )
+
+        first_log = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            dttm=datetime.utcnow() - timedelta(minutes=12),
+        )
+        second_log = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            dttm=datetime.utcnow() - timedelta(minutes=1),
+        )
+
+        response_page_0 = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/"
+            "?action_type=view&page=0&page_size=1&days=30",
+            "activity",
+        )
+        assert response_page_0.status_code == 200
+        payload_page_0 = json.loads(response_page_0.data.decode("utf-8"))["result"]
+        assert payload_page_0["count"] == 2
+        assert payload_page_0["activities"][0]["id"] == second_log.id
+
+        response_page_1 = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/"
+            "?action_type=view&page=1&page_size=1&days=30",
+            "activity",
+        )
+        assert response_page_1.status_code == 200
+        payload_page_1 = json.loads(response_page_1.data.decode("utf-8"))["result"]
+        assert payload_page_1["count"] == 2
+        assert payload_page_1["activities"][0]["id"] == first_log.id
+
+        db.session.delete(first_log)
+        db.session.delete(second_log)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity_coalesces_bursts(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-coalesce",
+            "activity-coalesce",
+            [admin_user.id],
+        )
+
+        first_log = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            dttm=datetime.utcnow() - timedelta(minutes=3),
+        )
+        second_log = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            dttm=datetime.utcnow() - timedelta(minutes=2),
+        )
+
+        response = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/?action_type=view&page=0&page_size=10&days=30",
+            "activity",
+        )
+        assert response.status_code == 200
+        payload = json.loads(response.data.decode("utf-8"))["result"]
+        assert payload["count"] == 1
+        assert payload["activities"][0]["event_count"] == 2
+        assert payload["activities"][0]["id"] == second_log.id
+
+        db.session.delete(first_log)
+        db.session.delete(second_log)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity_filters_chart_pipeline_in_chart_interaction(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-chart-filter",
+            "activity-chart-filter",
+            [admin_user.id],
+        )
+
+        chart_log = self.insert_log(
+            action="load_chart",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+        )
+        view_log = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            dttm=datetime.utcnow() - timedelta(minutes=1),
+        )
+
+        response_view = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/?action_type=view&page=0&page_size=10&days=30",
+            "activity",
+        )
+        assert response_view.status_code == 200
+        payload_view = json.loads(response_view.data.decode("utf-8"))["result"]
+        assert payload_view["count"] == 1
+        assert payload_view["activities"][0]["id"] == view_log.id
+
+        response_chart = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/?action_type=chart_interaction&page=0&page_size=10&days=30",
+            "activity",
+        )
+        assert response_chart.status_code == 200
+        payload_chart = json.loads(response_chart.data.decode("utf-8"))["result"]
+        assert payload_chart["count"] == 1
+        assert payload_chart["activities"][0]["id"] == chart_log.id
+        assert payload_chart["activities"][0]["action_category"] == "chart_interaction"
+
+        db.session.delete(chart_log)
+        db.session.delete(view_log)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity_filters_by_days(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-days-filter",
+            "activity-days-filter",
+            [admin_user.id],
+        )
+
+        recent_log = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            dttm=datetime.utcnow() - timedelta(days=2),
+        )
+        old_log = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            dttm=datetime.utcnow() - timedelta(days=10),
+        )
+
+        response = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/?action_type=view&page=0&page_size=10&days=7",
+            "activity",
+        )
+        assert response.status_code == 200
+        payload = json.loads(response.data.decode("utf-8"))["result"]
+        assert payload["count"] == 1
+        assert payload["activities"][0]["id"] == recent_log.id
+
+        db.session.delete(recent_log)
+        db.session.delete(old_log)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity_includes_export_rows_without_dashboard_id(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-export",
+            "activity-export",
+            [admin_user.id],
+        )
+
+        dashboard_export = self.insert_log(
+            action="DashboardRestApi.export",
+            user=admin_user,
+            dashboard_id=None,
+            payload=f'{{"path": "/api/v1/dashboard/export/", "q": "!({dashboard.id})", "rison": [{dashboard.id}]}}',  # noqa: E501
+            dttm=datetime.utcnow(),
+        )
+        chart_export = self.insert_log(
+            action="log",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+            payload='{"event_name": "export_csv_dashboard_chart"}',
+            dttm=datetime.utcnow() - timedelta(minutes=1),
+        )
+
+        response = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/?action_type=export&page=0&page_size=10&days=30",
+            "activity",
+        )
+        assert response.status_code == 200
+        payload = json.loads(response.data.decode("utf-8"))["result"]
+        assert payload["count"] == 2
+        assert payload["activities"][0]["id"] == dashboard_export.id
+        assert payload["activities"][0]["action_category"] == "export"
+        assert payload["activities"][1]["id"] == chart_export.id
+        assert payload["activities"][1]["action"] == "export_csv_dashboard_chart"
+        assert payload["activities"][1]["action_category"] == "export"
+
+        db.session.delete(dashboard_export)
+        db.session.delete(chart_export)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_ACTIVITY_FEED=True)
+    def test_get_activity_summary(self) -> None:
+        self.login(ADMIN_USERNAME)
+        admin_user = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "activity-summary",
+            "activity-summary",
+            [admin_user.id],
+        )
+
+        view_log_1 = self.insert_log(
+            action="dashboard",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+        )
+        view_log_2 = self.insert_log(
+            action="DashboardRestApi.get",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+        )
+        edit_log = self.insert_log(
+            action="DashboardRestApi.put",
+            user=admin_user,
+            dashboard_id=dashboard.id,
+        )
+
+        response = self.get_assert_metric(
+            f"/api/v1/dashboard/{dashboard.id}/activity/summary/?days=30",
+            "activity_summary",
+        )
+        assert response.status_code == 200
+        summary = json.loads(response.data.decode("utf-8"))["result"]
+        assert summary["total_views"] == 2
+        assert summary["unique_viewers"] == 1
+        assert ADMIN_USERNAME in summary["recent_editors"]
+        assert summary["period_days"] == 30
+
+        db.session.delete(view_log_1)
+        db.session.delete(view_log_2)
+        db.session.delete(edit_log)
+        db.session.delete(dashboard)
+        db.session.commit()


### PR DESCRIPTION
 ### SUMMARY

  Adds a dashboard-level activity feed and an admin-wide activity panel to Apache Superset.

  **Dashboard Activity Feed** — A drawer accessible from the dashboard header that shows a timeline of recent activity
  (views, edits, exports, chart interactions) for that dashboard. Includes summary stats (views today, unique viewers,
  recent editors), action type and time range filters, event coalescing (groups repeated actions within a 5-minute
  window), and pagination.

  **Admin Activity Panel** — A new collapsible section on the welcome/home page showing a card-based grid of recent
  activity across all dashboards and charts, with the same filtering and coalescing capabilities.

  Both features are gated behind feature flags (`DASHBOARD_ACTIVITY_FEED` and `ADMIN_ACTIVITY_FEED`) and backed by new
  REST API endpoints with OpenAPI documentation.

  **Key implementation details:**
  - New API endpoints: `GET /api/v1/dashboard/<id_or_slug>/activity/`, `GET
  /api/v1/dashboard/<id_or_slug>/activity/summary/`, `GET /api/v1/log/admin_activity/`
  - `GetDashboardActivityCommand` with intelligent dashboard ID resolution from multiple log payload formats
  - Event coalescing groups bursts of the same action by the same user within 5-minute windows
  - Composite DB index on `logs(dashboard_id, dttm)` for query performance
  - Color-coded, icon-based activity items categorized by action type

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
  <img width="821" height="796" alt="image" src="https://github.com/user-attachments/assets/2c424a2c-66a7-495d-bbf7-a82b3c26dba1" />
<img width="798" height="590" alt="image" src="https://github.com/user-attachments/assets/f0b7de82-d0d3-4474-b9e9-c0a52f1ef03d" />
<img width="657" height="265" alt="image" src="https://github.com/user-attachments/assets/bed78327-288a-4bb7-b827-6995f0045aac" />
<img width="2676" height="1302" alt="image" src="https://github.com/user-attachments/assets/9550ae08-1946-4f40-85d6-fb1a8fa12443" />

https://github.com/user-attachments/assets/20aaa678-ade0-4f6b-a0a4-b42fc7dd7593

  ### TESTING INSTRUCTIONS

  **Dashboard Activity Feed:**
  1. Ensure the `DASHBOARD_ACTIVITY_FEED` feature flag is enabled (on by default).
  2. Open any dashboard — the header should show an activity button with today's view count.
  3. Click the button to open the activity drawer.
  4. Verify activity items appear with user names, action descriptions, and timestamps.
  5. Test the action type filter (All, Views, Edits, Exports, Chart interactions).
  6. Test the time range filter (7 / 30 / 90 days).
  7. If enough activity exists, verify "Load more" pagination works.
  8. Verify coalesced events show an event count badge.

  **Admin Activity Panel:**
  1. Ensure the `ADMIN_ACTIVITY_FEED` feature flag is enabled (on by default).
  2. Navigate to the home page.
  3. Verify the "Activity Feed" collapsible panel appears.
  4. Verify cards display dashboard/chart title, actor, action, and timestamp.
  5. Click a card and verify it navigates to the correct dashboard or chart.
  6. Verify that a non-admin user who receives a 403 sees the panel gracefully hidden.

  **Unit tests:**
  ```bash
  # Frontend
  npm run test -- dashboard/components/ActivityFeed/api.test.ts
  npm run test -- features/home/AdminActivityPanel.test.tsx

  # Backend
  pytest tests/integration_tests/dashboards/activity_api_tests.py
  ```

  ADDITIONAL INFORMATION

  - Has associated issue:
  - Required feature flags: DASHBOARD_ACTIVITY_FEED, ADMIN_ACTIVITY_FEED
  - Changes UI
  - Includes DB Migration (follow approval process in https://github.com/apache/superset/issues/13351)
    - Migration is atomic, supports rollback & is backwards-compatible
    - Confirm DB migration upgrade and downgrade tested
    - Runtime estimates and downtime expectations provided
  - Introduces new feature or API
  - Removes existing feature or API