### PR TITLE
fix: Unreachable drop zones within tabs in dashbboard editor

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -250,11 +250,6 @@ const DashboardContentWrapper = styled.div`
         z-index: ${EMPTY_CONTAINER_Z_INDEX};
         position: absolute;
         width: 100%;
-        pointer-events: none;
-
-        & > .drop-indicator {
-          pointer-events: auto;
-        }
       }
 
       & > .empty-droptarget:first-child:not(.empty-droptarget--full) {

--- a/superset-frontend/src/dashboard/components/gridComponents/Column/Column.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column/Column.test.tsx
@@ -226,6 +226,16 @@ test.skip('should pass appropriate dimensions to ResizableContainer', () => {
   // );
 });
 
+test('should render between-items Droppables for each child in editMode', () => {
+  const { getAllByTestId } = setup({ editMode: true });
+  // 1 top-edge droptarget + 1 after-child droptarget = 2 total
+  const droppables = getAllByTestId('mock-droppable');
+  expect(droppables).toHaveLength(2);
+  droppables.forEach(droppable => {
+    expect(droppable).toHaveAttribute('data-depth', `${props.depth}`);
+  });
+});
+
 test('should increment the depth of its children', () => {
   const { getByTestId } = setup();
   expect(getByTestId('mock-dashboard-component')).toHaveAttribute(

--- a/superset-frontend/src/dashboard/components/gridComponents/Column/Column.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column/Column.tsx
@@ -101,6 +101,8 @@ const ColumnStyles = styled.div<{ editMode: boolean }>`
       &.droptarget-edge {
         position: absolute;
         z-index: ${EMPTY_CONTAINER_Z_INDEX};
+        width: 100%;
+        height: ${theme.sizeUnit * 4}px;
         &:first-child {
           inset-block-start: 0;
         }
@@ -110,6 +112,10 @@ const ColumnStyles = styled.div<{ editMode: boolean }>`
         z-index: ${EMPTY_CONTAINER_Z_INDEX};
         width: 100%;
         height: 100%;
+      }
+      &:not(:first-child):not(.droptarget-edge) {
+        width: 100%;
+        min-height: ${theme.sizeUnit * 4}px;
       }
     }
   `}


### PR DESCRIPTION
### SUMMARY
In dashboard editor, when user added a tabs element and put something in the tab (for example a chart), drop zones within that tab above or below added element were unreachable. This PR fixes the issue

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/7f227913-649c-45ec-b3b0-4b5ee98db359

After:


https://github.com/user-attachments/assets/63ef7abe-7331-40a1-9563-b54bfb5f04ba



### TESTING INSTRUCTIONS
1. Open the dashboard editor
2. Add tabs element
3. Put something in the tab, for example a chart
4. Try to add another element within the tab, above or below added chart
5. Drop zone should highlight on hover, new element should be added correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
