### PR TITLE
fix: Search in folders editor with verbose names

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
@@ -124,6 +124,43 @@ describe('folderUtils', () => {
 
       expect(result.size).toBe(4);
     });
+
+    test('should match by verbose_name', () => {
+      const metrics: Metric[] = [
+        {
+          uuid: 'metric-v1',
+          metric_name: 'count',
+          verbose_name: 'COUNT(*)',
+          expression: 'COUNT(*)',
+        } as Metric,
+      ];
+      const result = filterItemsBySearch('COUNT', metrics);
+
+      expect(result.size).toBe(1);
+      expect(result.has('metric-v1')).toBe(true);
+    });
+
+    test('should match by expression', () => {
+      const result = filterItemsBySearch('COUNT(*)', mockMetrics);
+
+      expect(result.size).toBe(1);
+      expect(result.has('metric-1')).toBe(true);
+    });
+
+    test('should match special characters in search term', () => {
+      const metrics: Metric[] = [
+        {
+          uuid: 'metric-special',
+          metric_name: 'count',
+          verbose_name: 'COUNT(*)',
+          expression: 'COUNT(*)',
+        } as Metric,
+      ];
+      const result = filterItemsBySearch('(*)', metrics);
+
+      expect(result.size).toBe(1);
+      expect(result.has('metric-special')).toBe(true);
+    });
   });
 
   describe('isDefaultFolder', () => {

--- a/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.ts
@@ -79,8 +79,15 @@ export const filterItemsBySearch = (
   const matchingIds = new Set<string>();
 
   items.forEach(item => {
-    const name = 'metric_name' in item ? item.metric_name : item.column_name;
-    if (name?.toLowerCase().includes(lowerSearch)) {
+    const name =
+      'metric_name' in item ? item.metric_name : item.column_name;
+    const { verbose_name: verboseName, expression } = item;
+
+    if (
+      name?.toLowerCase().includes(lowerSearch) ||
+      verboseName?.toLowerCase().includes(lowerSearch) ||
+      expression?.toLowerCase().includes(lowerSearch)
+    ) {
       matchingIds.add(item.uuid);
     }
   });

--- a/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.ts
@@ -79,8 +79,7 @@ export const filterItemsBySearch = (
   const matchingIds = new Set<string>();
 
   items.forEach(item => {
-    const name =
-      'metric_name' in item ? item.metric_name : item.column_name;
+    const name = 'metric_name' in item ? item.metric_name : item.column_name;
     const { verbose_name: verboseName, expression } = item;
 
     if (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes the folder search to match against `verbose_name` and `expression` fields in addition to `metric_name`/`column_name`. Previously, searching for an expression like `COUNT(*)` or a verbose name would not find the matching item.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Open the dataset editor folders view
2. Search for a metric by its expression (e.g., `COUNT(*)`)
3. Search for a metric by its verbose name
4. Verify matching items are shown in the results

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
