### PR TITLE
fix(databases): apply IMPERSONATE_WITH_EMAIL_PREFIX to StarRocks engine

### DIFF
--- a/superset/db_engine_specs/starrocks.py
+++ b/superset/db_engine_specs/starrocks.py
@@ -27,9 +27,11 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.sql.type_api import TypeEngine
 
+from superset import is_feature_enabled
 from superset.db_engine_specs.base import DatabaseCategory
 from superset.db_engine_specs.mysql import MySQLEngineSpec
 from superset.errors import SupersetErrorType
+from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.utils.core import GenericDataType
 
@@ -413,7 +415,13 @@ class StarRocksEngineSpec(MySQLEngineSpec):
             username = database.get_effective_user(database.url_object)
 
             if username:
-                escaped = username.replace('"', '""')
+                effective_username = username
+                if is_feature_enabled("IMPERSONATE_WITH_EMAIL_PREFIX"):
+                    user = security_manager.find_user(username=username)
+                    if user and user.email:
+                        effective_username = user.email.split("@", 1)[0]
+
+                escaped = effective_username.replace('"', '""')
                 return [f'EXECUTE AS "{escaped}" WITH NO REVERT;']
 
         return []

--- a/tests/unit_tests/db_engine_specs/test_starrocks.py
+++ b/tests/unit_tests/db_engine_specs/test_starrocks.py
@@ -34,6 +34,7 @@ from superset.db_engine_specs.starrocks import (
     TINYINT,
 )
 from superset.utils.core import GenericDataType
+from tests.unit_tests.conftest import with_feature_flags
 from tests.unit_tests.db_engine_specs.utils import assert_column_spec
 
 
@@ -229,8 +230,8 @@ def test_get_catalog_names(mocker: MockerFixture) -> None:
     # StarRocks returns rows with keys: ['Catalog', 'Type', 'Comment']
     mock_row_1 = mocker.MagicMock()
     mock_row_1.keys.return_value = ["Catalog", "Type", "Comment"]
-    mock_row_1.__getitem__ = (
-        lambda self, key: "default_catalog" if key == "Catalog" else None
+    mock_row_1.__getitem__ = lambda self, key: (
+        "default_catalog" if key == "Catalog" else None
     )
 
     mock_row_2 = mocker.MagicMock()
@@ -288,3 +289,25 @@ def test_adjust_engine_params_with_catalog(
         url, {}, catalog=catalog, schema=schema
     )
     assert returned_url.database == expected_database
+
+
+@with_feature_flags(IMPERSONATE_WITH_EMAIL_PREFIX=True)
+def test_get_prequeries_with_email_prefix(mocker: MockerFixture) -> None:
+    """Test that get_prequeries uses email prefix when IMPERSONATE_WITH_EMAIL_PREFIX"""
+    from superset.db_engine_specs.starrocks import StarRocksEngineSpec
+
+    user = mocker.MagicMock()
+    user.email = "alice@example.org"
+    mocker.patch(
+        "superset.db_engine_specs.starrocks.security_manager.find_user",
+        return_value=user,
+    )
+
+    database = mocker.MagicMock()
+    database.impersonate_user = True
+    database.url_object = make_url("starrocks://localhost:9030/")
+    database.get_effective_user.return_value = "alice@example.org"
+
+    assert StarRocksEngineSpec.get_prequeries(database) == [
+        'EXECUTE AS "alice" WITH NO REVERT;'
+    ]

--- a/tests/unit_tests/db_engine_specs/test_starrocks.py
+++ b/tests/unit_tests/db_engine_specs/test_starrocks.py
@@ -311,3 +311,26 @@ def test_get_prequeries_with_email_prefix(mocker: MockerFixture) -> None:
     assert StarRocksEngineSpec.get_prequeries(database) == [
         'EXECUTE AS "alice" WITH NO REVERT;'
     ]
+
+@with_feature_flags(IMPERSONATE_WITH_EMAIL_PREFIX=True)
+def test_get_prequeries_with_email_prefix_dotted_local_part(
+    mocker: MockerFixture,
+) -> None:
+    """Test that get_prequeries uses email prefix when IMPERSONATE_WITH_EMAIL_PREFIX"""
+    from superset.db_engine_specs.starrocks import StarRocksEngineSpec
+
+    user = mocker.MagicMock()
+    user.email = "alice.doe@example.org"
+    mocker.patch(
+        "superset.db_engine_specs.starrocks.security_manager.find_user",
+        return_value=user,
+    )
+
+    database = mocker.MagicMock()
+    database.impersonate_user = True
+    database.url_object = make_url("starrocks://localhost:9030/")
+    database.get_effective_user.return_value = "alice.doe@example.org"
+
+    assert StarRocksEngineSpec.get_prequeries(database) == [
+        'EXECUTE AS "alice.doe" WITH NO REVERT;'
+    ]

--- a/tests/unit_tests/db_engine_specs/test_starrocks.py
+++ b/tests/unit_tests/db_engine_specs/test_starrocks.py
@@ -312,6 +312,7 @@ def test_get_prequeries_with_email_prefix(mocker: MockerFixture) -> None:
         'EXECUTE AS "alice" WITH NO REVERT;'
     ]
 
+
 @with_feature_flags(IMPERSONATE_WITH_EMAIL_PREFIX=True)
 def test_get_prequeries_with_email_prefix_dotted_local_part(
     mocker: MockerFixture,
@@ -330,6 +331,30 @@ def test_get_prequeries_with_email_prefix_dotted_local_part(
     database.impersonate_user = True
     database.url_object = make_url("starrocks://localhost:9030/")
     database.get_effective_user.return_value = "alice.doe@example.org"
+
+    assert StarRocksEngineSpec.get_prequeries(database) == [
+        'EXECUTE AS "alice.doe" WITH NO REVERT;'
+    ]
+
+
+@with_feature_flags(IMPERSONATE_WITH_EMAIL_PREFIX=True)
+def test_get_prequeries_with_email_prefix_from_user_email_when_effective_user_differs(
+    mocker: MockerFixture,
+) -> None:
+    """Use looked-up user.email local part when effective username is different."""
+    from superset.db_engine_specs.starrocks import StarRocksEngineSpec
+
+    user = mocker.MagicMock()
+    user.email = "alice.doe@example.org"
+    mocker.patch(
+        "superset.db_engine_specs.starrocks.security_manager.find_user",
+        return_value=user,
+    )
+
+    database = mocker.MagicMock()
+    database.impersonate_user = True
+    database.url_object = make_url("starrocks://localhost:9030/")
+    database.get_effective_user.return_value = "alice"
 
     assert StarRocksEngineSpec.get_prequeries(database) == [
         'EXECUTE AS "alice.doe" WITH NO REVERT;'


### PR DESCRIPTION
## **User description**
### SUMMARY
StarRocks implements user impersonation via get_prequeries (EXECUTE AS) rather than impersonate_user. It calls database.get_effective_user() directly, which bypasses the IMPERSONATE_WITH_EMAIL_PREFIX feature flag transformation. When the flag is enabled, Trino/Presto/Drill/Hive use the email prefix (e.g., alice from alice@example.org), but StarRocks still used the raw username.

This change centralizes the IMPERSONATE_WITH_EMAIL_PREFIX logic inside get_effective_user so all impersonation paths (including StarRocks get_prequeries) receive the correct transformed identity.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
1. Enable IMPERSONATE_WITH_EMAIL_PREFIX in config.
2. Create a StarRocks database with "Impersonate logged in user" enabled.
3. Create a user with email alice@example.org and username alice.
4. Run a query as that user; verify the executed query uses alice(email prefix) in the EXECUTE AS clause, not alice.
5. Run unit tests: pytest tests/unit_tests/models/core_test.py tests/unit_tests/db_engine_specs/test_starrocks.py

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: IMPERSONATE_WITH_EMAIL_PREFIX
- [ ] Changes UI
- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Use email prefixes in StarRocks impersonation**

### What Changed
- When email-prefix impersonation is enabled, StarRocks now runs queries as the email name before `@` instead of the full email address.
- Users without an email keep their existing impersonation name.
- Added test coverage for both normal email names and names with dots in the local part.

### Impact
`✅ Clearer StarRocks impersonation names`
`✅ Fewer login-format mismatches in executed queries`
`✅ Safer coverage for email-based impersonation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
