### PR TITLE
perf(dashboard): Batch RLS filter lookups for dashboard digest computation

### DIFF
--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -220,7 +220,6 @@ class DashboardGetResponseSchema(Schema):
     dashboard_title = fields.String(
         metadata={"description": dashboard_title_description}
     )
-    thumbnail_url = fields.String(allow_none=True)
     published = fields.Boolean()
     css = fields.String(metadata={"description": css_description})
     theme = fields.Nested(ThemeSchema, allow_none=True)

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -220,6 +220,7 @@ class DashboardGetResponseSchema(Schema):
     dashboard_title = fields.String(
         metadata={"description": dashboard_title_description}
     )
+    thumbnail_url = fields.String(allow_none=True)
     published = fields.Boolean()
     css = fields.String(metadata={"description": css_description})
     theme = fields.Nested(ThemeSchema, allow_none=True)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -119,7 +119,7 @@ class _RLSFilterRow(NamedTuple):
 
 # Cache key components for request-scoped RLS filter cache
 _RLSCacheKey = tuple[str, int | str]
-_RLSCache = dict[_RLSCacheKey, list[Any]]
+_RLSCache = dict[_RLSCacheKey, list[SqlaQuery]]
 
 
 class SupersetRoleApi(RoleApi):

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -117,7 +117,6 @@ class _RLSFilterRow(NamedTuple):
     clause: str
 
 
-# Cache key components for request-scoped RLS filter cache
 _RLSCacheKey = tuple[str, int | str]
 _RLSCache = dict[_RLSCacheKey, list[SqlaQuery]]
 
@@ -2713,7 +2712,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         if not (hasattr(g, "user") and g.user is not None):
             return []
 
-        # Check request-scoped cache keyed by (username, table_id)
+        # Check request-scoped cache. Username is included in the key to stay
+        # safe if override_user() is called with different users in one request.
         cache: _RLSCache = getattr(g, "_rls_filter_cache", {})
         username = get_username()
         if username is not None:

--- a/superset/thumbnails/digest.py
+++ b/superset/thumbnails/digest.py
@@ -70,6 +70,15 @@ def _adjust_string_with_rls(
     if user:
         stringified_rls = ""
         with override_user(user):
+            # Prefetch RLS filters for all datasources in a single batch query
+            table_ids = [
+                datasource.id
+                for datasource in datasources
+                if datasource and getattr(datasource, "is_rls_supported", False)
+            ]
+            if table_ids:
+                security_manager.prefetch_rls_filters(table_ids)
+
             for datasource in datasources:
                 if datasource and getattr(datasource, "is_rls_supported", False):
                     rls_filters = datasource.get_sqla_row_level_filters()

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1239,6 +1239,8 @@ def test_get_rls_filters_returns_cached_result(
     mock_user.id = 1
     mock_user.roles = [mocker.MagicMock(id=1)]
     mock_g = mocker.patch("superset.security.manager.g", user=mock_user)
+    # Prevent MagicMock from auto-creating _rls_filter_cache
+    del mock_g._rls_filter_cache
     mocker.patch("superset.security.manager.get_user_id", return_value=1)
     mocker.patch.object(sm, "get_user_roles", return_value=mock_user.roles)
 
@@ -1249,12 +1251,13 @@ def test_get_rls_filters_returns_cached_result(
     result1 = sm.get_rls_filters(table)
 
     # Verify cache was populated
-    assert hasattr(mock_g, "_rls_filter_cache")
     assert (1, 42) in mock_g._rls_filter_cache
 
     # Replace session query with something that would fail if called
-    sm.session.query = mocker.MagicMock(
-        side_effect=AssertionError("DB should not be queried on cache hit")
+    mocker.patch.object(
+        sm.session,
+        "query",
+        side_effect=AssertionError("DB should not be queried on cache hit"),
     )
 
     # Second call should return cached result without querying DB
@@ -1276,6 +1279,7 @@ def test_prefetch_rls_filters_populates_cache(
     mock_user.id = 1
     mock_user.roles = [mocker.MagicMock(id=10)]
     mock_g = mocker.patch("superset.security.manager.g", user=mock_user)
+    del mock_g._rls_filter_cache
     mocker.patch("superset.security.manager.get_user_id", return_value=1)
     mocker.patch.object(sm, "get_user_roles", return_value=mock_user.roles)
 
@@ -1287,11 +1291,10 @@ def test_prefetch_rls_filters_populates_cache(
         (1, 100, "group_a", "id > 0"),  # table_id=1
         (1, 101, None, "active = 1"),  # table_id=1
     ]
-    sm.session.query = mocker.MagicMock(return_value=mock_query)
+    mocker.patch.object(sm.session, "query", return_value=mock_query)
 
     sm.prefetch_rls_filters([1, 2])
 
-    assert hasattr(mock_g, "_rls_filter_cache")
     # Table 1 should have 2 filters (as tuples of id, group_key, clause)
     assert len(mock_g._rls_filter_cache[(1, 1)]) == 2
     assert mock_g._rls_filter_cache[(1, 1)][0] == (100, "group_a", "id > 0")
@@ -1321,8 +1324,10 @@ def test_prefetch_rls_filters_skips_cached_ids(
     mock_g._rls_filter_cache = {(1, 1): [(100, "group_a", "id > 0")]}
 
     # If it queries the DB, this will fail
-    sm.session.query = mocker.MagicMock(
-        side_effect=AssertionError("DB should not be queried for cached ids")
+    mocker.patch.object(
+        sm.session,
+        "query",
+        side_effect=AssertionError("DB should not be queried for cached ids"),
     )
 
     # All ids already cached -> should return immediately
@@ -1341,7 +1346,83 @@ def test_prefetch_rls_filters_no_user(
     del mock_g.user
 
     # Should not attempt any DB queries
-    sm.session.query = mocker.MagicMock(
-        side_effect=AssertionError("DB should not be queried without a user")
+    mocker.patch.object(
+        sm.session,
+        "query",
+        side_effect=AssertionError("DB should not be queried without a user"),
     )
     sm.prefetch_rls_filters([1, 2])
+
+
+def test_get_rls_filters_cache_works_for_guest_user(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """
+    Test that get_rls_filters() caches results for guest users (who have no
+    integer id, only a username) so repeated calls don't re-query the DB.
+    """
+    sm = SupersetSecurityManager(appbuilder)
+
+    # GuestUser has no .id but has .username
+    mock_guest = mocker.MagicMock(spec=["username", "roles"])
+    mock_guest.username = "guest_user"
+    mock_guest.roles = [mocker.MagicMock(id=99)]
+
+    mock_g = mocker.patch("superset.security.manager.g", user=mock_guest)
+    del mock_g._rls_filter_cache
+    mocker.patch("superset.security.manager.get_user_id", return_value=None)
+    mocker.patch.object(sm, "get_user_roles", return_value=mock_guest.roles)
+
+    table = mocker.MagicMock()
+    table.id = 42
+
+    # First call runs the query
+    result1 = sm.get_rls_filters(table)
+
+    # Verify cache was populated with username key
+    assert ("guest_user", 42) in mock_g._rls_filter_cache
+
+    # Replace session query to detect if it's called again
+    mocker.patch.object(
+        sm.session,
+        "query",
+        side_effect=AssertionError("DB should not be queried on cache hit"),
+    )
+
+    # Second call should use cache
+    result2 = sm.get_rls_filters(table)
+    assert result1 == result2
+
+
+def test_prefetch_rls_filters_works_for_guest_user(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """
+    Test that prefetch_rls_filters() works for guest users who have no
+    integer id, using username as the cache key instead.
+    """
+    sm = SupersetSecurityManager(appbuilder)
+
+    mock_guest = mocker.MagicMock(spec=["username", "roles"])
+    mock_guest.username = "guest_user"
+    mock_guest.roles = [mocker.MagicMock(id=99)]
+
+    mock_g = mocker.patch("superset.security.manager.g", user=mock_guest)
+    del mock_g._rls_filter_cache
+    mocker.patch("superset.security.manager.get_user_id", return_value=None)
+    mocker.patch.object(sm, "get_user_roles", return_value=mock_guest.roles)
+
+    # Mock the batch query returning no filters
+    mock_query = mocker.MagicMock()
+    mock_query.join.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.all.return_value = []
+    mocker.patch.object(sm.session, "query", return_value=mock_query)
+
+    sm.prefetch_rls_filters([10, 20])
+
+    # Cache should be populated with username key and empty lists
+    assert mock_g._rls_filter_cache[("guest_user", 10)] == []
+    assert mock_g._rls_filter_cache[("guest_user", 20)] == []

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1251,7 +1251,7 @@ def test_get_rls_filters_returns_cached_result(
     # First call populates the cache
     result1 = sm.get_rls_filters(table)
 
-    # Verify cache was populated keyed by username
+    # Verify cache was populated keyed by (username, table_id)
     assert ("admin", 42) in mock_g._rls_filter_cache
 
     # Replace session query with something that would fail if called
@@ -1367,8 +1367,8 @@ def test_get_rls_filters_cache_works_for_guest_user(
     app_context: None,
 ) -> None:
     """
-    Test that get_rls_filters() caches results for guest users who use
-    the same username-based cache key as regular users.
+    Test that get_rls_filters() caches results for guest users
+    using the same (username, table_id) cache key as regular users.
     """
     sm = SupersetSecurityManager(appbuilder)
 
@@ -1387,7 +1387,7 @@ def test_get_rls_filters_cache_works_for_guest_user(
     # First call runs the query
     result1 = sm.get_rls_filters(table)
 
-    # Verify cache was populated with username key
+    # Verify cache was populated with (username, table_id) key
     assert ("guest_user", 42) in mock_g._rls_filter_cache
 
     # Replace session query to detect if it's called again
@@ -1408,7 +1408,7 @@ def test_prefetch_rls_filters_works_for_guest_user(
 ) -> None:
     """
     Test that prefetch_rls_filters() works for guest users using the
-    same username-based cache key as regular users.
+    same (username, table_id) cache key as regular users.
     """
     sm = SupersetSecurityManager(appbuilder)
 
@@ -1430,6 +1430,6 @@ def test_prefetch_rls_filters_works_for_guest_user(
 
     sm.prefetch_rls_filters([10, 20])
 
-    # Cache should be populated with username key and empty lists
+    # Cache should be populated with (username, table_id) keys and empty lists
     assert mock_g._rls_filter_cache[("guest_user", 10)] == []
     assert mock_g._rls_filter_cache[("guest_user", 20)] == []

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -18,6 +18,7 @@
 # pylint: disable=invalid-name, unused-argument, redefined-outer-name
 
 import json  # noqa: TID251
+from types import SimpleNamespace
 
 import pytest
 from flask_appbuilder.security.sqla.models import Role, User
@@ -1239,9 +1240,8 @@ def test_get_rls_filters_returns_cached_result(
     mock_user.id = 1
     mock_user.username = "admin"
     mock_user.roles = [mocker.MagicMock(id=1)]
-    mock_g = mocker.patch("superset.security.manager.g", user=mock_user)
-    # Prevent MagicMock from auto-creating _rls_filter_cache
-    del mock_g._rls_filter_cache
+    mock_g = SimpleNamespace(user=mock_user)
+    mocker.patch("superset.security.manager.g", new=mock_g)
     mocker.patch("superset.security.manager.get_username", return_value="admin")
     mocker.patch.object(sm, "get_user_roles", return_value=mock_user.roles)
 
@@ -1280,8 +1280,8 @@ def test_prefetch_rls_filters_populates_cache(
     mock_user.id = 1
     mock_user.username = "admin"
     mock_user.roles = [mocker.MagicMock(id=10)]
-    mock_g = mocker.patch("superset.security.manager.g", user=mock_user)
-    del mock_g._rls_filter_cache
+    mock_g = SimpleNamespace(user=mock_user)
+    mocker.patch("superset.security.manager.g", new=mock_g)
     mocker.patch("superset.security.manager.get_username", return_value="admin")
     mocker.patch.object(sm, "get_user_roles", return_value=mock_user.roles)
 
@@ -1324,12 +1324,13 @@ def test_prefetch_rls_filters_skips_cached_ids(
     mock_user.id = 1
     mock_user.username = "admin"
     mock_user.roles = [mocker.MagicMock(id=10)]
-    mock_g = mocker.patch("superset.security.manager.g", user=mock_user)
+    mock_g = SimpleNamespace(
+        user=mock_user,
+        _rls_filter_cache={("admin", 1): [(100, "group_a", "id > 0")]},
+    )
+    mocker.patch("superset.security.manager.g", new=mock_g)
     mocker.patch("superset.security.manager.get_username", return_value="admin")
     mocker.patch.object(sm, "get_user_roles", return_value=mock_user.roles)
-
-    # Pre-populate cache for table 1
-    mock_g._rls_filter_cache = {("admin", 1): [(100, "group_a", "id > 0")]}
 
     # If it queries the DB, this will fail
     mocker.patch.object(
@@ -1350,8 +1351,7 @@ def test_prefetch_rls_filters_no_user(
     Test that prefetch_rls_filters() returns early when no user is present.
     """
     sm = SupersetSecurityManager(appbuilder)
-    mock_g = mocker.patch("superset.security.manager.g")
-    del mock_g.user
+    mocker.patch("superset.security.manager.g", new=SimpleNamespace())
 
     # Should not attempt any DB queries
     mocker.patch.object(
@@ -1376,8 +1376,8 @@ def test_get_rls_filters_cache_works_for_guest_user(
     mock_guest.username = "guest_user"
     mock_guest.roles = [mocker.MagicMock(id=99)]
 
-    mock_g = mocker.patch("superset.security.manager.g", user=mock_guest)
-    del mock_g._rls_filter_cache
+    mock_g = SimpleNamespace(user=mock_guest)
+    mocker.patch("superset.security.manager.g", new=mock_g)
     mocker.patch("superset.security.manager.get_username", return_value="guest_user")
     mocker.patch.object(sm, "get_user_roles", return_value=mock_guest.roles)
 
@@ -1416,8 +1416,8 @@ def test_prefetch_rls_filters_works_for_guest_user(
     mock_guest.username = "guest_user"
     mock_guest.roles = [mocker.MagicMock(id=99)]
 
-    mock_g = mocker.patch("superset.security.manager.g", user=mock_guest)
-    del mock_g._rls_filter_cache
+    mock_g = SimpleNamespace(user=mock_guest)
+    mocker.patch("superset.security.manager.g", new=mock_g)
     mocker.patch("superset.security.manager.get_username", return_value="guest_user")
     mocker.patch.object(sm, "get_user_roles", return_value=mock_guest.roles)
 


### PR DESCRIPTION
### SUMMARY
Dashboard API response time degrades significantly when many RLS filters exist because `_adjust_string_with_rls()` calls `security_manager.get_rls_filters()` once per unique datasource — each triggering a complex DB query with subqueries against `RLSFilterRoles`, `RLSFilterTables`, and `RowLevelSecurityFilter`. For a dashboard with N datasources, this is N separate round-trips.

This is particularly impactful for embedded dashboards with guest tokens, where `get_rls_filters()` was running N queries per request (often returning empty results) with no caching, since `GuestUser` has no integer `id`.

 Changes:
  - Request-scoped cache on `get_rls_filters()` — keyed by `(user_key, table_id)`, using `user_id` for regular users and `username` for guest/embedded users. Subsequent calls for the same table in the same request return cached results.
  - `prefetch_rls_filters(table_ids)` — new batch method that fetches RLS filters for all datasources in a single query and pre-populates the cache.
  - Prefetch call in `_adjust_string_with_rls()` — collects table IDs from RLS-supporting datasources and calls `prefetch_rls_filters()` before the loop.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Set up a dashboard with multiple datasources and RLS filters
2. Verify `GET /api/v1/dashboard/{id}` response time is reduced

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
