### PR TITLE
fix: Warning toast copy in folders editor

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useDragHandlers.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useDragHandlers.ts
@@ -332,14 +332,14 @@ export function useDragHandlers({
             isDefaultMetricsFolder &&
             draggedItem.type === FoldersEditorItemType.Column
           ) {
-            addWarningToast(t('This folder only accepts metrics'));
+            addWarningToast(t('This folder only supports metrics'));
             return;
           }
           if (
             isDefaultColumnsFolder &&
             draggedItem.type === FoldersEditorItemType.Metric
           ) {
-            addWarningToast(t('This folder only accepts columns'));
+            addWarningToast(t('This folder only supports columns'));
             return;
           }
         }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Small copy change - `This folder only accepts metrics` -> `This folder only supports metrics`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
