### PR TITLE
chore(deps): Update sqlalchemy-utils to 0.42.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dependencies = [
     "simplejson>=3.15.0",
     "slack_sdk>=3.19.0, <4",
     "sqlalchemy>=1.4, <2",
-    "sqlalchemy-utils>=0.38.3, <0.39",
+    "sqlalchemy-utils>=0.42.0, <0.43",
     "sqlglot>=28.10.0, <29",
     # newer pandas needs 0.9+
     "tabulate>=0.9.0, <1.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -399,7 +399,7 @@ sqlalchemy==1.4.54
     #   marshmallow-sqlalchemy
     #   shillelagh
     #   sqlalchemy-utils
-sqlalchemy-utils==0.38.3
+sqlalchemy-utils==0.42.0
     # via
     #   apache-superset (pyproject.toml)
     #   apache-superset-core

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -990,7 +990,7 @@ sqlalchemy==1.4.54
     #   sqlalchemy-utils
 sqlalchemy-bigquery==1.15.0
     # via apache-superset
-sqlalchemy-utils==0.38.3
+sqlalchemy-utils==0.42.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/superset-core/pyproject.toml
+++ b/superset-core/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "flask-appbuilder>=5.0.2,<6",
     "pydantic>=2.8.0",
     "sqlalchemy>=1.4.0,<2.0",
-    "sqlalchemy-utils>=0.38.0",
+    "sqlalchemy-utils>=0.42.0",
     "sqlglot>=28.10.0, <29",
     "typing-extensions>=4.0.0",
 ]


### PR DESCRIPTION
## SUMMARY
Updates sqlalchemy-utils to version 0.42.0 (from 0.38.3).

This PR supersedes #36240 with resolved merge conflicts. Credit to @rad-pat for the original PR.

**Why this upgrade is needed:**
- Previous version 0.38.3 did not support Python 3.11 or 3.12
- Some database dialects require newer versions

**Changes in sqlalchemy-utils 0.38.3 → 0.42.0:**
- Added Python 3.11, 3.12, 3.13 support
- Added SQLAlchemy 2.0 compatibility
- Dropped Python 3.7/3.8 support (Superset requires 3.10+, so no impact)
- Dropped SQLAlchemy 1.3 support (Superset uses 1.4, so no impact)

The upgrade is safe for Superset as we only use stable types (UUIDType, EncryptedType).

Closes #36240

### TESTING INSTRUCTIONS
- CI covers database migrations and model operations that use sqlalchemy-utils types

### ADDITIONAL INFORMATION
- [x] Has associated issue: #36240
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Pat Buxton <patrick.buxton@tartansolutions.com>