### PR TITLE
fix(thumbnails): stabilize digest by sorting datasources and charts

### DIFF
--- a/superset/thumbnails/digest.py
+++ b/superset/thumbnails/digest.py
@@ -79,7 +79,7 @@ def _adjust_string_with_rls(
             if table_ids:
                 security_manager.prefetch_rls_filters(table_ids)
 
-            for datasource in datasources:
+            for datasource in sorted(datasources, key=lambda d: d.id if d else -1):
                 if datasource and getattr(datasource, "is_rls_supported", False):
                     rls_filters = datasource.get_sqla_row_level_filters()
 
@@ -110,7 +110,7 @@ def get_dashboard_digest(dashboard: Dashboard) -> str | None:
         return func(dashboard, executor_type, executor)
 
     unique_string = (
-        f"{dashboard.id}\n{dashboard.charts}\n{dashboard.position_json}\n"
+        f"{dashboard.id}\n{sorted(dashboard.charts)}\n{dashboard.position_json}\n"
         f"{dashboard.css}\n{dashboard.json_metadata}"
     )
 

--- a/tests/unit_tests/thumbnails/test_digest.py
+++ b/tests/unit_tests/thumbnails/test_digest.py
@@ -435,6 +435,65 @@ def test_chart_digest(
             assert get_chart_digest(chart=chart) == expected_result
 
 
+def test_dashboard_digest_deterministic_datasource_order(
+    app_context: None,
+) -> None:
+    """
+    Test that different datasource orderings produce the same digest.
+
+    dashboard.datasources returns a set, whose iteration order is
+    non-deterministic across Python processes (due to PYTHONHASHSEED).
+    The digest must sort datasources by ID to ensure stability.
+    """
+    from superset import security_manager
+    from superset.models.dashboard import Dashboard
+    from superset.models.slice import Slice
+    from superset.thumbnails.digest import get_dashboard_digest
+
+    kwargs = {**_DEFAULT_DASHBOARD_KWARGS}
+    slices = [Slice(**slice_kwargs) for slice_kwargs in kwargs.pop("slices")]
+    dashboard = Dashboard(**kwargs, slices=slices)
+
+    def make_datasource(ds_id: int) -> MagicMock:
+        ds = MagicMock(spec=BaseDatasource)
+        ds.id = ds_id
+        ds.type = DatasourceType.TABLE
+        ds.is_rls_supported = True
+        ds.get_sqla_row_level_filters = MagicMock(return_value=[f"filter_ds_{ds_id}"])
+        return ds
+
+    ds_a = make_datasource(5)
+    ds_b = make_datasource(3)
+    ds_c = make_datasource(9)
+
+    user = User(id=1, username="1")
+
+    digests = []
+    for ordering in [[ds_a, ds_b, ds_c], [ds_c, ds_a, ds_b], [ds_b, ds_c, ds_a]]:
+        with (
+            patch.dict(
+                current_app.config,
+                {
+                    "THUMBNAIL_EXECUTORS": [ExecutorType.CURRENT_USER],
+                    "THUMBNAIL_DASHBOARD_DIGEST_FUNC": None,
+                },
+            ),
+            patch.object(
+                type(dashboard),
+                "datasources",
+                new_callable=PropertyMock,
+                return_value=ordering,
+            ),
+            patch.object(security_manager, "find_user", return_value=user),
+            patch.object(security_manager, "prefetch_rls_filters", return_value=None),
+            override_user(user),
+        ):
+            digests.append(get_dashboard_digest(dashboard=dashboard))
+
+    assert digests[0] == digests[1] == digests[2]
+    assert digests[0] is not None
+
+
 def test_dashboard_digest_prefetches_rls_filters(
     app_context: None,
 ) -> None:


### PR DESCRIPTION
### SUMMARY

The dashboard thumbnail digest computation is non-deterministic, causing excessive cache misses and unnecessary Selenium screenshot regeneration. This was observed in production with a **4.3% cache hit rate** (24 hits out of 555 triggers over 14 days) for a single workspace, with one dashboard being re-screenshotted **132 times in a single day**.

#### Root cause

1. **`dashboard.datasources` returns a Python `set`**, and `_adjust_string_with_rls()` iterates over it to build the hash input string. Python sets have non-deterministic iteration order across different processes (different `PYTHONHASHSEED`). Different Gunicorn workers produce different digests for the same dashboard+user → cache miss → Selenium screenshot → all chart queries fire against the data warehouse.

2. **`dashboard.charts`** depends on `self.slices`, a SQLAlchemy relationship with no `order_by` clause, adding another source of ordering instability.

#### Fix

- Sort datasources by ID before iterating in `_adjust_string_with_rls()`
- Sort chart names in `get_dashboard_digest()` before including in the hash input

These are minimal, targeted changes that ensure digest stability without changing any other behavior.

### BEFORE/AFTER SCREENSHOTS OR COVERAGE URL

N/A - backend-only change, no UI impact.

### TESTING INSTRUCTIONS

1. **Unit tests**
   - Run `pytest tests/unit_tests/thumbnails/test_digest.py -v`
   - All existing tests pass unchanged (single-datasource cases produce the same hash)
   - New test `test_dashboard_digest_deterministic_datasource_order` passes — verifies 3 different orderings of the same datasources produce identical digests

2. **Manual verification — digest stability**
   - Pick a dashboard with multiple datasources
   - Call the thumbnail API multiple times: `GET /api/v1/dashboard/{id}/thumbnail/{digest}/`
   - Verify the digest in the redirect URL is consistent across requests (previously it could vary per-worker due to set iteration order)

3. **Manual verification — cache hit rate**
   - After deploying, monitor for "Caching dashboard" events
   - Cache hit rate should increase significantly (from ~4% to near 100% for steady-state dashboards)
   - Selenium screenshot generation count should drop drastically

4. **Regression checks**
   - Thumbnails still update when dashboard content actually changes (edit chart → save → new thumbnail generated)
   - RLS-filtered users still get user-specific thumbnails when `CURRENT_USER` executor is configured

### ADDITIONAL INFORMATION

- **Related PRs**: #37895, #37899, #37941 (reduce per-computation DB cost but don't fix the digest instability)
- **Impact**: For a dashboard with N datasources, there are N! possible iteration orders from the set, each potentially producing a different digest. Sorting reduces this to exactly 1 deterministic result.