### PR TITLE
fix(charts): apply resample before rolling window in post-processing pipeline

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.test.ts
@@ -64,8 +64,8 @@ describe('BigNumberWithTrendline buildQuery', () => {
     expect(queryContext.queries.length).toBe(1);
     expect(queryContext.queries[0].post_processing).toEqual([
       { operation: 'pivot' },
-      { operation: 'rolling' },
       { operation: 'resample' },
+      { operation: 'rolling' },
       { operation: 'flatten' },
     ]);
   });
@@ -79,8 +79,8 @@ describe('BigNumberWithTrendline buildQuery', () => {
     expect(queryContext.queries.length).toBe(1);
     expect(queryContext.queries[0].post_processing).toEqual([
       { operation: 'pivot' },
-      { operation: 'rolling' },
       { operation: 'resample' },
+      { operation: 'rolling' },
       { operation: 'flatten' },
     ]);
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.ts
@@ -47,8 +47,8 @@ export default function buildQuery(formData: QueryFormData) {
         ...(timeColumn.length ? {} : { is_timeseries: true }),
         post_processing: [
           pivotOperator(formData, baseQueryObject),
-          rollingWindowOperator(formData, baseQueryObject),
           resampleOperator(formData, baseQueryObject),
+          rollingWindowOperator(formData, baseQueryObject),
           flattenOperator(formData, baseQueryObject),
         ].filter(Boolean),
       },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -75,9 +75,9 @@ export default function buildQuery(formData: QueryFormData) {
         time_offsets: isTimeComparison(fd, queryObject) ? fd.time_compare : [],
         post_processing: [
           pivotOperatorInRuntime,
+          resampleOperator(fd, queryObject),
           rollingWindowOperator(fd, queryObject),
           timeCompareOperator(fd, queryObject),
-          resampleOperator(fd, queryObject),
           renameOperator(fd, queryObject),
           flattenOperator(fd, queryObject),
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -94,13 +94,15 @@ export default function buildQuery(formData: QueryFormData) {
         time_offsets,
         /* Note that:
           1. The resample, rolling, cum, timeCompare operators should be after pivot.
-          2. the flatOperator makes multiIndex Dataframe into flat Dataframe
+          2. Resample must come before rolling so that imputed values are
+             included in the rolling window calculation.
+          3. the flatOperator makes multiIndex Dataframe into flat Dataframe
         */
         post_processing: [
           pivotOperatorInRuntime,
+          resampleOperator(formData, baseQueryObject),
           rollingWindowOperator(formData, baseQueryObject),
           timeCompareOperator(formData, baseQueryObject),
-          resampleOperator(formData, baseQueryObject),
           renameOperator(formData, baseQueryObject),
           contributionOperator(formData, baseQueryObject, time_offsets),
           sortOperator(formData, baseQueryObject),

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -431,5 +431,5 @@ test('should add a formula annotation when X-axis column has dataset-level label
   expect(formulaSeries).toBeDefined();
   expect(formulaSeries?.data).toBeDefined();
   expect(Array.isArray(formulaSeries?.data)).toBe(true);
-  expect((formulaSeries?.data as unknown[])?.length).toBeGreaterThan(0);
+  expect((formulaSeries!.data as unknown[]).length).toBeGreaterThan(0);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -304,8 +304,8 @@ describe('EchartsTimeseries transformProps', () => {
     expect(formulaSeries).toBeDefined();
     expect(formulaSeries?.data).toBeDefined();
     expect(Array.isArray(formulaSeries?.data)).toBe(true);
-    expect((formulaSeries?.data as unknown[])?.length).toBeGreaterThan(0);
-    const firstDataPoint = (formulaSeries?.data as [number, number][])?.[0];
+    expect((formulaSeries!.data as unknown[]).length).toBeGreaterThan(0);
+    const firstDataPoint = (formulaSeries!.data as [number, number][])[0];
     expect(firstDataPoint).toBeDefined();
     expect(firstDataPoint[1]).toBe(firstDataPoint[0] * 2);
   });
@@ -384,7 +384,7 @@ describe('EchartsTimeseries transformProps', () => {
       result.echartOptions.series as SeriesOption[] | undefined
     )?.find((s: SeriesOption) => s.name === 'My Formula');
     expect(formulaSeries).toBeDefined();
-    const firstDataPoint = (formulaSeries?.data as [number, number][])?.[0];
+    const firstDataPoint = (formulaSeries!.data as [number, number][])[0];
     expect(firstDataPoint).toBeDefined();
     expect(firstDataPoint[0]).toBe(firstDataPoint[1] * 2);
   });


### PR DESCRIPTION
### SUMMARY

When using both resampling (e.g., "1 calendar day frequency" with zero imputation) and a rolling window function (e.g., rolling mean) on time-series charts, the results come out wrong — you get a stepped graph alternating between the original values and zero instead of a smooth rolling curve.

The root cause is that the rolling window operator was being applied *before* the resample operator in the post-processing pipeline. This means the rolling calculation runs on the sparse original data, and then resampling fills in zeros afterward — which defeats the purpose. The correct order is to resample first (filling gaps with zeros or other imputation), and then apply the rolling window over that complete series.

This swaps the order in all three affected chart types:
- **Timeseries** (line, bar, area, step)
- **MixedTimeseries** (dual-axis)
- **BigNumberWithTrendline**

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before** (from issue report): stepped graph with values jumping between 5 and 0
![before](https://user-images.githubusercontent.com/108309305/218611115-b343b6b9-039c-4a23-9855-0dd19af974a0.png)

**Expected** (smooth rolling mean curve):
![expected](https://user-images.githubusercontent.com/108309305/218612718-10fd72e0-3966-4bc6-8081-360184505077.png)

### TESTING INSTRUCTIONS

1. Upload [demo.csv](https://github.com/apache/superset/files/10727554/demo.csv) from the issue as a dataset
2. Create a Time-series Line Chart, set metric to AVG(value)
3. Under Advanced Analytics, set resampling to "1 calendar day frequency" with "Zero imputation"
4. Set rolling window function to "mean" with period and min periods = 5
5. Update chart — should now show a smooth rolling curve instead of the stepped pattern

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #23072
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API