### PR TITLE
fix(chart): make chart error banners non-dismissible

### DIFF
--- a/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
@@ -82,4 +82,17 @@ describe('ChartErrorMessage', () => {
     expect(screen.getByText('Test error')).toBeInTheDocument();
     expect(screen.getByText('Test subtitle')).toBeInTheDocument();
   });
+
+  test('chart error banner is not dismissible', () => {
+    mockUseChartOwnerNames.mockReturnValue({
+      result: null,
+      status: ResourceStatus.Loading,
+      error: null,
+    });
+    render(<ChartErrorMessage {...defaultProps} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Close' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
@@ -92,7 +92,7 @@ describe('ChartErrorMessage', () => {
     render(<ChartErrorMessage {...defaultProps} />);
 
     expect(
-      screen.queryByRole('button', { name: 'Close' }),
+      screen.queryByRole('button', { name: /close/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
@@ -49,6 +49,7 @@ export const ChartErrorMessage: FC<Props> = ({ chartId, error, ...props }) => {
       {...props}
       error={ownedError}
       title={DEFAULT_CHART_ERROR}
+      closable={false}
     />
   );
 };

--- a/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatabaseErrorMessage.tsx
@@ -39,6 +39,7 @@ interface DatabaseErrorExtra {
 export function DatabaseErrorMessage({
   error,
   source,
+  closable,
 }: ErrorMessageComponentProps<DatabaseErrorExtra | null>) {
   const { extra, level, message } = error;
 
@@ -101,6 +102,7 @@ export function DatabaseErrorMessage({
       description={alertDescription}
       type={level}
       descriptionDetails={body}
+      closable={closable}
     />
   );
 }

--- a/superset-frontend/src/components/ErrorMessage/DatasetNotFoundErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/DatasetNotFoundErrorMessage.tsx
@@ -24,6 +24,7 @@ import { ErrorAlert } from './ErrorAlert';
 export function DatasetNotFoundErrorMessage({
   error,
   subtitle,
+  closable,
 }: ErrorMessageComponentProps) {
   const { level, message } = error;
   return (
@@ -32,6 +33,7 @@ export function DatasetNotFoundErrorMessage({
       message={subtitle}
       description={message}
       type={level}
+      closable={closable}
     />
   );
 }

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.test.tsx
@@ -58,6 +58,18 @@ test('should render the link', () => {
   expect(link).toHaveAttribute('href', mockedProps.link);
 });
 
+test('should render a close button by default', () => {
+  render(<ErrorMessageWithStackTrace {...mockedProps} />);
+  expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+});
+
+test('should not render a close button when closable is false', () => {
+  render(<ErrorMessageWithStackTrace {...mockedProps} closable={false} />);
+  expect(
+    screen.queryByRole('button', { name: /close/i }),
+  ).not.toBeInTheDocument();
+});
+
 test('should render the fallback', () => {
   const body = 'Blahblah';
   render(

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -38,6 +38,7 @@ type Props = {
   errorMitigationFunction?: () => void;
   fallback?: ReactNode;
   compact?: boolean;
+  closable?: boolean;
 };
 
 export function ErrorMessageWithStackTrace({
@@ -51,6 +52,7 @@ export function ErrorMessageWithStackTrace({
   descriptionDetails,
   fallback,
   compact,
+  closable = true,
 }: Props) {
   // Check if a custom error message component was registered for this message
   if (error) {
@@ -62,6 +64,7 @@ export function ErrorMessageWithStackTrace({
       return (
         <ErrorMessageComponent
           compact={compact}
+          closable={closable}
           error={error}
           source={source}
           subtitle={subtitle}
@@ -99,6 +102,7 @@ export function ErrorMessageWithStackTrace({
       description={description}
       descriptionDetails={computedDescriptionDetails}
       compact={compact}
+      closable={closable}
     />
   );
 }

--- a/superset-frontend/src/components/ErrorMessage/FrontendNetworkErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/FrontendNetworkErrorMessage.tsx
@@ -25,11 +25,13 @@ export function FrontendNetworkErrorMessage({
   error,
   subtitle,
   compact,
+  closable,
 }: ErrorMessageComponentProps) {
   const { level, message } = error;
   return (
     <ErrorAlert
       compact={compact}
+      closable={closable}
       errorType={t('Network Error')}
       message={message}
       type={level}

--- a/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.tsx
@@ -34,6 +34,7 @@ interface SupersetParseErrorExtra {
 export function InvalidSQLErrorMessage({
   error,
   subtitle,
+  closable,
 }: ErrorMessageComponentProps<SupersetParseErrorExtra>) {
   const { extra, level, message } = error;
 
@@ -58,6 +59,7 @@ export function InvalidSQLErrorMessage({
       message={subtitle}
       type={level}
       description={body}
+      closable={closable}
     />
   );
 }

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
@@ -63,6 +63,7 @@ interface OAuth2RedirectExtra {
 export function OAuth2RedirectMessage({
   error,
   source,
+  closable,
 }: ErrorMessageComponentProps<OAuth2RedirectExtra>) {
   const oAuthTab = useRef<Window | null>(null);
   const { extra, level } = error;
@@ -173,6 +174,7 @@ export function OAuth2RedirectMessage({
       message={subtitle}
       type={level}
       description={body}
+      closable={closable}
     />
   );
 }

--- a/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ParameterErrorMessage.tsx
@@ -56,6 +56,7 @@ const findMatches = (undefinedParameters: string[], templateKeys: string[]) => {
 export function ParameterErrorMessage({
   error,
   subtitle,
+  closable,
 }: ErrorMessageComponentProps<ParameterErrorExtra>) {
   const { extra = { issue_codes: [] }, level, message } = error;
 
@@ -118,6 +119,7 @@ export function ParameterErrorMessage({
       message={message}
       description={subtitle}
       descriptionDetails={body}
+      closable={closable}
     />
   );
 }

--- a/superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/TimeoutErrorMessage.tsx
@@ -36,6 +36,7 @@ interface TimeoutErrorExtra {
 export function TimeoutErrorMessage({
   error,
   source,
+  closable,
 }: ErrorMessageComponentProps<TimeoutErrorExtra>) {
   const { extra, level } = error;
 
@@ -95,6 +96,7 @@ export function TimeoutErrorMessage({
       message={subtitle}
       type={level}
       descriptionDetails={body}
+      closable={closable}
     />
   );
 }

--- a/superset-frontend/src/components/ErrorMessage/types.ts
+++ b/superset-frontend/src/components/ErrorMessage/types.ts
@@ -26,6 +26,7 @@ export type ErrorMessageComponentProps<ExtraType = Record<string, any> | null> =
     source?: ErrorSource;
     subtitle?: ReactNode;
     compact?: boolean;
+    closable?: boolean;
   };
 
 export type ErrorMessageComponent = ComponentType<ErrorMessageComponentProps>;

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
@@ -370,6 +370,31 @@ test('should fallback to formData state when runtime state not available', () =>
   expect(getByTestId('chart-container')).toBeInTheDocument();
 });
 
+test('should not show a close button on chart error banners', () => {
+  const { queryByRole } = setup(
+    {},
+    {
+      ...defaultState,
+      charts: {
+        ...defaultState.charts,
+        [queryId]: {
+          ...defaultState.charts[queryId],
+          chartStatus: 'failed',
+          chartAlert: 'Something went wrong',
+          queriesResponse: [
+            {
+              message: 'Something went wrong',
+              errors: [],
+            },
+          ],
+        },
+      },
+    },
+  );
+
+  expect(queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+});
+
 test('should handle chart state when no converter exists', () => {
   jest
     .spyOn(chartStateConverter, 'hasChartStateConverter')

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
@@ -392,7 +392,7 @@ test('should not show a close button on chart error banners', () => {
     },
   );
 
-  expect(queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+  expect(queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
 });
 
 test('should handle chart state when no converter exists', () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a chart query fails and an error banner is displayed inside the chart panel; whether on a dashboard or in the explore view; users could dismiss it via a close button. This was misleading because the error condition hasn't actually been resolved; the chart is still broken, and removing the banner just hides that fact. The user would then see an empty chart tile with no indication of what went wrong.

This change threads a closable prop through the error message component chain so that ChartErrorMessage can explicitly opt out of the close button. The default behavior for all other error surfaces (SQL Lab, standalone alerts, etc.) remains unchanged; they still render a dismissible close button as before.

### How the error rendering chain works

```
Chart.tsx (dashboard/explore)
  └─ ChartErrorMessage          ← entry point for chart errors; sets closable={false}
       └─ ErrorMessageWithStackTrace   ← routing layer; decides which component renders
            ├─ [Registered ErrorMessageComponent]  ← looked up from a registry by error_type
            │    e.g. DatabaseErrorMessage, TimeoutErrorMessage, ParameterErrorMessage...
            │    └─ ErrorAlert           ← the actual UI component (wraps antd Alert)
            └─ ErrorAlert (fallback)     ← used when no registered component matches
```

`ErrorMessageWithStackTrace` acts as a router: it checks a global registry `(getErrorMessageComponentRegistry())` for a component registered under the error's `error_type`. If one exists (e.g. `DatabaseErrorMessage` for database errors, `TimeoutErrorMessage` for timeouts), it renders that specialized component. Otherwise, it falls back to rendering `ErrorAlert` directly.

Each registered error component adds its own contextual information (e.g. suggested fixes, owner contact info) but ultimately delegates to `ErrorAlert` for the actual alert UI. `ErrorAlert` wraps antd's Alert component, which is where the close button lives.

Because closable needs to travel from `ChartErrorMessage` all the way down to `ErrorAlert`, every layer in this chain was updated to accept and forward the prop: the shared `ErrorMessageComponentProps` type, `ErrorMessageWithStackTrace`, and all seven registered error components.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

- Before
<img width="469" height="447" alt="Screenshot 2026-02-12 151813" src="https://github.com/user-attachments/assets/cb72c5ab-cec5-4837-b280-b3ca441dd5fa" />

- After

<img width="469" height="447" alt="x-after" src="https://github.com/user-attachments/assets/0c52313e-0fb8-4169-897b-281ab847ad8f" />

<img width="476" height="496" alt="Screenshot 2026-02-17 132337" src="https://github.com/user-attachments/assets/3c62c884-208d-4d9e-8c27-ca071460003e" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Open a dashboard that contains a chart with a known query error (or deliberately break a chart's query to trigger a failure)
2. Observe the error banner displayed inside the chart tile; verify there is no close/X button on the error alert
3. Open the explore view for the same broken chart; verify the error banner there also has no close button
4. Navigate to SQL Lab, run an invalid query that triggers an error; verify the error alert there still has a close button (this behavior should be unchanged)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
