### PR TITLE
ci: declare explicit permissions in maintenance workflows

### DIFF
--- a/.github/workflows/no-hold-label.yml
+++ b/.github/workflows/no-hold-label.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, synchronize]
 
+permissions:
+  pull-requests: read
+
 # cancel previous workflow jobs for PRs
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 # cancel previous workflow jobs for PRs
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/tech-debt.yml
+++ b/.github/workflows/tech-debt.yml
@@ -6,6 +6,9 @@ on:
       - master
       - "[0-9].[0-9]*"
 
+permissions:
+  contents: read
+
 jobs:
   config:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
Add explicit `GITHUB_TOKEN` permissions to maintenance workflows that currently rely on implicit defaults:

- `.github/workflows/no-hold-label.yml`
  - `pull-requests: read`
- `.github/workflows/pre-commit.yml`
  - `contents: read`
- `.github/workflows/tech-debt.yml`
  - `contents: read`

## Why
These workflows only need read access for their current steps (`checkout`, PR label inspection via event payload/script). Declaring the scopes explicitly improves least-privilege posture and makes required access clear.
