### PR TITLE
feat(mcp): expose current user identity in get_instance_info and add created_by_fk filter

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -76,7 +76,7 @@ Schema Discovery:
 - get_schema: Get schema metadata for chart/dataset/dashboard (columns, filters)
 
 System Information:
-- get_instance_info: Get instance-wide statistics and metadata
+- get_instance_info: Get instance-wide statistics, metadata, and current user identity
 - health_check: Simple health check tool (takes NO parameters, call without arguments)
 
 Available Resources:
@@ -94,6 +94,13 @@ To create a chart:
 2. get_dataset_info(id) -> examine columns and metrics
 3. generate_explore_link(dataset_id, config) -> preview interactively
 4. generate_chart(dataset_id, config, save_chart=True) -> save permanently
+
+To find your own charts/dashboards:
+1. get_instance_info -> get current_user.id
+2. list_charts(filters=[{{"col": "created_by_fk",
+   "opr": "eq", "value": current_user.id}}])
+3. Or: list_dashboards(filters=[{{"col": "created_by_fk",
+   "opr": "eq", "value": current_user.id}}])
 
 To explore data with SQL:
 1. get_instance_info -> find database_id
@@ -127,6 +134,10 @@ Query Examples:
 - List time series charts:
   filters=[{{"col": "viz_type", "opr": "sw", "value": "echarts_timeseries"}}]
 - Search by name: search="sales"
+- My charts (use current_user.id from get_instance_info):
+  filters=[{{"col": "created_by_fk", "opr": "eq", "value": <user_id>}}]
+- My dashboards:
+  filters=[{{"col": "created_by_fk", "opr": "eq", "value": <user_id>}}]
 
 General usage tips:
 - All listing tools use 1-based pagination (first page is 1)
@@ -143,6 +154,9 @@ Input format:
 
 If you are unsure which tool to use, start with get_instance_info
 or use the quickstart prompt for an interactive guide.
+
+When you first connect, call get_instance_info to learn the user's identity.
+Greet them by their first name (from current_user) and offer to help.
 """
 
 

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -270,10 +270,12 @@ class ChartFilter(ColumnOperator):
         "slice_name",
         "viz_type",
         "datasource_name",
+        "created_by_fk",
     ] = Field(
         ...,
         description="Column to filter on. Use get_schema(model_type='chart') for "
-        "available filter columns.",
+        "available filter columns. Use created_by_fk with the user ID from "
+        "get_instance_info's current_user to find charts created by a specific user.",
     )
     opr: ColumnOperatorEnum = Field(
         ...,

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -163,10 +163,16 @@ class DashboardFilter(ColumnOperator):
         "dashboard_title",
         "published",
         "favorite",
+        "created_by_fk",
     ] = Field(
         ...,
-        description="Column to filter on. Use get_schema(model_type='dashboard') for "
-        "available filter columns.",
+        description=(
+            "Column to filter on. Use "
+            "get_schema(model_type='dashboard') for available "
+            "filter columns. Use created_by_fk with the user "
+            "ID from get_instance_info's current_user to find "
+            "dashboards created by a specific user."
+        ),
     )
     opr: ColumnOperatorEnum = Field(
         ...,

--- a/superset/mcp_service/system/schemas.py
+++ b/superset/mcp_service/system/schemas.py
@@ -22,6 +22,8 @@ This module contains Pydantic models for serializing Superset instance metadata 
 system-level info.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Dict, List
 
@@ -121,6 +123,11 @@ class InstanceInfo(BaseModel):
     )
     popular_content: PopularContent = Field(
         ..., description="Popular content information"
+    )
+    current_user: UserInfo | None = Field(
+        None,
+        description="The authenticated user making the request. "
+        "Use current_user.id with created_by_fk filter to find your own assets.",
     )
     timestamp: datetime = Field(..., description="Response timestamp")
 

--- a/superset/mcp_service/utils/schema_utils.py
+++ b/superset/mcp_service/utils/schema_utils.py
@@ -446,10 +446,8 @@ def parse_request(
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         import types
 
-        parse_enabled = _is_parse_request_enabled()
-
         def _maybe_parse(request: Any) -> Any:
-            if parse_enabled:
+            if _is_parse_request_enabled():
                 return parse_json_or_model(request, request_class, "request")
             return request
 
@@ -501,7 +499,7 @@ def parse_request(
         # Copy docstring from original function (not wrapper, which has no docstring)
         new_wrapper.__doc__ = func.__doc__
 
-        request_annotation = str | request_class if parse_enabled else request_class
+        request_annotation = str | request_class
         _apply_signature_for_fastmcp(new_wrapper, func, request_annotation)
 
         return new_wrapper

--- a/tests/unit_tests/mcp_service/system/tool/test_get_current_user.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_current_user.py
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for current_user in get_instance_info and created_by_fk filtering."""
+
+import pytest
+from pydantic import ValidationError
+
+from superset.mcp_service.chart.schemas import ChartFilter
+from superset.mcp_service.dashboard.schemas import DashboardFilter
+from superset.mcp_service.system.schemas import InstanceInfo, UserInfo
+
+
+def test_instance_info_current_user_default_none():
+    """Test that InstanceInfo.current_user defaults to None."""
+    from datetime import datetime, timezone
+
+    from superset.mcp_service.system.schemas import (
+        DashboardBreakdown,
+        DatabaseBreakdown,
+        InstanceSummary,
+        PopularContent,
+        RecentActivity,
+    )
+
+    info = InstanceInfo(
+        instance_summary=InstanceSummary(
+            total_dashboards=0,
+            total_charts=0,
+            total_datasets=0,
+            total_databases=0,
+            total_users=0,
+            total_roles=0,
+            total_tags=0,
+            avg_charts_per_dashboard=0.0,
+        ),
+        recent_activity=RecentActivity(
+            dashboards_created_last_30_days=0,
+            charts_created_last_30_days=0,
+            datasets_created_last_30_days=0,
+            dashboards_modified_last_7_days=0,
+            charts_modified_last_7_days=0,
+            datasets_modified_last_7_days=0,
+        ),
+        dashboard_breakdown=DashboardBreakdown(
+            published=0,
+            unpublished=0,
+            certified=0,
+            with_charts=0,
+            without_charts=0,
+        ),
+        database_breakdown=DatabaseBreakdown(by_type={}),
+        popular_content=PopularContent(top_tags=[], top_creators=[]),
+        timestamp=datetime.now(timezone.utc),
+    )
+    assert info.current_user is None
+
+
+def test_instance_info_with_current_user():
+    """Test that InstanceInfo accepts a current_user UserInfo."""
+    from datetime import datetime, timezone
+
+    from superset.mcp_service.system.schemas import (
+        DashboardBreakdown,
+        DatabaseBreakdown,
+        InstanceSummary,
+        PopularContent,
+        RecentActivity,
+    )
+
+    user = UserInfo(
+        id=42,
+        username="sophie",
+        first_name="Sophie",
+        last_name="Test",
+        email="sophie@example.com",
+    )
+    info = InstanceInfo(
+        instance_summary=InstanceSummary(
+            total_dashboards=0,
+            total_charts=0,
+            total_datasets=0,
+            total_databases=0,
+            total_users=0,
+            total_roles=0,
+            total_tags=0,
+            avg_charts_per_dashboard=0.0,
+        ),
+        recent_activity=RecentActivity(
+            dashboards_created_last_30_days=0,
+            charts_created_last_30_days=0,
+            datasets_created_last_30_days=0,
+            dashboards_modified_last_7_days=0,
+            charts_modified_last_7_days=0,
+            datasets_modified_last_7_days=0,
+        ),
+        dashboard_breakdown=DashboardBreakdown(
+            published=0,
+            unpublished=0,
+            certified=0,
+            with_charts=0,
+            without_charts=0,
+        ),
+        database_breakdown=DatabaseBreakdown(by_type={}),
+        popular_content=PopularContent(top_tags=[], top_creators=[]),
+        current_user=user,
+        timestamp=datetime.now(timezone.utc),
+    )
+    assert info.current_user is not None
+    assert info.current_user.id == 42
+    assert info.current_user.username == "sophie"
+    assert info.current_user.first_name == "Sophie"
+    assert info.current_user.last_name == "Test"
+    assert info.current_user.email == "sophie@example.com"
+
+
+def test_user_info_with_minimal_fields():
+    """Test UserInfo with only required fields (all optional)."""
+    user = UserInfo(id=1, username="admin")
+    assert user.id == 1
+    assert user.username == "admin"
+    assert user.first_name is None
+    assert user.last_name is None
+    assert user.email is None
+
+
+def test_chart_filter_accepts_created_by_fk():
+    """Test that ChartFilter accepts created_by_fk as a valid column."""
+    f = ChartFilter(col="created_by_fk", opr="eq", value=42)
+    assert f.col == "created_by_fk"
+    assert f.opr == "eq"
+    assert f.value == 42
+
+
+def test_chart_filter_rejects_invalid_column():
+    """Test that ChartFilter rejects invalid column names."""
+    with pytest.raises(ValidationError):
+        ChartFilter(col="nonexistent_column", opr="eq", value=42)
+
+
+def test_dashboard_filter_accepts_created_by_fk():
+    """Test that DashboardFilter accepts created_by_fk as a valid column."""
+    f = DashboardFilter(col="created_by_fk", opr="eq", value=42)
+    assert f.col == "created_by_fk"
+    assert f.opr == "eq"
+    assert f.value == 42
+
+
+def test_dashboard_filter_rejects_invalid_column():
+    """Test that DashboardFilter rejects invalid column names."""
+    with pytest.raises(ValidationError):
+        DashboardFilter(col="nonexistent_column", opr="eq", value=42)

--- a/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
@@ -236,9 +236,15 @@ class TestGetSchemaToolViaClient:
             assert "dashboard_title" in info["sortable_columns"]
             assert "changed_on" in info["sortable_columns"]
 
+    @patch(
+        "superset.mcp_service.utils.schema_utils._is_parse_request_enabled",
+        return_value=True,
+    )
     @patch("superset.daos.chart.ChartDAO.get_filterable_columns_and_operators")
     @pytest.mark.asyncio
-    async def test_get_schema_with_json_string_request(self, mock_filters, mcp_server):
+    async def test_get_schema_with_json_string_request(
+        self, mock_filters, mock_parse_enabled, mcp_server
+    ):
         """Test get_schema accepts JSON string request (Claude Code compatibility)."""
         mock_filters.return_value = {"slice_name": ["eq"]}
 

--- a/tests/unit_tests/mcp_service/utils/test_schema_utils.py
+++ b/tests/unit_tests/mcp_service/utils/test_schema_utils.py
@@ -354,6 +354,17 @@ class TestParseRequestDecorator:
         name: str
         count: int
 
+    @pytest.fixture(autouse=True)
+    def _enable_parse_request(self):
+        """Ensure MCP_PARSE_REQUEST_ENABLED=True for all parsing tests."""
+        from unittest.mock import patch
+
+        with patch(
+            "superset.mcp_service.utils.schema_utils._is_parse_request_enabled",
+            return_value=True,
+        ):
+            yield
+
     def test_decorator_with_json_string_async(self):
         """Should parse JSON string request in async function."""
         from unittest.mock import MagicMock, patch


### PR DESCRIPTION
### SUMMARY

The AI chatbot didn't know who the current user was. When asked "what's the chart I created most recently?", it queried all charts and assumed the user was whoever created the top result (e.g., assumed Sophie was Antonio Rivero).

This PR adds:
1. **`current_user` field to `get_instance_info` response** - exposes `g.user` identity (id, username, first_name, last_name, email) so the LLM knows who it's talking to
2. **`created_by_fk` filter column** on `list_charts` and `list_dashboards` - lets the LLM filter assets by creator
3. **Updated LLM instructions** - tells the chatbot to greet the user by name and documents the workflow for finding own assets
4. **Fixed `parse_request` decorator bug** - was checking `MCP_PARSE_REQUEST_ENABLED` at decoration time instead of call time, causing string/dict parsing to silently fail

The LLM workflow becomes:
```
get_instance_info -> current_user.id -> list_charts(filters=[{col: "created_by_fk", opr: "eq", value: <user_id>}])
```

No `list_users` tool needed (privacy). RBAC already limits results to accessible assets.

[sc-98639]

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - backend/API only change

### TESTING INSTRUCTIONS

**QA Steps:**

1. **Verify current_user in get_instance_info:**
   - Call `get_instance_info` via MCP client
   - Confirm the response includes a `current_user` object with `id`, `username`, `first_name`, `last_name`, `email`
   - Verify the user info matches the authenticated user

2. **Verify created_by_fk filter on charts:**
   - Call `list_charts` with filter `[{"col": "created_by_fk", "opr": "eq", "value": <user_id>}]`
   - Confirm only charts created by that user are returned
   - Try with a different user ID and confirm different results

3. **Verify created_by_fk filter on dashboards:**
   - Call `list_dashboards` with filter `[{"col": "created_by_fk", "opr": "eq", "value": <user_id>}]`
   - Confirm only dashboards created by that user are returned

4. **Verify LLM chatbot behavior:**
   - Ask the chatbot "What's the most recent chart I created?"
   - Confirm it calls `get_instance_info` first, identifies you correctly, then filters charts by your user ID
   - Confirm it does NOT assume you are a different user

5. **Verify invalid filter column is rejected:**
   - Try `list_charts` with `col: "nonexistent_column"` and confirm it returns a validation error

### ADDITIONAL INFORMATION
- [x] Has associated issue: [sc-98639](https://app.shortcut.com/preset/story/98639)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API