### PR TITLE
fix(dataset): resolve duplicate virtual dataset validation error

### DIFF
--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -181,6 +181,7 @@ class TestDatasetApi(SupersetTestCase):
                         [admin.id],
                         main_db,
                         "SELECT * from ab_view_menu;",
+                        catalog=main_db.get_default_catalog(),
                     )
                 )
             yield datasets

--- a/tests/unit_tests/commands/dataset/test_duplicate.py
+++ b/tests/unit_tests/commands/dataset/test_duplicate.py
@@ -14,14 +14,26 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Unit tests for per-object access check in DuplicateDatasetCommand."""
+"""Unit tests for DuplicateDatasetCommand.
 
-from unittest.mock import MagicMock, patch
+Covers both the per-object access check and the virtual dataset
+duplication/validation behavior (including catalog handling).
+"""
+
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from sqlalchemy.orm.session import Session
 
-from superset.commands.dataset.exceptions import DatasetAccessDeniedError
+from superset.commands.dataset.duplicate import DuplicateDatasetCommand
+from superset.commands.dataset.exceptions import (
+    DatasetAccessDeniedError,
+    DatasetExistsValidationError,
+    DatasetInvalidError,
+    DatasetNotFoundError,
+)
+from superset.commands.exceptions import DatasourceTypeInvalidError
+from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetSecurityException
 
@@ -39,8 +51,6 @@ def _security_exception() -> SupersetSecurityException:
 def test_duplicate_dataset_forbidden_when_no_access() -> None:
     """DuplicateDatasetCommand.validate() must raise DatasetAccessDeniedError
     when the caller lacks read access to the source dataset."""
-    from superset.commands.dataset.duplicate import DuplicateDatasetCommand
-
     mock_dataset = MagicMock()
     mock_dataset.id = 1
     mock_dataset.kind = "virtual"
@@ -71,8 +81,6 @@ def test_duplicate_dataset_forbidden_when_no_access() -> None:
 def test_duplicate_dataset_access_check_passes_through() -> None:
     """DuplicateDatasetCommand.validate() must not raise DatasetAccessDeniedError
     when security_manager.raise_for_access() does not raise."""
-    from superset.commands.dataset.duplicate import DuplicateDatasetCommand
-
     mock_dataset = MagicMock()
     mock_dataset.id = 1
     mock_dataset.kind = "virtual"
@@ -118,9 +126,6 @@ def test_duplicate_dataset_blocked_by_soft_deleted_twin(session: Session) -> Non
     from datetime import datetime, timezone
 
     from superset import db
-    from superset.commands.dataset.duplicate import DuplicateDatasetCommand
-    from superset.commands.dataset.exceptions import DatasetInvalidError
-    from superset.connectors.sqla.models import SqlaTable
     from superset.models.core import Database
 
     SqlaTable.metadata.create_all(session.get_bind())
@@ -165,3 +170,360 @@ def test_duplicate_dataset_blocked_by_soft_deleted_twin(session: Session) -> Non
         )
         with pytest.raises(DatasetInvalidError):
             command.validate()
+
+
+def test_duplicate_dataset_success() -> None:
+    """Test successful duplication of a virtual dataset."""
+    # Create a mock base model (virtual dataset)
+    mock_base_model = Mock(spec=SqlaTable)
+    mock_base_model.id = 1
+    mock_base_model.database_id = 1
+    mock_base_model.table_name = "original_dataset"
+    mock_base_model.schema = "public"
+    mock_base_model.catalog = None
+    mock_base_model.kind = "virtual"
+    mock_base_model.sql = "SELECT 1 as c"
+    mock_base_model.template_params = None
+    mock_base_model.normalize_columns = False
+    mock_base_model.always_filter_main_dttm = False
+    mock_base_model.columns = []
+    mock_base_model.metrics = []
+
+    # Create a mock database without spec to allow SQLAlchemy relationship assignment
+    mock_database = MagicMock()
+    mock_database.id = 1
+    mock_database.get_default_catalog.return_value = None
+    # Add _sa_instance_state to allow SQLAlchemy relationship assignment
+    mock_database._sa_instance_state = MagicMock()
+
+    with (
+        patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.find_by_id",
+            return_value=mock_base_model,
+        ),
+        patch("superset.commands.dataset.duplicate.security_manager.raise_for_access"),
+    ):
+        with patch(
+            "superset.commands.dataset.duplicate.db.session.query"
+        ) as mock_query:
+            mock_query.return_value.get.return_value = mock_database
+            with patch(
+                "superset.commands.dataset.duplicate.DatasetDAO.validate_uniqueness",
+                return_value=True,
+            ):
+                with patch(
+                    "superset.commands.dataset.duplicate.DuplicateDatasetCommand.populate_owners",
+                    return_value=[],
+                ):
+                    with patch("superset.commands.dataset.duplicate.db.session.add"):
+                        command = DuplicateDatasetCommand(
+                            {
+                                "base_model_id": 1,
+                                "table_name": "duplicated_dataset",
+                                "owners": [],
+                            }
+                        )
+
+                        # Should not raise any errors
+                        command.validate()
+                        # Test the actual duplication
+                        result = command.run()
+                        assert result.table_name == "duplicated_dataset"
+                        assert result.database.id == 1
+                        assert result.schema == "public"
+                        assert result.is_sqllab_view is True
+                        assert result.sql == "SELECT 1 as c"
+
+
+def test_duplicate_dataset_not_found() -> None:
+    """Test duplication when base dataset doesn't exist."""
+    with patch(
+        "superset.commands.dataset.duplicate.DatasetDAO.find_by_id",
+        return_value=None,
+    ):
+        with patch(
+            "superset.commands.dataset.duplicate.DuplicateDatasetCommand.populate_owners",
+            return_value=[],
+        ):
+            command = DuplicateDatasetCommand(
+                {
+                    "base_model_id": 999,
+                    "table_name": "duplicated_dataset",
+                    "owners": [],
+                }
+            )
+
+            with pytest.raises(DatasetInvalidError) as exc_info:
+                command.validate()
+
+            # Verify the exception contains DatasetNotFoundError
+            validation_errors = exc_info.value._exceptions
+            assert any(
+                isinstance(error, DatasetNotFoundError) for error in validation_errors
+            )
+
+
+def test_duplicate_dataset_not_virtual() -> None:
+    """Test that duplication fails for physical (non-virtual) datasets."""
+    mock_base_model = Mock(spec=SqlaTable)
+    mock_base_model.id = 1
+    mock_base_model.database_id = 1
+    mock_base_model.kind = "physical"  # Not virtual
+
+    with (
+        patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.find_by_id",
+            return_value=mock_base_model,
+        ),
+        patch("superset.commands.dataset.duplicate.security_manager.raise_for_access"),
+    ):
+        with patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.validate_uniqueness",
+            return_value=True,
+        ):
+            with patch(
+                "superset.commands.dataset.duplicate.DuplicateDatasetCommand.populate_owners",
+                return_value=[],
+            ):
+                command = DuplicateDatasetCommand(
+                    {
+                        "base_model_id": 1,
+                        "table_name": "duplicated_dataset",
+                        "owners": [],
+                    }
+                )
+
+                with pytest.raises(DatasetInvalidError) as exc_info:
+                    command.validate()
+
+                # Verify the exception contains DatasourceTypeInvalidError
+                validation_errors = exc_info.value._exceptions
+                assert len(validation_errors) == 1
+                assert isinstance(validation_errors[0], DatasourceTypeInvalidError)
+
+
+def test_duplicate_dataset_name_exists_same_database_schema() -> None:
+    """Test that duplication fails when name exists in same database/schema."""
+    mock_base_model = Mock(spec=SqlaTable)
+    mock_base_model.id = 1
+    mock_base_model.database_id = 1
+    mock_base_model.table_name = "original_dataset"
+    mock_base_model.schema = "public"
+    mock_base_model.catalog = None
+    mock_base_model.kind = "virtual"
+
+    with (
+        patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.find_by_id",
+            return_value=mock_base_model,
+        ),
+        patch("superset.commands.dataset.duplicate.security_manager.raise_for_access"),
+    ):
+        with patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.validate_uniqueness",
+            return_value=False,  # Name already exists
+        ):
+            with patch(
+                "superset.commands.dataset.duplicate.DuplicateDatasetCommand.populate_owners",
+                return_value=[],
+            ):
+                command = DuplicateDatasetCommand(
+                    {
+                        "base_model_id": 1,
+                        "table_name": "existing_dataset",
+                        "owners": [],
+                    }
+                )
+
+                with pytest.raises(DatasetInvalidError) as exc_info:
+                    command.validate()
+
+                # Verify the exception contains DatasetExistsValidationError
+                validation_errors = exc_info.value._exceptions
+                assert len(validation_errors) == 1
+                assert isinstance(validation_errors[0], DatasetExistsValidationError)
+
+
+def test_duplicate_dataset_catalog_preserved() -> None:
+    """Test that catalog is preserved during duplication."""
+    mock_base_model = Mock(spec=SqlaTable)
+    mock_base_model.id = 1
+    mock_base_model.database_id = 1
+    mock_base_model.table_name = "original_dataset"
+    mock_base_model.schema = "public"
+    mock_base_model.catalog = "prod_catalog"
+    mock_base_model.kind = "virtual"
+    mock_base_model.sql = "SELECT 1 as c"
+    mock_base_model.template_params = None
+    mock_base_model.normalize_columns = False
+    mock_base_model.always_filter_main_dttm = False
+    mock_base_model.columns = []
+    mock_base_model.metrics = []
+
+    # Create a mock database without spec to allow SQLAlchemy relationship assignment
+    mock_database = MagicMock()
+    mock_database.id = 1
+    mock_database.get_default_catalog.return_value = None
+    # Add _sa_instance_state to allow SQLAlchemy relationship assignment
+    mock_database._sa_instance_state = MagicMock()
+
+    with (
+        patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.find_by_id",
+            return_value=mock_base_model,
+        ),
+        patch("superset.commands.dataset.duplicate.security_manager.raise_for_access"),
+    ):
+        with patch(
+            "superset.commands.dataset.duplicate.db.session.query"
+        ) as mock_query:
+            mock_query.return_value.get.return_value = mock_database
+            with patch(
+                "superset.commands.dataset.duplicate.DatasetDAO.validate_uniqueness",
+                return_value=True,
+            ):
+                with patch(
+                    "superset.commands.dataset.duplicate.DuplicateDatasetCommand.populate_owners",
+                    return_value=[],
+                ):
+                    with patch("superset.commands.dataset.duplicate.db.session.add"):
+                        command = DuplicateDatasetCommand(
+                            {
+                                "base_model_id": 1,
+                                "table_name": "duplicated_dataset",
+                                "owners": [],
+                            }
+                        )
+
+                        result = command.run()
+
+                        # Verify catalog was preserved
+                        assert result.catalog == "prod_catalog"
+
+
+def test_duplicate_dataset_catalog_passed_to_uniqueness_check() -> None:
+    """The uniqueness check receives the base model's database and a Table
+    scoped to its schema/catalog.
+
+    Default-catalog resolution for a NULL catalog happens inside
+    ``DatasetDAO.validate_uniqueness``; the command passes the raw catalog
+    through.
+    """
+    mock_base_model = Mock(spec=SqlaTable)
+    mock_base_model.id = 1
+    mock_base_model.database_id = 1
+    mock_base_model.table_name = "original_dataset"
+    mock_base_model.schema = "public"
+    mock_base_model.catalog = "prod_catalog"
+    mock_base_model.kind = "virtual"
+
+    with (
+        patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.find_by_id",
+            return_value=mock_base_model,
+        ),
+        patch("superset.commands.dataset.duplicate.security_manager.raise_for_access"),
+    ):
+        with patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.validate_uniqueness",
+            return_value=True,
+        ) as mock_validate:
+            with patch(
+                "superset.commands.dataset.duplicate.DuplicateDatasetCommand.populate_owners",
+                return_value=[],
+            ):
+                command = DuplicateDatasetCommand(
+                    {
+                        "base_model_id": 1,
+                        "table_name": "duplicated_dataset",
+                        "owners": [],
+                    }
+                )
+
+                command.validate()
+
+                # Verify the check is scoped to the base model's
+                # database/schema/catalog
+                mock_validate.assert_called_once()
+                database_arg, table_arg = mock_validate.call_args[0]
+                assert database_arg is mock_base_model.database
+                assert table_arg.table == "duplicated_dataset"
+                assert table_arg.schema == "public"
+                assert table_arg.catalog == "prod_catalog"
+
+
+def test_duplicate_dataset_with_columns_and_metrics() -> None:
+    """Test duplication preserves columns and metrics."""
+    mock_column = Mock(spec=TableColumn)
+    mock_column.column_name = "col1"
+    mock_column.verbose_name = "Column 1"
+    mock_column.expression = None
+    mock_column.is_dttm = False
+    mock_column.type = "VARCHAR"
+    mock_column.description = "Test column"
+
+    mock_metric = Mock(spec=SqlMetric)
+    mock_metric.metric_name = "count"
+    mock_metric.verbose_name = "Count"
+    mock_metric.expression = "COUNT(*)"
+    mock_metric.metric_type = "count"
+    mock_metric.description = "Row count"
+
+    mock_base_model = Mock(spec=SqlaTable)
+    mock_base_model.id = 1
+    mock_base_model.database_id = 1
+    mock_base_model.table_name = "original_dataset"
+    mock_base_model.schema = "public"
+    mock_base_model.catalog = None
+    mock_base_model.kind = "virtual"
+    mock_base_model.sql = "SELECT 1 as c"
+    mock_base_model.template_params = None
+    mock_base_model.normalize_columns = False
+    mock_base_model.always_filter_main_dttm = False
+    mock_base_model.columns = [mock_column]
+    mock_base_model.metrics = [mock_metric]
+
+    # Create a mock database without spec to allow SQLAlchemy relationship assignment
+    mock_database = MagicMock()
+    mock_database.id = 1
+    mock_database.get_default_catalog.return_value = None
+    # Add _sa_instance_state to allow SQLAlchemy relationship assignment
+    mock_database._sa_instance_state = MagicMock()
+
+    with (
+        patch(
+            "superset.commands.dataset.duplicate.DatasetDAO.find_by_id",
+            return_value=mock_base_model,
+        ),
+        patch("superset.commands.dataset.duplicate.security_manager.raise_for_access"),
+    ):
+        with patch(
+            "superset.commands.dataset.duplicate.db.session.query"
+        ) as mock_query:
+            mock_query.return_value.get.return_value = mock_database
+            with patch(
+                "superset.commands.dataset.duplicate.DatasetDAO.validate_uniqueness",
+                return_value=True,
+            ):
+                with patch(
+                    "superset.commands.dataset.duplicate.DuplicateDatasetCommand.populate_owners",
+                    return_value=[],
+                ):
+                    with patch("superset.commands.dataset.duplicate.db.session.add"):
+                        command = DuplicateDatasetCommand(
+                            {
+                                "base_model_id": 1,
+                                "table_name": "duplicated_dataset",
+                                "owners": [],
+                            }
+                        )
+
+                        result = command.run()
+
+                        # Verify columns were duplicated
+                        assert len(result.columns) == 1
+                        assert result.columns[0].column_name == "col1"
+
+                        # Verify metrics were duplicated
+                        assert len(result.metrics) == 1
+                        assert result.metrics[0].metric_name == "count"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Imagine a user who doesn't have "all database access" or "all datasource access" permissions, but has access to a certain set of database connections and can create/edit datasources pointing to them. Current implementation does not allow such users to duplicate their datasets, displaying vague 500 error.

This PR fixes duplication checks that are present in `superset/commands/dataset/duplicate.py` and allows users to create copies of their datasets.

### TESTING INSTRUCTIONS
Assuming that the test would be carried out on an installation of Superset with stock example (meta)data,

1. Create a copy of Alpha role and remove "all database access" and "all datasource access" permissions from it. Add "database access [examples]" permission to this role.
2. Create a new user and assign this role and "sql_lab" to it.
3. Log into Superset as this user and verify it has access to example datasets.
4. Create a new virtual dataset with some query (`select 1 as c`, for example).
5. On "Datasets" page, find your newly created dataset and hit "Duplicate" button.
6. Fill in a new unique name for the copy and hit "Duplicate" button.

Superset should create a copy of your test dataset with a new name, displaying no errors.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes [#27712](https://github.com/apache/superset/issues/27712)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
