### PR TITLE
fix(button): use colorLink token for link-style buttons

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Button/Button.stories.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Button/Button.stories.tsx
@@ -105,7 +105,7 @@ export const InteractiveButton = (args: ButtonProps & { children: string }) => (
 );
 
 InteractiveButton.args = {
-  buttonStyle: 'default',
+  buttonStyle: 'primary',
   buttonSize: 'default',
   children: 'Button!',
 };

--- a/superset-frontend/packages/superset-ui-core/src/components/Button/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Button/index.tsx
@@ -30,6 +30,22 @@ import type {
   OnClickHandler,
 } from './types';
 
+const BUTTON_STYLE_MAP: Record<
+  ButtonStyle,
+  {
+    type?: ButtonType;
+    variant?: ButtonVariantType;
+    color?: ButtonColorType;
+  }
+> = {
+  primary: { type: 'primary', variant: 'solid', color: 'primary' },
+  secondary: { variant: 'filled', color: 'primary' },
+  tertiary: { variant: 'outlined', color: 'default' },
+  dashed: { type: 'dashed', variant: 'dashed', color: 'primary' },
+  danger: { variant: 'solid', color: 'danger' },
+  link: { type: 'link' },
+};
+
 export function Button(props: ButtonProps) {
   const {
     tooltip,
@@ -62,27 +78,11 @@ export function Button(props: ButtonProps) {
     padding = 4;
   }
 
-  let antdType: ButtonType = 'default';
-  let variant: ButtonVariantType = 'solid';
-  let color: ButtonColorType = 'primary';
-
-  if (!buttonStyle || buttonStyle === 'primary') {
-    variant = 'solid';
-    antdType = 'primary';
-  } else if (buttonStyle === 'secondary') {
-    variant = 'filled';
-    color = 'primary';
-  } else if (buttonStyle === 'tertiary') {
-    variant = 'outlined';
-    color = 'default';
-  } else if (buttonStyle === 'dashed') {
-    variant = 'dashed';
-    antdType = 'dashed';
-  } else if (buttonStyle === 'danger') {
-    color = 'danger';
-  } else if (buttonStyle === 'link') {
-    variant = 'link';
-  }
+  const {
+    type: antdType = 'default',
+    variant,
+    color,
+  } = BUTTON_STYLE_MAP[buttonStyle ?? 'primary'];
 
   const element = children as ReactElement;
 


### PR DESCRIPTION
### SUMMARY
The Button wrapper was using `variant="link"` and `color="primary"` which caused antd to apply `colorPrimaryText` instead of `colorLink`. Switch to `type="link"` to match antd's default behavior. Also refactor the `buttonStyle` mapping into a lookup table for readability.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="437" height="202" alt="image" src="https://github.com/user-attachments/assets/9b55c6cd-89dd-417e-99bc-8cb1d7f66c5b" />

After:
<img width="674" height="284" alt="image" src="https://github.com/user-attachments/assets/03a13dc6-8d4c-4dd1-8b8d-9af26f4c9c34" />


### TESTING INSTRUCTIONS
1. Create a theme and set different colors to tokens `colorLink` and `colorPrimaryText`
2. Activate that theme
3. Go to a view with a link button - for example adding new database connection -> "Import database from file" button
4. Verify that it uses the colorLink token

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
