### PR TITLE
feat: support for import/export masked_encrypted_extra (backend)

### DIFF
--- a/superset/commands/database/export.py
+++ b/superset/commands/database/export.py
@@ -97,6 +97,15 @@ class ExportDatabasesCommand(ExportModelsCommand):
             )
             payload["ssh_tunnel"] = mask_password_info(ssh_tunnel_payload)
 
+        # If DB has sensitive fields in Secure Extra, export them masked.
+        # If not, export them as-is.
+        if encrypted_extra := model.encrypted_extra:
+            masked_encrypted_extra = model.masked_encrypted_extra
+            if encrypted_extra != masked_encrypted_extra:
+                payload["masked_encrypted_extra"] = masked_encrypted_extra
+            else:
+                payload["encrypted_extra"] = encrypted_extra
+
         payload["version"] = EXPORT_VERSION
 
         file_content = yaml.safe_dump(payload, sort_keys=False)

--- a/superset/commands/database/importers/v1/utils.py
+++ b/superset/commands/database/importers/v1/utils.py
@@ -84,7 +84,9 @@ def import_database(  # noqa: C901
         if existing and existing.encrypted_extra:
             old_config = json.loads(existing.encrypted_extra)
             new_config = json.loads(masked_encrypted_extra)
-            sensitive_fields = existing.db_engine_spec.encrypted_extra_sensitive_fields
+            sensitive_fields = (
+                existing.db_engine_spec.encrypted_extra_sensitive_field_paths()
+            )
             revealed = json.reveal_sensitive(
                 old_config,
                 new_config,

--- a/superset/commands/database/importers/v1/utils.py
+++ b/superset/commands/database/importers/v1/utils.py
@@ -26,7 +26,10 @@ from superset.commands.exceptions import ImportFailedError
 from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.exceptions import SupersetDBAPIConnectionError
-from superset.exceptions import SupersetSecurityException
+from superset.exceptions import (
+    OAuth2RedirectError,
+    SupersetSecurityException,
+)
 from superset.models.core import Database
 from superset.security.analytics_db_safety import check_sqlalchemy_uri
 from superset.utils import json
@@ -74,6 +77,23 @@ def import_database(  # noqa: C901
     # TODO (betodealmeida): move this logic to import_from_dict
     config["extra"] = json.dumps(config["extra"])
 
+    # Convert masked_encrypted_extra → encrypted_extra before importing.
+    # For existing DBs, reveal masked sensitive values from current encrypted_extra.
+    # For new DBs, schema validation already ensured no fields are still masked.
+    if masked_encrypted_extra := config.pop("masked_encrypted_extra", None):
+        if existing and existing.encrypted_extra:
+            old_config = json.loads(existing.encrypted_extra)
+            new_config = json.loads(masked_encrypted_extra)
+            sensitive_fields = existing.db_engine_spec.encrypted_extra_sensitive_fields
+            revealed = json.reveal_sensitive(
+                old_config,
+                new_config,
+                sensitive_fields,
+            )
+            config["encrypted_extra"] = json.dumps(revealed)
+        else:
+            config["encrypted_extra"] = masked_encrypted_extra
+
     ssh_tunnel_config = config.pop("ssh_tunnel", None)
 
     # set SQLAlchemy URI via `set_sqlalchemy_uri` so that the password gets masked
@@ -94,7 +114,7 @@ def import_database(  # noqa: C901
 
     try:
         add_permissions(database)
-    except SupersetDBAPIConnectionError as ex:
+    except (SupersetDBAPIConnectionError, OAuth2RedirectError) as ex:
         logger.warning(ex.message)
 
     return database

--- a/superset/commands/importers/v1/__init__.py
+++ b/superset/commands/importers/v1/__init__.py
@@ -63,6 +63,9 @@ class ImportModelsCommand(BaseCommand):
         self.ssh_tunnel_priv_key_passwords: dict[str, str] = (
             kwargs.get("ssh_tunnel_priv_key_passwords") or {}
         )
+        self.encrypted_extra_secrets: dict[str, dict[str, str]] = (
+            kwargs.get("encrypted_extra_secrets") or {}
+        )
         self.overwrite: bool = kwargs.get("overwrite", False)
         self._configs: dict[str, Any] = {}
 
@@ -111,6 +114,7 @@ class ImportModelsCommand(BaseCommand):
             self.ssh_tunnel_passwords,
             self.ssh_tunnel_private_keys,
             self.ssh_tunnel_priv_key_passwords,
+            self.encrypted_extra_secrets,
         )
         self._prevent_overwrite_existing_model(exceptions)
 

--- a/superset/commands/importers/v1/assets.py
+++ b/superset/commands/importers/v1/assets.py
@@ -82,6 +82,9 @@ class ImportAssetsCommand(BaseCommand):
         self.ssh_tunnel_priv_key_passwords: dict[str, str] = (
             kwargs.get("ssh_tunnel_priv_key_passwords") or {}
         )
+        self.encrypted_extra_secrets: dict[str, dict[str, str]] = (
+            kwargs.get("encrypted_extra_secrets") or {}
+        )
         self._configs: dict[str, Any] = {}
         self.sparse = kwargs.get("sparse", False)
 
@@ -199,6 +202,7 @@ class ImportAssetsCommand(BaseCommand):
             self.ssh_tunnel_passwords,
             self.ssh_tunnel_private_keys,
             self.ssh_tunnel_priv_key_passwords,
+            self.encrypted_extra_secrets,
         )
 
         if exceptions:

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1595,9 +1595,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                       description: >-
                         JSON map of sensitive values for masked_encrypted_extra fields.
                         Keys are file paths (e.g., "databases/db.yaml") and values
-                        are JSON objects with the restricted fields
+                        are JSON objects mapping JSONPath expressions to secrets.
                         (e.g., `{"databases/MyDatabase.yaml":
-                        {"credentials_info": {"private_key": "actual_key"}}}`).
+                        {"$.credentials_info.private_key": "actual_key"}}`).
                       type: string
           responses:
             200:

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1591,6 +1591,14 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                         the private_key should be provided in the following format:
                         `{"databases/MyDatabase.yaml": "my_private_key_password"}`.
                       type: string
+                    encrypted_extra_secrets:
+                      description: >-
+                        JSON map of sensitive values for masked_encrypted_extra fields.
+                        Keys are file paths (e.g., "databases/db.yaml") and values
+                        are JSON objects with the restricted fields
+                        (e.g., `{"databases/MyDatabase.yaml":
+                        {"credentials_info": {"private_key": "actual_key"}}}`).
+                      type: string
           responses:
             200:
               description: Database import result
@@ -1642,6 +1650,11 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             if "ssh_tunnel_private_key_passwords" in request.form
             else None
         )
+        encrypted_extra_secrets = (
+            json.loads(request.form["encrypted_extra_secrets"])
+            if "encrypted_extra_secrets" in request.form
+            else None
+        )
 
         command = ImportDatabasesCommand(
             contents,
@@ -1650,6 +1663,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             ssh_tunnel_passwords=ssh_tunnel_passwords,
             ssh_tunnel_private_keys=ssh_tunnel_private_keys,
             ssh_tunnel_priv_key_passwords=ssh_tunnel_priv_key_passwords,
+            encrypted_extra_secrets=encrypted_extra_secrets,
         )
         command.run()
         return self.response(200, message="OK")

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -1013,11 +1013,16 @@ class ImportV1DatabaseSchema(Schema):
         # Check if any sensitive field is still masked
         masked_fields = get_masked_fields(
             masked_encrypted_extra,
-            db_engine_spec.encrypted_extra_sensitive_fields,
+            db_engine_spec.encrypted_extra_sensitive_field_paths(),
         )
 
         if masked_fields:
-            labels = db_engine_spec.encrypted_extra_sensitive_field_labels
+            encrypted_extra_fields = db_engine_spec.encrypted_extra_sensitive_fields
+            labels = (
+                encrypted_extra_fields
+                if isinstance(encrypted_extra_fields, dict)
+                else {}
+            )
             raise ValidationError(
                 {
                     "_schema": [

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -59,6 +59,7 @@ from superset.models.core import ConfigurationMethod, Database
 from superset.security.analytics_db_safety import check_sqlalchemy_uri
 from superset.utils import json
 from superset.utils.core import markdown, parse_ssl_cert
+from superset.utils.json import get_masked_fields
 
 database_schemas_query_schema = {
     "type": "object",
@@ -239,6 +240,15 @@ def encrypted_extra_validator(value: str | None) -> None:
             raise ValidationError(
                 [_("Field cannot be decoded by JSON. %(msg)s", msg=str(ex))]
             ) from ex
+
+
+def masked_encrypted_extra_validator(value: str) -> None:
+    """
+    Validate that `masked_encrypted_extra` is a valid non-empty JSON string
+    """
+    if value == "{}":
+        raise ValidationError([_("Field cannot be empty.")])
+    encrypted_extra_validator(value)
 
 
 def extra_validator(value: str) -> str:
@@ -874,6 +884,9 @@ class ImportV1DatabaseSchema(Schema):
     sqlalchemy_uri = fields.String(required=True)
     password = fields.String(allow_none=True)
     encrypted_extra = fields.String(allow_none=True, validate=encrypted_extra_validator)
+    masked_encrypted_extra = fields.String(
+        allow_none=False, validate=masked_encrypted_extra_validator
+    )
     cache_timeout = fields.Integer(allow_none=True)
     expose_in_sqllab = fields.Boolean()
     allow_run_async = fields.Boolean()
@@ -970,6 +983,50 @@ class ImportV1DatabaseSchema(Schema):
                     # are empty, SSHTunnelMissingCredentials was already raised
                     raise ValidationError(exception_messages)
         return
+
+    @validates_schema
+    def validate_masked_encrypted_extra(
+        self, data: dict[str, Any], **kwargs: Any
+    ) -> None:
+        if "masked_encrypted_extra" not in data:
+            return
+
+        if "encrypted_extra" in data:
+            raise ValidationError(
+                "File contains both `encrypted_extra` and `masked_encrypted_extra`"
+            )
+
+        if db.session.query(Database).filter_by(uuid=data["uuid"]).first():
+            # Existing DB: sensitive values will be revealed from existing
+            # encrypted_extra in import_database()
+            return
+
+        masked_encrypted_extra = json.loads(data["masked_encrypted_extra"])
+
+        # Determine engine spec from sqlalchemy_uri to get sensitive fields
+        sqlalchemy_uri = data["sqlalchemy_uri"]
+        url = make_url_safe(sqlalchemy_uri)
+        backend = url.get_backend_name()
+        driver = url.get_driver_name()
+        db_engine_spec = get_engine_spec(backend, driver=driver)
+
+        # Check if any sensitive field is still masked
+        masked_fields = get_masked_fields(
+            masked_encrypted_extra,
+            db_engine_spec.encrypted_extra_sensitive_fields,
+        )
+
+        if masked_fields:
+            labels = db_engine_spec.encrypted_extra_sensitive_field_labels
+            raise ValidationError(
+                {
+                    "_schema": [
+                        f"Must provide value for masked_encrypted_extra field: {field}"
+                        + (f" ({labels[field]})" if field in labels else "")
+                        for field in masked_fields
+                    ]
+                }
+            )
 
 
 def encrypted_field_properties(self, field: Any, **_) -> dict[str, Any]:  # type: ignore

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -532,15 +532,13 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         Pattern[str], tuple[str, SupersetErrorType, dict[str, Any]]
     ] = {}
 
-    # List of JSON path to fields in `encrypted_extra` that should be masked when the
-    # database is edited. By default everything is masked.
+    # JSONPath fields in `encrypted_extra` that should be masked when the database is
+    # edited. Can be a set of paths (labels will default to the path) or a dict mapping
+    # paths to human-readable labels for import validation error messages.
     # pylint: disable=invalid-name
-    encrypted_extra_sensitive_fields: set[str] = {"$.*"}
-
-    # Labels for sensitive fields in `encrypted_extra`, mapping
-    # JSONPath → display label. Used in import validation error messages
-    # so the UI can show a human-readable name instead of a raw JSONPath.
-    encrypted_extra_sensitive_field_labels: dict[str, str] = {}
+    encrypted_extra_sensitive_fields: set[str] | dict[str, str] = {
+        "$.*": "Encrypted Extra",
+    }
 
     # Whether the engine supports file uploads
     # if True, database will be listed as option in the upload file form
@@ -584,6 +582,22 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # is determined only after the specific query is executed and it will update
     # the `cancel_query` value in the `extra` field of the `query` object
     has_query_id_before_execute = True
+
+    @classmethod
+    def encrypted_extra_sensitive_field_paths(cls) -> set[str]:
+        """
+        Returns a set of paths for fields that should be masked in the
+        ``masked_encrypted_extra`` JSON.
+
+        :param cls: Description
+        :return: Description
+        :rtype: set[str]
+        """
+        return (
+            set(cls.encrypted_extra_sensitive_fields)
+            if isinstance(cls.encrypted_extra_sensitive_fields, dict)
+            else cls.encrypted_extra_sensitive_fields
+        )
 
     @classmethod
     def get_rls_method(cls) -> RLSMethod:
@@ -2448,7 +2462,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
         masked_encrypted_extra = redact_sensitive(
             config,
-            cls.encrypted_extra_sensitive_fields,
+            cls.encrypted_extra_sensitive_field_paths(),
         )
 
         return json.dumps(masked_encrypted_extra)
@@ -2474,7 +2488,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         new_config = reveal_sensitive(
             old_config,
             new_config,
-            cls.encrypted_extra_sensitive_fields,
+            cls.encrypted_extra_sensitive_field_paths(),
         )
 
         return json.dumps(new_config)

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -537,6 +537,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # pylint: disable=invalid-name
     encrypted_extra_sensitive_fields: set[str] = {"$.*"}
 
+    # Labels for sensitive fields in `encrypted_extra`, mapping
+    # JSONPath → display label. Used in import validation error messages
+    # so the UI can show a human-readable name instead of a raw JSONPath.
+    encrypted_extra_sensitive_field_labels: dict[str, str] = {}
+
     # Whether the engine supports file uploads
     # if True, database will be listed as option in the upload file form
     supports_file_upload = True

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -192,6 +192,9 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
     # when editing the database, mask this field in `encrypted_extra`
     # pylint: disable=invalid-name
     encrypted_extra_sensitive_fields = {"$.credentials_info.private_key"}
+    encrypted_extra_sensitive_field_labels = {
+        "$.credentials_info.private_key": "Service Account Private Key",
+    }
 
     """
     https://www.python.org/dev/peps/pep-0249/#arraysize

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -191,8 +191,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
 
     # when editing the database, mask this field in `encrypted_extra`
     # pylint: disable=invalid-name
-    encrypted_extra_sensitive_fields = {"$.credentials_info.private_key"}
-    encrypted_extra_sensitive_field_labels = {
+    encrypted_extra_sensitive_fields = {
         "$.credentials_info.private_key": "Service Account Private Key",
     }
 

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -133,6 +133,10 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         "$.service_account_info.private_key",
         "$.oauth2_client_info.secret",
     }
+    encrypted_extra_sensitive_field_labels = {
+        "$.service_account_info.private_key": "Service Account Private Key",
+        "$.oauth2_client_info.secret": "OAuth2 Client Secret",
+    }
 
     custom_errors: dict[Pattern[str], tuple[str, SupersetErrorType, dict[str, Any]]] = {
         SYNTAX_ERROR_REGEX: (

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -130,10 +130,6 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
     # when editing the database, mask this field in `encrypted_extra`
     # pylint: disable=invalid-name
     encrypted_extra_sensitive_fields = {
-        "$.service_account_info.private_key",
-        "$.oauth2_client_info.secret",
-    }
-    encrypted_extra_sensitive_field_labels = {
         "$.service_account_info.private_key": "Service Account Private Key",
         "$.oauth2_client_info.secret": "OAuth2 Client Secret",
     }

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -310,6 +310,10 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
         "$.aws_iam.external_id",
         "$.aws_iam.role_arn",
     }
+    encrypted_extra_sensitive_field_labels = {
+        "$.aws_iam.external_id": "AWS IAM External ID",
+        "$.aws_iam.role_arn": "AWS IAM Role ARN",
+    }
 
     @staticmethod
     def update_params_from_encrypted_extra(

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -307,10 +307,6 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
     # This follows the pattern used by other engine specs (bigquery, snowflake, etc.)
     # that specify exact paths rather than using the base class's catch-all "$.*".
     encrypted_extra_sensitive_fields = {
-        "$.aws_iam.external_id",
-        "$.aws_iam.role_arn",
-    }
-    encrypted_extra_sensitive_field_labels = {
         "$.aws_iam.external_id": "AWS IAM External ID",
         "$.aws_iam.role_arn": "AWS IAM Role ARN",
     }

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -467,6 +467,10 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
         "$.aws_iam.external_id",
         "$.aws_iam.role_arn",
     }
+    encrypted_extra_sensitive_field_labels = {
+        "$.aws_iam.external_id": "AWS IAM External ID",
+        "$.aws_iam.role_arn": "AWS IAM Role ARN",
+    }
 
     column_type_mappings = (
         (

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -464,10 +464,6 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
     # This follows the pattern used by other engine specs (bigquery, snowflake, etc.)
     # that specify exact paths rather than using the base class's catch-all "$.*".
     encrypted_extra_sensitive_fields = {
-        "$.aws_iam.external_id",
-        "$.aws_iam.role_arn",
-    }
-    encrypted_extra_sensitive_field_labels = {
         "$.aws_iam.external_id": "AWS IAM External ID",
         "$.aws_iam.role_arn": "AWS IAM Role ARN",
     }

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -206,10 +206,6 @@ class RedshiftEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
     # This follows the pattern used by other engine specs (bigquery, snowflake, etc.)
     # that specify exact paths rather than using the base class's catch-all "$.*".
     encrypted_extra_sensitive_fields = {
-        "$.aws_iam.external_id",
-        "$.aws_iam.role_arn",
-    }
-    encrypted_extra_sensitive_field_labels = {
         "$.aws_iam.external_id": "AWS IAM External ID",
         "$.aws_iam.role_arn": "AWS IAM Role ARN",
     }

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -209,6 +209,10 @@ class RedshiftEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
         "$.aws_iam.external_id",
         "$.aws_iam.role_arn",
     }
+    encrypted_extra_sensitive_field_labels = {
+        "$.aws_iam.external_id": "AWS IAM External ID",
+        "$.aws_iam.role_arn": "AWS IAM Role ARN",
+    }
 
     @staticmethod
     def update_params_from_encrypted_extra(

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -154,6 +154,10 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         "$.auth_params.privatekey_body",
         "$.auth_params.privatekey_pass",
     }
+    encrypted_extra_sensitive_field_labels = {
+        "$.auth_params.privatekey_body": "Private Key Body",
+        "$.auth_params.privatekey_pass": "Private Key Password",
+    }
 
     _time_grain_expressions = {
         None: "{col}",

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -151,10 +151,6 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
 
     # pylint: disable=invalid-name
     encrypted_extra_sensitive_fields = {
-        "$.auth_params.privatekey_body",
-        "$.auth_params.privatekey_pass",
-    }
-    encrypted_extra_sensitive_field_labels = {
         "$.auth_params.privatekey_body": "Private Key Body",
         "$.auth_params.privatekey_pass": "Private Key Password",
     }

--- a/superset/db_engine_specs/ydb.py
+++ b/superset/db_engine_specs/ydb.py
@@ -43,8 +43,7 @@ class YDBEngineSpec(BaseEngineSpec):
     sqlalchemy_uri_placeholder = "ydb://{host}:{port}/{database_name}"
 
     # pylint: disable=invalid-name
-    encrypted_extra_sensitive_fields = {"$.connect_args.credentials", "$.credentials"}
-    encrypted_extra_sensitive_field_labels = {
+    encrypted_extra_sensitive_fields = {
         "$.connect_args.credentials": "Connection Credentials",
         "$.credentials": "Credentials",
     }

--- a/superset/db_engine_specs/ydb.py
+++ b/superset/db_engine_specs/ydb.py
@@ -44,6 +44,10 @@ class YDBEngineSpec(BaseEngineSpec):
 
     # pylint: disable=invalid-name
     encrypted_extra_sensitive_fields = {"$.connect_args.credentials", "$.credentials"}
+    encrypted_extra_sensitive_field_labels = {
+        "$.connect_args.credentials": "Connection Credentials",
+        "$.credentials": "Credentials",
+    }
 
     disable_ssh_tunneling = False
 

--- a/superset/importexport/api.py
+++ b/superset/importexport/api.py
@@ -147,6 +147,13 @@ class ImportExportRestApi(BaseSupersetApi):
                         the private_key should be provided in the following format:
                         `{"databases/MyDatabase.yaml": "my_private_key_password"}`.
                       type: string
+                    encrypted_extra_secrets:
+                      description: >-
+                        JSON map of secret values for masked encrypted_extra fields.
+                        Each key is a database file path and the value is a map of
+                        JSONPath expressions to secret values. For example:
+                        `{"databases/db.yaml": {"$.credentials_info.secret": "foo"}}`.
+                      type: string
                     sparse:
                       description: allow sparse update of resources
                       type: boolean
@@ -202,6 +209,11 @@ class ImportExportRestApi(BaseSupersetApi):
             if "ssh_tunnel_private_key_passwords" in request.form
             else None
         )
+        encrypted_extra_secrets = (
+            json.loads(request.form["encrypted_extra_secrets"])
+            if "encrypted_extra_secrets" in request.form
+            else None
+        )
 
         command = ImportAssetsCommand(
             contents,
@@ -210,6 +222,7 @@ class ImportExportRestApi(BaseSupersetApi):
             ssh_tunnel_passwords=ssh_tunnel_passwords,
             ssh_tunnel_private_keys=ssh_tunnel_private_keys,
             ssh_tunnel_priv_key_passwords=ssh_tunnel_priv_key_passwords,
+            encrypted_extra_secrets=encrypted_extra_secrets,
         )
         command.run()
         return self.response(200, message="OK")

--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -320,8 +320,9 @@ def get_masked_fields(
         jsonpath_expr = parse(json_path)
         for match in jsonpath_expr.find(payload):
             if match.value == PASSWORD_MASK:
-                masked.append(json_path)
-                break
+                # Using `match.full_path` instead of json_path to account
+                # for wildcards
+                masked.append(f"$.{match.full_path}")
     return masked
 
 

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -17,6 +17,8 @@
 from copy import deepcopy
 from typing import Any
 
+from superset.utils import json
+
 # example V0 import/export format
 dataset_ui_export: list[dict[str, Any]] = [
     {
@@ -396,6 +398,30 @@ database_config_no_creds: dict[str, Any] = {
     "extra": {},
     "sqlalchemy_uri": "bigquery://test-db/",
     "uuid": "2ff17edc-f3fa-4609-a5ac-b484281225bc",
+    "version": "1.0.0",
+}
+
+database_config_with_masked_encrypted_extra: dict[str, Any] = {
+    "allow_csv_upload": False,
+    "allow_ctas": False,
+    "allow_cvas": False,
+    "allow_dml": False,
+    "allow_run_async": False,
+    "cache_timeout": None,
+    "database_name": "imported_database_encrypted",
+    "expose_in_sqllab": True,
+    "extra": {},
+    "sqlalchemy_uri": "bigquery://test-project/",
+    "uuid": "c9a1dde3-889e-5bc0-9ae9-0bc229e8fa90",
+    "masked_encrypted_extra": json.dumps(
+        {
+            "credentials_info": {
+                "type": "service_account",
+                "project_id": "test-project",
+                "private_key": "-----BEGIN PRIVATE KEY-----\nMyPriVaTeKeY\n-----END PRIVATE KEY-----\n",  # noqa: E501
+            }
+        }
+    ),
     "version": "1.0.0",
 }
 

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -451,6 +451,76 @@ def test_import(
         ssh_tunnel_passwords=None,
         ssh_tunnel_private_keys=None,
         ssh_tunnel_priv_key_passwords=None,
+        encrypted_extra_secrets=None,
+    )
+
+
+def test_import_with_encrypted_extra_secrets(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that encrypted_extra_secrets are passed to ImportDatabasesCommand.
+    """
+    contents = {
+        "metadata.yaml": yaml.safe_dump(
+            {
+                "version": "1.0.0",
+                "type": "Database",
+                "timestamp": "2021-01-01T00:00:00Z",
+            }
+        ),
+        "databases/test.yaml": yaml.safe_dump(
+            {
+                "database_name": "test",
+                "sqlalchemy_uri": "bigquery://gcp-project-id/",
+                "cache_timeout": 0,
+                "expose_in_sqllab": True,
+                "allow_run_async": False,
+                "allow_ctas": False,
+                "allow_cvas": False,
+                "allow_dml": False,
+                "allow_file_upload": False,
+                "masked_encrypted_extra": json.dumps(
+                    {"credentials_info": {"private_key": "XXXXXXXXXX"}}
+                ),
+                "extra": json.dumps({"allows_virtual_table_explore": True}),
+                "uuid": "00000000-0000-0000-0000-123456789001",
+            }
+        ),
+    }
+    mocker.patch("superset.databases.api.is_zipfile", return_value=True)
+    mocker.patch("superset.databases.api.ZipFile")
+    mocker.patch(
+        "superset.databases.api.get_contents_from_bundle",
+        return_value=contents,
+    )
+    command = mocker.patch("superset.databases.api.ImportDatabasesCommand")
+
+    secrets = {
+        "databases/test.yaml": {
+            "$.credentials_info.private_key": "-----BEGIN PRIVATE KEY-----"
+        }
+    }
+    form_data = {
+        "formData": (BytesIO(b"test"), "test.zip"),
+        "encrypted_extra_secrets": json.dumps(secrets),
+    }
+    client.post(
+        "/api/v1/database/import/",
+        data=form_data,
+        content_type="multipart/form-data",
+    )
+
+    command.assert_called_with(
+        contents,
+        passwords=None,
+        overwrite=False,
+        ssh_tunnel_passwords=None,
+        ssh_tunnel_private_keys=None,
+        ssh_tunnel_priv_key_passwords=None,
+        encrypted_extra_secrets=secrets,
     )
 
 

--- a/tests/unit_tests/db_engine_specs/test_base.py
+++ b/tests/unit_tests/db_engine_specs/test_base.py
@@ -360,6 +360,51 @@ def test_unmask_encrypted_extra() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "masked_encrypted_extra,expected_result",
+    [
+        (
+            {
+                "$.credentials_info.private_key": "Private Key",
+                "$.access_token": "Access Token",
+            },
+            {
+                "$.credentials_info.private_key",
+                "$.access_token",
+            },
+        ),
+        (
+            {
+                "$.credentials_info.private_key",
+                "$.access_token",
+            },
+            {
+                "$.credentials_info.private_key",
+                "$.access_token",
+            },
+        ),
+        (
+            None,
+            {"$.*"},
+        ),
+    ],
+)
+def test_encrypted_extra_sensitive_field_paths_from_dict(
+    masked_encrypted_extra: set[str] | dict[str, str] | None,
+    expected_result: set[str],
+) -> None:
+    """
+    Test that `encrypted_extra_sensitive_field_paths` extracts the keys
+    when `encrypted_extra_sensitive_fields` is a dict.
+    """
+
+    class DictFieldsSpec(BaseEngineSpec):
+        if masked_encrypted_extra:
+            encrypted_extra_sensitive_fields = masked_encrypted_extra
+
+    assert DictFieldsSpec.encrypted_extra_sensitive_field_paths() == expected_result
+
+
 def test_impersonate_user_backwards_compatible(mocker: MockerFixture) -> None:
     """
     Test that the `impersonate_user` method calls the original methods it replaced.

--- a/tests/unit_tests/utils/json_tests.py
+++ b/tests/unit_tests/utils/json_tests.py
@@ -365,6 +365,30 @@ def test_set_masked_fields(
                 "$.oauth2_client_info.secret",
             ],
         ),
+        (
+            {
+                "foo": PASSWORD_MASK,
+                "service_account_info": PASSWORD_MASK,
+            },
+            {"$.*"},
+            ["$.foo", "$.service_account_info"],
+        ),
+        (
+            {
+                "foo": PASSWORD_MASK,
+                "bar": "actual_value",
+            },
+            {"$.*"},
+            ["$.foo"],
+        ),
+        (
+            {
+                "foo": "actual_value",
+                "bar": "other_value",
+            },
+            {"$.*"},
+            [],
+        ),
     ],
 )
 def test_get_masked_fields(
@@ -376,7 +400,7 @@ def test_get_masked_fields(
     Test that get_masked_fields returns paths where value equals PASSWORD_MASK.
     """
     masked = json.get_masked_fields(payload, sensitive_fields)
-    assert masked == sorted(expected_result)
+    assert sorted(masked) == sorted(expected_result)
 
 
 def test_format_timedelta():

--- a/tests/unit_tests/utils/json_tests.py
+++ b/tests/unit_tests/utils/json_tests.py
@@ -19,6 +19,7 @@ import math
 import uuid
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -26,6 +27,7 @@ import pandas as pd
 import pytest
 import pytz
 
+from superset.constants import PASSWORD_MASK
 from superset.utils import json
 from superset.utils.core import (
     zlib_compress,
@@ -262,6 +264,119 @@ def test_json_int_dttm_ser():
 
     with pytest.raises(TypeError):
         json.json_int_dttm_ser(np.datetime64())
+
+
+@pytest.mark.parametrize(
+    "payload,path_values,expected_result",
+    [
+        (
+            {
+                "credentials_info": {
+                    "type": "service_account",
+                    "private_key": "XXXXXXXXXX",
+                },
+            },
+            {"$.credentials_info.private_key": "NEW_KEY"},
+            {
+                "credentials_info": {
+                    "type": "service_account",
+                    "private_key": "NEW_KEY",
+                },
+            },
+        ),
+        (
+            {
+                "auth_params": {
+                    "privatekey_body": "XXXXXXXXXX",
+                    "privatekey_pass": "XXXXXXXXXX",
+                },
+                "other": "value",
+            },
+            {
+                "$.auth_params.privatekey_body": "-----BEGIN PRIVATE KEY-----",
+                "$.auth_params.privatekey_pass": "passphrase",
+            },
+            {
+                "auth_params": {
+                    "privatekey_body": "-----BEGIN PRIVATE KEY-----",
+                    "privatekey_pass": "passphrase",
+                },
+                "other": "value",
+            },
+        ),
+        (
+            {"existing": "value"},
+            {"$.nonexistent.path": "new_value"},
+            {"existing": "value"},
+        ),
+    ],
+)
+def test_set_masked_fields(
+    payload: dict[str, Any],
+    path_values: dict[str, Any],
+    expected_result: dict[str, Any],
+) -> None:
+    """
+    Test setting a value at a JSONPath location.
+    """
+    result = json.set_masked_fields(payload, path_values)
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "payload,sensitive_fields,expected_result",
+    [
+        (
+            {
+                "credentials_info": {
+                    "type": "service_account",
+                    "private_key": PASSWORD_MASK,
+                },
+            },
+            {"$.credentials_info.private_key", "$.credentials_info.type"},
+            ["$.credentials_info.private_key"],
+        ),
+        (
+            {
+                "credentials_info": {
+                    "private_key": "ACTUAL_KEY",
+                },
+            },
+            {"$.credentials_info.private_key"},
+            [],
+        ),
+        (
+            {
+                "auth_params": {
+                    "privatekey_body": PASSWORD_MASK,
+                    "privatekey_pass": "actual_pass",
+                },
+                "oauth2_client_info": {
+                    "secret": PASSWORD_MASK,
+                },
+            },
+            {
+                "$.auth_params.privatekey_body",
+                "$.auth_params.privatekey_pass",
+                "$.oauth2_client_info.secret",
+            },
+            [
+                "$.auth_params.privatekey_body",
+                "$.oauth2_client_info.secret",
+            ],
+        ),
+    ],
+)
+def test_get_masked_fields(
+    payload: dict[str, Any],
+    sensitive_fields: set[str],
+    expected_result: dict[str, Any],
+) -> None:
+    """
+    Test that get_masked_fields returns paths where value equals PASSWORD_MASK.
+    """
+    masked = json.get_masked_fields(payload, sensitive_fields)
+    assert masked == sorted(expected_result)
 
 
 def test_format_timedelta():


### PR DESCRIPTION
### SUMMARY
This PR adds support for exporting/importing `masked_encrypted_extra` info from DB connections. This is useful for:
* BQ connections
* GSheets connection
* OAuth connections
* Any DB connection that includes sensitive info in secure_extra

#### Stacked diffs implementation
The feature was split into 3 PRs:
* https://github.com/apache/superset/pull/38075: Labels for encrypted fields.
* https://github.com/apache/superset/pull/38077 (this one): Backend implementation.
* https://github.com/apache/superset/pull/38078: Frontend implementation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Videos added to https://github.com/apache/superset/pull/38078

### TESTING INSTRUCTIONS
Test coverage added

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
