### PR TITLE
fix(tags): expire tag relationship after deleting all tagged objects

### DIFF
--- a/superset/daos/tag.py
+++ b/superset/daos/tag.py
@@ -378,4 +378,11 @@ class TagDAO(BaseDAO[Tag]):
                     object_id,
                     tag.name,
                 )
+            # After deleting tagged objects, we need to expire the tag's 'objects'
+            # relationship to clear references to deleted TaggedObject instances.
+            # This prevents SQLAlchemy errors when the tag is later added to the
+            # session, as it would otherwise still hold references to deleted objects.
+            if tagged_objects_to_delete:
+                db.session.expire(tag, ["objects"])
+
         db.session.add_all(tagged_objects)


### PR DESCRIPTION
### SUMMARY

Fixes #36074

When removing all tagged objects from a tag via the Edit Tag UI, users encountered the error "Error Updating Tag". The root cause was a SQLAlchemy session state issue where the Tag model's `objects` relationship still held references to deleted `TaggedObject` instances after they were removed.

**Root Cause:**
1. `UpdateTagCommand.run()` calls `TagDAO.create_tag_relationship()` 
2. `create_tag_relationship()` deletes `TaggedObject` entries via `delete_tagged_object()`
3. After deletion, `tag.objects` relationship still references the deleted objects
4. When `db.session.add(self._model)` is called, SQLAlchemy encounters the deleted objects and raises: "Instance has been deleted. Use the make_transient() function to send this object back to the transient state."

**Fix:**
Call `db.session.expire(tag, ["objects"])` after deleting tagged objects to clear the stale references from the relationship. This allows SQLAlchemy to properly reload the relationship on next access.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable - this is a backend bug fix with no UI changes.

### TESTING INSTRUCTIONS

1. Enable the tagging feature flag if not already enabled
2. Create a new tag
3. Tag multiple objects (e.g., 2-3 saved queries or dashboards)
4. Navigate to the tag and click Edit
5. Remove ALL tagged objects from the tag
6. Click Save
7. Verify the tag saves successfully without errors

**Before fix:** Step 6 would fail with "Error Updating Tag"
**After fix:** Step 6 succeeds and the tag is updated with no tagged objects

### ADDITIONAL INFORMATION

- [x] Has associated issue: #36074
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API