### PR TITLE
fix: Fix SupersetClient.postForm calls when SUPERSET_APP_ROOT defined

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClient.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClient.ts
@@ -51,6 +51,7 @@ const SupersetClient: SupersetClientInterface = {
   reAuthenticate: () => getInstance().reAuthenticate(),
   request: request => getInstance().request(request),
   getCSRFToken: () => getInstance().getCSRFToken(),
+  getUrl: (...args) => getInstance().getUrl(...args),
 };
 
 export default SupersetClient;

--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -27,6 +27,7 @@ import {
   Headers,
   Host,
   Mode,
+  PostFormConfig,
   Protocol,
   RequestConfig,
   ParseMethod,
@@ -115,19 +116,18 @@ export default class SupersetClientClass {
     return this.fetchCSRFToken();
   }
 
-  async postForm(
-    endpoint: string,
-    payload: Record<string, any>,
-    target = '_blank',
-  ) {
-    if (endpoint) {
+  async postForm(postFormConfig: PostFormConfig) {
+    if (postFormConfig.endpoint || postFormConfig.url) {
       await this.ensureAuth();
       const hiddenForm = document.createElement('form');
-      hiddenForm.action = this.getUrl({ endpoint });
+      hiddenForm.action = this.getUrl({
+        endpoint: postFormConfig.endpoint,
+        url: postFormConfig.url,
+      });
       hiddenForm.method = 'POST';
-      hiddenForm.target = target;
+      hiddenForm.target = postFormConfig.target ?? '_blank';
       const payloadWithToken: Record<string, any> = {
-        ...payload,
+        ...postFormConfig.payload,
         csrf_token: this.csrfToken!,
       };
 

--- a/superset-frontend/packages/superset-ui-core/src/connection/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/types.ts
@@ -117,6 +117,23 @@ export interface RequestWithUrl extends RequestBase {
 // this make sure at least one of `url` or `endpoint` is set
 export type RequestConfig = RequestWithEndpoint | RequestWithUrl;
 
+export interface PostFormBase {
+  payload: Record<string, any>;
+  target?: string;
+}
+
+export interface PostFormWithEndpoint extends PostFormBase {
+  endpoint: Endpoint;
+  url?: Url;
+}
+
+export interface PostFormWithUrl extends PostFormBase {
+  url: Url;
+  endpoint?: Endpoint;
+}
+
+export type PostFormConfig = PostFormWithEndpoint | PostFormWithUrl;
+
 export interface JsonResponse {
   response: Response;
   json: JsonObject;
@@ -158,6 +175,7 @@ export interface SupersetClientInterface extends Pick<
   | 'isAuthenticated'
   | 'reAuthenticate'
   | 'getGuestToken'
+  | 'getUrl'
 > {
   configure: (config?: ClientConfig) => SupersetClientInterface;
   reset: () => void;

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClient.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClient.test.ts
@@ -31,7 +31,7 @@ describe('SupersetClient', () => {
 
   afterEach(() => SupersetClient.reset());
 
-  test('exposes reset, configure, init, get, post, postForm, isAuthenticated, and reAuthenticate methods', () => {
+  test('exposes reset, configure, init, get, post, postForm, isAuthenticated, reAuthenticate, getUrl methods', () => {
     expect(typeof SupersetClient.configure).toBe('function');
     expect(typeof SupersetClient.init).toBe('function');
     expect(typeof SupersetClient.get).toBe('function');
@@ -42,9 +42,10 @@ describe('SupersetClient', () => {
     expect(typeof SupersetClient.getGuestToken).toBe('function');
     expect(typeof SupersetClient.request).toBe('function');
     expect(typeof SupersetClient.reset).toBe('function');
+    expect(typeof SupersetClient.getUrl).toBe('function');
   });
 
-  test('throws if you call init, get, post, postForm, isAuthenticated, or reAuthenticate before configure', () => {
+  test('throws if you call init, get, post, postForm, isAuthenticated, and reAuthenticate before configure', () => {
     expect(SupersetClient.init).toThrow();
     expect(SupersetClient.get).toThrow();
     expect(SupersetClient.post).toThrow();
@@ -57,7 +58,7 @@ describe('SupersetClient', () => {
 
   // this also tests that the ^above doesn't throw if configure is called appropriately
   test('calls appropriate SupersetClient methods when configured', async () => {
-    expect.assertions(16);
+    expect.assertions(18);
     const mockGetUrl = '/mock/get/url';
     const mockPostUrl = '/mock/post/url';
     const mockRequestUrl = '/mock/request/url';
@@ -88,6 +89,13 @@ describe('SupersetClient', () => {
       SupersetClientClass.prototype,
       'getGuestToken',
     );
+    const getUrlSpy = jest.spyOn(SupersetClientClass.prototype, 'getUrl');
+
+    SupersetClient.configure({ appRoot: '/app' });
+    expect(SupersetClient.getUrl({ endpoint: '/some/path' })).toContain(
+      '/app/some/path',
+    );
+    expect(getUrlSpy).toHaveBeenCalledTimes(1);
 
     SupersetClient.configure({});
     await SupersetClient.init();
@@ -141,6 +149,7 @@ describe('SupersetClient', () => {
     postSpy.mockRestore();
     authenticatedSpy.mockRestore();
     csrfSpy.mockRestore();
+    getUrlSpy.mockRestore();
 
     fetchMock.clearHistory().removeRoutes();
   });

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -669,7 +669,7 @@ describe('SupersetClientClass', () => {
           authSpy = jest.spyOn(SupersetClientClass.prototype, 'ensureAuth');
           await client.init();
         }
-        await client.postForm(mockPostFormEndpoint, {});
+        await client.postForm({ endpoint: mockPostFormEndpoint, payload: {} });
 
         const hiddenForm = createElement.mock.results[0].value;
         const csrfTokenInput = createElement.mock.results[1].value;
@@ -696,7 +696,7 @@ describe('SupersetClientClass', () => {
       client = new SupersetClientClass({ protocol, host, guestToken });
       await client.init();
 
-      await client.postForm(mockPostFormUrl, {});
+      await client.postForm({ endpoint: mockPostFormUrl, payload: {} });
 
       const guestTokenInput = createElement.mock.results[2].value;
 
@@ -712,7 +712,10 @@ describe('SupersetClientClass', () => {
     });
 
     test('makes postForm request with payload', async () => {
-      await client.postForm(mockPostFormUrl, { form_data: postFormPayload });
+      await client.postForm({
+        url: mockPostFormUrl,
+        payload: { form_data: postFormPayload },
+      });
 
       const postFormPayloadInput = createElement.mock.results[1].value;
 
@@ -729,7 +732,7 @@ describe('SupersetClientClass', () => {
     });
 
     test('should do nothing when url is empty string', async () => {
-      const result = await client.postForm('', {});
+      const result = await client.postForm({ url: '', payload: {} });
       expect(result).toBeUndefined();
       expect(createElement.mock.calls).toHaveLength(0);
       expect(appendChild.mock.calls).toHaveLength(0);

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -696,7 +696,7 @@ describe('SupersetClientClass', () => {
       client = new SupersetClientClass({ protocol, host, guestToken });
       await client.init();
 
-      await client.postForm({ endpoint: mockPostFormUrl, payload: {} });
+      await client.postForm({ url: mockPostFormUrl, payload: {} });
 
       const guestTokenInput = createElement.mock.results[2].value;
 

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
@@ -69,9 +69,12 @@ describe('ExploreCtasResultsButton', () => {
 
     await waitFor(() => {
       expect(postFormSpy).toHaveBeenCalledTimes(1);
-      expect(postFormSpy).toHaveBeenCalledWith('http://localhost/explore/', {
-        form_data:
-          '{"datasource":"1234__table","metrics":["count"],"groupby":[],"viz_type":"table","since":"100 years ago","all_columns":[],"row_limit":1000}',
+      expect(postFormSpy).toHaveBeenCalledWith({
+        url: 'http://localhost/explore/',
+        payload: {
+          form_data:
+            '{"datasource":"1234__table","metrics":["count"],"groupby":[],"viz_type":"table","since":"100 years ago","all_columns":[],"row_limit":1000}',
+        },
       });
     });
   });

--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -48,7 +48,6 @@ import { Logger, LOG_ACTIONS_LOAD_CHART } from 'src/logger/LogUtils';
 import { allowCrossDomain as domainShardingEnabled } from 'src/utils/hostNamesConfig';
 import { updateDataMask } from 'src/dataMask/actions';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
-import { ensureAppRoot } from 'src/utils/pathUtils';
 import { safeStringify } from 'src/utils/safeStringify';
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 import type { Dispatch, Action, AnyAction } from 'redux';
@@ -930,9 +929,12 @@ export function redirectSQLLab(
             requestedQuery: payload,
           });
         } else {
-          SupersetClient.postForm({ endpoint: redirectUrl, payload: {
-            form_data: safeStringify(payload),
-          } });
+          SupersetClient.postForm({
+            endpoint: redirectUrl,
+            payload: {
+              form_data: safeStringify(payload),
+            },
+          });
         }
       })
       .catch(() =>

--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -930,9 +930,9 @@ export function redirectSQLLab(
             requestedQuery: payload,
           });
         } else {
-          SupersetClient.postForm(ensureAppRoot(redirectUrl), {
+          SupersetClient.postForm({ endpoint: redirectUrl, payload: {
             form_data: safeStringify(payload),
-          });
+          } });
         }
       })
       .catch(() =>

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.tsx
@@ -325,8 +325,11 @@ class DatasourceControl extends PureComponent<
             datasourceKey: `${datasource.id}__${datasource.type}`,
             sql: datasource.sql,
           };
-          SupersetClient.postForm('/sqllab/', {
-            form_data: safeStringify(payload),
+          SupersetClient.postForm({
+            endpoint: '/sqllab/',
+            payload: {
+              form_data: safeStringify(payload),
+            },
           });
         }
         break;

--- a/superset-frontend/src/explore/components/controls/ViewQueryModalFooter.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModalFooter.tsx
@@ -56,7 +56,7 @@ const ViewQueryModalFooter: FC<ViewQueryModalFooterProps> = (props: {
       sql,
     };
     if (openInNewWindow) {
-      SupersetClient.postForm('/sqllab/', payload);
+      SupersetClient.postForm({ endpoint: '/sqllab/', payload });
     } else {
       history.push({
         pathname: '/sqllab',

--- a/superset-frontend/src/explore/exploreUtils/exportChart.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/exportChart.test.ts
@@ -30,7 +30,7 @@ jest.mock('@superset-ui/core', () => ({
     postForm: jest.fn(),
     get: jest.fn().mockResolvedValue({ json: {} }),
     post: jest.fn().mockResolvedValue({ json: {} }),
-    getUrl: jest.fn()
+    getUrl: jest.fn(),
   },
   getChartBuildQueryRegistry: jest.fn().mockReturnValue({
     get: jest.fn().mockReturnValue(() => () => ({})),
@@ -61,7 +61,9 @@ beforeEach(() => {
 // Tests for exportChart URL prefix handling in streaming export
 test('exportChart v1 API passes prefixed URL to onStartStreamingExport when app root is configured', async () => {
   // Uses SupersetClient.getUrl
-  SupersetClient.getUrl.mockImplementation(({endpoint}: {endpoint: string}) => `/superset${endpoint}`);
+  SupersetClient.getUrl.mockImplementation(
+    ({ endpoint }: { endpoint: string }) => `/superset${endpoint}`,
+  );
 
   const onStartStreamingExport = jest.fn();
 
@@ -79,7 +81,9 @@ test('exportChart v1 API passes prefixed URL to onStartStreamingExport when app 
 
 test('exportChart v1 API passes unprefixed URL when no app root is configured', async () => {
   // Uses SupersetClient.getUrl
-  SupersetClient.getUrl.mockImplementation(({endpoint}: {endpoint: string}) => `${endpoint}`);
+  SupersetClient.getUrl.mockImplementation(
+    ({ endpoint }: { endpoint: string }) => `${endpoint}`,
+  );
 
   const onStartStreamingExport = jest.fn();
 
@@ -95,7 +99,10 @@ test('exportChart v1 API passes unprefixed URL when no app root is configured', 
 });
 
 test('exportChart v1 API passes nested prefix for deeply nested deployments', async () => {
-  SupersetClient.getUrl.mockImplementation(({endpoint}: {endpoint: string}) => `/my-company/analytics/superset${endpoint}`);
+  SupersetClient.getUrl.mockImplementation(
+    ({ endpoint }: { endpoint: string }) =>
+      `/my-company/analytics/superset${endpoint}`,
+  );
 
   const onStartStreamingExport = jest.fn();
 

--- a/superset-frontend/src/explore/exploreUtils/exportChart.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/exportChart.test.ts
@@ -18,7 +18,7 @@
  */
 import { exportChart } from '.';
 
-// Mock pathUtils to control app root prefix
+// Mock pathUtils to control app root prefix for legacy endpoint
 jest.mock('src/utils/pathUtils', () => ({
   ensureAppRoot: jest.fn((path: string) => path),
 }));
@@ -30,6 +30,7 @@ jest.mock('@superset-ui/core', () => ({
     postForm: jest.fn(),
     get: jest.fn().mockResolvedValue({ json: {} }),
     post: jest.fn().mockResolvedValue({ json: {} }),
+    getUrl: jest.fn()
   },
   getChartBuildQueryRegistry: jest.fn().mockReturnValue({
     get: jest.fn().mockReturnValue(() => () => ({})),
@@ -40,6 +41,7 @@ jest.mock('@superset-ui/core', () => ({
 }));
 
 const { ensureAppRoot } = jest.requireMock('src/utils/pathUtils');
+const { SupersetClient } = jest.requireMock('@superset-ui/core');
 const { getChartMetadataRegistry } = jest.requireMock('@superset-ui/core');
 
 // Minimal formData that won't trigger legacy API (useLegacyApi = false)
@@ -50,8 +52,6 @@ const baseFormData = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Default: no prefix
-  ensureAppRoot.mockImplementation((path: string) => path);
   // Default: v1 API (not legacy)
   getChartMetadataRegistry.mockReturnValue({
     get: jest.fn().mockReturnValue({ parseMethod: 'json' }),
@@ -60,8 +60,8 @@ beforeEach(() => {
 
 // Tests for exportChart URL prefix handling in streaming export
 test('exportChart v1 API passes prefixed URL to onStartStreamingExport when app root is configured', async () => {
-  const appRoot = '/superset';
-  ensureAppRoot.mockImplementation((path: string) => `${appRoot}${path}`);
+  // Uses SupersetClient.getUrl
+  SupersetClient.getUrl.mockImplementation(({endpoint}: {endpoint: string}) => `/superset${endpoint}`);
 
   const onStartStreamingExport = jest.fn();
 
@@ -78,7 +78,8 @@ test('exportChart v1 API passes prefixed URL to onStartStreamingExport when app 
 });
 
 test('exportChart v1 API passes unprefixed URL when no app root is configured', async () => {
-  ensureAppRoot.mockImplementation((path: string) => path);
+  // Uses SupersetClient.getUrl
+  SupersetClient.getUrl.mockImplementation(({endpoint}: {endpoint: string}) => `${endpoint}`);
 
   const onStartStreamingExport = jest.fn();
 
@@ -94,8 +95,7 @@ test('exportChart v1 API passes unprefixed URL when no app root is configured', 
 });
 
 test('exportChart v1 API passes nested prefix for deeply nested deployments', async () => {
-  const appRoot = '/my-company/analytics/superset';
-  ensureAppRoot.mockImplementation((path: string) => `${appRoot}${path}`);
+  SupersetClient.getUrl.mockImplementation(({endpoint}: {endpoint: string}) => `/my-company/analytics/superset${endpoint}`);
 
   const onStartStreamingExport = jest.fn();
 

--- a/superset-frontend/src/explore/exploreUtils/index.ts
+++ b/superset-frontend/src/explore/exploreUtils/index.ts
@@ -355,9 +355,13 @@ export const exportChart = async ({
       endpointType,
       allowDomainSharding: false,
     });
+    if (!url) {
+      console.warn('Failed to get explore url.');
+      return;
+    }
     payload = formData;
   } else {
-    url = ensureAppRoot('/api/v1/chart/data');
+    url = SupersetClient.getUrl({ endpoint: '/api/v1/chart/data' });
     payload = await buildV1ChartDataPayload({
       formData,
       force,
@@ -377,8 +381,11 @@ export const exportChart = async ({
     });
   } else {
     // Fallback to original behavior for non-streaming exports
-    SupersetClient.postForm(url as string, {
-      form_data: safeStringify(payload),
+    SupersetClient.postForm({
+      url,
+      payload: {
+        form_data: safeStringify(payload),
+      },
     });
   }
 };
@@ -393,8 +400,9 @@ export const exploreChart = (
     allowDomainSharding: false,
     requestParams,
   });
-  SupersetClient.postForm(url as string, {
-    form_data: safeStringify(formData),
+  SupersetClient.postForm({
+    url: url as string,
+    payload: { form_data: safeStringify(formData) },
   });
 };
 

--- a/superset-frontend/src/pages/Login/Login.test.tsx
+++ b/superset-frontend/src/pages/Login/Login.test.tsx
@@ -16,24 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { SupersetClient } from '@superset-ui/core';
+import getBootstrapData, { applicationRoot } from 'src/utils/getBootstrapData';
 import Login from './index';
+
+const defaultBootstrapData = (authUserRegistration: boolean = false) => ({
+  common: {
+    conf: {
+      AUTH_TYPE: 1,
+      AUTH_PROVIDERS: [],
+      AUTH_USER_REGISTRATION: authUserRegistration,
+    },
+    feature_flags: {},
+  },
+});
 
 jest.mock('src/utils/getBootstrapData', () => ({
   __esModule: true,
-  default: () => ({
-    common: {
-      conf: {
-        AUTH_TYPE: 1,
-        AUTH_PROVIDERS: [],
-        AUTH_USER_REGISTRATION: false,
-      },
-    },
-  }),
+  default: jest.fn(() => defaultBootstrapData()),
+  applicationRoot: jest.fn(() => ''),
 }));
 
+const mockGetBootstrapData = getBootstrapData as jest.Mock;
+const mockApplicationRoot = applicationRoot as jest.Mock;
+
+const renderLogin = () => render(<Login />, { useRedux: true });
+
 test('should render login form elements', () => {
-  render(<Login />, { useRedux: true });
+  renderLogin();
   expect(screen.getByTestId('login-form')).toBeInTheDocument();
   expect(screen.getByTestId('username-input')).toBeInTheDocument();
   expect(screen.getByTestId('password-input')).toBeInTheDocument();
@@ -42,14 +54,100 @@ test('should render login form elements', () => {
 });
 
 test('should render username and password labels', () => {
-  render(<Login />, { useRedux: true });
+  renderLogin();
   expect(screen.getByText('Username:')).toBeInTheDocument();
   expect(screen.getByText('Password:')).toBeInTheDocument();
 });
 
 test('should render form instruction text', () => {
-  render(<Login />, { useRedux: true });
+  renderLogin();
   expect(
     screen.getByText('Enter your login and password below:'),
   ).toBeInTheDocument();
 });
+
+test('should render registration button with correct app root URL when authRegister=true', () => {
+  mockGetBootstrapData.mockReturnValue(defaultBootstrapData(true));
+  mockApplicationRoot.mockReturnValue('/superset');
+
+  renderLogin();
+
+  const registerButton = screen.getByTestId('register-button');
+  expect(registerButton).toHaveAttribute('href', '/superset/register/');
+});
+
+test.each([['', '/superset']])(
+  'should render OAuth providers with app root %s',
+  (app_root: string) => {
+    mockGetBootstrapData.mockReturnValue({
+      common: {
+        conf: {
+          AUTH_TYPE: 4, // AuthType.AuthOauth
+          AUTH_PROVIDERS: [
+            { name: 'google', icon: 'google' },
+            { name: 'github', icon: 'github' },
+          ],
+          AUTH_USER_REGISTRATION: false,
+        },
+      },
+    });
+
+    mockApplicationRoot.mockReturnValue(app_root);
+
+    renderLogin();
+
+    const googleButton = screen.getByRole('link', {
+      name: /Sign in with Google/i,
+    });
+    const githubButton = screen.getByRole('link', {
+      name: /Sign in with Github/i,
+    });
+
+    expect(googleButton).toHaveAttribute('href', `${app_root}/login/google`);
+    expect(githubButton).toHaveAttribute('href', `${app_root}/login/github`);
+  },
+);
+
+test.each([[1, 2]])(
+  'should call SupersetClient.postForm with correct endpoint for AuthDB/AuthLDAP',
+  async (authType: number) => {
+    mockGetBootstrapData.mockReturnValue({
+      common: {
+        conf: {
+          AUTH_TYPE: authType,
+          AUTH_PROVIDERS: [],
+          AUTH_USER_REGISTRATION: false,
+        },
+      },
+    });
+    mockApplicationRoot.mockReturnValue('/superset');
+
+    const postFormSpy = jest
+      .spyOn(SupersetClient, 'postForm')
+      .mockResolvedValue();
+
+    renderLogin();
+
+    // Fill in the form
+    const usernameInput = screen.getByTestId('username-input');
+    const passwordInput = screen.getByTestId('password-input');
+    const loginButton = screen.getByTestId('login-button');
+
+    await userEvent.type(usernameInput, 'testuser');
+    await userEvent.type(passwordInput, 'testpass');
+    await userEvent.click(loginButton);
+
+    await waitFor(() => {
+      expect(postFormSpy).toHaveBeenCalledWith(
+        // Should be bare endpoint, not /superset/login/
+        {
+          endpoint: '/login/',
+          payload: { username: 'testuser', password: 'testpass' },
+          target: '',
+        },
+      );
+    });
+
+    postFormSpy.mockRestore();
+  },
+);

--- a/superset-frontend/src/pages/Login/Login.test.tsx
+++ b/superset-frontend/src/pages/Login/Login.test.tsx
@@ -76,7 +76,7 @@ test('should render registration button with correct app root URL when authRegis
   expect(registerButton).toHaveAttribute('href', '/superset/register/');
 });
 
-test.each([['', '/superset']])(
+test.each([[''], ['/superset']])(
   'should render OAuth providers with app root %s',
   (app_root: string) => {
     mockGetBootstrapData.mockReturnValue({
@@ -108,7 +108,7 @@ test.each([['', '/superset']])(
   },
 );
 
-test.each([[1, 2]])(
+test.each([[1], [2]])(
   'should call SupersetClient.postForm with correct endpoint for AuthDB/AuthLDAP',
   async (authType: number) => {
     mockGetBootstrapData.mockReturnValue({

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -34,6 +34,7 @@ import { capitalize } from 'lodash/fp';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { useDispatch } from 'react-redux';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { ensureAppRoot } from 'src/utils/pathUtils';
 
 type OAuthProvider = {
   name: string;
@@ -99,7 +100,7 @@ export default function Login() {
   );
 
   const buildProviderLoginUrl = (providerName: string) => {
-    const base = `/login/${providerName}`;
+    const base = ensureAppRoot(`/login/${providerName}`);
     return nextUrl
       ? `${base}${base.includes('?') ? '&' : '?'}next=${encodeURIComponent(nextUrl)}`
       : base;
@@ -131,7 +132,13 @@ export default function Login() {
     sessionStorage.setItem('login_attempted', 'true');
 
     // Use standard form submission for Flask-AppBuilder compatibility
-    SupersetClient.postForm(loginEndpoint, values, '');
+    SupersetClient.postForm({
+      endpoint: loginEndpoint,
+      payload: values,
+      target: '',
+    }).finally(() => {
+      setLoading(false);
+    });
   };
 
   const getAuthIconElement = (
@@ -254,7 +261,7 @@ export default function Login() {
                     <Button
                       block
                       type="default"
-                      href="/register/"
+                      href={ensureAppRoot('/register/')}
                       data-test="register-button"
                     >
                       {t('Register')}

--- a/superset-frontend/src/pages/Register/Register.test.tsx
+++ b/superset-frontend/src/pages/Register/Register.test.tsx
@@ -17,7 +17,8 @@
  * under the License.
  */
 import { render, screen } from 'spec/helpers/testing-library';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { applicationRoot } from 'src/utils/getBootstrapData';
 import Register from './index';
 
 jest.mock('src/utils/getBootstrapData', () => ({
@@ -29,6 +30,7 @@ jest.mock('src/utils/getBootstrapData', () => ({
       },
     },
   }),
+  applicationRoot: jest.fn(() => ''),
 }));
 
 jest.mock('react-google-recaptcha', () => ({
@@ -40,6 +42,13 @@ const renderRegister = () =>
   render(
     <MemoryRouter>
       <Register />
+    </MemoryRouter>,
+  );
+
+const renderActivated = () =>
+  render(
+    <MemoryRouter initialEntries={['/abcdefgh']}>
+      <Route path="/:activationHash" component={Register} />
     </MemoryRouter>,
   );
 
@@ -79,4 +88,19 @@ test('should render input placeholders', () => {
   expect(screen.getByPlaceholderText('Email')).toBeInTheDocument();
   expect(screen.getByPlaceholderText('Password')).toBeInTheDocument();
   expect(screen.getByPlaceholderText('Confirm password')).toBeInTheDocument();
+});
+
+test('should render login button with login URL when no app root', () => {
+  renderActivated();
+
+  const loginButton = screen.getByTestId('login-button');
+  expect(loginButton).toHaveAttribute('href', '/login/');
+});
+
+test('should render login button with login URL app root set', () => {
+  (applicationRoot as jest.Mock).mockReturnValue('/superset');
+  renderActivated();
+
+  const loginButton = screen.getByTestId('login-button');
+  expect(loginButton).toHaveAttribute('href', '/superset/login/');
 });

--- a/superset-frontend/src/pages/Register/index.tsx
+++ b/superset-frontend/src/pages/Register/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@superset-ui/core/components';
 import { useState } from 'react';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { ensureAppRoot } from 'src/utils/pathUtils';
 import ReactCAPTCHA from 'react-google-recaptcha';
 import { useParams } from 'react-router-dom';
 
@@ -89,7 +90,11 @@ export default function Login() {
           title="Registration successful"
           subTitle="Your account is activated. You can log in with your credentials."
           extra={[
-            <Button type="default" href="/login/" data-test="login-button">
+            <Button
+              type="default"
+              href={ensureAppRoot('/login/')}
+              data-test="login-button"
+            >
               {t('Login')}
             </Button>,
           ]}
@@ -109,7 +114,11 @@ export default function Login() {
       conf_password: values.confirmPassword,
       'g-recaptcha-response': captchaResponse,
     };
-    SupersetClient.postForm('/register/form', payload, '').finally(() => {
+    SupersetClient.postForm({
+      endpoint: '/register/form',
+      payload,
+      target: '',
+    }).finally(() => {
       setLoading(false);
     });
   };

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -78,9 +78,9 @@ def redirect_to_login(next_target: str | None = None) -> FlaskResponse:
     target = next_target
     if target is None and has_request_context():
         if request.query_string:
-            target = request.full_path.rstrip("?")
+            target = request.script_root + request.full_path.rstrip("?")
         else:
-            target = request.path
+            target = request.script_root + request.path
 
     if target:
         query["next"] = [target]


### PR DESCRIPTION
### SUMMARY

The SupersetClient.postForm API only accepted an endpoint and when called with a url caused a doubling up of the app_root when it was defined. We have changed the postForm signature to accept either a url or endpoint that is passed to getUrl. Call sites and tests have been updated.

This PR required brings in changes from:

- #37360 by @innovark37 
- #35296 by @sadpandajoe

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Set `SUPERSET_APP_ROOT=/analytics` in `docker/.env-local` and boot up the docker-compose-light setup.

- Test login works and does not give a 404
- Test exporting a chart works and the url does not contain the app_root twice.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
