### PR TITLE
fix(mcp): add eager loading to get_info tools to prevent N+1 query timeouts

### DIFF
--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -248,6 +248,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         column_name: str,
         value: str | int,
         skip_base_filter: bool = False,
+        query_options: list | None = None,
     ) -> T | None:
         """
         Private method to find a model by any column value.
@@ -256,12 +257,17 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
             column_name: Name of the column to search by
             value: Value to search for
             skip_base_filter: Whether to skip base filtering
+            query_options: SQLAlchemy query options (e.g., joinedload,
+                subqueryload) to apply to the query for eager loading
 
         Returns:
             Model instance or None if not found
         """
         query = db.session.query(cls.model_cls)
         query = cls._apply_base_filter(query, skip_base_filter)
+
+        if query_options:
+            query = query.options(*query_options)
 
         if not hasattr(cls.model_cls, column_name):
             return None
@@ -283,6 +289,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         model_id: str | int,
         skip_base_filter: bool = False,
         id_column: str | None = None,
+        query_options: list | None = None,
     ) -> T | None:
         """
         Find a model by ID using specified or default ID column.
@@ -291,12 +298,14 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
             model_id: ID value to search for
             skip_base_filter: Whether to skip base filtering
             id_column: Column name to use (defaults to cls.id_column_name)
+            query_options: SQLAlchemy query options (e.g., joinedload,
+                subqueryload) to apply to the query for eager loading
 
         Returns:
             Model instance or None if not found
         """
         column = id_column or cls.id_column_name
-        return cls._find_by_column(column, model_id, skip_base_filter)
+        return cls._find_by_column(column, model_id, skip_base_filter, query_options)
 
     @classmethod
     def find_by_ids(

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -248,7 +248,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         column_name: str,
         value: str | int,
         skip_base_filter: bool = False,
-        query_options: list | None = None,
+        query_options: list[Any] | None = None,
     ) -> T | None:
         """
         Private method to find a model by any column value.
@@ -289,7 +289,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         model_id: str | int,
         skip_base_filter: bool = False,
         id_column: str | None = None,
-        query_options: list | None = None,
+        query_options: list[Any] | None = None,
     ) -> T | None:
         """
         Find a model by ID using specified or default ID column.

--- a/superset/daos/database.py
+++ b/superset/daos/database.py
@@ -70,11 +70,15 @@ class DatabaseDAO(BaseDAO[Database]):
         model_id: str | int,
         skip_base_filter: bool = False,
         id_column: str | None = None,
+        query_options: list[Any] | None = None,
     ) -> Database | None:
         """
         Find a database by id, eagerly loading the SSH tunnel relationship.
         """
-        query = db.session.query(cls.model_cls).options(joinedload(Database.ssh_tunnel))
+        all_options = [joinedload(Database.ssh_tunnel)]
+        if query_options:
+            all_options.extend(query_options)
+        query = db.session.query(cls.model_cls).options(*all_options)
         query = cls._apply_base_filter(query, skip_base_filter)
 
         column_name = id_column or cls.id_column_name

--- a/superset/mcp_service/mcp_core.py
+++ b/superset/mcp_service/mcp_core.py
@@ -240,6 +240,7 @@ class ModelGetInfoCore(BaseCore):
         serializer: Callable[[T], BaseModel],
         supports_slug: bool = False,
         logger: logging.Logger | None = None,
+        query_options: list | None = None,
     ) -> None:
         super().__init__(logger)
         self.dao_class = dao_class
@@ -247,29 +248,35 @@ class ModelGetInfoCore(BaseCore):
         self.error_schema = error_schema
         self.serializer = serializer
         self.supports_slug = supports_slug
+        self.query_options = query_options or []
 
     def _find_object(self, identifier: int | str) -> Any:
         """Find object by identifier using appropriate method."""
+        opts = self.query_options or None
         # If it's an integer or string that can be converted to int, use find_by_id
         if isinstance(identifier, int):
-            return self.dao_class.find_by_id(identifier)
+            return self.dao_class.find_by_id(identifier, query_options=opts)
 
         try:
             # Try to convert string to int
             id_val = int(identifier)
-            return self.dao_class.find_by_id(id_val)
+            return self.dao_class.find_by_id(id_val, query_options=opts)
         except ValueError:
             pass
 
         # Check if it's a UUID
         if _is_uuid(identifier):
             # Use the new flexible find_by_id with uuid column
-            return self.dao_class.find_by_id(identifier, id_column="uuid")
+            return self.dao_class.find_by_id(
+                identifier, id_column="uuid", query_options=opts
+            )
 
         # For dashboards, also check slug
         if self.supports_slug:
             # Try to find by slug using the new flexible method
-            result = self.dao_class.find_by_id(identifier, id_column="slug")
+            result = self.dao_class.find_by_id(
+                identifier, id_column="slug", query_options=opts
+            )
             if result:
                 return result
 
@@ -278,11 +285,10 @@ class ModelGetInfoCore(BaseCore):
             from superset.models.dashboard import id_or_slug_filter
 
             model_class = self.dao_class.model_cls
-            return (
-                db.session.query(model_class)
-                .filter(id_or_slug_filter(identifier))
-                .one_or_none()
-            )
+            query = db.session.query(model_class).filter(id_or_slug_filter(identifier))
+            if opts:
+                query = query.options(*opts)
+            return query.one_or_none()
 
         # If we get here, it's an invalid identifier
         return None

--- a/superset/mcp_service/mcp_core.py
+++ b/superset/mcp_service/mcp_core.py
@@ -240,7 +240,7 @@ class ModelGetInfoCore(BaseCore):
         serializer: Callable[[T], BaseModel],
         supports_slug: bool = False,
         logger: logging.Logger | None = None,
-        query_options: list | None = None,
+        query_options: list[Any] | None = None,
     ) -> None:
         super().__init__(logger)
         self.dao_class = dao_class

--- a/tests/unit_tests/mcp_service/system/tool/test_mcp_core.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_mcp_core.py
@@ -69,7 +69,7 @@ class DummyDAO:
         return [SimpleNamespace(id=1, name="foo"), SimpleNamespace(id=2, name="bar")], 2
 
     @classmethod
-    def find_by_id(cls, id):
+    def find_by_id(cls, id, **kwargs):
         if id == 1:
             return SimpleNamespace(id=1, name="foo")
         return None
@@ -196,7 +196,7 @@ def test_model_get_info_tool_not_found():
 def test_model_get_info_tool_exception():
     class FailingDAO:
         @classmethod
-        def find_by_id(cls, id):
+        def find_by_id(cls, id, **kwargs):
             raise Exception("fail")
 
     tool = ModelGetInfoCore(


### PR DESCRIPTION
## Summary

- Add eager loading (SQLAlchemy `subqueryload`/`joinedload`) to all MCP `get_info` tools to prevent N+1 query patterns that cause timeouts on large datasets, dashboards with many charts, etc.
- Add a generic `query_options` parameter to `BaseDAO.find_by_id()` and `ModelGetInfoCore` so any tool can specify eager loading options

## Problem

The MCP `get_dataset_info`, `get_chart_info`, and `get_dashboard_info` tools use `BaseDAO.find_by_id()` which loads the model with lazy relationships. When the serializer subsequently accesses collection relationships (columns, metrics, owners, tags, slices, roles), each triggers a separate SQL query. For a dataset with 200+ columns or a dashboard with 30+ charts, this creates hundreds of queries and can exceed the per-tool timeout (30s).

## Changes

### `superset/daos/base.py`
- Add optional `query_options` parameter to `_find_by_column()` and `find_by_id()` to accept SQLAlchemy loading strategies (backwards-compatible, defaults to `None`)

### `superset/mcp_service/mcp_core.py`
- Add `query_options` parameter to `ModelGetInfoCore.__init__()`, propagated through all `_find_object()` code paths (ID, UUID, slug, fallback)

### `superset/mcp_service/dataset/tool/get_dataset_info.py`
- Eager load `columns` (subqueryload), `metrics` (subqueryload), and `database` (joinedload) — the three relationships accessed by `serialize_dataset_object()`

### `superset/mcp_service/chart/tool/get_chart_info.py`
- Eager load `owners` and `tags` (subqueryload) — accessed by `serialize_chart_object()`

### `superset/mcp_service/dashboard/tool/get_dashboard_info.py`
- Eager load `slices`, `owners`, `tags`, `roles` (subqueryload)
- Nested eager loading: `slices.owners` and `slices.tags` since `dashboard_serializer` calls `serialize_chart_object()` for each chart

## Test plan

- [ ] Existing MCP dataset/chart/dashboard unit tests pass
- [ ] `get_dataset_info` on a dataset with 200+ columns completes within timeout
- [ ] `get_dashboard_info` on a dashboard with 30+ charts completes within timeout
- [ ] `get_chart_info` returns correct owners and tags
- [ ] Tools still work with UUID and slug identifiers (not just numeric IDs)