### PR TITLE
refactor(extensions): simplify registerEditorProvider API

### DIFF
--- a/docs/developer_portal/extensions/extension-points/editors.md
+++ b/docs/developer_portal/extensions/extension-points/editors.md
@@ -172,13 +172,9 @@ import { editors } from '@apache-superset/core';
 import MonacoSQLEditor from './MonacoSQLEditor';
 
 export function activate(context) {
-  // Register the Monaco editor for SQL
+  // Register the Monaco editor for SQL using the contribution ID from extension.json
   const disposable = editors.registerEditorProvider(
-    {
-      id: 'monaco-sql-editor.sql',
-      name: 'Monaco SQL Editor',
-      languages: ['sql'],
-    },
+    'monaco-sql-editor.sql',
     MonacoSQLEditor,
   );
 

--- a/superset-frontend/packages/superset-core/src/api/editors.ts
+++ b/superset-frontend/packages/superset-core/src/api/editors.ts
@@ -497,25 +497,25 @@ export interface EditorProviderUnregisteredEvent {
  * Register an editor provider for specific languages.
  * When an extension registers an editor, it replaces the default for those languages.
  *
- * @param contribution The editor contribution metadata from extension.json
+ * The contribution metadata (name, languages, description) is read from the
+ * extension's manifest (extension.json), so only the contribution ID and
+ * component are needed at registration time.
+ *
+ * @param id The editor contribution ID declared in extension.json
  * @param component The React component implementing EditorProps
  * @returns A Disposable to unregister the provider
  *
  * @example
  * ```typescript
  * const disposable = registerEditorProvider(
- *   {
- *     id: 'acme.monaco-sql',
- *     name: 'Monaco SQL Editor',
- *     languages: ['sql'],
- *   },
+ *   'acme.monaco-sql',
  *   MonacoSQLEditor
  * );
  * context.disposables.push(disposable);
  * ```
  */
 export declare function registerEditorProvider(
-  contribution: EditorContribution,
+  id: string,
   component: EditorComponent,
 ): Disposable;
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Simplifies the `registerEditorProvider` API by removing redundant metadata that is already declared in `extension.json`.

**Before:** Extension authors had to pass the full `EditorContribution` object (id, name, languages, description) even though the same information is already in the manifest:

```typescript
editors.registerEditorProvider(
  { id: 'acme.monaco-sql', name: 'Monaco SQL Editor', languages: ['sql'] },
  MonacoSQLEditor,
);
```

**After:** Only the contribution ID and component are needed — metadata is resolved from the manifest automatically, matching the `registerViewProvider` pattern:

```typescript
editors.registerEditorProvider('acme.monaco-sql', MonacoSQLEditor);
```

### TESTING INSTRUCTIONS

1. Verify existing editor tests pass: `npx jest --no-coverage src/core/editors/`
2. Load an extension that registers an editor provider using the new `(id, component)` signature
3. Confirm the editor renders in the expected locations (SQL Lab, Dashboard CSS, etc.)
4. Confirm a warning is logged if a non-existent ID is passed to `registerEditorProvider`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
