### PR TITLE
fix(athena): pass schema to connect_args for PyAthena metadata discovery

### DIFF
--- a/superset/db_engine_specs/athena.py
+++ b/superset/db_engine_specs/athena.py
@@ -57,7 +57,7 @@ class AthenaEngineSpec(BaseEngineSpec):
         "connection_string": (
             "awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}"
             "@athena.{region_name}.amazonaws.com/{schema_name}"
-            "?s3_staging_dir={s3_staging_dir}"
+            "?s3_staging_dir={s3_staging_dir}&catalog_name={catalog_name}"
         ),
         "drivers": [
             {
@@ -71,7 +71,9 @@ class AthenaEngineSpec(BaseEngineSpec):
                 "is_recommended": True,
                 "notes": (
                     "No Java required. URL-encode special characters "
-                    "(e.g., s3:// -> s3%3A//)."
+                    "(e.g., s3:// -> s3%3A//). "
+                    "For IAM role authentication, omit credentials: "
+                    "awsathena+rest://@athena.{region}.amazonaws.com/{schema}?s3_staging_dir={dir}"
                 ),
             },
             {
@@ -167,12 +169,18 @@ class AthenaEngineSpec(BaseEngineSpec):
         For AWS Athena the SQLAlchemy URI looks like this:
 
             awsathena+rest://athena.{region_name}.amazonaws.com:443/{schema_name}?catalog_name={catalog_name}&s3_staging_dir={s3_staging_dir}
+
+        When using IAM role authentication, credentials can be omitted from the URI:
+
+            awsathena+rest://@athena.{region_name}.amazonaws.com:443/{schema_name}?s3_staging_dir={s3_staging_dir}
         """
         if catalog:
             uri = uri.update_query_dict({"catalog_name": catalog})
 
         if schema:
             uri = uri.set(database=schema)
+            # PyAthena also needs schema_name in connect_args for proper metadata discovery
+            connect_args["schema_name"] = schema
 
         return uri, connect_args
 


### PR DESCRIPTION
Fixes issues where Athena connections would validate successfully but fail during database creation or dataset discovery, especially when using IAM role authentication or working with multiple schemas.

This ensures schema context and authentication details are consistently applied during connection setup and metadata discovery. The change is minimal and preserves existing authentication and connection behavior.

TESTING INSTRUCTIONS

Tested Athena connection using IAM role authentication

Verified database creation works after connection test

Verified correct schema is used during table/dataset discovery

Confirmed no regression for key/secret based auth

ADDITIONAL INFORMATION

 Has associated issue: Fixes #17182

 Changes UI

 Includes DB Migration

 Introduces new feature or API
