### PR TITLE
fix(jest): ignore storybook-static and package __mocks__ directories

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -42,6 +42,9 @@ module.exports = {
     '<rootDir>/packages/.*/lib',
     '<rootDir>/plugins/.*/esm',
     '<rootDir>/plugins/.*/lib',
+    // Ignore build artifacts that contain duplicate package.json or mock files
+    '<rootDir>/storybook-static',
+    '<rootDir>/packages/.*/__mocks__',
   ],
   setupFilesAfterEnv: ['<rootDir>/spec/helpers/setup.ts'],
   snapshotSerializers: ['@emotion/jest/serializer'],

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -44,7 +44,9 @@ module.exports = {
     '<rootDir>/plugins/.*/lib',
     // Ignore build artifacts that contain duplicate package.json or mock files
     '<rootDir>/storybook-static',
-    '<rootDir>/packages/.*/__mocks__',
+    // Ignore duplicate __mocks__ at package root level (e.g., packages/superset-ui-core/__mocks__)
+    // but not test __mocks__ directories (e.g., packages/superset-ui-core/test/__mocks/)
+    '<rootDir>/packages/[^/]+/__mocks__',
   ],
   setupFilesAfterEnv: ['<rootDir>/spec/helpers/setup.ts'],
   snapshotSerializers: ['@emotion/jest/serializer'],


### PR DESCRIPTION
## Summary

Fixes local Jest test runs that were failing with confusing errors due to duplicate files being scanned.

### Issues Fixed

1. **Haste module naming collision**
   ```
   jest-haste-map: Haste module naming collision: superset
     * <rootDir>/package.json
     * <rootDir>/storybook-static/package.json
   ```
   The `storybook-static/` build artifact contains a copy of `package.json` with `"name": "superset"`, causing Jest's Haste module resolver to fail.

2. **Duplicate manual mock warnings**
   ```
   jest-haste-map: duplicate manual mock found: mockExportObject
     * <rootDir>/spec/__mocks__/mockExportObject.js
     * <rootDir>/packages/superset-ui-core/__mocks__/mockExportObject.js
   ```
   The `packages/superset-ui-core/__mocks__/` directory contains copies of the canonical mocks in `spec/__mocks__/`, causing ambiguity.

### Solution

Add these directories to `modulePathIgnorePatterns` in `jest.config.js`:
- `<rootDir>/storybook-static` - build artifact directory
- `<rootDir>/packages/.*/__mocks__` - package-level mocks (canonical mocks are in `spec/__mocks__/`)

## Test Plan

- [x] Ran `npx jest --testPathPatterns="deckgl"` - all 273 tests pass
- [x] No more Haste naming collision or duplicate mock warnings

🤖 Generated with [Claude Code](https://claude.ai/code)