### PR TITLE
feat(ci): only run precommit on changed files

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -63,14 +63,14 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: ./.github/actions/files-change-action
+        uses: ./.github/actions/file-changes-action
         with:
           output: ' '
 
       - name: pre-commit
         run: |
           set +e  # Don't exit immediately on failure
-          export SKIP=eslint-frontend,type-checking-frontend
+          export SKIP=type-checking-frontend
           pre-commit run --files ${{ steps.changed_files.outputs.files }}
           PRE_COMMIT_EXIT_CODE=$?
           git diff --quiet --exit-code

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -61,11 +61,17 @@ jobs:
           restore-keys: |
             pre-commit-v2-${{ runner.os }}-py${{ matrix.python-version }}-
 
+      - name: Get changed files
+        id: changed_files
+        uses: ./.github/actions/files-change-action
+        with:
+          output: ' '
+
       - name: pre-commit
         run: |
           set +e  # Don't exit immediately on failure
           export SKIP=eslint-frontend,type-checking-frontend
-          pre-commit run --all-files
+          pre-commit run --files ${{ steps.changed_files.outputs.files }}
           PRE_COMMIT_EXIT_CODE=$?
           git diff --quiet --exit-code
           GIT_DIFF_EXIT_CODE=$?

--- a/superset-frontend/oxlint.json
+++ b/superset-frontend/oxlint.json
@@ -223,8 +223,7 @@
     "jsx-a11y/no-noninteractive-tabindex": "error",
     "jsx-a11y/no-redundant-roles": "error",
     "jsx-a11y/no-static-element-interactions": "off",
-    // TODO: Fix missing aria-selected on tab roles
-    "jsx-a11y/role-has-required-aria-props": "warn",
+    "jsx-a11y/role-has-required-aria-props": "error",
     "jsx-a11y/role-supports-aria-props": "error",
     "jsx-a11y/scope": "error",
     "jsx-a11y/tabindex-no-positive": "error",

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
@@ -119,6 +119,7 @@ const FilterTitleContainer = forwardRef<HTMLDivElement, Props>(
           key={`filter-title-tab-${id}`}
           onClick={() => onChange(id)}
           className={classNames.join(' ')}
+          aria-selected={isActive}
         >
           <div css={{ display: 'flex', width: '100%', alignItems: 'center' }}>
             <div

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ItemTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ItemTitleContainer.tsx
@@ -119,6 +119,7 @@ const ItemTitleContainer = forwardRef<HTMLDivElement, Props>(
           key={`item-title-tab-${id}`}
           onClick={() => onChange(id)}
           className={classNames.join(' ')}
+          aria-selected={isActive}
         >
           <div css={{ display: 'flex', width: '100%', alignItems: 'center' }}>
             <div


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(ci): only run precommit on change files

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Only run `precommit` Git hooks for changed files in a PR. 
Additionally, It doesn't make sense for PR's author to fix for issues in files they didn't modify. Plus we'll save off CI resources by not running `pre-commit` excessively so.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Green CI as acceptance of threshold.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
