### PR TITLE
fix(utils): datetime_to_epoch function is fixed to timezone aware epoch

### DIFF
--- a/superset/utils/dates.py
+++ b/superset/utils/dates.py
@@ -24,7 +24,7 @@ EPOCH = datetime(1970, 1, 1)
 def datetime_to_epoch(dttm: datetime) -> float:
     """Convert datetime to milliseconds to epoch"""
     if dttm.tzinfo:
-        dttm = dttm.replace(tzinfo=pytz.utc)
+        dttm = dttm.astimezone(pytz.utc)
         epoch_with_tz = pytz.utc.localize(EPOCH)
         return (dttm - epoch_with_tz).total_seconds() * 1000
     return (dttm - EPOCH).total_seconds() * 1000

--- a/tests/unit_tests/utils/json_tests.py
+++ b/tests/unit_tests/utils/json_tests.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
+import pytz
 import pytest
 
 from superset.utils import json
@@ -252,6 +253,11 @@ def test_json_int_dttm_ser():
     assert json.json_int_dttm_ser(datetime(1970, 1, 1)) == 0
     assert json.json_int_dttm_ser(date(1970, 1, 1)) == 0
     assert json.json_int_dttm_ser(dttm + timedelta(milliseconds=1)) == (ts + 1)
+
+    # Timezone-aware datetime should preserve the absolute instant.
+    # 2020-01-01 00:00:00+08:00 == 2019-12-31 16:00:00Z
+    dttm_tz = datetime(2020, 1, 1, tzinfo=pytz.FixedOffset(8 * 60))
+    assert json.json_int_dttm_ser(dttm_tz) == 1577808000000.0
     assert json.json_int_dttm_ser(np.int64(1)) == 1
 
     with pytest.raises(TypeError):

--- a/tests/unit_tests/utils/json_tests.py
+++ b/tests/unit_tests/utils/json_tests.py
@@ -23,8 +23,8 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
-import pytz
 import pytest
+import pytz
 
 from superset.utils import json
 from superset.utils.core import (


### PR DESCRIPTION
### SUMMARY
Fixes an epoch-shift bug in Explore Results when switching “Formatted date” ↔ “Original value” by correcting timezone-aware datetime → epoch conversion to preserve the absolute instant.

Convert tz-aware datetimes to UTC using astimezone(pytz.utc) instead of re-labeling tzinfo with replace(tzinfo=UTC).
Add a regression unit test covering tz-aware datetime serialization to epoch.

replace(tzinfo=UTC) changes the represented instant for tz-aware datetimes, causing offsets like +8 hours in the serialized epoch; astimezone(UTC) performs a true conversion and keeps the instant consistent.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1919" height="976" alt="Screenshot 2026-02-15 at 00 21 58" src="https://github.com/user-attachments/assets/48f5a0ff-33fb-4feb-ac30-9bcc5a29ee07" />
<img width="1920" height="980" alt="Screenshot 2026-02-15 at 00 22 06" src="https://github.com/user-attachments/assets/092a043c-6dcc-4b4a-bb3e-a78ce31162fa" />


After:
<img width="1920" height="1040" alt="Screenshot 2026-02-15 at 00 21 09" src="https://github.com/user-attachments/assets/ab3e353e-9bf6-4519-911b-08a315f88794" />

<img width="1920" height="976" alt="Screenshot 2026-02-15 at 00 21 31" src="https://github.com/user-attachments/assets/fbe7933f-0952-42a8-bc6f-d8fa14031d3c" />



### TESTING INSTRUCTIONS
- Create a local postgres db instance on docker with a certain timezone other than UTC.
`docker run -d --name postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e TZ=Asia/Shanghai -p 5432:5432 postgres:latest`
- Create an example dataset on this DB which looks like this:
<img width="1515" height="656" alt="Screenshot 2026-02-15 at 00 26 58" src="https://github.com/user-attachments/assets/59e86e88-0f38-4a84-beb6-aba1d6a3bc5f" />
- Explore the dataset as explained in the issue.
- Also you can run this test:
`python -m pytest tests/unit_tests/utils/json_tests.py::test_json_int_dttm_ser`

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #37947.
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
