### PR TITLE
perf(explore): reuse chart query data in Results tab

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -87,6 +87,7 @@ export const DataTablesPane = ({
   errorMessage,
   setForceQuery,
   canDownload,
+  queriesResponse,
 }: DataTablesPaneProps) => {
   const [activeTabKey, setActiveTabKey] = useState<string>(ResultTypes.Results);
   const [isRequest, setIsRequest] = useState<Record<ResultTypes, boolean>>({
@@ -110,6 +111,10 @@ export const DataTablesPane = ({
         results: false,
         samples: false,
       });
+    }
+
+    if (panelOpen && chartStatus === 'loading') {
+      setIsRequest(prev => ({ ...prev, results: false }));
     }
 
     if (
@@ -191,6 +196,7 @@ export const DataTablesPane = ({
     setForceQuery,
     isVisible: ResultTypes.Results === activeTabKey,
     canDownload,
+    queriesResponse,
   }).map((pane, idx) => ({
     key: idx === 0 ? ResultTypes.Results : `${ResultTypes.Results} ${idx + 1}`,
     label: idx === 0 ? t('Results') : t('Results %s', idx + 1),

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -20,6 +20,7 @@ import { useState, useEffect, ReactElement, useCallback } from 'react';
 
 import { t } from '@apache-superset/core';
 import {
+  ChartDataResponseResult,
   ensureIsArray,
   getChartMetadataRegistry,
   getClientErrorObject,
@@ -56,6 +57,7 @@ export const useResultsPane = ({
   dataSize = 50,
   canDownload,
   columnDisplayNames,
+  queriesResponse,
 }: ResultsPaneProps): ReactElement[] => {
   const metadata = getChartMetadataRegistry().get(
     queryFormData?.viz_type || queryFormData?.vizType,
@@ -72,7 +74,35 @@ export const useResultsPane = ({
   useEffect(() => {
     // it's an invalid formData when gets a errorMessage
     if (errorMessage) return;
-    if (isRequest && cache.has(queryFormData)) {
+    if (!isRequest) return;
+
+    // Reuse chart data from Redux when available. The chart visualization
+    // query and the results query produce identical SQL on the backend,
+    // so there is no need for a separate network request.
+    if (
+      queriesResponse?.length &&
+      'colnames' in queriesResponse[0]
+    ) {
+      const mapped = queriesResponse.map(q => {
+        const result = q as ChartDataResponseResult;
+        return {
+          colnames: result.colnames,
+          coltypes: result.coltypes,
+          data: result.data,
+          rowcount: result.rowcount,
+        };
+      }) as unknown as QueryResultInterface[];
+      setResultResp(mapped);
+      setResponseError('');
+      if (queryForce) {
+        setForceQuery?.(false);
+      }
+      setIsLoading(false);
+      return;
+    }
+
+    // Fallback: use cached data
+    if (cache.has(queryFormData)) {
       setResultResp(
         ensureIsArray(cache.get(queryFormData)) as QueryResultInterface[],
       );
@@ -81,33 +111,34 @@ export const useResultsPane = ({
         setForceQuery?.(false);
       }
       setIsLoading(false);
+      return;
     }
-    if (isRequest && !cache.has(queryFormData)) {
-      setIsLoading(true);
-      getChartDataRequest({
-        formData: queryFormData,
-        force: queryForce,
-        resultFormat: 'json',
-        resultType: 'results',
-        ownState,
+
+    // Fallback: fetch from API (legacy charts without queriesResponse)
+    setIsLoading(true);
+    getChartDataRequest({
+      formData: queryFormData,
+      force: queryForce,
+      resultFormat: 'json',
+      resultType: 'results',
+      ownState,
+    })
+      .then(({ json }) => {
+        setResultResp(ensureIsArray(json.result) as QueryResultInterface[]);
+        setResponseError('');
+        cache.set(queryFormData, json.result);
+        if (queryForce) {
+          setForceQuery?.(false);
+        }
       })
-        .then(({ json }) => {
-          setResultResp(ensureIsArray(json.result) as QueryResultInterface[]);
-          setResponseError('');
-          cache.set(queryFormData, json.result);
-          if (queryForce) {
-            setForceQuery?.(false);
-          }
-        })
-        .catch(response => {
-          getClientErrorObject(response).then(({ error, message }) => {
-            setResponseError(error || message || t('Sorry, an error occurred'));
-          });
-        })
-        .finally(() => {
-          setIsLoading(false);
+      .catch(response => {
+        getClientErrorObject(response).then(({ error, message }) => {
+          setResponseError(error || message || t('Sorry, an error occurred'));
         });
-    }
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
   }, [queryFormData, isRequest]);
 
   useEffect(() => {

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { JsonObject, LatestQueryFormData } from '@superset-ui/core';
+import { JsonObject, LatestQueryFormData, QueryData } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import type { ChartStatus, Datasource } from 'src/explore/types';
 
@@ -36,6 +36,7 @@ export interface DataTablesPaneProps {
   errorMessage?: React.ReactNode;
   setForceQuery: SetForceQueryAction;
   canDownload: boolean;
+  queriesResponse?: QueryData[] | null;
 }
 
 export interface ResultsPaneProps {
@@ -51,6 +52,7 @@ export interface ResultsPaneProps {
   canDownload: boolean;
   // Optional map of column/metric name -> verbose label
   columnDisplayNames?: Record<string, string>;
+  queriesResponse?: QueryData[] | null;
 }
 
 export interface SamplesPaneProps {

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
@@ -500,6 +500,7 @@ const ExploreChartPanel = ({
           errorMessage={errorMessage}
           setForceQuery={actions.setForceQuery}
           canDownload={canDownload}
+          queriesResponse={chart.queriesResponse}
         />
       </Split>
       {showDatasetModal && (


### PR DESCRIPTION
The Results tab in DataTablesPane independently fires a separate API request with resultType='results', which produces identical SQL to the chart's resultType='full' request on the backend. This doubles database load on every chart execution when the Results tab is open.

- Reset isRequest.results to false during chart loading to prevent race condition where both requests fire simultaneously
- Pass chart.queriesResponse from Redux through to useResultsPane
- Reuse chart data directly when available (v1 API), falling back to API call for legacy charts

Closes #38152

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The Results tab in the Explore view's DataTablesPane fires an independent API request (`resultType='results'`) every time a chart query runs. On the backend, `_get_results()` is a pure pass-through to `_get_full()` — both produce **identical SQL**. This means every chart execution with the Results tab open sends two duplicate database queries simultaneously.        

**Root cause (two issues):**                                                                                                                           

1. **Race condition in `DataTablesPane`**: `isRequest.results` is not reset to `false` when `chartStatus` transitions to `'loading'`. When`queryFormData` changes during chart loading, `useResultsPane`'s effect fires immediately — sending the Results request at the same time as the chart request.

2. **Redundant API call in `useResultsPane`**: The hook always fetches data via a separate network request, even though identical data is already available in Redux (`chart.queriesResponse`) after the chart query completes.

**Fix:**
- Reset `isRequest.results` to `false` when `chartStatus === 'loading'` to prevent the race condition
- Pass `chart.queriesResponse` from Redux through `ExploreChartPanel` → `DataTablesPane` → `useResultsPane`
- When `queriesResponse` contains v1 API data (has `colnames` field), reuse it directly — skipping the separate API call entirely
- Legacy charts without typed `queriesResponse` fall back to the existing API call

**Result:** One database query instead of two per chart execution. Results tab data appears instantly from Redux without a network round-trip.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="2548" height="1277" alt="스크린샷 2026-02-21 오후 12 44 59" src="https://github.com/user-attachments/assets/2261fdfb-3a02-4b2b-8cfb-ffdad035735d" />

AS-IS duplicated query was submitted to trino

<img width="2426" height="1285" alt="스크린샷 2026-02-21 오후 9 23 49" src="https://github.com/user-attachments/assets/1d4ca034-0d74-41a9-8ff2-6cb3044e993f" />

TO-BE only one query was submitted to trino and the result will be used in chart and result panels.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Build it locally and creating environment with docker-compose and tested it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/38152
- [ ] Required feature flags:
- [ ] Changes UI : No changes in UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
