### PR TITLE
fix(table): preserve time grain aggregation when temporal column casing changes

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -273,7 +273,7 @@ const config: ControlPanelConfig = {
               visibility: ({ controls }) => {
                 const dttmLookup = Object.fromEntries(
                   ensureIsArray(controls?.groupby?.options).map(option => [
-                    option.column_name,
+                    (option.column_name || '').toLowerCase(),
                     option.is_dttm,
                   ]),
                 );
@@ -284,7 +284,7 @@ const config: ControlPanelConfig = {
                       return true;
                     }
                     if (isPhysicalColumn(selection)) {
-                      return !!dttmLookup[selection];
+                      return !!dttmLookup[(selection || '').toLowerCase()];
                     }
                     return false;
                   })

--- a/superset-frontend/plugins/plugin-chart-table/test/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/controlPanel.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable camelcase */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {
+  ControlPanelConfig,
+  ControlPanelsContainerProps,
+  ControlState,
+  CustomControlItem,
+} from '@superset-ui/chart-controls';
+import config from '../src/controlPanel';
+
+type VisibilityFn = (
+  props: ControlPanelsContainerProps,
+  control?: ControlState,
+) => boolean;
+
+function isControlWithVisibility(
+  controlItem: unknown,
+): controlItem is CustomControlItem & {
+  config: Required<CustomControlItem['config']> & { visibility: VisibilityFn };
+} {
+  return (
+    typeof controlItem === 'object' &&
+    controlItem !== null &&
+    'name' in controlItem &&
+    'config' in controlItem &&
+    typeof (controlItem as CustomControlItem).config?.visibility === 'function'
+  );
+}
+
+function getVisibility(
+  panel: ControlPanelConfig,
+  controlName: string,
+): VisibilityFn {
+  const item = (panel.controlPanelSections || [])
+    .flatMap(section => section?.controlSetRows || [])
+    .flat()
+    .find(c => isControlWithVisibility(c) && c.name === controlName);
+
+  if (!isControlWithVisibility(item)) {
+    throw new Error(`Control "${controlName}" with visibility not found`);
+  }
+  return item.config.visibility;
+}
+
+function mkProps(
+  groupbyValue: string[],
+  options = [
+    { column_name: 'ORDERDATE', is_dttm: true },
+    { column_name: 'some_other_col', is_dttm: false },
+  ],
+): ControlPanelsContainerProps {
+  return {
+    controls: {
+      groupby: { value: groupbyValue, options },
+    },
+  } as unknown as ControlPanelsContainerProps;
+}
+
+test('time_grain_sqla visibility should be case-insensitive', () => {
+  const vis = getVisibility(config, 'time_grain_sqla');
+  const controlState = {} as ControlState;
+
+  expect(vis(mkProps(['orderdate']), controlState)).toBe(true);
+  expect(vis(mkProps(['ORDERDATE']), controlState)).toBe(true);
+  expect(vis(mkProps(['some_other_col']), controlState)).toBe(false);
+});


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a case-sensitivity issue causing table aggregation to break when a temporal column is renamed with different casing. The `time_grain_sqla` visibility check in the Table control panel is made case-insensitive, ensuring time grain aggregation is applied even after renaming. Adds a unit test to prevent regressions.

This fix applies the same case-insensitive validation from PR #36990 (AG Grid Table) to the regular Table chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE
<img width="1721" height="905" alt="image" src="https://github.com/user-attachments/assets/81715af0-b543-4ee5-bc3b-d923815400bd" />


AFTER
<img width="1723" height="917" alt="image" src="https://github.com/user-attachments/assets/21da4428-b5b6-429c-891e-3731fb87b051" />

<hr />

<img width="1715" height="905" alt="image" src="https://github.com/user-attachments/assets/90551371-6f1c-426a-939a-22e72a5833f9" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. In Explore, create a Table chart with a dataset that has an uppercase temporal column (e.g., `ORDERDATE`).
2. Enable Aggregate mode, add the temporal column to Dimensions, set Month time grain, update chart. Verify aggregation works.
3. Rename the temporal column to lowercase (e.g., `orderdate`) and update chart.
4. Verify aggregation still follows the selected time grain.

Unit test:
- From superset-frontend, run:
  - `npm run test -- plugins/plugin-chart-table/test/controlPanel.test.ts`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
