### PR TITLE
fix(sqllab): fix tables not loading after database and schema selection

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -19,17 +19,22 @@
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { resetState } from 'src/SqlLab/actions/sqlLab';
+import {
+  resetState,
+  addQueryEditor,
+} from 'src/SqlLab/actions/sqlLab';
 import {
   Button,
+  Divider,
   EmptyState,
   Flex,
   Icons,
+  Label,
   Popover,
   Typography,
 } from '@superset-ui/core/components';
 import { t } from '@apache-superset/core';
-import { styled, css } from '@apache-superset/core/ui';
+import { styled } from '@apache-superset/core/ui';
 import type { SchemaOption, CatalogOption } from 'src/hooks/apiResources';
 import { DatabaseSelector, type DatabaseObject } from 'src/components';
 
@@ -41,25 +46,33 @@ export interface SqlEditorLeftBarProps {
 }
 
 const LeftBarStyles = styled.div`
+  height: 100%;
   display: flex;
   flex-direction: column;
   gap: ${({ theme }) => theme.sizeUnit * 2}px;
-
-  ${({ theme }) => css`
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-
-    .divider {
-      border-bottom: 1px solid ${theme.colorSplit};
-      margin: ${theme.sizeUnit * 1}px 0;
-    }
-  `}
 `;
 
-const StyledDivider = styled.div`
-  border-bottom: 1px solid ${({ theme }) => theme.colorSplit};
-  margin: 0 -${({ theme }) => theme.sizeUnit * 2.5}px 0;
+const SelectorTrigger = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.sizeUnit}px;
+  min-width: 0;
+  overflow: hidden;
+  padding: ${({ theme }) => theme.sizeUnit}px ${({ theme }) => theme.sizeUnit * 1.5}px;
+  border: 1px solid ${({ theme }) => theme.colorBorder};
+  border-radius: ${({ theme }) => theme.borderRadius}px;
+  cursor: pointer;
+  transition: border-color ${({ theme }) => theme.motionDurationMid};
+
+  &:hover,
+  &:focus-visible {
+    border-color: ${({ theme }) => theme.colorPrimary};
+  }
+`;
+
+const EllipsisText = styled(Typography.Text)`
+  min-width: 0;
+  flex: 1;
 `;
 
 const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
@@ -96,6 +109,21 @@ const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
   }, []);
 
   const handleModalOk = useCallback(() => {
+    // When there is no active query editor tab, create a new one with the
+    // selected database + schema so the Redux state is initialised correctly.
+    if (!queryEditorId && modalDb) {
+      dispatch(
+        addQueryEditor({
+          dbId: modalDb.id,
+          catalog: modalCatalog?.value,
+          schema: modalSchema?.value,
+          sql: 'SELECT ...',
+        }),
+      );
+      setSelectorModalOpen(false);
+      return;
+    }
+
     if (modalDb && modalDb.id !== db?.id) {
       onDbChange?.(modalDb);
     }
@@ -107,6 +135,8 @@ const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
     }
     setSelectorModalOpen(false);
   }, [
+    queryEditorId,
+    dispatch,
     modalDb,
     modalCatalog,
     modalSchema,
@@ -127,9 +157,7 @@ const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
       vertical
       gap="middle"
       data-test="DatabaseSelector"
-      css={css`
-        min-width: 500px;
-      `}
+      style={{ minWidth: 500 }}
     >
       <Typography.Title level={5} style={{ margin: 0 }}>
         {t('Select Database and Schema')}
@@ -187,17 +215,37 @@ const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
         placement="bottomLeft"
         trigger="click"
       >
-        <DatabaseSelector
-          key={`db-selector-${db ? db.id : 'no-db'}:${catalog ?? 'no-catalog'}:${
-            schema ?? 'no-schema'
-          }`}
-          {...dbSelectorProps}
-          emptyState={<EmptyState />}
-          sqlLabMode
-          onOpenModal={openSelectorModal}
-        />
+        {/* Display-only sidebar header reading directly from Redux via
+            useDatabaseSelector. Using DatabaseSelector here with sqlLabMode
+            caused its internal hooks (useSchemas, useCatalogs) to fire and
+            clear the selected schema before it could render. */}
+        <SelectorTrigger
+          data-test="DatabaseSelector"
+          onClick={openSelectorModal}
+          role="button"
+          tabIndex={0}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              openSelectorModal();
+            }
+          }}
+        >
+          {db ? (
+            <EllipsisText ellipsis>
+              <Label>{db.backend || ''}</Label> {db.database_name}
+            </EllipsisText>
+          ) : (
+            <EllipsisText ellipsis type="secondary">
+              {t('Select database or type to search databases')}
+            </EllipsisText>
+          )}
+          <Icons.RightOutlined />
+          <EllipsisText ellipsis type={schema ? undefined : 'secondary'}>
+            {schema || t('Select schema or type to search schemas')}
+          </EllipsisText>
+        </SelectorTrigger>
       </Popover>
-      <StyledDivider />
+      <Divider style={{ margin: 0 }} />
       <TableExploreTree queryEditorId={queryEditorId} />
       {shouldShowReset && (
         <Button

--- a/superset-frontend/src/SqlLab/components/SqlEditorTopBar/useDatabaseSelector.ts
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTopBar/useDatabaseSelector.ts
@@ -58,17 +58,21 @@ export default function useDatabaseSelector(queryEditorId: string) {
   const { catalog, schema } = queryEditor;
 
   const onDbChange = useCallback(
-    ({ id: dbId }: { id: number }) => {
-      if (queryEditor) {
-        dispatch(queryEditorSetDb(queryEditor, dbId));
+    (db: DatabaseObject) => {
+      if (queryEditor?.id) {
+        dispatch(queryEditorSetDb(queryEditor, db.id));
       }
+      // Immediately update the local selection so the sidebar reflects
+      // the chosen database without waiting for the Redux databases map
+      // to be repopulated via getDbList.
+      setUserSelected(db);
     },
     [dispatch, queryEditor],
   );
 
   const handleCatalogChange = useCallback(
     (catalog?: string | null) => {
-      if (queryEditor) {
+      if (queryEditor?.id) {
         dispatch(queryEditorSetCatalog(queryEditor, catalog ?? null));
       }
     },
@@ -77,7 +81,7 @@ export default function useDatabaseSelector(queryEditorId: string) {
 
   const handleSchemaChange = useCallback(
     (schema: string) => {
-      if (queryEditor) {
+      if (queryEditor?.id) {
         dispatch(queryEditorSetSchema(queryEditor, schema));
       }
     },

--- a/superset-frontend/src/hooks/apiResources/tables.test.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.test.ts
@@ -58,8 +58,6 @@ const fakeHasMoreApiResult = {
   ],
 };
 
-const fakeSchemaApiResult = ['schema1', 'schema2'];
-
 const expectedData = {
   options: fakeApiResult.result,
   hasMore: false,
@@ -80,14 +78,8 @@ describe('useTables hook', () => {
   test('returns api response mapping json options', async () => {
     const expectDbId = 'db1';
     const expectedSchema = 'schema1';
-    const catalogApiRoute = `glob:*/api/v1/database/${expectDbId}/catalogs/*`;
-    const schemaApiRoute = `glob:*/api/v1/database/${expectDbId}/schemas/*`;
     const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
     fetchMock.get(tableApiRoute, fakeApiResult);
-    fetchMock.get(catalogApiRoute, { count: 0, result: [] });
-    fetchMock.get(schemaApiRoute, {
-      result: fakeSchemaApiResult,
-    });
     const { result, waitFor } = renderHook(
       () =>
         useTables({
@@ -102,7 +94,6 @@ describe('useTables hook', () => {
       },
     );
     await waitFor(() => expect(result.current.data).toEqual(expectedData));
-    expect(fetchMock.callHistory.calls(schemaApiRoute).length).toBe(1);
     expect(
       fetchMock.callHistory.calls(
         `end:api/v1/database/${expectDbId}/tables/?q=${rison.encode({
@@ -124,26 +115,17 @@ describe('useTables hook', () => {
         ).length,
       ).toBe(1),
     );
-    expect(fetchMock.callHistory.calls(schemaApiRoute).length).toBe(1);
     expect(result.current.data).toEqual(expectedData);
   });
 
-  test('skips the deprecated schema option', async () => {
-    const expectDbId = 'db1';
-    const unexpectedSchema = 'invalid schema';
-    const catalogApiRoute = `glob:*/api/v1/database/${expectDbId}/catalogs/*`;
-    const schemaApiRoute = `glob:*/api/v1/database/${expectDbId}/schemas/*`;
-    const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
+  test('skips the query when dbId is missing', async () => {
+    const tableApiRoute = `glob:*/api/v1/database/*/tables/?q=*`;
     fetchMock.get(tableApiRoute, fakeApiResult);
-    fetchMock.get(catalogApiRoute, { count: 0, result: [] });
-    fetchMock.get(schemaApiRoute, {
-      result: fakeSchemaApiResult,
-    });
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () =>
         useTables({
-          dbId: expectDbId,
-          schema: unexpectedSchema,
+          dbId: undefined,
+          schema: 'schema1',
         }),
       {
         wrapper: createWrapper({
@@ -152,18 +134,29 @@ describe('useTables hook', () => {
         }),
       },
     );
-    await waitFor(() =>
-      expect(fetchMock.callHistory.calls(schemaApiRoute).length).toBe(1),
+    expect(result.current.data).toBeUndefined();
+    expect(fetchMock.callHistory.calls(tableApiRoute).length).toBe(0);
+  });
+
+  test('skips the query when schema is missing', async () => {
+    const expectDbId = 'db1';
+    const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
+    fetchMock.get(tableApiRoute, fakeApiResult);
+    const { result } = renderHook(
+      () =>
+        useTables({
+          dbId: expectDbId,
+          schema: undefined,
+        }),
+      {
+        wrapper: createWrapper({
+          useRedux: true,
+          store,
+        }),
+      },
     );
-    expect(result.current.data).toEqual(undefined);
-    expect(
-      fetchMock.callHistory.calls(
-        `end:api/v1/database/${expectDbId}/tables/?q=${rison.encode({
-          force: false,
-          schema_name: unexpectedSchema,
-        })}`,
-      ).length,
-    ).toBe(0);
+    expect(result.current.data).toBeUndefined();
+    expect(fetchMock.callHistory.calls(tableApiRoute).length).toBe(0);
   });
 
   test('returns hasMore when total is larger than result size', async () => {
@@ -171,13 +164,6 @@ describe('useTables hook', () => {
     const expectedSchema = 'schema2';
     const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
     fetchMock.get(tableApiRoute, fakeHasMoreApiResult, { name: tableApiRoute });
-    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/catalogs/*`, {
-      count: 0,
-      result: [],
-    });
-    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/schemas/*`, {
-      result: fakeSchemaApiResult,
-    });
     const { result, waitFor } = renderHook(
       () =>
         useTables({
@@ -202,13 +188,6 @@ describe('useTables hook', () => {
     const expectedSchema = 'schema1';
     const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
     fetchMock.get(tableApiRoute, fakeApiResult);
-    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/catalogs/*`, {
-      count: 0,
-      result: [],
-    });
-    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/schemas/*`, {
-      result: fakeSchemaApiResult,
-    });
     const { result, rerender, waitFor } = renderHook(
       () =>
         useTables({
@@ -222,16 +201,6 @@ describe('useTables hook', () => {
         }),
       },
     );
-    console.log(
-      'Called URLs:',
-      fetchMock.callHistory.calls().map(call => call.url),
-    );
-
-    // Add a catch-all mock to see if any unmocked requests are being made
-    fetchMock.route('*', url => {
-      console.log('Unmocked request to:', url);
-      return 404;
-    });
     await waitFor(() =>
       expect(fetchMock.callHistory.calls(tableApiRoute).length).toBe(1),
     );
@@ -250,13 +219,6 @@ describe('useTables hook', () => {
         url.includes(expectedSchema) ? fakeApiResult : fakeHasMoreApiResult,
       { name: tableApiRoute },
     );
-    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/catalogs/*`, {
-      count: 0,
-      result: [],
-    });
-    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/schemas/*`, {
-      result: fakeSchemaApiResult,
-    });
     const { result, rerender, waitFor } = renderHook(
       ({ schema }) =>
         useTables({


### PR DESCRIPTION
### SUMMARY

The table selector in SQL Lab fails to load tables after the user selects a database and schema. Three interconnected issues cause this:

**1. No query editor tab = silent Redux failures**

When SQL Lab opens with an empty `tabHistory`, `queryEditorId` is `undefined`. The `useDatabaseSelector` hook returned an empty `queryEditor` object (`{}`), which is truthy but has no `id`. Dispatching `queryEditorSetDb` / `queryEditorSetSchema` with this empty object caused the reducer to silently discard the updates because it could not find a matching query editor.

**Fix:** Guard all dispatches in `useDatabaseSelector` with `queryEditor?.id` and, in `SqlEditorLeftBar.handleModalOk`, automatically create a new query editor tab via `addQueryEditor` when no active tab exists.

**2. Sidebar DatabaseSelector clearing schema via internal hooks**

The sidebar previously rendered a `DatabaseSelector` component in "display-only" mode (`sqlLabMode`). However, its internal `useSchemas` / `useCatalogs` hooks still fired on mount, and their `onSuccess` callbacks reset the local `currentSchema` state before the selected value could render.

**Fix:** Replace the sidebar `DatabaseSelector` with a lightweight read-only display that renders `db` and `schema` directly from the `useDatabaseSelector` hook, keeping `DatabaseSelector` only inside the selection popover.

**3. Stale test mocks for removed `useSchemas` dependency**

The `useTables` hook no longer validates schemas via `useSchemas` internally (that was removed in a prior commit), but the test file still mocked schema/catalog endpoints and asserted against them. The "skips the deprecated schema option" test was broken because `enabled = Boolean(dbId && schema)` treats any non-empty string as valid.

**Fix:** Remove stale schema/catalog mocks, replace the broken test with explicit "skips when dbId is missing" and "skips when schema is missing" tests, and remove debug `console.log` statements.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** After selecting a database and schema in SQL Lab, the table dropdown shows empty / "No data".

**After:** Tables load correctly after selecting database and schema.

### TESTING INSTRUCTIONS

1. Open SQL Lab
2. Select a database from the database dropdown
3. Select a schema from the schema dropdown
4. Verify that the table dropdown populates with tables from the selected schema
5. Switch databases and repeat — tables should load for the new database/schema combination
6. Verify that with no database selected, the tables query does not fire
7. Verify that with no schema selected, the tables query does not fire
8. Close all SQL Lab tabs and reopen — verify the sidebar still functions correctly (the empty `tabHistory` edge case)

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #38482
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API