### PR TITLE
fix(dashboard): prevent stale favorite status errors after navigation

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.ts
@@ -28,9 +28,13 @@ import {
   ON_FILTERS_REFRESH,
   ON_REFRESH,
   ON_REFRESH_SUCCESS,
+  TOGGLE_FAVE_STAR,
+  fetchFaveStar,
 } from 'src/dashboard/actions/dashboardState';
 import { refreshChart } from 'src/components/Chart/chartAction';
 import { UPDATE_COMPONENTS_PARENTS_LIST } from 'src/dashboard/actions/dashboardLayout';
+import { ADD_TOAST } from 'src/components/MessageToasts/actions';
+import { ToastType } from 'src/components/MessageToasts/types';
 import {
   DASHBOARD_GRID_ID,
   SAVE_TYPE_OVERWRITE,
@@ -399,5 +403,97 @@ describe('dashboardState actions', () => {
     expect(dispatchedTypes).toContain(ON_REFRESH_SUCCESS);
     expect(dispatchedTypes).not.toContain(ON_REFRESH);
     expect(dispatchedTypes).not.toContain(ON_FILTERS_REFRESH);
+  });
+
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
+  describe('fetchFaveStar race condition', () => {
+    test('dispatches TOGGLE_FAVE_STAR when the dashboard ID still matches', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      getStub.mockRestore();
+      getStub = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+        json: { result: [{ value: true }] },
+      } as any);
+
+      await fetchFaveStar(id)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: TOGGLE_FAVE_STAR,
+        isStarred: true,
+      });
+    });
+
+    test('does NOT dispatch when the dashboard ID changed before the response resolved', async () => {
+      const requestedId = 123;
+      // User navigated to a different dashboard by the time the response comes back
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id: 456,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      getStub.mockRestore();
+      getStub = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+        json: { result: [{ value: true }] },
+      } as any);
+
+      await fetchFaveStar(requestedId)(dispatch, getState);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    test('dispatches a danger toast on error when the dashboard ID still matches', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      getStub.mockRestore();
+      getStub = jest
+        .spyOn(SupersetClient, 'get')
+        .mockRejectedValue(new Error('network'));
+
+      await fetchFaveStar(id)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          type: ADD_TOAST,
+          payload: expect.objectContaining({
+            toastType: ToastType.Danger,
+          }),
+        }),
+      );
+    });
+
+    test('does NOT dispatch a danger toast on error when the dashboard ID changed', async () => {
+      const requestedId = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id: 456,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      getStub.mockRestore();
+      getStub = jest
+        .spyOn(SupersetClient, 'get')
+        .mockRejectedValue(new Error('network'));
+
+      await fetchFaveStar(requestedId)(dispatch, getState);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.ts
@@ -30,6 +30,7 @@ import {
   ON_REFRESH_SUCCESS,
   TOGGLE_FAVE_STAR,
   fetchFaveStar,
+  saveFaveStar,
 } from 'src/dashboard/actions/dashboardState';
 import { refreshChart } from 'src/components/Chart/chartAction';
 import { UPDATE_COMPONENTS_PARENTS_LIST } from 'src/dashboard/actions/dashboardLayout';
@@ -492,6 +493,131 @@ describe('dashboardState actions', () => {
         .mockRejectedValue(new Error('network'));
 
       await fetchFaveStar(requestedId)(dispatch, getState);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
+  describe('saveFaveStar race condition', () => {
+    let deleteStub: jest.SpyInstance;
+
+    beforeEach(() => {
+      deleteStub = jest
+        .spyOn(SupersetClient, 'delete')
+        .mockResolvedValue({} as any);
+    });
+
+    afterEach(() => {
+      deleteStub.mockRestore();
+    });
+
+    test('dispatches TOGGLE_FAVE_STAR when the dashboard ID still matches (starring)', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      postStub.mockRestore();
+      postStub = jest
+        .spyOn(SupersetClient, 'post')
+        .mockResolvedValue({} as any);
+
+      await saveFaveStar(id, false)(dispatch, getState);
+
+      expect(postStub).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: TOGGLE_FAVE_STAR,
+        isStarred: true,
+      });
+    });
+
+    test('dispatches TOGGLE_FAVE_STAR when the dashboard ID still matches (unstarring)', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      await saveFaveStar(id, true)(dispatch, getState);
+
+      expect(deleteStub).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: TOGGLE_FAVE_STAR,
+        isStarred: false,
+      });
+    });
+
+    test('does NOT dispatch when the dashboard ID changed before the response resolved', async () => {
+      const requestedId = 123;
+      // User navigated to a different dashboard by the time the response comes back
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id: 456,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      postStub.mockRestore();
+      postStub = jest
+        .spyOn(SupersetClient, 'post')
+        .mockResolvedValue({} as any);
+
+      await saveFaveStar(requestedId, false)(dispatch, getState);
+
+      expect(postStub).toHaveBeenCalledTimes(1);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    test('dispatches a danger toast on error when the dashboard ID still matches', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      postStub.mockRestore();
+      postStub = jest
+        .spyOn(SupersetClient, 'post')
+        .mockRejectedValue(new Error('network'));
+
+      await saveFaveStar(id, false)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          type: ADD_TOAST,
+          payload: expect.objectContaining({
+            toastType: ToastType.Danger,
+          }),
+        }),
+      );
+    });
+
+    test('does NOT dispatch a danger toast on error when the dashboard ID changed', async () => {
+      const requestedId = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id: 456,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      postStub.mockRestore();
+      postStub = jest
+        .spyOn(SupersetClient, 'post')
+        .mockRejectedValue(new Error('network'));
+
+      await saveFaveStar(requestedId, false)(dispatch, getState);
 
       expect(dispatch).not.toHaveBeenCalled();
     });

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.ts
@@ -16,7 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { SupersetClient, isFeatureEnabled } from '@superset-ui/core';
+import {
+  JsonResponse,
+  SupersetClient,
+  isFeatureEnabled,
+} from '@superset-ui/core';
 import { waitFor } from 'spec/helpers/testing-library';
 
 import {
@@ -420,7 +424,7 @@ describe('dashboardState actions', () => {
       getStub.mockRestore();
       getStub = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
         json: { result: [{ value: true }] },
-      } as any);
+      } as unknown as JsonResponse);
 
       await fetchFaveStar(id)(dispatch, getState);
 
@@ -444,7 +448,7 @@ describe('dashboardState actions', () => {
       getStub.mockRestore();
       getStub = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
         json: { result: [{ value: true }] },
-      } as any);
+      } as unknown as JsonResponse);
 
       await fetchFaveStar(requestedId)(dispatch, getState);
 
@@ -505,7 +509,7 @@ describe('dashboardState actions', () => {
     beforeEach(() => {
       deleteStub = jest
         .spyOn(SupersetClient, 'delete')
-        .mockResolvedValue({} as any);
+        .mockResolvedValue({} as unknown as JsonResponse);
     });
 
     afterEach(() => {
@@ -524,7 +528,7 @@ describe('dashboardState actions', () => {
       postStub.mockRestore();
       postStub = jest
         .spyOn(SupersetClient, 'post')
-        .mockResolvedValue({} as any);
+        .mockResolvedValue({} as unknown as JsonResponse);
 
       await saveFaveStar(id, false)(dispatch, getState);
 
@@ -568,7 +572,7 @@ describe('dashboardState actions', () => {
       postStub.mockRestore();
       postStub = jest
         .spyOn(SupersetClient, 'post')
-        .mockResolvedValue({} as any);
+        .mockResolvedValue({} as unknown as JsonResponse);
 
       await saveFaveStar(requestedId, false)(dispatch, getState);
 

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.ts
@@ -33,8 +33,10 @@ import {
   ON_REFRESH,
   ON_REFRESH_SUCCESS,
   TOGGLE_FAVE_STAR,
+  TOGGLE_PUBLISHED,
   fetchFaveStar,
   saveFaveStar,
+  savePublished,
 } from 'src/dashboard/actions/dashboardState';
 import { refreshChart } from 'src/components/Chart/chartAction';
 import { UPDATE_COMPONENTS_PARENTS_LIST } from 'src/dashboard/actions/dashboardLayout';
@@ -622,6 +624,107 @@ describe('dashboardState actions', () => {
         .mockRejectedValue(new Error('network'));
 
       await saveFaveStar(requestedId, false)(dispatch, getState);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
+  describe('savePublished race condition', () => {
+    test('dispatches success toast and TOGGLE_PUBLISHED when the dashboard ID still matches', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      putStub.mockRestore();
+      putStub = jest
+        .spyOn(SupersetClient, 'put')
+        .mockResolvedValue({} as unknown as JsonResponse);
+
+      await savePublished(id, true)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledTimes(2);
+      expect(dispatch.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          type: ADD_TOAST,
+          payload: expect.objectContaining({
+            toastType: ToastType.Success,
+          }),
+        }),
+      );
+      expect(dispatch).toHaveBeenCalledWith({
+        type: TOGGLE_PUBLISHED,
+        isPublished: true,
+      });
+    });
+
+    test('does NOT dispatch when the dashboard ID changed before the response resolved', async () => {
+      const requestedId = 123;
+      // User navigated to a different dashboard by the time the response comes back
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id: 456,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      putStub.mockRestore();
+      putStub = jest
+        .spyOn(SupersetClient, 'put')
+        .mockResolvedValue({} as unknown as JsonResponse);
+
+      await savePublished(requestedId, true)(dispatch, getState);
+
+      expect(putStub).toHaveBeenCalledTimes(1);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    test('dispatches a danger toast on error when the dashboard ID still matches', async () => {
+      const id = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      putStub.mockRestore();
+      putStub = jest
+        .spyOn(SupersetClient, 'put')
+        .mockRejectedValue(new Error('forbidden'));
+
+      await savePublished(id, true)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          type: ADD_TOAST,
+          payload: expect.objectContaining({
+            toastType: ToastType.Danger,
+          }),
+        }),
+      );
+    });
+
+    test('does NOT dispatch a danger toast on error when the dashboard ID changed', async () => {
+      const requestedId = 123;
+      const { getState, dispatch } = setup({
+        dashboardInfo: {
+          id: 456,
+          metadata: { color_scheme: 'supersetColors' },
+        },
+      });
+
+      putStub.mockRestore();
+      putStub = jest
+        .spyOn(SupersetClient, 'put')
+        .mockRejectedValue(new Error('forbidden'));
+
+      await savePublished(requestedId, true)(dispatch, getState);
 
       expect(dispatch).not.toHaveBeenCalled();
     });

--- a/superset-frontend/src/dashboard/actions/dashboardState.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.ts
@@ -160,7 +160,10 @@ export function toggleFaveStar(isStarred: boolean): ToggleFaveStarAction {
 }
 
 export function fetchFaveStar(id: number) {
-  return function fetchFaveStarThunk(dispatch: AppDispatch, getState: GetState) {
+  return function fetchFaveStarThunk(
+    dispatch: AppDispatch,
+    getState: GetState,
+  ) {
     return SupersetClient.get({
       endpoint: `/api/v1/dashboard/favorite_status/?q=${rison.encode([id])}`,
     })
@@ -169,7 +172,9 @@ export function fetchFaveStar(id: number) {
         // This prevents stale responses from affecting the UI after navigation
         const currentId = getState().dashboardInfo?.id;
         if (currentId === id) {
-          dispatch(toggleFaveStar(!!(json?.result as JsonObject[])?.[0]?.value));
+          dispatch(
+            toggleFaveStar(!!(json?.result as JsonObject[])?.[0]?.value),
+          );
         }
       })
       .catch(() => {

--- a/superset-frontend/src/dashboard/actions/dashboardState.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.ts
@@ -238,8 +238,11 @@ export function togglePublished(isPublished: boolean): TogglePublishedAction {
 export function savePublished(
   id: number,
   isPublished: boolean,
-): (dispatch: AppDispatch) => Promise<void> {
-  return function savePublishedThunk(dispatch: AppDispatch): Promise<void> {
+): (dispatch: AppDispatch, getState: GetState) => Promise<void> {
+  return function savePublishedThunk(
+    dispatch: AppDispatch,
+    getState: GetState,
+  ): Promise<void> {
     return SupersetClient.put({
       endpoint: `/api/v1/dashboard/${id}`,
       headers: { 'Content-Type': 'application/json' },
@@ -248,21 +251,30 @@ export function savePublished(
       }),
     })
       .then(() => {
-        dispatch(
-          addSuccessToast(
-            isPublished
-              ? t('This dashboard is now published')
-              : t('This dashboard is now hidden'),
-          ),
-        );
-        dispatch(togglePublished(isPublished));
+        // Only update state if this is still the current dashboard
+        // This prevents stale responses from affecting the UI after navigation
+        const currentId = getState().dashboardInfo?.id;
+        if (currentId === id) {
+          dispatch(
+            addSuccessToast(
+              isPublished
+                ? t('This dashboard is now published')
+                : t('This dashboard is now hidden'),
+            ),
+          );
+          dispatch(togglePublished(isPublished));
+        }
       })
       .catch(() => {
-        dispatch(
-          addDangerToast(
-            t('You do not have permissions to edit this dashboard.'),
-          ),
-        );
+        // Only show error if this is still the current dashboard
+        const currentId = getState().dashboardInfo?.id;
+        if (currentId === id) {
+          dispatch(
+            addDangerToast(
+              t('You do not have permissions to edit this dashboard.'),
+            ),
+          );
+        }
       });
   };
 }


### PR DESCRIPTION
### SUMMARY

Fixes a race condition where navigating between dashboards could show error toasts for dashboards the user is no longer viewing.

**The Problem:**
When a user:
1. Creates a dashboard (e.g., ID 258)
2. Deletes that dashboard
3. Navigates to another dashboard (e.g., ID 55)

The `favorite_status` API call for the deleted dashboard (258) would complete and show an error toast: "There was an issue fetching the favorite status of this dashboard." This is confusing because the user is now viewing a different dashboard.

**Root Cause:**
The `fetchFaveStar` and `saveFaveStar` Redux thunks would dispatch actions (including error toasts) regardless of whether the requested dashboard ID still matched the currently viewed dashboard. This allowed stale API responses to affect the UI after navigation.

**The Fix:**
Before dispatching any actions in the thunk callbacks, check if `dashboardInfo.id` from the current Redux state matches the `id` that was originally requested. If they don't match, the response is stale and should be silently ignored.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**
When navigating from a deleted dashboard to another dashboard, error toasts would appear for the deleted dashboard.

**After:**
Stale responses are silently ignored, preventing confusing error messages.

### TESTING INSTRUCTIONS

1. Create a new dashboard and save it
2. Note the dashboard ID from the URL
3. Delete the dashboard
4. Navigate to any other dashboard
5. Verify no error toast appears about "fetching the favorite status"

Alternative test (without deletion):
1. Open Network tab in DevTools
2. Add throttling to simulate slow network
3. Navigate from one dashboard to another quickly
4. Verify no duplicate/stale favorite status updates occur

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #32533
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)