### PR TITLE
fix: Include app_root in next param

### DIFF
--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -78,9 +78,9 @@ def redirect_to_login(next_target: str | None = None) -> FlaskResponse:
     target = next_target
     if target is None and has_request_context():
         if request.query_string:
-            target = request.full_path.rstrip("?")
+            target = request.script_root + request.full_path.rstrip("?")
         else:
-            target = request.path
+            target = request.script_root + request.path
 
     if target:
         query["next"] = [target]


### PR DESCRIPTION
### SUMMARY
When logging in, the URL includes a `next=` param that determines where users should be redirected to. This param was not including the `app_root` value, causing 404 errors.

I thought about fixing this in the backend (adding it if missing while doing the redirect) but I think it would require overriding a FAB method, so I think it's a good compromise. Happy to revisit if needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**
Users are redirected to a URL without the `app_root` value after logging in, causing a 404 error.

**After**
The `next=` param includes the `app_root` value so the redirect works properly.

### TESTING INSTRUCTIONS
Added integration tests. For manual testing, set a value for `SUPERSET_APP_ROOT` and check that the `next=` param during login works properly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
