### PR TITLE
fix: Allow non-owners to fave/unfave charts

### DIFF
--- a/superset/commands/chart/fave.py
+++ b/superset/commands/chart/fave.py
@@ -17,15 +17,12 @@
 import logging
 from functools import partial
 
-from superset import security_manager
 from superset.commands.base import BaseCommand
 from superset.commands.chart.exceptions import (
     ChartFaveError,
-    ChartForbiddenError,
     ChartNotFoundError,
 )
 from superset.daos.chart import ChartDAO
-from superset.exceptions import SupersetSecurityException
 from superset.models.slice import Slice
 from superset.utils.decorators import on_error, transaction
 
@@ -47,10 +44,5 @@ class AddFavoriteChartCommand(BaseCommand):
         chart = ChartDAO.find_by_id(self._chart_id)
         if not chart:
             raise ChartNotFoundError()
-
-        try:
-            security_manager.raise_for_ownership(chart)
-        except SupersetSecurityException as ex:
-            raise ChartForbiddenError() from ex
 
         self._chart = chart

--- a/superset/commands/chart/unfave.py
+++ b/superset/commands/chart/unfave.py
@@ -17,15 +17,12 @@
 import logging
 from functools import partial
 
-from superset import security_manager
 from superset.commands.base import BaseCommand
 from superset.commands.chart.exceptions import (
-    ChartForbiddenError,
     ChartNotFoundError,
     ChartUnfaveError,
 )
 from superset.daos.chart import ChartDAO
-from superset.exceptions import SupersetSecurityException
 from superset.models.slice import Slice
 from superset.utils.decorators import on_error, transaction
 
@@ -47,10 +44,5 @@ class DelFavoriteChartCommand(BaseCommand):
         chart = ChartDAO.find_by_id(self._chart_id)
         if not chart:
             raise ChartNotFoundError()
-
-        try:
-            security_manager.raise_for_ownership(chart)
-        except SupersetSecurityException as ex:
-            raise ChartForbiddenError() from ex
 
         self._chart = chart


### PR DESCRIPTION
### SUMMARY
Currently only chart owners are able to favorite charts. This is a bit too restrictive, and also inconsistent since non-owners can favorite dashboards.

This PR removes this limitation. Calling it a fix since the inconsistency with charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Test coverage addded.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
