### PR TITLE
feat: support for import/export masked_encrypted_extra (frontend)

### DIFF
--- a/superset-frontend/src/components/ImportModal/ImportModal.test.tsx
+++ b/superset-frontend/src/components/ImportModal/ImportModal.test.tsx
@@ -140,3 +140,47 @@ test('should render ssh_tunnel private_key_password fields when needed for impor
   });
   expect(getByTestId('ssh_tunnel_private_key_password')).toBeInTheDocument();
 });
+
+test('should render encrypted extra secret fields when needed for import', () => {
+  const { getByTestId } = setup({
+    encryptedExtraFields: [
+      {
+        fileName: 'databases/examples.yaml',
+        fields: [
+          {
+            path: '$.credentials_info.private_key',
+            label: 'Service Account Private Key',
+          },
+        ],
+      },
+    ],
+  });
+  expect(getByTestId('encrypted_extra_secret')).toBeInTheDocument();
+});
+
+test('should render multiple encrypted extra secret fields for multiple files', () => {
+  const { getAllByTestId } = setup({
+    encryptedExtraFields: [
+      {
+        fileName: 'databases/bigquery.yaml',
+        fields: [
+          {
+            path: '$.credentials_info.private_key',
+            label: 'Service Account Private Key',
+          },
+        ],
+      },
+      {
+        fileName: 'databases/snowflake.yaml',
+        fields: [
+          { path: '$.auth_params.privatekey_body', label: 'Private Key Body' },
+          {
+            path: '$.auth_params.privatekey_pass',
+            label: 'Private Key Password',
+          },
+        ],
+      },
+    ],
+  });
+  expect(getAllByTestId('encrypted_extra_secret')).toHaveLength(3);
+});

--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -78,6 +78,8 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
   setSSHTunnelPrivateKeyFields = () => {},
   sshTunnelPrivateKeyPasswordFields = [],
   setSSHTunnelPrivateKeyPasswordFields = () => {},
+  encryptedExtraFields = [],
+  setEncryptedExtraFields = () => {},
 }) => {
   const [isHidden, setIsHidden] = useState<boolean>(true);
   const [passwords, setPasswords] = useState<Record<string, string>>({});
@@ -95,6 +97,9 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
   >({});
   const [sshTunnelPrivateKeyPasswords, setSSHTunnelPrivateKeyPasswords] =
     useState<Record<string, string>>({});
+  const [encryptedExtraSecrets, setEncryptedExtraSecrets] = useState<
+    Record<string, Record<string, string>>
+  >({});
 
   const clearModal = () => {
     setFileList([]);
@@ -110,6 +115,8 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
     setSSHTunnelPasswords({});
     setSSHTunnelPrivateKeys({});
     setSSHTunnelPrivateKeyPasswords({});
+    setEncryptedExtraFields([]);
+    setEncryptedExtraSecrets({});
   };
 
   const handleErrorMsg = (msg: string) => {
@@ -123,6 +130,7 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
       sshPasswordNeeded,
       sshPrivateKeyNeeded,
       sshPrivateKeyPasswordNeeded,
+      encryptedExtraFieldsNeeded,
     },
     importResource,
   } = useImportResource(resourceName, resourceLabel, handleErrorMsg);
@@ -162,6 +170,13 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
     }
   }, [sshPrivateKeyPasswordNeeded, setSSHTunnelPrivateKeyPasswordFields]);
 
+  useEffect(() => {
+    setEncryptedExtraFields(encryptedExtraFieldsNeeded);
+    if (encryptedExtraFieldsNeeded.length > 0) {
+      setImportingModel(false);
+    }
+  }, [encryptedExtraFieldsNeeded, setEncryptedExtraFields]);
+
   // Functions
   const hide = () => {
     setIsHidden(true);
@@ -181,6 +196,7 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
       sshTunnelPasswords,
       sshTunnelPrivateKeys,
       sshTunnelPrivateKeyPasswords,
+      encryptedExtraSecrets,
       confirmedOverwrite,
     ).then(result => {
       if (result) {
@@ -214,7 +230,8 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
       passwordFields.length === 0 &&
       sshTunnelPasswordFields.length === 0 &&
       sshTunnelPrivateKeyFields.length === 0 &&
-      sshTunnelPrivateKeyPasswordFields.length === 0
+      sshTunnelPrivateKeyPasswordFields.length === 0 &&
+      encryptedExtraFields.length === 0
     ) {
       return null;
     }
@@ -320,6 +337,35 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
             )}
           </>
         ))}
+        {encryptedExtraFields.map(({ fileName, fields }) => (
+          <StyledContainer key={`encrypted-extra-for-${fileName}`}>
+            <div className="control-label">
+              {t('%s ENCRYPTED EXTRA', fileName.slice(10))}
+            </div>
+            {fields.map(field => (
+              <div key={`${fileName}-${field.path}`}>
+                <div className="control-label">
+                  {field.label}
+                  <span className="required">*</span>
+                </div>
+                <Input.Password
+                  name={`encrypted-extra-${fileName}-${field.path}`}
+                  value={encryptedExtraSecrets[fileName]?.[field.path] || ''}
+                  onChange={event =>
+                    setEncryptedExtraSecrets({
+                      ...encryptedExtraSecrets,
+                      [fileName]: {
+                        ...encryptedExtraSecrets[fileName],
+                        [field.path]: event.target.value,
+                      },
+                    })
+                  }
+                  data-test="encrypted_extra_secret"
+                />
+              </div>
+            ))}
+          </StyledContainer>
+        ))}
       </>
     );
   };
@@ -392,7 +438,8 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
             passwordFields.length > 0 ||
             sshTunnelPasswordFields.length > 0 ||
             sshTunnelPrivateKeyFields.length > 0 ||
-            sshTunnelPrivateKeyPasswordFields.length > 0
+            sshTunnelPrivateKeyPasswordFields.length > 0 ||
+            encryptedExtraFields.length > 0
           }
         />
       )}

--- a/superset-frontend/src/components/ImportModal/types.ts
+++ b/superset-frontend/src/components/ImportModal/types.ts
@@ -38,4 +38,14 @@ export interface ImportModelsModalProps {
   setSSHTunnelPrivateKeyPasswordFields?: (
     sshTunnelPrivateKeyPasswordFields: string[],
   ) => void;
+  encryptedExtraFields?: {
+    fileName: string;
+    fields: { path: string; label: string }[];
+  }[];
+  setEncryptedExtraFields?: (
+    encryptedExtraFields: {
+      fileName: string;
+      fields: { path: string; label: string }[];
+    }[],
+  ) => void;
 }

--- a/superset-frontend/src/components/ImportModal/types.ts
+++ b/superset-frontend/src/components/ImportModal/types.ts
@@ -16,7 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ImportResourceName } from 'src/views/CRUD/types';
+import {
+  FileEncryptedExtraFields,
+  ImportResourceName,
+} from 'src/views/CRUD/types';
 
 export interface ImportModelsModalProps {
   resourceName: ImportResourceName;
@@ -38,14 +41,8 @@ export interface ImportModelsModalProps {
   setSSHTunnelPrivateKeyPasswordFields?: (
     sshTunnelPrivateKeyPasswordFields: string[],
   ) => void;
-  encryptedExtraFields?: {
-    fileName: string;
-    fields: { path: string; label: string }[];
-  }[];
+  encryptedExtraFields?: FileEncryptedExtraFields[];
   setEncryptedExtraFields?: (
-    encryptedExtraFields: {
-      fileName: string;
-      fields: { path: string; label: string }[];
-    }[],
+    encryptedExtraFields: FileEncryptedExtraFields[],
   ) => void;
 }

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -62,6 +62,7 @@ import {
   getConnectionAlert,
   useImportResource,
 } from 'src/views/CRUD/hooks';
+import { FileEncryptedExtraFields } from 'src/views/CRUD/types';
 import { useCommonConf } from 'src/features/databases/state';
 import { isEmpty, pick } from 'lodash';
 import { OnlyKeyWithType } from 'src/utils/types';
@@ -647,7 +648,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     setSSHTunnelPrivateKeyPasswordFields,
   ] = useState<string[]>([]);
   const [encryptedExtraFields, setEncryptedExtraFields] = useState<
-    { fileName: string; fields: { path: string; label: string }[] }[]
+    FileEncryptedExtraFields[]
   >([]);
   const [encryptedExtraSecrets, setEncryptedExtraSecrets] = useState<
     Record<string, Record<string, string>>

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -646,6 +646,12 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     sshTunnelPrivateKeyPasswordFields,
     setSSHTunnelPrivateKeyPasswordFields,
   ] = useState<string[]>([]);
+  const [encryptedExtraFields, setEncryptedExtraFields] = useState<
+    { fileName: string; fields: { path: string; label: string }[] }[]
+  >([]);
+  const [encryptedExtraSecrets, setEncryptedExtraSecrets] = useState<
+    Record<string, Record<string, string>>
+  >({});
   const [extraExtensionComponentState, setExtraExtensionComponentState] =
     useState<object>({});
 
@@ -821,6 +827,8 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     setSSHTunnelPasswords({});
     setSSHTunnelPrivateKeys({});
     setSSHTunnelPrivateKeyPasswords({});
+    setEncryptedExtraFields([]);
+    setEncryptedExtraSecrets({});
     setConfirmedOverwrite(false);
     setUseSSHTunneling(undefined);
     onHide();
@@ -838,6 +846,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       sshPasswordNeeded,
       sshPrivateKeyNeeded,
       sshPrivateKeyPasswordNeeded,
+      encryptedExtraFieldsNeeded,
       loading: importLoading,
       failed: importErrored,
     },
@@ -1026,6 +1035,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         sshTunnelPasswords,
         sshTunnelPrivateKeys,
         sshTunnelPrivateKeyPasswords,
+        encryptedExtraSecrets,
         confirmedOverwrite,
       );
       if (dbId) {
@@ -1230,16 +1240,24 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       setSSHTunnelPasswordFields([]);
       setSSHTunnelPrivateKeyFields([]);
       setSSHTunnelPrivateKeyPasswordFields([]);
+      setEncryptedExtraFields([]);
       setPasswords({});
       setSSHTunnelPasswords({});
       setSSHTunnelPrivateKeys({});
       setSSHTunnelPrivateKeyPasswords({});
+      setEncryptedExtraSecrets({});
     }
     setDB({ type: ActionType.Reset });
     setFileList([]);
   };
 
   const handleDisableOnImport = () => {
+    // Check if any encrypted extra field is missing a secret
+    const hasEmptyEncryptedExtraSecrets = encryptedExtraFields.some(
+      ({ fileName, fields }) =>
+        fields.some(field => !encryptedExtraSecrets[fileName]?.[field.path]),
+    );
+
     if (
       importLoading ||
       (alreadyExists.length && !confirmedOverwrite) ||
@@ -1249,7 +1267,8 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       (sshPrivateKeyNeeded.length &&
         JSON.stringify(sshTunnelPrivateKeys) === '{}') ||
       (sshPrivateKeyPasswordNeeded.length &&
-        JSON.stringify(sshTunnelPrivateKeyPasswords) === '{}')
+        JSON.stringify(sshTunnelPrivateKeyPasswords) === '{}') ||
+      (encryptedExtraFields.length && hasEmptyEncryptedExtraSecrets)
     )
       return true;
     return false;
@@ -1369,6 +1388,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       !sshPasswordNeeded.length &&
       !sshPrivateKeyNeeded.length &&
       !sshPrivateKeyPasswordNeeded.length &&
+      !encryptedExtraFieldsNeeded.length &&
       !isLoading && // This prevents a double toast for non-related imports
       !importErrored // This prevents a success toast on error
     ) {
@@ -1383,6 +1403,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     sshPasswordNeeded,
     sshPrivateKeyNeeded,
     sshPrivateKeyPasswordNeeded,
+    encryptedExtraFieldsNeeded,
   ]);
 
   useEffect(() => {
@@ -1424,7 +1445,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     if (importingModal) {
       document
         ?.getElementsByClassName('ant-upload-list-item-name')[0]
-        .scrollIntoView();
+        ?.scrollIntoView();
     }
   }, [importingModal]);
 
@@ -1445,6 +1466,10 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   }, [sshPrivateKeyPasswordNeeded]);
 
   useEffect(() => {
+    setEncryptedExtraFields([...encryptedExtraFieldsNeeded]);
+  }, [encryptedExtraFieldsNeeded]);
+
+  useEffect(() => {
     if (db?.parameters?.ssh !== undefined) {
       setUseSSHTunneling(db.parameters.ssh);
     }
@@ -1456,10 +1481,12 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     setSSHTunnelPasswordFields([]);
     setSSHTunnelPrivateKeyFields([]);
     setSSHTunnelPrivateKeyPasswordFields([]);
+    setEncryptedExtraFields([]);
     setPasswords({});
     setSSHTunnelPasswords({});
     setSSHTunnelPrivateKeys({});
     setSSHTunnelPrivateKeyPasswords({});
+    setEncryptedExtraSecrets({});
     setImportingModal(true);
     setFileList([
       {
@@ -1475,6 +1502,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       sshTunnelPasswords,
       sshTunnelPrivateKeys,
       sshTunnelPrivateKeyPasswords,
+      encryptedExtraSecrets,
       confirmedOverwrite,
     );
     if (dbId) onDatabaseAdd?.();
@@ -1508,7 +1536,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
             showIcon
             message="Database passwords"
             description={t(
-              `The passwords for the databases below are needed in order to import them. Please note that the "Secure Extra" and "Certificate" sections of the database configuration are not present in explore files and should be added manually after the import if they are needed.`,
+              `The passwords for the databases below are needed in order to import them.`,
             )}
           />
         </StyledAlertMargin>
@@ -1588,6 +1616,50 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           />
         )}
       </>
+    ));
+  };
+
+  const encryptedExtraNeededField = () => {
+    if (!encryptedExtraFields.length) return null;
+
+    return encryptedExtraFields.map(({ fileName, fields }) => (
+      <div key={fileName}>
+        <StyledAlertMargin>
+          <Alert
+            closable={false}
+            css={(theme: SupersetTheme) => antDAlertStyles(theme)}
+            type="info"
+            showIcon
+            message={t('Encrypted extra fields')}
+            description={t(
+              `The following fields contain sensitive information that was masked during export. Please provide the values to import this database.`,
+            )}
+          />
+        </StyledAlertMargin>
+        {fields.map(field => (
+          <ValidatedInput
+            key={`${fileName}-${field.path}`}
+            id={`encrypted_extra_${field.path}`}
+            name={`encrypted_extra_${field.path}`}
+            required
+            visibilityToggle
+            value={encryptedExtraSecrets[fileName]?.[field.path] || ''}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              setEncryptedExtraSecrets({
+                ...encryptedExtraSecrets,
+                [fileName]: {
+                  ...encryptedExtraSecrets[fileName],
+                  [field.path]: event.target.value,
+                },
+              })
+            }
+            isValidating={isValidating}
+            validationMethods={{ onBlur: () => {} }}
+            label={t('%s %s', fileName.slice(10), field.label)}
+            css={formScrollableStyles}
+          />
+        ))}
+      </div>
     ));
   };
 
@@ -1868,7 +1940,8 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       passwordFields.length ||
       sshTunnelPasswordFields.length ||
       sshTunnelPrivateKeyFields.length ||
-      sshTunnelPrivateKeyPasswordFields.length)
+      sshTunnelPrivateKeyPasswordFields.length ||
+      encryptedExtraFields.length)
   ) {
     return (
       <Modal
@@ -1907,6 +1980,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         {confirmOverwriteField()}
         {importingErrorAlert()}
         {passwordNeededField()}
+        {encryptedExtraNeededField()}
       </Modal>
     );
   }

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -45,7 +45,11 @@ import copyTextToClipboard from 'src/utils/copy';
 import { ensureAppRoot } from 'src/utils/pathUtils';
 import SupersetText from 'src/utils/textUtils';
 import { DatabaseObject } from 'src/features/databases/types';
-import { FavoriteStatus, ImportResourceName } from './types';
+import {
+  FavoriteStatus,
+  FileEncryptedExtraFields,
+  ImportResourceName,
+} from './types';
 
 interface ListViewResourceState<D extends object = any> {
   loading: boolean;
@@ -440,10 +444,7 @@ interface ImportResourceState {
   sshPasswordNeeded: string[];
   sshPrivateKeyNeeded: string[];
   sshPrivateKeyPasswordNeeded: string[];
-  encryptedExtraFieldsNeeded: {
-    fileName: string;
-    fields: { path: string; label: string }[];
-  }[];
+  encryptedExtraFieldsNeeded: FileEncryptedExtraFields[];
   failed: boolean;
 }
 

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -34,6 +34,7 @@ import {
   getSSHPasswordsNeeded,
   getSSHPrivateKeysNeeded,
   getSSHPrivateKeyPasswordsNeeded,
+  getEncryptedExtraFieldsNeeded,
 } from 'src/views/CRUD/utils';
 import type {
   ListViewFetchDataConfig as FetchDataConfig,
@@ -439,6 +440,10 @@ interface ImportResourceState {
   sshPasswordNeeded: string[];
   sshPrivateKeyNeeded: string[];
   sshPrivateKeyPasswordNeeded: string[];
+  encryptedExtraFieldsNeeded: {
+    fileName: string;
+    fields: { path: string; label: string }[];
+  }[];
   failed: boolean;
 }
 
@@ -454,6 +459,7 @@ export function useImportResource(
     sshPasswordNeeded: [],
     sshPrivateKeyNeeded: [],
     sshPrivateKeyPasswordNeeded: [],
+    encryptedExtraFieldsNeeded: [],
     failed: false,
   });
 
@@ -468,6 +474,7 @@ export function useImportResource(
       sshTunnelPasswords: Record<string, string> = {},
       sshTunnelPrivateKey: Record<string, string> = {},
       sshTunnelPrivateKeyPasswords: Record<string, string> = {},
+      encryptedExtraSecrets: Record<string, Record<string, string>> = {},
       overwrite = false,
     ) => {
       // Set loading state
@@ -522,6 +529,18 @@ export function useImportResource(
           JSON.stringify(sshTunnelPrivateKeyPasswords),
         );
       }
+      /* The import bundle may contain masked_encrypted_extra; if required
+       * the secrets should be provided by the user during import.
+       */
+      if (
+        encryptedExtraSecrets &&
+        Object.keys(encryptedExtraSecrets).length > 0
+      ) {
+        formData.append(
+          'encrypted_extra_secrets',
+          JSON.stringify(encryptedExtraSecrets),
+        );
+      }
 
       return SupersetClient.post({
         endpoint: `/api/v1/${resourceName}/import/`,
@@ -535,6 +554,7 @@ export function useImportResource(
             sshPasswordNeeded: [],
             sshPrivateKeyNeeded: [],
             sshPrivateKeyPasswordNeeded: [],
+            encryptedExtraFieldsNeeded: [],
             failed: false,
           });
           return true;
@@ -571,6 +591,9 @@ export function useImportResource(
                 sshPasswordNeeded: getSSHPasswordsNeeded(error.errors),
                 sshPrivateKeyNeeded: getSSHPrivateKeysNeeded(error.errors),
                 sshPrivateKeyPasswordNeeded: getSSHPrivateKeyPasswordsNeeded(
+                  error.errors,
+                ),
+                encryptedExtraFieldsNeeded: getEncryptedExtraFieldsNeeded(
                   error.errors,
                 ),
                 alreadyExists: getAlreadyExists(error.errors),

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -154,3 +154,13 @@ export interface Tag {
 
 export type DatabaseObject = Partial<Database> &
   Pick<Database, 'sqlalchemy_uri'>;
+
+export interface EncryptedExtraField {
+  path: string;
+  label: string;
+}
+
+export interface FileEncryptedExtraFields {
+  fileName: string;
+  fields: EncryptedExtraField[];
+}

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -42,7 +42,13 @@ import {
   OWNER_TEXT_LABEL_PROP,
   OWNER_EMAIL_PROP,
 } from 'src/features/owners/OwnerSelectLabel';
-import { Dashboard, Filter, TableTab } from './types';
+import {
+  Dashboard,
+  EncryptedExtraField,
+  FileEncryptedExtraFields,
+  Filter,
+  TableTab,
+} from './types';
 
 // Modifies the rison encoding slightly to match the backend's rison encoding/decoding. Applies globally.
 // Code pulled from rison.js (https://github.com/Nanonid/rison), rison is licensed under the MIT license.
@@ -522,11 +528,6 @@ export const getAlreadyExists = (errors: Record<string, any>[]) =>
 const ENCRYPTED_EXTRA_FIELD_REGEX =
   /^Must provide value for masked_encrypted_extra field: (.+?)(?:\s+\((.+)\))?$/;
 
-export interface EncryptedExtraField {
-  path: string;
-  label: string;
-}
-
 export /* eslint-disable no-underscore-dangle */
 const isNeedsEncryptedExtraField = (payload: any) =>
   typeof payload === 'object' &&
@@ -535,25 +536,23 @@ const isNeedsEncryptedExtraField = (payload: any) =>
 
 export const getEncryptedExtraFieldsNeeded = (
   errors: Record<string, any>[],
-): { fileName: string; fields: EncryptedExtraField[] }[] =>
-  errors
-    .map(error =>
-      Object.entries(error.extra)
-        .filter(([, payload]) => isNeedsEncryptedExtraField(payload))
-        .map(([fileName, payload]) => ({
-          fileName,
-          fields: (payload as any)._schema
-            .filter((e: string) => ENCRYPTED_EXTRA_FIELD_REGEX.test(e))
-            .map((e: string) => {
-              const match = e.match(ENCRYPTED_EXTRA_FIELD_REGEX);
-              if (!match) return null;
-              const path = match[1];
-              return { path, label: match[2] || path };
-            })
-            .filter(Boolean) as EncryptedExtraField[],
-        })),
-    )
-    .flat();
+): FileEncryptedExtraFields[] =>
+  errors.flatMap(error =>
+    Object.entries(error.extra)
+      .filter(([, payload]) => isNeedsEncryptedExtraField(payload))
+      .map(([fileName, payload]) => ({
+        fileName,
+        fields: (payload as any)._schema
+          .filter((e: string) => ENCRYPTED_EXTRA_FIELD_REGEX.test(e))
+          .map((e: string) => {
+            const match = e.match(ENCRYPTED_EXTRA_FIELD_REGEX);
+            if (!match) return null;
+            const path = match[1];
+            return { path, label: match[2] || path };
+          })
+          .filter(Boolean) as EncryptedExtraField[],
+      })),
+  );
 
 export const hasTerminalValidation = (errors: Record<string, any>[]) =>
   errors.some(error => {

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -516,6 +516,45 @@ export const getAlreadyExists = (errors: Record<string, any>[]) =>
       .map(([fileName]) => fileName),
   );
 
+// Matches error messages for masked_encrypted_extra fields.
+// Format: "Must provide value for masked_encrypted_extra field: $.path (Label)"
+// The label in parentheses is optional.
+const ENCRYPTED_EXTRA_FIELD_REGEX =
+  /^Must provide value for masked_encrypted_extra field: (.+?)(?:\s+\((.+)\))?$/;
+
+export interface EncryptedExtraField {
+  path: string;
+  label: string;
+}
+
+export /* eslint-disable no-underscore-dangle */
+const isNeedsEncryptedExtraField = (payload: any) =>
+  typeof payload === 'object' &&
+  Array.isArray(payload._schema) &&
+  payload._schema?.some((e: string) => ENCRYPTED_EXTRA_FIELD_REGEX.test(e));
+
+export const getEncryptedExtraFieldsNeeded = (
+  errors: Record<string, any>[],
+): { fileName: string; fields: EncryptedExtraField[] }[] =>
+  errors
+    .map(error =>
+      Object.entries(error.extra)
+        .filter(([, payload]) => isNeedsEncryptedExtraField(payload))
+        .map(([fileName, payload]) => ({
+          fileName,
+          fields: (payload as any)._schema
+            .filter((e: string) => ENCRYPTED_EXTRA_FIELD_REGEX.test(e))
+            .map((e: string) => {
+              const match = e.match(ENCRYPTED_EXTRA_FIELD_REGEX);
+              if (!match) return null;
+              const path = match[1];
+              return { path, label: match[2] || path };
+            })
+            .filter(Boolean) as EncryptedExtraField[],
+        })),
+    )
+    .flat();
+
 export const hasTerminalValidation = (errors: Record<string, any>[]) =>
   errors.some(error => {
     const noIssuesCodes = Object.entries(error.extra).filter(
@@ -530,7 +569,8 @@ export const hasTerminalValidation = (errors: Record<string, any>[]) =>
         isAlreadyExists(payload) ||
         isNeedsSSHPassword(payload) ||
         isNeedsSSHPrivateKey(payload) ||
-        isNeedsSSHPrivateKeyPassword(payload),
+        isNeedsSSHPrivateKeyPassword(payload) ||
+        isNeedsEncryptedExtraField(payload),
     );
   });
 


### PR DESCRIPTION
## **User description**
### SUMMARY
This PR adds support for exporting/importing `masked_encrypted_extra` info from DB connections. This is useful for:
- BQ connections
- GSheets connection
- OAuth connections
- Any DB connection that includes sensitive info in `secure_extra`

#### Stacked diffs implementation
The feature was split into 3 PRs:
* https://github.com/apache/superset/pull/38075: Labels for encrypted fields.
* https://github.com/apache/superset/pull/38077: Backend implementation.
* https://github.com/apache/superset/pull/38078 (this one): Frontend implementation.

https://github.com/apache/superset/pull/38075 can be merged now. Once it gets merged, https://github.com/apache/superset/pull/38077 can get merged as well (shouldn't impact the frontend) and this one can be merged last. As they get merged I'll update the PRs to point to `master`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Export demo**
During the export, Superset checks if there's any diff between `encrypted_extra` and `masked_encrypted_extra`:
- In case there is, it exports `masked_encrypted_extra` with fields properly masked.
- If not, it exports `encrypted_extra` directly. Note that the import already supports `encrypted_extra` (not part of this PR).

https://github.com/user-attachments/assets/1e2c8ac5-6179-4f2a-a773-eaa4b7949e74

**Import demo**
During the import, the modal prompts users to provide masked fields:

https://github.com/user-attachments/assets/d6275645-eb43-4688-a2a3-91896ed838a7

I also forced a test connection to prompt both for password and secure extra info:

<img width="513" height="865" alt="image" src="https://github.com/user-attachments/assets/4f77adba-6293-49ad-a3e5-22275c7747d0" />


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Support importing masked encrypted extra fields (frontend)**

### What Changed
- Import flow now detects when exported files require values for masked encrypted fields and asks the user to enter those secrets before importing.
- Import modal and Database import dialog show per-file, per-field prompts (with labels when available) for masked encrypted extra values and include those secrets in the import request.
- Client-side logic extracts encrypted-extra requirements from import errors, treats them as non-terminal validation (so users can supply secrets), and unit tests added to validate parsing and UI behavior.

### Impact
`✅ Clearer encrypted-field prompts during import`
`✅ Fewer import failures due to missing masked secrets`
`✅ Ability to import databases with masked secure extras`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
