### PR TITLE
fix: Conditional formatting painting empty cells

### DIFF
--- a/superset-frontend/packages/superset-core/src/utils/isBlank.test.ts
+++ b/superset-frontend/packages/superset-core/src/utils/isBlank.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import isBlank from './isBlank';
+
+test('returns true for null', () => {
+  expect(isBlank(null)).toBe(true);
+});
+
+test('returns true for undefined', () => {
+  expect(isBlank(undefined)).toBe(true);
+});
+
+test('returns true for empty string', () => {
+  expect(isBlank('')).toBe(true);
+});
+
+test('returns true for whitespace-only strings', () => {
+  expect(isBlank(' ')).toBe(true);
+  expect(isBlank('  ')).toBe(true);
+  expect(isBlank('\t')).toBe(true);
+  expect(isBlank('\n')).toBe(true);
+  expect(isBlank(' \t\n ')).toBe(true);
+});
+
+test('returns false for non-empty strings', () => {
+  expect(isBlank('hello')).toBe(false);
+  expect(isBlank(' hello ')).toBe(false);
+});
+
+test('returns true for NaN', () => {
+  expect(isBlank(NaN)).toBe(true);
+});
+
+test('returns false for numbers', () => {
+  expect(isBlank(0)).toBe(false);
+  expect(isBlank(50)).toBe(false);
+  expect(isBlank(-1)).toBe(false);
+});
+
+test('returns false for booleans', () => {
+  expect(isBlank(true)).toBe(false);
+  expect(isBlank(false)).toBe(false);
+});

--- a/superset-frontend/packages/superset-core/src/utils/isBlank.ts
+++ b/superset-frontend/packages/superset-core/src/utils/isBlank.ts
@@ -16,6 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { isEmpty, isNaN, isNil, isString, trim } from 'lodash';
 
-export { default as isBlank } from './isBlank';
-export { default as logging } from './logging';
+/**
+ * Checks if a value is null, undefined, NaN, or a whitespace-only string.
+ */
+export default function isBlank(value: unknown): boolean {
+  return (
+    isNil(value) || isNaN(value) || (isString(value) && isEmpty(trim(value)))
+  );
+}

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 import memoizeOne from 'memoize-one';
+import { isString, isBoolean } from 'lodash';
+import { isBlank } from '@apache-superset/core';
 import { addAlpha, DataRecord } from '@superset-ui/core';
 import {
   ColorFormatters,
@@ -254,6 +256,9 @@ export const getColorFunction = (
   }
 
   return (value: number | string | boolean | null) => {
+    if (isBlank(value) && operator !== Comparator.IsNull) {
+      return undefined;
+    }
     const compareResult = comparatorFunction(value, columnValues);
     if (compareResult === false) return undefined;
     const { cutoffValue, extremeValue } = compareResult;
@@ -318,11 +323,3 @@ export const getColorFormatters = memoizeOne(
       [],
     ) ?? [],
 );
-
-function isString(value: unknown) {
-  return typeof value === 'string';
-}
-
-function isBoolean(value: unknown) {
-  return typeof value === 'boolean';
-}

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -506,6 +506,117 @@ test('getColorFunction IsNotNull', () => {
   expect(colorFunction(null)).toBeUndefined();
 });
 
+test('getColorFunction returns undefined for null values on numeric comparators', () => {
+  const operators = [
+    { operator: Comparator.LessThan, targetValue: 50 },
+    { operator: Comparator.LessOrEqual, targetValue: 50 },
+    { operator: Comparator.GreaterThan, targetValue: 50 },
+    { operator: Comparator.GreaterOrEqual, targetValue: 50 },
+    { operator: Comparator.Equal, targetValue: 50 },
+    { operator: Comparator.NotEqual, targetValue: 50 },
+  ];
+  operators.forEach(({ operator, targetValue }) => {
+    const colorFunction = getColorFunction(
+      {
+        operator,
+        targetValue,
+        colorScheme: '#FF0000',
+        column: 'count',
+      },
+      countValues,
+    );
+    expect(colorFunction(null)).toBeUndefined();
+    expect(colorFunction(undefined as unknown as null)).toBeUndefined();
+  });
+});
+
+test('getColorFunction returns undefined for null values on Between comparators', () => {
+  const operators = [
+    Comparator.Between,
+    Comparator.BetweenOrEqual,
+    Comparator.BetweenOrLeftEqual,
+    Comparator.BetweenOrRightEqual,
+  ];
+  operators.forEach(operator => {
+    const colorFunction = getColorFunction(
+      {
+        operator,
+        targetValueLeft: -10,
+        targetValueRight: 50,
+        colorScheme: '#FF0000',
+        column: 'count',
+      },
+      countValues,
+    );
+    expect(colorFunction(null)).toBeUndefined();
+    expect(colorFunction(undefined as unknown as null)).toBeUndefined();
+  });
+});
+
+test('getColorFunction returns undefined for null values on None operator', () => {
+  const colorFunction = getColorFunction(
+    {
+      operator: Comparator.None,
+      colorScheme: '#FF0000',
+      column: 'count',
+    },
+    countValues,
+  );
+  expect(colorFunction(null)).toBeUndefined();
+  expect(colorFunction(undefined as unknown as null)).toBeUndefined();
+});
+
+test('getColorFunction returns undefined for null values on string comparators', () => {
+  const operators = [
+    Comparator.BeginsWith,
+    Comparator.EndsWith,
+    Comparator.Containing,
+    Comparator.NotContaining,
+  ];
+  operators.forEach(operator => {
+    const colorFunction = getColorFunction(
+      {
+        operator,
+        targetValue: 'test',
+        colorScheme: '#FF0000',
+        column: 'name',
+      },
+      strValues,
+    );
+    expect(colorFunction(null)).toBeUndefined();
+    expect(colorFunction(undefined as unknown as null)).toBeUndefined();
+  });
+});
+
+test('getColorFunction returns undefined for empty and whitespace string values', () => {
+  const colorFunction = getColorFunction(
+    {
+      operator: Comparator.LessThan,
+      targetValue: 50,
+      colorScheme: '#FF0000',
+      column: 'count',
+    },
+    countValues,
+  );
+  expect(colorFunction('' as unknown as number)).toBeUndefined();
+  expect(colorFunction('  ' as unknown as number)).toBeUndefined();
+  expect(colorFunction('\t' as unknown as number)).toBeUndefined();
+});
+
+test('getColorFunction IsNull still matches null values', () => {
+  const colorFunction = getColorFunction(
+    {
+      operator: Comparator.IsNull,
+      targetValue: '',
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+    boolValues,
+  );
+  expect(colorFunction(null)).toEqual('#FF0000FF');
+  expect(colorFunction(true)).toBeUndefined();
+});
+
 test('correct column config', () => {
   const columnConfig = [
     {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -614,9 +614,7 @@ describe('plugin-chart-table', () => {
         expect(getComputedStyle(screen.getByTitle('2467063')).background).toBe(
           '',
         );
-        expect(getComputedStyle(screen.getByText('N/A')).background).toBe(
-          'rgba(172, 225, 196, 1)',
-        );
+        expect(getComputedStyle(screen.getByText('N/A')).background).toBe('');
       });
       test('should display original label in grouped headers', () => {
         const props = transformProps(testData.comparison);


### PR DESCRIPTION
### SUMMARY

Fixes conditional formatting painting empty cells when blank values (null, undefined, NaN, whitespace-only strings) are present.

**Also in this PR:**
- Introduced a reusable `isBlank` utility in `@apache-superset/core` that checks for null, undefined, NaN, and whitespace-only strings using lodash functions
- Replaced local `isString`/`isBoolean` helper functions in `getColorFormatters.ts` with their lodash equivalents

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Empty cells are incorrectly colored when conditional formatting rules like `metric < 50` are applied (null is coerced to 0, which satisfies the condition).

<img width="1913" height="855" alt="Screenshot 2026-02-11 at 10 58 14" src="https://github.com/user-attachments/assets/0e6018a1-11fd-4423-ba29-efa1b94f164a" />

**After:** Empty cells are left unformatted. Only cells with actual values are evaluated against conditional formatting rules.

<img width="1911" height="864" alt="Screenshot 2026-02-11 at 11 11 20" src="https://github.com/user-attachments/assets/bb55502e-a90f-43d1-9db7-d470fe35da7a" />

### TESTING INSTRUCTIONS

1. Create a chart that supports conditional formatting (Pivot Table or Table) with a dataset that produces empty cells
2. Add a conditional formatting rule such as `metric < 50`
3. Verify that empty cells are **not** colored
4. Verify that cells with actual values below 50 **are** colored
5. Verify that `IsNull` conditional formatting still correctly highlights null cells
6. Verify that `IsTrue`/`IsFalse` conditional formatting still works on boolean columns

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
