### PR TITLE
feat(mcp): dynamic feature availability via menus and feature flags

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -153,8 +153,7 @@ Input format:
   accepted as input, which works around double-serialization bugs in some MCP clients
 
 Feature Availability:
-- Call get_instance_info to discover accessible menus and enabled feature flags
-  for the current user.
+- Call get_instance_info to discover accessible menus for the current user.
 - Do NOT assume features exist; always check get_instance_info first.
 
 If you are unsure which tool to use, start with get_instance_info

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -155,8 +155,8 @@ Input format:
   accepted as input, which works around double-serialization bugs in some MCP clients
 
 Feature Availability:
-- Call get_instance_info to discover accessible menus, enabled feature flags,
-  and any deployment-specific restrictions for the current user.
+- Call get_instance_info to discover accessible menus and enabled feature flags
+  for the current user.
 - Do NOT assume features exist; always check get_instance_info first.
 
 If you are unsure which tool to use, start with get_instance_info

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -31,9 +31,7 @@ from fastmcp.server.middleware import Middleware
 logger = logging.getLogger(__name__)
 
 
-def get_default_instructions(
-    branding: str = "Apache Superset",
-) -> str:
+def get_default_instructions(branding: str = "Apache Superset") -> str:
     """Get default instructions with configurable branding.
 
     Args:

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -31,16 +31,35 @@ from fastmcp.server.middleware import Middleware
 logger = logging.getLogger(__name__)
 
 
-def get_default_instructions(branding: str = "Apache Superset") -> str:
+def get_default_instructions(
+    branding: str = "Apache Superset",
+    unavailable_features: list[str] | None = None,
+) -> str:
     """Get default instructions with configurable branding.
 
     Args:
         branding: Product name to use in instructions
             (e.g., "ACME Analytics", "Apache Superset")
+        unavailable_features: List of features not available in this deployment
+            that LLMs should not suggest to users.
 
     Returns:
         Formatted instructions string with branding applied
     """
+    unavailable_section = ""
+    if unavailable_features:
+        features_list = "\n".join(f"- {f}" for f in unavailable_features)
+        unavailable_section = f"""
+
+IMPORTANT - Unavailable Features:
+The following features are NOT available in this deployment. Do NOT suggest
+or reference them when helping users, even if they exist in other deployments:
+{features_list}
+
+If a user asks about functionality related to these features, let them know
+it is not available and suggest alternatives using the MCP tools listed above.
+"""
+
     return f"""
 You are connected to the {branding} MCP (Model Context Protocol) service.
 This service provides programmatic access to {branding} dashboards, charts, datasets,
@@ -151,7 +170,7 @@ Input format:
 - Tool request parameters accept structured objects (dicts/JSON)
 - When MCP_PARSE_REQUEST_ENABLED is True (default), string-serialized JSON is also
   accepted as input, which works around double-serialization bugs in some MCP clients
-
+{unavailable_section}
 If you are unsure which tool to use, start with get_instance_info
 or use the quickstart prompt for an interactive guide.
 
@@ -394,11 +413,16 @@ def init_fastmcp_server(
     branding = app_name
     default_name = f"{app_name} MCP Server"
 
+    # Read unavailable features from Flask config
+    unavailable_features = flask_app.config.get("MCP_UNAVAILABLE_FEATURES", [])
+
     # Apply branding defaults if not explicitly provided
     if name is None:
         name = default_name
     if instructions is None:
-        instructions = get_default_instructions(branding)
+        instructions = get_default_instructions(
+            branding, unavailable_features=unavailable_features
+        )
 
     # Configure the global mcp instance with provided settings.
     # Tools are already registered on this instance via @tool decorator imports above.

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -33,33 +33,16 @@ logger = logging.getLogger(__name__)
 
 def get_default_instructions(
     branding: str = "Apache Superset",
-    unavailable_features: list[str] | None = None,
 ) -> str:
     """Get default instructions with configurable branding.
 
     Args:
         branding: Product name to use in instructions
             (e.g., "ACME Analytics", "Apache Superset")
-        unavailable_features: List of features not available in this deployment
-            that LLMs should not suggest to users.
 
     Returns:
         Formatted instructions string with branding applied
     """
-    unavailable_section = ""
-    if unavailable_features:
-        features_list = "\n".join(f"- {f}" for f in unavailable_features)
-        unavailable_section = f"""
-
-IMPORTANT - Unavailable Features:
-The following features are NOT available in this deployment. Do NOT suggest
-or reference them when helping users, even if they exist in other deployments:
-{features_list}
-
-If a user asks about functionality related to these features, let them know
-it is not available and suggest alternatives using the MCP tools listed above.
-"""
-
     return f"""
 You are connected to the {branding} MCP (Model Context Protocol) service.
 This service provides programmatic access to {branding} dashboards, charts, datasets,
@@ -170,7 +153,12 @@ Input format:
 - Tool request parameters accept structured objects (dicts/JSON)
 - When MCP_PARSE_REQUEST_ENABLED is True (default), string-serialized JSON is also
   accepted as input, which works around double-serialization bugs in some MCP clients
-{unavailable_section}
+
+Feature Availability:
+- Call get_instance_info to discover accessible menus, enabled feature flags,
+  and any deployment-specific restrictions for the current user.
+- Do NOT assume features exist; always check get_instance_info first.
+
 If you are unsure which tool to use, start with get_instance_info
 or use the quickstart prompt for an interactive guide.
 
@@ -413,16 +401,11 @@ def init_fastmcp_server(
     branding = app_name
     default_name = f"{app_name} MCP Server"
 
-    # Read unavailable features from Flask config
-    unavailable_features = flask_app.config.get("MCP_UNAVAILABLE_FEATURES", [])
-
     # Apply branding defaults if not explicitly provided
     if name is None:
         name = default_name
     if instructions is None:
-        instructions = get_default_instructions(
-            branding, unavailable_features=unavailable_features
-        )
+        instructions = get_default_instructions(branding)
 
     # Configure the global mcp instance with provided settings.
     # Tools are already registered on this instance via @tool decorator imports above.

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -75,6 +75,11 @@ MCP_FACTORY_CONFIG = {
     "config": None,  # No additional config
 }
 
+# Features unavailable in this deployment that LLMs should not suggest.
+# Override in superset_config.py to list features not available in your deployment.
+# Example: ["Action Log (Settings > Security > Action Log)", "List Users page"]
+MCP_UNAVAILABLE_FEATURES: list[str] = []
+
 # =============================================================================
 # MCP Storage and Caching Configuration
 # =============================================================================

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -75,15 +75,6 @@ MCP_FACTORY_CONFIG = {
     "config": None,  # No additional config
 }
 
-# Escape hatch for deployment-specific features that cannot be detected
-# dynamically via menu access or feature flags. Override in superset_config.py.
-# The get_instance_info tool dynamically reports accessible menus and enabled
-# feature flags at request time; use this only for custom notes.
-#
-# Example:
-#   MCP_UNAVAILABLE_FEATURES = ["Custom SSO Portal", "Legacy Export"]
-MCP_UNAVAILABLE_FEATURES: list[str] = []
-
 # =============================================================================
 # MCP Storage and Caching Configuration
 # =============================================================================

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -75,36 +75,13 @@ MCP_FACTORY_CONFIG = {
     "config": None,  # No additional config
 }
 
-# ---------------------------------------------------------------------------
-# Known Superset UI features that may not exist in all deployments.
-# Use these constants when configuring MCP_UNAVAILABLE_FEATURES to ensure
-# consistent naming across deployments. Custom strings are also accepted.
-# ---------------------------------------------------------------------------
-MCP_FEATURE_ACTION_LOG = "Action Log (Settings > Security > Action Log)"
-MCP_FEATURE_LIST_USERS = "List Users page (Settings > List Users)"
-MCP_FEATURE_LIST_ROLES = "List Roles page (Settings > List Roles)"
-
-# Convenience list of all known Superset-only features for reference.
-MCP_ALL_KNOWN_FEATURES: list[str] = [
-    MCP_FEATURE_ACTION_LOG,
-    MCP_FEATURE_LIST_USERS,
-    MCP_FEATURE_LIST_ROLES,
-]
-
-# Features unavailable in this deployment that LLMs should not suggest.
-# Override in superset_config.py to list features not available in your deployment.
-# You can use the constants above or pass custom strings.
+# Escape hatch for deployment-specific features that cannot be detected
+# dynamically via menu access or feature flags. Override in superset_config.py.
+# The get_instance_info tool dynamically reports accessible menus and enabled
+# feature flags at request time; use this only for custom notes.
 #
-# Example using constants:
-#   from superset.mcp_service.mcp_config import (
-#       MCP_FEATURE_ACTION_LOG, MCP_FEATURE_LIST_USERS, MCP_FEATURE_LIST_ROLES,
-#   )
-#   MCP_UNAVAILABLE_FEATURES = [
-#       MCP_FEATURE_ACTION_LOG, MCP_FEATURE_LIST_USERS, MCP_FEATURE_LIST_ROLES,
-#   ]
-#
-# Example using custom strings:
-#   MCP_UNAVAILABLE_FEATURES = ["Action Log", "Some Custom Feature"]
+# Example:
+#   MCP_UNAVAILABLE_FEATURES = ["Custom SSO Portal", "Legacy Export"]
 MCP_UNAVAILABLE_FEATURES: list[str] = []
 
 # =============================================================================

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -75,9 +75,36 @@ MCP_FACTORY_CONFIG = {
     "config": None,  # No additional config
 }
 
+# ---------------------------------------------------------------------------
+# Known Superset UI features that may not exist in all deployments.
+# Use these constants when configuring MCP_UNAVAILABLE_FEATURES to ensure
+# consistent naming across deployments. Custom strings are also accepted.
+# ---------------------------------------------------------------------------
+MCP_FEATURE_ACTION_LOG = "Action Log (Settings > Security > Action Log)"
+MCP_FEATURE_LIST_USERS = "List Users page (Settings > List Users)"
+MCP_FEATURE_LIST_ROLES = "List Roles page (Settings > List Roles)"
+
+# Convenience list of all known Superset-only features for reference.
+MCP_ALL_KNOWN_FEATURES: list[str] = [
+    MCP_FEATURE_ACTION_LOG,
+    MCP_FEATURE_LIST_USERS,
+    MCP_FEATURE_LIST_ROLES,
+]
+
 # Features unavailable in this deployment that LLMs should not suggest.
 # Override in superset_config.py to list features not available in your deployment.
-# Example: ["Action Log (Settings > Security > Action Log)", "List Users page"]
+# You can use the constants above or pass custom strings.
+#
+# Example using constants:
+#   from superset.mcp_service.mcp_config import (
+#       MCP_FEATURE_ACTION_LOG, MCP_FEATURE_LIST_USERS, MCP_FEATURE_LIST_ROLES,
+#   )
+#   MCP_UNAVAILABLE_FEATURES = [
+#       MCP_FEATURE_ACTION_LOG, MCP_FEATURE_LIST_USERS, MCP_FEATURE_LIST_ROLES,
+#   ]
+#
+# Example using custom strings:
+#   MCP_UNAVAILABLE_FEATURES = ["Action Log", "Some Custom Feature"]
 MCP_UNAVAILABLE_FEATURES: list[str] = []
 
 # =============================================================================

--- a/superset/mcp_service/system/schemas.py
+++ b/superset/mcp_service/system/schemas.py
@@ -127,13 +127,6 @@ class FeatureAvailability(BaseModel):
         default_factory=dict,
         description="Feature flags and their current enabled/disabled state",
     )
-    custom_unavailable_features: List[str] = Field(
-        default_factory=list,
-        description=(
-            "Deployment-specific features that are unavailable, "
-            "configured via MCP_UNAVAILABLE_FEATURES"
-        ),
-    )
 
 
 class InstanceInfo(BaseModel):

--- a/superset/mcp_service/system/schemas.py
+++ b/superset/mcp_service/system/schemas.py
@@ -108,6 +108,34 @@ class PopularContent(BaseModel):
     top_creators: List[str] = Field(..., description="Most active creators")
 
 
+class FeatureAvailability(BaseModel):
+    """Dynamic feature availability for the current user and deployment.
+
+    Menus and feature flags are detected at request time from the security
+    manager and feature flag configuration, so they reflect the actual state
+    of the deployment and the permissions of the requesting user.
+    """
+
+    accessible_menus: List[str] = Field(
+        default_factory=list,
+        description=(
+            "UI menu items accessible to the current user, "
+            "derived from FAB role permissions"
+        ),
+    )
+    enabled_feature_flags: Dict[str, bool] = Field(
+        default_factory=dict,
+        description="Feature flags and their current enabled/disabled state",
+    )
+    custom_unavailable_features: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Deployment-specific features that are unavailable, "
+            "configured via MCP_UNAVAILABLE_FEATURES"
+        ),
+    )
+
+
 class InstanceInfo(BaseModel):
     instance_summary: InstanceSummary = Field(
         ..., description="Instance summary information"
@@ -128,6 +156,12 @@ class InstanceInfo(BaseModel):
         None,
         description="The authenticated user making the request. "
         "Use current_user.id with created_by_fk filter to find your own assets.",
+    )
+    feature_availability: FeatureAvailability = Field(
+        ...,
+        description=(
+            "Dynamic feature availability for the current user and deployment"
+        ),
     )
     timestamp: datetime = Field(..., description="Response timestamp")
 

--- a/superset/mcp_service/system/schemas.py
+++ b/superset/mcp_service/system/schemas.py
@@ -111,9 +111,8 @@ class PopularContent(BaseModel):
 class FeatureAvailability(BaseModel):
     """Dynamic feature availability for the current user and deployment.
 
-    Menus and feature flags are detected at request time from the security
-    manager and feature flag configuration, so they reflect the actual state
-    of the deployment and the permissions of the requesting user.
+    Menus are detected at request time from the security manager,
+    so they reflect the actual permissions of the requesting user.
     """
 
     accessible_menus: List[str] = Field(
@@ -122,10 +121,6 @@ class FeatureAvailability(BaseModel):
             "UI menu items accessible to the current user, "
             "derived from FAB role permissions"
         ),
-    )
-    enabled_feature_flags: Dict[str, bool] = Field(
-        default_factory=dict,
-        description="Feature flags and their current enabled/disabled state",
     )
 
 

--- a/superset/mcp_service/system/system_utils.py
+++ b/superset/mcp_service/system/system_utils.py
@@ -205,15 +205,13 @@ def calculate_feature_availability(
     time_metrics: Dict[str, Dict[str, int]],
     dao_classes: Dict[str, Any],
 ) -> FeatureAvailability:
-    """Detect available features dynamically from menus and feature flags.
+    """Detect available features dynamically from menus.
 
     Queries the FAB security manager for menu items accessible to the
-    current user and reads the runtime feature flag state.
+    current user.
     """
     accessible_menus: list[str] = []
-    enabled_flags: Dict[str, bool] = {}
 
-    # --- accessible menus via FAB security manager ---
     try:
         from superset import security_manager
 
@@ -222,15 +220,6 @@ def calculate_feature_availability(
     except Exception as exc:
         logger.debug("Could not retrieve accessible menus: %s", exc)
 
-    # --- feature flags ---
-    try:
-        from superset import get_feature_flags
-
-        enabled_flags = get_feature_flags()
-    except Exception as exc:
-        logger.debug("Could not retrieve feature flags: %s", exc)
-
     return FeatureAvailability(
         accessible_menus=accessible_menus,
-        enabled_feature_flags=enabled_flags,
     )

--- a/superset/mcp_service/system/system_utils.py
+++ b/superset/mcp_service/system/system_utils.py
@@ -205,15 +205,13 @@ def calculate_feature_availability(
     time_metrics: Dict[str, Dict[str, int]],
     dao_classes: Dict[str, Any],
 ) -> FeatureAvailability:
-    """Detect available features dynamically from menus, flags, and config.
+    """Detect available features dynamically from menus and feature flags.
 
     Queries the FAB security manager for menu items accessible to the
-    current user, reads the runtime feature flag state, and includes any
-    custom ``MCP_UNAVAILABLE_FEATURES`` strings from the deployment config.
+    current user and reads the runtime feature flag state.
     """
     accessible_menus: list[str] = []
     enabled_flags: Dict[str, bool] = {}
-    custom_unavailable: list[str] = []
 
     # --- accessible menus via FAB security manager ---
     try:
@@ -232,16 +230,7 @@ def calculate_feature_availability(
     except Exception as exc:
         logger.debug("Could not retrieve feature flags: %s", exc)
 
-    # --- custom deployment-level unavailable features ---
-    try:
-        from flask import current_app
-
-        custom_unavailable = current_app.config.get("MCP_UNAVAILABLE_FEATURES", [])
-    except Exception as exc:
-        logger.debug("Could not read MCP_UNAVAILABLE_FEATURES: %s", exc)
-
     return FeatureAvailability(
         accessible_menus=accessible_menus,
         enabled_feature_flags=enabled_flags,
-        custom_unavailable_features=custom_unavailable,
     )

--- a/superset/mcp_service/system/system_utils.py
+++ b/superset/mcp_service/system/system_utils.py
@@ -22,15 +22,19 @@ This module contains helper functions used by system tools for calculating
 instance metrics, dashboard breakdowns, database breakdowns, and activity summaries.
 """
 
+import logging
 from typing import Any, Dict
 
 from superset.mcp_service.system.schemas import (
     DashboardBreakdown,
     DatabaseBreakdown,
+    FeatureAvailability,
     InstanceSummary,
     PopularContent,
     RecentActivity,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def calculate_dashboard_breakdown(
@@ -193,4 +197,51 @@ def calculate_popular_content(
     return PopularContent(
         top_tags=[],
         top_creators=[],
+    )
+
+
+def calculate_feature_availability(
+    base_counts: Dict[str, int],
+    time_metrics: Dict[str, Dict[str, int]],
+    dao_classes: Dict[str, Any],
+) -> FeatureAvailability:
+    """Detect available features dynamically from menus, flags, and config.
+
+    Queries the FAB security manager for menu items accessible to the
+    current user, reads the runtime feature flag state, and includes any
+    custom ``MCP_UNAVAILABLE_FEATURES`` strings from the deployment config.
+    """
+    accessible_menus: list[str] = []
+    enabled_flags: Dict[str, bool] = {}
+    custom_unavailable: list[str] = []
+
+    # --- accessible menus via FAB security manager ---
+    try:
+        from superset import security_manager
+
+        menu_names = security_manager.user_view_menu_names("menu_access")
+        accessible_menus = sorted(menu_names)
+    except Exception as exc:
+        logger.debug("Could not retrieve accessible menus: %s", exc)
+
+    # --- feature flags ---
+    try:
+        from superset import get_feature_flags
+
+        enabled_flags = get_feature_flags()
+    except Exception as exc:
+        logger.debug("Could not retrieve feature flags: %s", exc)
+
+    # --- custom deployment-level unavailable features ---
+    try:
+        from flask import current_app
+
+        custom_unavailable = current_app.config.get("MCP_UNAVAILABLE_FEATURES", [])
+    except Exception as exc:
+        logger.debug("Could not read MCP_UNAVAILABLE_FEATURES: %s", exc)
+
+    return FeatureAvailability(
+        accessible_menus=accessible_menus,
+        enabled_feature_flags=enabled_flags,
+        custom_unavailable_features=custom_unavailable,
     )

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -35,6 +35,7 @@ from superset.mcp_service.system.schemas import (
 from superset.mcp_service.system.system_utils import (
     calculate_dashboard_breakdown,
     calculate_database_breakdown,
+    calculate_feature_availability,
     calculate_instance_summary,
     calculate_popular_content,
     calculate_recent_activity,
@@ -61,6 +62,7 @@ _instance_info_core = InstanceInfoCore(
         "dashboard_breakdown": calculate_dashboard_breakdown,
         "database_breakdown": calculate_database_breakdown,
         "popular_content": calculate_popular_content,
+        "feature_availability": calculate_feature_availability,
     },
     time_windows={
         "recent": 7,

--- a/tests/unit_tests/mcp_service/system/test_system_utils.py
+++ b/tests/unit_tests/mcp_service/system/test_system_utils.py
@@ -33,19 +33,14 @@ def test_calculate_feature_availability_returns_menus_and_flags():
 
     mock_flags = {"ALERT_REPORTS": True, "DASHBOARD_VIRTUALIZATION": False}
 
-    mock_app = MagicMock()
-    mock_app.config.get.return_value = ["Custom Portal"]
-
     with (
         patch("superset.security_manager", mock_sm),
         patch("superset.get_feature_flags", return_value=mock_flags),
-        patch("flask.current_app", mock_app),
     ):
         result = calculate_feature_availability({}, {}, {})
 
     assert result.accessible_menus == ["Charts", "Dashboards", "SQL Lab"]
     assert result.enabled_feature_flags == mock_flags
-    assert result.custom_unavailable_features == ["Custom Portal"]
     mock_sm.user_view_menu_names.assert_called_once_with("menu_access")
 
 
@@ -54,36 +49,25 @@ def test_calculate_feature_availability_empty_when_no_context():
     broken_sm = MagicMock()
     broken_sm.user_view_menu_names.side_effect = RuntimeError("no ctx")
 
-    broken_app = MagicMock()
-    broken_app.config.get.side_effect = RuntimeError("no ctx")
-
     with (
         patch("superset.security_manager", broken_sm),
         patch("superset.get_feature_flags", side_effect=RuntimeError("no ctx")),
-        patch("flask.current_app", broken_app),
     ):
         result = calculate_feature_availability({}, {}, {})
 
     assert result.accessible_menus == []
     assert result.enabled_feature_flags == {}
-    assert result.custom_unavailable_features == []
 
 
-def test_calculate_feature_availability_no_custom_unavailable():
-    """Test when MCP_UNAVAILABLE_FEATURES is not configured."""
+def test_calculate_feature_availability_menus_sorted():
+    """Test that accessible menus are returned in sorted order."""
     mock_sm = MagicMock()
-    mock_sm.user_view_menu_names.return_value = {"Dashboards"}
-
-    mock_app = MagicMock()
-    mock_app.config.get.return_value = []
+    mock_sm.user_view_menu_names.return_value = {"Zzz", "Aaa", "Mmm"}
 
     with (
         patch("superset.security_manager", mock_sm),
-        patch("superset.get_feature_flags", return_value={"SOME_FLAG": True}),
-        patch("flask.current_app", mock_app),
+        patch("superset.get_feature_flags", return_value={}),
     ):
         result = calculate_feature_availability({}, {}, {})
 
-    assert result.accessible_menus == ["Dashboards"]
-    assert result.enabled_feature_flags == {"SOME_FLAG": True}
-    assert result.custom_unavailable_features == []
+    assert result.accessible_menus == ["Aaa", "Mmm", "Zzz"]

--- a/tests/unit_tests/mcp_service/system/test_system_utils.py
+++ b/tests/unit_tests/mcp_service/system/test_system_utils.py
@@ -22,8 +22,8 @@ from unittest.mock import MagicMock, patch
 from superset.mcp_service.system.system_utils import calculate_feature_availability
 
 
-def test_calculate_feature_availability_returns_menus_and_flags():
-    """Test that accessible menus and feature flags are returned."""
+def test_calculate_feature_availability_returns_menus():
+    """Test that accessible menus are returned."""
     mock_sm = MagicMock()
     mock_sm.user_view_menu_names.return_value = {
         "SQL Lab",
@@ -31,32 +31,22 @@ def test_calculate_feature_availability_returns_menus_and_flags():
         "Charts",
     }
 
-    mock_flags = {"ALERT_REPORTS": True, "DASHBOARD_VIRTUALIZATION": False}
-
-    with (
-        patch("superset.security_manager", mock_sm),
-        patch("superset.get_feature_flags", return_value=mock_flags),
-    ):
+    with patch("superset.security_manager", mock_sm):
         result = calculate_feature_availability({}, {}, {})
 
     assert result.accessible_menus == ["Charts", "Dashboards", "SQL Lab"]
-    assert result.enabled_feature_flags == mock_flags
     mock_sm.user_view_menu_names.assert_called_once_with("menu_access")
 
 
 def test_calculate_feature_availability_empty_when_no_context():
-    """Test graceful fallback when security manager or flags are unavailable."""
+    """Test graceful fallback when security manager is unavailable."""
     broken_sm = MagicMock()
     broken_sm.user_view_menu_names.side_effect = RuntimeError("no ctx")
 
-    with (
-        patch("superset.security_manager", broken_sm),
-        patch("superset.get_feature_flags", side_effect=RuntimeError("no ctx")),
-    ):
+    with patch("superset.security_manager", broken_sm):
         result = calculate_feature_availability({}, {}, {})
 
     assert result.accessible_menus == []
-    assert result.enabled_feature_flags == {}
 
 
 def test_calculate_feature_availability_menus_sorted():
@@ -64,10 +54,7 @@ def test_calculate_feature_availability_menus_sorted():
     mock_sm = MagicMock()
     mock_sm.user_view_menu_names.return_value = {"Zzz", "Aaa", "Mmm"}
 
-    with (
-        patch("superset.security_manager", mock_sm),
-        patch("superset.get_feature_flags", return_value={}),
-    ):
+    with patch("superset.security_manager", mock_sm):
         result = calculate_feature_availability({}, {}, {})
 
     assert result.accessible_menus == ["Aaa", "Mmm", "Zzz"]

--- a/tests/unit_tests/mcp_service/system/test_system_utils.py
+++ b/tests/unit_tests/mcp_service/system/test_system_utils.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for system-level utility functions."""
+
+from unittest.mock import MagicMock, patch
+
+from superset.mcp_service.system.system_utils import calculate_feature_availability
+
+
+def test_calculate_feature_availability_returns_menus_and_flags():
+    """Test that accessible menus and feature flags are returned."""
+    mock_sm = MagicMock()
+    mock_sm.user_view_menu_names.return_value = {
+        "SQL Lab",
+        "Dashboards",
+        "Charts",
+    }
+
+    mock_flags = {"ALERT_REPORTS": True, "DASHBOARD_VIRTUALIZATION": False}
+
+    mock_app = MagicMock()
+    mock_app.config.get.return_value = ["Custom Portal"]
+
+    with (
+        patch("superset.security_manager", mock_sm),
+        patch("superset.get_feature_flags", return_value=mock_flags),
+        patch("flask.current_app", mock_app),
+    ):
+        result = calculate_feature_availability({}, {}, {})
+
+    assert result.accessible_menus == ["Charts", "Dashboards", "SQL Lab"]
+    assert result.enabled_feature_flags == mock_flags
+    assert result.custom_unavailable_features == ["Custom Portal"]
+    mock_sm.user_view_menu_names.assert_called_once_with("menu_access")
+
+
+def test_calculate_feature_availability_empty_when_no_context():
+    """Test graceful fallback when security manager or flags are unavailable."""
+    broken_sm = MagicMock()
+    broken_sm.user_view_menu_names.side_effect = RuntimeError("no ctx")
+
+    broken_app = MagicMock()
+    broken_app.config.get.side_effect = RuntimeError("no ctx")
+
+    with (
+        patch("superset.security_manager", broken_sm),
+        patch("superset.get_feature_flags", side_effect=RuntimeError("no ctx")),
+        patch("flask.current_app", broken_app),
+    ):
+        result = calculate_feature_availability({}, {}, {})
+
+    assert result.accessible_menus == []
+    assert result.enabled_feature_flags == {}
+    assert result.custom_unavailable_features == []
+
+
+def test_calculate_feature_availability_no_custom_unavailable():
+    """Test when MCP_UNAVAILABLE_FEATURES is not configured."""
+    mock_sm = MagicMock()
+    mock_sm.user_view_menu_names.return_value = {"Dashboards"}
+
+    mock_app = MagicMock()
+    mock_app.config.get.return_value = []
+
+    with (
+        patch("superset.security_manager", mock_sm),
+        patch("superset.get_feature_flags", return_value={"SOME_FLAG": True}),
+        patch("flask.current_app", mock_app),
+    ):
+        result = calculate_feature_availability({}, {}, {})
+
+    assert result.accessible_menus == ["Dashboards"]
+    assert result.enabled_feature_flags == {"SOME_FLAG": True}
+    assert result.custom_unavailable_features == []

--- a/tests/unit_tests/mcp_service/system/tool/test_get_current_user.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_current_user.py
@@ -60,6 +60,7 @@ def _make_instance_info(**kwargs):
     from superset.mcp_service.system.schemas import (
         DashboardBreakdown,
         DatabaseBreakdown,
+        FeatureAvailability,
         InstanceSummary,
         PopularContent,
         RecentActivity,
@@ -93,6 +94,7 @@ def _make_instance_info(**kwargs):
         ),
         "database_breakdown": DatabaseBreakdown(by_type={}),
         "popular_content": PopularContent(top_tags=[], top_creators=[]),
+        "feature_availability": FeatureAvailability(),
         "timestamp": datetime.now(timezone.utc),
     }
     defaults.update(kwargs)

--- a/tests/unit_tests/mcp_service/test_mcp_config.py
+++ b/tests/unit_tests/mcp_service/test_mcp_config.py
@@ -180,7 +180,7 @@ def test_get_default_instructions_with_unavailable_features():
 
 
 def test_init_fastmcp_server_reads_unavailable_features_from_config():
-    """Test that init_fastmcp_server reads MCP_UNAVAILABLE_FEATURES from Flask config."""
+    """Test that init reads MCP_UNAVAILABLE_FEATURES from Flask config."""
     features = ["Action Log", "List Users"]
     mock_flask_app = MagicMock()
 

--- a/tests/unit_tests/mcp_service/test_mcp_config.py
+++ b/tests/unit_tests/mcp_service/test_mcp_config.py
@@ -150,3 +150,57 @@ def test_init_fastmcp_server_applies_middleware_to_global_instance():
 
             # Middleware should be added via add_middleware
             mock_mcp.add_middleware.assert_called_once_with(mock_mw)
+
+
+def test_get_default_instructions_without_unavailable_features():
+    """Test that no unavailable features section appears when list is empty."""
+    instructions = get_default_instructions()
+    assert "Unavailable Features" not in instructions
+
+    instructions_empty = get_default_instructions(unavailable_features=[])
+    assert "Unavailable Features" not in instructions_empty
+
+    instructions_none = get_default_instructions(unavailable_features=None)
+    assert "Unavailable Features" not in instructions_none
+
+
+def test_get_default_instructions_with_unavailable_features():
+    """Test that unavailable features section is included when list is non-empty."""
+    features = [
+        "Action Log (Settings > Security > Action Log)",
+        "List Users page (Settings > List Users)",
+    ]
+    instructions = get_default_instructions(unavailable_features=features)
+
+    assert "IMPORTANT - Unavailable Features" in instructions
+    assert "Action Log (Settings > Security > Action Log)" in instructions
+    assert "List Users page (Settings > List Users)" in instructions
+    assert "Do NOT suggest" in instructions
+    assert "suggest alternatives using the MCP tools" in instructions
+
+
+def test_init_fastmcp_server_reads_unavailable_features_from_config():
+    """Test that init_fastmcp_server reads MCP_UNAVAILABLE_FEATURES from Flask config."""
+    features = ["Action Log", "List Users"]
+    mock_flask_app = MagicMock()
+
+    def config_get(key, default=None):
+        if key == "APP_NAME":
+            return "Superset"
+        if key == "MCP_UNAVAILABLE_FEATURES":
+            return features
+        return default
+
+    mock_flask_app.config.get.side_effect = config_get
+
+    with patch.dict(
+        "sys.modules",
+        {"superset.mcp_service.flask_singleton": MagicMock(app=mock_flask_app)},
+    ):
+        with patch("superset.mcp_service.app.mcp") as mock_mcp:
+            init_fastmcp_server()
+
+            instructions = mock_mcp._mcp_server.instructions
+            assert "Unavailable Features" in instructions
+            assert "Action Log" in instructions
+            assert "List Users" in instructions

--- a/tests/unit_tests/mcp_service/test_mcp_config.py
+++ b/tests/unit_tests/mcp_service/test_mcp_config.py
@@ -20,6 +20,12 @@
 from unittest.mock import MagicMock, patch
 
 from superset.mcp_service.app import get_default_instructions, init_fastmcp_server
+from superset.mcp_service.mcp_config import (
+    MCP_ALL_KNOWN_FEATURES,
+    MCP_FEATURE_ACTION_LOG,
+    MCP_FEATURE_LIST_ROLES,
+    MCP_FEATURE_LIST_USERS,
+)
 
 
 def test_get_default_instructions_with_default_branding():
@@ -180,7 +186,7 @@ def test_get_default_instructions_with_unavailable_features():
 
 
 def test_init_fastmcp_server_reads_unavailable_features_from_config():
-    """Test that init reads MCP_UNAVAILABLE_FEATURES from Flask config."""
+    """Test init_fastmcp_server reads MCP_UNAVAILABLE_FEATURES from config."""
     features = ["Action Log", "List Users"]
     mock_flask_app = MagicMock()
 
@@ -204,3 +210,13 @@ def test_init_fastmcp_server_reads_unavailable_features_from_config():
             assert "Unavailable Features" in instructions
             assert "Action Log" in instructions
             assert "List Users" in instructions
+
+
+def test_get_default_instructions_with_feature_constants():
+    """Test that MCP_FEATURE_* constants work with get_default_instructions."""
+    instructions = get_default_instructions(unavailable_features=MCP_ALL_KNOWN_FEATURES)
+
+    assert "IMPORTANT - Unavailable Features" in instructions
+    assert MCP_FEATURE_ACTION_LOG in instructions
+    assert MCP_FEATURE_LIST_USERS in instructions
+    assert MCP_FEATURE_LIST_ROLES in instructions

--- a/tests/unit_tests/mcp_service/test_mcp_config.py
+++ b/tests/unit_tests/mcp_service/test_mcp_config.py
@@ -20,12 +20,6 @@
 from unittest.mock import MagicMock, patch
 
 from superset.mcp_service.app import get_default_instructions, init_fastmcp_server
-from superset.mcp_service.mcp_config import (
-    MCP_ALL_KNOWN_FEATURES,
-    MCP_FEATURE_ACTION_LOG,
-    MCP_FEATURE_LIST_ROLES,
-    MCP_FEATURE_LIST_USERS,
-)
 
 
 def test_get_default_instructions_with_default_branding():
@@ -59,6 +53,16 @@ def test_get_default_instructions_with_enterprise_branding():
     assert "list_dashboards" in instructions
     assert "list_charts" in instructions
     assert "execute_sql" in instructions
+
+
+def test_get_default_instructions_mentions_feature_availability():
+    """Test that instructions direct LLMs to get_instance_info for features."""
+    instructions = get_default_instructions()
+
+    assert "get_instance_info" in instructions
+    assert "Feature Availability" in instructions
+    assert "accessible menus" in instructions
+    assert "feature flags" in instructions
 
 
 def test_init_fastmcp_server_with_default_app_name():
@@ -156,67 +160,3 @@ def test_init_fastmcp_server_applies_middleware_to_global_instance():
 
             # Middleware should be added via add_middleware
             mock_mcp.add_middleware.assert_called_once_with(mock_mw)
-
-
-def test_get_default_instructions_without_unavailable_features():
-    """Test that no unavailable features section appears when list is empty."""
-    instructions = get_default_instructions()
-    assert "Unavailable Features" not in instructions
-
-    instructions_empty = get_default_instructions(unavailable_features=[])
-    assert "Unavailable Features" not in instructions_empty
-
-    instructions_none = get_default_instructions(unavailable_features=None)
-    assert "Unavailable Features" not in instructions_none
-
-
-def test_get_default_instructions_with_unavailable_features():
-    """Test that unavailable features section is included when list is non-empty."""
-    features = [
-        "Action Log (Settings > Security > Action Log)",
-        "List Users page (Settings > List Users)",
-    ]
-    instructions = get_default_instructions(unavailable_features=features)
-
-    assert "IMPORTANT - Unavailable Features" in instructions
-    assert "Action Log (Settings > Security > Action Log)" in instructions
-    assert "List Users page (Settings > List Users)" in instructions
-    assert "Do NOT suggest" in instructions
-    assert "suggest alternatives using the MCP tools" in instructions
-
-
-def test_init_fastmcp_server_reads_unavailable_features_from_config():
-    """Test init_fastmcp_server reads MCP_UNAVAILABLE_FEATURES from config."""
-    features = ["Action Log", "List Users"]
-    mock_flask_app = MagicMock()
-
-    def config_get(key, default=None):
-        if key == "APP_NAME":
-            return "Superset"
-        if key == "MCP_UNAVAILABLE_FEATURES":
-            return features
-        return default
-
-    mock_flask_app.config.get.side_effect = config_get
-
-    with patch.dict(
-        "sys.modules",
-        {"superset.mcp_service.flask_singleton": MagicMock(app=mock_flask_app)},
-    ):
-        with patch("superset.mcp_service.app.mcp") as mock_mcp:
-            init_fastmcp_server()
-
-            instructions = mock_mcp._mcp_server.instructions
-            assert "Unavailable Features" in instructions
-            assert "Action Log" in instructions
-            assert "List Users" in instructions
-
-
-def test_get_default_instructions_with_feature_constants():
-    """Test that MCP_FEATURE_* constants work with get_default_instructions."""
-    instructions = get_default_instructions(unavailable_features=MCP_ALL_KNOWN_FEATURES)
-
-    assert "IMPORTANT - Unavailable Features" in instructions
-    assert MCP_FEATURE_ACTION_LOG in instructions
-    assert MCP_FEATURE_LIST_USERS in instructions
-    assert MCP_FEATURE_LIST_ROLES in instructions

--- a/tests/unit_tests/mcp_service/test_mcp_config.py
+++ b/tests/unit_tests/mcp_service/test_mcp_config.py
@@ -62,7 +62,6 @@ def test_get_default_instructions_mentions_feature_availability():
     assert "get_instance_info" in instructions
     assert "Feature Availability" in instructions
     assert "accessible menus" in instructions
-    assert "feature flags" in instructions
 
 
 def test_init_fastmcp_server_with_default_app_name():


### PR DESCRIPTION
### SUMMARY

When the MCP service can't answer a user's question via available tools, LLMs fall back to suggesting UI features that may not exist in a given deployment. This misleads users.

This PR adds **dynamic feature detection** to `get_instance_info` so LLMs know what's actually available at request time:

- **`get_instance_info`** now returns a `feature_availability` section containing `accessible_menus` — the menu items the current user can access (via `security_manager.user_view_menu_names("menu_access")`)
- MCP instructions now direct LLMs to call `get_instance_info` for feature availability instead of assuming what exists

**Why dynamic?** Menus already track what's available per-user and per-deployment via FAB role permissions. Querying them at request time means feature availability stays in sync automatically — no manual configuration needed.

#### Example `get_instance_info` response (truncated)

```json
{
  "instance_summary": { "total_dashboards": 0, "total_charts": 0, "total_datasets": 15, ... },
  "current_user": { "id": 1, "username": "admin", "first_name": "Admin I.", ... },
  "feature_availability": {
    "accessible_menus": [
      "Action Log", "Alerts & Report", "Annotation Layers", "CSS Templates",
      "Charts", "Dashboards", "Data", "Databases", "Datasets", "Extensions",
      "Home", "List Groups", "List Roles", "List Users", "Manage", "Plugins",
      "Query Search", "Row Level Security", "SQL Editor", "SQL Lab",
      "Saved Queries", "Security", "Tags", "Tasks", "Themes", "User Registrations"
    ]
  },
  "timestamp": "2026-02-24T18:23:43.927486Z"
}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - backend change, no UI impact

### TESTING INSTRUCTIONS

#### Automated Tests
```bash
pytest tests/unit_tests/mcp_service/test_mcp_config.py tests/unit_tests/mcp_service/system/test_system_utils.py -x -v
```

#### QA Manual Testing Steps

**Test 1: Feature availability in get_instance_info**
1. Connect an MCP client and call `get_instance_info`
2. **Expected**: Response includes `feature_availability` with `accessible_menus` populated from the user's FAB permissions

**Test 2: Per-user menu access**
1. Connect as a user with limited roles (e.g., Gamma)
2. Call `get_instance_info`
3. **Expected**: `accessible_menus` only contains menus the user has `menu_access` permission for — admin-only menus should not appear

**Test 3: Instructions reference get_instance_info**
1. Inspect the MCP server instructions
2. **Expected**: Instructions mention "Feature Availability" and direct LLMs to call `get_instance_info` for accessible menus

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API