### PR TITLE
fix(dataset-modal): fix folders tab scrollbar by establishing proper flex chain

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -45,23 +45,14 @@ const DatasourceEditor = AsyncEsmComponent(
 );
 
 const StyledDatasourceModal = styled(Modal)`
-  .modal-content {
+  && .ant-modal-content {
     height: 900px;
+  }
+
+  && .ant-modal-body {
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
-    align-items: stretch;
-  }
-
-  .modal-header {
-    flex: 0 1 auto;
-  }
-  .modal-body {
-    flex: 1 1 auto;
-    overflow: auto;
-  }
-
-  .modal-footer {
-    flex: 0 1 auto;
   }
 
   .ant-tabs-top {

--- a/superset-frontend/src/components/Datasource/FoldersEditor/styles.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/styles.tsx
@@ -22,7 +22,7 @@ export const FoldersContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: relative;
-  height: 70vh;
+  height: 100%;
   gap: ${({ theme }) => theme.paddingMD}px;
 `;
 

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -319,6 +319,11 @@ interface OwnersSelectorProps {
 }
 
 const DatasourceContainer = styled.div`
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+
   .change-warning {
     margin: 16px 10px 0;
     color: ${({ theme }) => theme.colorWarning};
@@ -347,9 +352,23 @@ const FlexRowContainer = styled.div`
 `;
 
 const StyledTableTabs = styled(Tabs)`
-  overflow: visible;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+
   .ant-tabs-content-holder {
-    overflow: visible;
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+  }
+
+  .ant-tabs-content {
+    height: 100%;
+  }
+
+  .ant-tabs-tabpane-active {
+    height: 100%;
   }
 `;
 


### PR DESCRIPTION

### SUMMARY
The DatasourceModal's CSS selectors targeted Bootstrap-era class names (.modal-content, .modal-body, etc.) instead of antd v5's .ant-modal-* classes, so the intended 900px height and flex layout were never applied. This left the modal body without a definite height, forcing FoldersEditor to use a hardcoded 70vh that caused an unnecessary scrollbar.

Fix the selectors and establish a complete flex chain from the modal body through DatasourceContainer and Tabs down to FoldersContainer, which can now use height: 100% instead of the viewport-relative workaround.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Open dataset modal
2. Verify that the modal has a fixed height
3. Verify that there's no unnecessary scrollbar in Folders tab

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
