### PR TITLE
fix(docker): prevent static asset 404s by waiting for webpack dev server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,9 @@ services:
     volumes:
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/nginx/templates:/etc/nginx/templates:ro
+    depends_on:
+      superset-node:
+        condition: service_healthy
 
   redis:
     image: redis:7
@@ -186,6 +189,14 @@ services:
       - path: docker/.env-local # optional override
         required: false
     volumes: *superset-volumes
+    healthcheck:
+      # Check if webpack dev server is responding on port 9000
+      # This prevents nginx from proxying before the frontend is ready
+      test: ["CMD-SHELL", "node -e \"const http = require('http'); http.get('http://localhost:9000', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
   superset-worker:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,9 +61,22 @@ services:
     volumes:
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/nginx/templates:/etc/nginx/templates:ro
-    depends_on:
-      superset-node:
-        condition: service_healthy
+    # Wait for the webpack dev server's manifest.json to be served before
+    # starting nginx. This prevents 404s on static assets at startup. The
+    # probe targets host.docker.internal so it works regardless of whether
+    # the dev server runs in the superset-node container
+    # (BUILD_SUPERSET_FRONTEND_IN_DOCKER=true, the default) or directly on
+    # the host (BUILD_SUPERSET_FRONTEND_IN_DOCKER=false).
+    command:
+      - /bin/bash
+      - -c
+      - |
+        echo "Waiting for webpack dev server at host.docker.internal:9000/static/assets/manifest.json..."
+        until curl -sf -o /dev/null http://host.docker.internal:9000/static/assets/manifest.json; do
+          sleep 2
+        done
+        echo "Webpack dev server is ready; starting nginx."
+        exec nginx -g 'daemon off;'
 
   redis:
     image: redis:7
@@ -189,14 +202,6 @@ services:
       - path: docker/.env-local # optional override
         required: false
     volumes: *superset-volumes
-    healthcheck:
-      # Check if webpack dev server is responding on port 9000
-      # This prevents nginx from proxying before the frontend is ready
-      test: ["CMD-SHELL", "node -e \"const http = require('http'); http.get('http://localhost:9000', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""]
-      interval: 10s
-      timeout: 5s
-      retries: 30
-      start_period: 60s
 
   superset-worker:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,8 +71,17 @@ services:
       - /bin/bash
       - -c
       - |
-        echo "Waiting for webpack dev server at host.docker.internal:9000/static/assets/manifest.json..."
-        until curl -sf -o /dev/null http://host.docker.internal:9000/static/assets/manifest.json; do
+        url="http://host.docker.internal:9000/static/assets/manifest.json"
+        max_attempts=150  # ~5 minutes at 2s intervals
+        echo "Waiting for webpack dev server at $url..."
+        attempt=0
+        until curl -sf --max-time 5 -o /dev/null "$url"; do
+          attempt=$((attempt + 1))
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "ERROR: webpack dev server did not serve $url after $max_attempts attempts (~5 minutes)." >&2
+            echo "Is the dev server running? With BUILD_SUPERSET_FRONTEND_IN_DOCKER=false you must start it on the host (e.g. 'npm run dev' in superset-frontend)." >&2
+            exit 1
+          fi
           sleep 2
         done
         echo "Webpack dev server is ready; starting nginx."


### PR DESCRIPTION
### SUMMARY

Fixes a race condition in the Docker development setup where nginx starts before the webpack dev server is ready, causing 404 errors for all static assets (`/static/assets/images/superset-logo-horiz.png`, etc.).

**Root Cause:**
When running `docker compose up`, nginx starts immediately and proxies `/static` requests to port 9000. However, the webpack dev server needs time to:
1. Run `npm install` (can take several minutes)
2. Start and complete its first compile

During this startup period, all static asset requests fail with 404 errors.

**The Fix:**
nginx's `command` is overridden with a small wait loop that polls `http://host.docker.internal:9000/static/assets/manifest.json` (served directly by webpack's devMiddleware, and only written after the first compile — exactly the readiness signal we want) before `exec`-ing nginx. Probing via `host.docker.internal` means it works whether the dev server runs inside the `superset-node` container (`BUILD_SUPERSET_FRONTEND_IN_DOCKER=true`, the default) or directly on the host (`BUILD_SUPERSET_FRONTEND_IN_DOCKER=false`), so the existing flag keeps working with no breaking change.

The loop caps at ~5 minutes (150 attempts at 2s intervals) and exits with a diagnostic message if the dev server never comes up, rather than hanging indefinitely. `curl --max-time 5` keeps a stalled connection from blocking a single attempt.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Static assets return 404 during startup, broken UI
**After:** Nginx waits for the webpack dev server to serve `manifest.json` before starting

### TESTING INSTRUCTIONS

1. Clean your Docker environment:
   ```bash
   docker compose down -v
   docker builder prune --all --force
   ```

2. Start fresh:
   ```bash
   docker compose up
   ```

3. Watch the logs - you should see:
   - `superset-node` running `npm install` and starting the dev server
   - nginx logging "Waiting for webpack dev server..." and polling
   - nginx logging "Webpack dev server is ready; starting nginx." only after the first compile

4. Access http://localhost - static assets should load correctly

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #30183
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)
