### PR TITLE
fix(alerts): show friendly filter names in report edit modal

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -842,9 +842,13 @@ test('filter reappears in dropdown after clearing with X icon', async () => {
     { name: 'clear-icon-tabs' },
   );
 
-  fetchMock.post(chartDataEndpoint, { result: [{ data: [] }] }, {
-    name: 'clear-icon-chart-data',
-  });
+  fetchMock.post(
+    chartDataEndpoint,
+    { result: [{ data: [] }] },
+    {
+      name: 'clear-icon-chart-data',
+    },
+  );
 
   render(<AlertReportModal {...generateMockedProps(true, true)} />, {
     useRedux: true,
@@ -976,14 +980,16 @@ test('tabs metadata overwrites seeded filter options', async () => {
 
   // Replace only the tabs route with a deferred version
   fetchMock.removeRoute(tabsEndpoint);
-  fetchMock.get(
-    tabsEndpoint,
-    () => deferredTabs.then(() => tabsResult),
-    { name: 'deferred-tabs' },
-  );
-  fetchMock.post(chartDataEndpoint, { result: [{ data: [] }] }, {
-    name: 'overwrite-chart-data',
+  fetchMock.get(tabsEndpoint, () => deferredTabs.then(() => tabsResult), {
+    name: 'deferred-tabs',
   });
+  fetchMock.post(
+    chartDataEndpoint,
+    { result: [{ data: [] }] },
+    {
+      name: 'overwrite-chart-data',
+    },
+  );
 
   const props = generateMockedProps(true, true);
   const editProps = {

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -196,6 +196,38 @@ fetchMock.get(
   { name: tabsEndpoint },
 );
 
+// Restore the default tabs route and remove any test-specific overrides.
+// Called in afterEach so cleanup runs even when a test fails mid-way.
+const restoreDefaultTabsRoute = () => {
+  for (const name of [
+    'clear-icon-tabs',
+    'clear-icon-chart-data',
+    'deferred-tabs',
+    'overwrite-chart-data',
+  ]) {
+    try {
+      fetchMock.removeRoute(name);
+    } catch {
+      // route may not exist if the test that adds it didn't run
+    }
+  }
+  // Re-add the default empty tabs route if it was replaced
+  try {
+    fetchMock.removeRoute(tabsEndpoint);
+  } catch {
+    // already removed
+  }
+  fetchMock.get(
+    tabsEndpoint,
+    { result: { all_tabs: {}, tab_tree: [] } },
+    { name: tabsEndpoint },
+  );
+};
+
+afterEach(() => {
+  restoreDefaultTabsRoute();
+});
+
 // Create a valid alert with all required fields entered for validation check
 
 // @ts-expect-error will add id in factory function
@@ -864,15 +896,6 @@ test('filter reappears in dropdown after clearing with X icon', async () => {
       within(virtualList as HTMLElement).getByText('Test Filter 1'),
     ).toBeInTheDocument();
   });
-
-  // Restore original tabs mock and remove chart data mock
-  fetchMock.removeRoute('clear-icon-tabs');
-  fetchMock.removeRoute('clear-icon-chart-data');
-  fetchMock.get(
-    tabsEndpoint,
-    { result: { all_tabs: {}, tab_tree: [] } },
-    { name: tabsEndpoint },
-  );
 });
 
 test('edit mode shows friendly filter names instead of raw IDs', async () => {
@@ -997,13 +1020,4 @@ test('tabs metadata overwrites seeded filter options', async () => {
   expect(
     within(selectContainer).queryByTitle('Country'),
   ).not.toBeInTheDocument();
-
-  // Restore the tabs route and remove chart data mock
-  fetchMock.removeRoute('deferred-tabs');
-  fetchMock.removeRoute('overwrite-chart-data');
-  fetchMock.get(
-    tabsEndpoint,
-    { result: { all_tabs: {}, tab_tree: [] } },
-    { name: tabsEndpoint },
-  );
 });

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -106,6 +106,7 @@ const FETCH_DASHBOARD_ENDPOINT = 'glob:*/api/v1/report/1';
 const FETCH_CHART_ENDPOINT = 'glob:*/api/v1/report/2';
 const FETCH_REPORT_WITH_FILTERS_ENDPOINT = 'glob:*/api/v1/report/3';
 const FETCH_REPORT_NO_FILTER_NAME_ENDPOINT = 'glob:*/api/v1/report/4';
+const FETCH_REPORT_OVERWRITE_ENDPOINT = 'glob:*/api/v1/report/5';
 
 fetchMock.get(FETCH_DASHBOARD_ENDPOINT, { result: generateMockPayload(true) });
 fetchMock.get(FETCH_CHART_ENDPOINT, { result: generateMockPayload(false) });
@@ -144,6 +145,27 @@ fetchMock.get(FETCH_REPORT_NO_FILTER_NAME_ENDPOINT, {
             columnName: 'region',
             columnLabel: 'Region',
             filterValues: ['West'],
+          },
+        ],
+      },
+    },
+  },
+});
+fetchMock.get(FETCH_REPORT_OVERWRITE_ENDPOINT, {
+  result: {
+    ...generateMockPayload(true),
+    id: 5,
+    type: 'Report',
+    extra: {
+      dashboard: {
+        nativeFilters: [
+          {
+            nativeFilterId: 'NATIVE_FILTER-abc123',
+            filterName: 'Country',
+            filterType: 'filter_select',
+            columnName: 'country',
+            columnLabel: 'Country',
+            filterValues: ['USA'],
           },
         ],
       },
@@ -883,4 +905,84 @@ test('edit mode falls back to raw ID when filterName is missing', async () => {
     );
     expect(selectionItem).toBeInTheDocument();
   });
+});
+
+test('tabs metadata overwrites seeded filter options', async () => {
+  const chartDataEndpoint = 'glob:*/api/v1/chart/data*';
+
+  // Clear all routes and re-establish the ones needed for this test
+  fetchMock.removeRoutes();
+  fetchMock.get(FETCH_REPORT_OVERWRITE_ENDPOINT, {
+    result: {
+      ...generateMockPayload(true),
+      id: 5,
+      type: 'Report',
+      extra: {
+        dashboard: {
+          nativeFilters: [
+            {
+              nativeFilterId: 'NATIVE_FILTER-abc123',
+              filterName: 'Country',
+              filterType: 'filter_select',
+              columnName: 'country',
+              columnLabel: 'Country',
+              filterValues: ['USA'],
+            },
+          ],
+        },
+      },
+    },
+  });
+  fetchMock.get(ownersEndpoint, { result: [] });
+  fetchMock.get(databaseEndpoint, { result: [] });
+  fetchMock.get(dashboardEndpoint, { result: [] });
+  fetchMock.get(chartEndpoint, {
+    result: [{ text: 'table chart', value: 1 }],
+  });
+  fetchMock.get(tabsEndpoint, {
+    result: {
+      all_tabs: { tab1: 'Tab 1' },
+      tab_tree: [{ title: 'Tab 1', value: 'tab1' }],
+      native_filters: {
+        all: [
+          {
+            id: 'NATIVE_FILTER-abc123',
+            name: 'Country (All Filters)',
+            filterType: 'filter_select',
+            targets: [{ column: { name: 'country' }, datasetId: 1 }],
+            adhoc_filters: [],
+          },
+        ],
+        tab1: [],
+      },
+    },
+  });
+  fetchMock.post(chartDataEndpoint, { result: [{ data: [] }] });
+
+  const props = generateMockedProps(true, true);
+  const editProps = {
+    ...props,
+    alert: { ...validAlert, id: 5 },
+  };
+
+  render(<AlertReportModal {...editProps} />, {
+    useRedux: true,
+  });
+
+  userEvent.click(screen.getByTestId('contents-panel'));
+
+  // Tabs metadata should overwrite the seeded "Country" with "Country (All Filters)"
+  await waitFor(() => {
+    const updatedItem = document.querySelector(
+      '.ant-select-selection-item[title="Country (All Filters)"]',
+    );
+    expect(updatedItem).toBeInTheDocument();
+  });
+
+  // The original seeded label should no longer be displayed
+  expect(
+    document.querySelector(
+      '.ant-select-selection-item[title="Country"]',
+    ),
+  ).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -104,9 +104,52 @@ const generateMockPayload = (dashboard = true) => {
 // mocking resource endpoints
 const FETCH_DASHBOARD_ENDPOINT = 'glob:*/api/v1/report/1';
 const FETCH_CHART_ENDPOINT = 'glob:*/api/v1/report/2';
+const FETCH_REPORT_WITH_FILTERS_ENDPOINT = 'glob:*/api/v1/report/3';
+const FETCH_REPORT_NO_FILTER_NAME_ENDPOINT = 'glob:*/api/v1/report/4';
 
 fetchMock.get(FETCH_DASHBOARD_ENDPOINT, { result: generateMockPayload(true) });
 fetchMock.get(FETCH_CHART_ENDPOINT, { result: generateMockPayload(false) });
+fetchMock.get(FETCH_REPORT_WITH_FILTERS_ENDPOINT, {
+  result: {
+    ...generateMockPayload(true),
+    id: 3,
+    type: 'Report',
+    extra: {
+      dashboard: {
+        nativeFilters: [
+          {
+            nativeFilterId: 'NATIVE_FILTER-abc123',
+            filterName: 'Country',
+            filterType: 'filter_select',
+            columnName: 'country',
+            columnLabel: 'Country',
+            filterValues: ['USA'],
+          },
+        ],
+      },
+    },
+  },
+});
+fetchMock.get(FETCH_REPORT_NO_FILTER_NAME_ENDPOINT, {
+  result: {
+    ...generateMockPayload(true),
+    id: 4,
+    type: 'Report',
+    extra: {
+      dashboard: {
+        nativeFilters: [
+          {
+            nativeFilterId: 'NATIVE_FILTER-xyz789',
+            filterType: 'filter_select',
+            columnName: 'region',
+            columnLabel: 'Region',
+            filterValues: ['West'],
+          },
+        ],
+      },
+    },
+  },
+});
 
 // Related mocks
 const ownersEndpoint = 'glob:*/api/v1/alert/related/owners?*';
@@ -791,5 +834,53 @@ test('filter reappears in dropdown after clearing with X icon', async () => {
     expect(
       within(virtualList as HTMLElement).getByText('Test Filter 1'),
     ).toBeInTheDocument();
+  });
+});
+
+test('edit mode shows friendly filter names instead of raw IDs', async () => {
+  const props = generateMockedProps(true, true);
+  const editProps = {
+    ...props,
+    alert: { ...validAlert, id: 3 },
+  };
+
+  render(<AlertReportModal {...editProps} />, {
+    useRedux: true,
+  });
+
+  userEvent.click(screen.getByTestId('contents-panel'));
+
+  await waitFor(() => {
+    const selectionItem = document.querySelector(
+      '.ant-select-selection-item[title="Country"]',
+    );
+    expect(selectionItem).toBeInTheDocument();
+  });
+
+  expect(
+    document.querySelector(
+      '.ant-select-selection-item[title="NATIVE_FILTER-abc123"]',
+    ),
+  ).not.toBeInTheDocument();
+});
+
+test('edit mode falls back to raw ID when filterName is missing', async () => {
+  const props = generateMockedProps(true, true);
+  const editProps = {
+    ...props,
+    alert: { ...validAlert, id: 4 },
+  };
+
+  render(<AlertReportModal {...editProps} />, {
+    useRedux: true,
+  });
+
+  userEvent.click(screen.getByTestId('contents-panel'));
+
+  await waitFor(() => {
+    const selectionItem = document.querySelector(
+      '.ant-select-selection-item[title="NATIVE_FILTER-xyz789"]',
+    );
+    expect(selectionItem).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -18,6 +18,7 @@
  */
 import fetchMock from 'fetch-mock';
 import {
+  act,
   render,
   screen,
   userEvent,
@@ -778,34 +779,40 @@ test('filter reappears in dropdown after clearing with X icon', async () => {
   const chartDataEndpoint = 'glob:*/api/v1/chart/data*';
 
   fetchMock.removeRoute(tabsEndpoint);
-  fetchMock.get(tabsEndpoint, {
-    result: {
-      all_tabs: { tab1: 'Tab 1' },
-      tab_tree: [{ title: 'Tab 1', value: 'tab1' }],
-      native_filters: {
-        all: [
-          {
-            id: 'NATIVE_FILTER-test1',
-            name: 'Test Filter 1',
-            filterType: 'filter_select',
-            targets: [{ column: { name: 'test_column_1' } }],
-            adhoc_filters: [],
-          },
-        ],
-        tab1: [
-          {
-            id: 'NATIVE_FILTER-test2',
-            name: 'Test Filter 2',
-            filterType: 'filter_select',
-            targets: [{ column: { name: 'test_column_2' } }],
-            adhoc_filters: [],
-          },
-        ],
+  fetchMock.get(
+    tabsEndpoint,
+    {
+      result: {
+        all_tabs: { tab1: 'Tab 1' },
+        tab_tree: [{ title: 'Tab 1', value: 'tab1' }],
+        native_filters: {
+          all: [
+            {
+              id: 'NATIVE_FILTER-test1',
+              name: 'Test Filter 1',
+              filterType: 'filter_select',
+              targets: [{ column: { name: 'test_column_1' } }],
+              adhoc_filters: [],
+            },
+          ],
+          tab1: [
+            {
+              id: 'NATIVE_FILTER-test2',
+              name: 'Test Filter 2',
+              filterType: 'filter_select',
+              targets: [{ column: { name: 'test_column_2' } }],
+              adhoc_filters: [],
+            },
+          ],
+        },
       },
     },
-  });
+    { name: 'clear-icon-tabs' },
+  );
 
-  fetchMock.post(chartDataEndpoint, { result: [{ data: [] }] });
+  fetchMock.post(chartDataEndpoint, { result: [{ data: [] }] }, {
+    name: 'clear-icon-chart-data',
+  });
 
   render(<AlertReportModal {...generateMockedProps(true, true)} />, {
     useRedux: true,
@@ -857,6 +864,15 @@ test('filter reappears in dropdown after clearing with X icon', async () => {
       within(virtualList as HTMLElement).getByText('Test Filter 1'),
     ).toBeInTheDocument();
   });
+
+  // Restore original tabs mock and remove chart data mock
+  fetchMock.removeRoute('clear-icon-tabs');
+  fetchMock.removeRoute('clear-icon-chart-data');
+  fetchMock.get(
+    tabsEndpoint,
+    { result: { all_tabs: {}, tab_tree: [] } },
+    { name: tabsEndpoint },
+  );
 });
 
 test('edit mode shows friendly filter names instead of raw IDs', async () => {
@@ -910,36 +926,13 @@ test('edit mode falls back to raw ID when filterName is missing', async () => {
 test('tabs metadata overwrites seeded filter options', async () => {
   const chartDataEndpoint = 'glob:*/api/v1/chart/data*';
 
-  // Clear all routes and re-establish the ones needed for this test
-  fetchMock.removeRoutes();
-  fetchMock.get(FETCH_REPORT_OVERWRITE_ENDPOINT, {
-    result: {
-      ...generateMockPayload(true),
-      id: 5,
-      type: 'Report',
-      extra: {
-        dashboard: {
-          nativeFilters: [
-            {
-              nativeFilterId: 'NATIVE_FILTER-abc123',
-              filterName: 'Country',
-              filterType: 'filter_select',
-              columnName: 'country',
-              columnLabel: 'Country',
-              filterValues: ['USA'],
-            },
-          ],
-        },
-      },
-    },
+  // Deferred promise to control when the tabs response resolves
+  let resolveTabsResponse!: (value: unknown) => void;
+  const deferredTabs = new Promise(resolve => {
+    resolveTabsResponse = resolve;
   });
-  fetchMock.get(ownersEndpoint, { result: [] });
-  fetchMock.get(databaseEndpoint, { result: [] });
-  fetchMock.get(dashboardEndpoint, { result: [] });
-  fetchMock.get(chartEndpoint, {
-    result: [{ text: 'table chart', value: 1 }],
-  });
-  fetchMock.get(tabsEndpoint, {
+
+  const tabsResult = {
     result: {
       all_tabs: { tab1: 'Tab 1' },
       tab_tree: [{ title: 'Tab 1', value: 'tab1' }],
@@ -956,8 +949,18 @@ test('tabs metadata overwrites seeded filter options', async () => {
         tab1: [],
       },
     },
+  };
+
+  // Replace only the tabs route with a deferred version
+  fetchMock.removeRoute(tabsEndpoint);
+  fetchMock.get(
+    tabsEndpoint,
+    () => deferredTabs.then(() => tabsResult),
+    { name: 'deferred-tabs' },
+  );
+  fetchMock.post(chartDataEndpoint, { result: [{ data: [] }] }, {
+    name: 'overwrite-chart-data',
   });
-  fetchMock.post(chartDataEndpoint, { result: [{ data: [] }] });
 
   const props = generateMockedProps(true, true);
   const editProps = {
@@ -971,18 +974,36 @@ test('tabs metadata overwrites seeded filter options', async () => {
 
   userEvent.click(screen.getByTestId('contents-panel'));
 
-  // Tabs metadata should overwrite the seeded "Country" with "Country (All Filters)"
+  // Seeded label from saved data appears before tabs respond
+  const filterSelect = screen.getByRole('combobox', {
+    name: /select filter/i,
+  });
+  const selectContainer = filterSelect.closest('.ant-select') as HTMLElement;
   await waitFor(() => {
-    const updatedItem = document.querySelector(
-      '.ant-select-selection-item[title="Country (All Filters)"]',
-    );
-    expect(updatedItem).toBeInTheDocument();
+    expect(within(selectContainer).getByTitle('Country')).toBeInTheDocument();
   });
 
-  // The original seeded label should no longer be displayed
+  // Resolve the deferred tabs response
+  await act(async () => {
+    resolveTabsResponse(undefined);
+  });
+
+  // Tabs metadata overwrites the seeded label
+  await waitFor(() => {
+    expect(
+      within(selectContainer).getByTitle('Country (All Filters)'),
+    ).toBeInTheDocument();
+  });
   expect(
-    document.querySelector(
-      '.ant-select-selection-item[title="Country"]',
-    ),
+    within(selectContainer).queryByTitle('Country'),
   ).not.toBeInTheDocument();
+
+  // Restore the tabs route and remove chart data mock
+  fetchMock.removeRoute('deferred-tabs');
+  fetchMock.removeRoute('overwrite-chart-data');
+  fetchMock.get(
+    tabsEndpoint,
+    { result: { all_tabs: {}, tab_tree: [] } },
+    { name: tabsEndpoint },
+  );
 });

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1877,6 +1877,13 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       if (resource.extra?.dashboard?.nativeFilters) {
         const filters = resource.extra.dashboard.nativeFilters;
         setNativeFilterData(filters);
+        // Seed options from saved data so names display while dashboard metadata loads
+        const savedOptions = filters
+          .filter(f => f.nativeFilterId && f.filterName)
+          .map(f => ({ value: f.nativeFilterId!, label: f.filterName! }));
+        if (savedOptions.length > 0) {
+          setNativeFilterOptions(savedOptions);
+        }
       }
 
       // Add notification settings


### PR DESCRIPTION
### SUMMARY

When editing an existing report with saved dashboard filters, the filter dropdown shows raw native filter IDs (e.g., `NATIVE_FILTER-HX2lV--YaAZRQfJ_yfYB2`) instead of friendly names (e.g., "Country").

**Root cause:** Race condition between two useEffect hooks in `AlertReportModal.tsx`:
1. The resource useEffect sets `nativeFilterData` (with `nativeFilterId` + `filterName`) synchronously from saved data
2. The dashboard tabs useEffect fetches `/api/v1/dashboard/{id}/tabs` asynchronously and populates `nativeFilterOptions` (with `{value, label}` pairs)
3. The `Select` component renders with `value={nativeFilterId}` but `options` is still empty — so it can't match the ID to a label and displays the raw ID

**Fix:** Seed `nativeFilterOptions` from the saved `filterName` values in the resource useEffect, so the Select has matching options immediately. When the dashboard tabs API responds later, it overwrites with the full filter list.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**
<img width="1536" height="848" alt="before-raw-filter-ids" src="https://github.com/user-attachments/assets/de1ed05b-1121-487c-9113-d7d942403211" />

**After:**
<img width="1536" height="848" alt="after-filter-names-scrolled" src="https://github.com/user-attachments/assets/5389e7df-6e70-48eb-bcc7-c0626b876369" />


<!-- Drag-drop the screenshots from pr-screenshots/ directory:
  - before: pr-screenshots/before-raw-filter-ids.png
  - after: pr-screenshots/after-filter-names-scrolled.png
-->

### TESTING INSTRUCTIONS

1. Create a report with dashboard filters (select a dashboard with native filters, add filter rows with values)
2. Save the report
3. Re-open the report in edit mode
4. Expand "Report contents" section
5. Verify filter dropdowns show friendly names (e.g., "Country") instead of raw IDs (e.g., `NATIVE_FILTER-HX2lV--YaAZRQfJ_yfYB2`)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `ALERT_REPORTS_FILTER`, `ALERT_REPORT_TABS`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### FEATURE FLAGS
FEATURE_ALERT_REPORTS=true
FEATURE_ALERT_REPORTS_FILTER=true
FEATURE_ALERT_REPORT_TABS=true