### PR TITLE
fix(webpack): skip building service worker in dev

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -317,7 +317,10 @@ const config = {
     menu: addPreamble('src/views/menu.tsx'),
     spa: addPreamble('src/views/index.tsx'),
     embedded: addPreamble('src/embedded/index.tsx'),
-    'service-worker': path.join(APP_DIR, 'src/service-worker.ts'),
+    // Skip service-worker build in dev mode to avoid overwriting the placeholder
+    ...(isDevMode ? {} : {
+      'service-worker': path.join(APP_DIR, 'src/service-worker.ts'),
+    }),
   },
   cache: {
     type: 'filesystem',

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -318,9 +318,11 @@ const config = {
     spa: addPreamble('src/views/index.tsx'),
     embedded: addPreamble('src/embedded/index.tsx'),
     // Skip service-worker build in dev mode to avoid overwriting the placeholder
-    ...(isDevMode ? {} : {
-      'service-worker': path.join(APP_DIR, 'src/service-worker.ts'),
-    }),
+    ...(isDevMode
+      ? {}
+      : {
+          'service-worker': path.join(APP_DIR, 'src/service-worker.ts'),
+        }),
   },
   cache: {
     type: 'filesystem',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/apache/superset/pull/36191 Introduced a service-worker file and the build output file in static directory. With this pr we ignore it in development mode to prevent webpack creating a build file everytime and prevents accidental committing of that generated file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Run webpack dev server with npm run dev-server
2. New service-worker.js file should not be created

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
