### PR TITLE
chore(deps): Relax sqlalchemy-utils lower bound for pydoris compatibility 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dependencies = [
     "simplejson>=3.15.0",
     "slack_sdk>=3.19.0, <4",
     "sqlalchemy>=1.4, <2",
-    "sqlalchemy-utils>=0.42.0, <0.43",
+    "sqlalchemy-utils>=0.38.0, <0.43", # expanding lowerbound to work with pydoris
     "sqlglot>=28.10.0, <29",
     # newer pandas needs 0.9+
     "tabulate>=0.9.0, <1.0",

--- a/superset-core/pyproject.toml
+++ b/superset-core/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "flask-appbuilder>=5.0.2,<6",
     "pydantic>=2.8.0",
     "sqlalchemy>=1.4.0,<2.0",
-    "sqlalchemy-utils>=0.42.0",
+    "sqlalchemy-utils>=0.38.0, <0.43", # expanding lowerbound to work with pydoris
     "sqlglot>=28.10.0, <29",
     "typing-extensions>=4.0.0",
 ]


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Relaxes the sqlalchemy-utils lower bound from >=0.42.0 to >=0.38.0 in both pyproject.toml and superset-core/pyproject.toml.

The recent bump in #36240 raised the floor to >=0.42.0, which conflicts with pydoris (all versions including latest 1.1.0 require sqlalchemy-utils<0.39). This makes it impossible to install Superset with Apache Doris support.                                                                                             

Superset only uses UUIDType and EncryptedType from sqlalchemy-utils — both available and unchanged since 0.38.x. The lock files (requirements/base.txt) remain pinned at ==0.42.0, so default installs are unaffected. This change only widens the acceptable range so that downstream consumers can resolve to an older version when needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
