### PR TITLE
docs(api): add Theme API endpoints to OpenAPI spec

### DIFF
--- a/docs/developer_docs/api.mdx
+++ b/docs/developer_docs/api.mdx
@@ -412,7 +412,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 |--------|----------|-------------|
 | `GET` | [Get security roles](/developer-docs/api/get-security-roles) | `/api/v1/security/roles/` |
 | `POST` | [Create security roles](/developer-docs/api/create-security-roles) | `/api/v1/security/roles/` |
-| `GET` | [Get security roles  info](/developer-docs/api/get-security-roles-info) | `/api/v1/security/roles/_info` |
+| `GET` | [Get security roles info](/developer-docs/api/get-security-roles-info) | `/api/v1/security/roles/_info` |
 | `DELETE` | [Delete security roles by pk](/developer-docs/api/delete-security-roles-by-pk) | `/api/v1/security/roles/{pk}` |
 | `GET` | [Get security roles by pk](/developer-docs/api/get-security-roles-by-pk) | `/api/v1/security/roles/{pk}` |
 | `PUT` | [Update security roles by pk](/developer-docs/api/update-security-roles-by-pk) | `/api/v1/security/roles/{pk}` |
@@ -430,7 +430,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 |--------|----------|-------------|
 | `GET` | [Get security users](/developer-docs/api/get-security-users) | `/api/v1/security/users/` |
 | `POST` | [Create security users](/developer-docs/api/create-security-users) | `/api/v1/security/users/` |
-| `GET` | [Get security users  info](/developer-docs/api/get-security-users-info) | `/api/v1/security/users/_info` |
+| `GET` | [Get security users info](/developer-docs/api/get-security-users-info) | `/api/v1/security/users/_info` |
 | `DELETE` | [Delete security users by pk](/developer-docs/api/delete-security-users-by-pk) | `/api/v1/security/users/{pk}` |
 | `GET` | [Get security users by pk](/developer-docs/api/get-security-users-by-pk) | `/api/v1/security/users/{pk}` |
 | `PUT` | [Update security users by pk](/developer-docs/api/update-security-users-by-pk) | `/api/v1/security/users/{pk}` |
@@ -443,7 +443,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | [Get security permissions](/developer-docs/api/get-security-permissions) | `/api/v1/security/permissions/` |
-| `GET` | [Get security permissions  info](/developer-docs/api/get-security-permissions-info) | `/api/v1/security/permissions/_info` |
+| `GET` | [Get security permissions info](/developer-docs/api/get-security-permissions-info) | `/api/v1/security/permissions/_info` |
 | `GET` | [Get security permissions by pk](/developer-docs/api/get-security-permissions-by-pk) | `/api/v1/security/permissions/{pk}` |
 
 </details>
@@ -455,7 +455,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 |--------|----------|-------------|
 | `GET` | [Get security resources](/developer-docs/api/get-security-resources) | `/api/v1/security/resources/` |
 | `POST` | [Create security resources](/developer-docs/api/create-security-resources) | `/api/v1/security/resources/` |
-| `GET` | [Get security resources  info](/developer-docs/api/get-security-resources-info) | `/api/v1/security/resources/_info` |
+| `GET` | [Get security resources info](/developer-docs/api/get-security-resources-info) | `/api/v1/security/resources/_info` |
 | `DELETE` | [Delete security resources by pk](/developer-docs/api/delete-security-resources-by-pk) | `/api/v1/security/resources/{pk}` |
 | `GET` | [Get security resources by pk](/developer-docs/api/get-security-resources-by-pk) | `/api/v1/security/resources/{pk}` |
 | `PUT` | [Update security resources by pk](/developer-docs/api/update-security-resources-by-pk) | `/api/v1/security/resources/{pk}` |
@@ -469,7 +469,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 |--------|----------|-------------|
 | `GET` | [Get security permissions resources](/developer-docs/api/get-security-permissions-resources) | `/api/v1/security/permissions-resources/` |
 | `POST` | [Create security permissions resources](/developer-docs/api/create-security-permissions-resources) | `/api/v1/security/permissions-resources/` |
-| `GET` | [Get security permissions resources  info](/developer-docs/api/get-security-permissions-resources-info) | `/api/v1/security/permissions-resources/_info` |
+| `GET` | [Get security permissions resources info](/developer-docs/api/get-security-permissions-resources-info) | `/api/v1/security/permissions-resources/_info` |
 | `DELETE` | [Delete security permissions resources by pk](/developer-docs/api/delete-security-permissions-resources-by-pk) | `/api/v1/security/permissions-resources/{pk}` |
 | `GET` | [Get security permissions resources by pk](/developer-docs/api/get-security-permissions-resources-by-pk) | `/api/v1/security/permissions-resources/{pk}` |
 | `PUT` | [Update security permissions resources by pk](/developer-docs/api/update-security-permissions-resources-by-pk) | `/api/v1/security/permissions-resources/{pk}` |
@@ -578,7 +578,29 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | [Get api by version  openapi](/developer-docs/api/get-api-by-version-openapi) | `/api/{version}/_openapi` |
+| `GET` | [Get api by version openapi](/developer-docs/api/get-api-by-version-openapi) | `/api/{version}/_openapi` |
+
+</details>
+
+<details>
+<summary><strong>Themes</strong> (14 endpoints) — Manage UI themes for customizing Superset's appearance.</summary>
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `DELETE` | [Bulk delete themes](/developer-docs/api/bulk-delete-themes) | `/api/v1/theme/` |
+| `GET` | [Get a list of themes](/developer-docs/api/get-a-list-of-themes) | `/api/v1/theme/` |
+| `POST` | [Create a theme](/developer-docs/api/create-a-theme) | `/api/v1/theme/` |
+| `GET` | [Get metadata information about this API resource (theme-info)](/developer-docs/api/get-metadata-information-about-this-api-resource-theme-info) | `/api/v1/theme/_info` |
+| `DELETE` | [Delete a theme](/developer-docs/api/delete-a-theme) | `/api/v1/theme/{pk}` |
+| `GET` | [Get a theme](/developer-docs/api/get-a-theme) | `/api/v1/theme/{pk}` |
+| `PUT` | [Update a theme](/developer-docs/api/update-a-theme) | `/api/v1/theme/{pk}` |
+| `PUT` | [Set a theme as the system dark theme](/developer-docs/api/set-a-theme-as-the-system-dark-theme) | `/api/v1/theme/{pk}/set_system_dark` |
+| `PUT` | [Set a theme as the system default theme](/developer-docs/api/set-a-theme-as-the-system-default-theme) | `/api/v1/theme/{pk}/set_system_default` |
+| `GET` | [Download multiple themes as YAML files](/developer-docs/api/download-multiple-themes-as-yaml-files) | `/api/v1/theme/export/` |
+| `POST` | [Import themes from a ZIP file](/developer-docs/api/import-themes-from-a-zip-file) | `/api/v1/theme/import/` |
+| `GET` | [Get related fields data (theme-related-column-name)](/developer-docs/api/get-related-fields-data-theme-related-column-name) | `/api/v1/theme/related/{column_name}` |
+| `DELETE` | [Clear the system dark theme](/developer-docs/api/clear-the-system-dark-theme) | `/api/v1/theme/unset_system_dark` |
+| `DELETE` | [Clear the system default theme](/developer-docs/api/clear-the-system-default-theme) | `/api/v1/theme/unset_system_default` |
 
 </details>
 

--- a/docs/scripts/fix-openapi-spec.py
+++ b/docs/scripts/fix-openapi-spec.py
@@ -295,6 +295,7 @@ TAG_DESCRIPTIONS = {
     "Security Roles": "Manage security roles and their permissions.",
     "Security Users": "Manage user accounts.",
     "Tags": "Organize assets with tags.",
+    "Themes": "Manage UI themes for customizing Superset's appearance.",
     "User": "User profile and preferences.",
 }
 

--- a/docs/scripts/fix-openapi-spec.py
+++ b/docs/scripts/fix-openapi-spec.py
@@ -129,6 +129,30 @@ def add_missing_schemas(spec: dict[str, Any]) -> tuple[dict[str, Any], list[str]
         }
         fixed.append("DashboardColorsConfigUpdateSchema")
 
+    # DashboardChartCustomizationsConfigUpdateSchema - based on superset/dashboards/schemas.py
+    if "DashboardChartCustomizationsConfigUpdateSchema" not in schemas:
+        schemas["DashboardChartCustomizationsConfigUpdateSchema"] = {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of deleted chart customization IDs.",
+                },
+                "modified": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "List of modified chart customization configurations.",
+                },
+                "reordered": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of chart customization IDs in new order.",
+                },
+            },
+        }
+        fixed.append("DashboardChartCustomizationsConfigUpdateSchema")
+
     # FormatQueryPayloadSchema - based on superset/sqllab/schemas.py
     if "FormatQueryPayloadSchema" not in schemas:
         schemas["FormatQueryPayloadSchema"] = {

--- a/docs/scripts/fix-openapi-spec.py
+++ b/docs/scripts/fix-openapi-spec.py
@@ -129,7 +129,7 @@ def add_missing_schemas(spec: dict[str, Any]) -> tuple[dict[str, Any], list[str]
         }
         fixed.append("DashboardColorsConfigUpdateSchema")
 
-    # DashboardChartCustomizationsConfigUpdateSchema - based on superset/dashboards/schemas.py
+    # DashboardChartCustomizationsConfigUpdateSchema (dashboards/schemas.py)
     if "DashboardChartCustomizationsConfigUpdateSchema" not in schemas:
         schemas["DashboardChartCustomizationsConfigUpdateSchema"] = {
             "type": "object",
@@ -142,7 +142,7 @@ def add_missing_schemas(spec: dict[str, Any]) -> tuple[dict[str, Any], list[str]
                 "modified": {
                     "type": "array",
                     "items": {"type": "object"},
-                    "description": "List of modified chart customization configurations.",
+                    "description": "List of modified chart customizations.",
                 },
                 "reordered": {
                     "type": "array",

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -12701,6 +12701,32 @@
             "description": "Whether to match channel names exactly."
           }
         }
+      },
+      "DashboardChartCustomizationsConfigUpdateSchema": {
+        "type": "object",
+        "properties": {
+          "deleted": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of deleted chart customization IDs."
+          },
+          "modified": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "List of modified chart customization configurations."
+          },
+          "reordered": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of chart customization IDs in new order."
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -19095,6 +19121,17 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardChartCustomizationsConfigUpdateSchema"
+              },
+              "example": {
+                "deleted": [
+                  "string"
+                ],
+                "modified": [
+                  {}
+                ],
+                "reordered": [
+                  "string"
+                ]
               }
             }
           },

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -11,6 +11,9 @@
                 }
               },
               "type": "object"
+            },
+            "example": {
+              "message": "Bad request: Invalid parameters provided"
             }
           }
         },
@@ -26,6 +29,9 @@
                 }
               },
               "type": "object"
+            },
+            "example": {
+              "message": "Unauthorized: Authentication required"
             }
           }
         },
@@ -41,6 +47,9 @@
                 }
               },
               "type": "object"
+            },
+            "example": {
+              "message": "Forbidden: You don't have permission to access this resource"
             }
           }
         },
@@ -56,6 +65,9 @@
                 }
               },
               "type": "object"
+            },
+            "example": {
+              "message": "Not found: The requested resource does not exist"
             }
           }
         },
@@ -167,6 +179,9 @@
                 }
               },
               "type": "object"
+            },
+            "example": {
+              "message": "Unprocessable entity: Validation error"
             }
           }
         },
@@ -182,6 +197,9 @@
                 }
               },
               "type": "object"
+            },
+            "example": {
+              "message": "Internal server error: An unexpected error occurred"
             }
           }
         },
@@ -1742,14 +1760,6 @@
       },
       "ChartDataResponseSchema": {
         "properties": {
-          "dashboard_filters": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DashboardFiltersResponseSchema"
-              }
-            ],
-            "description": "Metadata about dashboard native filters applied to the query. Only present when filters_dashboard_id is provided."
-          },
           "result": {
             "description": "A list of results for each corresponding query in the request.",
             "items": {
@@ -2003,10 +2013,6 @@
       },
       "ChartDataRestApi.get_list.User3": {
         "properties": {
-          "email": {
-            "maxLength": 320,
-            "type": "string"
-          },
           "first_name": {
             "maxLength": 64,
             "type": "string"
@@ -2020,7 +2026,6 @@
           }
         },
         "required": [
-          "email",
           "first_name",
           "last_name"
         ],
@@ -2814,10 +2819,6 @@
       },
       "ChartRestApi.get_list.User3": {
         "properties": {
-          "email": {
-            "maxLength": 320,
-            "type": "string"
-          },
           "first_name": {
             "maxLength": 64,
             "type": "string"
@@ -2831,7 +2832,6 @@
           }
         },
         "required": [
-          "email",
           "first_name",
           "last_name"
         ],
@@ -3458,45 +3458,6 @@
         },
         "type": "object"
       },
-      "DashboardFilterInfo": {
-        "properties": {
-          "column": {
-            "description": "Target column name for the filter",
-            "nullable": true,
-            "type": "string"
-          },
-          "id": {
-            "description": "The native filter ID",
-            "type": "string"
-          },
-          "name": {
-            "description": "The native filter name",
-            "type": "string"
-          },
-          "status": {
-            "description": "Filter status: 'applied' (default value was included in the query), 'not_applied' (filter had no default value and was omitted, matching dashboard initial-load behavior), or 'not_applied_uses_default_to_first_item_prequery' (filter uses defaultToFirstItem which requires a pre-query to resolve and cannot be applied server-side)",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "status"
-        ],
-        "type": "object"
-      },
-      "DashboardFiltersResponseSchema": {
-        "properties": {
-          "filters": {
-            "description": "Metadata about each in-scope dashboard native filter and whether its default value was applied to the query",
-            "items": {
-              "$ref": "#/components/schemas/DashboardFilterInfo"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
       "DashboardGetResponseSchema": {
         "properties": {
           "certification_details": {
@@ -3806,10 +3767,6 @@
       },
       "DashboardRestApi.get_list.User2": {
         "properties": {
-          "email": {
-            "maxLength": 320,
-            "type": "string"
-          },
           "first_name": {
             "maxLength": 64,
             "type": "string"
@@ -3823,7 +3780,6 @@
           }
         },
         "required": [
-          "email",
           "first_name",
           "last_name"
         ],
@@ -6402,11 +6358,6 @@
       },
       "ExplorePermalinkStateSchema": {
         "properties": {
-          "chartState": {
-            "description": "Chart-level state for stateful tables (column filters, sorting, column order)",
-            "nullable": true,
-            "type": "object"
-          },
           "formData": {
             "description": "Chart form data",
             "type": "object"
@@ -6971,9 +6922,6 @@
           "is_managed_externally": {
             "nullable": true,
             "type": "boolean"
-          },
-          "masked_encrypted_extra": {
-            "type": "string"
           },
           "password": {
             "nullable": true,
@@ -8314,10 +8262,6 @@
       },
       "ReportScheduleRestApi.get.User": {
         "properties": {
-          "email": {
-            "maxLength": 320,
-            "type": "string"
-          },
           "first_name": {
             "maxLength": 64,
             "type": "string"
@@ -8331,7 +8275,6 @@
           }
         },
         "required": [
-          "email",
           "first_name",
           "last_name"
         ],
@@ -8474,10 +8417,6 @@
       },
       "ReportScheduleRestApi.get_list.User2": {
         "properties": {
-          "email": {
-            "maxLength": 320,
-            "type": "string"
-          },
           "first_name": {
             "maxLength": 64,
             "type": "string"
@@ -8491,7 +8430,6 @@
           }
         },
         "required": [
-          "email",
           "first_name",
           "last_name"
         ],
@@ -9287,7 +9225,6 @@
             "type": "integer"
           },
           "database": {
-            "nullable": true,
             "type": "integer"
           },
           "description": {
@@ -12067,9 +12004,6 @@
       },
       "User": {
         "properties": {
-          "email": {
-            "type": "string"
-          },
           "first_name": {
             "type": "string"
           },
@@ -12674,6 +12608,99 @@
           }
         },
         "type": "object"
+      },
+      "DashboardNativeFiltersConfigUpdateSchema": {
+        "type": "object",
+        "properties": {
+          "deleted": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of deleted filter IDs."
+          },
+          "modified": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "List of modified filter configurations."
+          },
+          "reordered": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of filter IDs in new order."
+          }
+        }
+      },
+      "DashboardColorsConfigUpdateSchema": {
+        "type": "object",
+        "properties": {
+          "color_namespace": {
+            "type": "string",
+            "nullable": true,
+            "description": "The color namespace."
+          },
+          "color_scheme": {
+            "type": "string",
+            "nullable": true,
+            "description": "The color scheme name."
+          },
+          "map_label_colors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Mapping of labels to colors."
+          },
+          "shared_label_colors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Shared label colors across charts."
+          },
+          "label_colors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Label to color mapping."
+          },
+          "color_scheme_domain": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Color scheme domain values."
+          }
+        }
+      },
+      "get_slack_channels_schema": {
+        "type": "object",
+        "properties": {
+          "search_string": {
+            "type": "string",
+            "description": "String to search for in channel names."
+          },
+          "types": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "public_channel",
+                "private_channel"
+              ]
+            },
+            "description": "Types of channels to search."
+          },
+          "exact_match": {
+            "type": "boolean",
+            "description": "Whether to match channel names exactly."
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -12718,6 +12745,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AdvancedDataTypeSchema"
+                },
+                "example": {
+                  "display_value": "string",
+                  "error_message": "string",
+                  "valid_filter_operators": [
+                    "string"
+                  ],
+                  "values": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -12747,6 +12784,23 @@
         "summary": "Return an AdvancedDataTypeResponse",
         "tags": [
           "Advanced Data Type"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/advanced_data_type/convert\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/advanced_data_type/convert\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/advanced_data_type/convert\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -12766,6 +12820,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -12792,6 +12851,23 @@
         "summary": "Return a list of available advanced data types",
         "tags": [
           "Advanced Data Type"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/advanced_data_type/types\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/advanced_data_type/types\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/advanced_data_type/types\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -12821,6 +12897,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -12847,6 +12926,23 @@
         "summary": "Delete multiple annotation layers in a bulk operation",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/annotation_layer/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/annotation_layer/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -12929,6 +13025,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -12952,9 +13070,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get a list of annotation layers",
+        "summary": "Get a list of annotation layers (annotation-layer)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -12963,6 +13098,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AnnotationLayerRestApi.post"
+              },
+              "example": {
+                "descr": "string",
+                "name": "string"
               }
             }
           },
@@ -12983,6 +13122,13 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "descr": "string",
+                    "name": "string"
+                  }
                 }
               }
             },
@@ -13006,9 +13152,26 @@
             "jwt": []
           }
         ],
-        "summary": "Create an annotation layer",
+        "summary": "Create an annotation layer (annotation-layer)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/annotation_layer/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/annotation_layer/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13070,6 +13233,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -13093,9 +13268,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (annotation-layer--info)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13128,6 +13320,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -13151,9 +13347,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (annotation-layer-related-column-name)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13181,6 +13394,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -13201,9 +13417,26 @@
             "jwt": []
           }
         ],
-        "summary": "Delete annotation layer",
+        "summary": "Delete annotation layer (annotation-layer-pk)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/annotation_layer/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/annotation_layer/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -13276,6 +13509,24 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "descr": "string",
+                    "id": 1,
+                    "name": "string"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -13302,9 +13553,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get an annotation layer",
+        "summary": "Get an annotation layer (annotation-layer-pk)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -13324,6 +13592,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AnnotationLayerRestApi.put"
+              },
+              "example": {
+                "descr": "string",
+                "name": "string"
               }
             }
           },
@@ -13344,6 +13616,13 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "descr": "string",
+                    "name": "string"
+                  }
                 }
               }
             },
@@ -13367,9 +13646,26 @@
             "jwt": []
           }
         ],
-        "summary": "Update an annotation layer",
+        "summary": "Update an annotation layer (annotation-layer-pk)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/annotation_layer/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/annotation_layer/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13408,6 +13704,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -13434,6 +13733,23 @@
         "summary": "Bulk delete annotation layers",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -13486,6 +13802,15 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "ids": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -13509,9 +13834,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get a list of annotation layers",
+        "summary": "Get a list of annotation layers (annotation-layer-pk-annotation)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -13531,6 +13873,13 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AnnotationRestApi.post"
+              },
+              "example": {
+                "end_dttm": "2024-01-15T10:30:00Z",
+                "json_metadata": "string",
+                "long_descr": "string",
+                "short_descr": "string",
+                "start_dttm": "2024-01-15T10:30:00Z"
               }
             }
           },
@@ -13551,6 +13900,16 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "end_dttm": "2024-01-15T10:30:00Z",
+                    "json_metadata": "string",
+                    "long_descr": "string",
+                    "short_descr": "string",
+                    "start_dttm": "2024-01-15T10:30:00Z"
+                  }
                 }
               }
             },
@@ -13574,9 +13933,26 @@
             "jwt": []
           }
         ],
-        "summary": "Create an annotation layer",
+        "summary": "Create an annotation layer (annotation-layer-pk-annotation)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13613,6 +13989,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -13633,9 +14012,26 @@
             "jwt": []
           }
         ],
-        "summary": "Delete annotation layer",
+        "summary": "Delete annotation layer (annotation-layer-pk-annotation-annotation-id)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -13685,6 +14081,17 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "end_dttm": "2024-01-15T10:30:00Z",
+                    "id": 1,
+                    "json_metadata": "string",
+                    "long_descr": "string",
+                    "short_descr": "string",
+                    "start_dttm": "2024-01-15T10:30:00Z"
+                  }
                 }
               }
             },
@@ -13711,9 +14118,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get an annotation layer",
+        "summary": "Get an annotation layer (annotation-layer-pk-annotation-annotation-id)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -13742,6 +14166,13 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AnnotationRestApi.put"
+              },
+              "example": {
+                "end_dttm": "2024-01-15T10:30:00Z",
+                "json_metadata": "string",
+                "long_descr": "string",
+                "short_descr": "string",
+                "start_dttm": "2024-01-15T10:30:00Z"
               }
             }
           },
@@ -13762,6 +14193,16 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "end_dttm": "2024-01-15T10:30:00Z",
+                    "json_metadata": "string",
+                    "long_descr": "string",
+                    "short_descr": "string",
+                    "start_dttm": "2024-01-15T10:30:00Z"
+                  }
                 }
               }
             },
@@ -13785,9 +14226,26 @@
             "jwt": []
           }
         ],
-        "summary": "Update an annotation layer",
+        "summary": "Update an annotation layer (annotation-layer-pk-annotation-annotation-id)",
         "tags": [
           "Annotation Layers"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13824,6 +14282,23 @@
         "summary": "Export all assets",
         "tags": [
           "Import/export"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/assets/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/assets/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/assets/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13837,10 +14312,6 @@
                   "bundle": {
                     "description": "upload file (ZIP or JSON)",
                     "format": "binary",
-                    "type": "string"
-                  },
-                  "encrypted_extra_secrets": {
-                    "description": "JSON map of secret values for masked encrypted_extra fields. Each key is a database file path and the value is a map of JSONPath expressions to secret values. For example: `{\"databases/db.yaml\": {\"$.credentials_info.secret\": \"foo\"}}`.",
                     "type": "string"
                   },
                   "passwords": {
@@ -13881,6 +14352,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -13907,6 +14381,23 @@
         "summary": "Import multiple assets",
         "tags": [
           "Import/export"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/assets/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/assets/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/assets/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13963,6 +14454,19 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {
+                      "channel_id": "string",
+                      "errors": [],
+                      "id": "string",
+                      "job_id": "string",
+                      "result_url": "string",
+                      "status": "string",
+                      "user_id": 1
+                    }
+                  ]
                 }
               }
             },
@@ -13983,6 +14487,23 @@
         "summary": "Read off of the Redis events stream",
         "tags": [
           "AsyncEventsRestApi"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/async_event/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/async_event/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/async_event/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -13999,6 +14520,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "domains": []
+                  }
                 }
               }
             },
@@ -14019,6 +14545,23 @@
         "summary": "Get all available domains",
         "tags": [
           "Available Domains"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/available_domains/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/available_domains/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/available_domains/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14030,6 +14573,14 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CacheInvalidationRequestSchema"
+              },
+              "example": {
+                "datasource_uids": [
+                  "string"
+                ],
+                "datasources": [
+                  {}
+                ]
               }
             }
           },
@@ -14055,6 +14606,23 @@
         "summary": "Invalidate cache records and remove the database records",
         "tags": [
           "CacheRestApi"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/cachekey/invalidate\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/cachekey/invalidate\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/cachekey/invalidate\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14084,6 +14652,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -14113,6 +14684,23 @@
         "summary": "Bulk delete charts",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/chart/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/chart/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -14195,6 +14783,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -14221,6 +14831,23 @@
         "summary": "Get a list of charts",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -14229,6 +14856,33 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChartRestApi.post"
+              },
+              "example": {
+                "cache_timeout": 1,
+                "certification_details": "string",
+                "certified_by": "string",
+                "dashboards": [
+                  1
+                ],
+                "datasource_id": 1,
+                "datasource_name": "string",
+                "datasource_type": "table",
+                "description": "string",
+                "external_url": "string",
+                "is_managed_externally": true,
+                "owners": [
+                  1
+                ],
+                "params": "string",
+                "query_context": "string",
+                "query_context_generation": true,
+                "slice_name": "string",
+                "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                "viz_type": [
+                  "bar",
+                  "area",
+                  "table"
+                ]
               }
             }
           },
@@ -14249,6 +14903,32 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "cache_timeout": 1,
+                    "certification_details": "string",
+                    "certified_by": "string",
+                    "dashboards": [],
+                    "datasource_id": 1,
+                    "datasource_name": "string",
+                    "datasource_type": "table",
+                    "description": "string",
+                    "external_url": "string",
+                    "is_managed_externally": true,
+                    "owners": [],
+                    "params": "string",
+                    "query_context": "string",
+                    "query_context_generation": true,
+                    "slice_name": "string",
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                    "viz_type": [
+                      "bar",
+                      "area",
+                      "table"
+                    ]
+                  }
                 }
               }
             },
@@ -14278,6 +14958,23 @@
         "summary": "Create a new chart",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/chart/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/chart/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14339,6 +15036,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -14362,9 +15071,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (chart--info)",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14376,6 +15102,20 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChartDataQueryContextSchema"
+              },
+              "example": {
+                "custom_cache_timeout": 1,
+                "datasource": {
+                  "id": {},
+                  "type": "table"
+                },
+                "force": true,
+                "form_data": {},
+                "queries": [
+                  {}
+                ],
+                "result_format": {},
+                "result_type": {}
               }
             }
           },
@@ -14388,6 +15128,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -14398,6 +15141,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
+                },
+                "example": {
+                  "channel_id": "string",
+                  "job_id": "string",
+                  "result_url": "string",
+                  "status": "string",
+                  "user_id": "string"
                 }
               }
             },
@@ -14418,9 +15168,26 @@
             "jwt": []
           }
         ],
-        "summary": "Return payload data response for the given query",
+        "summary": "Return payload data response for the given query (chart-data)",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/chart/data\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/chart/data\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/data\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14443,6 +15210,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -14469,9 +15239,26 @@
             "jwt": []
           }
         ],
-        "summary": "Return payload data response for the given query",
+        "summary": "Return payload data response for the given query (chart-data-cache-key)",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/data/{cache_key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/data/{cache_key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/data/{cache_key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14523,6 +15310,23 @@
         "summary": "Download multiple charts as YAML files",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14547,6 +15351,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -14573,6 +15380,23 @@
         "summary": "Check favorited charts for current user",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/favorite_status/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/favorite_status/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/favorite_status/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14626,6 +15450,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -14652,6 +15479,23 @@
         "summary": "Import chart(s) with associated datasets and databases",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/chart/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/chart/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14685,6 +15529,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -14708,9 +15556,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (chart-related-column-name)",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14722,6 +15587,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChartCacheWarmUpRequestSchema"
+              },
+              "example": {
+                "chart_id": 1,
+                "dashboard_id": 1,
+                "extra_filters": "string"
               }
             }
           },
@@ -14734,6 +15604,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartCacheWarmUpResponseSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -14757,6 +15630,23 @@
         "summary": "Warm up the cache for the chart",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/chart/warm_up_cache\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/chart/warm_up_cache\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/warm_up_cache\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14785,6 +15675,32 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "cache_timeout": "string",
+                    "certification_details": "string",
+                    "certified_by": "string",
+                    "changed_on_delta_humanized": "string",
+                    "dashboards": [],
+                    "datasource_id": 1,
+                    "datasource_name_text": {},
+                    "datasource_type": "string",
+                    "datasource_url": {},
+                    "datasource_uuid": "550e8400-e29b-41d4-a716-446655440000",
+                    "description": "string",
+                    "id": 1,
+                    "is_managed_externally": true,
+                    "owners": [],
+                    "params": "string",
+                    "query_context": "string",
+                    "slice_name": "string",
+                    "tags": [],
+                    "thumbnail_url": "string",
+                    "url": "string",
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                    "viz_type": "string"
+                  }
                 }
               }
             },
@@ -14811,6 +15727,23 @@
         "summary": "Get a chart detail information",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/{id_or_uuid}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/{id_or_uuid}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/{id_or_uuid}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14837,6 +15770,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -14866,6 +15802,23 @@
         "summary": "Delete a chart",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/chart/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/chart/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "put": {
@@ -14884,6 +15837,35 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChartRestApi.put"
+              },
+              "example": {
+                "cache_timeout": 1,
+                "certification_details": "string",
+                "certified_by": "string",
+                "dashboards": [
+                  1
+                ],
+                "datasource_id": 1,
+                "datasource_type": "table",
+                "description": "string",
+                "external_url": "string",
+                "is_managed_externally": true,
+                "owners": [
+                  1
+                ],
+                "params": "string",
+                "query_context": "string",
+                "query_context_generation": true,
+                "slice_name": "string",
+                "tags": [
+                  1
+                ],
+                "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                "viz_type": [
+                  "bar",
+                  "area",
+                  "table"
+                ]
               }
             }
           },
@@ -14904,6 +15886,32 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "cache_timeout": 1,
+                    "certification_details": "string",
+                    "certified_by": "string",
+                    "dashboards": [],
+                    "datasource_id": 1,
+                    "datasource_type": "table",
+                    "description": "string",
+                    "external_url": "string",
+                    "is_managed_externally": true,
+                    "owners": [],
+                    "params": "string",
+                    "query_context": "string",
+                    "query_context_generation": true,
+                    "slice_name": "string",
+                    "tags": [],
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                    "viz_type": [
+                      "bar",
+                      "area",
+                      "table"
+                    ]
+                  }
                 }
               }
             },
@@ -14936,6 +15944,23 @@
         "summary": "Update a chart",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/chart/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/chart/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -14968,6 +15993,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartCacheScreenshotResponseSchema"
+                },
+                "example": {
+                  "cache_key": "string",
+                  "chart_url": "string",
+                  "image_url": "string",
+                  "task_status": "string",
+                  "task_updated_at": "string"
                 }
               }
             },
@@ -14978,6 +16010,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartCacheScreenshotResponseSchema"
+                },
+                "example": {
+                  "cache_key": "string",
+                  "chart_url": "string",
+                  "image_url": "string",
+                  "task_status": "string",
+                  "task_updated_at": "string"
                 }
               }
             },
@@ -15001,15 +16040,32 @@
             "jwt": []
           }
         ],
-        "summary": "Compute and cache a screenshot",
+        "summary": "Compute and cache a screenshot (chart-pk-cache-screenshot)",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/1/cache_screenshot/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/1/cache_screenshot/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/cache_screenshot/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
     "/api/v1/chart/{pk}/data/": {
       "get": {
-        "description": "Takes a chart ID and uses the query context stored when the chart was saved to return payload data response. When filters_dashboard_id is provided, the chart's compiled SQL includes in scope dashboard filter default values.",
+        "description": "Takes a chart ID and uses the query context stored when the chart was saved to return payload data response.",
         "parameters": [
           {
             "description": "The chart ID",
@@ -15043,14 +16099,6 @@
             "schema": {
               "type": "boolean"
             }
-          },
-          {
-            "description": "Dashboard ID whose filter defaults should be applied to the chart's query context. The chart must belong to the specified dashboard. Only in scope filters with static default values are applied; filters that require a database query (I.E. defaultToFirstItem) or have no default are reported in the dashboard_filters response metadata.",
-            "in": "query",
-            "name": "filters_dashboard_id",
-            "schema": {
-              "type": "integer"
-            }
           }
         ],
         "responses": {
@@ -15059,6 +16107,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -15069,6 +16120,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
+                },
+                "example": {
+                  "channel_id": "string",
+                  "job_id": "string",
+                  "result_url": "string",
+                  "status": "string",
+                  "user_id": "string"
                 }
               }
             },
@@ -15079,12 +16137,6 @@
           },
           "401": {
             "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
           },
           "500": {
             "$ref": "#/components/responses/500"
@@ -15098,6 +16150,23 @@
         "summary": "Return payload data response for a chart",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/1/data/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/1/data/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/data/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -15124,6 +16193,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -15147,6 +16219,23 @@
         "summary": "Remove the chart from the user favorite list",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/chart/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/chart/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/favorites/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "post": {
@@ -15171,6 +16260,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -15194,6 +16286,23 @@
         "summary": "Mark the chart as favorite for the current user",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/chart/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/chart/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/favorites/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -15247,9 +16356,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get a computed screenshot from cache",
+        "summary": "Get a computed screenshot from cache (chart-pk-screenshot-digest)",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/1/screenshot/{digest}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/1/screenshot/{digest}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/screenshot/{digest}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -15311,6 +16437,23 @@
         "summary": "Get chart thumbnail",
         "tags": [
           "Charts"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/1/thumbnail/{digest}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/1/thumbnail/{digest}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/thumbnail/{digest}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -15340,6 +16483,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -15366,6 +16512,23 @@
         "summary": "Bulk delete CSS templates",
         "tags": [
           "CSS Templates"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/css_template/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/css_template/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -15448,6 +16611,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -15474,6 +16659,23 @@
         "summary": "Get a list of CSS templates",
         "tags": [
           "CSS Templates"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/css_template/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/css_template/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -15482,6 +16684,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CssTemplateRestApi.post"
+              },
+              "example": {
+                "css": "string",
+                "template_name": "string"
               }
             }
           },
@@ -15502,6 +16708,13 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "css": "string",
+                    "template_name": "string"
+                  }
                 }
               }
             },
@@ -15528,6 +16741,23 @@
         "summary": "Create a CSS template",
         "tags": [
           "CSS Templates"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/css_template/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/css_template/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -15589,6 +16819,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -15612,9 +16854,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (css-template--info)",
         "tags": [
           "CSS Templates"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/css_template/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/css_template/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -15647,6 +16906,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -15670,9 +16933,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (css-template-related-column-name)",
         "tags": [
           "CSS Templates"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/css_template/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/css_template/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -15699,6 +16979,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -15722,6 +17005,23 @@
         "summary": "Delete a CSS template",
         "tags": [
           "CSS Templates"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/css_template/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/css_template/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -15794,6 +17094,25 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "changed_on_delta_humanized": {},
+                    "css": "string",
+                    "id": 1,
+                    "template_name": "string"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -15823,6 +17142,23 @@
         "summary": "Get a CSS template",
         "tags": [
           "CSS Templates"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/css_template/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/css_template/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -15841,6 +17177,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CssTemplateRestApi.put"
+              },
+              "example": {
+                "css": "string",
+                "template_name": "string"
               }
             }
           },
@@ -15858,6 +17198,12 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "css": "string",
+                    "template_name": "string"
+                  }
                 }
               }
             },
@@ -15887,6 +17233,23 @@
         "summary": "Update a CSS template",
         "tags": [
           "CSS Templates"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/css_template/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/css_template/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -15916,6 +17279,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -15945,6 +17311,23 @@
         "summary": "Bulk delete dashboards",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -15985,6 +17368,15 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1,
+                  "ids": [
+                    1
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -16011,6 +17403,23 @@
         "summary": "Get a list of dashboards",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -16019,6 +17428,26 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardRestApi.post"
+              },
+              "example": {
+                "certification_details": "string",
+                "certified_by": "string",
+                "css": "string",
+                "dashboard_title": "string",
+                "external_url": "string",
+                "is_managed_externally": true,
+                "json_metadata": "string",
+                "owners": [
+                  1
+                ],
+                "position_json": "string",
+                "published": true,
+                "roles": [
+                  1
+                ],
+                "slug": "string",
+                "theme_id": 1,
+                "uuid": "550e8400-e29b-41d4-a716-446655440000"
               }
             }
           },
@@ -16039,6 +17468,25 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "certification_details": "string",
+                    "certified_by": "string",
+                    "css": "string",
+                    "dashboard_title": "string",
+                    "external_url": "string",
+                    "is_managed_externally": true,
+                    "json_metadata": "string",
+                    "owners": [],
+                    "position_json": "string",
+                    "published": true,
+                    "roles": [],
+                    "slug": "string",
+                    "theme_id": 1,
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
+                  }
                 }
               }
             },
@@ -16065,6 +17513,23 @@
         "summary": "Create a new dashboard",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16126,6 +17591,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -16149,9 +17626,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (dashboard--info)",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16205,6 +17699,23 @@
         "summary": "Download multiple dashboards as YAML files",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16229,6 +17740,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -16255,6 +17769,23 @@
         "summary": "Check favorited dashboards for current user",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/favorite_status/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/favorite_status/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/favorite_status/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16308,6 +17839,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -16334,6 +17868,23 @@
         "summary": "Import dashboard(s) with associated charts/datasets/databases",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16361,6 +17912,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "state": {}
                 }
               }
             },
@@ -16390,6 +17944,23 @@
         "summary": "Get dashboard's permanent link state",
         "tags": [
           "Dashboard Permanent Link"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/permalink/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/permalink/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/permalink/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16423,6 +17994,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -16446,9 +18021,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (dashboard-related-column-name)",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16463,17 +18055,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_item_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
           }
         ],
         "responses": {
@@ -16487,6 +18068,33 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "certification_details": "string",
+                    "certified_by": "string",
+                    "changed_by_name": "string",
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "changed_on_delta_humanized": "string",
+                    "charts": [],
+                    "created_on_delta_humanized": "string",
+                    "css": "string",
+                    "custom_tags": [],
+                    "dashboard_title": "string",
+                    "id": 1,
+                    "is_managed_externally": true,
+                    "json_metadata": "string",
+                    "owners": [],
+                    "position_json": "string",
+                    "published": true,
+                    "roles": [],
+                    "slug": "string",
+                    "tags": [],
+                    "theme": {},
+                    "thumbnail_url": "string",
+                    "url": "string",
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
+                  }
                 }
               }
             },
@@ -16513,6 +18121,23 @@
         "summary": "Get a dashboard detail information",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16542,6 +18167,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -16568,6 +18198,23 @@
         "summary": "Get a dashboard's chart definitions.",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/charts\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/charts\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/charts\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16589,6 +18236,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardCopySchema"
+              },
+              "example": {
+                "css": "string",
+                "dashboard_title": "string",
+                "duplicate_slices": true,
+                "json_metadata": "string"
               }
             }
           },
@@ -16608,6 +18261,10 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "last_modified_time": 1.0
                 }
               }
             },
@@ -16637,6 +18294,23 @@
         "summary": "Create a copy of an existing dashboard",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/copy/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/copy/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/copy/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16668,6 +18342,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -16694,6 +18373,23 @@
         "summary": "Get dashboard's datasets",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/datasets\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/datasets\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/datasets\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16721,6 +18417,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -16741,6 +18440,23 @@
         "summary": "Delete a dashboard's embedded configuration",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/1/embedded\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -16766,6 +18482,14 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "allowed_domains": [],
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "dashboard_id": "string",
+                    "uuid": "string"
+                  }
                 }
               }
             },
@@ -16786,6 +18510,23 @@
         "summary": "Get the dashboard's embedded configuration",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/embedded\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -16805,6 +18546,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/EmbeddedDashboardConfig"
+              },
+              "example": {
+                "allowed_domains": [
+                  "string"
+                ]
               }
             }
           },
@@ -16822,6 +18568,14 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "allowed_domains": [],
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "dashboard_id": "string",
+                    "uuid": "string"
+                  }
                 }
               }
             },
@@ -16842,6 +18596,23 @@
         "summary": "Set a dashboard's embedded configuration",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/embedded\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -16862,6 +18633,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/EmbeddedDashboardConfig"
+              },
+              "example": {
+                "allowed_domains": [
+                  "string"
+                ]
               }
             }
           },
@@ -16879,6 +18655,14 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "allowed_domains": [],
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "dashboard_id": "string",
+                    "uuid": "string"
+                  }
                 }
               }
             },
@@ -16898,6 +18682,25 @@
         ],
         "tags": [
           "Dashboards"
+        ],
+        "operationId": "update_dashboard_by_id_or_slug_embedded",
+        "summary": "Update dashboard by id_or_slug embedded",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/embedded\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16929,6 +18732,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -16955,6 +18761,23 @@
         "summary": "Get dashboard's tabs",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/tabs\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/tabs\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/tabs\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -16981,6 +18804,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -17010,6 +18836,23 @@
         "summary": "Delete a dashboard",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "put": {
@@ -17028,6 +18871,29 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardRestApi.put"
+              },
+              "example": {
+                "certification_details": "string",
+                "certified_by": "string",
+                "css": "string",
+                "dashboard_title": "string",
+                "external_url": "string",
+                "is_managed_externally": true,
+                "json_metadata": "string",
+                "owners": [
+                  1
+                ],
+                "position_json": "string",
+                "published": true,
+                "roles": [
+                  1
+                ],
+                "slug": "string",
+                "tags": [
+                  1
+                ],
+                "theme_id": 1,
+                "uuid": "550e8400-e29b-41d4-a716-446655440000"
               }
             }
           },
@@ -17051,6 +18917,27 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "last_modified_time": 1.0,
+                  "result": {
+                    "certification_details": "string",
+                    "certified_by": "string",
+                    "css": "string",
+                    "dashboard_title": "string",
+                    "external_url": "string",
+                    "is_managed_externally": true,
+                    "json_metadata": "string",
+                    "owners": [],
+                    "position_json": "string",
+                    "published": true,
+                    "roles": [],
+                    "slug": "string",
+                    "tags": [],
+                    "theme_id": 1,
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
+                  }
                 }
               }
             },
@@ -17083,6 +18970,23 @@
         "summary": "Update a dashboard",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -17103,6 +19007,14 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardScreenshotPostSchema"
+              },
+              "example": {
+                "activeTabs": [
+                  "string"
+                ],
+                "anchor": "string",
+                "dataMask": {},
+                "urlParams": []
               }
             }
           }
@@ -17113,6 +19025,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DashboardCacheScreenshotResponseSchema"
+                },
+                "example": {
+                  "cache_key": "string",
+                  "dashboard_url": "string",
+                  "image_url": "string",
+                  "task_status": "string",
+                  "task_updated_at": "string"
                 }
               }
             },
@@ -17136,9 +19055,26 @@
             "jwt": []
           }
         ],
-        "summary": "Compute and cache a screenshot",
+        "summary": "Compute and cache a screenshot (dashboard-pk-cache-dashboard-screenshot)",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/cache_dashboard_screenshot/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/cache_dashboard_screenshot/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/cache_dashboard_screenshot/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -17176,6 +19112,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -17208,6 +19147,23 @@
         "summary": "Update chart customizations configuration for a dashboard.",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/chart_customizations\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/chart_customizations\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/chart_customizations\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -17236,6 +19192,22 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardColorsConfigUpdateSchema"
+              },
+              "example": {
+                "color_namespace": "string",
+                "color_scheme": "string",
+                "map_label_colors": {
+                  "key": "value"
+                },
+                "shared_label_colors": {
+                  "key": "value"
+                },
+                "label_colors": {
+                  "key": "value"
+                },
+                "color_scheme_domain": [
+                  "string"
+                ]
               }
             }
           },
@@ -17253,6 +19225,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -17285,6 +19260,23 @@
         "summary": "Update colors configuration for a dashboard.",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/colors\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/colors\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/colors\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -17352,6 +19344,23 @@
         "summary": "Export dashboard as example bundle",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/export_as_example/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/export_as_example/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/export_as_example/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -17378,6 +19387,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -17401,6 +19413,23 @@
         "summary": "Remove the dashboard from the user favorite list",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/favorites/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "post": {
@@ -17425,6 +19454,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -17448,6 +19480,23 @@
         "summary": "Mark the dashboard as favorite for the current user",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/favorites/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -17576,6 +19625,9 @@
               },
               "schema": {
                 "$ref": "#/components/schemas/TemporaryCachePostSchema"
+              },
+              "example": {
+                "value": "string"
               }
             }
           },
@@ -17593,6 +19645,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "key": "string"
                 }
               }
             },
@@ -17619,6 +19674,23 @@
         "summary": "Create a dashboard's filter state",
         "tags": [
           "Dashboard Filter State"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/filter_state\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/filter_state\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filter_state\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -17655,6 +19727,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -17684,6 +19759,23 @@
         "summary": "Delete a dashboard's filter state value",
         "tags": [
           "Dashboard Filter State"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -17717,6 +19809,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "value": "string"
                 }
               }
             },
@@ -17746,6 +19841,23 @@
         "summary": "Get a dashboard's filter state value",
         "tags": [
           "Dashboard Filter State"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -17779,6 +19891,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TemporaryCachePutSchema"
+              },
+              "example": {
+                "value": "string"
               }
             }
           },
@@ -17796,6 +19911,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "key": "string"
                 }
               }
             },
@@ -17825,6 +19943,23 @@
         "summary": "Update a dashboard's filter state value",
         "tags": [
           "Dashboard Filter State"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -17845,6 +19980,17 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardNativeFiltersConfigUpdateSchema"
+              },
+              "example": {
+                "deleted": [
+                  "string"
+                ],
+                "modified": [
+                  {}
+                ],
+                "reordered": [
+                  "string"
+                ]
               }
             }
           },
@@ -17862,6 +20008,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -17894,6 +20043,23 @@
         "summary": "Update native filters configuration for a dashboard.",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/filters\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/filters\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filters\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18020,6 +20186,17 @@
               },
               "schema": {
                 "$ref": "#/components/schemas/DashboardPermalinkStateSchema"
+              },
+              "example": {
+                "activeTabs": [
+                  "string"
+                ],
+                "anchor": "string",
+                "chartStates": {},
+                "dataMask": {},
+                "urlParams": [
+                  {}
+                ]
               }
             }
           },
@@ -18041,6 +20218,10 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "key": "string",
+                  "url": "string"
                 }
               }
             },
@@ -18067,6 +20248,23 @@
         "summary": "Create a new dashboard's permanent link",
         "tags": [
           "Dashboard Permanent Link"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/permalink\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/permalink\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/permalink\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18131,9 +20329,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get a computed screenshot from cache",
+        "summary": "Get a computed screenshot from cache (dashboard-pk-screenshot-digest)",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/screenshot/{digest}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/screenshot/{digest}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/screenshot/{digest}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18181,6 +20396,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -18210,6 +20428,23 @@
         "summary": "Get dashboard's thumbnail",
         "tags": [
           "Dashboards"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/thumbnail/{digest}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/thumbnail/{digest}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/thumbnail/{digest}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18294,6 +20529,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -18320,6 +20577,23 @@
         "summary": "Get a list of databases",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -18328,6 +20602,30 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseRestApi.post"
+              },
+              "example": {
+                "allow_ctas": true,
+                "allow_cvas": true,
+                "allow_dml": true,
+                "allow_file_upload": true,
+                "allow_run_async": true,
+                "cache_timeout": 1,
+                "configuration_method": {},
+                "database_name": "string",
+                "driver": "string",
+                "engine": "string",
+                "expose_in_sqllab": true,
+                "external_url": "string",
+                "extra": "string",
+                "force_ctas_schema": "string",
+                "impersonate_user": true,
+                "is_managed_externally": true,
+                "masked_encrypted_extra": "string",
+                "parameters": {},
+                "server_cert": "string",
+                "sqlalchemy_uri": "string",
+                "ssh_tunnel": {},
+                "uuid": "string"
               }
             }
           },
@@ -18348,6 +20646,33 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "allow_ctas": true,
+                    "allow_cvas": true,
+                    "allow_dml": true,
+                    "allow_file_upload": true,
+                    "allow_run_async": true,
+                    "cache_timeout": 1,
+                    "configuration_method": {},
+                    "database_name": "string",
+                    "driver": "string",
+                    "engine": "string",
+                    "expose_in_sqllab": true,
+                    "external_url": "string",
+                    "extra": "string",
+                    "force_ctas_schema": "string",
+                    "impersonate_user": true,
+                    "is_managed_externally": true,
+                    "masked_encrypted_extra": "string",
+                    "parameters": {},
+                    "server_cert": "string",
+                    "sqlalchemy_uri": "string",
+                    "ssh_tunnel": {},
+                    "uuid": "string"
+                  }
                 }
               }
             },
@@ -18374,6 +20699,23 @@
         "summary": "Create a new database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/database/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18435,6 +20777,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -18458,9 +20812,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (database--info)",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18522,7 +20893,24 @@
                     "type": "object"
                   },
                   "type": "array"
-                }
+                },
+                "example": [
+                  {
+                    "available_drivers": [
+                      "string"
+                    ],
+                    "default_driver": "string",
+                    "engine": "string",
+                    "engine_information": {
+                      "disable_ssh_tunneling": true,
+                      "supports_file_upload": true
+                    },
+                    "name": "string",
+                    "parameters": {},
+                    "preferred": true,
+                    "sqlalchemy_uri_placeholder": "string"
+                  }
+                ]
               }
             },
             "description": "Database names"
@@ -18542,6 +20930,23 @@
         "summary": "Get names of databases currently available",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/available/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/available/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/available/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18590,6 +20995,23 @@
         "summary": "Download database(s) and associated dataset(s) as a zip file",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18600,10 +21022,6 @@
             "multipart/form-data": {
               "schema": {
                 "properties": {
-                  "encrypted_extra_secrets": {
-                    "description": "JSON map of sensitive values for masked_encrypted_extra fields. Keys are file paths (e.g., \"databases/db.yaml\") and values are JSON objects mapping JSONPath expressions to secrets. (e.g., `{\"databases/MyDatabase.yaml\": {\"$.credentials_info.private_key\": \"actual_key\"}}`).",
-                    "type": "string"
-                  },
                   "formData": {
                     "description": "upload file (ZIP)",
                     "format": "binary",
@@ -18647,6 +21065,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -18673,6 +21094,23 @@
         "summary": "Import database(s) with associated datasets",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/database/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18738,6 +21176,23 @@
         "summary": "Receive personal access tokens from OAuth2",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/oauth2/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/oauth2/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/oauth2/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18770,6 +21225,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -18793,9 +21252,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (database-related-column-name)",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18806,6 +21282,19 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseTestConnectionSchema"
+              },
+              "example": {
+                "configuration_method": {},
+                "database_name": "string",
+                "driver": "string",
+                "engine": "string",
+                "extra": "string",
+                "impersonate_user": true,
+                "masked_encrypted_extra": "string",
+                "parameters": {},
+                "server_cert": "string",
+                "sqlalchemy_uri": "string",
+                "ssh_tunnel": {}
               }
             }
           },
@@ -18823,6 +21312,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -18846,6 +21338,23 @@
         "summary": "Test a database connection",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/database/test_connection/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/test_connection/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/test_connection/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18872,6 +21381,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "items": []
+                  }
                 }
               }
             },
@@ -18898,6 +21412,23 @@
         "summary": "Upload a file and returns file metadata",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/database/upload_metadata/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/upload_metadata/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/upload_metadata/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18908,6 +21439,23 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseValidateParametersSchema"
+              },
+              "example": {
+                "catalog": {
+                  "key": "value"
+                },
+                "configuration_method": {},
+                "database_name": "string",
+                "driver": "string",
+                "engine": "string",
+                "extra": "string",
+                "id": 1,
+                "impersonate_user": true,
+                "masked_encrypted_extra": "string",
+                "parameters": {
+                  "key": "value"
+                },
+                "server_cert": "string"
               }
             }
           },
@@ -18925,6 +21473,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -18948,6 +21499,23 @@
         "summary": "Validate database connection parameters",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/database/validate_parameters/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/validate_parameters/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/validate_parameters/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -18974,6 +21542,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -19003,6 +21574,23 @@
         "summary": "Delete a database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/database/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/database/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -19049,6 +21637,23 @@
         "summary": "Get a database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -19067,6 +21672,30 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseRestApi.put"
+              },
+              "example": {
+                "allow_ctas": true,
+                "allow_cvas": true,
+                "allow_dml": true,
+                "allow_file_upload": true,
+                "allow_run_async": true,
+                "cache_timeout": 1,
+                "configuration_method": {},
+                "database_name": "string",
+                "driver": "string",
+                "engine": "string",
+                "expose_in_sqllab": true,
+                "external_url": "string",
+                "extra": "string",
+                "force_ctas_schema": "string",
+                "impersonate_user": true,
+                "is_managed_externally": true,
+                "masked_encrypted_extra": "string",
+                "parameters": {},
+                "server_cert": "string",
+                "sqlalchemy_uri": "string",
+                "ssh_tunnel": {},
+                "uuid": "string"
               }
             }
           },
@@ -19087,6 +21716,33 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "allow_ctas": true,
+                    "allow_cvas": true,
+                    "allow_dml": true,
+                    "allow_file_upload": true,
+                    "allow_run_async": true,
+                    "cache_timeout": 1,
+                    "configuration_method": {},
+                    "database_name": "string",
+                    "driver": "string",
+                    "engine": "string",
+                    "expose_in_sqllab": true,
+                    "external_url": "string",
+                    "extra": "string",
+                    "force_ctas_schema": "string",
+                    "impersonate_user": true,
+                    "is_managed_externally": true,
+                    "masked_encrypted_extra": "string",
+                    "parameters": {},
+                    "server_cert": "string",
+                    "sqlalchemy_uri": "string",
+                    "ssh_tunnel": {},
+                    "uuid": "string"
+                  }
                 }
               }
             },
@@ -19119,6 +21775,23 @@
         "summary": "Change a database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/database/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/database/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19152,6 +21825,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CatalogsResponseSchema"
+                },
+                "example": {
+                  "result": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -19178,6 +21856,23 @@
         "summary": "Get all catalogs from a database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/catalogs/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/catalogs/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/catalogs/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19200,6 +21895,32 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseConnectionSchema"
+                },
+                "example": {
+                  "allow_ctas": true,
+                  "allow_cvas": true,
+                  "allow_dml": true,
+                  "allow_file_upload": true,
+                  "allow_run_async": true,
+                  "backend": "string",
+                  "cache_timeout": 1,
+                  "configuration_method": "string",
+                  "database_name": "string",
+                  "driver": "string",
+                  "engine_information": {},
+                  "expose_in_sqllab": true,
+                  "extra": "string",
+                  "force_ctas_schema": "string",
+                  "id": 1,
+                  "impersonate_user": true,
+                  "is_managed_externally": true,
+                  "masked_encrypted_extra": "string",
+                  "parameters": {},
+                  "parameters_schema": {},
+                  "server_cert": "string",
+                  "sqlalchemy_uri": "string",
+                  "ssh_tunnel": {},
+                  "uuid": "string"
                 }
               }
             },
@@ -19226,6 +21947,23 @@
         "summary": "Get a database connection info",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/connection\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/connection\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/connection\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19247,6 +21985,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseFunctionNamesResponse"
+                },
+                "example": {
+                  "function_names": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -19270,6 +22013,23 @@
         "summary": "Get function names supported by a database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/function_names/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/function_names/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/function_names/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19291,6 +22051,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseRelatedObjectsResponse"
+                },
+                "example": {
+                  "charts": {},
+                  "dashboards": {}
                 }
               }
             },
@@ -19314,6 +22078,23 @@
         "summary": "Get charts and dashboards count associated to a database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/related_objects/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/related_objects/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/related_objects/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19347,6 +22128,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SchemasResponseSchema"
+                },
+                "example": {
+                  "result": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -19373,6 +22159,23 @@
         "summary": "Get all schemas from a database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/schemas/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/schemas/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/schemas/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19394,6 +22197,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseSchemaAccessForFileUploadResponse"
+                },
+                "example": {
+                  "schemas": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -19417,6 +22225,23 @@
         "summary": "The list of the database schemas where to upload information",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/schemas_access_for_file_upload/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/schemas_access_for_file_upload/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/schemas_access_for_file_upload/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19457,6 +22282,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SelectStarResponseSchema"
+                },
+                "example": {
+                  "result": "string"
                 }
               }
             },
@@ -19483,9 +22311,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get database select star for table",
+        "summary": "Get database select star for table (database-pk-select-star-table-name)",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19526,6 +22371,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SelectStarResponseSchema"
+                },
+                "example": {
+                  "result": "string"
                 }
               }
             },
@@ -19552,9 +22400,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get database select star for table",
+        "summary": "Get database select star for table (database-pk-select-star-table-name-schema-name)",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/{schema_name}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/{schema_name}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/{schema_name}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19582,6 +22447,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -19608,6 +22476,23 @@
         "summary": "Re-sync all permissions for a database connection",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/database/1/sync_permissions/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/1/sync_permissions/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/sync_permissions/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19648,6 +22533,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TableMetadataResponseSchema"
+                },
+                "example": {
+                  "columns": [],
+                  "foreignKeys": [],
+                  "indexes": [],
+                  "name": "string",
+                  "primaryKey": {},
+                  "selectStar": "string"
                 }
               }
             },
@@ -19677,6 +22570,23 @@
         "summary": "Get database table metadata",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/table/{table_name}/{schema_name}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/table/{table_name}/{schema_name}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/table/{table_name}/{schema_name}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19718,6 +22628,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
+                },
+                "example": {
+                  "clustering": {},
+                  "metadata": {},
+                  "partitions": {}
                 }
               }
             },
@@ -19744,9 +22659,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get table extra metadata",
+        "summary": "Get table extra metadata (database-pk-table-extra-table-name-schema-name)",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/table_extra/{table_name}/{schema_name}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/table_extra/{table_name}/{schema_name}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/table_extra/{table_name}/{schema_name}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19795,6 +22727,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
+                },
+                "example": {
+                  "clustering": {},
+                  "metadata": {},
+                  "partitions": {}
                 }
               }
             },
@@ -19818,6 +22755,23 @@
         "summary": "Get table metadata",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/table_metadata/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/table_metadata/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/table_metadata/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19866,6 +22820,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
+                },
+                "example": {
+                  "clustering": {},
+                  "metadata": {},
+                  "partitions": {}
                 }
               }
             },
@@ -19886,9 +22845,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get table extra metadata",
+        "summary": "Get table extra metadata (database-pk-table-metadata-extra)",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/table_metadata/extra/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/table_metadata/extra/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/table_metadata/extra/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19934,6 +22910,12 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1,
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -19963,6 +22945,23 @@
         "summary": "Get a list of tables for given database",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/tables/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/tables/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/tables/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -19999,6 +22998,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -20028,6 +23030,23 @@
         "summary": "Upload a file to a database table",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/database/1/upload/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/1/upload/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/upload/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20049,6 +23068,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ValidateSQLRequest"
+              },
+              "example": {
+                "catalog": "string",
+                "schema": "string",
+                "sql": "string",
+                "template_params": {}
               }
             }
           },
@@ -20070,6 +23095,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -20096,6 +23126,23 @@
         "summary": "Validate arbitrary SQL",
         "tags": [
           "Database"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/database/1/validate_sql/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/1/validate_sql/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/validate_sql/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20125,6 +23172,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -20157,6 +23207,23 @@
         "summary": "Bulk delete datasets",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dataset/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dataset/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -20239,6 +23306,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -20265,6 +23354,23 @@
         "summary": "Get a list of datasets",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -20273,6 +23379,22 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatasetRestApi.post"
+              },
+              "example": {
+                "always_filter_main_dttm": true,
+                "catalog": "string",
+                "database": 1,
+                "external_url": "string",
+                "is_managed_externally": true,
+                "normalize_columns": true,
+                "owners": [
+                  1
+                ],
+                "schema": "string",
+                "sql": "string",
+                "table_name": "string",
+                "template_params": "string",
+                "uuid": "550e8400-e29b-41d4-a716-446655440000"
               }
             }
           },
@@ -20293,6 +23415,23 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "always_filter_main_dttm": true,
+                    "catalog": "string",
+                    "database": 1,
+                    "external_url": "string",
+                    "is_managed_externally": true,
+                    "normalize_columns": true,
+                    "owners": [],
+                    "schema": "string",
+                    "sql": "string",
+                    "table_name": "string",
+                    "template_params": "string",
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
+                  }
                 }
               }
             },
@@ -20319,6 +23458,23 @@
         "summary": "Create a new dataset",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dataset/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dataset/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20380,6 +23536,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -20403,9 +23571,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (dataset--info)",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20438,6 +23623,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DistincResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -20461,9 +23650,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get distinct values from field data",
+        "summary": "Get distinct values from field data (dataset-distinct-column-name)",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/distinct/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/distinct/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/distinct/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20474,6 +23680,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatasetDuplicateSchema"
+              },
+              "example": {
+                "base_model_id": 1,
+                "table_name": "string"
               }
             }
           },
@@ -20494,6 +23704,13 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "base_model_id": 1,
+                    "table_name": "string"
+                  }
                 }
               }
             },
@@ -20526,6 +23743,23 @@
         "summary": "Duplicate a dataset",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dataset/duplicate\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dataset/duplicate\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/duplicate\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20576,6 +23810,23 @@
         "summary": "Download multiple datasets as YAML files",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20586,6 +23837,15 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/GetOrCreateDatasetSchema"
+              },
+              "example": {
+                "always_filter_main_dttm": true,
+                "catalog": "string",
+                "database_id": 1,
+                "normalize_columns": true,
+                "schema": "string",
+                "table_name": "string",
+                "template_params": "string"
               }
             }
           },
@@ -20607,6 +23867,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "table_id": 1
+                  }
                 }
               }
             },
@@ -20633,6 +23898,23 @@
         "summary": "Retrieve a table by name, or create it if it does not exist",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dataset/get_or_create/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dataset/get_or_create/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/get_or_create/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20694,6 +23976,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -20720,6 +24005,23 @@
         "summary": "Import dataset(s) with associated databases",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/dataset/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dataset/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20752,6 +24054,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -20775,9 +24081,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (dataset-related-column-name)",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20789,6 +24112,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatasetCacheWarmUpRequestSchema"
+              },
+              "example": {
+                "dashboard_id": 1,
+                "db_name": "string",
+                "extra_filters": "string",
+                "table_name": "string"
               }
             }
           },
@@ -20801,6 +24130,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetCacheWarmUpResponseSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -20824,6 +24156,23 @@
         "summary": "Warm up the cache for each chart powered by the given table",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dataset/warm_up_cache\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dataset/warm_up_cache\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/warm_up_cache\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20875,6 +24224,48 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "always_filter_main_dttm": true,
+                    "cache_timeout": {},
+                    "catalog": "string",
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "changed_on_humanized": {},
+                    "column_formats": {},
+                    "created_on": "2024-01-15T10:30:00Z",
+                    "created_on_humanized": {},
+                    "currency_code_column": "string",
+                    "datasource_name": {},
+                    "datasource_type": {},
+                    "default_endpoint": "string",
+                    "description": "string",
+                    "extra": "string",
+                    "fetch_values_predicate": "string",
+                    "filter_select_enabled": true,
+                    "folders": {},
+                    "granularity_sqla": {},
+                    "id": 1,
+                    "is_managed_externally": true,
+                    "is_sqllab_view": true,
+                    "kind": {},
+                    "main_dttm_col": "string",
+                    "name": {},
+                    "normalize_columns": true,
+                    "offset": 1,
+                    "order_by_choices": {},
+                    "schema": "string",
+                    "select_star": {},
+                    "sql": "string",
+                    "table_name": "string",
+                    "template_params": "string",
+                    "time_grain_sqla": {},
+                    "uid": {},
+                    "url": {},
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                    "verbose_map": {}
+                  }
                 }
               }
             },
@@ -20901,6 +24292,23 @@
         "summary": "Get a dataset",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/{id_or_uuid}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/{id_or_uuid}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/{id_or_uuid}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20922,6 +24330,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetRelatedObjectsResponse"
+                },
+                "example": {
+                  "charts": {},
+                  "dashboards": {}
                 }
               }
             },
@@ -20945,6 +24357,23 @@
         "summary": "Get charts and dashboards count associated to a dataset",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/{id_or_uuid}/related_objects\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/{id_or_uuid}/related_objects\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/{id_or_uuid}/related_objects\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -20971,6 +24400,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -21000,6 +24432,23 @@
         "summary": "Delete a dataset",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dataset/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dataset/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "put": {
@@ -21025,6 +24474,41 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatasetRestApi.put"
+              },
+              "example": {
+                "always_filter_main_dttm": true,
+                "cache_timeout": 1,
+                "catalog": "string",
+                "columns": [
+                  {}
+                ],
+                "currency_code_column": "string",
+                "database_id": 1,
+                "default_endpoint": "string",
+                "description": "string",
+                "external_url": "string",
+                "extra": "string",
+                "fetch_values_predicate": "string",
+                "filter_select_enabled": true,
+                "folders": [
+                  {}
+                ],
+                "is_managed_externally": true,
+                "is_sqllab_view": true,
+                "main_dttm_col": "string",
+                "metrics": [
+                  {}
+                ],
+                "normalize_columns": true,
+                "offset": 1,
+                "owners": [
+                  1
+                ],
+                "schema": "string",
+                "sql": "string",
+                "table_name": "string",
+                "template_params": "string",
+                "uuid": "550e8400-e29b-41d4-a716-446655440000"
               }
             }
           },
@@ -21045,6 +24529,36 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "always_filter_main_dttm": true,
+                    "cache_timeout": 1,
+                    "catalog": "string",
+                    "columns": [],
+                    "currency_code_column": "string",
+                    "database_id": 1,
+                    "default_endpoint": "string",
+                    "description": "string",
+                    "external_url": "string",
+                    "extra": "string",
+                    "fetch_values_predicate": "string",
+                    "filter_select_enabled": true,
+                    "folders": [],
+                    "is_managed_externally": true,
+                    "is_sqllab_view": true,
+                    "main_dttm_col": "string",
+                    "metrics": [],
+                    "normalize_columns": true,
+                    "offset": 1,
+                    "owners": [],
+                    "schema": "string",
+                    "sql": "string",
+                    "table_name": "string",
+                    "template_params": "string",
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
+                  }
                 }
               }
             },
@@ -21077,6 +24591,23 @@
         "summary": "Update a dataset",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dataset/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dataset/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21113,6 +24644,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -21142,6 +24676,23 @@
         "summary": "Delete a dataset column",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dataset/1/column/{column_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dataset/1/column/{column_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1/column/{column_id}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       }
     },
@@ -21169,6 +24720,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -21198,6 +24752,23 @@
         "summary": "Get dataset drill info",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/1/drill_info/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/1/drill_info/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1/drill_info/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21234,6 +24805,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -21263,6 +24837,23 @@
         "summary": "Delete a dataset metric",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dataset/1/metric/{metric_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dataset/1/metric/{metric_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1/metric/{metric_id}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       }
     },
@@ -21289,6 +24880,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -21318,6 +24912,23 @@
         "summary": "Refresh and update columns of a dataset",
         "tags": [
           "Datasets"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/dataset/1/refresh\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dataset/1/refresh\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1/refresh\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21382,6 +24993,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -21411,6 +25027,23 @@
         "summary": "Get possible values for a datasource column",
         "tags": [
           "Datasources"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21469,6 +25102,11 @@
                   "expression"
                 ],
                 "type": "object"
+              },
+              "example": {
+                "clause": "WHERE",
+                "expression": "string",
+                "expression_type": "column"
               }
             }
           },
@@ -21503,6 +25141,16 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {
+                      "end_column": 1,
+                      "line_number": 1,
+                      "message": "string",
+                      "start_column": 1
+                    }
+                  ]
                 }
               }
             },
@@ -21532,6 +25180,23 @@
         "summary": "Validate a SQL expression against a datasource",
         "tags": [
           "Datasources"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/validate_expression/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/validate_expression/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/validate_expression/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21599,6 +25264,14 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "allowed_domains": [],
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "dashboard_id": "string",
+                    "uuid": "string"
+                  }
                 }
               },
               "text/html": {
@@ -21624,9 +25297,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get a report schedule log",
+        "summary": "Get a report schedule log (embedded-dashboard-uuid)",
         "tags": [
           "Embedded Dashboard"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/embedded_dashboard/{uuid}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/embedded_dashboard/{uuid}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/embedded_dashboard/{uuid}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21676,6 +25366,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExploreContextSchema"
+                },
+                "example": {
+                  "dataset": {},
+                  "form_data": {},
+                  "message": "string",
+                  "slice": {}
                 }
               }
             },
@@ -21705,6 +25401,23 @@
         "summary": "Assemble Explore related information in a single endpoint",
         "tags": [
           "Explore"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/explore/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/explore/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21724,6 +25437,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/FormDataPostSchema"
+              },
+              "example": {
+                "chart_id": 1,
+                "datasource_id": 1,
+                "datasource_type": "table",
+                "form_data": "string"
               }
             }
           },
@@ -21741,6 +25460,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "key": "string"
                 }
               }
             },
@@ -21767,6 +25489,23 @@
         "summary": "Create a new form_data",
         "tags": [
           "Explore Form Data"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/explore/form_data\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/explore/form_data\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/form_data\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21795,6 +25534,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -21824,6 +25566,23 @@
         "summary": "Delete a form_data",
         "tags": [
           "Explore Form Data"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/explore/form_data/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -21849,6 +25608,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "form_data": "string"
                 }
               }
             },
@@ -21878,6 +25640,23 @@
         "summary": "Get a form_data",
         "tags": [
           "Explore Form Data"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/explore/form_data/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -21903,6 +25682,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/FormDataPutSchema"
+              },
+              "example": {
+                "chart_id": 1,
+                "datasource_id": 1,
+                "datasource_type": "table",
+                "form_data": "string"
               }
             }
           },
@@ -21920,6 +25705,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "key": "string"
                 }
               }
             },
@@ -21949,6 +25737,23 @@
         "summary": "Update an existing form_data",
         "tags": [
           "Explore Form Data"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/explore/form_data/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -21959,6 +25764,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ExplorePermalinkStateSchema"
+              },
+              "example": {
+                "formData": {},
+                "urlParams": [
+                  {}
+                ]
               }
             }
           },
@@ -21980,6 +25791,10 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "key": "string",
+                  "url": "string"
                 }
               }
             },
@@ -22003,9 +25818,26 @@
             "jwt": []
           }
         ],
-        "summary": "Create a new permanent link",
+        "summary": "Create a new permanent link (explore-permalink)",
         "tags": [
           "Explore Permanent Link"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/explore/permalink\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/explore/permalink\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/permalink\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22033,6 +25865,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "state": {}
                 }
               }
             },
@@ -22062,6 +25897,23 @@
         "summary": "Get chart's permanent link state",
         "tags": [
           "Explore Permanent Link"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/explore/permalink/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/explore/permalink/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/permalink/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22146,6 +25998,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -22172,6 +26046,23 @@
         "summary": "Get a list of logs",
         "tags": [
           "LogRestApi"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/log/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/log/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/log/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -22180,6 +26071,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/LogRestApi.post"
+              },
+              "example": {
+                "id": 1
               }
             }
           },
@@ -22200,6 +26094,12 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "id": 1
+                  }
                 }
               }
             },
@@ -22225,6 +26125,25 @@
         ],
         "tags": [
           "LogRestApi"
+        ],
+        "operationId": "create_log",
+        "summary": "Create log",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/log/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/log/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/log/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22258,6 +26177,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RecentActivityResponseSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -22284,6 +26206,23 @@
         "summary": "Get recent activity data for a user",
         "tags": [
           "LogRestApi"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/log/recent_activity/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/log/recent_activity/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/log/recent_activity/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22358,6 +26297,29 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "action": "string",
+                    "dashboard_id": 1,
+                    "dttm": "2024-01-15T10:30:00Z",
+                    "duration_ms": 1,
+                    "json": "string",
+                    "referrer": "string",
+                    "slice_id": 1,
+                    "user_id": {}
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -22387,6 +26349,23 @@
         "summary": "Get a log detail information",
         "tags": [
           "LogRestApi"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/log/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/log/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/log/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22404,6 +26383,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "email": "string",
+                    "first_name": "string",
+                    "id": 1,
+                    "is_active": true,
+                    "is_anonymous": true,
+                    "last_name": "string",
+                    "login_count": 1,
+                    "username": "string"
+                  }
                 }
               }
             },
@@ -22421,6 +26412,23 @@
         "summary": "Get the user object",
         "tags": [
           "Current User"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/me/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/me/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/me/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -22430,6 +26438,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CurrentUserPutSchema"
+              },
+              "example": {
+                "first_name": "string",
+                "last_name": "string",
+                "password": "string"
               }
             }
           },
@@ -22446,6 +26459,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "email": "string",
+                    "first_name": "string",
+                    "id": 1,
+                    "is_active": true,
+                    "is_anonymous": true,
+                    "last_name": "string",
+                    "login_count": 1,
+                    "username": "string"
+                  }
                 }
               }
             },
@@ -22466,6 +26491,23 @@
         "summary": "Update the current user",
         "tags": [
           "Current User"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/me/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/me/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/me/\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22483,6 +26525,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "email": "string",
+                    "first_name": "string",
+                    "id": 1,
+                    "is_active": true,
+                    "is_anonymous": true,
+                    "last_name": "string",
+                    "login_count": 1,
+                    "username": "string"
+                  }
                 }
               }
             },
@@ -22500,6 +26554,23 @@
         "summary": "Get the user roles",
         "tags": [
           "Current User"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/me/roles/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/me/roles/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/me/roles/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22545,6 +26616,17 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {
+                      "childs": [],
+                      "icon": "string",
+                      "label": "string",
+                      "name": "string",
+                      "url": "string"
+                    }
+                  ]
                 }
               }
             },
@@ -22561,6 +26643,25 @@
         ],
         "tags": [
           "Menu"
+        ],
+        "operationId": "get_menu",
+        "summary": "Get menu",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/menu/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/menu/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/menu/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22645,6 +26746,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -22671,6 +26794,23 @@
         "summary": "Get a list of queries",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/query/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22703,6 +26843,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DistincResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -22726,9 +26870,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get distinct values from field data",
+        "summary": "Get distinct values from field data (query-distinct-column-name)",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/query/distinct/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/distinct/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/distinct/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22761,6 +26922,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -22784,9 +26949,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (query-related-column-name)",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/query/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22797,6 +26979,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/StopQuerySchema"
+              },
+              "example": {
+                "client_id": "string"
               }
             }
           },
@@ -22814,6 +26999,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": "string"
                 }
               }
             },
@@ -22840,6 +27028,23 @@
         "summary": "Manually stop a query with client_id",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/query/stop\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/query/stop\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/stop\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22873,6 +27078,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -22899,6 +27109,23 @@
         "summary": "Get a list of queries that changed after last_updated_ms",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/query/updated_since\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/updated_since\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/updated_since\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -22973,6 +27200,45 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "client_id": "string",
+                    "end_result_backend_time": 1.0,
+                    "end_time": 1.0,
+                    "error_message": "string",
+                    "executed_sql": "string",
+                    "id": 1,
+                    "limit": 1,
+                    "progress": 1,
+                    "results_key": "string",
+                    "rows": 1,
+                    "schema": "string",
+                    "select_as_cta": true,
+                    "select_as_cta_used": true,
+                    "select_sql": "string",
+                    "sql": "string",
+                    "sql_editor_id": "string",
+                    "start_running_time": 1.0,
+                    "start_time": 1.0,
+                    "status": "string",
+                    "tab_name": "string",
+                    "tmp_schema_name": "string",
+                    "tmp_table_name": "string",
+                    "tracking_url": {}
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -23002,6 +27268,23 @@
         "summary": "Get query detail information",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/query/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -23031,6 +27314,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -23060,6 +27346,23 @@
         "summary": "Bulk delete report schedules",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/report/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/report/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -23142,6 +27445,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -23168,6 +27493,23 @@
         "summary": "Get a list of report schedules",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/report/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -23176,6 +27518,42 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ReportScheduleRestApi.post"
+              },
+              "example": {
+                "active": true,
+                "chart": 1,
+                "context_markdown": "string",
+                "creation_method": {},
+                "crontab": "*/5 * * * *",
+                "custom_width": 1000,
+                "dashboard": 1,
+                "database": 1,
+                "description": "Daily sales dashboard to marketing",
+                "email_subject": "[Report]  Report name: Dashboard or chart name",
+                "extra": {},
+                "force_screenshot": true,
+                "grace_period": 14400,
+                "log_retention": 90,
+                "name": "Daily dashboard email",
+                "owners": [
+                  1
+                ],
+                "recipients": [
+                  {}
+                ],
+                "report_format": "PDF",
+                "selected_tabs": [
+                  1
+                ],
+                "sql": "SELECT value FROM time_series_table",
+                "timezone": "Africa/Abidjan",
+                "type": "Alert",
+                "validator_config_json": {
+                  "op": "<",
+                  "threshold": 1.0
+                },
+                "validator_type": "not null",
+                "working_timeout": 3600
               }
             }
           },
@@ -23196,6 +27574,35 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "active": true,
+                    "chart": 1,
+                    "context_markdown": "string",
+                    "creation_method": {},
+                    "crontab": "*/5 * * * *",
+                    "custom_width": 1000,
+                    "dashboard": 1,
+                    "database": 1,
+                    "description": "Daily sales dashboard to marketing",
+                    "email_subject": "[Report]  Report name: Dashboard or chart name",
+                    "extra": {},
+                    "force_screenshot": true,
+                    "grace_period": 14400,
+                    "log_retention": 90,
+                    "name": "Daily dashboard email",
+                    "owners": [],
+                    "recipients": [],
+                    "report_format": "PDF",
+                    "selected_tabs": [],
+                    "sql": "SELECT value FROM time_series_table",
+                    "timezone": "Africa/Abidjan",
+                    "type": "Alert",
+                    "validator_type": "not null",
+                    "working_timeout": 3600
+                  }
                 }
               }
             },
@@ -23225,6 +27632,23 @@
         "summary": "Create a report schedule",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/report/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/report/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -23286,6 +27710,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -23309,9 +27745,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (report--info)",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/report/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -23344,6 +27797,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -23367,9 +27824,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (report-related-column-name)",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/report/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -23411,6 +27885,14 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {
+                      "id": "string",
+                      "name": "string"
+                    }
+                  ]
                 }
               }
             },
@@ -23440,6 +27922,23 @@
         "summary": "Get slack channels",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/report/slack_channels/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/slack_channels/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/slack_channels/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -23467,6 +27966,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -23493,6 +27995,23 @@
         "summary": "Delete a report schedule",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/report/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/report/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -23565,6 +28084,45 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "active": true,
+                    "context_markdown": "string",
+                    "creation_method": "string",
+                    "crontab": "string",
+                    "custom_width": 1,
+                    "description": "string",
+                    "email_subject": "string",
+                    "extra": {},
+                    "force_screenshot": true,
+                    "grace_period": 1,
+                    "id": 1,
+                    "last_eval_dttm": "2024-01-15T10:30:00Z",
+                    "last_state": "string",
+                    "last_value": 1.0,
+                    "last_value_row_json": "string",
+                    "log_retention": 1,
+                    "name": "string",
+                    "report_format": "string",
+                    "sql": "string",
+                    "timezone": "string",
+                    "type": "string",
+                    "validator_config_json": "string",
+                    "validator_type": "string",
+                    "working_timeout": 1
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -23594,6 +28152,23 @@
         "summary": "Get a report schedule",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/report/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -23613,6 +28188,39 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ReportScheduleRestApi.put"
+              },
+              "example": {
+                "active": true,
+                "chart": 1,
+                "context_markdown": "string",
+                "creation_method": {},
+                "crontab": "string",
+                "custom_width": 1000,
+                "dashboard": 1,
+                "database": 1,
+                "description": "Daily sales dashboard to marketing",
+                "email_subject": "[Report]  Report name: Dashboard or chart name",
+                "extra": {},
+                "force_screenshot": true,
+                "grace_period": 14400,
+                "log_retention": 90,
+                "name": "string",
+                "owners": [
+                  1
+                ],
+                "recipients": [
+                  {}
+                ],
+                "report_format": "PDF",
+                "sql": "SELECT value FROM time_series_table",
+                "timezone": "Africa/Abidjan",
+                "type": "Alert",
+                "validator_config_json": {
+                  "op": "<",
+                  "threshold": 1.0
+                },
+                "validator_type": "not null",
+                "working_timeout": 3600
               }
             }
           },
@@ -23633,6 +28241,34 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "active": true,
+                    "chart": 1,
+                    "context_markdown": "string",
+                    "creation_method": {},
+                    "crontab": "string",
+                    "custom_width": 1000,
+                    "dashboard": 1,
+                    "database": 1,
+                    "description": "Daily sales dashboard to marketing",
+                    "email_subject": "[Report]  Report name: Dashboard or chart name",
+                    "extra": {},
+                    "force_screenshot": true,
+                    "grace_period": 14400,
+                    "log_retention": 90,
+                    "name": "string",
+                    "owners": [],
+                    "recipients": [],
+                    "report_format": "PDF",
+                    "sql": "SELECT value FROM time_series_table",
+                    "timezone": "Africa/Abidjan",
+                    "type": "Alert",
+                    "validator_type": "not null",
+                    "working_timeout": 3600
+                  }
                 }
               }
             },
@@ -23665,6 +28301,23 @@
         "summary": "Update a report schedule",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/report/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/report/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -23719,6 +28372,15 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "ids": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -23745,6 +28407,23 @@
         "summary": "Get a list of report schedule logs",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/report/1/log/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/1/log/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1/log/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -23796,6 +28475,20 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "end_dttm": "2024-01-15T10:30:00Z",
+                    "error_message": "string",
+                    "id": 1,
+                    "scheduled_dttm": "2024-01-15T10:30:00Z",
+                    "start_dttm": "2024-01-15T10:30:00Z",
+                    "state": "string",
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                    "value": 1.0,
+                    "value_row_json": "string"
+                  }
                 }
               }
             },
@@ -23822,9 +28515,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get a report schedule log",
+        "summary": "Get a report schedule log (report-pk-log-log-id)",
         "tags": [
           "Report Schedules"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/report/1/log/{log_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/1/log/{log_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1/log/{log_id}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -23854,6 +28564,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -23883,6 +28596,23 @@
         "summary": "Bulk delete RLS rules",
         "tags": [
           "Row Level Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/rowlevelsecurity/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -23965,6 +28695,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -23991,6 +28743,23 @@
         "summary": "Get a list of RLS",
         "tags": [
           "Row Level Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/rowlevelsecurity/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -23999,6 +28768,19 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RLSRestApi.post"
+              },
+              "example": {
+                "clause": "string",
+                "description": "string",
+                "filter_type": "Regular",
+                "group_key": "string",
+                "name": "string",
+                "roles": [
+                  1
+                ],
+                "tables": [
+                  1
+                ]
               }
             }
           },
@@ -24019,6 +28801,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "clause": "string",
+                    "description": "string",
+                    "filter_type": "Regular",
+                    "group_key": "string",
+                    "name": "string",
+                    "roles": [],
+                    "tables": []
+                  }
                 }
               }
             },
@@ -24048,6 +28842,23 @@
         "summary": "Create a new RLS rule",
         "tags": [
           "Row Level Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/rowlevelsecurity/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24109,6 +28920,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -24132,9 +28955,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (rowlevelsecurity--info)",
         "tags": [
           "Row Level Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/rowlevelsecurity/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24167,6 +29007,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -24190,9 +29034,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (rowlevelsecurity-related-column-name)",
         "tags": [
           "Row Level Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/rowlevelsecurity/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24219,6 +29080,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -24242,6 +29106,23 @@
         "summary": "Delete an RLS",
         "tags": [
           "Row Level Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/rowlevelsecurity/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -24314,6 +29195,29 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "clause": "string",
+                    "description": "string",
+                    "filter_type": "Regular",
+                    "group_key": "string",
+                    "id": 1,
+                    "name": "string",
+                    "roles": [],
+                    "tables": []
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -24343,6 +29247,23 @@
         "summary": "Get an RLS",
         "tags": [
           "Row Level Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/rowlevelsecurity/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -24362,6 +29283,19 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RLSRestApi.put"
+              },
+              "example": {
+                "clause": "string",
+                "description": "string",
+                "filter_type": "Regular",
+                "group_key": "string",
+                "name": "string",
+                "roles": [
+                  1
+                ],
+                "tables": [
+                  1
+                ]
               }
             }
           },
@@ -24382,6 +29316,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "clause": "string",
+                    "description": "string",
+                    "filter_type": "Regular",
+                    "group_key": "string",
+                    "name": "string",
+                    "roles": [],
+                    "tables": []
+                  }
                 }
               }
             },
@@ -24414,6 +29360,23 @@
         "summary": "Update an RLS rule",
         "tags": [
           "Row Level Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/rowlevelsecurity/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24443,6 +29406,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -24469,6 +29435,23 @@
         "summary": "Bulk delete saved queries",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/saved_query/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/saved_query/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -24551,6 +29534,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -24577,6 +29582,23 @@
         "summary": "Get a list of saved queries",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -24585,6 +29607,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SavedQueryRestApi.post"
+              },
+              "example": {
+                "catalog": "string",
+                "db_id": {},
+                "description": "string",
+                "extra_json": "string",
+                "label": "string",
+                "schema": "string",
+                "sql": "string",
+                "template_parameters": "string"
               }
             }
           },
@@ -24605,6 +29637,19 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "catalog": "string",
+                    "db_id": {},
+                    "description": "string",
+                    "extra_json": "string",
+                    "label": "string",
+                    "schema": "string",
+                    "sql": "string",
+                    "template_parameters": "string"
+                  }
                 }
               }
             },
@@ -24631,6 +29676,23 @@
         "summary": "Create a saved query",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/saved_query/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/saved_query/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24692,6 +29754,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -24715,9 +29789,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (saved-query--info)",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24750,6 +29841,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DistincResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -24773,9 +29868,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get distinct values from field data",
+        "summary": "Get distinct values from field data (saved-query-distinct-column-name)",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/distinct/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/distinct/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/distinct/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24827,6 +29939,23 @@
         "summary": "Download multiple saved queries as YAML files",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24880,6 +30009,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -24906,6 +30038,23 @@
         "summary": "Import saved queries with associated databases",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/saved_query/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/saved_query/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24938,6 +30087,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -24961,9 +30114,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (saved-query-related-column-name)",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -24990,6 +30160,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -25013,6 +30186,23 @@
         "summary": "Delete a saved query",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/saved_query/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/saved_query/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -25085,6 +30275,31 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "catalog": "string",
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "changed_on_delta_humanized": {},
+                    "description": "string",
+                    "id": 1,
+                    "label": "string",
+                    "schema": "string",
+                    "sql": "string",
+                    "sql_tables": {},
+                    "template_parameters": "string"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -25114,6 +30329,23 @@
         "summary": "Get a saved query",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -25132,6 +30364,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SavedQueryRestApi.put"
+              },
+              "example": {
+                "catalog": "string",
+                "db_id": {},
+                "description": "string",
+                "extra_json": "string",
+                "label": "string",
+                "schema": "string",
+                "sql": "string",
+                "template_parameters": "string"
               }
             }
           },
@@ -25149,6 +30391,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "catalog": "string",
+                    "db_id": {},
+                    "description": "string",
+                    "extra_json": "string",
+                    "label": "string",
+                    "schema": "string",
+                    "sql": "string",
+                    "template_parameters": "string"
+                  }
                 }
               }
             },
@@ -25178,6 +30432,23 @@
         "summary": "Update a saved query",
         "tags": [
           "Queries"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/saved_query/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/saved_query/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -25194,6 +30465,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": "string"
                 }
               }
             },
@@ -25214,6 +30488,23 @@
         "summary": "Get the CSRF token",
         "tags": [
           "Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/csrf_token/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/csrf_token/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/csrf_token/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -25298,6 +30589,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -25323,6 +30636,25 @@
         ],
         "tags": [
           "Security Groups"
+        ],
+        "operationId": "get_security_groups",
+        "summary": "Get security groups",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/groups/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/groups/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -25331,6 +30663,17 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/GroupPostSchema"
+              },
+              "example": {
+                "description": "string",
+                "label": "string",
+                "name": "string",
+                "roles": [
+                  1
+                ],
+                "users": [
+                  1
+                ]
               }
             }
           },
@@ -25348,6 +30691,15 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "description": "string",
+                    "label": "string",
+                    "name": "string",
+                    "roles": [],
+                    "users": []
+                  }
                 }
               }
             },
@@ -25373,6 +30725,25 @@
         ],
         "tags": [
           "Security Groups"
+        ],
+        "operationId": "create_security_groups",
+        "summary": "Create security groups",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/groups/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/groups/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -25434,6 +30805,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -25459,6 +30842,25 @@
         ],
         "tags": [
           "Security Groups"
+        ],
+        "operationId": "get_security_groups__info",
+        "summary": "Get security groups  info",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/groups/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/groups/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -25485,6 +30887,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -25507,6 +30912,25 @@
         ],
         "tags": [
           "Security Groups"
+        ],
+        "operationId": "delete_security_groups_by_pk",
+        "summary": "Delete security groups by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/groups/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/groups/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -25579,6 +31003,25 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "description": "string",
+                    "id": 1,
+                    "label": "string",
+                    "name": "string"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -25607,6 +31050,25 @@
         ],
         "tags": [
           "Security Groups"
+        ],
+        "operationId": "get_security_groups_by_pk",
+        "summary": "Get security groups by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/groups/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/groups/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -25625,6 +31087,17 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/GroupPutSchema"
+              },
+              "example": {
+                "description": "string",
+                "label": "string",
+                "name": "string",
+                "roles": [
+                  1
+                ],
+                "users": [
+                  1
+                ]
               }
             }
           },
@@ -25642,6 +31115,15 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "description": "string",
+                    "label": "string",
+                    "name": "string",
+                    "roles": [],
+                    "users": []
+                  }
                 }
               }
             },
@@ -25670,6 +31152,25 @@
         ],
         "tags": [
           "Security Groups"
+        ],
+        "operationId": "update_security_groups_by_pk",
+        "summary": "Update security groups by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/groups/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/groups/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -25680,6 +31181,19 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/GuestTokenCreate"
+              },
+              "example": {
+                "resources": [
+                  {}
+                ],
+                "rls": [
+                  {}
+                ],
+                "user": {
+                  "first_name": "string",
+                  "last_name": "string",
+                  "username": "string"
+                }
               }
             }
           },
@@ -25697,6 +31211,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "token": "string"
                 }
               }
             },
@@ -25720,6 +31237,23 @@
         "summary": "Get a guest token",
         "tags": [
           "Security"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/guest_token/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/guest_token/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/guest_token/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -25757,6 +31291,12 @@
                   }
                 },
                 "type": "object"
+              },
+              "example": {
+                "password": "complex-password",
+                "provider": "db",
+                "refresh": true,
+                "username": "admin"
               }
             }
           },
@@ -25776,6 +31316,10 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "access_token": "string",
+                  "refresh_token": "string"
                 }
               }
             },
@@ -25793,6 +31337,25 @@
         },
         "tags": [
           "Security"
+        ],
+        "operationId": "create_security_login",
+        "summary": "Create security login",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/login\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/login\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/login\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -25877,6 +31440,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -25902,6 +31487,25 @@
         ],
         "tags": [
           "Security Permissions on Resources (View Menus)"
+        ],
+        "operationId": "get_security_permissions_resources",
+        "summary": "Get security permissions resources",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions-resources/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions-resources/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -25910,6 +31514,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PermissionViewMenuApi.post"
+              },
+              "example": {
+                "permission_id": {},
+                "view_menu_id": {}
               }
             }
           },
@@ -25930,6 +31538,13 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "permission_id": {},
+                    "view_menu_id": {}
+                  }
                 }
               }
             },
@@ -25955,6 +31570,25 @@
         ],
         "tags": [
           "Security Permissions on Resources (View Menus)"
+        ],
+        "operationId": "create_security_permissions_resources",
+        "summary": "Create security permissions resources",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/permissions-resources/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/permissions-resources/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26016,6 +31650,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -26041,6 +31687,25 @@
         ],
         "tags": [
           "Security Permissions on Resources (View Menus)"
+        ],
+        "operationId": "get_security_permissions_resources__info",
+        "summary": "Get security permissions resources  info",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions-resources/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions-resources/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26067,6 +31732,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -26089,6 +31757,25 @@
         ],
         "tags": [
           "Security Permissions on Resources (View Menus)"
+        ],
+        "operationId": "delete_security_permissions_resources_by_pk",
+        "summary": "Delete security permissions resources by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/permissions-resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -26161,6 +31848,22 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "id": 1
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -26189,6 +31892,25 @@
         ],
         "tags": [
           "Security Permissions on Resources (View Menus)"
+        ],
+        "operationId": "get_security_permissions_resources_by_pk",
+        "summary": "Get security permissions resources by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions-resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -26207,6 +31929,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PermissionViewMenuApi.put"
+              },
+              "example": {
+                "permission_id": {},
+                "view_menu_id": {}
               }
             }
           },
@@ -26224,6 +31950,12 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "permission_id": {},
+                    "view_menu_id": {}
+                  }
                 }
               }
             },
@@ -26252,6 +31984,25 @@
         ],
         "tags": [
           "Security Permissions on Resources (View Menus)"
+        ],
+        "operationId": "update_security_permissions_resources_by_pk",
+        "summary": "Update security permissions resources by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/permissions-resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26336,6 +32087,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -26361,6 +32134,25 @@
         ],
         "tags": [
           "Security Permissions"
+        ],
+        "operationId": "get_security_permissions",
+        "summary": "Get security permissions",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26422,6 +32214,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -26447,6 +32251,25 @@
         ],
         "tags": [
           "Security Permissions"
+        ],
+        "operationId": "get_security_permissions__info",
+        "summary": "Get security permissions  info",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26521,6 +32344,23 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "id": 1,
+                    "name": "string"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -26549,6 +32389,25 @@
         ],
         "tags": [
           "Security Permissions"
+        ],
+        "operationId": "get_security_permissions_by_pk",
+        "summary": "Get security permissions by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26567,6 +32426,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "access_token": "string"
                 }
               }
             },
@@ -26586,6 +32448,25 @@
         ],
         "tags": [
           "Security"
+        ],
+        "operationId": "create_security_refresh",
+        "summary": "Create security refresh",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/refresh\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/refresh\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/refresh\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26670,6 +32551,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -26695,6 +32598,25 @@
         ],
         "tags": [
           "Security Resources (View Menus)"
+        ],
+        "operationId": "get_security_resources",
+        "summary": "Get security resources",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/resources/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/resources/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -26703,6 +32625,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ViewMenuApi.post"
+              },
+              "example": {
+                "name": "string"
               }
             }
           },
@@ -26723,6 +32648,12 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "name": "string"
+                  }
                 }
               }
             },
@@ -26748,6 +32679,25 @@
         ],
         "tags": [
           "Security Resources (View Menus)"
+        ],
+        "operationId": "create_security_resources",
+        "summary": "Create security resources",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/resources/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/resources/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26809,6 +32759,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -26834,6 +32796,25 @@
         ],
         "tags": [
           "Security Resources (View Menus)"
+        ],
+        "operationId": "get_security_resources__info",
+        "summary": "Get security resources  info",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/resources/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/resources/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -26860,6 +32841,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -26882,6 +32866,25 @@
         ],
         "tags": [
           "Security Resources (View Menus)"
+        ],
+        "operationId": "delete_security_resources_by_pk",
+        "summary": "Delete security resources by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -26954,6 +32957,23 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "id": 1,
+                    "name": "string"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -26982,6 +33002,25 @@
         ],
         "tags": [
           "Security Resources (View Menus)"
+        ],
+        "operationId": "get_security_resources_by_pk",
+        "summary": "Get security resources by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -27000,6 +33039,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ViewMenuApi.put"
+              },
+              "example": {
+                "name": "string"
               }
             }
           },
@@ -27017,6 +33059,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "name": "string"
+                  }
                 }
               }
             },
@@ -27045,6 +33092,25 @@
         ],
         "tags": [
           "Security Resources (View Menus)"
+        ],
+        "operationId": "update_security_resources_by_pk",
+        "summary": "Update security resources by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27129,6 +33195,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -27154,6 +33242,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "get_security_roles",
+        "summary": "Get security roles",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -27162,6 +33269,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SupersetRoleApi.post"
+              },
+              "example": {
+                "name": "string"
               }
             }
           },
@@ -27182,6 +33292,12 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "name": "string"
+                  }
                 }
               }
             },
@@ -27207,6 +33323,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "create_security_roles",
+        "summary": "Create security roles",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/roles/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/roles/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27268,6 +33403,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -27293,6 +33440,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "get_security_roles__info",
+        "summary": "Get security roles  info",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27359,6 +33525,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RolesResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "ids": [
+                    1
+                  ],
+                  "result": []
                 }
               }
             },
@@ -27374,6 +33547,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "error": "string"
                 }
               }
             },
@@ -27389,6 +33565,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "error": "string"
                 }
               }
             },
@@ -27403,6 +33582,23 @@
         "summary": "List roles",
         "tags": [
           "Security Roles"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/search/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/search/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/search/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27429,6 +33625,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -27451,6 +33650,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "delete_security_roles_by_pk",
+        "summary": "Delete security roles by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/roles/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/roles/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -27523,6 +33741,23 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "id": 1,
+                    "name": "string"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -27551,6 +33786,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "get_security_roles_by_pk",
+        "summary": "Get security roles by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -27569,6 +33823,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SupersetRoleApi.put"
+              },
+              "example": {
+                "name": "string"
               }
             }
           },
@@ -27586,6 +33843,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "name": "string"
+                  }
                 }
               }
             },
@@ -27614,6 +33876,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "update_security_roles_by_pk",
+        "summary": "Update security roles by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/roles/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/roles/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27634,6 +33915,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RoleGroupPutSchema"
+              },
+              "example": {
+                "group_ids": [
+                  1
+                ]
               }
             }
           },
@@ -27651,6 +33937,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "group_ids": []
+                  }
                 }
               }
             },
@@ -27679,6 +33970,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "update_security_roles_by_role_id_groups",
+        "summary": "Update security roles by role_id groups",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/roles/{role_id}/groups\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/roles/{role_id}/groups\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/{role_id}/groups\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27699,6 +34009,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RolePermissionPostSchema"
+              },
+              "example": {
+                "permission_view_menu_ids": [
+                  1
+                ]
               }
             }
           },
@@ -27716,6 +34031,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "permission_view_menu_ids": []
+                  }
                 }
               }
             },
@@ -27744,6 +34064,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "create_security_roles_by_role_id_permissions",
+        "summary": "Create security roles by role_id permissions",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27773,6 +34112,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -27801,6 +34145,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "get_security_roles_by_role_id_permissions",
+        "summary": "Get security roles by role_id permissions",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27821,6 +34184,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RoleUserPutSchema"
+              },
+              "example": {
+                "user_ids": [
+                  1
+                ]
               }
             }
           },
@@ -27838,6 +34206,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "user_ids": []
+                  }
                 }
               }
             },
@@ -27866,6 +34239,25 @@
         ],
         "tags": [
           "Security Roles"
+        ],
+        "operationId": "update_security_roles_by_role_id_users",
+        "summary": "Update security roles by role_id users",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/roles/{role_id}/users\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/roles/{role_id}/users\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/{role_id}/users\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -27950,6 +34342,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -27975,6 +34389,25 @@
         ],
         "tags": [
           "UserRegistrationsRestAPI"
+        ],
+        "operationId": "get_security_user_registrations",
+        "summary": "Get security user registrations",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -27983,6 +34416,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/UserRegistrationsRestAPI.post"
+              },
+              "example": {
+                "id": 1
               }
             }
           },
@@ -28003,6 +34439,12 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": "string",
+                  "result": {
+                    "id": 1
+                  }
                 }
               }
             },
@@ -28028,6 +34470,25 @@
         ],
         "tags": [
           "UserRegistrationsRestAPI"
+        ],
+        "operationId": "create_security_user_registrations",
+        "summary": "Create security user registrations",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/user_registrations/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/user_registrations/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28089,6 +34550,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -28114,6 +34587,25 @@
         ],
         "tags": [
           "UserRegistrationsRestAPI"
+        ],
+        "operationId": "get_security_user_registrations__info",
+        "summary": "Get security user registrations  info",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28146,6 +34638,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DistincResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -28169,9 +34665,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get distinct values from field data",
+        "summary": "Get distinct values from field data (security-user-registrations-distinct-column-name)",
         "tags": [
           "UserRegistrationsRestAPI"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/distinct/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/distinct/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/distinct/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28204,6 +34717,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -28227,9 +34744,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (security-user-registrations-related-column-name)",
         "tags": [
           "UserRegistrationsRestAPI"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28256,6 +34790,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -28278,6 +34815,25 @@
         ],
         "tags": [
           "UserRegistrationsRestAPI"
+        ],
+        "operationId": "delete_security_user_registrations_by_pk",
+        "summary": "Delete security user registrations by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/user_registrations/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/user_registrations/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -28350,6 +34906,22 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "id": 1
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -28378,6 +34950,25 @@
         ],
         "tags": [
           "UserRegistrationsRestAPI"
+        ],
+        "operationId": "get_security_user_registrations_by_pk",
+        "summary": "Get security user registrations by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -28396,6 +34987,9 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/UserRegistrationsRestAPI.put"
+              },
+              "example": {
+                "id": 1
               }
             }
           },
@@ -28413,6 +35007,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "id": 1
+                  }
                 }
               }
             },
@@ -28441,6 +35040,25 @@
         ],
         "tags": [
           "UserRegistrationsRestAPI"
+        ],
+        "operationId": "update_security_user_registrations_by_pk",
+        "summary": "Update security user registrations by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/user_registrations/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/user_registrations/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28525,6 +35143,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -28550,6 +35190,25 @@
         ],
         "tags": [
           "Security Users"
+        ],
+        "operationId": "get_security_users",
+        "summary": "Get security users",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/users/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/users/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -28558,6 +35217,20 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SupersetUserApi.post"
+              },
+              "example": {
+                "active": true,
+                "email": "string",
+                "first_name": "string",
+                "groups": [
+                  1
+                ],
+                "last_name": "string",
+                "password": "string",
+                "roles": [
+                  1
+                ],
+                "username": "string"
               }
             }
           },
@@ -28575,6 +35248,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "active": true,
+                    "email": "string",
+                    "first_name": "string",
+                    "groups": [],
+                    "last_name": "string",
+                    "password": "string",
+                    "roles": [],
+                    "username": "string"
+                  }
                 }
               }
             },
@@ -28603,6 +35288,25 @@
         ],
         "tags": [
           "Security Users"
+        ],
+        "operationId": "create_security_users",
+        "summary": "Create security users",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/security/users/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/users/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28664,6 +35368,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -28689,6 +35405,25 @@
         ],
         "tags": [
           "Security Users"
+        ],
+        "operationId": "get_security_users__info",
+        "summary": "Get security users  info",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/users/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/users/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28715,6 +35450,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -28737,6 +35475,25 @@
         ],
         "tags": [
           "Security Users"
+        ],
+        "operationId": "delete_security_users_by_pk",
+        "summary": "Delete security users by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/users/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/users/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -28809,6 +35566,32 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "active": true,
+                    "changed_on": "2024-01-15T10:30:00Z",
+                    "created_on": "2024-01-15T10:30:00Z",
+                    "email": "string",
+                    "fail_login_count": 1,
+                    "first_name": "string",
+                    "id": 1,
+                    "last_login": "2024-01-15T10:30:00Z",
+                    "last_name": "string",
+                    "login_count": 1,
+                    "username": "string"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -28837,6 +35620,25 @@
         ],
         "tags": [
           "Security Users"
+        ],
+        "operationId": "get_security_users_by_pk",
+        "summary": "Get security users by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/security/users/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/users/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -28855,6 +35657,20 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SupersetUserApi.put"
+              },
+              "example": {
+                "active": true,
+                "email": "string",
+                "first_name": "string",
+                "groups": [
+                  1
+                ],
+                "last_name": "string",
+                "password": "string",
+                "roles": [
+                  1
+                ],
+                "username": "string"
               }
             }
           },
@@ -28872,6 +35688,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {
+                    "active": true,
+                    "email": "string",
+                    "first_name": "string",
+                    "groups": [],
+                    "last_name": "string",
+                    "password": "string",
+                    "roles": [],
+                    "username": "string"
+                  }
                 }
               }
             },
@@ -28900,6 +35728,25 @@
         ],
         "tags": [
           "Security Users"
+        ],
+        "operationId": "update_security_users_by_pk",
+        "summary": "Update security users by pk",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/users/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/users/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28912,6 +35759,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SQLLabBootstrapSchema"
+                },
+                "example": {
+                  "active_tab": {},
+                  "databases": {
+                    "key": "value"
+                  },
+                  "queries": {
+                    "key": "value"
+                  },
+                  "tab_state_ids": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -28938,6 +35797,23 @@
         "summary": "Get the bootstrap data for SqlLab page",
         "tags": [
           "SQL Lab"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/sqllab/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/sqllab/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -28948,6 +35824,13 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/EstimateQueryCostSchema"
+              },
+              "example": {
+                "catalog": "string",
+                "database_id": 1,
+                "schema": "string",
+                "sql": "string",
+                "template_params": {}
               }
             }
           },
@@ -28965,6 +35848,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -28991,6 +35877,23 @@
         "summary": "Estimate the SQL query execution cost",
         "tags": [
           "SQL Lab"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/estimate/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/estimate/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/estimate/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29001,6 +35904,22 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ExecutePayloadSchema"
+              },
+              "example": {
+                "catalog": "string",
+                "client_id": "string",
+                "ctas_method": "string",
+                "database_id": 1,
+                "expand_data": true,
+                "queryLimit": 1,
+                "runAsync": true,
+                "schema": "string",
+                "select_as_cta": true,
+                "sql": "string",
+                "sql_editor_id": "string",
+                "tab": "string",
+                "templateParams": "string",
+                "tmp_table_name": "string"
               }
             }
           },
@@ -29013,6 +35932,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueryExecutionResponseSchema"
+                },
+                "example": {
+                  "columns": [
+                    {}
+                  ],
+                  "data": [
+                    {}
+                  ],
+                  "expanded_columns": [
+                    {}
+                  ],
+                  "query": {},
+                  "query_id": 1,
+                  "selected_columns": [
+                    {}
+                  ],
+                  "status": "string"
                 }
               }
             },
@@ -29023,6 +35959,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueryExecutionResponseSchema"
+                },
+                "example": {
+                  "columns": [
+                    {}
+                  ],
+                  "data": [
+                    {}
+                  ],
+                  "expanded_columns": [
+                    {}
+                  ],
+                  "query": {},
+                  "query_id": 1,
+                  "selected_columns": [
+                    {}
+                  ],
+                  "status": "string"
                 }
               }
             },
@@ -29052,6 +36005,23 @@
         "summary": "Execute a SQL query",
         "tags": [
           "SQL Lab"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/execute/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/execute/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/execute/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29103,6 +36073,23 @@
         "summary": "Export the SQL query results to a CSV",
         "tags": [
           "SQL Lab"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/sqllab/export/{client_id}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/sqllab/export/{client_id}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/export/{client_id}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29168,6 +36155,23 @@
         "summary": "Export SQL query results to CSV with streaming",
         "tags": [
           "SQL Lab"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/export_streaming/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/export_streaming/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/export_streaming/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29178,6 +36182,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/FormatQueryPayloadSchema"
+              },
+              "example": {
+                "database_id": 1,
+                "engine": "string",
+                "sql": "string",
+                "template_params": "string"
               }
             }
           },
@@ -29195,6 +36205,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": "string"
                 }
               }
             },
@@ -29221,6 +36234,23 @@
         "summary": "Format SQL code",
         "tags": [
           "SQL Lab"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/format_sql/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/format_sql/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/format_sql/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29231,6 +36261,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ExplorePermalinkStateSchema"
+              },
+              "example": {
+                "formData": {},
+                "urlParams": [
+                  {}
+                ]
               }
             }
           },
@@ -29252,6 +36288,10 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "key": "string",
+                  "url": "string"
                 }
               }
             },
@@ -29275,9 +36315,26 @@
             "jwt": []
           }
         ],
-        "summary": "Create a new permanent link",
+        "summary": "Create a new permanent link (sqllab-permalink)",
         "tags": [
           "SQL Lab Permanent Link"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/permalink\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/permalink\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/permalink\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29305,6 +36362,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "state": {}
                 }
               }
             },
@@ -29334,6 +36394,23 @@
         "summary": "Get permanent link state for SQLLab editor.",
         "tags": [
           "SQL Lab Permanent Link"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/sqllab/permalink/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/sqllab/permalink/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/permalink/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29358,6 +36435,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueryExecutionResponseSchema"
+                },
+                "example": {
+                  "columns": [
+                    {}
+                  ],
+                  "data": [
+                    {}
+                  ],
+                  "expanded_columns": [
+                    {}
+                  ],
+                  "query": {},
+                  "query_id": 1,
+                  "selected_columns": [
+                    {}
+                  ],
+                  "status": "string"
                 }
               }
             },
@@ -29390,6 +36484,23 @@
         "summary": "Get the result of a SQL query execution",
         "tags": [
           "SQL Lab"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/sqllab/results/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/sqllab/results/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/results/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29420,6 +36531,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -29449,6 +36563,23 @@
         "summary": "Bulk delete tags",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/tag/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/tag/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -29531,6 +36662,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -29557,6 +36710,23 @@
         "summary": "Get a list of tags",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -29566,6 +36736,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TagRestApi.post"
+              },
+              "example": {
+                "description": "string",
+                "name": "string",
+                "objects_to_tag": []
               }
             }
           },
@@ -29586,6 +36761,14 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "description": "string",
+                    "name": "string",
+                    "objects_to_tag": []
+                  }
                 }
               }
             },
@@ -29612,6 +36795,23 @@
         "summary": "Create a tag",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/tag/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/tag/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29673,6 +36873,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -29699,6 +36911,23 @@
         "summary": "Get metadata information about tag API endpoints",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29709,6 +36938,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TagPostBulkSchema"
+              },
+              "example": {
+                "tags": [
+                  {}
+                ]
               }
             }
           },
@@ -29721,6 +36955,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagPostBulkResponseSchema"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -29750,6 +36987,23 @@
         "summary": "Bulk create tags and tagged objects",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/tag/bulk_create\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/tag/bulk_create\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/bulk_create\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29775,6 +37029,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
+                },
+                "example": {
+                  "result": []
                 }
               }
             },
@@ -29800,6 +37057,25 @@
         ],
         "tags": [
           "Tags"
+        ],
+        "operationId": "get_tag_favorite_status",
+        "summary": "Get tag favorite status",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/favorite_status/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/favorite_status/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/favorite_status/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29829,6 +37105,11 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -29858,6 +37139,23 @@
         "summary": "Get all objects associated with a tag",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/get_objects/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/get_objects/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/get_objects/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29890,6 +37188,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -29913,9 +37215,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (tag-related-column-name)",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -29954,6 +37273,11 @@
                   }
                 },
                 "type": "object"
+              },
+              "example": {
+                "tags": [
+                  "string"
+                ]
               }
             }
           },
@@ -29988,6 +37312,23 @@
         "summary": "Add tags to an object",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -30030,6 +37371,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -30059,6 +37403,23 @@
         "summary": "Delete a tagged object",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/{tag}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/{tag}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/{tag}/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       }
     },
@@ -30085,6 +37446,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -30108,6 +37472,23 @@
         "summary": "Delete a tag",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/tag/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/tag/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -30180,6 +37561,27 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "changed_on_delta_humanized": {},
+                    "created_on_delta_humanized": {},
+                    "description": "string",
+                    "id": 1,
+                    "name": "string",
+                    "type": {}
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -30209,6 +37611,23 @@
         "summary": "Get a tag detail information",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -30228,6 +37647,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TagRestApi.put"
+              },
+              "example": {
+                "description": "string",
+                "name": "string",
+                "objects_to_tag": []
               }
             }
           },
@@ -30248,6 +37672,14 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "description": "string",
+                    "name": "string",
+                    "objects_to_tag": []
+                  }
                 }
               }
             },
@@ -30280,6 +37712,23 @@
         "summary": "Update a tag",
         "tags": [
           "Tags"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/tag/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/tag/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -30307,6 +37756,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -30332,6 +37784,25 @@
         ],
         "tags": [
           "Tags"
+        ],
+        "operationId": "delete_tag_by_pk_favorites",
+        "summary": "Delete tag by pk favorites",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/tag/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/tag/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1/favorites/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "post": {
@@ -30357,6 +37828,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": {}
                 }
               }
             },
@@ -30382,6 +37856,25 @@
         ],
         "tags": [
           "Tags"
+        ],
+        "operationId": "create_tag_by_pk_favorites",
+        "summary": "Create tag by pk favorites",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/tag/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/tag/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1/favorites/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -30411,6 +37904,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -30437,6 +37933,23 @@
         "summary": "Bulk delete themes",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/theme/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/theme/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -30519,6 +38032,28 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "count": 1.0,
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "ids": [
+                    "string"
+                  ],
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "list_columns": [
+                    "string"
+                  ],
+                  "list_title": "List Items",
+                  "order_columns": [
+                    "string"
+                  ],
+                  "result": [
+                    {}
+                  ]
                 }
               }
             },
@@ -30545,6 +38080,23 @@
         "summary": "Get a list of themes",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "post": {
@@ -30553,6 +38105,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ThemeRestApi.post"
+              },
+              "example": {
+                "json_data": "string",
+                "theme_name": "string"
               }
             }
           },
@@ -30573,6 +38129,13 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "json_data": "string",
+                    "theme_name": "string"
+                  }
                 }
               }
             },
@@ -30599,6 +38162,23 @@
         "summary": "Create a theme",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/theme/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/theme/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -30660,6 +38240,18 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "add_columns": {},
+                  "edit_columns": {},
+                  "filters": {
+                    "column_name": [
+                      {}
+                    ]
+                  },
+                  "permissions": [
+                    "string"
+                  ]
                 }
               }
             },
@@ -30683,9 +38275,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get metadata information about this API resource",
+        "summary": "Get metadata information about this API resource (theme--info)",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -30740,6 +38349,23 @@
         "summary": "Download multiple themes as YAML files",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -30775,6 +38401,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -30801,6 +38430,23 @@
         "summary": "Import themes from a ZIP file",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X POST \"http://localhost:8088/api/v1/theme/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/theme/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -30833,6 +38479,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
+                },
+                "example": {
+                  "count": 1,
+                  "result": []
                 }
               }
             },
@@ -30856,9 +38506,26 @@
             "jwt": []
           }
         ],
-        "summary": "Get related fields data",
+        "summary": "Get related fields data (theme-related-column-name)",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -30875,6 +38542,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": "string"
                 }
               }
             },
@@ -30898,6 +38568,23 @@
         "summary": "Clear the system dark theme",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/theme/unset_system_dark\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/theme/unset_system_dark\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/unset_system_dark\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       }
     },
@@ -30914,6 +38601,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "result": "string"
                 }
               }
             },
@@ -30937,6 +38627,23 @@
         "summary": "Clear the system default theme",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/theme/unset_system_default\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/theme/unset_system_default\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/unset_system_default\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       }
     },
@@ -30963,6 +38670,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "message": "string"
                 }
               }
             },
@@ -30992,6 +38702,23 @@
         "summary": "Delete a theme",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X DELETE \"http://localhost:8088/api/v1/theme/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/theme/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
+          }
         ]
       },
       "get": {
@@ -31064,6 +38791,29 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "description_columns": {
+                    "column_name": "A Nice description for the column"
+                  },
+                  "id": "string",
+                  "label_columns": {
+                    "column_name": "A Nice label for the column"
+                  },
+                  "result": {
+                    "changed_on_delta_humanized": {},
+                    "id": 1,
+                    "is_system": true,
+                    "is_system_dark": true,
+                    "is_system_default": true,
+                    "json_data": "string",
+                    "theme_name": "string",
+                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
+                  },
+                  "show_columns": [
+                    "string"
+                  ],
+                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -31093,6 +38843,23 @@
         "summary": "Get a theme",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       },
       "put": {
@@ -31111,6 +38878,10 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ThemeRestApi.put"
+              },
+              "example": {
+                "json_data": "string",
+                "theme_name": "string"
               }
             }
           },
@@ -31131,6 +38902,13 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1.0,
+                  "result": {
+                    "json_data": "string",
+                    "theme_name": "string"
+                  }
                 }
               }
             },
@@ -31163,6 +38941,23 @@
         "summary": "Update a theme",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/theme/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/theme/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -31193,6 +38988,10 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1,
+                  "result": "string"
                 }
               }
             },
@@ -31225,6 +39024,23 @@
         "summary": "Set a theme as the system dark theme",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/theme/1/set_system_dark\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/theme/1/set_system_dark\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1/set_system_dark\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -31255,6 +39071,10 @@
                     }
                   },
                   "type": "object"
+                },
+                "example": {
+                  "id": 1,
+                  "result": "string"
                 }
               }
             },
@@ -31287,6 +39107,23 @@
         "summary": "Set a theme as the system default theme",
         "tags": [
           "Themes"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X PUT \"http://localhost:8088/api/v1/theme/1/set_system_default\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/theme/1/set_system_default\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1/set_system_default\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -31318,6 +39155,23 @@
         "summary": "Get the user avatar",
         "tags": [
           "User"
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/v1/user/{user_id}/avatar.png\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/user/{user_id}/avatar.png\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/user/{user_id}/avatar.png\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     },
@@ -31359,13 +39213,209 @@
         ],
         "tags": [
           "OpenApi"
+        ],
+        "operationId": "get_api_by_version__openapi",
+        "summary": "Get api by version  openapi",
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl -X GET \"http://localhost:8088/api/{version}/_openapi\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+          },
+          {
+            "lang": "Python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/{version}/_openapi\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  \"http://localhost:8088/api/{version}/_openapi\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          }
         ]
       }
     }
   },
   "servers": [
     {
-      "url": "http://localhost:8088"
+      "url": "http://localhost:8088",
+      "description": "Local development server"
+    },
+    {
+      "url": "{protocol}://{host}:{port}",
+      "description": "Custom server",
+      "variables": {
+        "protocol": {
+          "default": "http",
+          "enum": [
+            "http",
+            "https"
+          ],
+          "description": "HTTP protocol"
+        },
+        "host": {
+          "default": "localhost",
+          "description": "Server hostname or IP"
+        },
+        "port": {
+          "default": "8088",
+          "description": "Server port"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "Advanced Data Type",
+      "description": "Advanced data type operations and conversions."
+    },
+    {
+      "name": "Annotation Layers",
+      "description": "Manage annotation layers and annotations for charts."
+    },
+    {
+      "name": "AsyncEventsRestApi",
+      "description": "Real-time event streaming via Server-Sent Events (SSE)."
+    },
+    {
+      "name": "Available Domains",
+      "description": "Get available domains for the Superset instance."
+    },
+    {
+      "name": "CSS Templates",
+      "description": "Manage CSS templates for custom dashboard styling."
+    },
+    {
+      "name": "CacheRestApi",
+      "description": "Cache management and invalidation operations."
+    },
+    {
+      "name": "Charts",
+      "description": "Create, read, update, and delete charts (slices)."
+    },
+    {
+      "name": "Current User",
+      "description": "Get information about the authenticated user."
+    },
+    {
+      "name": "Dashboard Filter State",
+      "description": "Manage temporary filter state for dashboards."
+    },
+    {
+      "name": "Dashboard Permanent Link",
+      "description": "Permanent links to dashboard states."
+    },
+    {
+      "name": "Dashboards",
+      "description": "Create, read, update, and delete dashboards."
+    },
+    {
+      "name": "Database",
+      "description": "Manage database connections and metadata."
+    },
+    {
+      "name": "Datasets",
+      "description": "Manage datasets (tables) used for building charts."
+    },
+    {
+      "name": "Datasources",
+      "description": "Query datasource metadata and column values."
+    },
+    {
+      "name": "Embedded Dashboard",
+      "description": "Configure embedded dashboard settings."
+    },
+    {
+      "name": "Explore",
+      "description": "Chart exploration and data querying endpoints."
+    },
+    {
+      "name": "Explore Form Data",
+      "description": "Manage temporary form data for chart exploration."
+    },
+    {
+      "name": "Explore Permanent Link",
+      "description": "Permanent links to chart explore states."
+    },
+    {
+      "name": "Import/export",
+      "description": "Import and export Superset assets."
+    },
+    {
+      "name": "LogRestApi",
+      "description": "Access audit logs and activity history."
+    },
+    {
+      "name": "Menu",
+      "description": "Get the Superset menu structure."
+    },
+    {
+      "name": "OpenApi",
+      "description": "Access the OpenAPI specification."
+    },
+    {
+      "name": "Queries",
+      "description": "View and manage SQL Lab query history."
+    },
+    {
+      "name": "Report Schedules",
+      "description": "Configure scheduled reports and alerts."
+    },
+    {
+      "name": "Row Level Security",
+      "description": "Manage row-level security rules for data access."
+    },
+    {
+      "name": "SQL Lab",
+      "description": "Execute SQL queries and manage SQL Lab sessions."
+    },
+    {
+      "name": "SQL Lab Permanent Link",
+      "description": "Permanent links to SQL Lab states."
+    },
+    {
+      "name": "Security",
+      "description": "Authentication and token management."
+    },
+    {
+      "name": "Security Groups",
+      "description": "Endpoints related to Security Groups."
+    },
+    {
+      "name": "Security Permissions",
+      "description": "View available permissions."
+    },
+    {
+      "name": "Security Permissions on Resources (View Menus)",
+      "description": "Permission-resource mappings."
+    },
+    {
+      "name": "Security Resources (View Menus)",
+      "description": "Manage security resources (view menus)."
+    },
+    {
+      "name": "Security Roles",
+      "description": "Manage security roles and their permissions."
+    },
+    {
+      "name": "Security Users",
+      "description": "Manage user accounts."
+    },
+    {
+      "name": "Tags",
+      "description": "Organize assets with tags."
+    },
+    {
+      "name": "Themes",
+      "description": "Manage UI themes for customizing Superset's appearance."
+    },
+    {
+      "name": "User",
+      "description": "User profile and preferences."
+    },
+    {
+      "name": "UserRegistrationsRestAPI",
+      "description": "Endpoints related to UserRegistrationsRestAPI."
     }
   ]
 }


### PR DESCRIPTION
## Summary

The Theme API was added in #34182 but the OpenAPI spec used for the [API documentation](https://superset.apache.org/docs/api) hadn't been regenerated to include these endpoints.

This PR:
- Regenerates `docs/static/resources/openapi.json` from a running Superset instance
- Adds all Theme API endpoints that were missing from the docs
- Adds a "Themes" tag description to `fix-openapi-spec.py`

### Theme API endpoints now documented:

| Endpoint | Description |
|----------|-------------|
| `GET /api/v1/theme/` | List all themes |
| `POST /api/v1/theme/` | Create a new theme |
| `GET /api/v1/theme/{pk}` | Get a theme by ID |
| `PUT /api/v1/theme/{pk}` | Update a theme |
| `DELETE /api/v1/theme/{pk}` | Delete a theme |
| `PUT /api/v1/theme/{pk}/set_system_default` | Set as system default theme |
| `PUT /api/v1/theme/{pk}/set_system_dark` | Set as system dark theme |
| `DELETE /api/v1/theme/unset_system_default` | Remove system default designation |
| `DELETE /api/v1/theme/unset_system_dark` | Remove system dark designation |
| `GET /api/v1/theme/export/` | Export themes as YAML |
| `POST /api/v1/theme/import/` | Import themes from YAML |

## Testing Instructions

1. Build the docs site locally: `cd docs && yarn build`
2. Serve and navigate to API reference
3. Verify "Themes" section appears with all endpoints

## Additional Information

This aligns the auto-generated API docs at https://superset.apache.org/docs/api with the manually documented API endpoints at https://superset.apache.org/docs/configuration/theming/#api-access

🤖 Generated with [Claude Code](https://claude.ai/code)