### PR TITLE
perf: fix N+1 query in Slice.datasource property

### DIFF
--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -678,7 +678,7 @@ class TestSqlaTableModel(SupersetTestCase):
             datasource_id=tbl.id,
         )
         dashboard.slices.append(slc)
-        datasource_info = slc.datasource.data_for_slices([slc])
+        datasource_info = tbl.data_for_slices([slc])
         assert "database" in datasource_info
 
         # clean up and auto commit


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Continuation of http://github.com/apache/superset/pull/37895

`Slice.datasource` executed a raw `db.session.query()` every time it was accessed, causing N+1 query issues across many code paths (dashboard loading, chart lists, etc.). The `Slice.table` relationship already points to the same SqlaTable and is eagerly loaded via `lazy="subquery"` — so the data is already in memory.

This PR:
  - Changes `Slice.datasource` to return `self.table` instead of issuing a DB query
  - Removes the now-dead `get_datasource` method and `cls_model` property from Slice
  - Inlines the `DatasourceDAO.sources` lookup into `set_related_perm` (the only remaining caller of cls_model)
  - Simplifies `Dashboard.datasources` and `Dashboard.datasets_trimmed_for_slices` to use the eagerly-loaded relationship instead of manual batch queries via cls_model

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
  1. Load a dashboard with many charts and verify all charts render correctly
  2. Check the SQL Lab chart explore view works as expected
  3. Verify the chart list API returns correct datasource information
 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
