### PR TITLE
fix(FilterBar): always show 'More filters' button when items exist

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.test.tsx
@@ -51,8 +51,16 @@ test('renders children with custom horizontal spacing', () => {
   expect(screen.getByTestId('container')).toHaveStyle('gap: 20px');
 });
 
-test('does not render a dropdown button when not overflowing', () => {
+test('renders dropdown button when items exist even when not overflowing', () => {
   render(<DropdownContainer items={generateItems(3)} />);
+  // Button should always be visible when items exist to prevent layout shifts
+  expect(screen.getByText('More')).toBeInTheDocument();
+  // Badge should show 0 when nothing is overflowing
+  expect(screen.getByText('0')).toBeInTheDocument();
+});
+
+test('does not render a dropdown button when no items', () => {
+  render(<DropdownContainer items={[]} />);
   expect(screen.queryByText('More')).not.toBeInTheDocument();
 });
 

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.test.tsx
@@ -57,6 +57,8 @@ test('renders dropdown button when items exist even when not overflowing', () =>
   expect(screen.getByText('More')).toBeInTheDocument();
   // Badge should show 0 when nothing is overflowing
   expect(screen.getByText('0')).toBeInTheDocument();
+  // Button is disabled when there is nothing to open, so it can't reveal an empty popover
+  expect(screen.getByTestId('dropdown-container-btn')).toBeDisabled();
 });
 
 test('does not render a dropdown button when no items', () => {

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -234,6 +234,10 @@ export const DropdownContainer = forwardRef(
     const overflowingCount =
       overflowingIndex !== -1 ? items.length - overflowingIndex : 0;
 
+    // Always show button when items exist to prevent layout shifts
+    // and ensure consistent UI even when nothing is currently overflowing
+    const shouldShowButton = items.length > 0 || !!dropdownContent;
+
     const popoverContent = useMemo(
       () =>
         dropdownContent || overflowingCount ? (
@@ -314,7 +318,7 @@ export const DropdownContainer = forwardRef(
         >
           {notOverflowedItems.map(item => item.element)}
         </div>
-        {popoverContent && (
+        {shouldShowButton && (
           <>
             <Global
               styles={css`

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -34,7 +34,7 @@ import { t } from '@apache-superset/core/translation';
 import { usePrevious } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { useResizeDetector } from 'react-resize-detector';
-import { Badge, Icons, Button, Tooltip, Popover } from '..';
+import { Badge, Icons, Button, Popover } from '..';
 import { DropdownContainerProps, DropdownItem, DropdownRef } from './types';
 
 const MAX_HEIGHT = 500;
@@ -298,42 +298,41 @@ export const DropdownContainer = forwardRef(
     }, [popoverVisible]);
 
     const triggerButton = (
-      <Tooltip title={dropdownTriggerTooltip}>
-        <Button
-          buttonStyle="secondary"
-          data-test="dropdown-container-btn"
-          icon={dropdownTriggerIcon}
-          disabled={!popoverContent}
+      <Button
+        buttonStyle="secondary"
+        data-test="dropdown-container-btn"
+        icon={dropdownTriggerIcon}
+        disabled={!popoverContent}
+        tooltip={dropdownTriggerTooltip}
+        css={css`
+          padding-left: ${theme.paddingXS}px;
+          padding-right: ${theme.paddingXXS}px;
+          gap: ${theme.sizeXXS}px;
+        `}
+      >
+        {dropdownTriggerText}
+        <Badge
+          count={dropdownTriggerCount ?? overflowingCount}
+          color={
+            (dropdownTriggerCount ?? overflowingCount) > 0
+              ? theme.colorPrimary
+              : theme.colorTextSecondary
+          }
+          showZero
           css={css`
-            padding-left: ${theme.paddingXS}px;
-            padding-right: ${theme.paddingXXS}px;
-            gap: ${theme.sizeXXS}px;
+            margin-left: ${theme.sizeUnit * 2}px;
           `}
-        >
-          {dropdownTriggerText}
-          <Badge
-            count={dropdownTriggerCount ?? overflowingCount}
-            color={
-              (dropdownTriggerCount ?? overflowingCount) > 0
-                ? theme.colorPrimary
-                : theme.colorTextSecondary
+        />
+        <Icons.DownOutlined
+          iconSize="m"
+          iconColor={theme.colorIcon}
+          css={css`
+            .anticon {
+              display: flex;
             }
-            showZero
-            css={css`
-              margin-left: ${theme.sizeUnit * 2}px;
-            `}
-          />
-          <Icons.DownOutlined
-            iconSize="m"
-            iconColor={theme.colorIcon}
-            css={css`
-              .anticon {
-                display: flex;
-              }
-            `}
-          />
-        </Button>
-      </Tooltip>
+          `}
+        />
+      </Button>
     );
 
     return (

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -235,7 +235,7 @@ export const DropdownContainer = forwardRef(
       overflowingIndex !== -1 ? items.length - overflowingIndex : 0;
 
     // Always show button when items exist to prevent layout shifts
-    // and ensure consistent UI even when nothing is currently overflowing
+    // and ensure consistent UI even when no items are overflowing
     const shouldShowButton = items.length > 0 || !!dropdownContent;
 
     const popoverContent = useMemo(

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -297,6 +297,45 @@ export const DropdownContainer = forwardRef(
       };
     }, [popoverVisible]);
 
+    const triggerButton = (
+      <Tooltip title={dropdownTriggerTooltip}>
+        <Button
+          buttonStyle="secondary"
+          data-test="dropdown-container-btn"
+          icon={dropdownTriggerIcon}
+          disabled={!popoverContent}
+          css={css`
+            padding-left: ${theme.paddingXS}px;
+            padding-right: ${theme.paddingXXS}px;
+            gap: ${theme.sizeXXS}px;
+          `}
+        >
+          {dropdownTriggerText}
+          <Badge
+            count={dropdownTriggerCount ?? overflowingCount}
+            color={
+              (dropdownTriggerCount ?? overflowingCount) > 0
+                ? theme.colorPrimary
+                : theme.colorTextSecondary
+            }
+            showZero
+            css={css`
+              margin-left: ${theme.sizeUnit * 2}px;
+            `}
+          />
+          <Icons.DownOutlined
+            iconSize="m"
+            iconColor={theme.colorIcon}
+            css={css`
+              .anticon {
+                display: flex;
+              }
+            `}
+          />
+        </Button>
+      </Tooltip>
+    );
+
     return (
       <div
         ref={ref}
@@ -343,57 +382,27 @@ export const DropdownContainer = forwardRef(
               `}
             />
 
-            <Popover
-              styles={{
-                body: {
-                  maxHeight: `${MAX_HEIGHT}px`,
-                  overflow: showOverflow ? 'auto' : 'visible',
-                },
-              }}
-              content={popoverContent}
-              trigger="click"
-              open={popoverVisible}
-              onOpenChange={visible => setPopoverVisible(visible)}
-              placement="bottom"
-              forceRender={forceRender}
-              fresh // This prop prevents caching and stale data for filter scoping.
-            >
-              <Tooltip title={dropdownTriggerTooltip}>
-                <Button
-                  buttonStyle="secondary"
-                  data-test="dropdown-container-btn"
-                  icon={dropdownTriggerIcon}
-                  css={css`
-                    padding-left: ${theme.paddingXS}px;
-                    padding-right: ${theme.paddingXXS}px;
-                    gap: ${theme.sizeXXS}px;
-                  `}
-                >
-                  {dropdownTriggerText}
-                  <Badge
-                    count={dropdownTriggerCount ?? overflowingCount}
-                    color={
-                      (dropdownTriggerCount ?? overflowingCount) > 0
-                        ? theme.colorPrimary
-                        : theme.colorTextSecondary
-                    }
-                    showZero
-                    css={css`
-                      margin-left: ${theme.sizeUnit * 2}px;
-                    `}
-                  />
-                  <Icons.DownOutlined
-                    iconSize="m"
-                    iconColor={theme.colorIcon}
-                    css={css`
-                      .anticon {
-                        display: flex;
-                      }
-                    `}
-                  />
-                </Button>
-              </Tooltip>
-            </Popover>
+            {popoverContent ? (
+              <Popover
+                styles={{
+                  body: {
+                    maxHeight: `${MAX_HEIGHT}px`,
+                    overflow: showOverflow ? 'auto' : 'visible',
+                  },
+                }}
+                content={popoverContent}
+                trigger="click"
+                open={popoverVisible}
+                onOpenChange={visible => setPopoverVisible(visible)}
+                placement="bottom"
+                forceRender={forceRender}
+                fresh // This prop prevents caching and stale data for filter scoping.
+              >
+                {triggerButton}
+              </Popover>
+            ) : (
+              triggerButton
+            )}
           </>
         )}
       </div>

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -235,7 +235,10 @@ export const DropdownContainer = forwardRef(
       overflowingIndex !== -1 ? items.length - overflowingIndex : 0;
 
     // Always show button when items exist to prevent layout shifts
-    // and ensure consistent UI even when no items are overflowing
+    // and ensure consistent UI even when no items are overflowing.
+    // When items exist but nothing overflows, the button is rendered
+    // disabled (not hidden) with a 0 badge so the container width stays
+    // constant across overflow state changes.
     const shouldShowButton = items.length > 0 || !!dropdownContent;
 
     const popoverContent = useMemo(

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -246,7 +246,7 @@ export const DropdownContainer = forwardRef(
       overflowingIndex !== -1 ? items.length - overflowingIndex : 0;
 
     // Always show button when items exist to prevent layout shifts
-    // and ensure consistent UI even when nothing is currently overflowing
+    // and ensure consistent UI even when no items are overflowing
     const shouldShowButton = items.length > 0 || !!dropdownContent;
 
     const popoverContent = useMemo(

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -34,7 +34,7 @@ import { t } from '@apache-superset/core/translation';
 import { usePrevious } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { useResizeDetector } from 'react-resize-detector';
-import { Badge, Icons, Button, Tooltip, Popover } from '..';
+import { Badge, Icons, Button, Popover } from '..';
 import { DropdownContainerProps, DropdownItem, DropdownRef } from './types';
 
 const MAX_HEIGHT = 500;
@@ -309,42 +309,41 @@ export const DropdownContainer = forwardRef(
     }, [popoverVisible]);
 
     const triggerButton = (
-      <Tooltip title={dropdownTriggerTooltip}>
-        <Button
-          buttonStyle="secondary"
-          data-test="dropdown-container-btn"
-          icon={dropdownTriggerIcon}
-          disabled={!popoverContent}
+      <Button
+        buttonStyle="secondary"
+        data-test="dropdown-container-btn"
+        icon={dropdownTriggerIcon}
+        disabled={!popoverContent}
+        tooltip={dropdownTriggerTooltip}
+        css={css`
+          padding-left: ${theme.paddingXS}px;
+          padding-right: ${theme.paddingXXS}px;
+          gap: ${theme.sizeXXS}px;
+        `}
+      >
+        {dropdownTriggerText}
+        <Badge
+          count={dropdownTriggerCount ?? overflowingCount}
+          color={
+            (dropdownTriggerCount ?? overflowingCount) > 0
+              ? theme.colorPrimary
+              : theme.colorTextSecondary
+          }
+          showZero
           css={css`
-            padding-left: ${theme.paddingXS}px;
-            padding-right: ${theme.paddingXXS}px;
-            gap: ${theme.sizeXXS}px;
+            margin-left: ${theme.sizeUnit * 2}px;
           `}
-        >
-          {dropdownTriggerText}
-          <Badge
-            count={dropdownTriggerCount ?? overflowingCount}
-            color={
-              (dropdownTriggerCount ?? overflowingCount) > 0
-                ? theme.colorPrimary
-                : theme.colorTextSecondary
+        />
+        <Icons.DownOutlined
+          iconSize="m"
+          iconColor={theme.colorIcon}
+          css={css`
+            .anticon {
+              display: flex;
             }
-            showZero
-            css={css`
-              margin-left: ${theme.sizeUnit * 2}px;
-            `}
-          />
-          <Icons.DownOutlined
-            iconSize="m"
-            iconColor={theme.colorIcon}
-            css={css`
-              .anticon {
-                display: flex;
-              }
-            `}
-          />
-        </Button>
-      </Tooltip>
+          `}
+        />
+      </Button>
     );
 
     return (

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -245,6 +245,10 @@ export const DropdownContainer = forwardRef(
     const overflowingCount =
       overflowingIndex !== -1 ? items.length - overflowingIndex : 0;
 
+    // Always show button when items exist to prevent layout shifts
+    // and ensure consistent UI even when nothing is currently overflowing
+    const shouldShowButton = items.length > 0 || !!dropdownContent;
+
     const popoverContent = useMemo(
       () =>
         dropdownContent || overflowingCount ? (
@@ -271,15 +275,6 @@ export const DropdownContainer = forwardRef(
         overflowedItems,
       ],
     );
-
-    // The trigger had content in the previous render if popoverContent was
-    // truthy then. During the brief mid-recalculation render where
-    // popoverContent flips to null, this still reflects the prior (non-empty)
-    // value, letting us keep the trigger mounted across the transient.
-    const hadPopoverContent = usePrevious(!!popoverContent, false);
-
-    const showDropdownButton =
-      !!popoverContent || (recalculating && hadPopoverContent);
 
     useLayoutEffect(() => {
       if (popoverVisible) {
@@ -334,7 +329,7 @@ export const DropdownContainer = forwardRef(
         >
           {notOverflowedItems.map(item => item.element)}
         </div>
-        {showDropdownButton && (
+        {shouldShowButton && (
           <>
             <Global
               styles={css`

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -308,6 +308,45 @@ export const DropdownContainer = forwardRef(
       };
     }, [popoverVisible]);
 
+    const triggerButton = (
+      <Tooltip title={dropdownTriggerTooltip}>
+        <Button
+          buttonStyle="secondary"
+          data-test="dropdown-container-btn"
+          icon={dropdownTriggerIcon}
+          disabled={!popoverContent}
+          css={css`
+            padding-left: ${theme.paddingXS}px;
+            padding-right: ${theme.paddingXXS}px;
+            gap: ${theme.sizeXXS}px;
+          `}
+        >
+          {dropdownTriggerText}
+          <Badge
+            count={dropdownTriggerCount ?? overflowingCount}
+            color={
+              (dropdownTriggerCount ?? overflowingCount) > 0
+                ? theme.colorPrimary
+                : theme.colorTextSecondary
+            }
+            showZero
+            css={css`
+              margin-left: ${theme.sizeUnit * 2}px;
+            `}
+          />
+          <Icons.DownOutlined
+            iconSize="m"
+            iconColor={theme.colorIcon}
+            css={css`
+              .anticon {
+                display: flex;
+              }
+            `}
+          />
+        </Button>
+      </Tooltip>
+    );
+
     return (
       <div
         ref={ref}
@@ -354,62 +393,27 @@ export const DropdownContainer = forwardRef(
               `}
             />
 
-            <Popover
-              styles={{
-                body: {
-                  maxHeight: `${MAX_HEIGHT}px`,
-                  overflow: showOverflow ? 'auto' : 'visible',
-                },
-              }}
-              content={popoverContent}
-              trigger="click"
-              open={popoverVisible && !!popoverContent}
-              onOpenChange={visible => {
-                // While a recalculation keeps the trigger mounted but there is
-                // no content yet, ignore open attempts so it stays visible
-                // without opening an empty popover.
-                if (popoverContent) setPopoverVisible(visible);
-              }}
-              placement="bottom"
-              forceRender={forceRender}
-              fresh // This prop prevents caching and stale data for filter scoping.
-            >
-              <Tooltip title={dropdownTriggerTooltip}>
-                <Button
-                  buttonStyle="secondary"
-                  data-test="dropdown-container-btn"
-                  icon={dropdownTriggerIcon}
-                  css={css`
-                    padding-left: ${theme.paddingXS}px;
-                    padding-right: ${theme.paddingXXS}px;
-                    gap: ${theme.sizeXXS}px;
-                  `}
-                >
-                  {dropdownTriggerText}
-                  <Badge
-                    count={dropdownTriggerCount ?? overflowingCount}
-                    color={
-                      (dropdownTriggerCount ?? overflowingCount) > 0
-                        ? theme.colorPrimary
-                        : theme.colorTextSecondary
-                    }
-                    showZero
-                    css={css`
-                      margin-left: ${theme.sizeUnit * 2}px;
-                    `}
-                  />
-                  <Icons.DownOutlined
-                    iconSize="m"
-                    iconColor={theme.colorIcon}
-                    css={css`
-                      .anticon {
-                        display: flex;
-                      }
-                    `}
-                  />
-                </Button>
-              </Tooltip>
-            </Popover>
+            {popoverContent ? (
+              <Popover
+                styles={{
+                  body: {
+                    maxHeight: `${MAX_HEIGHT}px`,
+                    overflow: showOverflow ? 'auto' : 'visible',
+                  },
+                }}
+                content={popoverContent}
+                trigger="click"
+                open={popoverVisible}
+                onOpenChange={visible => setPopoverVisible(visible)}
+                placement="bottom"
+                forceRender={forceRender}
+                fresh // This prop prevents caching and stale data for filter scoping.
+              >
+                {triggerButton}
+              </Popover>
+            ) : (
+              triggerButton
+            )}
           </>
         )}
       </div>

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -72,15 +72,6 @@ export const DropdownContainer = forwardRef(
 
     const [showOverflow, setShowOverflow] = useState(false);
 
-    // When the item set changes, the overflow index is briefly reset while the
-    // new widths are measured (see the layout effect below). During that window
-    // the dropdown content momentarily becomes empty, which would hide and then
-    // re-show the trigger, causing a flicker. We track whether a recalculation
-    // is pending so the trigger can stay mounted across the transient (when it
-    // was showing content just before) without lingering in the steady state
-    // when nothing actually overflows.
-    const [recalculating, setRecalculating] = useState(false);
-
     // callback to update item widths so that the useLayoutEffect runs whenever
     // width of any of the child changes
     const recalculateItemWidths = useCallback(() => {
@@ -180,7 +171,6 @@ export const DropdownContainer = forwardRef(
             );
           } else {
             setOverflowingIndex(-1);
-            setRecalculating(true);
             return;
           }
         }
@@ -221,7 +211,6 @@ export const DropdownContainer = forwardRef(
         }
 
         setOverflowingIndex(newOverflowingIndex);
-        setRecalculating(false);
       }
     }, [
       current,


### PR DESCRIPTION
## Summary

Fixes #28060 - "Default filters values cause filter fields to disappear in dashboards"

This PR fixes an issue where the "More filters" button would disappear when filter values were set to their defaults and nothing was overflowing the filter bar container.

### Changes
- Added `shouldShowButton` flag in `DropdownContainer` that ensures the button is always visible when items exist
- The button now remains stable regardless of overflow state, preventing layout shifts
- The badge correctly shows 0 when nothing is overflowing
- Updated tests to reflect the new expected behavior

### Root Cause
The button rendering was conditioned on `popoverContent` being truthy, which required either:
1. `dropdownContent` prop to be defined, OR
2. `overflowingCount > 0`

When neither condition was met (common when all filters fit in the container with default values), the button would completely disappear.

### Before/After
| Before | After |
|--------|-------|
| Button disappears when no overflow | Button always visible with badge showing "0" |
| Layout shifts when resizing window | Consistent, stable UI |

## Test plan
1. Create a dashboard with multiple filters
2. Set all filters to their default values
3. Make the filter bar wide enough that nothing overflows
4. ✅ Verify the "More filters" button remains visible with a "0" badge
5. ✅ Resize the window to trigger overflow - button should update count accordingly

🤖 Generated with [Claude Code](https://claude.ai/code)