### PR TITLE
chore: fix lint issue with `no-unsafe-optional-chaining` rule

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -431,5 +431,5 @@ test('should add a formula annotation when X-axis column has dataset-level label
   expect(formulaSeries).toBeDefined();
   expect(formulaSeries?.data).toBeDefined();
   expect(Array.isArray(formulaSeries?.data)).toBe(true);
-  expect((formulaSeries?.data as unknown[]).length).toBeGreaterThan(0);
+  expect((formulaSeries?.data as unknown[])?.length).toBeGreaterThan(0);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -304,8 +304,8 @@ describe('EchartsTimeseries transformProps', () => {
     expect(formulaSeries).toBeDefined();
     expect(formulaSeries?.data).toBeDefined();
     expect(Array.isArray(formulaSeries?.data)).toBe(true);
-    expect((formulaSeries?.data as unknown[]).length).toBeGreaterThan(0);
-    const firstDataPoint = (formulaSeries?.data as [number, number][])[0];
+    expect((formulaSeries?.data as unknown[])?.length).toBeGreaterThan(0);
+    const firstDataPoint = (formulaSeries?.data as [number, number][])?.[0];
     expect(firstDataPoint).toBeDefined();
     expect(firstDataPoint[1]).toBe(firstDataPoint[0] * 2);
   });
@@ -384,7 +384,7 @@ describe('EchartsTimeseries transformProps', () => {
       result.echartOptions.series as SeriesOption[] | undefined
     )?.find((s: SeriesOption) => s.name === 'My Formula');
     expect(formulaSeries).toBeDefined();
-    const firstDataPoint = (formulaSeries?.data as [number, number][])[0];
+    const firstDataPoint = (formulaSeries?.data as [number, number][])?.[0];
     expect(firstDataPoint).toBeDefined();
     expect(firstDataPoint[0]).toBe(firstDataPoint[1] * 2);
   });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore: fix lint issue with `no-unsafe-optional-chaining` rule

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To unblock failing CI after stricter enformence of Oxlint rule `no-unsafe-optional-chaining` rule. All changes happen in Jest test files so there's no impact on production functionalities.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
