### PR TITLE
feat: Persist default folders location when repositioned in folders editor

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
@@ -263,14 +263,14 @@ describe('folderUtils', () => {
       const savedFolders = [
         {
           uuid: DEFAULT_METRICS_FOLDER_UUID,
-          type: FoldersEditorItemType.Folder,
+          type: FoldersEditorItemType.Folder as const,
           name: 'Metrics',
           children: [{ uuid: 'metric-2', type: FoldersEditorItemType.Metric }],
         },
         customFolder,
         {
           uuid: DEFAULT_COLUMNS_FOLDER_UUID,
-          type: FoldersEditorItemType.Folder,
+          type: FoldersEditorItemType.Folder as const,
           name: 'Columns',
           children: [
             { uuid: 'column-1', type: FoldersEditorItemType.Column },
@@ -294,13 +294,13 @@ describe('folderUtils', () => {
       const savedFolders = [
         {
           uuid: DEFAULT_METRICS_FOLDER_UUID,
-          type: FoldersEditorItemType.Folder,
+          type: FoldersEditorItemType.Folder as const,
           name: 'Metrics',
           children: [{ uuid: 'metric-1', type: FoldersEditorItemType.Metric }],
         },
         {
           uuid: DEFAULT_COLUMNS_FOLDER_UUID,
-          type: FoldersEditorItemType.Folder,
+          type: FoldersEditorItemType.Folder as const,
           name: 'Columns',
           children: [{ uuid: 'column-1', type: FoldersEditorItemType.Column }],
         },

--- a/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
@@ -250,5 +250,85 @@ describe('folderUtils', () => {
       expect(result.length).toBeGreaterThan(2);
       expect(result.find(f => f.name === 'Custom Folder')).toBeDefined();
     });
+
+    test('should preserve default folder positions when saved', () => {
+      const customFolder = createFolder('Custom');
+      customFolder.children = [
+        {
+          uuid: 'metric-1',
+          type: FoldersEditorItemType.Metric,
+          name: 'Test Metric 1',
+        },
+      ];
+      const savedFolders = [
+        {
+          uuid: DEFAULT_METRICS_FOLDER_UUID,
+          type: FoldersEditorItemType.Folder,
+          name: 'Metrics',
+          children: [{ uuid: 'metric-2', type: FoldersEditorItemType.Metric }],
+        },
+        customFolder,
+        {
+          uuid: DEFAULT_COLUMNS_FOLDER_UUID,
+          type: FoldersEditorItemType.Folder,
+          name: 'Columns',
+          children: [
+            { uuid: 'column-1', type: FoldersEditorItemType.Column },
+            { uuid: 'column-2', type: FoldersEditorItemType.Column },
+          ],
+        },
+      ];
+      const result = ensureDefaultFolders(
+        savedFolders,
+        mockMetrics,
+        mockColumns,
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result[0].uuid).toBe(DEFAULT_METRICS_FOLDER_UUID);
+      expect(result[1].uuid).toBe(customFolder.uuid);
+      expect(result[2].uuid).toBe(DEFAULT_COLUMNS_FOLDER_UUID);
+    });
+
+    test('should add unassigned items to existing default folders', () => {
+      const savedFolders = [
+        {
+          uuid: DEFAULT_METRICS_FOLDER_UUID,
+          type: FoldersEditorItemType.Folder,
+          name: 'Metrics',
+          children: [{ uuid: 'metric-1', type: FoldersEditorItemType.Metric }],
+        },
+        {
+          uuid: DEFAULT_COLUMNS_FOLDER_UUID,
+          type: FoldersEditorItemType.Folder,
+          name: 'Columns',
+          children: [{ uuid: 'column-1', type: FoldersEditorItemType.Column }],
+        },
+      ];
+      const result = ensureDefaultFolders(
+        savedFolders,
+        mockMetrics,
+        mockColumns,
+      );
+
+      const metricsFolder = result.find(
+        f => f.uuid === DEFAULT_METRICS_FOLDER_UUID,
+      );
+      const columnsFolder = result.find(
+        f => f.uuid === DEFAULT_COLUMNS_FOLDER_UUID,
+      );
+
+      // metric-2 was unassigned, should be appended
+      expect(metricsFolder?.children).toHaveLength(2);
+      expect(metricsFolder?.children?.some(c => c.uuid === 'metric-2')).toBe(
+        true,
+      );
+
+      // column-2 was unassigned, should be appended
+      expect(columnsFolder?.children).toHaveLength(2);
+      expect(columnsFolder?.children?.some(c => c.uuid === 'column-2')).toBe(
+        true,
+      );
+    });
   });
 });

--- a/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
@@ -265,7 +265,13 @@ describe('folderUtils', () => {
           uuid: DEFAULT_METRICS_FOLDER_UUID,
           type: FoldersEditorItemType.Folder as const,
           name: 'Metrics',
-          children: [{ uuid: 'metric-2', name: 'metric-2', type: FoldersEditorItemType.Metric }],
+          children: [
+            {
+              uuid: 'metric-2',
+              name: 'metric-2',
+              type: FoldersEditorItemType.Metric,
+            },
+          ],
         },
         customFolder,
         {

--- a/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/folderOperations.test.ts
@@ -265,7 +265,7 @@ describe('folderUtils', () => {
           uuid: DEFAULT_METRICS_FOLDER_UUID,
           type: FoldersEditorItemType.Folder as const,
           name: 'Metrics',
-          children: [{ uuid: 'metric-2', type: FoldersEditorItemType.Metric }],
+          children: [{ uuid: 'metric-2', name: 'metric-2', type: FoldersEditorItemType.Metric }],
         },
         customFolder,
         {
@@ -273,8 +273,16 @@ describe('folderUtils', () => {
           type: FoldersEditorItemType.Folder as const,
           name: 'Columns',
           children: [
-            { uuid: 'column-1', type: FoldersEditorItemType.Column },
-            { uuid: 'column-2', type: FoldersEditorItemType.Column },
+            {
+              uuid: 'column-1',
+              name: 'column-1',
+              type: FoldersEditorItemType.Column,
+            },
+            {
+              uuid: 'column-2',
+              name: 'column-2',
+              type: FoldersEditorItemType.Column,
+            },
           ],
         },
       ];
@@ -296,13 +304,25 @@ describe('folderUtils', () => {
           uuid: DEFAULT_METRICS_FOLDER_UUID,
           type: FoldersEditorItemType.Folder as const,
           name: 'Metrics',
-          children: [{ uuid: 'metric-1', type: FoldersEditorItemType.Metric }],
+          children: [
+            {
+              uuid: 'metric-1',
+              name: 'metric-1',
+              type: FoldersEditorItemType.Metric,
+            },
+          ],
         },
         {
           uuid: DEFAULT_COLUMNS_FOLDER_UUID,
           type: FoldersEditorItemType.Folder as const,
           name: 'Columns',
-          children: [{ uuid: 'column-1', type: FoldersEditorItemType.Column }],
+          children: [
+            {
+              uuid: 'column-1',
+              name: 'column-1',
+              type: FoldersEditorItemType.Column,
+            },
+          ],
         },
       ];
       const result = ensureDefaultFolders(

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -915,7 +915,9 @@ class DatasourceEditor extends PureComponent<
       folderCount: (() => {
         const savedFolders = props.datasource.folders || [];
         const savedCount = countAllFolders(savedFolders);
-        const hasDefaultsSaved = savedFolders.some(f => isDefaultFolder(f.uuid));
+        const hasDefaultsSaved = savedFolders.some(f =>
+          isDefaultFolder(f.uuid),
+        );
         return savedCount + (hasDefaultsSaved ? 0 : DEFAULT_FOLDERS_COUNT);
       })(),
       metadataLoading: false,
@@ -2424,7 +2426,10 @@ class DatasourceEditor extends PureComponent<
                         metrics={
                           sortedMetrics as unknown as import('@superset-ui/chart-controls').Metric[]
                         }
-                        columns={[...this.state.databaseColumns, ...this.state.calculatedColumns]}
+                        columns={[
+                          ...this.state.databaseColumns,
+                          ...this.state.calculatedColumns,
+                        ]}
                         onChange={this.handleFoldersChange}
                       />
                     ),

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -90,9 +90,8 @@ import Field from '../Field';
 import { fetchSyncedColumns, updateColumns } from '../../utils';
 import DatasetUsageTab from './components/DatasetUsageTab';
 import {
-  DEFAULT_COLUMNS_FOLDER_UUID,
   DEFAULT_FOLDERS_COUNT,
-  DEFAULT_METRICS_FOLDER_UUID,
+  isDefaultFolder,
 } from '../../FoldersEditor/constants';
 import { validateFolders } from '../../FoldersEditor/folderValidation';
 import { countAllFolders } from '../../FoldersEditor/treeUtils';
@@ -913,8 +912,12 @@ class DatasourceEditor extends PureComponent<
         col => !!col.expression,
       ),
       folders: props.datasource.folders || [],
-      folderCount:
-        countAllFolders(props.datasource.folders || []) + DEFAULT_FOLDERS_COUNT,
+      folderCount: (() => {
+        const savedFolders = props.datasource.folders || [];
+        const savedCount = countAllFolders(savedFolders);
+        const hasDefaultsSaved = savedFolders.some(f => isDefaultFolder(f.uuid));
+        return savedCount + (hasDefaultsSaved ? 0 : DEFAULT_FOLDERS_COUNT);
+      })(),
       metadataLoading: false,
       activeTabKey: TABS_KEYS.SOURCE,
       datasourceType: props.datasource.sql
@@ -999,16 +1002,10 @@ class DatasourceEditor extends PureComponent<
 
   handleFoldersChange(folders: DatasourceFolder[]) {
     const folderCount = countAllFolders(folders);
-    const userMadeFolders = folders.filter(
-      f =>
-        f.uuid !== DEFAULT_METRICS_FOLDER_UUID &&
-        f.uuid !== DEFAULT_COLUMNS_FOLDER_UUID &&
-        (f.children?.length ?? 0) > 0,
-    );
-    this.setState({ folders: userMadeFolders, folderCount }, () => {
+    this.setState({ folders, folderCount }, () => {
       this.onDatasourceChange({
         ...this.state.datasource,
-        folders: userMadeFolders,
+        folders,
       });
     });
   }
@@ -2427,7 +2424,7 @@ class DatasourceEditor extends PureComponent<
                         metrics={
                           sortedMetrics as unknown as import('@superset-ui/chart-controls').Metric[]
                         }
-                        columns={this.state.databaseColumns}
+                        columns={[...this.state.databaseColumns, ...this.state.calculatedColumns]}
                         onChange={this.handleFoldersChange}
                       />
                     ),

--- a/superset-frontend/src/explore/components/DatasourcePanel/transformDatasourceFolders.test.ts
+++ b/superset-frontend/src/explore/components/DatasourcePanel/transformDatasourceFolders.test.ts
@@ -21,6 +21,10 @@ import { Metric } from '@superset-ui/core';
 import { transformDatasourceWithFolders } from './transformDatasourceFolders';
 import { DatasourceFolder, DatasourcePanelColumn } from './types';
 import { FoldersEditorItemType } from 'src/components/Datasource/types';
+import {
+  DEFAULT_METRICS_FOLDER_UUID,
+  DEFAULT_COLUMNS_FOLDER_UUID,
+} from 'src/components/Datasource/FoldersEditor/constants';
 
 const mockMetrics: Metric[] = [
   { metric_name: 'metric1', uuid: 'metric1-uuid', expression: 'SUM(col1)' },
@@ -45,13 +49,13 @@ test('transforms data into default folders when no folder config is provided', (
 
   expect(result).toHaveLength(2);
 
-  expect(result[0].id).toBe('metrics-default');
+  expect(result[0].id).toBe(DEFAULT_METRICS_FOLDER_UUID);
   expect(result[0].name).toBe('Metrics');
   expect(result[0].items).toHaveLength(3);
   expect(result[0].items[0].uuid).toBe('metric1-uuid');
   expect(result[0].items[0].type).toBe(FoldersEditorItemType.Metric);
 
-  expect(result[1].id).toBe('columns-default');
+  expect(result[1].id).toBe(DEFAULT_COLUMNS_FOLDER_UUID);
   expect(result[1].name).toBe('Columns');
   expect(result[1].items).toHaveLength(3);
   expect(result[1].items[0].uuid).toBe('column1-uuid');
@@ -118,11 +122,11 @@ test('transforms data according to folder configuration', () => {
   expect(result[1].items).toHaveLength(1);
   expect(result[1].items[0].uuid).toBe('column1-uuid');
 
-  expect(result[2].id).toBe('metrics-default');
+  expect(result[2].id).toBe(DEFAULT_METRICS_FOLDER_UUID);
   expect(result[2].items).toHaveLength(1);
   expect(result[2].items[0].uuid).toBe('metric3-uuid');
 
-  expect(result[3].id).toBe('columns-default');
+  expect(result[3].id).toBe(DEFAULT_COLUMNS_FOLDER_UUID);
   expect(result[3].items).toHaveLength(2);
 });
 

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -54,6 +54,12 @@ from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
+# Default folder UUIDs matching the frontend constants.
+# Stored as strings so comparisons work whether obj["uuid"] is str or UUID.
+DEFAULT_METRICS_FOLDER_UUID = "255b537d-58c8-443d-9fc1-4e4dc75047e2"
+DEFAULT_COLUMNS_FOLDER_UUID = "83a7ae8f-2e8a-4f2b-a8cb-ebaebef95b9b"
+DEFAULT_FOLDER_UUIDS = frozenset({DEFAULT_METRICS_FOLDER_UUID, DEFAULT_COLUMNS_FOLDER_UUID})
+
 
 class UpdateDatasetCommand(UpdateMixin, BaseCommand):
     def __init__(
@@ -320,11 +326,12 @@ def validate_folders(  # noqa: C901
                 raise ValidationError(f"Duplicate folder name: {name}")
             seen_fqns.add(fqn)
 
-            if name.lower() in {"metrics", "columns"}:
+            # Allow default folders (by UUID) to use reserved names
+            if name.lower() in {"metrics", "columns"} and str(uuid) not in DEFAULT_FOLDER_UUIDS:
                 raise ValidationError(f"Folder cannot have name '{name}'")
 
-        # check if metric/column UUID exists
-        elif not name and uuid not in valid_uuids:
+        # check if metric/column UUID exists (skip default folders)
+        elif not name and uuid not in valid_uuids and str(uuid) not in DEFAULT_FOLDER_UUIDS:
             raise ValidationError(f"Invalid UUID: {uuid}")
 
         # traverse children

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -58,7 +58,9 @@ logger = logging.getLogger(__name__)
 # Stored as strings so comparisons work whether obj["uuid"] is str or UUID.
 DEFAULT_METRICS_FOLDER_UUID = "255b537d-58c8-443d-9fc1-4e4dc75047e2"
 DEFAULT_COLUMNS_FOLDER_UUID = "83a7ae8f-2e8a-4f2b-a8cb-ebaebef95b9b"
-DEFAULT_FOLDER_UUIDS = frozenset({DEFAULT_METRICS_FOLDER_UUID, DEFAULT_COLUMNS_FOLDER_UUID})
+DEFAULT_FOLDER_UUIDS = frozenset(
+    {DEFAULT_METRICS_FOLDER_UUID, DEFAULT_COLUMNS_FOLDER_UUID}
+)
 
 
 class UpdateDatasetCommand(UpdateMixin, BaseCommand):
@@ -327,11 +329,18 @@ def validate_folders(  # noqa: C901
             seen_fqns.add(fqn)
 
             # Allow default folders (by UUID) to use reserved names
-            if name.lower() in {"metrics", "columns"} and str(uuid) not in DEFAULT_FOLDER_UUIDS:
+            if (
+                name.lower() in {"metrics", "columns"}
+                and str(uuid) not in DEFAULT_FOLDER_UUIDS
+            ):
                 raise ValidationError(f"Folder cannot have name '{name}'")
 
         # check if metric/column UUID exists (skip default folders)
-        elif not name and uuid not in valid_uuids and str(uuid) not in DEFAULT_FOLDER_UUIDS:
+        elif (
+            not name
+            and uuid not in valid_uuids
+            and str(uuid) not in DEFAULT_FOLDER_UUIDS
+        ):
             raise ValidationError(f"Invalid UUID: {uuid}")
 
         # traverse children

--- a/tests/unit_tests/commands/dataset/update_test.py
+++ b/tests/unit_tests/commands/dataset/update_test.py
@@ -575,37 +575,26 @@ def test_validate_folders_allows_default_folders(mocker: MockerFixture) -> None:
     Test that default system folders (Metrics/Columns) are allowed when using
     the well-known default folder UUIDs, so their position can be persisted.
     """
-    from uuid import UUID
-
-    metric_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-    column_uuid = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-
-    valid_uuids = {metric_uuid, column_uuid}
-
     folders = cast(
         list[FolderSchema],
         [
             {
-                "uuid": str(DEFAULT_METRICS_FOLDER_UUID),
+                "uuid": DEFAULT_METRICS_FOLDER_UUID,
                 "type": "folder",
                 "name": "Metrics",
-                "children": [
-                    {"uuid": str(metric_uuid), "type": "metric"},
-                ],
+                "children": [],
             },
             {
-                "uuid": str(DEFAULT_COLUMNS_FOLDER_UUID),
+                "uuid": DEFAULT_COLUMNS_FOLDER_UUID,
                 "type": "folder",
                 "name": "Columns",
-                "children": [
-                    {"uuid": str(column_uuid), "type": "column"},
-                ],
+                "children": [],
             },
         ],
     )
 
     # Should not raise - default folders are allowed to use reserved names
-    validate_folders(folders=folders, valid_uuids=valid_uuids)
+    validate_folders(folders=folders, valid_uuids=set())
 
 
 @with_feature_flags(DATASET_FOLDERS=True)

--- a/tests/unit_tests/commands/dataset/update_test.py
+++ b/tests/unit_tests/commands/dataset/update_test.py
@@ -29,7 +29,12 @@ from superset.commands.dataset.exceptions import (
     DatasetNotFoundError,
     MultiCatalogDisabledValidationError,
 )
-from superset.commands.dataset.update import UpdateDatasetCommand, validate_folders
+from superset.commands.dataset.update import (
+    DEFAULT_COLUMNS_FOLDER_UUID,
+    DEFAULT_METRICS_FOLDER_UUID,
+    UpdateDatasetCommand,
+    validate_folders,
+)
 from superset.commands.exceptions import OwnersNotFoundValidationError
 from superset.datasets.schemas import FolderSchema
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -562,6 +567,45 @@ def test_validate_folders_invalid_names(mocker: MockerFixture) -> None:
     with pytest.raises(ValidationError) as excinfo:
         validate_folders(folders=folders_with_columns, valid_uuids=set())
     assert str(excinfo.value) == "Folder cannot have name 'Columns'"
+
+
+@with_feature_flags(DATASET_FOLDERS=True)
+def test_validate_folders_allows_default_folders(mocker: MockerFixture) -> None:
+    """
+    Test that default system folders (Metrics/Columns) are allowed when using
+    the well-known default folder UUIDs, so their position can be persisted.
+    """
+    from uuid import UUID
+
+    metric_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    column_uuid = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+    valid_uuids = {metric_uuid, column_uuid}
+
+    folders = cast(
+        list[FolderSchema],
+        [
+            {
+                "uuid": str(DEFAULT_METRICS_FOLDER_UUID),
+                "type": "folder",
+                "name": "Metrics",
+                "children": [
+                    {"uuid": str(metric_uuid), "type": "metric"},
+                ],
+            },
+            {
+                "uuid": str(DEFAULT_COLUMNS_FOLDER_UUID),
+                "type": "folder",
+                "name": "Columns",
+                "children": [
+                    {"uuid": str(column_uuid), "type": "column"},
+                ],
+            },
+        ],
+    )
+
+    # Should not raise - default folders are allowed to use reserved names
+    validate_folders(folders=folders, valid_uuids=valid_uuids)
 
 
 @with_feature_flags(DATASET_FOLDERS=True)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Previously, the default Metrics and Columns folders were stripped before saving and recreated on load, which meant their position relative to custom folders was lost. This change persists default folders so their ordering is preserved across saves.
Unassigned metrics/columns (e.g., newly added after last save) are now appended to existing default folders rather than creating duplicate fallback folders.
Also includes a fix for calculated columns, which were not appearing in folders editor

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Enable `DATASET_FOLDERS` ff
2. Open the dataset editor with folders enabled
3. Create a custom folder and drag it between the default Metrics and Columns folders
4. Save the dataset
5. Verify that the order is persisted in the datasource panel in Explore
6. Verify that the order is persisted in the folders editor
7. Add a new metric or column to the dataset, reopen folders, and verify it appears in the appropriate default folder

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

FEATURE_DATASET_FOLDERS=true