### PR TITLE
fix(mcp): Remove unsupported thumbnail/preview URLs and internal fields from MCP schemas

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -88,11 +88,9 @@ class ChartInfo(BaseModel):
     viz_type: str | None = Field(None, description="Visualization type")
     datasource_name: str | None = Field(None, description="Datasource name")
     datasource_type: str | None = Field(None, description="Datasource type")
-    url: str | None = Field(None, description="Chart URL")
+    url: str | None = Field(None, description="Chart explore page URL")
     description: str | None = Field(None, description="Chart description")
     cache_timeout: int | None = Field(None, description="Cache timeout")
-    form_data: Dict[str, Any] | None = Field(None, description="Chart form data")
-    query_context: Any | None = Field(None, description="Query context")
     changed_by: str | None = Field(None, description="Last modifier (username)")
     changed_by_name: str | None = Field(
         None, description="Last modifier (display name)"
@@ -231,8 +229,6 @@ def serialize_chart_object(chart: ChartLike | None) -> ChartInfo | None:
         url=chart_url,
         description=getattr(chart, "description", None),
         cache_timeout=getattr(chart, "cache_timeout", None),
-        form_data=getattr(chart, "form_data", None),
-        query_context=getattr(chart, "query_context", None),
         changed_by=getattr(chart, "changed_by_name", None)
         or (str(chart.changed_by) if getattr(chart, "changed_by", None) else None),
         changed_by_name=getattr(chart, "changed_by_name", None),
@@ -1039,9 +1035,8 @@ class ChartPreview(BaseModel):
 
     # Backward compatibility fields (populated based on content type)
     format: str | None = Field(
-        None, description="Format of the preview (url, ascii, table, base64)"
+        None, description="Format of the preview (ascii, table, vega_lite)"
     )
-    preview_url: str | None = Field(None, description="Image URL for 'url' format")
     ascii_chart: str | None = Field(
         None, description="ASCII art chart for 'ascii' format"
     )

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -45,8 +45,7 @@ async def get_chart_info(
     """Get chart metadata by ID or UUID.
 
     IMPORTANT FOR LLM CLIENTS:
-    - ALWAYS display the chart URL when returned
-    - URL field contains chart's screenshot URL for preview
+    - URL field links to the chart's explore page in Superset
     - Use numeric ID or UUID string (NOT chart name)
     - To find a chart ID, use the list_charts tool first
 

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1978,12 +1978,7 @@ async def _get_chart_preview_internal(  # noqa: C901
         )
 
         # Add format-specific fields for backward compatibility
-        if isinstance(content, URLPreview):
-            result.format = "url"
-            result.preview_url = content.preview_url
-            result.width = content.width
-            result.height = content.height
-        elif isinstance(content, ASCIIPreview):
+        if isinstance(content, ASCIIPreview):
             result.format = "ascii"
             result.ascii_chart = content.ascii_content
             result.width = content.width

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -307,7 +307,6 @@ class DashboardInfo(BaseModel):
     changed_by: str | None = Field(None, description="Last modifier (username)")
     uuid: str | None = Field(None, description="Dashboard UUID (converted to string)")
     url: str | None = Field(None, description="Dashboard URL")
-    thumbnail_url: str | None = Field(None, description="Thumbnail URL")
     created_on_humanized: str | None = Field(
         None, description="Humanized creation time"
     )
@@ -452,7 +451,6 @@ def dashboard_serializer(dashboard: "Dashboard") -> DashboardInfo:
         else None,
         uuid=str(dashboard.uuid) if dashboard.uuid else None,
         url=dashboard.url,
-        thumbnail_url=dashboard.thumbnail_url,
         created_on_humanized=dashboard.created_on_humanized,
         changed_on_humanized=dashboard.changed_on_humanized,
         chart_count=len(dashboard.slices) if dashboard.slices else 0,
@@ -504,7 +502,6 @@ def serialize_dashboard_object(dashboard: Any) -> DashboardInfo:
         uuid=str(getattr(dashboard, "uuid", ""))
         if getattr(dashboard, "uuid", None)
         else None,
-        thumbnail_url=getattr(dashboard, "thumbnail_url", None),
         chart_count=len(getattr(dashboard, "slices", [])),
         owners=getattr(dashboard, "owners", []),
         tags=getattr(dashboard, "tags", []),

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
@@ -145,7 +145,7 @@ class TestPreviewXAxisInQueryContext:
 class TestGetChartPreview:
     """Tests for get_chart_preview MCP tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_chart_preview_request_structure(self):
         """Test that preview request structures are properly formed."""
         # Numeric ID request
@@ -172,7 +172,7 @@ class TestGetChartPreview:
         request4 = GetChartPreviewRequest(identifier=789)
         assert request4.format == "url"  # default
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_preview_format_types(self):
         """Test different preview format types."""
         formats = ["url", "ascii", "table"]
@@ -180,7 +180,7 @@ class TestGetChartPreview:
             request = GetChartPreviewRequest(identifier=1, format=fmt)
             assert request.format == fmt
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_url_preview_structure(self):
         """Test URLPreview response structure."""
         preview = URLPreview(
@@ -195,7 +195,7 @@ class TestGetChartPreview:
         assert preview.height == 600
         assert preview.supports_interaction is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_ascii_preview_structure(self):
         """Test ASCIIPreview response structure."""
         ascii_art = """
@@ -218,7 +218,7 @@ class TestGetChartPreview:
         assert preview.width == 25
         assert preview.height == 8
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_table_preview_structure(self):
         """Test TablePreview response structure."""
         table_content = """
@@ -240,7 +240,7 @@ class TestGetChartPreview:
         assert preview.row_count == 4
         assert preview.supports_sorting is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_chart_preview_response_structure(self):
         """Test the expected response structure for chart preview."""
         # Core fields that should always be present
@@ -258,7 +258,6 @@ class TestGetChartPreview:
         # Additional fields that may be present for backward compatibility
         _ = [
             "format",
-            "preview_url",
             "ascii_chart",
             "table_data",
             "width",
@@ -270,7 +269,7 @@ class TestGetChartPreview:
         # This is a structural test - actual integration tests would verify
         # the tool returns data matching this structure
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_preview_dimensions(self):
         """Test preview dimensions in response."""
         # Standard dimensions that may appear in preview responses
@@ -292,7 +291,7 @@ class TestGetChartPreview:
             assert url_preview.width == width
             assert url_preview.height == height
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_error_response_structures(self):
         """Test error response structures."""
         # Error responses typically follow this structure
@@ -313,7 +312,7 @@ class TestGetChartPreview:
         }
         assert preview_error["error_type"] == "preview_error"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_accessibility_metadata(self):
         """Test accessibility metadata structure."""
         from superset.mcp_service.chart.schemas import AccessibilityMetadata
@@ -327,7 +326,7 @@ class TestGetChartPreview:
         assert "sales by region" in metadata.alt_text
         assert metadata.high_contrast_available is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_performance_metadata(self):
         """Test performance metadata structure."""
         from superset.mcp_service.chart.schemas import PerformanceMetadata
@@ -341,7 +340,7 @@ class TestGetChartPreview:
         assert metadata.cache_status == "hit"
         assert len(metadata.optimization_suggestions) == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_chart_types_support(self):
         """Test that various chart types are supported."""
         chart_types = [
@@ -363,7 +362,7 @@ class TestGetChartPreview:
             # This would be tested in integration tests
             pass
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_ascii_art_variations(self):
         """Test ASCII art generation for different chart types."""
         # Line chart ASCII

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
@@ -145,7 +145,7 @@ class TestPreviewXAxisInQueryContext:
 class TestGetChartPreview:
     """Tests for get_chart_preview MCP tool."""
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_get_chart_preview_request_structure(self):
         """Test that preview request structures are properly formed."""
         # Numeric ID request
@@ -172,7 +172,7 @@ class TestGetChartPreview:
         request4 = GetChartPreviewRequest(identifier=789)
         assert request4.format == "url"  # default
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_preview_format_types(self):
         """Test different preview format types."""
         formats = ["url", "ascii", "table"]
@@ -180,7 +180,7 @@ class TestGetChartPreview:
             request = GetChartPreviewRequest(identifier=1, format=fmt)
             assert request.format == fmt
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_url_preview_structure(self):
         """Test URLPreview response structure."""
         preview = URLPreview(
@@ -195,7 +195,7 @@ class TestGetChartPreview:
         assert preview.height == 600
         assert preview.supports_interaction is False
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_ascii_preview_structure(self):
         """Test ASCIIPreview response structure."""
         ascii_art = """
@@ -218,7 +218,7 @@ class TestGetChartPreview:
         assert preview.width == 25
         assert preview.height == 8
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_table_preview_structure(self):
         """Test TablePreview response structure."""
         table_content = """
@@ -240,7 +240,7 @@ class TestGetChartPreview:
         assert preview.row_count == 4
         assert preview.supports_sorting is True
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_chart_preview_response_structure(self):
         """Test the expected response structure for chart preview."""
         # Core fields that should always be present
@@ -269,7 +269,7 @@ class TestGetChartPreview:
         # This is a structural test - actual integration tests would verify
         # the tool returns data matching this structure
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_preview_dimensions(self):
         """Test preview dimensions in response."""
         # Standard dimensions that may appear in preview responses
@@ -291,7 +291,7 @@ class TestGetChartPreview:
             assert url_preview.width == width
             assert url_preview.height == height
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_error_response_structures(self):
         """Test error response structures."""
         # Error responses typically follow this structure
@@ -312,7 +312,7 @@ class TestGetChartPreview:
         }
         assert preview_error["error_type"] == "preview_error"
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_accessibility_metadata(self):
         """Test accessibility metadata structure."""
         from superset.mcp_service.chart.schemas import AccessibilityMetadata
@@ -326,7 +326,7 @@ class TestGetChartPreview:
         assert "sales by region" in metadata.alt_text
         assert metadata.high_contrast_available is False
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_performance_metadata(self):
         """Test performance metadata structure."""
         from superset.mcp_service.chart.schemas import PerformanceMetadata
@@ -340,7 +340,7 @@ class TestGetChartPreview:
         assert metadata.cache_status == "hit"
         assert len(metadata.optimization_suggestions) == 1
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_chart_types_support(self):
         """Test that various chart types are supported."""
         chart_types = [
@@ -362,7 +362,7 @@ class TestGetChartPreview:
             # This would be tested in integration tests
             pass
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_ascii_art_variations(self):
         """Test ASCII art generation for different chart types."""
         # Line chart ASCII

--- a/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
@@ -30,12 +30,12 @@ from superset.mcp_service.chart.schemas import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mcp_server():
     return mcp
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_chart():
     """Create a mock chart object."""
     chart = Mock()

--- a/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
@@ -30,12 +30,12 @@ from superset.mcp_service.chart.schemas import (
 )
 
 
-@pytest.fixture
+@pytest.fixture()
 def mcp_server():
     return mcp
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_chart():
     """Create a mock chart object."""
     chart = Mock()
@@ -201,12 +201,12 @@ class TestChartDefaultColumnFiltering:
     def test_explicit_select_columns(self):
         """Test that explicit select_columns can include non-default columns."""
         request = ListChartsRequest(
-            select_columns=["id", "slice_name", "description", "form_data"]
+            select_columns=["id", "slice_name", "description", "cache_timeout"]
         )
         # Verify exact columns are present - explicit request should match exactly
         assert set(request.select_columns) == {
             "id",
             "slice_name",
             "description",
-            "form_data",
+            "cache_timeout",
         }


### PR DESCRIPTION
## Summary

MCP tool responses currently expose several fields that cause issues for AI assistant clients:

- **`thumbnail_url`** on `DashboardInfo` — This is an internal API endpoint (`/api/v1/dashboard/{id}/thumbnail/...`) that returns JSON metadata, not a viewable image. AI chatbots present it as a clickable "Preview Image" link, which shows raw JSON when clicked, confusing users.

- **`form_data`** and **`query_context`** on `ChartInfo` — These are internal technical fields containing raw chart configuration JSON. They bloat responses and cause chatbots to display unnecessary technical details to users.

- **`preview_url`** backward-compat field on `ChartPreview` — URL-based screenshot previews are not supported (`URLPreviewStrategy` already returns an error), so this field was dead code that could mislead AI clients.

- **`get_chart_info` docstring** misleadingly described the `url` field as a "screenshot URL" when it actually links to the chart's explore page.

### Changes

1. Remove `thumbnail_url` from `DashboardInfo` schema and both serializer functions
2. Remove `form_data` and `query_context` from `ChartInfo` schema and serializer
3. Remove `preview_url` backward-compat field from `ChartPreview` and dead URL preview code path in `get_chart_preview`
4. Fix `get_chart_info` docstring and `ChartInfo.url` field description

## Test plan

- [x] All 505 MCP unit tests pass
- [x] Verified `thumbnail_url` no longer appears in dashboard info responses
- [x] Verified `form_data`/`query_context` no longer appear in chart info responses
- [x] Verified chart preview no longer includes dead URL preview code path