### PR TITLE
fix(GAQ): don't use async queries when cache timeout is -1

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -30,7 +30,6 @@ from werkzeug.utils import secure_filename
 from superset import is_feature_enabled, security_manager
 from superset.async_events.async_query_manager import AsyncQueryTokenException
 from superset.charts.api import ChartRestApi
-from superset.constants import CACHE_DISABLED_TIMEOUT
 from superset.charts.client_processing import apply_client_processing
 from superset.charts.data.query_context_cache_loader import QueryContextCacheLoader
 from superset.charts.schemas import ChartDataQueryContextSchema
@@ -47,6 +46,7 @@ from superset.commands.chart.exceptions import (
 )
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.connectors.sqla.models import BaseDatasource
+from superset.constants import CACHE_DISABLED_TIMEOUT
 from superset.daos.exceptions import DatasourceNotFound
 from superset.exceptions import QueryObjectValidationError
 from superset.extensions import event_logger

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -30,6 +30,7 @@ from werkzeug.utils import secure_filename
 from superset import is_feature_enabled, security_manager
 from superset.async_events.async_query_manager import AsyncQueryTokenException
 from superset.charts.api import ChartRestApi
+from superset.constants import CACHE_DISABLED_TIMEOUT
 from superset.charts.client_processing import apply_client_processing
 from superset.charts.data.query_context_cache_loader import QueryContextCacheLoader
 from superset.charts.schemas import ChartDataQueryContextSchema
@@ -171,11 +172,16 @@ class ChartDataRestApi(ChartRestApi):
             )
 
         # TODO: support CSV, SQL query and other non-JSON types
-        if (
+        # Don't use async queries when cache is disabled (cache_timeout=-1)
+        # as async queries depend on caching to retrieve results
+        cache_timeout = query_context.get_cache_timeout()
+        use_async = (
             is_feature_enabled("GLOBAL_ASYNC_QUERIES")
             and query_context.result_format == ChartDataResultFormat.JSON
             and query_context.result_type == ChartDataResultType.FULL
-        ):
+            and cache_timeout != CACHE_DISABLED_TIMEOUT
+        )
+        if use_async:
             return self._run_async(json_body, command, add_extra_log_payload)
 
         try:
@@ -265,11 +271,16 @@ class ChartDataRestApi(ChartRestApi):
             )
 
         # TODO: support CSV, SQL query and other non-JSON types
-        if (
+        # Don't use async queries when cache is disabled (cache_timeout=-1)
+        # as async queries depend on caching to retrieve results
+        cache_timeout = query_context.get_cache_timeout()
+        use_async = (
             is_feature_enabled("GLOBAL_ASYNC_QUERIES")
             and query_context.result_format == ChartDataResultFormat.JSON
             and query_context.result_type == ChartDataResultType.FULL
-        ):
+            and cache_timeout != CACHE_DISABLED_TIMEOUT
+        )
+        if use_async:
             return self._run_async(json_body, command, add_extra_log_payload)
 
         form_data = json_body.get("form_data")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

  This PR fixes an issue where force refreshing a chart with Global Async Queries (GAQ) enabled and cache timeout set to -1 returns a 404 error.

  The Problem

  When cache timeout is configured as -1 (cache bypass), the system attempts to use async queries which depend on caching to store and retrieve results. Since caching is disabled, the
  async query results cannot be retrieved, leading to a 404 error.

  The Solution

  The fix adds a check to skip the async query path when cache_timeout == -1. Instead, it uses synchronous query execution which doesn't require caching.
  

> [!NOTE]
> Tests related to the chart data api are currently being skipped due to environment issues.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

  1. Enable Global Async Queries feature flag
  2. Create a chart
  3. Edit chart properties and set cache timeout to -1
  4. Force refresh the chart
  5. Verify the chart refreshes successfully without errors

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
