### PR TITLE
fix(screenshots): downgrade screenshot timeout logs from ERROR to WARNING

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -912,9 +912,9 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.put_chart_customizations",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.put_chart_customizations"
+        ),
         log_to_statsd=False,
     )
     @requires_json
@@ -1261,8 +1261,9 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
     @permission_name("export")
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".export_as_example",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.export_as_example"
+        ),
         log_to_statsd=False,
     )
     def export_as_example(self, pk: int) -> Response:
@@ -1352,8 +1353,9 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".cache_dashboard_screenshot",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.cache_dashboard_screenshot"
+        ),
         log_to_statsd=False,
     )
     def cache_dashboard_screenshot(self, pk: int, **kwargs: Any) -> WerkzeugResponse:
@@ -1670,7 +1672,7 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
         except ScreenshotImageNotAvailableException:
             return self.response_404()
         except Exception as ex:  # pylint: disable=broad-except
-            logger.error(
+            logger.warning(
                 "Error retrieving thumbnail for dashboard %s: %s",
                 str(dashboard.id),
                 str(ex),
@@ -1689,8 +1691,9 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
     @statsd_metrics
     @rison(get_fav_star_ids_schema)
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".favorite_status",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.favorite_status"
+        ),
         log_to_statsd=False,
     )
     def favorite_status(self, **kwargs: Any) -> Response:
@@ -1783,8 +1786,9 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".remove_favorite",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.remove_favorite"
+        ),
         log_to_statsd=False,
     )
     def remove_favorite(self, pk: int) -> Response:
@@ -2081,9 +2085,9 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
     @permission_name("set_embedded")
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.delete_embedded",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.delete_embedded"
+        ),
         log_to_statsd=False,
     )
     @with_dashboard

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -611,7 +611,9 @@ class WebDriverSelenium(WebDriverProxy):
                     EC.presence_of_element_located((By.CLASS_NAME, element_name))
                 )
             except TimeoutException:
-                logger.exception("Selenium timed out requesting url %s", url)
+                logger.warning(
+                    "Selenium timed out requesting url %s", url, exc_info=True
+                )
                 raise
 
             try:
@@ -631,10 +633,11 @@ class WebDriverSelenium(WebDriverProxy):
                             (By.CLASS_NAME, "grid-container")
                         )
                     )
-                except:
-                    logger.exception(
+                except Exception:
+                    logger.warning(
                         "Selenium timed out waiting for dashboard to draw at url %s",
                         url,
+                        exc_info=True,
                     )
                     raise
 
@@ -647,8 +650,10 @@ class WebDriverSelenium(WebDriverProxy):
                     EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))
                 )
             except TimeoutException:
-                logger.exception(
-                    "Selenium timed out waiting for charts to load at url %s", url
+                logger.warning(
+                    "Selenium timed out waiting for charts to load at url %s",
+                    url,
+                    exc_info=True,
                 )
                 raise
 
@@ -672,22 +677,25 @@ class WebDriverSelenium(WebDriverProxy):
                     )
 
             img = element.screenshot_as_png
-        except Exception as ex:
-            logger.warning("exception in webdriver", exc_info=ex)
-            raise
         except TimeoutException:
-            # raise again for the finally block, but handled above
+            # Already logged at WARNING in the inner handlers above
             raise
         except StaleElementReferenceException:
-            logger.exception(
+            logger.warning(
                 "Selenium got a stale element while requesting url %s",
                 url,
+                exc_info=True,
             )
             raise
         except WebDriverException:
-            logger.exception(
-                "Encountered an unexpected error when requesting url %s", url
+            logger.warning(
+                "Encountered an unexpected error when requesting url %s",
+                url,
+                exc_info=True,
             )
+            raise
+        except Exception as ex:
+            logger.warning("exception in webdriver", exc_info=ex)
             raise
         finally:
             self.destroy(driver, app.config["SCREENSHOT_SELENIUM_RETRIES"])


### PR DESCRIPTION
### SUMMARY

Selenium timeout exceptions during screenshot generation are expected operational behavior (slow-loading dashboards, network latency, etc.) and not actual server errors. These were being logged at ERROR level via `logger.exception()`, creating significant noise in log aggregators like Datadog.

**Changes:**
- `webdriver.py`: Change `logger.exception()` to `logger.warning(..., exc_info=True)` for all three timeout scenarios (page load, dashboard draw, chart load)
- `webdriver.py`: Fix bare `except:` clause to use `except Exception:`
- `webdriver.py`: Reorder outer except blocks so specific exceptions (`TimeoutException`, `StaleElementReferenceException`, `WebDriverException`) are caught before the generic `Exception` handler — previously these were unreachable dead code
- `dashboards/api.py`: Downgrade `logger.error()` to `logger.warning()` in the thumbnail endpoint's catch-all handler that returns 404 (inconsistent to log ERROR for a 404 response)

### BEFORE/AFTER SCREENSHOTS OR COVERAGE URL
N/A - logging level changes only, no UI impact.

### TESTING INSTRUCTIONS
1. Trigger a dashboard thumbnail generation for a dashboard that takes a long time to load
2. Check that selenium timeout messages are logged at WARNING level instead of ERROR
3. Verify that the `ScreenshotImageNotAvailableException` still returns 404 properly
4. Unit tests: `pytest tests/unit_tests/utils/webdriver_test.py` (16/17 pass - the 1 failure is pre-existing in Playwright test, unrelated to these changes)

### ADDITIONAL INFORMATION
- These changes directly address Datadog `[remove]` exclusion filters for selenium timeout errors
- The outer except block reordering fixes a bug where `except Exception` caught everything before the more specific handlers, making them dead code
- `logger.warning(..., exc_info=True)` preserves the full stack trace for debugging while correctly classifying the severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)