### PR TITLE
fix(charts): improve error display for failed charts in dashboards

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.test.tsx
+++ b/superset-frontend/src/components/Chart/Chart.test.tsx
@@ -84,7 +84,5 @@ test('shows loading spinner for client-side errors without errors array when dat
   );
 
   expect(screen.getByRole('status')).toBeInTheDocument();
-  expect(
-    screen.queryByText(/Some client-side error/),
-  ).not.toBeInTheDocument();
+  expect(screen.queryByText(/Some client-side error/)).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/components/Chart/Chart.test.tsx
+++ b/superset-frontend/src/components/Chart/Chart.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from 'spec/helpers/testing-library';
+import '@testing-library/jest-dom';
+import { PLACEHOLDER_DATASOURCE } from 'src/dashboard/constants';
+import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
+import Chart from './Chart';
+import type { Actions } from './Chart';
+
+const mockActions: Actions = {
+  logEvent: jest.fn() as unknown as Actions['logEvent'],
+  chartRenderingFailed: jest.fn() as unknown as Actions['chartRenderingFailed'],
+  chartRenderingSucceeded:
+    jest.fn() as unknown as Actions['chartRenderingSucceeded'],
+  postChartFormData: jest.fn() as unknown as Actions['postChartFormData'],
+};
+
+const baseProps = {
+  chartId: 1,
+  width: 800,
+  height: 600,
+  actions: mockActions,
+  formData: { datasource: '1__table', viz_type: 'table' },
+  vizType: 'table',
+  setControlValue: jest.fn(),
+};
+
+test('shows backend error instead of loading spinner when datasource is still a placeholder', () => {
+  render(
+    <Chart
+      {...baseProps}
+      chartStatus="failed"
+      chartAlert="Your default credentials were not found."
+      datasource={PLACEHOLDER_DATASOURCE}
+      datasetsStatus={ResourceStatus.Loading}
+      queriesResponse={[
+        {
+          errors: [
+            {
+              error_type: 'GENERIC_BACKEND_ERROR',
+              message: 'Your default credentials were not found.',
+              extra: {
+                issue_codes: [{ code: 1011, message: 'Issue 1011' }],
+              },
+              level: 'error',
+            },
+          ],
+        },
+      ]}
+    />,
+  );
+
+  expect(
+    screen.getByText(/Your default credentials were not found/),
+  ).toBeInTheDocument();
+});
+
+test('shows loading spinner for client-side errors without errors array when datasource is still a placeholder', () => {
+  render(
+    <Chart
+      {...baseProps}
+      chartStatus="failed"
+      chartAlert="Some client-side error"
+      datasource={PLACEHOLDER_DATASOURCE}
+      datasetsStatus={ResourceStatus.Loading}
+      queriesResponse={[{}]}
+    />,
+  );
+
+  expect(screen.getByRole('status')).toBeInTheDocument();
+  expect(
+    screen.queryByText(/Some client-side error/),
+  ).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -168,6 +168,11 @@ const LoadingDiv = styled.div`
   transform: translate(-50%, -50%);
 `;
 
+const ErrorContainer = styled.div<{ height: number }>`
+  height: ${p => p.height}px;
+  overflow: auto;
+`;
+
 const MessageSpan = styled.span`
   display: block;
   text-align: center;
@@ -261,7 +266,10 @@ class Chart extends PureComponent<ChartProps, {}> {
     const message = chartAlert || queryResponse?.message;
 
     // if datasource is still loading, don't render JS errors
+    // but always show backend API errors (which have an errors array)
+    // so users can see real issues like auth failures
     if (
+      !error &&
       chartAlert !== undefined &&
       chartAlert !== NONEXISTENT_DATASET &&
       datasource === PLACEHOLDER_DATASOURCE &&
@@ -353,8 +361,12 @@ class Chart extends PureComponent<ChartProps, {}> {
     const isLoading = chartStatus === 'loading';
 
     if (chartStatus === 'failed') {
-      return queriesResponse?.map(item =>
-        this.renderErrorMessage(item as ChartErrorType),
+      return (
+        <ErrorContainer height={height}>
+          {queriesResponse?.map(item =>
+            this.renderErrorMessage(item as ChartErrorType),
+          )}
+        </ErrorContainer>
       );
     }
 

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -203,13 +203,18 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         In case the token was manually revoked on Google side, `google-auth` will
         try to automatically refresh credentials, but it fails since it only has the
         access token. This override catches this scenario as well.
+
+        Also catches the case where no credentials are configured at all
+        (missing Application Default Credentials).
         """
+        error_message = str(ex)
         return (
             g
             and hasattr(g, "user")
             and (
                 isinstance(ex, cls.oauth2_exception)
-                or "credentials do not contain the necessary fields" in str(ex)
+                or "credentials do not contain the necessary fields" in error_message
+                or "default credentials were not found" in error_message.lower()
             )
         )
 

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -207,14 +207,14 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         Also catches the case where no credentials are configured at all
         (missing Application Default Credentials).
         """
-        error_message = str(ex)
+        error_message = str(ex).lower()
         return (
             g
             and hasattr(g, "user")
             and (
                 isinstance(ex, cls.oauth2_exception)
                 or "credentials do not contain the necessary fields" in error_message
-                or "default credentials were not found" in error_message.lower()
+                or "default credentials were not found" in error_message
             )
         )
 

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -757,6 +757,26 @@ def test_needs_oauth2_with_credentials_error(mocker: MockerFixture) -> None:
     assert GSheetsEngineSpec.needs_oauth2(ex) is True
 
 
+def test_needs_oauth2_with_default_credentials_not_found(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that needs_oauth2 returns True when Application Default Credentials
+    are not configured.
+    """
+    from superset.db_engine_specs.gsheets import GSheetsEngineSpec
+
+    g = mocker.patch("superset.db_engine_specs.gsheets.g")
+    g.user = mocker.MagicMock()
+
+    ex = Exception(
+        "Your default credentials were not found. To set up Application Default "
+        "Credentials, see https://cloud.google.com/docs/authentication/external/"
+        "set-up-adc for more information."
+    )
+    assert GSheetsEngineSpec.needs_oauth2(ex) is True
+
+
 def test_needs_oauth2_with_other_error(mocker: MockerFixture) -> None:
     """
     Test that needs_oauth2 returns False for other errors.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a chart query fails on a dashboard — for example due to missing Google Sheets OAuth2 credentials — the error message was not always visible to the user. There were two separate issues:

First, when a chart's datasource metadata was still loading (showing the placeholder datasource), any backend error was being suppressed in favor of a loading spinner. This meant that real failures like authentication errors would appear as an infinite loading state rather than showing the actual error to the user. The fix adds a check for the presence of a backend errors array in the query response: if the backend explicitly returned an error, we now show it immediately instead of waiting for the datasource to finish loading.

Second, when error messages were displayed, they could be taller than the chart's allocated space in the dashboard grid. Because the parent container used overflow: hidden, longer messages — such as the "default credentials were not found" error with its issue codes and chart owner information — were clipped with no way to scroll. The fix wraps the error output in a styled ErrorContainer that constrains the height to the chart's dimensions and enables vertical scrolling.

On the backend, the Google Sheets engine spec's needs_oauth2 method did not recognize the "default credentials were not found" error message. When a GSheets connection had no service account and no Application Default Credentials configured, the error would bypass the OAuth2 authorization flow and surface as a generic DB engine error instead of prompting the user to authorize. The fix extends the error matching to also catch this case, so the user sees the "Authorization needed" prompt with the "provide authorization" link.

All changes include corresponding tests. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
- Before

https://github.com/user-attachments/assets/7dfd06b7-62bd-43b7-bfa4-f679c01505e7


- After

https://github.com/user-attachments/assets/a41b41eb-97ff-4f2d-80bb-c349461f60d2


- Before
<img width="469" height="447" alt="Screenshot 2026-02-12 151813" src="https://github.com/user-attachments/assets/acf03ef8-9ae3-45b5-a639-ad9cdc68703c" />

- After
<img width="652" height="612" alt="Screenshot 2026-02-12 152527" src="https://github.com/user-attachments/assets/7aabea58-0c5e-4d7c-b6fc-7028a81b0511" />


- Before
<img width="1411" height="893" alt="Screenshot 2026-02-12 184133" src="https://github.com/user-attachments/assets/42baea49-a119-4c3f-8c40-72d296d9e2e7" />

- After
<img width="1418" height="954" alt="Screenshot 2026-02-12 152542" src="https://github.com/user-attachments/assets/de25c3ab-5172-45b8-8d45-24d57aedd45a" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Set up a Google Sheets database connection with OAuth2 enabled but without service account credentials or Application Default Credentials configured
2. Create a chart using this GSheets connection and add it to a dashboard
3. Open the dashboard — verify the chart shows "Authorization needed" with a "provide authorization" link instead of a generic "DB engine Error"
4. Click "provide authorization" and complete the OAuth2 flow; verify the chart loads data after authorization
5. Add a chart that produces a long error message (e.g., a BigQuery chart without credentials) to a dashboard
6. Verify the error message container has a scrollbar when the content exceeds the chart height
7. Scroll down within the error — verify you can see the full message including issue codes, "See more/less" link, and chart owner information
8. Add a chart whose datasource is still loading (e.g., newly imported) and that has a backend error in queriesResponse.errors — verify the error is displayed immediately instead of showing an infinite loading spinner
9. Add a chart whose datasource is still loading but has only a client-side error (no errors array in the response) — verify it shows a loading spinner, not the error
10. Run frontend tests: npx jest --no-coverage src/components/Chart/Chart.test.tsx — verify both tests pass
11. Run backend tests: pytest tests/unit_tests/db_engine_specs/test_gsheets.py -v -k "needs_oauth2" — verify all three needs_oauth2 tests pass including the new test_needs_oauth2_with_default_credentials_not_found

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
