### PR TITLE
fix: Badge count in folders editor

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/constants.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/constants.ts
@@ -29,6 +29,9 @@ export const DEFAULT_METRICS_FOLDER_UUID =
 export const DEFAULT_COLUMNS_FOLDER_UUID =
   '83a7ae8f-2e8a-4f2b-a8cb-ebaebef95b9b';
 
+// Number of default folders (Metrics, Columns)
+export const DEFAULT_FOLDERS_COUNT = 2;
+
 // Drag & drop constants
 export const DRAG_INDENTATION_WIDTH = 64;
 export const MAX_DEPTH = 3;

--- a/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.test.ts
@@ -676,12 +676,8 @@ test('countAllFolders returns 0 for empty array', () => {
 
 test('countAllFolders counts flat folders', () => {
   const folders: DatasourceFolder[] = [
-    createFolderItem('f1', 'Metrics', [
-      createMetricItem('m1', 'Metric 1'),
-    ]),
-    createFolderItem('f2', 'Columns', [
-      createColumnItem('c1', 'Column 1'),
-    ]),
+    createFolderItem('f1', 'Metrics', [createMetricItem('m1', 'Metric 1')]),
+    createFolderItem('f2', 'Columns', [createColumnItem('c1', 'Column 1')]),
   ] as DatasourceFolder[];
 
   expect(countAllFolders(folders)).toBe(2);

--- a/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.test.ts
@@ -28,8 +28,10 @@ import {
   removeChildrenOf,
   serializeForAPI,
   getProjection,
+  countAllFolders,
 } from './treeUtils';
 import { FoldersEditorItemType } from '../types';
+import { DatasourceFolder } from 'src/explore/components/DatasourcePanel/types';
 
 const createMetricItem = (uuid: string, name: string): TreeItem => ({
   uuid,
@@ -666,4 +668,65 @@ test('getProjection nests item under folder when dragging down with offset', () 
   // maxDepth from metric1 (non-folder) = metric1.depth = 1
   expect(projection!.depth).toBe(1);
   expect(projection!.parentId).toBe('folder1');
+});
+
+test('countAllFolders returns 0 for empty array', () => {
+  expect(countAllFolders([])).toBe(0);
+});
+
+test('countAllFolders counts flat folders', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('f1', 'Metrics', [
+      createMetricItem('m1', 'Metric 1'),
+    ]),
+    createFolderItem('f2', 'Columns', [
+      createColumnItem('c1', 'Column 1'),
+    ]),
+  ] as DatasourceFolder[];
+
+  expect(countAllFolders(folders)).toBe(2);
+});
+
+test('countAllFolders counts nested folders recursively', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('metrics', 'Metrics', [
+      createMetricItem('m1', 'Metric 1'),
+    ]),
+    createFolderItem('columns', 'Columns', [
+      createColumnItem('c1', 'Column 1'),
+    ]),
+    createFolderItem('custom', 'Custom Folder', [
+      createFolderItem('nested', 'Nested Folder', [
+        createMetricItem('m2', 'Metric 2'),
+      ]),
+    ]),
+  ] as DatasourceFolder[];
+
+  expect(countAllFolders(folders)).toBe(4);
+});
+
+test('countAllFolders counts deeply nested folders', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('level0', 'Level 0', [
+      createFolderItem('level1', 'Level 1', [
+        createFolderItem('level2', 'Level 2', [
+          createMetricItem('m1', 'Metric 1'),
+        ]),
+      ]),
+    ]),
+  ] as DatasourceFolder[];
+
+  expect(countAllFolders(folders)).toBe(3);
+});
+
+test('countAllFolders ignores non-folder children', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('f1', 'Folder', [
+      createMetricItem('m1', 'Metric 1'),
+      createColumnItem('c1', 'Column 1'),
+      createMetricItem('m2', 'Metric 2'),
+    ]),
+  ] as DatasourceFolder[];
+
+  expect(countAllFolders(folders)).toBe(1);
 });

--- a/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.ts
@@ -330,3 +330,22 @@ export function serializeForAPI(items: TreeItem[]): DatasourceFolder[] {
     })
     .filter((folder): folder is DatasourceFolder => folder !== null);
 }
+
+/**
+ * Recursively counts all folders in a DatasourceFolder array,
+ * including nested sub-folders within children.
+ */
+export function countAllFolders(folders: DatasourceFolder[]): number {
+  let count = 0;
+  for (const folder of folders) {
+    count += 1;
+    if (folder.children) {
+      for (const child of folder.children) {
+        if ('children' in child) {
+          count += countAllFolders([child as DatasourceFolder]);
+        }
+      }
+    }
+  }
+  return count;
+}

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -91,9 +91,11 @@ import { fetchSyncedColumns, updateColumns } from '../../utils';
 import DatasetUsageTab from './components/DatasetUsageTab';
 import {
   DEFAULT_COLUMNS_FOLDER_UUID,
+  DEFAULT_FOLDERS_COUNT,
   DEFAULT_METRICS_FOLDER_UUID,
 } from '../../FoldersEditor/constants';
 import { validateFolders } from '../../FoldersEditor/folderValidation';
+import { countAllFolders } from '../../FoldersEditor/treeUtils';
 import FoldersEditor from '../../FoldersEditor';
 import { DatasourceFolder } from 'src/explore/components/DatasourcePanel/types';
 
@@ -266,6 +268,7 @@ interface DatasourceEditorState {
   databaseColumns: Column[];
   calculatedColumns: Column[];
   folders: DatasourceFolder[];
+  folderCount: number;
   metadataLoading: boolean;
   activeTabKey: string;
   datasourceType: string;
@@ -284,6 +287,7 @@ interface AbortControllers {
 interface CollectionTabTitleProps {
   title: string;
   collection?: unknown[] | { length: number };
+  count?: number;
 }
 
 interface ColumnCollectionTableProps {
@@ -458,6 +462,7 @@ DATASOURCE_TYPES_ARR.forEach(o => {
 function CollectionTabTitle({
   title,
   collection,
+  count,
 }: CollectionTabTitleProps): JSX.Element {
   return (
     <div
@@ -465,7 +470,10 @@ function CollectionTabTitle({
       data-test={`collection-tab-${title}`}
     >
       {title}{' '}
-      <StyledBadge count={collection ? collection.length : 0} showZero />
+      <StyledBadge
+        count={count ?? (collection ? collection.length : 0)}
+        showZero
+      />
     </div>
   );
 }
@@ -905,6 +913,9 @@ class DatasourceEditor extends PureComponent<
         col => !!col.expression,
       ),
       folders: props.datasource.folders || [],
+      folderCount:
+        countAllFolders(props.datasource.folders || []) +
+        DEFAULT_FOLDERS_COUNT,
       metadataLoading: false,
       activeTabKey: TABS_KEYS.SOURCE,
       datasourceType: props.datasource.sql
@@ -988,13 +999,14 @@ class DatasourceEditor extends PureComponent<
   }
 
   handleFoldersChange(folders: DatasourceFolder[]) {
+    const folderCount = countAllFolders(folders);
     const userMadeFolders = folders.filter(
       f =>
         f.uuid !== DEFAULT_METRICS_FOLDER_UUID &&
         f.uuid !== DEFAULT_COLUMNS_FOLDER_UUID &&
         (f.children?.length ?? 0) > 0,
     );
-    this.setState({ folders: userMadeFolders }, () => {
+    this.setState({ folders: userMadeFolders, folderCount }, () => {
       this.onDatasourceChange({
         ...this.state.datasource,
         folders: userMadeFolders,
@@ -2405,7 +2417,7 @@ class DatasourceEditor extends PureComponent<
                     key: TABS_KEYS.FOLDERS,
                     label: (
                       <CollectionTabTitle
-                        collection={this.state.folders}
+                        count={this.state.folderCount}
                         title={t('Folders')}
                       />
                     ),

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -914,8 +914,7 @@ class DatasourceEditor extends PureComponent<
       ),
       folders: props.datasource.folders || [],
       folderCount:
-        countAllFolders(props.datasource.folders || []) +
-        DEFAULT_FOLDERS_COUNT,
+        countAllFolders(props.datasource.folders || []) + DEFAULT_FOLDERS_COUNT,
       metadataLoading: false,
       activeTabKey: TABS_KEYS.SOURCE,
       datasourceType: props.datasource.sql


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes the Folders tab badge count to accurately reflect all folders including nested sub-folders, instead of only counting top-level folders

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
1. Open the dataset editor with folders enabled
2. Create nested sub-folders
3. Verify the badge count on the "Folders" tab matches the total number of folders (including nested ones and the default Metrics/Columns folders)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
