### PR TITLE
feat(mcp): add LIKE, ILIKE, IN, NOT IN filter operators to MCP chart tools

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -458,6 +458,11 @@ def map_filter_operator(op: str) -> str:
         ">=": ">=",
         "<=": "<=",
         "!=": "!=",
+        "LIKE": "LIKE",
+        "ILIKE": "ILIKE",
+        "NOT LIKE": "NOT LIKE",
+        "IN": "IN",
+        "NOT IN": "NOT IN",
     }
     return operator_map.get(op, op)
 


### PR DESCRIPTION
### SUMMARY

The MCP service's `FilterConfig` schema only supported basic comparison operators (`=`, `>`, `<`, `>=`, `<=`, `!=`). This meant that when creating or updating charts via MCP tools (`generate_chart`, `generate_explore_link`, `update_chart`), users could not:

- Filter with **pattern matching** (e.g., find games where name contains "Mario")
- Filter with **set membership** (e.g., platforms in ["Wii", "PS3", "Xbox360"])

These operators are already fully supported by Superset's native `adhoc_filters` system and the frontend UI — they were just missing from the MCP schema layer.

This PR adds support for **5 new filter operators**:

| Operator | Type | Example |
|----------|------|---------|
| `LIKE` | Pattern matching (case-sensitive) | `name LIKE '%mario%'` |
| `ILIKE` | Pattern matching (case-insensitive) | `name ILIKE '%mario%'` |
| `NOT LIKE` | Negated pattern matching | `name NOT LIKE '%test%'` |
| `IN` | Set membership | `platform IN ['Wii', 'PS3']` |
| `NOT IN` | Negated set membership | `status NOT IN ['archived']` |

**Key design decisions:**

- `IN`/`NOT IN` operators require the `value` field to be a **list** (validated at schema level)
- All other operators require a **scalar** value (string, number, or boolean)
- List values are individually sanitized through the existing `sanitize_filter_value` function
- No changes needed in the `adhoc_filters` conversion — Superset handles list comparators natively for `IN`/`NOT IN`

```mermaid
flowchart LR
    A[MCP Client] -->|FilterConfig| B[Schema Validation]
    B -->|"op: ILIKE<br>value: '%mario%'"| C[map_filter_operator]
    B -->|"op: IN<br>value: ['Wii','PS3']"| C
    C --> D[adhoc_filters]
    D -->|"operator: ILIKE<br>comparator: '%mario%'"| E[Superset Query Engine]
    D -->|"operator: IN<br>comparator: ['Wii','PS3']"| E
    E --> F[SQL WHERE clause]
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — Backend-only change to the MCP schema layer. No UI changes.

**Before:** Only 6 operators available: `=`, `>`, `<`, `>=`, `<=`, `!=`
**After:** 11 operators available, adding: `LIKE`, `ILIKE`, `NOT LIKE`, `IN`, `NOT IN`

### TESTING INSTRUCTIONS

1. Run the MCP chart utils unit tests:
   ```bash
   pytest tests/unit_tests/mcp_service/chart/test_chart_utils.py -v
   ```

2. Verify new filter operators work via MCP tools:
   ```json
   {
     "filters": [
       {"column": "name", "op": "ILIKE", "value": "%mario%"},
       {"column": "platform", "op": "IN", "value": ["Wii", "PS3"]}
     ]
   }
   ```

3. Verify validation rejects invalid combinations:
   - `IN` with scalar value → error
   - `=` with list value → error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API