### PR TITLE
fix(plugin/cal-heatmap): properly color tooltip's text for both dark/light theme

### DIFF
--- a/superset-frontend/packages/superset-ui-core/test/utils/getSelectedText.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/getSelectedText.test.ts
@@ -27,8 +27,7 @@ test('Returns null if Selection object is null', () => {
 test('Returns selection text if Selection object is not null', () => {
   jest
     .spyOn(window, 'getSelection')
-    // @ts-expect-error
-    .mockImplementationOnce(() => ({ toString: () => 'test string' }));
+    .mockImplementationOnce(() => ({ toString: () => 'test string' }) as any);
   expect(getSelectedText()).toEqual('test string');
   jest.restoreAllMocks();
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/ReactCalendar.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/ReactCalendar.tsx
@@ -46,7 +46,7 @@ const Calendar = ({ className, ...otherProps }: CalendarWrapperProps) => {
             line-height: 1;
             padding: ${theme.sizeUnit * 3}px;
             background: ${theme.colorBgElevated};
-            color: ${theme.colorTextLightSolid};
+            color: ${theme.colorTextBase};
             border-radius: 4px;
             pointer-events: none;
             z-index: 1000;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(plugin/cal-heatmap): properly color tooltip's text for both dark/light theme

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #37991

Color the text in cal-heatmap's tooltip across dark and light theme

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
| Theme | Before | After |
| :--- | :--- | :--- |
| **Light** | <img width="744" alt="image" src="https://github.com/user-attachments/assets/7940d43e-5c25-4a7b-bada-ecf2223f9fb8" /> | <img src="https://github.com/user-attachments/assets/680b7ee7-9ad5-4a16-82be-d64b593282cf" width="744" /> |
| **Dark** | <img src="https://github.com/user-attachments/assets/5e3e01b7-dea8-49ca-801c-905d5581cffd" width="744" /> | <img src="https://github.com/user-attachments/assets/05351d34-86d5-4cd7-8db1-27c785af3a60" width="744" /> |


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Follow instructions in the linked issue.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
