### PR TITLE
fix(explore): prevent theme object from being passed to ReactAce in TextAreaControl

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
@@ -141,21 +141,44 @@ class TextAreaControl extends Component<TextAreaControlProps> {
   }
 
   renderEditor(inModal = false) {
-    const minLines = inModal ? 40 : this.props.minLines || 12;
-    if (this.props.language) {
+    // Exclude props that shouldn't be passed to TextAreaEditor:
+    // - theme: TextAreaEditor expects theme as a string, not the theme object from withTheme HOC
+    // - height: ReactAce expects string, we pass number (height is controlled via minLines/maxLines)
+    // - other control-specific props and explicitly-set props to avoid duplicate/conflicting assignments
+    const {
+      theme,
+      height,
+      offerEditInModal,
+      aboveEditorSection,
+      resize,
+      textAreaStyles,
+      tooltipOptions,
+      hotkeys,
+      debounceDelay,
+      language,
+      initialValue,
+      readOnly,
+      name,
+      onChange,
+      minLines: minLinesProp,
+      maxLines: maxLinesProp,
+      ...editorProps
+    } = this.props;
+    const minLines = inModal ? 40 : minLinesProp || 12;
+    if (language) {
       const style: React.CSSProperties = {
-        border: this.props.theme?.colorBorder
-          ? `1px solid ${this.props.theme.colorBorder}`
+        border: theme?.colorBorder
+          ? `1px solid ${theme.colorBorder}`
           : undefined,
         minHeight: `${minLines}em`,
         width: 'auto',
-        ...this.props.textAreaStyles,
+        ...textAreaStyles,
       };
-      if (this.props.resize) {
-        style.resize = this.props.resize;
+      if (resize) {
+        style.resize = resize;
       }
-      if (this.props.readOnly) {
-        style.backgroundColor = this.props.theme?.colorBgMask;
+      if (readOnly) {
+        style.backgroundColor = theme?.colorBgMask;
       }
       const onEditorLoad = (editor: {
         commands: {
@@ -166,7 +189,7 @@ class TextAreaControl extends Component<TextAreaControlProps> {
           }) => void;
         };
       }) => {
-        this.props.hotkeys?.forEach(keyConfig => {
+        hotkeys?.forEach(keyConfig => {
           editor.commands.addCommand({
             name: keyConfig.name,
             bindKey: { win: keyConfig.key, mac: keyConfig.key },
@@ -174,42 +197,26 @@ class TextAreaControl extends Component<TextAreaControlProps> {
           });
         });
       };
-      // Exclude props that shouldn't be passed to TextAreaEditor
-      // - theme: TextAreaEditor expects theme as a string, not the theme object from withTheme HOC
-      // - height: ReactAce expects string, we pass number (height is controlled via minLines/maxLines)
-      // - other control-specific props that ReactAce doesn't need
-      const {
-        theme,
-        height,
-        offerEditInModal,
-        aboveEditorSection,
-        resize,
-        textAreaStyles,
-        tooltipOptions,
-        hotkeys,
-        debounceDelay,
-        ...editorProps
-      } = this.props;
       const codeEditor = (
         <div>
           <TextAreaEditor
-            mode={this.props.language}
+            mode={language}
             style={style}
             minLines={minLines}
-            maxLines={inModal ? 1000 : this.props.maxLines}
+            maxLines={inModal ? 1000 : maxLinesProp}
             editorProps={{ $blockScrolling: true }}
             onLoad={onEditorLoad}
-            defaultValue={this.props.initialValue}
-            readOnly={this.props.readOnly}
-            key={this.props.name}
+            defaultValue={initialValue}
+            readOnly={readOnly}
+            key={name}
             {...editorProps}
             onChange={this.handleChange.bind(this)}
           />
         </div>
       );
 
-      if (this.props.tooltipOptions) {
-        return <Tooltip {...this.props.tooltipOptions}>{codeEditor}</Tooltip>;
+      if (tooltipOptions) {
+        return <Tooltip {...tooltipOptions}>{codeEditor}</Tooltip>;
       }
       return codeEditor;
     }

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
@@ -174,6 +174,22 @@ class TextAreaControl extends Component<TextAreaControlProps> {
           });
         });
       };
+      // Exclude props that shouldn't be passed to TextAreaEditor
+      // - theme: TextAreaEditor expects theme as a string, not the theme object from withTheme HOC
+      // - height: ReactAce expects string, we pass number (height is controlled via minLines/maxLines)
+      // - other control-specific props that ReactAce doesn't need
+      const {
+        theme,
+        height,
+        offerEditInModal,
+        aboveEditorSection,
+        resize,
+        textAreaStyles,
+        tooltipOptions,
+        hotkeys,
+        debounceDelay,
+        ...editorProps
+      } = this.props;
       const codeEditor = (
         <div>
           <TextAreaEditor
@@ -186,7 +202,7 @@ class TextAreaControl extends Component<TextAreaControlProps> {
             defaultValue={this.props.initialValue}
             readOnly={this.props.readOnly}
             key={this.props.name}
-            {...this.props}
+            {...editorProps}
             onChange={this.handleChange.bind(this)}
           />
         </div>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
 Fixes a bug where the theme object from the `withTheme()` HOC was incorrectly passed to the `TextAreaEditor` component, causing prop type errors and failed module loading attempts.

 The `TextAreaControl` component is wrapped with the `withTheme()` HOC which injects a theme object containing style tokens (e.g., `{colorBorder, colorBgMask, sizeUnit}`). Previously, the component used `{...this.props}` to spread all props to the `TextAreaEditor` component, including this theme object.

  However, `TextAreaEditor` (which wraps `AsyncAceEditor`) expects the `theme` prop to be a string like `'github'` or `'textmate'` that specifies which ace editor theme to load. When the theme object was passed instead, it was stringified to `[object Object]` in the dynamic import path, causing a 404 error.

  **The Fix:**
  Destructure and exclude incompatible props before spreading to `TextAreaEditor`:
  - `theme` - Theme object from HOC (incompatible with ReactAce's string theme prop)
  - `height` - Number value (ReactAce expects string)
  - Other TextAreaControl-specific props that ReactAce doesn't recognize

  The theme object is still used by TextAreaControl for its own styling needs, but is no longer passed down to the editor component.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before - 
When opening forms with TextAreaControl components (e.g., datasource modal metrics tab), the following issues occurred:
  - React prop type warning: `Invalid prop 'theme' of type 'object' supplied to ReactAce, expected 'string'`
  - Network error: `GET http://localhost:9000/static/assets/theme-[object%20Object].js 404 (Not Found)`
  - Additional prop type warnings for `height` prop
<img width="1701" height="598" alt="image" src="https://github.com/user-attachments/assets/db748a58-1c62-4d71-aacf-57087a7f0245" />

After - 
 - No more prop type warnings
  - No more failed network requests for `theme-[object Object].js`
  - TextAreaEditor receives only compatible props
<img width="1704" height="667" alt="image" src="https://github.com/user-attachments/assets/d4d0f393-6a68-4ed3-b043-4ad673c80297" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://gith
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
