### PR TITLE
chore: use Node's native UUID v4 instead of third party

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -149,7 +149,6 @@
         "use-event-callback": "^0.1.0",
         "use-immer": "^0.11.0",
         "use-query-params": "^2.2.2",
-        "uuid": "^13.0.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "yargs": "^17.7.2"
       },
@@ -49556,19 +49555,6 @@
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/uvu": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -230,7 +230,6 @@
     "use-event-callback": "^0.1.0",
     "use-immer": "^0.11.0",
     "use-query-params": "^2.2.2",
-    "uuid": "^13.0.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yargs": "^17.7.2"
   },

--- a/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.ts
@@ -24,7 +24,7 @@
 
 import { Metric, ColumnMeta } from '@superset-ui/chart-controls';
 import { t } from '@apache-superset/core';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import {
   DatasourceFolder,
   DatasourceFolderItem,
@@ -36,7 +36,7 @@ import {
 } from './constants';
 
 export const createFolder = (name: string): DatasourceFolder => ({
-  uuid: uuidv4(),
+  uuid: randomUUID(),
   type: FoldersEditorItemType.Folder,
   name,
   children: [],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore: use Node's native UUID v4 instead of third party

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A very small PR to replace third party `uuid` v4 usage with Node's native equivalent; [randomUUID](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Green CI as acceptance criterion

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
