### PR TITLE
perf: fix N+1 query in chart list API when thumbnail_url is requested

### DIFF
--- a/superset/thumbnails/digest.py
+++ b/superset/thumbnails/digest.py
@@ -128,6 +128,6 @@ def get_chart_digest(chart: Slice) -> str | None:
 
     unique_string = f"{chart.params or ''}.{executor}"
     unique_string = _adjust_string_for_executor(unique_string, executor_type, executor)
-    unique_string = _adjust_string_with_rls(unique_string, [chart.datasource], executor)
+    unique_string = _adjust_string_with_rls(unique_string, [chart.table], executor)
 
     return hash_from_str(unique_string)

--- a/tests/unit_tests/thumbnails/test_digest.py
+++ b/tests/unit_tests/thumbnails/test_digest.py
@@ -407,6 +407,7 @@ def test_chart_digest(
         **(chart_overrides or {}),
     }
     chart = Slice(**kwargs)
+    chart.table = datasource
 
     user: User | None = None
     if has_current_user:
@@ -421,12 +422,6 @@ def test_chart_digest(
                 "THUMBNAIL_EXECUTORS": execute_as,
                 "THUMBNAIL_CHART_DIGEST_FUNC": func,
             },
-        ),
-        patch.object(
-            type(chart),
-            "datasource",
-            new_callable=PropertyMock,
-            return_value=datasource,
         ),
         patch.object(security_manager, "find_user", return_value=user),
         override_user(user),


### PR DESCRIPTION
### SUMMARY
`GET /api/v1/chart/` with `thumbnail_url` in columns takes ~15s vs <1s without it. The root cause is an N+1 query problem: for each chart, `thumbnail_url → digest → get_chart_digest()` accesses chart.datasource, which is a computed property that fires a fresh `db.session.query(...).filter_by(id=...).one_or_none()` every time. With 200 charts, that's 200+ individual DB queries.

The Slice model already has a table relationship with `lazy="subquery"` that bulk-loads datasources in a single subquery when Slices are queried, so we should use that instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Load a Superset instance with 100+ charts and `THUMBNAILS` feature flag enabled
2. Call GET /api/v1/chart/?q=(columns:!(thumbnail_url)) and observe response time - you could simply do that by going to Dashboard edit mode and unselecting "Show only my charts"
3. Verify thumbnail URLs are still returned correctly
 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags: `THUMBNAILS`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
