### PR TITLE
fix: Add editors to ContributionConfig and additional properties to EditorKeyword

### DIFF
--- a/superset-core/src/superset_core/extensions/types.py
+++ b/superset-core/src/superset_core/extensions/types.py
@@ -88,6 +88,10 @@ class ContributionConfig(BaseModel):
         default_factory=dict,
         description="Menu contributions by scope and location",
     )
+    editors: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Editor contributions",
+    )
 
 
 class BaseExtension(BaseModel):

--- a/superset-frontend/packages/superset-core/src/api/editors.ts
+++ b/superset-frontend/packages/superset-core/src/api/editors.ts
@@ -294,6 +294,10 @@ export interface EditorKeyword {
   meta?: string;
   /** Sorting priority; higher scores appear first in the completion list */
   score?: number;
+  /** Short supplementary text such as a type signature or the full value when truncated */
+  detail?: string;
+  /** Longer documentation content as an HTML string, shown in a documentation popup */
+  documentation?: string;
 }
 
 /**

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/useKeywords.test.ts
@@ -295,7 +295,7 @@ test('returns column keywords among selected tables', async () => {
   );
 });
 
-test('returns long keywords with docText', async () => {
+test('returns long keywords with detail', async () => {
   const expectLongKeywordDbId = 2;
   const longKeyword = 'veryveryveryveryverylongtablename';
   const dbFunctionNamesApiRoute = `glob:*/api/v1/database/${expectLongKeywordDbId}/function_names/`;
@@ -335,7 +335,7 @@ test('returns long keywords with docText', async () => {
       expect.objectContaining({
         name: longKeyword,
         value: longKeyword,
-        docText: longKeyword,
+        detail: longKeyword,
       }),
     ),
   );

--- a/superset-frontend/src/SqlLab/components/EditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/EditorWrapper/useKeywords.ts
@@ -55,7 +55,7 @@ const { useQueryState: useTablesQueryState } = tableEndpoints.tables;
 
 const getHelperText = (value: string) =>
   value.length > 30 && {
-    docText: value,
+    detail: value,
   };
 
 const extensionsRegistry = getExtensionsRegistry();

--- a/superset-frontend/src/core/editors/AceEditorProvider.tsx
+++ b/superset-frontend/src/core/editors/AceEditorProvider.tsx
@@ -189,6 +189,8 @@ const toAceKeyword = (keyword: EditorKeyword): AceCompleterKeyword => ({
   value: keyword.value ?? keyword.name,
   score: keyword.score ?? 0,
   meta: keyword.meta ?? '',
+  docText: keyword.detail,
+  docHTML: keyword.documentation,
 });
 
 /**

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -184,13 +184,13 @@ test('passes keywords as objects to SQLEditorWithValidation for autocomplete', (
     expect(keyword).toHaveProperty('meta');
   });
 
-  // Verify column keywords specifically have docHTML for rich tooltips
+  // Verify column keywords specifically have documentation for rich tooltips
   const columnKeywords = keywords.filter(
     (k: Record<string, unknown>) => k.meta === 'column',
   );
   expect(columnKeywords.length).toBe(2); // We passed 2 columns
   columnKeywords.forEach((keyword: Record<string, unknown>) => {
-    expect(keyword).toHaveProperty('docHTML');
+    expect(keyword).toHaveProperty('documentation');
   });
 });
 

--- a/superset-frontend/src/explore/controlUtils/getColumnKeywords.test.tsx
+++ b/superset-frontend/src/explore/controlUtils/getColumnKeywords.test.tsx
@@ -31,7 +31,7 @@ test('returns HTML for a column tooltip', () => {
   expect(getColumnKeywords([expected])).toContainEqual({
     name: expected.column_name,
     value: expected.column_name,
-    docHTML: expect.stringContaining(expected.description),
+    documentation: expect.stringContaining(expected.description),
     score: 50,
     meta: 'column',
   });

--- a/superset-frontend/src/explore/controlUtils/getColumnKeywords.tsx
+++ b/superset-frontend/src/explore/controlUtils/getColumnKeywords.tsx
@@ -34,7 +34,7 @@ export function getColumnKeywords(columns: ColumnMeta[]) {
     }) => ({
       name: verbose_name || column_name,
       value: column_name,
-      docHTML: getTooltipHTML({
+      documentation: getTooltipHTML({
         title: column_name,
         body: `type: ${type || 'unknown'}<br />${description ? `description: ${description}` : ''}`,
         footer: is_certified ? t('Certified by %s', certified_by) : undefined,


### PR DESCRIPTION
### SUMMARY
Follow-up of https://github.com/apache/superset/pull/37499.

- Add `editors` to `ContributionConfig`
- Add `detail` and `documentation` properties to `EditorKeyword`

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
