### PR TITLE
fix(types): add explicit types for extendedDayjs plugin methods

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/dates.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/dates.ts
@@ -55,8 +55,8 @@ export interface ExtendedDayjs extends Dayjs {
 
 // Type for dayjs factory with all plugins loaded
 type DayjsWithPlugins = {
-  (config?: ConfigType, format?: string): ExtendedDayjs;
-  utc(config?: ConfigType, format?: string): ExtendedDayjs;
+  (config?: ConfigType, format?: string, strict?: boolean): ExtendedDayjs;
+  utc(config?: ConfigType, format?: string, strict?: boolean): ExtendedDayjs;
   tz: {
     (input?: ConfigType, timezone?: string): ExtendedDayjs;
     guess(): string;

--- a/superset-frontend/packages/superset-ui-core/src/utils/dates.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/dates.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs, { Dayjs, ConfigType } from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import calendar from 'dayjs/plugin/calendar';
@@ -40,8 +40,33 @@ dayjs.updateLocale('en', {
   invalidDate: 'Invalid date',
 });
 
-export const extendedDayjs = dayjs;
-export type { Dayjs };
+// Extended Dayjs instance type with plugin methods
+export interface ExtendedDayjs extends Dayjs {
+  utc(keepLocalTime?: boolean): ExtendedDayjs;
+  local(): ExtendedDayjs;
+  isUTC(): boolean;
+  tz(timezone?: string, keepLocalTime?: boolean): ExtendedDayjs;
+  fromNow(withoutSuffix?: boolean): string;
+  toNow(withoutSuffix?: boolean): string;
+  from(compared: ConfigType, withoutSuffix?: boolean): string;
+  to(compared: ConfigType, withoutSuffix?: boolean): string;
+  calendar(referenceTime?: ConfigType, formats?: object): string;
+}
+
+// Type for dayjs factory with all plugins loaded
+type DayjsWithPlugins = {
+  (config?: ConfigType, format?: string): ExtendedDayjs;
+  utc(config?: ConfigType, format?: string): ExtendedDayjs;
+  tz: {
+    (input?: ConfigType, timezone?: string): ExtendedDayjs;
+    guess(): string;
+    setDefault(timezone?: string): void;
+  };
+  updateLocale(locale: string, config: object): object;
+} & Omit<typeof dayjs, 'utc' | 'tz'>;
+
+export const extendedDayjs = dayjs as unknown as DayjsWithPlugins;
+export type { Dayjs, ConfigType };
 
 export const fDuration = function (
   t1: number,

--- a/superset-frontend/packages/superset-ui-core/src/utils/dates.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/dates.ts
@@ -40,28 +40,37 @@ dayjs.updateLocale('en', {
   invalidDate: 'Invalid date',
 });
 
-// Extended Dayjs instance type with plugin methods
+// Extended Dayjs instance type with plugin methods.
+// When extending dayjs with a new plugin, add its instance methods here.
 export interface ExtendedDayjs extends Dayjs {
+  // Derived from dayjs/plugin/utc
   utc(keepLocalTime?: boolean): ExtendedDayjs;
   local(): ExtendedDayjs;
   isUTC(): boolean;
+  // Derived from dayjs/plugin/timezone
   tz(timezone?: string, keepLocalTime?: boolean): ExtendedDayjs;
+  // Derived from dayjs/plugin/relativeTime
   fromNow(withoutSuffix?: boolean): string;
   toNow(withoutSuffix?: boolean): string;
   from(compared: ConfigType, withoutSuffix?: boolean): string;
   to(compared: ConfigType, withoutSuffix?: boolean): string;
+  // Derived from dayjs/plugin/calendar
   calendar(referenceTime?: ConfigType, formats?: object): string;
 }
 
-// Type for dayjs factory with all plugins loaded
+// Type for dayjs factory with all plugins loaded.
+// When extending dayjs with a new plugin, add its static methods here.
 type DayjsWithPlugins = {
   (config?: ConfigType, format?: string, strict?: boolean): ExtendedDayjs;
+  // Derived from dayjs/plugin/utc
   utc(config?: ConfigType, format?: string, strict?: boolean): ExtendedDayjs;
+  // Derived from dayjs/plugin/timezone
   tz: {
     (input?: ConfigType, timezone?: string): ExtendedDayjs;
     guess(): string;
     setDefault(timezone?: string): void;
   };
+  // Derived from dayjs/plugin/updateLocale
   updateLocale(locale: string, config: object): object;
 } & Omit<typeof dayjs, 'utc' | 'tz'>;
 


### PR DESCRIPTION
## Summary

The `extendedDayjs` export was typed as `typeof dayjs` which didn't include the plugin methods (`utc`, `tz`, `local`, `fromNow`, etc.) added at runtime via `dayjs.extend()`. This caused TS2339 errors in consuming code:

```
Property 'utc' does not exist on type 'typeof import(".../dayjs/index.d.ts")'.
Property 'local' does not exist on type 'Dayjs'.
```

## Solution

Added minimal type definitions for the plugin methods:

**`ExtendedDayjs` interface** - instance methods:
- `utc()`, `local()`, `isUTC()` (utc plugin)
- `tz()` (timezone plugin)
- `fromNow()`, `toNow()`, `from()`, `to()` (relativeTime plugin)
- `calendar()` (calendar plugin)

**`DayjsWithPlugins` type** - factory/static methods:
- `utc()`, `tz()`, `updateLocale()`

Note: The dayjs plugin types use module augmentation, but this only works when consumers directly import the plugins. Since we export a pre-extended `extendedDayjs`, consumers need these explicit types.

## Test plan

- [x] Pre-commit type checking passes on previously failing files
- [x] `npm run plugins:build` succeeds
- [x] Method chaining works with proper types (e.g., `extendedDayjs.utc().local().fromNow()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)