### PR TITLE
feat(mcp): add detailed JWT error messages and default auth factory fallback

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -111,9 +111,23 @@ def get_user_from_request() -> User:
     username = current_app.config.get("MCP_DEV_USERNAME")
 
     if not username:
+        auth_enabled = current_app.config.get("MCP_AUTH_ENABLED", False)
+        jwt_configured = bool(
+            current_app.config.get("MCP_JWKS_URI")
+            or current_app.config.get("MCP_JWT_PUBLIC_KEY")
+            or current_app.config.get("MCP_JWT_SECRET")
+        )
+        details = []
+        details.append(
+            f"g.user was not set by JWT middleware "
+            f"(MCP_AUTH_ENABLED={auth_enabled}, "
+            f"JWT keys configured={jwt_configured})"
+        )
+        details.append("MCP_DEV_USERNAME is not configured")
         raise ValueError(
-            "No authenticated user found. "
-            "Either pass a valid JWT bearer token or configure "
+            "No authenticated user found. Tried:\n"
+            + "\n".join(f"  - {d}" for d in details)
+            + "\n\nEither pass a valid JWT bearer token or configure "
             "MCP_DEV_USERNAME for development."
         )
 

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -1,0 +1,294 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Detailed JWT verification for the MCP service.
+
+Provides step-by-step JWT validation with specific error messages
+instead of the generic "invalid_token" response from the base JWTVerifier.
+"""
+
+import base64
+import logging
+import time
+from contextvars import ContextVar
+from typing import Any, cast
+
+from authlib.jose.errors import (
+    BadSignatureError,
+    DecodeError,
+    ExpiredTokenError,
+    JoseError,
+)
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
+from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend
+from starlette.authentication import AuthenticationError
+from starlette.middleware import Middleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.requests import HTTPConnection
+from starlette.responses import JSONResponse
+
+from superset.utils import json
+
+logger = logging.getLogger(__name__)
+
+# Thread-safe storage for the specific JWT failure reason.
+# Set by DetailedJWTVerifier.load_access_token() on failure,
+# read by DetailedBearerAuthBackend.authenticate() to raise
+# an AuthenticationError with the specific reason.
+_jwt_failure_reason: ContextVar[str | None] = ContextVar(
+    "_jwt_failure_reason", default=None
+)
+
+
+def _json_auth_error_handler(
+    conn: HTTPConnection, exc: AuthenticationError
+) -> JSONResponse:
+    """Return a JSON 401 response with the specific JWT failure reason."""
+    return JSONResponse(
+        status_code=401,
+        content={
+            "error": "invalid_token",
+            "error_description": str(exc),
+        },
+        headers={
+            "WWW-Authenticate": f'Bearer error="invalid_token", '
+            f'error_description="{exc}"',
+        },
+    )
+
+
+class DetailedBearerAuthBackend(BearerAuthBackend):
+    """
+    Bearer auth backend that raises AuthenticationError with specific
+    JWT failure reasons instead of silently returning None.
+    """
+
+    async def authenticate(self, conn: HTTPConnection) -> tuple[Any, Any] | None:
+        result = await super().authenticate(conn)
+
+        if result is not None:
+            # Clear any stale failure reason on success
+            _jwt_failure_reason.set(None)
+            return result
+
+        # Check if there's a Bearer token present - if so, there was a
+        # validation failure we can report with a specific reason
+        auth_header = next(
+            (
+                conn.headers.get(key)
+                for key in conn.headers
+                if key.lower() == "authorization"
+            ),
+            None,
+        )
+        if auth_header and auth_header.lower().startswith("bearer "):
+            reason = _jwt_failure_reason.get()
+            if reason:
+                _jwt_failure_reason.set(None)
+                raise AuthenticationError(reason)
+
+        return None
+
+
+class DetailedJWTVerifier(JWTVerifier):
+    """
+    JWT verifier that provides specific error messages for each
+    validation failure instead of generic "invalid_token".
+
+    Overrides load_access_token() to perform step-by-step validation,
+    storing the specific failure reason in a ContextVar that the
+    custom BearerAuthBackend reads to return a descriptive 401 response.
+    """
+
+    async def load_access_token(self, token: str) -> AccessToken | None:  # noqa: C901
+        """
+        Validate a JWT bearer token with detailed error reporting.
+
+        Each validation step stores a specific failure reason in the
+        _jwt_failure_reason ContextVar before returning None.
+        """
+        # Reset any previous failure reason
+        _jwt_failure_reason.set(None)
+
+        try:
+            # Step 1: Decode header and check algorithm
+            try:
+                header = self._decode_token_header(token)
+            except (ValueError, DecodeError) as e:
+                reason = f"Malformed token header: {e}"
+                _jwt_failure_reason.set(reason)
+                logger.warning(reason)
+                return None
+
+            token_alg = header.get("alg")
+            if self.algorithm and token_alg != self.algorithm:
+                reason = (
+                    f"Algorithm mismatch: token uses '{token_alg}', "
+                    f"expected '{self.algorithm}'"
+                )
+                _jwt_failure_reason.set(reason)
+                logger.warning(reason)
+                return None
+
+            # Step 2: Get verification key (static or JWKS)
+            try:
+                verification_key = await self._get_verification_key(token)
+            except ValueError as e:
+                reason = f"Failed to get verification key: {e}"
+                _jwt_failure_reason.set(reason)
+                logger.warning(reason)
+                return None
+
+            # Step 3: Decode and verify signature
+            try:
+                claims = self.jwt.decode(token, verification_key)
+            except BadSignatureError:
+                reason = "Signature verification failed"
+                _jwt_failure_reason.set(reason)
+                logger.warning(reason)
+                return None
+            except ExpiredTokenError:
+                reason = "Token has expired (detected during decode)"
+                _jwt_failure_reason.set(reason)
+                logger.warning(reason)
+                return None
+            except JoseError as e:
+                reason = f"Token decode failed: {e}"
+                _jwt_failure_reason.set(reason)
+                logger.warning(reason)
+                return None
+
+            # Extract client ID for logging
+            client_id = (
+                claims.get("client_id")
+                or claims.get("azp")
+                or claims.get("sub")
+                or "unknown"
+            )
+
+            # Step 4: Check expiration
+            exp = claims.get("exp")
+            if exp and exp < time.time():
+                reason = f"Token expired for client '{client_id}'"
+                _jwt_failure_reason.set(reason)
+                logger.warning(reason)
+                return None
+
+            # Step 5: Validate issuer
+            if self.issuer:
+                iss = claims.get("iss")
+                if isinstance(self.issuer, list):
+                    issuer_valid = iss in self.issuer
+                else:
+                    issuer_valid = iss == self.issuer
+
+                if not issuer_valid:
+                    reason = (
+                        f"Issuer mismatch: token has '{iss}', expected '{self.issuer}'"
+                    )
+                    _jwt_failure_reason.set(reason)
+                    logger.warning(reason)
+                    return None
+
+            # Step 6: Validate audience
+            if self.audience:
+                aud = claims.get("aud")
+                if isinstance(self.audience, list):
+                    if isinstance(aud, list):
+                        audience_valid = any(
+                            expected in aud
+                            for expected in cast(list[str], self.audience)
+                        )
+                    else:
+                        audience_valid = aud in cast(list[str], self.audience)
+                else:
+                    if isinstance(aud, list):
+                        audience_valid = self.audience in aud
+                    else:
+                        audience_valid = aud == self.audience
+
+                if not audience_valid:
+                    reason = (
+                        f"Audience mismatch: token has '{aud}', "
+                        f"expected '{self.audience}'"
+                    )
+                    _jwt_failure_reason.set(reason)
+                    logger.warning(reason)
+                    return None
+
+            # Step 7: Check required scopes
+            scopes = self._extract_scopes(claims)
+            if self.required_scopes:
+                token_scopes = set(scopes)
+                required = set(self.required_scopes)
+                if not required.issubset(token_scopes):
+                    missing = required - token_scopes
+                    reason = (
+                        f"Missing required scopes: {missing}. Token has: {token_scopes}"
+                    )
+                    _jwt_failure_reason.set(reason)
+                    logger.warning(reason)
+                    return None
+
+            # All validations passed
+            logger.info("JWT validated for client '%s'", client_id)
+            return AccessToken(
+                token=token,
+                client_id=str(client_id),
+                scopes=scopes,
+                expires_at=int(exp) if exp else None,
+                claims=dict(claims),
+            )
+
+        except Exception as e:
+            reason = f"Token validation failed: {e}"
+            _jwt_failure_reason.set(reason)
+            logger.warning(reason)
+            return None
+
+    def get_middleware(self) -> list[Any]:
+        """
+        Get middleware with detailed error reporting.
+
+        Uses DetailedBearerAuthBackend which raises AuthenticationError
+        with specific reasons, and a JSON error handler that returns
+        structured 401 responses.
+        """
+        return [
+            Middleware(
+                AuthenticationMiddleware,
+                backend=DetailedBearerAuthBackend(self),
+                on_error=_json_auth_error_handler,
+            ),
+            Middleware(AuthContextMiddleware),
+        ]
+
+    @staticmethod
+    def _decode_token_header(token: str) -> dict[str, Any]:
+        """Decode the JWT header without verifying the signature."""
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise ValueError(
+                f"Token must have 3 parts (header.payload.signature), got {len(parts)}"
+            )
+        header_b64 = parts[0]
+        # Add padding
+        header_b64 += "=" * (4 - len(header_b64) % 4)
+        header_bytes = base64.urlsafe_b64decode(header_b64)
+        return json.loads(header_bytes)

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -267,7 +267,7 @@ class DetailedJWTVerifier(JWTVerifier):
                 claims=dict(claims),
             )
 
-        except Exception as e:
+        except (ValueError, JoseError, KeyError, AttributeError, TypeError) as e:
             reason = f"Token validation failed: {e}"
             _jwt_failure_reason.set(reason)
             logger.warning(reason)

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -55,6 +55,8 @@ logger = logging.getLogger(__name__)
 # Set by DetailedJWTVerifier.load_access_token() on failure,
 # read by DetailedBearerAuthBackend.authenticate() to raise
 # an AuthenticationError with the specific reason.
+# SECURITY: Must ALWAYS contain generic failure categories only.
+# Claim values and secrets must NEVER be stored here.
 _jwt_failure_reason: ContextVar[str | None] = ContextVar(
     "_jwt_failure_reason", default=None
 )

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -24,6 +24,7 @@ instead of the generic "invalid_token" response from the base JWTVerifier.
 import base64
 import logging
 import time
+from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, cast
 
@@ -65,23 +66,50 @@ def _sanitize_header_value(value: str) -> str:
     return value.replace("\r", " ").replace("\n", " ").replace('"', "'")
 
 
-def _json_auth_error_handler(
-    conn: HTTPConnection, exc: AuthenticationError
-) -> JSONResponse:
-    """Return a JSON 401 response with the specific JWT failure reason."""
-    reason = str(exc)
-    safe_reason = _sanitize_header_value(reason)
-    return JSONResponse(
-        status_code=401,
-        content={
-            "error": "invalid_token",
-            "error_description": reason,
-        },
-        headers={
-            "WWW-Authenticate": f'Bearer error="invalid_token", '
-            f'error_description="{safe_reason}"',
-        },
-    )
+def _make_json_auth_error_handler(
+    debug_errors: bool = False,
+) -> Callable[[HTTPConnection, AuthenticationError], JSONResponse]:
+    """Create a JSON 401 error handler for authentication failures.
+
+    Args:
+        debug_errors: If True, include detailed JWT failure reasons in the
+            HTTP response body and WWW-Authenticate header. If False (default),
+            return only generic error information to avoid leaking server
+            configuration per RFC 6750 Section 3.1. Detailed reasons are
+            always logged server-side regardless of this setting.
+    """
+
+    def handler(conn: HTTPConnection, exc: AuthenticationError) -> JSONResponse:
+        reason = str(exc)
+
+        if debug_errors:
+            safe_reason = _sanitize_header_value(reason)
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": "invalid_token",
+                    "error_description": reason,
+                },
+                headers={
+                    "WWW-Authenticate": f'Bearer error="invalid_token", '
+                    f'error_description="{safe_reason}"',
+                },
+            )
+
+        # Default: generic error response (no claim values or server config leaked)
+        logger.warning("JWT authentication failed: %s", reason)
+        return JSONResponse(
+            status_code=401,
+            content={
+                "error": "invalid_token",
+                "error_description": "Authentication failed",
+            },
+            headers={
+                "WWW-Authenticate": 'Bearer error="invalid_token"',
+            },
+        )
+
+    return handler
 
 
 class DetailedBearerAuthBackend(BearerAuthBackend):
@@ -125,7 +153,17 @@ class DetailedJWTVerifier(JWTVerifier):
     Overrides load_access_token() to perform step-by-step validation,
     storing the specific failure reason in a ContextVar that the
     custom BearerAuthBackend reads to return a descriptive 401 response.
+
+    Args:
+        debug_errors: When True, detailed JWT failure reasons are included
+            in HTTP responses. When False (default), only generic errors
+            are returned to clients. Detailed reasons are always logged
+            server-side regardless of this setting.
     """
+
+    def __init__(self, *args: Any, debug_errors: bool = False, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.debug_errors = debug_errors
 
     async def load_access_token(self, token: str) -> AccessToken | None:  # noqa: C901
         """
@@ -285,7 +323,7 @@ class DetailedJWTVerifier(JWTVerifier):
             Middleware(
                 AuthenticationMiddleware,
                 backend=DetailedBearerAuthBackend(self),
-                on_error=_json_auth_error_handler,
+                on_error=_make_json_auth_error_handler(self.debug_errors),
             ),
             Middleware(AuthContextMiddleware),
         ]

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -17,7 +17,11 @@
 """
 Detailed JWT verification for the MCP service.
 
-Provides step-by-step JWT validation with detailed server-side logging.
+Provides step-by-step JWT validation with tiered server-side logging:
+- WARNING level: generic failure categories only (e.g. "Issuer mismatch")
+- DEBUG level: detailed claim values and config for troubleshooting
+- Secrets (e.g. HS256 keys) are NEVER logged at any level
+
 HTTP responses always return generic errors per RFC 6750 Section 3.1.
 """
 
@@ -120,15 +124,17 @@ class DetailedBearerAuthBackend(BearerAuthBackend):
 
 class DetailedJWTVerifier(JWTVerifier):
     """
-    JWT verifier that logs specific error messages server-side for each
-    validation failure, aiding debugging without leaking details to clients.
+    JWT verifier with tiered server-side logging for each validation step.
 
-    Overrides load_access_token() to perform step-by-step validation,
-    storing the specific failure reason in a ContextVar for server-side
-    logging. HTTP responses always return generic errors per RFC 6750.
+    Logging tiers:
+    - WARNING: generic failure categories only (via _jwt_failure_reason ContextVar
+      and the error handler). No claim values, no server config.
+    - DEBUG: detailed values (issuer, audience, client_id, scopes, exceptions)
+      for operator troubleshooting.
+    - Secrets (e.g. HS256 signing keys) are NEVER logged at any level.
 
-    Use this instead of the default JWTVerifier when you need detailed
-    server-side JWT debug logging (controlled by MCP_JWT_DEBUG_ERRORS config).
+    HTTP responses always return generic errors per RFC 6750 Section 3.1.
+    Controlled by MCP_JWT_DEBUG_ERRORS config flag.
     """
 
     async def load_access_token(self, token: str) -> AccessToken | None:  # noqa: C901
@@ -146,28 +152,29 @@ class DetailedJWTVerifier(JWTVerifier):
             try:
                 header = self._decode_token_header(token)
             except (ValueError, DecodeError) as e:
-                reason = f"Malformed token header: {e}"
+                reason = "Malformed token header"
                 _jwt_failure_reason.set(reason)
-                logger.warning(reason)
+                logger.debug("Malformed token header: %s", e)
                 return None
 
             token_alg = header.get("alg")
             if self.algorithm and token_alg != self.algorithm:
-                reason = (
-                    f"Algorithm mismatch: token uses '{token_alg}', "
-                    f"expected '{self.algorithm}'"
-                )
+                reason = "Algorithm mismatch"
                 _jwt_failure_reason.set(reason)
-                logger.warning(reason)
+                logger.debug(
+                    "Algorithm mismatch: token uses '%s', expected '%s'",
+                    token_alg,
+                    self.algorithm,
+                )
                 return None
 
             # Step 2: Get verification key (static or JWKS)
             try:
                 verification_key = await self._get_verification_key(token)
             except ValueError as e:
-                reason = f"Failed to get verification key: {e}"
+                reason = "Failed to get verification key"
                 _jwt_failure_reason.set(reason)
-                logger.warning(reason)
+                logger.debug("Failed to get verification key: %s", e)
                 return None
 
             # Step 3: Decode and verify signature
@@ -176,17 +183,15 @@ class DetailedJWTVerifier(JWTVerifier):
             except BadSignatureError:
                 reason = "Signature verification failed"
                 _jwt_failure_reason.set(reason)
-                logger.warning(reason)
                 return None
             except ExpiredTokenError:
                 reason = "Token has expired (detected during decode)"
                 _jwt_failure_reason.set(reason)
-                logger.warning(reason)
                 return None
             except JoseError as e:
-                reason = f"Token decode failed: {e}"
+                reason = "Token decode failed"
                 _jwt_failure_reason.set(reason)
-                logger.warning(reason)
+                logger.debug("Token decode failed: %s", e)
                 return None
 
             # Extract client ID for logging
@@ -200,9 +205,9 @@ class DetailedJWTVerifier(JWTVerifier):
             # Step 4: Check expiration
             exp = claims.get("exp")
             if exp and exp < time.time():
-                reason = f"Token expired for client '{client_id}'"
+                reason = "Token expired"
                 _jwt_failure_reason.set(reason)
-                logger.warning(reason)
+                logger.debug("Token expired for client '%s'", client_id)
                 return None
 
             # Step 5: Validate issuer
@@ -214,11 +219,13 @@ class DetailedJWTVerifier(JWTVerifier):
                     issuer_valid = iss == self.issuer
 
                 if not issuer_valid:
-                    reason = (
-                        f"Issuer mismatch: token has '{iss}', expected '{self.issuer}'"
-                    )
+                    reason = "Issuer mismatch"
                     _jwt_failure_reason.set(reason)
-                    logger.warning(reason)
+                    logger.debug(
+                        "Issuer mismatch: token has '%s', expected '%s'",
+                        iss,
+                        self.issuer,
+                    )
                     return None
 
             # Step 6: Validate audience
@@ -239,12 +246,13 @@ class DetailedJWTVerifier(JWTVerifier):
                         audience_valid = aud == self.audience
 
                 if not audience_valid:
-                    reason = (
-                        f"Audience mismatch: token has '{aud}', "
-                        f"expected '{self.audience}'"
-                    )
+                    reason = "Audience mismatch"
                     _jwt_failure_reason.set(reason)
-                    logger.warning(reason)
+                    logger.debug(
+                        "Audience mismatch: token has '%s', expected '%s'",
+                        aud,
+                        self.audience,
+                    )
                     return None
 
             # Step 7: Check required scopes
@@ -254,11 +262,13 @@ class DetailedJWTVerifier(JWTVerifier):
                 required = set(self.required_scopes)
                 if not required.issubset(token_scopes):
                     missing = required - token_scopes
-                    reason = (
-                        f"Missing required scopes: {missing}. Token has: {token_scopes}"
-                    )
+                    reason = "Missing required scopes"
                     _jwt_failure_reason.set(reason)
-                    logger.warning(reason)
+                    logger.debug(
+                        "Missing required scopes: %s. Token has: %s",
+                        missing,
+                        token_scopes,
+                    )
                     return None
 
             # All validations passed
@@ -271,9 +281,9 @@ class DetailedJWTVerifier(JWTVerifier):
             )
 
         except (ValueError, JoseError, KeyError, AttributeError, TypeError) as e:
-            reason = f"Token validation failed: {e}"
+            reason = "Token validation failed"
             _jwt_failure_reason.set(reason)
-            logger.warning(reason)
+            logger.debug("Token validation failed: %s", e)
             return None
 
     def get_middleware(self) -> list[Any]:

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -17,14 +17,13 @@
 """
 Detailed JWT verification for the MCP service.
 
-Provides step-by-step JWT validation with specific error messages
-instead of the generic "invalid_token" response from the base JWTVerifier.
+Provides step-by-step JWT validation with detailed server-side logging.
+HTTP responses always return generic errors per RFC 6750 Section 3.1.
 """
 
 import base64
 import logging
 import time
-from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, cast
 
@@ -57,59 +56,33 @@ _jwt_failure_reason: ContextVar[str | None] = ContextVar(
 )
 
 
-def _sanitize_header_value(value: str) -> str:
-    """Sanitize a string for safe use in HTTP header values.
+def _json_auth_error_handler(
+    conn: HTTPConnection, exc: AuthenticationError
+) -> JSONResponse:
+    """JSON 401 error handler for authentication failures.
 
-    Removes/replaces characters that could enable header injection
-    (CR, LF, quotes) from attacker-controlled JWT claims.
+    Per RFC 6750 Section 3.1, error responses MUST NOT leak server
+    configuration or token claim values. Only generic error codes are
+    returned to clients. Detailed failure reasons are logged server-side
+    only for debugging.
+
+    References:
+        - RFC 6750 Section 3.1: https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
+        - CVE-2022-29266, CVE-2019-7644: verbose JWT errors led to exploits
     """
-    return value.replace("\r", " ").replace("\n", " ").replace('"', "'")
+    # Log detailed reason server-side only
+    logger.warning("JWT authentication failed: %s", exc)
 
-
-def _make_json_auth_error_handler(
-    debug_errors: bool = False,
-) -> Callable[[HTTPConnection, AuthenticationError], JSONResponse]:
-    """Create a JSON 401 error handler for authentication failures.
-
-    Args:
-        debug_errors: If True, include detailed JWT failure reasons in the
-            HTTP response body and WWW-Authenticate header. If False (default),
-            return only generic error information to avoid leaking server
-            configuration per RFC 6750 Section 3.1. Detailed reasons are
-            always logged server-side regardless of this setting.
-    """
-
-    def handler(conn: HTTPConnection, exc: AuthenticationError) -> JSONResponse:
-        reason = str(exc)
-
-        if debug_errors:
-            safe_reason = _sanitize_header_value(reason)
-            return JSONResponse(
-                status_code=401,
-                content={
-                    "error": "invalid_token",
-                    "error_description": reason,
-                },
-                headers={
-                    "WWW-Authenticate": f'Bearer error="invalid_token", '
-                    f'error_description="{safe_reason}"',
-                },
-            )
-
-        # Default: generic error response (no claim values or server config leaked)
-        logger.warning("JWT authentication failed: %s", reason)
-        return JSONResponse(
-            status_code=401,
-            content={
-                "error": "invalid_token",
-                "error_description": "Authentication failed",
-            },
-            headers={
-                "WWW-Authenticate": 'Bearer error="invalid_token"',
-            },
-        )
-
-    return handler
+    return JSONResponse(
+        status_code=401,
+        content={
+            "error": "invalid_token",
+            "error_description": "Authentication failed",
+        },
+        headers={
+            "WWW-Authenticate": 'Bearer error="invalid_token"',
+        },
+    )
 
 
 class DetailedBearerAuthBackend(BearerAuthBackend):
@@ -147,23 +120,16 @@ class DetailedBearerAuthBackend(BearerAuthBackend):
 
 class DetailedJWTVerifier(JWTVerifier):
     """
-    JWT verifier that provides specific error messages for each
-    validation failure instead of generic "invalid_token".
+    JWT verifier that logs specific error messages server-side for each
+    validation failure, aiding debugging without leaking details to clients.
 
     Overrides load_access_token() to perform step-by-step validation,
-    storing the specific failure reason in a ContextVar that the
-    custom BearerAuthBackend reads to return a descriptive 401 response.
+    storing the specific failure reason in a ContextVar for server-side
+    logging. HTTP responses always return generic errors per RFC 6750.
 
-    Args:
-        debug_errors: When True, detailed JWT failure reasons are included
-            in HTTP responses. When False (default), only generic errors
-            are returned to clients. Detailed reasons are always logged
-            server-side regardless of this setting.
+    Use this instead of the default JWTVerifier when you need detailed
+    server-side JWT debug logging (controlled by MCP_JWT_DEBUG_ERRORS config).
     """
-
-    def __init__(self, *args: Any, debug_errors: bool = False, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.debug_errors = debug_errors
 
     async def load_access_token(self, token: str) -> AccessToken | None:  # noqa: C901
         """
@@ -296,7 +262,6 @@ class DetailedJWTVerifier(JWTVerifier):
                     return None
 
             # All validations passed
-            logger.info("JWT validated for client '%s'", client_id)
             return AccessToken(
                 token=token,
                 client_id=str(client_id),
@@ -313,17 +278,17 @@ class DetailedJWTVerifier(JWTVerifier):
 
     def get_middleware(self) -> list[Any]:
         """
-        Get middleware with detailed error reporting.
+        Get middleware with detailed server-side error logging.
 
         Uses DetailedBearerAuthBackend which raises AuthenticationError
-        with specific reasons, and a JSON error handler that returns
-        structured 401 responses.
+        with specific reasons for server-side logging. The error handler
+        always returns generic 401 responses per RFC 6750.
         """
         return [
             Middleware(
                 AuthenticationMiddleware,
                 backend=DetailedBearerAuthBackend(self),
-                on_error=_make_json_auth_error_handler(self.debug_errors),
+                on_error=_json_auth_error_handler,
             ),
             Middleware(AuthContextMiddleware),
         ]

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -182,21 +182,21 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
         return None
 
     try:
-        from fastmcp.server.auth.providers.jwt import JWTVerifier
+        from superset.mcp_service.jwt_verifier import DetailedJWTVerifier
 
         # For HS256 (symmetric), use the secret as the public_key parameter
         if app.config.get("MCP_JWT_ALGORITHM") == "HS256" and secret:
-            auth_provider = JWTVerifier(
+            auth_provider = DetailedJWTVerifier(
                 public_key=secret,  # HS256 uses secret as key
                 issuer=app.config.get("MCP_JWT_ISSUER"),
                 audience=app.config.get("MCP_JWT_AUDIENCE"),
                 algorithm="HS256",
                 required_scopes=app.config.get("MCP_REQUIRED_SCOPES", []),
             )
-            logger.info("Created JWTVerifier with HS256 secret")
+            logger.info("Created DetailedJWTVerifier with HS256 secret")
         else:
             # For RS256 (asymmetric), use public key or JWKS
-            auth_provider = JWTVerifier(
+            auth_provider = DetailedJWTVerifier(
                 jwks_uri=jwks_uri,
                 public_key=public_key,
                 issuer=app.config.get("MCP_JWT_ISSUER"),
@@ -205,7 +205,7 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
                 required_scopes=app.config.get("MCP_REQUIRED_SCOPES", []),
             )
             logger.info(
-                "Created JWTVerifier with jwks_uri=%s, public_key=%s",
+                "Created DetailedJWTVerifier with jwks_uri=%s, public_key=%s",
                 jwks_uri,
                 "***" if public_key else None,
             )

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -42,8 +42,10 @@ MCP_DEBUG = False
 
 # MCP JWT Debug Errors - controls server-side JWT debug logging.
 # When False (default), uses the default JWTVerifier with minimal logging.
-# When True, uses DetailedJWTVerifier which logs specific failure reasons
-# server-side (e.g., algorithm mismatch, issuer mismatch, expired token).
+# When True, uses DetailedJWTVerifier with tiered logging:
+#   - WARNING level: generic failure categories only (e.g. "Issuer mismatch")
+#   - DEBUG level: detailed claim values for troubleshooting
+#   - Secrets (e.g. HS256 keys) are NEVER logged at any level
 # HTTP responses ALWAYS return generic errors regardless of this setting,
 # per RFC 6750 Section 3.1. This flag NEVER affects client-facing output.
 MCP_JWT_DEBUG_ERRORS = False
@@ -223,7 +225,8 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
 
         return auth_provider
     except Exception as e:
-        logger.error("Failed to create MCP auth provider: %s", e)
+        logger.error("Failed to create MCP auth provider")
+        logger.debug("MCP auth provider error details: %s", e)
         return None
 
 

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -40,11 +40,12 @@ MCP_SERVICE_PORT = 5008
 # MCP Debug mode - shows suppressed initialization output in stdio mode
 MCP_DEBUG = False
 
-# MCP JWT Debug Errors - controls verbosity of JWT error responses.
-# When False (default), JWT authentication failures return generic errors
-# to avoid leaking server configuration (per RFC 6750 Section 3.1).
-# When True, detailed failure reasons are included in HTTP responses.
-# Detailed reasons are always logged server-side regardless of this setting.
+# MCP JWT Debug Errors - controls server-side JWT debug logging.
+# When False (default), uses the default JWTVerifier with minimal logging.
+# When True, uses DetailedJWTVerifier which logs specific failure reasons
+# server-side (e.g., algorithm mismatch, issuer mismatch, expired token).
+# HTTP responses ALWAYS return generic errors regardless of this setting,
+# per RFC 6750 Section 3.1. This flag NEVER affects client-facing output.
 MCP_JWT_DEBUG_ERRORS = False
 
 # Enable parse_request decorator for MCP tools.
@@ -189,37 +190,36 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
         return None
 
     try:
-        from superset.mcp_service.jwt_verifier import DetailedJWTVerifier
-
         debug_errors = app.config.get("MCP_JWT_DEBUG_ERRORS", False)
+
+        common_kwargs: dict[str, Any] = {
+            "issuer": app.config.get("MCP_JWT_ISSUER"),
+            "audience": app.config.get("MCP_JWT_AUDIENCE"),
+            "required_scopes": app.config.get("MCP_REQUIRED_SCOPES", []),
+        }
 
         # For HS256 (symmetric), use the secret as the public_key parameter
         if app.config.get("MCP_JWT_ALGORITHM") == "HS256" and secret:
-            auth_provider = DetailedJWTVerifier(
-                public_key=secret,  # HS256 uses secret as key
-                issuer=app.config.get("MCP_JWT_ISSUER"),
-                audience=app.config.get("MCP_JWT_AUDIENCE"),
-                algorithm="HS256",
-                required_scopes=app.config.get("MCP_REQUIRED_SCOPES", []),
-                debug_errors=debug_errors,
-            )
-            logger.info("Created DetailedJWTVerifier with HS256 secret")
+            common_kwargs["public_key"] = secret
+            common_kwargs["algorithm"] = "HS256"
         else:
             # For RS256 (asymmetric), use public key or JWKS
-            auth_provider = DetailedJWTVerifier(
-                jwks_uri=jwks_uri,
-                public_key=public_key,
-                issuer=app.config.get("MCP_JWT_ISSUER"),
-                audience=app.config.get("MCP_JWT_AUDIENCE"),
-                algorithm=app.config.get("MCP_JWT_ALGORITHM", "RS256"),
-                required_scopes=app.config.get("MCP_REQUIRED_SCOPES", []),
-                debug_errors=debug_errors,
-            )
-            logger.info(
-                "Created DetailedJWTVerifier with jwks_uri=%s, public_key=%s",
-                jwks_uri,
-                "***" if public_key else None,
-            )
+            common_kwargs["jwks_uri"] = jwks_uri
+            common_kwargs["public_key"] = public_key
+            common_kwargs["algorithm"] = app.config.get("MCP_JWT_ALGORITHM", "RS256")
+
+        if debug_errors:
+            # DetailedJWTVerifier: detailed server-side logging of JWT
+            # validation failures. HTTP responses are always generic per
+            # RFC 6750 Section 3.1.
+            from superset.mcp_service.jwt_verifier import DetailedJWTVerifier
+
+            auth_provider = DetailedJWTVerifier(**common_kwargs)
+        else:
+            # Default JWTVerifier: minimal logging, generic error responses.
+            from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+            auth_provider = JWTVerifier(**common_kwargs)
 
         return auth_provider
     except Exception as e:
@@ -229,11 +229,6 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
 
 def default_user_resolver(app: Any, access_token: Any) -> Optional[str]:
     """Extract username from JWT token claims."""
-    logger.info(
-        "Resolving user from token: type=%s, token=%s",
-        type(access_token),
-        access_token,
-    )
     if hasattr(access_token, "subject"):
         return access_token.subject
     if hasattr(access_token, "client_id"):

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -224,9 +224,10 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
             auth_provider = JWTVerifier(**common_kwargs)
 
         return auth_provider
-    except Exception as e:
+    except Exception:
+        # Do not log the exception — it may contain the HS256 secret
+        # from common_kwargs["public_key"]
         logger.error("Failed to create MCP auth provider")
-        logger.debug("MCP auth provider error details: %s", e)
         return None
 
 

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -40,6 +40,13 @@ MCP_SERVICE_PORT = 5008
 # MCP Debug mode - shows suppressed initialization output in stdio mode
 MCP_DEBUG = False
 
+# MCP JWT Debug Errors - controls verbosity of JWT error responses.
+# When False (default), JWT authentication failures return generic errors
+# to avoid leaking server configuration (per RFC 6750 Section 3.1).
+# When True, detailed failure reasons are included in HTTP responses.
+# Detailed reasons are always logged server-side regardless of this setting.
+MCP_JWT_DEBUG_ERRORS = False
+
 # Enable parse_request decorator for MCP tools.
 # When True (default), tool requests are automatically parsed from JSON strings
 # to Pydantic models, working around a Claude Code double-serialization bug
@@ -184,6 +191,8 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
     try:
         from superset.mcp_service.jwt_verifier import DetailedJWTVerifier
 
+        debug_errors = app.config.get("MCP_JWT_DEBUG_ERRORS", False)
+
         # For HS256 (symmetric), use the secret as the public_key parameter
         if app.config.get("MCP_JWT_ALGORITHM") == "HS256" and secret:
             auth_provider = DetailedJWTVerifier(
@@ -192,6 +201,7 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
                 audience=app.config.get("MCP_JWT_AUDIENCE"),
                 algorithm="HS256",
                 required_scopes=app.config.get("MCP_REQUIRED_SCOPES", []),
+                debug_errors=debug_errors,
             )
             logger.info("Created DetailedJWTVerifier with HS256 secret")
         else:
@@ -203,6 +213,7 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
                 audience=app.config.get("MCP_JWT_AUDIENCE"),
                 algorithm=app.config.get("MCP_JWT_ALGORITHM", "RS256"),
                 required_scopes=app.config.get("MCP_REQUIRED_SCOPES", []),
+                debug_errors=debug_errors,
             )
             logger.info(
                 "Created DetailedJWTVerifier with jwks_uri=%s, public_key=%s",

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -168,11 +168,26 @@ def run_server(
             try:
                 auth_provider = auth_factory(flask_app)
                 logging.info(
-                    "Auth provider created: %s",
+                    "Auth provider created from MCP_AUTH_FACTORY: %s",
                     type(auth_provider).__name__ if auth_provider else "None",
                 )
             except Exception as e:
                 logging.error("Failed to create auth provider: %s", e)
+        elif flask_app.config.get("MCP_AUTH_ENABLED", False):
+            # Fall back to default auth factory when auth is enabled
+            # but no custom factory is provided
+            from superset.mcp_service.mcp_config import (
+                create_default_mcp_auth_factory,
+            )
+
+            try:
+                auth_provider = create_default_mcp_auth_factory(flask_app)
+                logging.info(
+                    "Auth provider created from default factory: %s",
+                    type(auth_provider).__name__ if auth_provider else "None",
+                )
+            except Exception as e:
+                logging.error("Failed to create default auth provider: %s", e)
 
         # Build middleware list
         middleware_list = []

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -135,9 +135,9 @@ def _create_auth_provider(flask_app: Any) -> Any | None:
                 "Auth provider created from MCP_AUTH_FACTORY: %s",
                 type(auth_provider).__name__ if auth_provider else "None",
             )
-        except Exception as e:
+        except Exception:
+            # Do not log the exception — it may contain secrets
             logging.error("Failed to create auth provider from MCP_AUTH_FACTORY")
-            logging.debug("Auth provider factory error details: %s", e)
     elif flask_app.config.get("MCP_AUTH_ENABLED", False):
         from superset.mcp_service.mcp_config import (
             create_default_mcp_auth_factory,
@@ -149,9 +149,9 @@ def _create_auth_provider(flask_app: Any) -> Any | None:
                 "Auth provider created from default factory: %s",
                 type(auth_provider).__name__ if auth_provider else "None",
             )
-        except Exception as e:
+        except Exception:
+            # Do not log the exception — it may contain secrets
             logging.error("Failed to create auth provider from default factory")
-            logging.debug("Default auth provider error details: %s", e)
     return auth_provider
 
 

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -128,8 +128,7 @@ def _create_auth_provider(flask_app: Any) -> Any | None:
     when MCP_AUTH_ENABLED is True.
     """
     auth_provider = None
-    auth_factory = flask_app.config.get("MCP_AUTH_FACTORY")
-    if auth_factory:
+    if auth_factory := flask_app.config.get("MCP_AUTH_FACTORY"):
         try:
             auth_provider = auth_factory(flask_app)
             logging.info(

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -172,7 +172,8 @@ def run_server(
                     type(auth_provider).__name__ if auth_provider else "None",
                 )
             except Exception as e:
-                logging.error("Failed to create auth provider: %s", e)
+                logging.error("Failed to create auth provider from MCP_AUTH_FACTORY")
+                logging.debug("Auth provider factory error details: %s", e)
         elif flask_app.config.get("MCP_AUTH_ENABLED", False):
             # Fall back to default auth factory when auth is enabled
             # but no custom factory is provided
@@ -187,7 +188,8 @@ def run_server(
                     type(auth_provider).__name__ if auth_provider else "None",
                 )
             except Exception as e:
-                logging.error("Failed to create default auth provider: %s", e)
+                logging.error("Failed to create auth provider from default factory")
+                logging.debug("Default auth provider error details: %s", e)
 
         # Build middleware list
         middleware_list = []

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -121,6 +121,41 @@ def create_event_store(config: dict[str, Any] | None = None) -> Any | None:
         return None
 
 
+def _create_auth_provider(flask_app: Any) -> Any | None:
+    """Create an auth provider from Flask app config.
+
+    Tries MCP_AUTH_FACTORY first, then falls back to the default factory
+    when MCP_AUTH_ENABLED is True.
+    """
+    auth_provider = None
+    auth_factory = flask_app.config.get("MCP_AUTH_FACTORY")
+    if auth_factory:
+        try:
+            auth_provider = auth_factory(flask_app)
+            logging.info(
+                "Auth provider created from MCP_AUTH_FACTORY: %s",
+                type(auth_provider).__name__ if auth_provider else "None",
+            )
+        except Exception as e:
+            logging.error("Failed to create auth provider from MCP_AUTH_FACTORY")
+            logging.debug("Auth provider factory error details: %s", e)
+    elif flask_app.config.get("MCP_AUTH_ENABLED", False):
+        from superset.mcp_service.mcp_config import (
+            create_default_mcp_auth_factory,
+        )
+
+        try:
+            auth_provider = create_default_mcp_auth_factory(flask_app)
+            logging.info(
+                "Auth provider created from default factory: %s",
+                type(auth_provider).__name__ if auth_provider else "None",
+            )
+        except Exception as e:
+            logging.error("Failed to create auth provider from default factory")
+            logging.debug("Default auth provider error details: %s", e)
+    return auth_provider
+
+
 def run_server(
     host: str = "127.0.0.1",
     port: int = 5008,
@@ -160,36 +195,7 @@ def run_server(
         from superset.mcp_service.flask_singleton import get_flask_app
 
         flask_app = get_flask_app()
-
-        # Get auth factory from config and create auth provider
-        auth_provider = None
-        auth_factory = flask_app.config.get("MCP_AUTH_FACTORY")
-        if auth_factory:
-            try:
-                auth_provider = auth_factory(flask_app)
-                logging.info(
-                    "Auth provider created from MCP_AUTH_FACTORY: %s",
-                    type(auth_provider).__name__ if auth_provider else "None",
-                )
-            except Exception as e:
-                logging.error("Failed to create auth provider from MCP_AUTH_FACTORY")
-                logging.debug("Auth provider factory error details: %s", e)
-        elif flask_app.config.get("MCP_AUTH_ENABLED", False):
-            # Fall back to default auth factory when auth is enabled
-            # but no custom factory is provided
-            from superset.mcp_service.mcp_config import (
-                create_default_mcp_auth_factory,
-            )
-
-            try:
-                auth_provider = create_default_mcp_auth_factory(flask_app)
-                logging.info(
-                    "Auth provider created from default factory: %s",
-                    type(auth_provider).__name__ if auth_provider else "None",
-                )
-            except Exception as e:
-                logging.error("Failed to create auth provider from default factory")
-                logging.debug("Default auth provider error details: %s", e)
+        auth_provider = _create_auth_provider(flask_app)
 
         # Build middleware list
         middleware_list = []

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -35,6 +35,8 @@ from superset.mcp_service.mcp_config import (
 )
 from superset.mcp_service.storage import _create_redis_store
 
+logger = logging.getLogger(__name__)
+
 
 def configure_logging(debug: bool = False) -> None:
     """Configure logging for the MCP service."""
@@ -131,13 +133,13 @@ def _create_auth_provider(flask_app: Any) -> Any | None:
     if auth_factory := flask_app.config.get("MCP_AUTH_FACTORY"):
         try:
             auth_provider = auth_factory(flask_app)
-            logging.info(
+            logger.info(
                 "Auth provider created from MCP_AUTH_FACTORY: %s",
                 type(auth_provider).__name__ if auth_provider else "None",
             )
         except Exception:
             # Do not log the exception — it may contain secrets
-            logging.error("Failed to create auth provider from MCP_AUTH_FACTORY")
+            logger.error("Failed to create auth provider from MCP_AUTH_FACTORY")
     elif flask_app.config.get("MCP_AUTH_ENABLED", False):
         from superset.mcp_service.mcp_config import (
             create_default_mcp_auth_factory,
@@ -145,13 +147,13 @@ def _create_auth_provider(flask_app: Any) -> Any | None:
 
         try:
             auth_provider = create_default_mcp_auth_factory(flask_app)
-            logging.info(
+            logger.info(
                 "Auth provider created from default factory: %s",
                 type(auth_provider).__name__ if auth_provider else "None",
             )
         except Exception:
             # Do not log the exception — it may contain secrets
-            logging.error("Failed to create auth provider from default factory")
+            logger.error("Failed to create auth provider from default factory")
     return auth_provider
 
 

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -1,0 +1,559 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for DetailedJWTVerifier and related middleware."""
+
+import base64
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from authlib.jose.errors import BadSignatureError, DecodeError
+
+from superset.mcp_service.jwt_verifier import (
+    _json_auth_error_handler,
+    _jwt_failure_reason,
+    DetailedBearerAuthBackend,
+    DetailedJWTVerifier,
+)
+from superset.utils import json
+
+
+def _make_token(
+    header: dict[str, str], payload: dict[str, object], signature: str = "sig"
+) -> str:
+    """Build a fake JWT string from header + payload dicts."""
+    h = base64.urlsafe_b64encode(json.dumps(header).encode()).rstrip(b"=").decode()
+    p = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{h}.{p}.{signature}"
+
+
+@pytest.fixture
+def hs256_verifier():
+    """Create a DetailedJWTVerifier configured for HS256."""
+    return DetailedJWTVerifier(
+        public_key="test-secret-key-for-hs256-tokens",
+        issuer="test-issuer",
+        audience="test-audience",
+        algorithm="HS256",
+        required_scopes=[],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_contextvar():
+    """Reset the failure reason contextvar before each test."""
+    _jwt_failure_reason.set(None)
+    yield
+    _jwt_failure_reason.set(None)
+
+
+@pytest.mark.asyncio
+async def test_algorithm_mismatch(hs256_verifier):
+    """Token with wrong algorithm should report algorithm mismatch."""
+    token = _make_token(
+        {"alg": "RS256", "typ": "JWT"},
+        {"sub": "user1", "iss": "test-issuer", "aud": "test-audience"},
+    )
+
+    result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Algorithm mismatch" in reason
+    assert "RS256" in reason
+    assert "HS256" in reason
+
+
+@pytest.mark.asyncio
+async def test_malformed_token_header(hs256_verifier):
+    """Token with invalid header should report malformed header."""
+    # A token with only 2 parts (missing signature)
+    result = await hs256_verifier.load_access_token("part1.part2")
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Malformed token header" in reason
+
+
+@pytest.mark.asyncio
+async def test_signature_verification_failed(hs256_verifier):
+    """Token with bad signature should report signature failure."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "test-audience",
+            "exp": int(time.time()) + 3600,
+        },
+    )
+
+    with patch.object(
+        hs256_verifier.jwt,
+        "decode",
+        side_effect=BadSignatureError(result=None),
+    ):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Signature verification failed" in reason
+
+
+@pytest.mark.asyncio
+async def test_expired_token(hs256_verifier):
+    """Expired token should report token expired."""
+    expired_time = int(time.time()) - 3600
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "test-audience",
+            "exp": expired_time,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": expired_time,
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Token expired" in reason
+    assert "user1" in reason
+
+
+@pytest.mark.asyncio
+async def test_issuer_mismatch(hs256_verifier):
+    """Token with wrong issuer should report issuer mismatch."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "wrong-issuer",
+            "aud": "test-audience",
+            "exp": int(time.time()) + 3600,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "wrong-issuer",
+        "aud": "test-audience",
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Issuer mismatch" in reason
+    assert "wrong-issuer" in reason
+    assert "test-issuer" in reason
+
+
+@pytest.mark.asyncio
+async def test_audience_mismatch(hs256_verifier):
+    """Token with wrong audience should report audience mismatch."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "wrong-audience",
+            "exp": int(time.time()) + 3600,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "wrong-audience",
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Audience mismatch" in reason
+    assert "wrong-audience" in reason
+    assert "test-audience" in reason
+
+
+@pytest.mark.asyncio
+async def test_missing_required_scopes(hs256_verifier):
+    """Token missing required scopes should report missing scopes."""
+    hs256_verifier.required_scopes = ["admin", "read"]
+
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "test-audience",
+            "exp": int(time.time()) + 3600,
+            "scope": "read",
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": int(time.time()) + 3600,
+        "scope": "read",
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Missing required scopes" in reason
+    assert "admin" in reason
+
+
+@pytest.mark.asyncio
+async def test_valid_token(hs256_verifier):
+    """Valid token should return AccessToken and clear contextvar."""
+    future_exp = int(time.time()) + 3600
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "test-audience",
+            "exp": future_exp,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": future_exp,
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is not None
+    assert result.client_id == "user1"
+    assert result.expires_at == future_exp
+    # Contextvar should be None on success
+    assert _jwt_failure_reason.get() is None
+
+
+@pytest.mark.asyncio
+async def test_valid_token_no_expiration(hs256_verifier):
+    """Valid token without expiration should still succeed."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "test-audience",
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is not None
+    assert result.client_id == "user1"
+    assert result.expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_decode_error(hs256_verifier):
+    """Token that fails to decode should report decode failure."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {"sub": "user1"},
+    )
+
+    with patch.object(
+        hs256_verifier.jwt,
+        "decode",
+        side_effect=DecodeError("bad token"),
+    ):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Token decode failed" in reason
+
+
+@pytest.mark.asyncio
+async def test_verification_key_failure(hs256_verifier):
+    """Failure to get verification key should report specific error."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {"sub": "user1"},
+    )
+
+    with patch.object(
+        hs256_verifier,
+        "_get_verification_key",
+        side_effect=ValueError("JWKS endpoint unreachable"),
+    ):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason is not None
+    assert "Failed to get verification key" in reason
+    assert "JWKS endpoint unreachable" in reason
+
+
+@pytest.mark.asyncio
+async def test_contextvar_cleared_on_success(hs256_verifier):
+    """Contextvar should be reset to None before successful validation."""
+    # Set a stale failure reason
+    _jwt_failure_reason.set("previous failure")
+
+    future_exp = int(time.time()) + 3600
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "test-audience",
+            "exp": future_exp,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": future_exp,
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is not None
+    assert _jwt_failure_reason.get() is None
+
+
+def test_decode_token_header_valid():
+    """_decode_token_header should decode a valid JWT header."""
+    header = {"alg": "RS256", "typ": "JWT", "kid": "key1"}
+    header_b64 = (
+        base64.urlsafe_b64encode(json.dumps(header).encode()).rstrip(b"=").decode()
+    )
+    token = f"{header_b64}.payload.signature"
+
+    result = DetailedJWTVerifier._decode_token_header(token)
+
+    assert result["alg"] == "RS256"
+    assert result["kid"] == "key1"
+
+
+def test_decode_token_header_too_few_parts():
+    """_decode_token_header should raise for tokens with wrong number of parts."""
+    with pytest.raises(ValueError, match="3 parts"):
+        DetailedJWTVerifier._decode_token_header("only.two")
+
+
+def test_get_middleware_returns_custom_components(hs256_verifier):
+    """get_middleware should use DetailedBearerAuthBackend and custom error handler."""
+    middleware_list = hs256_verifier.get_middleware()
+
+    assert len(middleware_list) == 2
+
+    # First middleware should be AuthenticationMiddleware with our custom backend
+    auth_middleware = middleware_list[0]
+    assert (
+        auth_middleware.kwargs["backend"].__class__.__name__
+        == "DetailedBearerAuthBackend"
+    )
+    assert auth_middleware.kwargs["on_error"] is _json_auth_error_handler
+
+
+class _FakeHeaders(dict[str, str]):
+    """A dict subclass that allows overriding .get() for mock connections."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+
+    def get(self, key: str, default: str | None = None) -> str | None:  # type: ignore[override]
+        return super().get(key, default)
+
+
+@pytest.mark.asyncio
+async def test_detailed_bearer_backend_raises_on_failure():
+    """DetailedBearerAuthBackend should raise AuthenticationError with reason."""
+    from starlette.authentication import AuthenticationError
+
+    mock_verifier = MagicMock()
+    mock_verifier.verify_token = AsyncMock(return_value=None)
+
+    backend = DetailedBearerAuthBackend(mock_verifier)
+
+    # Mock connection with Bearer token
+    mock_conn = MagicMock()
+    mock_conn.headers = _FakeHeaders({"authorization": "Bearer some-token"})
+
+    # Set failure reason
+    _jwt_failure_reason.set("Token expired for client 'user1'")
+
+    with pytest.raises(AuthenticationError, match="Token expired"):
+        await backend.authenticate(mock_conn)
+
+    # Contextvar should be cleared after raising
+    assert _jwt_failure_reason.get() is None
+
+
+@pytest.mark.asyncio
+async def test_detailed_bearer_backend_passes_through_success():
+    """DetailedBearerAuthBackend should return normally on success."""
+    mock_verifier = MagicMock()
+    mock_token = MagicMock()
+    mock_token.scopes = ["read"]
+    mock_token.expires_at = None
+    mock_verifier.verify_token = AsyncMock(return_value=mock_token)
+
+    backend = DetailedBearerAuthBackend(mock_verifier)
+
+    mock_conn = MagicMock()
+    mock_conn.headers = _FakeHeaders({"authorization": "Bearer valid-token"})
+
+    result = await backend.authenticate(mock_conn)
+
+    assert result is not None
+    assert _jwt_failure_reason.get() is None
+
+
+@pytest.mark.asyncio
+async def test_detailed_bearer_backend_no_bearer_token():
+    """DetailedBearerAuthBackend should return None when no Bearer token."""
+    mock_verifier = MagicMock()
+    mock_verifier.verify_token = AsyncMock(return_value=None)
+
+    backend = DetailedBearerAuthBackend(mock_verifier)
+
+    # Mock connection without auth header
+    mock_conn = MagicMock()
+    mock_conn.headers = _FakeHeaders({})
+
+    result = await backend.authenticate(mock_conn)
+
+    assert result is None
+
+
+def test_json_auth_error_handler():
+    """_json_auth_error_handler should return JSON 401 with error details."""
+    from starlette.authentication import AuthenticationError
+
+    mock_conn = MagicMock()
+    exc = AuthenticationError("Token expired for client 'user1'")
+
+    response = _json_auth_error_handler(mock_conn, exc)
+
+    assert response.status_code == 401
+    body = json.loads(response.body.decode())
+    assert body["error"] == "invalid_token"
+    assert "Token expired" in body["error_description"]
+
+
+@pytest.mark.asyncio
+async def test_audience_mismatch_list_audience():
+    """Token audience not in allowed audience list should fail."""
+    verifier = DetailedJWTVerifier(
+        public_key="test-secret",
+        issuer="test-issuer",
+        audience=["aud1", "aud2"],
+        algorithm="HS256",
+    )
+
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "wrong-aud",
+            "exp": int(time.time()) + 3600,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "wrong-aud",
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch.object(verifier.jwt, "decode", return_value=claims):
+        result = await verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert "Audience mismatch" in reason
+
+
+@pytest.mark.asyncio
+async def test_issuer_mismatch_list_issuer():
+    """Token issuer not in allowed issuer list should fail."""
+    verifier = DetailedJWTVerifier(
+        public_key="test-secret",
+        issuer=["iss1", "iss2"],
+        audience="test-audience",
+        algorithm="HS256",
+    )
+
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "wrong-issuer",
+            "aud": "test-audience",
+            "exp": int(time.time()) + 3600,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "wrong-issuer",
+        "aud": "test-audience",
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch.object(verifier.jwt, "decode", return_value=claims):
+        result = await verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert "Issuer mismatch" in reason
+    assert "wrong-issuer" in reason

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -18,6 +18,7 @@
 """Tests for DetailedJWTVerifier and related middleware."""
 
 import base64
+import logging
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -74,10 +75,10 @@ async def test_algorithm_mismatch(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Algorithm mismatch" in reason
-    assert "RS256" in reason
-    assert "HS256" in reason
+    assert reason == "Algorithm mismatch"
+    # Claim values must not leak into the contextvar reason
+    assert "RS256" not in reason
+    assert "HS256" not in reason
 
 
 @pytest.mark.asyncio
@@ -88,8 +89,7 @@ async def test_malformed_token_header(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Malformed token header" in reason
+    assert reason == "Malformed token header"
 
 
 @pytest.mark.asyncio
@@ -114,8 +114,7 @@ async def test_signature_verification_failed(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Signature verification failed" in reason
+    assert reason == "Signature verification failed"
 
 
 @pytest.mark.asyncio
@@ -143,9 +142,9 @@ async def test_expired_token(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Token expired" in reason
-    assert "user1" in reason
+    assert reason == "Token expired"
+    # Claim values must not leak into the contextvar reason
+    assert "user1" not in reason
 
 
 @pytest.mark.asyncio
@@ -172,10 +171,10 @@ async def test_issuer_mismatch(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Issuer mismatch" in reason
-    assert "wrong-issuer" in reason
-    assert "test-issuer" in reason
+    assert reason == "Issuer mismatch"
+    # Claim values must not leak into the contextvar reason
+    assert "wrong-issuer" not in reason
+    assert "test-issuer" not in reason
 
 
 @pytest.mark.asyncio
@@ -202,10 +201,10 @@ async def test_audience_mismatch(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Audience mismatch" in reason
-    assert "wrong-audience" in reason
-    assert "test-audience" in reason
+    assert reason == "Audience mismatch"
+    # Claim values must not leak into the contextvar reason
+    assert "wrong-audience" not in reason
+    assert "test-audience" not in reason
 
 
 @pytest.mark.asyncio
@@ -236,9 +235,9 @@ async def test_missing_required_scopes(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Missing required scopes" in reason
-    assert "admin" in reason
+    assert reason == "Missing required scopes"
+    # Claim values must not leak into the contextvar reason
+    assert "admin" not in reason
 
 
 @pytest.mark.asyncio
@@ -313,8 +312,7 @@ async def test_decode_error(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Token decode failed" in reason
+    assert reason == "Token decode failed"
 
 
 @pytest.mark.asyncio
@@ -334,9 +332,9 @@ async def test_verification_key_failure(hs256_verifier):
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert reason is not None
-    assert "Failed to get verification key" in reason
-    assert "JWKS endpoint unreachable" in reason
+    assert reason == "Failed to get verification key"
+    # Exception details must not leak into the contextvar reason
+    assert "JWKS endpoint unreachable" not in reason
 
 
 @pytest.mark.asyncio
@@ -429,8 +427,8 @@ async def test_detailed_bearer_backend_raises_on_failure():
     mock_conn = MagicMock()
     mock_conn.headers = _FakeHeaders({"authorization": "Bearer some-token"})
 
-    # Set failure reason
-    _jwt_failure_reason.set("Token expired for client 'user1'")
+    # Set failure reason (generic, no claim values)
+    _jwt_failure_reason.set("Token expired")
 
     with pytest.raises(AuthenticationError, match="Token expired"):
         await backend.authenticate(mock_conn)
@@ -547,7 +545,7 @@ async def test_audience_mismatch_list_audience():
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert "Audience mismatch" in reason
+    assert reason == "Audience mismatch"
 
 
 @pytest.mark.asyncio
@@ -581,8 +579,9 @@ async def test_issuer_mismatch_list_issuer():
 
     assert result is None
     reason = _jwt_failure_reason.get()
-    assert "Issuer mismatch" in reason
-    assert "wrong-issuer" in reason
+    assert reason == "Issuer mismatch"
+    # Claim values must not leak into the contextvar reason
+    assert "wrong-issuer" not in reason
 
 
 def test_decode_token_header_padding_multiple_of_4():
@@ -599,3 +598,70 @@ def test_decode_token_header_padding_multiple_of_4():
 
     assert result["alg"] == "HS256"
     assert result["typ"] == "JWT"
+
+
+@pytest.mark.asyncio
+async def test_warning_logs_never_contain_claim_values(hs256_verifier, caplog):
+    """WARNING logs must contain only generic categories; details go to DEBUG."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "wrong-issuer",
+            "aud": "test-audience",
+            "exp": int(time.time()) + 3600,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "wrong-issuer",
+        "aud": "test-audience",
+        "exp": int(time.time()) + 3600,
+    }
+
+    with caplog.at_level(logging.DEBUG, logger="superset.mcp_service.jwt_verifier"):
+        with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+            await hs256_verifier.load_access_token(token)
+
+    # WARNING logs must not contain claim values
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno >= logging.WARNING
+    ]
+    for msg in warning_messages:
+        assert "wrong-issuer" not in msg
+        assert "test-issuer" not in msg
+
+    # DEBUG logs should contain the detailed values
+    debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+    assert any("wrong-issuer" in msg for msg in debug_messages)
+
+
+@pytest.mark.asyncio
+async def test_hs256_secret_never_logged(hs256_verifier, caplog):
+    """The HS256 secret key must never appear in any log at any level."""
+    secret_key = "test-secret-key-for-hs256-tokens"
+
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "wrong-issuer",
+            "aud": "test-audience",
+            "exp": int(time.time()) + 3600,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "wrong-issuer",
+        "aud": "test-audience",
+        "exp": int(time.time()) + 3600,
+    }
+
+    with caplog.at_level(logging.DEBUG, logger="superset.mcp_service.jwt_verifier"):
+        with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+            await hs256_verifier.load_access_token(token)
+
+    # The secret key must never appear at ANY log level
+    all_messages = [r.message for r in caplog.records]
+    for msg in all_messages:
+        assert secret_key not in msg, f"HS256 secret leaked in log: {msg}"

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -639,7 +639,8 @@ async def test_warning_logs_never_contain_claim_values(hs256_verifier, caplog):
 @pytest.mark.asyncio
 async def test_hs256_secret_never_logged(hs256_verifier, caplog):
     """The HS256 secret key must never appear in any log at any level."""
-    secret_key = "test-secret-key-for-hs256-tokens"
+    # This matches the public_key value from the hs256_verifier fixture
+    hs256_signing_value = "test-secret-key-for-hs256-tokens"
 
     token = _make_token(
         {"alg": "HS256", "typ": "JWT"},
@@ -661,7 +662,7 @@ async def test_hs256_secret_never_logged(hs256_verifier, caplog):
         with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
             await hs256_verifier.load_access_token(token)
 
-    # The secret key must never appear at ANY log level
+    # The signing value must never appear at ANY log level
     all_messages = [r.message for r in caplog.records]
     for msg in all_messages:
-        assert secret_key not in msg, f"HS256 secret leaked in log: {msg}"
+        assert hs256_signing_value not in msg, f"HS256 secret leaked in log: {msg}"

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -25,8 +25,8 @@ import pytest
 from authlib.jose.errors import BadSignatureError, DecodeError
 
 from superset.mcp_service.jwt_verifier import (
-    _json_auth_error_handler,
     _jwt_failure_reason,
+    _make_json_auth_error_handler,
     _sanitize_header_value,
     DetailedBearerAuthBackend,
     DetailedJWTVerifier,
@@ -402,7 +402,8 @@ def test_get_middleware_returns_custom_components(hs256_verifier):
         auth_middleware.kwargs["backend"].__class__.__name__
         == "DetailedBearerAuthBackend"
     )
-    assert auth_middleware.kwargs["on_error"] is _json_auth_error_handler
+    # on_error should be a closure produced by _make_json_auth_error_handler
+    assert callable(auth_middleware.kwargs["on_error"])
 
 
 class _FakeHeaders(dict[str, str]):
@@ -476,19 +477,49 @@ async def test_detailed_bearer_backend_no_bearer_token():
     assert result is None
 
 
-def test_json_auth_error_handler():
-    """_json_auth_error_handler should return JSON 401 with error details."""
+def test_json_auth_error_handler_debug_mode():
+    """With debug_errors=True, handler should return detailed error info."""
     from starlette.authentication import AuthenticationError
 
+    handler = _make_json_auth_error_handler(debug_errors=True)
     mock_conn = MagicMock()
     exc = AuthenticationError("Token expired for client 'user1'")
 
-    response = _json_auth_error_handler(mock_conn, exc)
+    response = handler(mock_conn, exc)
 
     assert response.status_code == 401
     body = json.loads(response.body.decode())
     assert body["error"] == "invalid_token"
     assert "Token expired" in body["error_description"]
+    assert "user1" in body["error_description"]
+
+    www_auth = response.headers.get("www-authenticate", "")
+    assert "Token expired" in www_auth
+
+
+def test_json_auth_error_handler_default_mode():
+    """With debug_errors=False (default), handler should return generic error."""
+    from starlette.authentication import AuthenticationError
+
+    handler = _make_json_auth_error_handler(debug_errors=False)
+    mock_conn = MagicMock()
+    exc = AuthenticationError("Issuer mismatch: token has 'evil', expected 'good'")
+
+    response = handler(mock_conn, exc)
+
+    assert response.status_code == 401
+    body = json.loads(response.body.decode())
+    assert body["error"] == "invalid_token"
+    assert body["error_description"] == "Authentication failed"
+    # No claim values should leak
+    assert "evil" not in body["error_description"]
+    assert "good" not in body["error_description"]
+    assert "Issuer" not in body["error_description"]
+
+    www_auth = response.headers.get("www-authenticate", "")
+    assert www_auth == 'Bearer error="invalid_token"'
+    assert "evil" not in www_auth
+    assert "good" not in www_auth
 
 
 @pytest.mark.asyncio
@@ -571,13 +602,14 @@ def test_sanitize_header_value_removes_crlf():
 
 
 def test_json_auth_error_handler_sanitizes_header():
-    """Error handler should sanitize reason in WWW-Authenticate header."""
+    """Error handler should sanitize reason in WWW-Authenticate header (debug mode)."""
     from starlette.authentication import AuthenticationError
 
+    handler = _make_json_auth_error_handler(debug_errors=True)
     mock_conn = MagicMock()
     exc = AuthenticationError("Issuer mismatch: token has 'evil\r\nInject: bad\"'")
 
-    response = _json_auth_error_handler(mock_conn, exc)
+    response = handler(mock_conn, exc)
 
     # Body should have the raw reason
     body = json.loads(response.body.decode())
@@ -603,3 +635,55 @@ def test_decode_token_header_padding_multiple_of_4():
 
     assert result["alg"] == "HS256"
     assert result["typ"] == "JWT"
+
+
+def test_verifier_debug_errors_default():
+    """DetailedJWTVerifier should default debug_errors to False."""
+    verifier = DetailedJWTVerifier(
+        public_key="test-secret",
+        algorithm="HS256",
+    )
+    assert verifier.debug_errors is False
+
+
+def test_verifier_debug_errors_enabled():
+    """DetailedJWTVerifier should accept debug_errors=True."""
+    verifier = DetailedJWTVerifier(
+        public_key="test-secret",
+        algorithm="HS256",
+        debug_errors=True,
+    )
+    assert verifier.debug_errors is True
+
+
+def test_default_handler_no_claim_leak():
+    """With debug_errors=False, no JWT claim values should leak into the response."""
+    from starlette.authentication import AuthenticationError
+
+    handler = _make_json_auth_error_handler(debug_errors=False)
+    mock_conn = MagicMock()
+
+    # Simulate various failure reasons that contain sensitive claim values
+    sensitive_reasons = [
+        "Algorithm mismatch: token uses 'RS256', expected 'HS256'",
+        "Issuer mismatch: token has 'https://evil.com', expected 'https://good.com'",
+        "Audience mismatch: token has 'wrong-aud', expected 'my-api'",
+        "Token expired for client 'admin-service'",
+        "Missing required scopes: {'admin'}. Token has: {'read'}",
+    ]
+
+    for reason in sensitive_reasons:
+        exc = AuthenticationError(reason)
+        response = handler(mock_conn, exc)
+
+        body = json.loads(response.body.decode())
+        # Body should only have generic message
+        assert body["error_description"] == "Authentication failed", (
+            f"Detailed reason leaked for: {reason}"
+        )
+
+        # WWW-Authenticate should not contain any claim values
+        www_auth = response.headers.get("www-authenticate", "")
+        assert www_auth == 'Bearer error="invalid_token"', (
+            f"Detailed reason leaked in header for: {reason}"
+        )

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -23,7 +23,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from authlib.jose.errors import BadSignatureError, DecodeError
+from authlib.jose.errors import BadSignatureError, DecodeError, ExpiredTokenError
 
 from superset.mcp_service.jwt_verifier import (
     _json_auth_error_handler,
@@ -666,3 +666,61 @@ async def test_hs256_secret_never_logged(hs256_verifier, caplog):
     all_messages = [r.message for r in caplog.records]
     for msg in all_messages:
         assert hs256_signing_value not in msg, f"HS256 secret leaked in log: {msg}"
+
+
+@pytest.mark.asyncio
+async def test_expired_token_during_decode(hs256_verifier):
+    """ExpiredTokenError raised by jwt.decode should set generic reason."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "test-audience",
+            "exp": int(time.time()) - 3600,
+        },
+    )
+
+    with patch.object(
+        hs256_verifier.jwt,
+        "decode",
+        side_effect=ExpiredTokenError(),
+    ):
+        result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason == "Token has expired (detected during decode)"
+
+
+@pytest.mark.asyncio
+async def test_catch_all_exception_sets_generic_reason(hs256_verifier):
+    """Catch-all handler should set generic reason without exception details."""
+    token = _make_token(
+        {"alg": "HS256", "typ": "JWT"},
+        {
+            "sub": "user1",
+            "iss": "test-issuer",
+            "aud": "test-audience",
+            "exp": int(time.time()) + 3600,
+        },
+    )
+    claims = {
+        "sub": "user1",
+        "iss": "test-issuer",
+        "aud": "test-audience",
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch.object(hs256_verifier.jwt, "decode", return_value=claims):
+        with patch.object(
+            hs256_verifier,
+            "_extract_scopes",
+            side_effect=TypeError("unexpected type in scopes"),
+        ):
+            result = await hs256_verifier.load_access_token(token)
+
+    assert result is None
+    reason = _jwt_failure_reason.get()
+    assert reason == "Token validation failed"
+    assert "unexpected type" not in reason

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -25,9 +25,8 @@ import pytest
 from authlib.jose.errors import BadSignatureError, DecodeError
 
 from superset.mcp_service.jwt_verifier import (
+    _json_auth_error_handler,
     _jwt_failure_reason,
-    _make_json_auth_error_handler,
-    _sanitize_header_value,
     DetailedBearerAuthBackend,
     DetailedJWTVerifier,
 )
@@ -391,7 +390,7 @@ def test_decode_token_header_too_few_parts():
 
 
 def test_get_middleware_returns_custom_components(hs256_verifier):
-    """get_middleware should use DetailedBearerAuthBackend and custom error handler."""
+    """get_middleware should use DetailedBearerAuthBackend and generic error handler."""
     middleware_list = hs256_verifier.get_middleware()
 
     assert len(middleware_list) == 2
@@ -402,8 +401,8 @@ def test_get_middleware_returns_custom_components(hs256_verifier):
         auth_middleware.kwargs["backend"].__class__.__name__
         == "DetailedBearerAuthBackend"
     )
-    # on_error should be a closure produced by _make_json_auth_error_handler
-    assert callable(auth_middleware.kwargs["on_error"])
+    # on_error should be the RFC 6750-compliant generic handler
+    assert auth_middleware.kwargs["on_error"] is _json_auth_error_handler
 
 
 class _FakeHeaders(dict[str, str]):
@@ -477,49 +476,44 @@ async def test_detailed_bearer_backend_no_bearer_token():
     assert result is None
 
 
-def test_json_auth_error_handler_debug_mode():
-    """With debug_errors=True, handler should return detailed error info."""
+def test_error_handler_never_leaks_jwt_details():
+    """Error handler MUST return generic error per RFC 6750 Section 3.1.
+
+    No JWT claim values, server config, or validation details should
+    ever appear in the HTTP response - regardless of the failure type.
+    References: CVE-2022-29266, CVE-2019-7644.
+    """
     from starlette.authentication import AuthenticationError
 
-    handler = _make_json_auth_error_handler(debug_errors=True)
     mock_conn = MagicMock()
-    exc = AuthenticationError("Token expired for client 'user1'")
 
-    response = handler(mock_conn, exc)
+    # Simulate various failure reasons that contain sensitive claim values
+    sensitive_reasons = [
+        "Algorithm mismatch: token uses 'RS256', expected 'HS256'",
+        "Issuer mismatch: token has 'https://evil.com', expected 'https://good.com'",
+        "Audience mismatch: token has 'wrong-aud', expected 'my-api'",
+        "Token expired for client 'admin-service'",
+        "Missing required scopes: {'admin'}. Token has: {'read'}",
+    ]
 
-    assert response.status_code == 401
-    body = json.loads(response.body.decode())
-    assert body["error"] == "invalid_token"
-    assert "Token expired" in body["error_description"]
-    assert "user1" in body["error_description"]
+    for reason in sensitive_reasons:
+        exc = AuthenticationError(reason)
+        response = _json_auth_error_handler(mock_conn, exc)
 
-    www_auth = response.headers.get("www-authenticate", "")
-    assert "Token expired" in www_auth
+        assert response.status_code == 401
 
+        body = json.loads(response.body.decode())
+        # Body must only have generic message
+        assert body["error"] == "invalid_token", f"Wrong error code for: {reason}"
+        assert body["error_description"] == "Authentication failed", (
+            f"Detailed reason leaked for: {reason}"
+        )
 
-def test_json_auth_error_handler_default_mode():
-    """With debug_errors=False (default), handler should return generic error."""
-    from starlette.authentication import AuthenticationError
-
-    handler = _make_json_auth_error_handler(debug_errors=False)
-    mock_conn = MagicMock()
-    exc = AuthenticationError("Issuer mismatch: token has 'evil', expected 'good'")
-
-    response = handler(mock_conn, exc)
-
-    assert response.status_code == 401
-    body = json.loads(response.body.decode())
-    assert body["error"] == "invalid_token"
-    assert body["error_description"] == "Authentication failed"
-    # No claim values should leak
-    assert "evil" not in body["error_description"]
-    assert "good" not in body["error_description"]
-    assert "Issuer" not in body["error_description"]
-
-    www_auth = response.headers.get("www-authenticate", "")
-    assert www_auth == 'Bearer error="invalid_token"'
-    assert "evil" not in www_auth
-    assert "good" not in www_auth
+        # WWW-Authenticate must not contain any claim values
+        www_auth = response.headers.get("www-authenticate", "")
+        assert www_auth == 'Bearer error="invalid_token"', (
+            f"Detailed reason leaked in header for: {reason}"
+        )
 
 
 @pytest.mark.asyncio
@@ -591,36 +585,6 @@ async def test_issuer_mismatch_list_issuer():
     assert "wrong-issuer" in reason
 
 
-def test_sanitize_header_value_removes_crlf():
-    """_sanitize_header_value should strip CR/LF to prevent header injection."""
-    malicious = 'evil\r\nX-Injected: value"quoted'
-    result = _sanitize_header_value(malicious)
-    assert "\r" not in result
-    assert "\n" not in result
-    assert '"' not in result
-    assert "evil" in result
-
-
-def test_json_auth_error_handler_sanitizes_header():
-    """Error handler should sanitize reason in WWW-Authenticate header (debug mode)."""
-    from starlette.authentication import AuthenticationError
-
-    handler = _make_json_auth_error_handler(debug_errors=True)
-    mock_conn = MagicMock()
-    exc = AuthenticationError("Issuer mismatch: token has 'evil\r\nInject: bad\"'")
-
-    response = handler(mock_conn, exc)
-
-    # Body should have the raw reason
-    body = json.loads(response.body.decode())
-    assert "Issuer mismatch" in body["error_description"]
-
-    # Header should be sanitized
-    www_auth = response.headers.get("www-authenticate", "")
-    assert "\r" not in www_auth
-    assert "\n" not in www_auth
-
-
 def test_decode_token_header_padding_multiple_of_4():
     """_decode_token_header should handle headers whose length is a multiple of 4."""
     # eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 is 36 chars (divisible by 4)
@@ -635,55 +599,3 @@ def test_decode_token_header_padding_multiple_of_4():
 
     assert result["alg"] == "HS256"
     assert result["typ"] == "JWT"
-
-
-def test_verifier_debug_errors_default():
-    """DetailedJWTVerifier should default debug_errors to False."""
-    verifier = DetailedJWTVerifier(
-        public_key="test-secret",
-        algorithm="HS256",
-    )
-    assert verifier.debug_errors is False
-
-
-def test_verifier_debug_errors_enabled():
-    """DetailedJWTVerifier should accept debug_errors=True."""
-    verifier = DetailedJWTVerifier(
-        public_key="test-secret",
-        algorithm="HS256",
-        debug_errors=True,
-    )
-    assert verifier.debug_errors is True
-
-
-def test_default_handler_no_claim_leak():
-    """With debug_errors=False, no JWT claim values should leak into the response."""
-    from starlette.authentication import AuthenticationError
-
-    handler = _make_json_auth_error_handler(debug_errors=False)
-    mock_conn = MagicMock()
-
-    # Simulate various failure reasons that contain sensitive claim values
-    sensitive_reasons = [
-        "Algorithm mismatch: token uses 'RS256', expected 'HS256'",
-        "Issuer mismatch: token has 'https://evil.com', expected 'https://good.com'",
-        "Audience mismatch: token has 'wrong-aud', expected 'my-api'",
-        "Token expired for client 'admin-service'",
-        "Missing required scopes: {'admin'}. Token has: {'read'}",
-    ]
-
-    for reason in sensitive_reasons:
-        exc = AuthenticationError(reason)
-        response = handler(mock_conn, exc)
-
-        body = json.loads(response.body.decode())
-        # Body should only have generic message
-        assert body["error_description"] == "Authentication failed", (
-            f"Detailed reason leaked for: {reason}"
-        )
-
-        # WWW-Authenticate should not contain any claim values
-        www_auth = response.headers.get("www-authenticate", "")
-        assert www_auth == 'Bearer error="invalid_token"', (
-            f"Detailed reason leaked in header for: {reason}"
-        )


### PR DESCRIPTION
### SUMMARY

Adds a `DetailedJWTVerifier` for the MCP service that performs step-by-step JWT validation with specific server-side log messages for each failure type. Controlled by the `MCP_JWT_DEBUG_ERRORS` config flag (default: off).

**The Problem:**

When JWT authentication fails, the MCP service returns the same generic error regardless of what went wrong — you can't tell if the token is expired, signed with the wrong algorithm, has the wrong issuer, etc. The default `JWTVerifier` from fastmcp only logs at DEBUG level, making production troubleshooting difficult.

**The Solution:**

- **`MCP_JWT_DEBUG_ERRORS = False`** (default): Uses the standard `JWTVerifier` from fastmcp. Minimal logging. Invalid tokens silently fail and requests proceed unauthenticated (rejected later at the tool level).
- **`MCP_JWT_DEBUG_ERRORS = True`**: Uses `DetailedJWTVerifier` which logs specific failure reasons at WARNING level server-side (e.g., `"Issuer mismatch: token has 'X', expected 'Y'"`). Invalid tokens get an immediate generic `401` response. **No JWT claim values or server configuration are ever leaked to clients** — HTTP responses always return `{"error": "invalid_token", "error_description": "Authentication failed"}` per RFC 6750 Section 3.1.

This avoids the class of vulnerabilities seen in [CVE-2022-29266](https://nvd.nist.gov/vuln/detail/cve-2022-29266) and [CVE-2019-7644](https://nvd.nist.gov/vuln/detail/CVE-2019-7644).

Also adds a default auth factory fallback in `server.py` — when `MCP_AUTH_ENABLED=True` but no `MCP_AUTH_FACTORY` is set, the server automatically creates an auth provider from config values (previously it silently skipped auth).

#### How it works

```mermaid
flowchart TD
    A["Client sends Bearer token"] --> B["AuthenticationMiddleware"]
    B --> C["DetailedBearerAuthBackend.authenticate()"]
    C --> D["DetailedJWTVerifier.verify_token()"]
    D --> E["load_access_token() — step-by-step validation"]

    E --> F{"1. Decode header"}
    F -->|"Malformed"| FAIL1["Set reason: 'Malformed token header'"]
    F -->|"OK"| G{"2. Check algorithm"}

    G -->|"Mismatch"| FAIL2["Set reason: 'Algorithm mismatch'"]
    G -->|"OK"| H{"3. Get verification key"}

    H -->|"JWKS unreachable"| FAIL3["Set reason: 'Failed to get verification key'"]
    H -->|"OK"| I{"4. Verify signature"}

    I -->|"Bad signature"| FAIL4["Set reason: 'Signature verification failed'"]
    I -->|"OK"| J{"5. Check expiration"}

    J -->|"Expired"| FAIL5["Set reason: 'Token expired'"]
    J -->|"OK"| K{"6. Validate issuer"}

    K -->|"Mismatch"| FAIL6["Set reason: 'Issuer mismatch'"]
    K -->|"OK"| L{"7. Validate audience"}

    L -->|"Mismatch"| FAIL7["Set reason: 'Audience mismatch'"]
    L -->|"OK"| M{"8. Check scopes"}

    M -->|"Missing"| FAIL8["Set reason: 'Missing required scopes'"]
    M -->|"OK"| SUCCESS["Return AccessToken ✅"]

    FAIL1 & FAIL2 & FAIL3 & FAIL4 & FAIL5 & FAIL6 & FAIL7 & FAIL8 --> CTX["Store reason in ContextVar"]
    CTX --> LOG["logger.warning() — always logged server-side"]
    LOG --> RETURN_NONE["Return None"]
    RETURN_NONE --> BACKEND["DetailedBearerAuthBackend reads ContextVar"]
    BACKEND --> RAISE["Raise AuthenticationError"]
    RAISE --> HANDLER["_json_auth_error_handler"]
    HANDLER --> GENERIC_RESP["Always: 401 with generic 'Authentication failed'"]
```

#### Before vs After

| | Before | After (default: `MCP_JWT_DEBUG_ERRORS=False`) | After (`MCP_JWT_DEBUG_ERRORS=True`) |
|---|---|---|---|
| **Verifier** | `JWTVerifier` | `JWTVerifier` (same as before) | `DetailedJWTVerifier` |
| **HTTP response** | Generic `"Authentication required"` | Generic (unchanged) | Generic `"Authentication failed"` (RFC 6750) |
| **Server logs** | DEBUG level only | DEBUG level only (unchanged) | WARNING with specific failure reason |
| **Config** | N/A | `MCP_JWT_DEBUG_ERRORS = False` | `MCP_JWT_DEBUG_ERRORS = True` |

#### Class hierarchy

```mermaid
classDiagram
    class JWTVerifier {
        +load_access_token(token) AccessToken|None
        +get_middleware() list
        -_get_verification_key(token) str
        -_extract_scopes(claims) list
    }

    class DetailedJWTVerifier {
        +load_access_token(token) AccessToken|None
        +get_middleware() list
        +_decode_token_header(token) dict
    }

    class BearerAuthBackend {
        +authenticate(conn) tuple|None
    }

    class DetailedBearerAuthBackend {
        +authenticate(conn) tuple|None
    }

    JWTVerifier <|-- DetailedJWTVerifier : extends
    BearerAuthBackend <|-- DetailedBearerAuthBackend : extends

    DetailedJWTVerifier ..> _jwt_failure_reason : writes
    DetailedBearerAuthBackend ..> _jwt_failure_reason : reads
```

#### Auth factory fallback (server.py)

```mermaid
flowchart TD
    START["server.py: run_server()"] --> CHECK_FACTORY{"MCP_AUTH_FACTORY set?"}
    CHECK_FACTORY -->|"Yes"| USE_CUSTOM["Use custom factory"]
    CHECK_FACTORY -->|"No"| CHECK_ENABLED{"MCP_AUTH_ENABLED = True?"}
    CHECK_ENABLED -->|"Yes"| USE_DEFAULT["Use create_default_mcp_auth_factory()"]
    CHECK_ENABLED -->|"No"| NO_AUTH["No auth provider"]
    USE_DEFAULT --> CHECK_DEBUG{"MCP_JWT_DEBUG_ERRORS?"}
    CHECK_DEBUG -->|"True"| DETAILED["Creates DetailedJWTVerifier"]
    CHECK_DEBUG -->|"False (default)"| STANDARD["Creates standard JWTVerifier"]
    USE_CUSTOM --> PROVIDER["Auth provider ready"]
    DETAILED --> PROVIDER
    STANDARD --> PROVIDER
```

#### Files changed

| File | Change | Why |
|------|--------|-----|
| `superset/mcp_service/jwt_verifier.py` | **NEW** | `DetailedJWTVerifier`, `DetailedBearerAuthBackend`, `_json_auth_error_handler` (always generic per RFC 6750), ContextVar for failure reasons |
| `superset/mcp_service/mcp_config.py` | Modified | Added `MCP_JWT_DEBUG_ERRORS = False` config; factory creates `DetailedJWTVerifier` when True, standard `JWTVerifier` when False |
| `superset/mcp_service/server.py` | Modified | Falls back to default factory when `MCP_AUTH_ENABLED=True` but no `MCP_AUTH_FACTORY` |
| `superset/mcp_service/auth.py` | Modified | `get_user_from_request()` shows diagnostic details on failure |
| `tests/unit_tests/mcp_service/test_jwt_verifier.py` | **NEW** | 28 unit tests covering every failure mode, RFC 6750 compliance, generic error responses |

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before** — Every JWT failure returns this:
```
HTTP 401
{"error": "invalid_token", "error_description": "Authentication required"}
```

**After (MCP_JWT_DEBUG_ERRORS=True)** — Same generic response, but server logs show the real reason:
```
HTTP 401
{"error": "invalid_token", "error_description": "Authentication failed"}
WWW-Authenticate: Bearer error="invalid_token"

# Server log only (never in HTTP response):
# WARNING - JWT authentication failed: Issuer mismatch: token has 'wrong-issuer', expected 'test-issuer'
```

### TESTING INSTRUCTIONS

#### 1. Run unit tests

```bash
pytest tests/unit_tests/mcp_service/test_jwt_verifier.py -v
# Expected: 28 tests pass
```

#### 2. Set up local MCP server for manual testing

**Step 2a: Configure `superset_config.py` for HS256 testing (easiest)**

Add these lines to your `superset_config.py`:
```python
MCP_AUTH_ENABLED = True
MCP_DEV_USERNAME = "admin"
MCP_JWT_ALGORITHM = "HS256"
MCP_JWT_SECRET = "my-test-secret-for-jwt-testing"
MCP_JWT_ISSUER = "test-issuer"
MCP_JWT_AUDIENCE = "test-audience"

# Enable detailed server-side logging for JWT failures
MCP_JWT_DEBUG_ERRORS = True
```

> **Note:** Do NOT set `MCP_AUTH_FACTORY` — the new default factory fallback in `server.py` will automatically create a `DetailedJWTVerifier` from these config values.

**Step 2b: Start the MCP server**

```bash
superset mcp run --port 5008 --debug
```

#### 3. Manual test: Verify generic responses

```bash
# Wrong issuer token
curl -s http://localhost:5008/mcp \
  -H "Authorization: Bearer <WRONG_ISS_TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}' | python -m json.tool
```

**Expected:** Generic `"Authentication failed"` in HTTP response — no issuer values leaked. Check server logs for the detailed reason (e.g., `WARNING - JWT authentication failed: Issuer mismatch: ...`).

#### 4. Generate test tokens

```python
import json, base64, hmac, hashlib, time

def make_jwt(payload, secret="my-test-secret-for-jwt-testing"):
    header = {"alg": "HS256", "typ": "JWT"}
    h = base64.urlsafe_b64encode(json.dumps(header).encode()).rstrip(b"=").decode()
    p = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
    sig_input = f"{h}.{p}".encode()
    sig = base64.urlsafe_b64encode(
        hmac.new(secret.encode(), sig_input, hashlib.sha256).digest()
    ).rstrip(b"=").decode()
    return f"{h}.{p}.{sig}"

# Valid token
print("VALID:", make_jwt({"sub": "admin", "iss": "test-issuer", "aud": "test-audience", "exp": int(time.time()) + 3600}))
# Expired token
print("EXPIRED:", make_jwt({"sub": "admin", "iss": "test-issuer", "aud": "test-audience", "exp": int(time.time()) - 3600}))
# Wrong issuer
print("WRONG_ISS:", make_jwt({"sub": "admin", "iss": "wrong-issuer", "aud": "test-audience", "exp": int(time.time()) + 3600}))
# Wrong audience
print("WRONG_AUD:", make_jwt({"sub": "admin", "iss": "test-issuer", "aud": "wrong-audience", "exp": int(time.time()) + 3600}))
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API