### PR TITLE
feat(explore-chart-panel): darken the color of vertical split for better recognizability

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -431,5 +431,5 @@ test('should add a formula annotation when X-axis column has dataset-level label
   expect(formulaSeries).toBeDefined();
   expect(formulaSeries?.data).toBeDefined();
   expect(Array.isArray(formulaSeries?.data)).toBe(true);
-  expect((formulaSeries?.data as unknown[]).length).toBeGreaterThan(0);
+  expect((formulaSeries?.data as unknown[])?.length).toBeGreaterThan(0);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -304,8 +304,8 @@ describe('EchartsTimeseries transformProps', () => {
     expect(formulaSeries).toBeDefined();
     expect(formulaSeries?.data).toBeDefined();
     expect(Array.isArray(formulaSeries?.data)).toBe(true);
-    expect((formulaSeries?.data as unknown[]).length).toBeGreaterThan(0);
-    const firstDataPoint = (formulaSeries?.data as [number, number][])[0];
+    expect((formulaSeries?.data as unknown[])?.length).toBeGreaterThan(0);
+    const firstDataPoint = (formulaSeries?.data as [number, number][])?.[0];
     expect(firstDataPoint).toBeDefined();
     expect(firstDataPoint[1]).toBe(firstDataPoint[0] * 2);
   });
@@ -384,7 +384,7 @@ describe('EchartsTimeseries transformProps', () => {
       result.echartOptions.series as SeriesOption[] | undefined
     )?.find((s: SeriesOption) => s.name === 'My Formula');
     expect(formulaSeries).toBeDefined();
-    const firstDataPoint = (formulaSeries?.data as [number, number][])[0];
+    const firstDataPoint = (formulaSeries?.data as [number, number][])?.[0];
     expect(firstDataPoint).toBeDefined();
     expect(firstDataPoint[0]).toBe(firstDataPoint[1] * 2);
   });

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
@@ -113,8 +113,10 @@ const Styles = styled.div<{ showSplite: boolean }>`
   }
 
   .gutter {
-    border-top: 1px solid color-mix(in srgb, ${({ theme }) => theme.colorSplit}, black 15%);
-    border-bottom: 1px solid color-mix(in srgb, ${({ theme }) => theme.colorSplit}, black 15%);
+    border-top: 1px solid
+      color-mix(in srgb, ${({ theme }) => theme.colorSplit}, black 15%);
+    border-bottom: 1px solid
+      color-mix(in srgb, ${({ theme }) => theme.colorSplit}, black 15%);
     width: ${({ theme }) => theme.sizeUnit * 9}px;
     margin: ${({ theme }) => theme.sizeUnit * GUTTER_SIZE_FACTOR}px auto;
   }

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
@@ -113,8 +113,8 @@ const Styles = styled.div<{ showSplite: boolean }>`
   }
 
   .gutter {
-    border-top: 1px solid ${({ theme }) => theme.colorSplit};
-    border-bottom: 1px solid ${({ theme }) => theme.colorSplit};
+    border-top: 1px solid color-mix(in srgb, ${({ theme }) => theme.colorSplit}, black 15%);
+    border-bottom: 1px solid color-mix(in srgb, ${({ theme }) => theme.colorSplit}, black 15%);
     width: ${({ theme }) => theme.sizeUnit * 9}px;
     margin: ${({ theme }) => theme.sizeUnit * GUTTER_SIZE_FACTOR}px auto;
   }


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(explore-chart-panel): darken the color of vertical split for better recognizability

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This should help users to find the vertical split to resize the explore panel in `Charts` page better. I have a whole white background and couldn't find it very easily, only knowing that it should be in the middle.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="898" height="666" alt="image" src="https://github.com/user-attachments/assets/8d7b98ae-c0cd-4e1d-8504-d59d900b9b47" />

After
<img width="898" height="666" alt="image" src="https://github.com/user-attachments/assets/203900b9-1255-4734-8484-c4634b9d399a" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
