### PR TITLE
feat: Larger folder drag area in folders editor

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/TreeItem.styles.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/TreeItem.styles.ts
@@ -83,6 +83,10 @@ export const TreeFolderContainer = styled(TreeItemContainer)<{
     margin-right: ${theme.marginMD}px;
     transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 
+    &:hover:not(:has(input)) [aria-label="move"] {
+      color: ${theme.colorText};
+    }
+
     /* Drop target styles - controlled via data attributes for performance */
     &[data-drop-target="true"] {
       background-color: ${theme.colorPrimaryBg};
@@ -116,15 +120,7 @@ export const DragHandle = styled.span`
     color: ${theme.colorTextTertiary};
     display: inline-flex;
     align-items: center;
-    cursor: grab;
-
-    &:hover {
-      color: ${theme.colorText};
-    }
-
-    &:active {
-      cursor: grabbing;
-    }
+    transition: color 0.15s ease-in-out;
   `}
 `;
 
@@ -158,6 +154,7 @@ export const FolderName = styled.span`
   ${({ theme }) => `
     margin-right: ${theme.marginMD}px;
     font-weight: ${theme.fontWeightStrong};
+    cursor: pointer;
   `}
 `;
 

--- a/superset-frontend/src/components/Datasource/FoldersEditor/TreeItem.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/TreeItem.tsx
@@ -262,8 +262,6 @@ function TreeItemComponent({
     <>
       {isFolder && (
         <DragHandle
-          {...attributes}
-          {...listeners}
           css={theme => css`
             margin-right: ${theme.marginSM}px;
           `}
@@ -348,9 +346,12 @@ function TreeItemComponent({
         {isFolder ? (
           <TreeFolderContainer
             {...restContainerProps}
+            {...attributes}
+            {...listeners}
             data-folder-id={id}
             data-drop-target={isDropTarget ? 'true' : undefined}
             isForbiddenDropTarget={isForbiddenDrop}
+            css={{ cursor: 'grab', '&:active': { cursor: 'grabbing' } }}
           >
             {containerContent}
           </TreeFolderContainer>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Moves the drag-and-drop listeners from the small grip icon to the entire folder row container, making it easier to grab and drag folders. Also adds a pointer cursor to the folder name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


### TESTING INSTRUCTIONS
1. Open the dataset editor with folders enabled
2. Grab anywhere on the folder row to reorder it
3. Verify dragging works from anywhere on the row, not just the grip icon

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
