### PR TITLE
feat(owners): display email in owner selectors

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -80,6 +80,7 @@ import { makeUrl } from 'src/utils/pathUtils';
 import {
   OwnerSelectLabel,
   OWNER_TEXT_LABEL_PROP,
+  OWNER_EMAIL_PROP,
   OWNER_OPTION_FILTER_PROPS,
 } from 'src/features/owners/OwnerSelectLabel';
 import { DatabaseSelector } from '../../../DatabaseSelector';
@@ -106,7 +107,7 @@ interface Owner {
   label?: ReactNode;
   first_name?: string;
   last_name?: string;
-  username?: string;
+  email?: string;
   [key: string]: unknown;
 }
 
@@ -766,9 +767,10 @@ function OwnersSelector({
             value: item.value as number,
             label: OwnerSelectLabel({
               name: item.text as string,
-              username: item.extra?.username as string | undefined,
+              email: item.extra?.email as string | undefined,
             }),
             [OWNER_TEXT_LABEL_PROP]: item.text as string,
+            [OWNER_EMAIL_PROP]: (item.extra?.email as string) ?? '',
           })),
         totalCount: response.json.count,
       }));
@@ -866,10 +868,11 @@ class DatasourceEditor extends PureComponent<
             value: owner.value || owner.id,
             label: OwnerSelectLabel({
               name: typeof ownerName === 'string' ? ownerName : '',
-              username: owner.username,
+              email: owner.email,
             }),
             [OWNER_TEXT_LABEL_PROP]:
               typeof ownerName === 'string' ? ownerName : '',
+            [OWNER_EMAIL_PROP]: owner.email ?? '',
           };
         }),
         metrics: props.datasource.metrics?.map(metric => {

--- a/superset-frontend/src/components/ListView/Filters/Select.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Select.tsx
@@ -35,6 +35,7 @@ interface SelectFilterProps extends BaseFilter {
   fetchSelects?: Filter['fetchSelects'];
   name?: string;
   onSelect: (selected: SelectOption | undefined, isClear?: boolean) => void;
+  optionFilterProps?: string[];
   paginate?: boolean;
   selects: Filter['selects'];
   loading?: boolean;
@@ -48,6 +49,7 @@ function SelectFilter(
     fetchSelects,
     initialValue,
     onSelect,
+    optionFilterProps,
     selects = [],
     loading = false,
     dropdownStyle,
@@ -58,7 +60,15 @@ function SelectFilter(
 
   const onChange = (selected: SelectOption) => {
     onSelect(
-      selected ? { label: selected.label, value: selected.value } : undefined,
+      selected
+        ? {
+            label:
+              typeof selected.label === 'string'
+                ? selected.label
+                : String(selected.value),
+            value: selected.value,
+          }
+        : undefined,
     );
     setSelectedOption(selected);
   };
@@ -108,6 +118,7 @@ function SelectFilter(
           onChange={onChange}
           onClear={onClear}
           options={fetchAndFormatSelects}
+          optionFilterProps={optionFilterProps}
           placeholder={placeholder}
           dropdownStyle={dropdownStyle}
           showSearch

--- a/superset-frontend/src/components/ListView/Filters/index.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.tsx
@@ -72,6 +72,7 @@ function UIFilters(
             key,
             id,
             input,
+            optionFilterProps,
             paginate,
             selects,
             toolTipDescription,
@@ -109,6 +110,7 @@ function UIFilters(
 
                   updateFilterValue(index, option);
                 }}
+                optionFilterProps={optionFilterProps}
                 paginate={paginate}
                 selects={selects}
                 loading={loading ?? false}

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 export interface SortColumn {
   id: string;
@@ -24,8 +24,9 @@ export interface SortColumn {
 }
 
 export interface SelectOption {
-  label: string;
+  label: ReactNode;
   value: any;
+  [key: string]: unknown;
 }
 
 export interface CardSortSelectOption {
@@ -59,6 +60,7 @@ export interface ListViewFilter {
     page: number,
     pageSize: number,
   ) => Promise<{ data: SelectOption[]; totalCount: number }>;
+  optionFilterProps?: string[];
   paginate?: boolean;
   loading?: boolean;
   dateFilterValueType?: 'unix' | 'iso';
@@ -81,7 +83,7 @@ export type InnerFilterValue =
   | undefined
   | string[]
   | number[]
-  | { label: string; value: string | number }
+  | { label: ReactNode; value: string | number }
   | [number | null, number | null];
 
 export interface ListViewFilterValue {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/hooks/useAccessOptions.ts
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/hooks/useAccessOptions.ts
@@ -22,6 +22,7 @@ import rison from 'rison';
 import {
   OwnerSelectLabel,
   OWNER_TEXT_LABEL_PROP,
+  OWNER_EMAIL_PROP,
 } from 'src/features/owners/OwnerSelectLabel';
 
 /**
@@ -46,16 +47,17 @@ export const useAccessOptions = () => {
             (item: {
               value: number;
               text: string;
-              extra: { username?: string };
+              extra: { email?: string };
             }) => {
               if (accessType === 'owners') {
                 return {
                   value: item.value,
                   label: OwnerSelectLabel({
                     name: item.text,
-                    username: item.extra?.username,
+                    email: item.extra?.email,
                   }),
                   [OWNER_TEXT_LABEL_PROP]: item.text,
+                  [OWNER_EMAIL_PROP]: item.extra?.email ?? '',
                 };
               }
               return {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/hooks/useAccessOptions.ts
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/hooks/useAccessOptions.ts
@@ -19,6 +19,10 @@
 import { useCallback } from 'react';
 import { SupersetClient } from '@superset-ui/core';
 import rison from 'rison';
+import {
+  OwnerSelectLabel,
+  OWNER_TEXT_LABEL_PROP,
+} from 'src/features/owners/OwnerSelectLabel';
 
 /**
  * Hook for loading dashboard access options (owners and roles)
@@ -38,10 +42,28 @@ export const useAccessOptions = () => {
           .filter((item: { extra: { active: boolean } }) =>
             item.extra.active !== undefined ? item.extra.active : true,
           )
-          .map((item: { value: number; text: string }) => ({
-            value: item.value,
-            label: item.text,
-          })),
+          .map(
+            (item: {
+              value: number;
+              text: string;
+              extra: { username?: string };
+            }) => {
+              if (accessType === 'owners') {
+                return {
+                  value: item.value,
+                  label: OwnerSelectLabel({
+                    name: item.text,
+                    username: item.extra?.username,
+                  }),
+                  [OWNER_TEXT_LABEL_PROP]: item.text,
+                };
+              }
+              return {
+                value: item.value,
+                label: item.text,
+              };
+            },
+          ),
         totalCount: response.json.count,
       }));
     },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -80,7 +80,7 @@ type Owners = {
   full_name?: string;
   first_name?: string;
   last_name?: string;
-  username?: string;
+  email?: string;
 }[];
 type DashboardInfo = {
   id: number;

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -38,6 +38,7 @@ import {
 } from '@superset-ui/core';
 
 import withToasts from 'src/components/MessageToasts/withToasts';
+import { OWNER_TEXT_LABEL_PROP } from 'src/features/owners/OwnerSelectLabel';
 import { fetchTags, OBJECT_TYPES } from 'src/features/tags/tags';
 import {
   applyColors,
@@ -79,6 +80,7 @@ type Owners = {
   full_name?: string;
   first_name?: string;
   last_name?: string;
+  username?: string;
 }[];
 type DashboardInfo = {
   id: number;
@@ -240,10 +242,15 @@ const PropertiesModal = ({
     }
   };
 
-  const handleOnChangeOwners = (owners: { value: number; label: string }[]) => {
-    const parsedOwners: Owners = ensureIsArray(owners).map(o => ({
+  const handleOnChangeOwners = (
+    owners: { value: number; label: string }[],
+    options: Record<string, unknown>[],
+  ) => {
+    const parsedOwners: Owners = ensureIsArray(owners).map((o, i) => ({
       id: o.value,
-      full_name: o.label,
+      full_name:
+        (options?.[i]?.[OWNER_TEXT_LABEL_PROP] as string) ||
+        (typeof o.label === 'string' ? o.label : ''),
     }));
     setOwners(parsedOwners);
   };

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -38,7 +38,10 @@ import {
 } from '@superset-ui/core';
 
 import withToasts from 'src/components/MessageToasts/withToasts';
-import { OWNER_TEXT_LABEL_PROP } from 'src/features/owners/OwnerSelectLabel';
+import {
+  OWNER_TEXT_LABEL_PROP,
+  OWNER_EMAIL_PROP,
+} from 'src/features/owners/OwnerSelectLabel';
 import { fetchTags, OBJECT_TYPES } from 'src/features/tags/tags';
 import {
   applyColors,
@@ -251,6 +254,7 @@ const PropertiesModal = ({
       full_name:
         (options?.[i]?.[OWNER_TEXT_LABEL_PROP] as string) ||
         (typeof o.label === 'string' ? o.label : ''),
+      email: (options?.[i]?.[OWNER_EMAIL_PROP] as string) || '',
     }));
     setOwners(parsedOwners);
   };

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/AccessSection.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/AccessSection.tsx
@@ -28,6 +28,7 @@ import { ModalFormField } from 'src/components/Modal';
 import {
   OwnerSelectLabel,
   OWNER_TEXT_LABEL_PROP,
+  OWNER_EMAIL_PROP,
   OWNER_OPTION_FILTER_PROPS,
 } from 'src/features/owners/OwnerSelectLabel';
 import { useAccessOptions } from '../hooks/useAccessOptions';
@@ -38,7 +39,7 @@ type Owners = {
   full_name?: string;
   first_name?: string;
   last_name?: string;
-  username?: string;
+  email?: string;
 }[];
 
 interface AccessSectionProps {
@@ -69,13 +70,14 @@ const AccessSection = ({
 
   const ownersSelectValue = useMemo(
     () =>
-      (owners || []).map((owner: Owner & { username?: string }) => ({
+      (owners || []).map((owner: Owner & { email?: string }) => ({
         value: owner.id,
         label: OwnerSelectLabel({
           name: getOwnerName(owner),
-          username: owner.username,
+          email: owner.email,
         }),
         [OWNER_TEXT_LABEL_PROP]: getOwnerName(owner),
+        [OWNER_EMAIL_PROP]: owner.email ?? '',
       })),
     [owners],
   );

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/AccessSection.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/AccessSection.tsx
@@ -25,6 +25,11 @@ import { loadTags } from 'src/components/Tag/utils';
 import getOwnerName from 'src/utils/getOwnerName';
 import Owner from 'src/types/Owner';
 import { ModalFormField } from 'src/components/Modal';
+import {
+  OwnerSelectLabel,
+  OWNER_TEXT_LABEL_PROP,
+  OWNER_OPTION_FILTER_PROPS,
+} from 'src/features/owners/OwnerSelectLabel';
 import { useAccessOptions } from '../hooks/useAccessOptions';
 
 type Roles = { id: number; name: string }[];
@@ -33,6 +38,7 @@ type Owners = {
   full_name?: string;
   first_name?: string;
   last_name?: string;
+  username?: string;
 }[];
 
 interface AccessSectionProps {
@@ -40,7 +46,10 @@ interface AccessSectionProps {
   owners: Owners;
   roles: Roles;
   tags: TagType[];
-  onChangeOwners: (owners: { value: number; label: string }[]) => void;
+  onChangeOwners: (
+    owners: { value: number; label: string }[],
+    options: Record<string, unknown>[],
+  ) => void;
   onChangeRoles: (roles: { value: number; label: string }[]) => void;
   onChangeTags: (tags: { label: string; value: number }[]) => void;
   onClearTags: () => void;
@@ -60,9 +69,13 @@ const AccessSection = ({
 
   const ownersSelectValue = useMemo(
     () =>
-      (owners || []).map((owner: Owner) => ({
+      (owners || []).map((owner: Owner & { username?: string }) => ({
         value: owner.id,
-        label: getOwnerName(owner),
+        label: OwnerSelectLabel({
+          name: getOwnerName(owner),
+          username: owner.username,
+        }),
+        [OWNER_TEXT_LABEL_PROP]: getOwnerName(owner),
       })),
     [owners],
   );
@@ -107,6 +120,7 @@ const AccessSection = ({
           value={ownersSelectValue}
           showSearch
           placeholder={t('Search owners')}
+          optionFilterProps={OWNER_OPTION_FILTER_PROPS}
         />
       </ModalFormField>
       {isFeatureEnabled(FeatureFlag.DashboardRbac) && (

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -40,6 +40,7 @@ import { type TagType } from 'src/components';
 import {
   OwnerSelectLabel,
   OWNER_TEXT_LABEL_PROP,
+  OWNER_EMAIL_PROP,
   OWNER_OPTION_FILTER_PROPS,
 } from 'src/features/owners/OwnerSelectLabel';
 import { TagTypeEnum } from 'src/components/Tag/TagType';
@@ -158,7 +159,7 @@ function PropertiesModal({
           'owners.id',
           'owners.first_name',
           'owners.last_name',
-          'owners.username',
+          'owners.email',
           'tags.id',
           'tags.name',
           'tags.type',
@@ -175,16 +176,17 @@ function PropertiesModal({
               id: number;
               first_name: string;
               last_name: string;
-              username?: string;
+              email?: string;
             }) => {
               const ownerName = `${owner.first_name} ${owner.last_name}`;
               return {
                 value: owner.id,
                 label: OwnerSelectLabel({
                   name: ownerName,
-                  username: owner.username,
+                  email: owner.email,
                 }),
                 [OWNER_TEXT_LABEL_PROP]: ownerName,
+                [OWNER_EMAIL_PROP]: owner.email ?? '',
               };
             },
           ),
@@ -215,21 +217,20 @@ function PropertiesModal({
           endpoint: `/api/v1/chart/related/owners?q=${query}`,
         }).then(response => ({
           data: response.json.result
-            .filter(
-              (item: { extra: { active: boolean } }) => item.extra.active,
-            )
+            .filter((item: { extra: { active: boolean } }) => item.extra.active)
             .map(
               (item: {
                 value: number;
                 text: string;
-                extra: { username?: string };
+                extra: { email?: string };
               }) => ({
                 value: item.value,
                 label: OwnerSelectLabel({
                   name: item.text,
-                  username: item.extra?.username,
+                  email: item.extra?.email,
                 }),
                 [OWNER_TEXT_LABEL_PROP]: item.text,
+                [OWNER_EMAIL_PROP]: item.extra?.email ?? '',
               }),
             ),
           totalCount: response.json.count,

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1956,7 +1956,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               label: (resource.database as DatabaseObject).database_name,
             }
           : undefined,
-        owners: (alert?.owners || []).map(owner => {
+        owners: (resource.owners || []).map(owner => {
           const ownerName =
             (owner as MetaObject).label ||
             `${(owner as Owner).first_name} ${(owner as Owner).last_name}`;

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -42,6 +42,7 @@ import Owner from 'src/types/Owner';
 import {
   OwnerSelectLabel,
   OWNER_TEXT_LABEL_PROP,
+  OWNER_EMAIL_PROP,
   OWNER_OPTION_FILTER_PROPS,
 } from 'src/features/owners/OwnerSelectLabel';
 // import { Form as AntdForm } from 'src/components/Form';
@@ -988,14 +989,15 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
             (item: {
               value: number;
               text: string;
-              extra: { username?: string };
+              extra: { email?: string };
             }) => ({
               value: item.value,
               label: OwnerSelectLabel({
                 name: item.text,
-                username: item.extra?.username,
+                email: item.extra?.email,
               }),
               [OWNER_TEXT_LABEL_PROP]: item.text,
+              [OWNER_EMAIL_PROP]: item.extra?.email ?? '',
             }),
           ),
           totalCount: response.json.count,
@@ -1865,9 +1867,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 value: currentUser.userId,
                 label: OwnerSelectLabel({
                   name: `${currentUser.firstName} ${currentUser.lastName}`,
-                  username: currentUser.username,
+                  email: currentUser.email,
                 }),
                 [OWNER_TEXT_LABEL_PROP]: `${currentUser.firstName} ${currentUser.lastName}`,
+                [OWNER_EMAIL_PROP]: currentUser.email ?? '',
               },
             ]
           : [],
@@ -1961,10 +1964,11 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
             value: (owner as MetaObject).value || owner.id,
             label: OwnerSelectLabel({
               name: typeof ownerName === 'string' ? ownerName : '',
-              username: (owner as Owner).username,
+              email: (owner as Owner).email,
             }),
             [OWNER_TEXT_LABEL_PROP]:
               typeof ownerName === 'string' ? ownerName : '',
+            [OWNER_EMAIL_PROP]: (owner as Owner).email ?? '',
           };
         }),
         validator_config_json:

--- a/superset-frontend/src/features/alerts/types.ts
+++ b/superset-frontend/src/features/alerts/types.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import type { ReactNode } from 'react';
 import Owner from 'src/types/Owner';
 import { NotificationFormats } from 'src/features/reports/types';
 
@@ -85,8 +86,9 @@ export type Recipient = {
 
 export type MetaObject = {
   id?: number;
-  label?: string;
+  label?: ReactNode;
   value?: number | string;
+  [key: string]: unknown;
 };
 
 export type DashboardState = {

--- a/superset-frontend/src/features/owners/OwnerSelectLabel/OwnerSelectLabel.test.tsx
+++ b/superset-frontend/src/features/owners/OwnerSelectLabel/OwnerSelectLabel.test.tsx
@@ -19,19 +19,19 @@
 import { render, screen } from 'spec/helpers/testing-library';
 import { OwnerSelectLabel } from '.';
 
-test('renders name and username', () => {
-  render(OwnerSelectLabel({ name: 'John Doe', username: 'jdoe' }));
+test('renders name and email', () => {
+  render(OwnerSelectLabel({ name: 'John Doe', email: 'jdoe@example.com' }));
   expect(screen.getByText('John Doe')).toBeInTheDocument();
-  expect(screen.getByText('jdoe')).toBeInTheDocument();
+  expect(screen.getByText('jdoe@example.com')).toBeInTheDocument();
 });
 
-test('renders only name when username is undefined', () => {
+test('renders only name when email is undefined', () => {
   render(OwnerSelectLabel({ name: 'Jane Smith' }));
   expect(screen.getByText('Jane Smith')).toBeInTheDocument();
 });
 
-test('renders only name when username is empty string', () => {
-  render(OwnerSelectLabel({ name: 'Jane Smith', username: '' }));
+test('renders only name when email is empty string', () => {
+  render(OwnerSelectLabel({ name: 'Jane Smith', email: '' }));
   expect(screen.getByText('Jane Smith')).toBeInTheDocument();
   const container = screen.getByText('Jane Smith').parentElement;
   expect(container?.children).toHaveLength(1);

--- a/superset-frontend/src/features/owners/OwnerSelectLabel/OwnerSelectLabel.test.tsx
+++ b/superset-frontend/src/features/owners/OwnerSelectLabel/OwnerSelectLabel.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from 'spec/helpers/testing-library';
+import { OwnerSelectLabel } from '.';
+
+test('renders name and username', () => {
+  render(OwnerSelectLabel({ name: 'John Doe', username: 'jdoe' }));
+  expect(screen.getByText('John Doe')).toBeInTheDocument();
+  expect(screen.getByText('jdoe')).toBeInTheDocument();
+});
+
+test('renders only name when username is undefined', () => {
+  render(OwnerSelectLabel({ name: 'Jane Smith' }));
+  expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+});
+
+test('renders only name when username is empty string', () => {
+  render(OwnerSelectLabel({ name: 'Jane Smith', username: '' }));
+  expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+  const container = screen.getByText('Jane Smith').parentElement;
+  expect(container?.children).toHaveLength(1);
+});

--- a/superset-frontend/src/features/owners/OwnerSelectLabel/index.tsx
+++ b/superset-frontend/src/features/owners/OwnerSelectLabel/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { styled } from '@apache-superset/core/ui';
+
+const StyledLabelContainer = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+`;
+
+const StyledLabel = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+`;
+
+const StyledLabelDetail = styled.span`
+  ${({ theme: { fontSizeSM, colorTextSecondary } }) => `
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: ${fontSizeSM}px;
+    color: ${colorTextSecondary};
+    line-height: 1.6;
+    display: block;
+  `}
+`;
+
+export const OWNER_TEXT_LABEL_PROP = 'textLabel';
+export const OWNER_OPTION_FILTER_PROPS = [OWNER_TEXT_LABEL_PROP];
+
+export const OwnerSelectLabel = ({
+  name,
+  username,
+}: {
+  name: string;
+  username?: string;
+}) => (
+  <StyledLabelContainer>
+    <StyledLabel>{name}</StyledLabel>
+    {username && <StyledLabelDetail>{username}</StyledLabelDetail>}
+  </StyledLabelContainer>
+);

--- a/superset-frontend/src/features/owners/OwnerSelectLabel/index.tsx
+++ b/superset-frontend/src/features/owners/OwnerSelectLabel/index.tsx
@@ -42,17 +42,18 @@ const StyledLabelDetail = styled.span`
 `;
 
 export const OWNER_TEXT_LABEL_PROP = 'textLabel';
-export const OWNER_OPTION_FILTER_PROPS = [OWNER_TEXT_LABEL_PROP];
+export const OWNER_EMAIL_PROP = 'ownerEmail';
+export const OWNER_OPTION_FILTER_PROPS = [OWNER_TEXT_LABEL_PROP, OWNER_EMAIL_PROP];
 
 export const OwnerSelectLabel = ({
   name,
-  username,
+  email,
 }: {
   name: string;
-  username?: string;
+  email?: string;
 }) => (
   <StyledLabelContainer>
     <StyledLabel>{name}</StyledLabel>
-    {username && <StyledLabelDetail>{username}</StyledLabelDetail>}
+    {email && <StyledLabelDetail>{email}</StyledLabelDetail>}
   </StyledLabelContainer>
 );

--- a/superset-frontend/src/features/owners/OwnerSelectLabel/index.tsx
+++ b/superset-frontend/src/features/owners/OwnerSelectLabel/index.tsx
@@ -43,7 +43,10 @@ const StyledLabelDetail = styled.span`
 
 export const OWNER_TEXT_LABEL_PROP = 'textLabel';
 export const OWNER_EMAIL_PROP = 'ownerEmail';
-export const OWNER_OPTION_FILTER_PROPS = [OWNER_TEXT_LABEL_PROP, OWNER_EMAIL_PROP];
+export const OWNER_OPTION_FILTER_PROPS = [
+  OWNER_TEXT_LABEL_PROP,
+  OWNER_EMAIL_PROP,
+];
 
 export const OwnerSelectLabel = ({
   name,

--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -53,7 +53,12 @@ import {
   useListViewResource,
   useSingleViewResource,
 } from 'src/views/CRUD/hooks';
-import { createErrorHandler, createFetchRelated } from 'src/views/CRUD/utils';
+import {
+  createErrorHandler,
+  createFetchRelated,
+  createFetchOwners,
+} from 'src/views/CRUD/utils';
+import { OWNER_OPTION_FILTER_PROPS } from 'src/features/owners/OwnerSelectLabel';
 import { isUserAdmin } from 'src/dashboard/util/permissionUtils';
 import Owner from 'src/types/Owner';
 import AlertReportModal from 'src/features/alerts/AlertReportModal';
@@ -480,14 +485,14 @@ function AlertList({
         input: 'select',
         operator: FilterOperator.RelationManyMany,
         unfilteredLabel: t('All'),
-        fetchSelects: createFetchRelated(
+        fetchSelects: createFetchOwners(
           'report',
-          'owners',
           createErrorHandler(errMsg =>
             t('An error occurred while fetching owners values: %s', errMsg),
           ),
           user,
         ),
+        optionFilterProps: OWNER_OPTION_FILTER_PROPS,
         paginate: true,
         dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -33,8 +33,10 @@ import { useSelector } from 'react-redux';
 import {
   createErrorHandler,
   createFetchRelated,
+  createFetchOwners,
   handleChartDelete,
 } from 'src/views/CRUD/utils';
+import { OWNER_OPTION_FILTER_PROPS } from 'src/features/owners/OwnerSelectLabel';
 import {
   useChartEditModal,
   useFavoriteStatus,
@@ -676,9 +678,8 @@ function ChartList(props: ChartListProps) {
         input: 'select',
         operator: FilterOperator.RelationManyMany,
         unfilteredLabel: t('All'),
-        fetchSelects: createFetchRelated(
+        fetchSelects: createFetchOwners(
           'chart',
-          'owners',
           createErrorHandler(errMsg =>
             addDangerToast(
               t(
@@ -689,6 +690,7 @@ function ChartList(props: ChartListProps) {
           ),
           props.user,
         ),
+        optionFilterProps: OWNER_OPTION_FILTER_PROPS,
         paginate: true,
         dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -29,9 +29,11 @@ import { Link } from 'react-router-dom';
 import rison from 'rison';
 import {
   createFetchRelated,
+  createFetchOwners,
   createErrorHandler,
   handleDashboardDelete,
 } from 'src/views/CRUD/utils';
+import { OWNER_OPTION_FILTER_PROPS } from 'src/features/owners/OwnerSelectLabel';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
 import {
   CertifiedBadge,
@@ -582,9 +584,8 @@ function DashboardList(props: DashboardListProps) {
         input: 'select',
         operator: FilterOperator.RelationManyMany,
         unfilteredLabel: t('All'),
-        fetchSelects: createFetchRelated(
+        fetchSelects: createFetchOwners(
           'dashboard',
-          'owners',
           createErrorHandler(errMsg =>
             addDangerToast(
               t(
@@ -595,6 +596,7 @@ function DashboardList(props: DashboardListProps) {
           ),
           props.user,
         ),
+        optionFilterProps: OWNER_OPTION_FILTER_PROPS,
         paginate: true,
         dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -25,8 +25,10 @@ import rison from 'rison';
 import {
   createFetchRelated,
   createFetchDistinct,
+  createFetchOwners,
   createErrorHandler,
 } from 'src/views/CRUD/utils';
+import { OWNER_OPTION_FILTER_PROPS } from 'src/features/owners/OwnerSelectLabel';
 import { ColumnObject } from 'src/features/datasets/types';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import {
@@ -579,9 +581,8 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         input: 'select',
         operator: FilterOperator.RelationManyMany,
         unfilteredLabel: 'All',
-        fetchSelects: createFetchRelated(
+        fetchSelects: createFetchOwners(
           'dataset',
-          'owners',
           createErrorHandler(errMsg =>
             t(
               'An error occurred while fetching dataset owner values: %s',
@@ -590,6 +591,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           ),
           user,
         ),
+        optionFilterProps: OWNER_OPTION_FILTER_PROPS,
         paginate: true,
         dropdownStyle: { minWidth: WIDER_DROPDOWN_WIDTH },
       },

--- a/superset-frontend/src/types/Owner.ts
+++ b/superset-frontend/src/types/Owner.ts
@@ -26,4 +26,5 @@ export default interface Owner {
   id: number;
   last_name?: string;
   full_name?: string;
+  username?: string;
 }

--- a/superset-frontend/src/types/Owner.ts
+++ b/superset-frontend/src/types/Owner.ts
@@ -26,5 +26,5 @@ export default interface Owner {
   id: number;
   last_name?: string;
   full_name?: string;
-  username?: string;
+  email?: string;
 }

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -282,6 +282,7 @@ export const createFetchOwners = (
         return {
           label: OwnerSelectLabel({ name: item.label, email }),
           value: item.value,
+          title: item.label,
           [OWNER_TEXT_LABEL_PROP]: item.label,
           [OWNER_EMAIL_PROP]: email ?? '',
         };

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -36,6 +36,11 @@ import SupersetText from 'src/utils/textUtils';
 import { findPermission } from 'src/utils/findPermission';
 import { User } from 'src/types/bootstrapTypes';
 import { RecentActivity, WelcomeTable } from 'src/features/home/types';
+import {
+  OwnerSelectLabel,
+  OWNER_TEXT_LABEL_PROP,
+  OWNER_EMAIL_PROP,
+} from 'src/features/owners/OwnerSelectLabel';
 import { Dashboard, Filter, TableTab } from './types';
 
 // Modifies the rison encoding slightly to match the backend's rison encoding/decoding. Applies globally.
@@ -91,6 +96,7 @@ const createFetchResourceMethod =
     });
 
     let fetchedLoggedUser = false;
+    let loggedUserExtra: Record<string, unknown> | undefined;
     const loggedUser = user
       ? {
           label: `${user.firstName} ${user.lastName}`,
@@ -98,26 +104,42 @@ const createFetchResourceMethod =
         }
       : undefined;
 
-    const data: { label: string; value: string | number }[] = [];
+    const data: {
+      label: string;
+      value: string | number;
+      extra?: Record<string, unknown>;
+    }[] = [];
     json?.result
       ?.filter(({ text }: { text: string }) => text.trim().length > 0)
-      .forEach(({ text, value }: { text: string; value: string | number }) => {
-        if (
-          loggedUser &&
-          value === loggedUser.value &&
-          text === loggedUser.label
-        ) {
-          fetchedLoggedUser = true;
-        } else {
-          data.push({
-            label: text,
-            value,
-          });
-        }
-      });
+      .forEach(
+        ({
+          text,
+          value,
+          extra,
+        }: {
+          text: string;
+          value: string | number;
+          extra?: Record<string, unknown>;
+        }) => {
+          if (
+            loggedUser &&
+            value === loggedUser.value &&
+            text === loggedUser.label
+          ) {
+            fetchedLoggedUser = true;
+            loggedUserExtra = extra;
+          } else {
+            data.push({
+              label: text,
+              value,
+              extra,
+            });
+          }
+        },
+      );
 
     if (loggedUser && (!filterValue || fetchedLoggedUser)) {
-      data.unshift(loggedUser);
+      data.unshift({ ...loggedUser, extra: loggedUserExtra });
     }
 
     return {
@@ -239,6 +261,34 @@ export const getRecentActivityObjs = (
 
 export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');
+
+export const createFetchOwners = (
+  resource: string,
+  handleError: (error: Response) => void,
+  user?: { userId: string | number; firstName: string; lastName: string },
+) => {
+  const fetchRelated = createFetchRelated(
+    resource,
+    'owners',
+    handleError,
+    user,
+  );
+  return async (filterValue = '', page: number, pageSize: number) => {
+    const result = await fetchRelated(filterValue, page, pageSize);
+    return {
+      ...result,
+      data: result.data.map(item => {
+        const email = item.extra?.email as string | undefined;
+        return {
+          label: OwnerSelectLabel({ name: item.label, email }),
+          value: item.value,
+          [OWNER_TEXT_LABEL_PROP]: item.label,
+          [OWNER_EMAIL_PROP]: email ?? '',
+        };
+      }),
+    };
+  };
+};
 
 export function createErrorHandler(
   handleErrorFunc: (

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -167,6 +167,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "owners.first_name",
         "owners.id",
         "owners.last_name",
+        "owners.username",
         "dashboards.id",
         "dashboards.dashboard_title",
         "params",

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -167,7 +167,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "owners.first_name",
         "owners.id",
         "owners.last_name",
-        "owners.username",
+        "owners.email",
         "dashboards.id",
         "dashboards.dashboard_title",
         "params",

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1671,7 +1671,7 @@ class UserSchema(Schema):
     id = fields.Int()
     first_name = fields.String()
     last_name = fields.String()
-    username = fields.String()
+    email = fields.String()
 
 
 class DashboardSchema(Schema):

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1671,6 +1671,7 @@ class UserSchema(Schema):
     id = fields.Int()
     first_name = fields.String()
     last_name = fields.String()
+    username = fields.String()
 
 
 class DashboardSchema(Schema):

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -197,7 +197,7 @@ BASE_LIST_COLUMNS = [
     "owners.id",
     "owners.first_name",
     "owners.last_name",
-    "owners.username",
+    "owners.email",
     "roles.id",
     "roles.name",
     "is_managed_externally",

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -197,6 +197,7 @@ BASE_LIST_COLUMNS = [
     "owners.id",
     "owners.first_name",
     "owners.last_name",
+    "owners.username",
     "roles.id",
     "roles.name",
     "is_managed_externally",

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -414,6 +414,7 @@ class DatasetColumnDrillInfoSchema(Schema):
 class UserSchema(Schema):
     first_name = fields.String()
     last_name = fields.String()
+    username = fields.String()
 
 
 class DatasetDrillInfoSchema(Schema):

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -414,7 +414,7 @@ class DatasetColumnDrillInfoSchema(Schema):
 class UserSchema(Schema):
     first_name = fields.String()
     last_name = fields.String()
-    username = fields.String()
+    email = fields.String()
 
 
 class DatasetDrillInfoSchema(Schema):

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -83,8 +83,8 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     allow_browser_login = True
 
     extra_fields_rel_fields = {
-        "owners": ["email", "active", "username"],
-        "created_by": ["email", "active", "username"],
+        **BaseSupersetModelRestApi.extra_fields_rel_fields,
+        "created_by": ["email", "active"],
     }
 
     base_filters = [
@@ -118,7 +118,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "owners.first_name",
         "owners.id",
         "owners.last_name",
-        "owners.username",
+        "owners.email",
         "recipients.id",
         "recipients.recipient_config_json",
         "recipients.type",
@@ -158,7 +158,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "owners.first_name",
         "owners.id",
         "owners.last_name",
-        "owners.username",
+        "owners.email",
         "recipients.id",
         "recipients.type",
         "timezone",

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -82,6 +82,11 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     resource_name = "report"
     allow_browser_login = True
 
+    extra_fields_rel_fields = {
+        "owners": ["email", "active", "username"],
+        "created_by": ["email", "active", "username"],
+    }
+
     base_filters = [
         ["id", ReportScheduleFilter, lambda: []],
     ]
@@ -113,6 +118,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "owners.first_name",
         "owners.id",
         "owners.last_name",
+        "owners.username",
         "recipients.id",
         "recipients.recipient_config_json",
         "recipients.type",
@@ -152,6 +158,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "owners.first_name",
         "owners.id",
         "owners.last_name",
+        "owners.username",
         "recipients.id",
         "recipients.type",
         "timezone",

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -324,9 +324,7 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         }
     """
 
-    extra_fields_rel_fields: dict[str, list[str]] = {
-        "owners": ["email", "active", "username"]
-    }
+    extra_fields_rel_fields: dict[str, list[str]] = {"owners": ["email", "active"]}
     """
     Declare extra fields for the representation of the Model object::
 

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -324,7 +324,9 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         }
     """
 
-    extra_fields_rel_fields: dict[str, list[str]] = {"owners": ["email", "active"]}
+    extra_fields_rel_fields: dict[str, list[str]] = {
+        "owners": ["email", "active", "username"]
+    }
     """
     Declare extra fields for the representation of the Model object::
 

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1035,6 +1035,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
                     "id": 1,
                     "first_name": "admin",
                     "last_name": "user",
+                    "email": "admin@fab.org",
                 }
             ],
             "params": None,

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -301,12 +301,18 @@ class TestReportSchedulesApi(SupersetTestCase):
         for key in expected_result:
             assert data["result"][key] == expected_result[key]
         # needed because order may vary
-        assert {"first_name": "admin", "id": 1, "last_name": "user"} in data["result"][
-            "owners"
-        ]
-        assert {"first_name": "alpha", "id": 5, "last_name": "user"} in data["result"][
-            "owners"
-        ]
+        assert {
+            "email": "admin@fab.org",
+            "first_name": "admin",
+            "id": 1,
+            "last_name": "user",
+        } in data["result"]["owners"]
+        assert {
+            "email": "alpha@fab.org",
+            "first_name": "alpha",
+            "id": 5,
+            "last_name": "user",
+        } in data["result"]["owners"]
         assert len(data["result"]["owners"]) == 2
 
     def test_info_report_schedule(self):
@@ -382,7 +388,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         assert expected_fields == data_keys
 
         # Assert nested fields
-        expected_owners_fields = ["first_name", "id", "last_name"]
+        expected_owners_fields = ["email", "first_name", "id", "last_name"]
         data_keys = sorted(list(data["result"][0]["owners"][0].keys()))  # noqa: C414
         assert expected_owners_fields == data_keys
 


### PR DESCRIPTION
### SUMMARY

Adds owner email as secondary text beneath the owner name in all owner selector dropdowns across the application. Users can also search for owners by email in addition to name. This makes it easier to distinguish between owners who may share similar names and find the right person quickly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1100" height="392" alt="Screenshot 2026-02-12 at 10 54 32" src="https://github.com/user-attachments/assets/02eee13f-2109-4f6c-8cae-7c1f4acb04c2" />
<img width="497" height="632" alt="Screenshot 2026-02-12 at 10 54 48" src="https://github.com/user-attachments/assets/696d22d7-21f5-4e06-af90-05b026d305e9" />


### TESTING INSTRUCTIONS

1. **Dashboard list** — Click the "Owner" filter dropdown. Verify owners show name + email, and you can search by email.
2. **Dashboard properties modal** — Edit a dashboard, check the Owners selector shows email beneath each name.
3. **Chart properties modal** — Edit a chart, verify the Owners selector shows email.
4. **Dataset editor** — Edit a dataset, verify the Owners selector shows email.
5. **Alert/Report modal** — Create or edit an alert/report, verify the Owners selector shows email, including for the current logged-in user.
6. **Chart list / Dataset list / Alert list** — Check owner filter dropdowns all show email and support email search.
7. **URL persistence** — Select an owner filter in a list view, verify the page reloads correctly with the filter preserved in the URL (no circular JSON errors).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
