### PR TITLE
build(deps): migrate to lighter and modern `react-icons`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -139,6 +139,9 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/plugin-chart-pivot-table/"
+    ignore:
+      # TODO: remove below entries until React >= 19.0.0
+      - dependency-name: "react-icons"
     schedule:
       interval: "daily"
     labels:
@@ -189,6 +192,9 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/plugin-chart-table/"
+    ignore:
+      # TODO: remove below entries until React >= 19.0.0
+      - dependency-name: "react-icons"
     schedule:
       interval: "daily"
     labels:

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -9846,15 +9846,6 @@
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
       "license": "MIT"
     },
-    "node_modules/@react-icons/all-files": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
-      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@react-spring/animated": {
       "version": "9.7.5",
       "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
@@ -42435,6 +42426,15 @@
         "react": ">=16.4.1"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-intersection-observer": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.0.3.tgz",
@@ -51830,7 +51830,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@apache-superset/core": "*",
-        "@react-icons/all-files": "^4.1.0",
         "@types/react": "*",
         "lodash": "^4.17.23"
       },
@@ -53009,63 +53008,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "packages/superset-ui-demo": {
-      "name": "@superset-ui/demo",
-      "version": "0.20.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@emotion/cache": "^11.14.0",
-        "@emotion/react": "^11.14.0",
-        "@emotion/styled": "^11.14.1",
-        "@mihkeleidast/storybook-addon-source": "^1.0.1",
-        "@react-icons/all-files": "^4.1.0",
-        "@storybook/addon-actions": "^8.6.15",
-        "@storybook/addon-controls": "^8.6.15",
-        "@storybook/addon-links": "^8.6.15",
-        "@storybook/react": "^8.6.15",
-        "@storybook/types": "^8.6.15",
-        "@types/react-loadable": "^5.5.11",
-        "core-js": "3.48.0",
-        "gh-pages": "^6.3.0",
-        "jquery": "^4.0.0",
-        "memoize-one": "^6.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "react-loadable": "^5.5.0",
-        "react-resizable": "^3.1.3"
-      },
-      "devDependencies": {
-        "@babel/core": "^7.29.0",
-        "@babel/preset-env": "^7.29.0",
-        "@babel/preset-react": "^7.28.5",
-        "@babel/preset-typescript": "^7.28.5",
-        "@storybook/react-webpack5": "^8.6.15",
-        "babel-loader": "^10.0.0",
-        "fork-ts-checker-webpack-plugin": "^9.1.0",
-        "ts-loader": "^9.5.4",
-        "typescript": "^5.9.3"
-      },
-      "peerDependencies": {
-        "@apache-superset/core": "*",
-        "@superset-ui/core": "*",
-        "@superset-ui/legacy-plugin-chart-calendar": "*",
-        "@superset-ui/legacy-plugin-chart-chord": "*",
-        "@superset-ui/legacy-plugin-chart-country-map": "*",
-        "@superset-ui/legacy-plugin-chart-horizon": "*",
-        "@superset-ui/legacy-plugin-chart-map-box": "*",
-        "@superset-ui/legacy-plugin-chart-paired-t-test": "*",
-        "@superset-ui/legacy-plugin-chart-parallel-coordinates": "*",
-        "@superset-ui/legacy-plugin-chart-partition": "*",
-        "@superset-ui/legacy-plugin-chart-rose": "*",
-        "@superset-ui/legacy-plugin-chart-world-map": "*",
-        "@superset-ui/legacy-preset-chart-deckgl": "*",
-        "@superset-ui/legacy-preset-chart-nvd3": "*",
-        "@superset-ui/plugin-chart-echarts": "*",
-        "@superset-ui/plugin-chart-table": "*",
-        "@superset-ui/plugin-chart-word-cloud": "*"
-      }
-    },
     "packages/superset-ui-switchboard": {
       "name": "@superset-ui/switchboard",
       "version": "0.20.3",
@@ -53451,7 +53393,6 @@
       "version": "0.20.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-icons/all-files": "^4.1.0",
         "@types/d3-array": "^3.2.2",
         "@types/react-table": "^7.7.20",
         "classnames": "^2.5.1",
@@ -53606,13 +53547,13 @@
       "peerDependencies": {
         "@ant-design/icons": "^5.2.6",
         "@apache-superset/core": "*",
-        "@react-icons/all-files": "^4.1.0",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "lodash": "^4.17.11",
         "prop-types": "*",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "react-icons": "5.4.0"
       }
     },
     "plugins/plugin-chart-table": {
@@ -53620,13 +53561,13 @@
       "version": "0.20.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-icons/all-files": "^4.1.0",
         "@types/d3-array": "^3.2.2",
         "@types/react-table": "^7.7.20",
         "classnames": "^2.5.1",
         "d3-array": "^3.2.4",
         "lodash": "^4.17.23",
         "memoize-one": "^5.2.1",
+        "react-icons": "5.4.0",
         "react-table": "^7.8.0",
         "regenerator-runtime": "^0.14.1",
         "xss": "^1.0.15"

--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/package-lock.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/package-lock.erb
@@ -4144,15 +4144,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@react-icons/all-files": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
-      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
-      "peer": true,
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4186,7 +4177,6 @@
       "integrity": "sha512-zi2DJ2cTpgR1HugPX3yBHJAaBo7XYhodgZqj0BsKNMoexrLvHyPYsN+cw5xXFE1Q1ZyeKtQBB5m41+CKKfwQYw==",
       "peer": true,
       "dependencies": {
-        "@react-icons/all-files": "^4.1.0",
         "@superset-ui/core": "0.18.25",
         "lodash": "^4.17.15",
         "prop-types": "^15.7.2"
@@ -21330,13 +21320,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@react-icons/all-files": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
-      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
-      "peer": true,
-      "requires": {}
-    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -21367,7 +21350,6 @@
       "integrity": "sha512-zi2DJ2cTpgR1HugPX3yBHJAaBo7XYhodgZqj0BsKNMoexrLvHyPYsN+cw5xXFE1Q1ZyeKtQBB5m41+CKKfwQYw==",
       "peer": true,
       "requires": {
-        "@react-icons/all-files": "^4.1.0",
         "@superset-ui/core": "0.18.25",
         "lodash": "^4.17.15",
         "prop-types": "^15.7.2"

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -25,7 +25,6 @@
   ],
   "dependencies": {
     "@apache-superset/core": "*",
-    "@react-icons/all-files": "^4.1.0",
     "@types/react": "*",
     "lodash": "^4.17.23"
   },

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/package.json
@@ -24,7 +24,6 @@
     "lib"
   ],
   "dependencies": {
-    "@react-icons/all-files": "^4.1.0",
     "@types/d3-array": "^3.2.2",
     "@types/react-table": "^7.7.20",
     "classnames": "^2.5.1",

--- a/superset-frontend/plugins/plugin-chart-pivot-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@react-icons/all-files": "^4.1.0",
+    "react-icons": "5.4.0",
     "@apache-superset/core": "*",
     "@ant-design/icons": "^5.2.6",
     "@superset-ui/chart-controls": "*",

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -21,9 +21,9 @@ import { Component, ReactNode, MouseEvent } from 'react';
 import { safeHtmlSpan } from '@superset-ui/core';
 import { t } from '@apache-superset/core/ui';
 import PropTypes from 'prop-types';
-import { FaSort } from '@react-icons/all-files/fa/FaSort';
-import { FaSortDown as FaSortDesc } from '@react-icons/all-files/fa/FaSortDown';
-import { FaSortUp as FaSortAsc } from '@react-icons/all-files/fa/FaSortUp';
+import { FaSort } from 'react-icons/fa';
+import { FaSortDown as FaSortDesc } from 'react-icons/fa';
+import { FaSortUp as FaSortAsc } from 'react-icons/fa';
 import { PivotData, flatKey } from './utilities';
 import { Styles } from './Styles';
 

--- a/superset-frontend/plugins/plugin-chart-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-table/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "@react-icons/all-files": "^4.1.0",
+    "react-icons": "5.4.0",
     "@types/d3-array": "^3.2.2",
     "@types/react-table": "^7.7.20",
     "classnames": "^2.5.1",

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -35,9 +35,9 @@ import {
   Row,
 } from 'react-table';
 import { extent as d3Extent, max as d3Max } from 'd3-array';
-import { FaSort } from '@react-icons/all-files/fa/FaSort';
-import { FaSortDown as FaSortDesc } from '@react-icons/all-files/fa/FaSortDown';
-import { FaSortUp as FaSortAsc } from '@react-icons/all-files/fa/FaSortUp';
+import { FaSort } from 'react-icons/fa';
+import { FaSortDown as FaSortDesc } from 'react-icons/fa';
+import { FaSortUp as FaSortAsc } from 'react-icons/fa';
 import cx from 'classnames';
 import {
   DataRecord,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Migrate to more modern and lightweight `react-icons` as suggested by official [doc](https://react-icons.github.io/react-icons/). This PR also removes extraneously added `@react-icons/all-files` dep in packages not even import like `chart-controls` or `plugin-ag-grid-table`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Functionalities are still intact, for example in the `plugin-chart-table`


https://github.com/user-attachments/assets/f3854bf2-8c34-4c69-aa2c-4bcbc8f7a0ca

Bundled size got cut down by half

Before
<img width="574" height="608" alt="Screenshot 2026-02-20 at 23 58 03" src="https://github.com/user-attachments/assets/1d9083be-a6fc-4890-8112-adf1fe8fa902" />

After
<img width="519" height="375" alt="Screenshot 2026-02-20 at 23 57 28" src="https://github.com/user-attachments/assets/2d8b8afa-05a7-4586-8d87-5cf585e09fd0" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
