### PR TITLE
perf(explore): reuse chart query data in Results tab

### DIFF
--- a/superset-frontend/playwright/pages/ExplorePage.ts
+++ b/superset-frontend/playwright/pages/ExplorePage.ts
@@ -19,6 +19,7 @@
 
 import { Page, Locator } from '@playwright/test';
 import { TIMEOUT } from '../utils/constants';
+import { AgGrid } from '../components/core/AgGrid';
 
 /**
  * Explore Page object
@@ -30,6 +31,11 @@ export class ExplorePage {
     DATASOURCE_CONTROL: '[data-test="datasource-control"]',
     VIZ_SWITCHER: '[data-test="fast-viz-switcher"]',
     CHART_CONTAINER: '[data-test="chart-container"]',
+    // The bottom data panel (DataTablesPane / SouthPane) with Results/Samples tabs
+    SOUTH_PANE: '[data-test="some-purposeful-instance"]',
+    EXPAND_DATA_PANEL: '[aria-label="Expand data panel"]',
+    RESULTS_TAB: '[data-node-key="results"]',
+    ACTIVE_TABPANE: '.ant-tabs-tabpane-active',
   } as const;
 
   constructor(page: Page) {
@@ -105,5 +111,45 @@ export class ExplorePage {
    */
   getVizSwitcher(): Locator {
     return this.page.locator(ExplorePage.SELECTORS.VIZ_SWITCHER);
+  }
+
+  /**
+   * Expands the bottom data panel if it is currently collapsed.
+   * Safe to call when already expanded (no-op).
+   */
+  async expandDataPanel(): Promise<void> {
+    const expandButton = this.page.locator(
+      ExplorePage.SELECTORS.EXPAND_DATA_PANEL,
+    );
+    if (await expandButton.isVisible().catch(() => false)) {
+      await expandButton.click();
+    }
+  }
+
+  /**
+   * Opens the bottom data panel and activates the "Results" tab. Clicking the
+   * already-active tab collapses the panel, so the click is guarded.
+   */
+  async openResultsTab(): Promise<void> {
+    await this.expandDataPanel();
+    const resultsTab = this.page
+      .locator(ExplorePage.SELECTORS.SOUTH_PANE)
+      .locator(ExplorePage.SELECTORS.RESULTS_TAB);
+    const className = (await resultsTab.getAttribute('class')) ?? '';
+    if (!className.includes('ant-tabs-tab-active')) {
+      await resultsTab.click();
+    }
+  }
+
+  /**
+   * Returns an AgGrid wrapper around the currently active Results tab grid.
+   */
+  getResultsGrid(): AgGrid {
+    const grid = this.page
+      .locator(ExplorePage.SELECTORS.SOUTH_PANE)
+      .locator(ExplorePage.SELECTORS.ACTIVE_TABPANE)
+      .locator('[role="grid"]')
+      .first();
+    return new AgGrid(this.page, grid);
   }
 }

--- a/superset-frontend/playwright/tests/experimental/explore/results-tab-reuse.spec.ts
+++ b/superset-frontend/playwright/tests/experimental/explore/results-tab-reuse.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Regression coverage for #38152 (PR #38165): the Explore "Results" tab reuses
+ * the chart's already-fetched query data instead of firing a second, identical
+ * request to /api/v1/chart/data. The duplicate only exists across the real
+ * backend round-trip; the reuse-vs-fallback and row-limit slicing logic is
+ * unit-tested in useResultsPane.test.tsx, so this E2E asserts only the
+ * end-to-end win: opening Results issues no extra chart/data request.
+ *
+ * Lives under tests/experimental/ until proven stable in CI; run with:
+ *   INCLUDE_EXPERIMENTAL=true npm run playwright:test \
+ *     tests/experimental/explore/results-tab-reuse.spec.ts -- --headed
+ */
+import { testWithAssets, expect } from '../../../helpers/fixtures';
+import { apiPostChart } from '../../../helpers/api/chart';
+import { getDatasetByName } from '../../../helpers/api/dataset';
+import { ExplorePage } from '../../../pages/ExplorePage';
+import { TIMEOUT } from '../../../utils/constants';
+
+const DATASET_NAME = 'birth_names';
+const CHART_DATA_PATH = '/api/v1/chart/data';
+
+testWithAssets(
+  'Results tab reuses chart data without a duplicate query (#38165)',
+  async ({ page, testAssets }) => {
+    testWithAssets.setTimeout(TIMEOUT.SLOW_TEST);
+
+    let chartDataRequests = 0;
+    page.on('request', request => {
+      if (
+        request.method() === 'POST' &&
+        request.url().includes(CHART_DATA_PATH)
+      ) {
+        chartDataRequests += 1;
+      }
+    });
+
+    const dataset = await getDatasetByName(page, DATASET_NAME);
+    if (!dataset) {
+      throw new Error(`Dataset ${DATASET_NAME} not found`);
+    }
+    const datasetId = dataset.id;
+
+    const params = {
+      datasource: `${datasetId}__table`,
+      viz_type: 'table',
+      query_mode: 'raw',
+      all_columns: ['name', 'gender', 'num'],
+      adhoc_filters: [],
+      order_by_cols: [],
+      row_limit: 1000,
+      server_pagination: false,
+    };
+    const chartResp = await apiPostChart(page, {
+      slice_name: `results_tab_reuse_${Date.now()}`,
+      viz_type: 'table',
+      datasource_id: datasetId,
+      datasource_type: 'table',
+      params: JSON.stringify(params),
+    });
+    expect(chartResp.ok()).toBe(true);
+    const chartBody = await chartResp.json();
+    const chartId: number = chartBody.result?.id ?? chartBody.id;
+    expect(chartId, 'chart creation should return an id').toBeTruthy();
+    testAssets.trackChart(chartId);
+
+    // Wait for the chart query to finish so its result is in Redux; opening
+    // Results before that races and falls back to its own request.
+    const explorePage = new ExplorePage(page);
+    const chartQueryFinished = page.waitForResponse(
+      response =>
+        response.request().method() === 'POST' &&
+        response.url().includes(CHART_DATA_PATH),
+      { timeout: TIMEOUT.API_RESPONSE },
+    );
+    await explorePage.goto(chartId);
+    await chartQueryFinished;
+
+    const chartContainer = explorePage.getChartContainer();
+    await chartContainer.waitFor({
+      state: 'visible',
+      timeout: TIMEOUT.PAGE_LOAD,
+    });
+    await chartContainer
+      .getByRole('status', { name: 'Loading' })
+      .waitFor({ state: 'hidden', timeout: TIMEOUT.API_RESPONSE })
+      .catch(() => {}); // spinner may have already cleared
+
+    expect(chartDataRequests).toBeGreaterThanOrEqual(1);
+    const requestsAfterChartLoad = chartDataRequests;
+
+    await explorePage.openResultsTab();
+    const grid = explorePage.getResultsGrid();
+    await grid.waitForRows({ timeout: TIMEOUT.API_RESPONSE });
+    expect(await grid.getRowCount()).toBeGreaterThan(0);
+
+    // Allow time for an unwanted duplicate request, then assert none fired.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(1500);
+    expect(
+      chartDataRequests,
+      'opening Results must not trigger a second chart/data query',
+    ).toBe(requestsAfterChartLoad);
+  },
+);

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -103,6 +103,7 @@ export const DataTablesPane = ({
   errorMessage,
   setForceQuery,
   canDownload,
+  queriesResponse,
 }: DataTablesPaneProps) => {
   const [activeTabKey, setActiveTabKey] = useState<string>(ResultTypes.Results);
   const [isRequest, setIsRequest] = useState<Record<ResultTypes, boolean>>({
@@ -126,6 +127,10 @@ export const DataTablesPane = ({
         results: false,
         samples: false,
       });
+    }
+
+    if (panelOpen && chartStatus === 'loading') {
+      setIsRequest(prev => ({ ...prev, results: false }));
     }
 
     if (
@@ -206,6 +211,7 @@ export const DataTablesPane = ({
     isRequest: isRequest.results,
     setForceQuery,
     canDownload,
+    queriesResponse,
   }).map((pane, idx) => {
     const tabKey =
       idx === 0 ? ResultTypes.Results : `${ResultTypes.Results} ${idx + 1}`;

--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
@@ -56,6 +56,7 @@ export const ResultsPaneOnDashboard = ({
   dataSize = 50,
   canDownload,
   columnDisplayNames,
+  queriesResponse,
 }: ResultsPaneProps) => {
   const resultsPanes = useResultsPane({
     errorMessage,
@@ -68,6 +69,7 @@ export const ResultsPaneOnDashboard = ({
     isVisible,
     canDownload,
     columnDisplayNames,
+    queriesResponse,
   });
 
   if (resultsPanes.length === 1) {

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -20,6 +20,7 @@ import { useState, useEffect, useMemo, ReactElement, useCallback } from 'react';
 
 import { t } from '@apache-superset/core/translation';
 import {
+  ChartDataResponseResult,
   ensureIsArray,
   getChartMetadataRegistry,
   getClientErrorObject,
@@ -55,6 +56,7 @@ export const useResultsPane = ({
   isVisible,
   canDownload,
   columnDisplayNames,
+  queriesResponse,
 }: ResultsPaneProps): ReactElement[] => {
   const metadata = getChartMetadataRegistry().get(
     queryFormData?.viz_type || queryFormData?.vizType,
@@ -89,7 +91,32 @@ export const useResultsPane = ({
   useEffect(() => {
     // it's an invalid formData when gets a errorMessage
     if (errorMessage) return;
-    if (isRequest && cache.has(cappedFormData)) {
+    if (!isRequest) return;
+
+    // Reuse chart data from Redux when available. The chart visualization
+    // query and the results query produce identical SQL on the backend,
+    // so there is no need for a separate network request.
+    if (queriesResponse?.length && 'colnames' in queriesResponse[0]) {
+      const mapped = queriesResponse.map(q => {
+        const result = q as ChartDataResponseResult;
+        return {
+          colnames: result.colnames,
+          coltypes: result.coltypes,
+          data: result.data,
+          rowcount: result.rowcount,
+        };
+      }) as unknown as QueryResultInterface[];
+      setResultResp(mapped);
+      setResponseError('');
+      if (queryForce) {
+        setForceQuery?.(false);
+      }
+      setIsLoading(false);
+      return;
+    }
+
+    // Fallback: use cached data
+    if (cache.has(cappedFormData)) {
       setResultResp(
         ensureIsArray(cache.get(cappedFormData)) as QueryResultInterface[],
       );
@@ -98,34 +125,35 @@ export const useResultsPane = ({
         setForceQuery?.(false);
       }
       setIsLoading(false);
+      return;
     }
-    if (isRequest && !cache.has(cappedFormData)) {
-      setIsLoading(true);
-      getChartDataRequest({
-        formData: cappedFormData,
-        force: queryForce,
-        resultFormat: 'json',
-        resultType: 'results',
-        ownState,
+
+    // Fallback: fetch from API (legacy charts without queriesResponse)
+    setIsLoading(true);
+    getChartDataRequest({
+      formData: cappedFormData,
+      force: queryForce,
+      resultFormat: 'json',
+      resultType: 'results',
+      ownState,
+    })
+      .then(({ json }) => {
+        setResultResp(ensureIsArray(json.result) as QueryResultInterface[]);
+        setResponseError('');
+        cache.set(cappedFormData, json.result);
+        if (queryForce) {
+          setForceQuery?.(false);
+        }
       })
-        .then(({ json }) => {
-          setResultResp(ensureIsArray(json.result) as QueryResultInterface[]);
-          setResponseError('');
-          cache.set(cappedFormData, json.result);
-          if (queryForce) {
-            setForceQuery?.(false);
-          }
-        })
-        .catch(response => {
-          getClientErrorObject(response).then(({ error, message }) => {
-            setResponseError(error || message || t('Sorry, an error occurred'));
-          });
-        })
-        .finally(() => {
-          setIsLoading(false);
+      .catch(response => {
+        getClientErrorObject(response).then(({ error, message }) => {
+          setResponseError(error || message || t('Sorry, an error occurred'));
         });
-    }
-  }, [cappedFormData, isRequest]);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [cappedFormData, isRequest, queriesResponse]);
 
   useEffect(() => {
     if (errorMessage) {

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -24,6 +24,7 @@ import {
   ensureIsArray,
   getChartMetadataRegistry,
   getClientErrorObject,
+  QueryData,
 } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { EmptyState, Loading } from '@superset-ui/core/components';
@@ -45,6 +46,13 @@ const StyledDiv = styled.div`
 `;
 
 const cache = new WeakMap();
+
+// `queriesResponse` is the loose `QueryData`; only reuse it when every entry is
+// a full v1 result (colnames/coltypes/data arrays), else fall back to the API.
+const isV1QueryResult = (query: QueryData): query is ChartDataResponseResult =>
+  Array.isArray((query as ChartDataResponseResult).colnames) &&
+  Array.isArray((query as ChartDataResponseResult).coltypes) &&
+  Array.isArray((query as ChartDataResponseResult).data);
 
 export const useResultsPane = ({
   isRequest,
@@ -93,17 +101,23 @@ export const useResultsPane = ({
     if (errorMessage) return;
     if (!isRequest) return;
 
-    // Reuse chart data from Redux when available. The chart visualization
-    // query and the results query produce identical SQL on the backend,
-    // so there is no need for a separate network request.
-    if (queriesResponse?.length && 'colnames' in queriesResponse[0]) {
+    // The chart query and the results query produce identical SQL, so reuse the
+    // chart's data instead of a second request. The chart always ran with a
+    // row_limit >= effectiveRowLimit, so its first `effectiveRowLimit` rows
+    // match what a dedicated results query would return — slice locally to keep
+    // the row-limit dropdown working without a duplicate query.
+    if (queriesResponse?.length && queriesResponse.every(isV1QueryResult)) {
       const mapped = queriesResponse.map(q => {
         const result = q as ChartDataResponseResult;
+        const limitedData = ensureIsArray(result.data).slice(
+          0,
+          effectiveRowLimit,
+        );
         return {
           colnames: result.colnames,
           coltypes: result.coltypes,
-          data: result.data,
-          rowcount: result.rowcount,
+          data: limitedData,
+          rowcount: limitedData.length,
         };
       }) as unknown as QueryResultInterface[];
       setResultResp(mapped);
@@ -153,7 +167,7 @@ export const useResultsPane = ({
       .finally(() => {
         setIsLoading(false);
       });
-  }, [cappedFormData, isRequest, queriesResponse]);
+  }, [cappedFormData, isRequest, queriesResponse, effectiveRowLimit]);
 
   useEffect(() => {
     if (errorMessage) {

--- a/superset-frontend/src/explore/components/DataTablesPane/test/fixture.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/fixture.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ReactElement } from 'react';
-import { DatasourceType, VizType } from '@superset-ui/core';
+import { DatasourceType, QueryData, VizType } from '@superset-ui/core';
 import { ChartStatus } from 'src/explore/types';
 import {
   DataTablesPaneProps,
@@ -106,12 +106,16 @@ export const createResultsPaneOnDashboardProps = ({
   vizType = VizType.Table,
   queryForce = false,
   isRequest = true,
+  queriesResponse,
+  rowLimit,
 }: {
   sliceId: number;
   vizType?: string;
   errorMessage?: ReactElement;
   queryForce?: boolean;
   isRequest?: boolean;
+  queriesResponse?: QueryData[] | null;
+  rowLimit?: number;
 }) =>
   ({
     isRequest,
@@ -119,10 +123,12 @@ export const createResultsPaneOnDashboardProps = ({
       ...queryFormData,
       slice_id: sliceId,
       viz_type: vizType,
+      ...(rowLimit !== undefined ? { row_limit: rowLimit } : {}),
     },
     queryForce,
     isVisible: true,
     setForceQuery: jest.fn(),
     errorMessage,
     canDownload: true,
+    queriesResponse,
   }) as ResultsPaneProps;

--- a/superset-frontend/src/explore/components/DataTablesPane/test/useResultsPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/useResultsPane.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { screen, render, waitFor } from 'spec/helpers/testing-library';
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
+import { getChartDataRequest } from 'src/components/Chart/chartAction';
+import { ResultsPaneOnDashboard } from '../components';
+import { createResultsPaneOnDashboardProps } from './fixture';
+
+// Mocked so each test can assert whether the results branch hit the network.
+jest.mock('src/components/Chart/chartAction', () => ({
+  getChartDataRequest: jest.fn(),
+}));
+
+const mockedGetChartDataRequest = getChartDataRequest as jest.Mock;
+
+beforeAll(() => {
+  setupAGGridModules();
+});
+
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
+describe('useResultsPane query data reuse', () => {
+  beforeEach(() => {
+    mockedGetChartDataRequest.mockReset();
+  });
+
+  test('reuses queriesResponse from Redux and skips the results API call (v1 charts)', async () => {
+    const props = createResultsPaneOnDashboardProps({
+      sliceId: 201,
+      queriesResponse: [
+        {
+          colnames: ['genre'],
+          coltypes: [1],
+          data: [{ genre: 'Action' }, { genre: 'Horror' }],
+          rowcount: 2,
+        },
+      ],
+    });
+
+    render(<ResultsPaneOnDashboard {...props} />, { useRedux: true });
+
+    expect(await screen.findByText('Action')).toBeVisible();
+    expect(screen.getByText('Horror')).toBeVisible();
+    expect(mockedGetChartDataRequest).not.toHaveBeenCalled();
+  });
+
+  test('falls back to the results API for legacy charts without a typed queriesResponse', async () => {
+    mockedGetChartDataRequest.mockResolvedValue({
+      json: {
+        result: [
+          {
+            colnames: ['genre'],
+            coltypes: [1],
+            data: [{ genre: 'Drama' }],
+            rowcount: 1,
+          },
+        ],
+      },
+    });
+    const props = createResultsPaneOnDashboardProps({ sliceId: 202 });
+
+    render(<ResultsPaneOnDashboard {...props} />, { useRedux: true });
+
+    expect(await screen.findByText('Drama')).toBeVisible();
+    expect(mockedGetChartDataRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to the results API when queriesResponse has no colnames', async () => {
+    mockedGetChartDataRequest.mockResolvedValue({
+      json: {
+        result: [
+          {
+            colnames: ['genre'],
+            coltypes: [1],
+            data: [{ genre: 'Thriller' }],
+            rowcount: 1,
+          },
+        ],
+      },
+    });
+    const props = createResultsPaneOnDashboardProps({
+      sliceId: 203,
+      queriesResponse: [{ data: [{ genre: 'ignored' }] }],
+    });
+
+    render(<ResultsPaneOnDashboard {...props} />, { useRedux: true });
+
+    expect(await screen.findByText('Thriller')).toBeVisible();
+    expect(mockedGetChartDataRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to the API when queriesResponse has colnames but not the full v1 shape', async () => {
+    mockedGetChartDataRequest.mockResolvedValue({
+      json: {
+        result: [
+          {
+            colnames: ['genre'],
+            coltypes: [1],
+            data: [{ genre: 'Indie' }],
+            rowcount: 1,
+          },
+        ],
+      },
+    });
+    const props = createResultsPaneOnDashboardProps({
+      sliceId: 207,
+      // colnames present but coltypes/data missing: not a real v1 result
+      queriesResponse: [{ colnames: ['genre'] }],
+    });
+
+    render(<ResultsPaneOnDashboard {...props} />, { useRedux: true });
+
+    expect(await screen.findByText('Indie')).toBeVisible();
+    expect(mockedGetChartDataRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test('reuse path honors the effective row limit (slices Redux data, no extra query)', async () => {
+    const props = createResultsPaneOnDashboardProps({
+      sliceId: 204,
+      rowLimit: 2,
+      queriesResponse: [
+        {
+          colnames: ['genre'],
+          coltypes: [1],
+          data: [
+            { genre: 'Action' },
+            { genre: 'Horror' },
+            { genre: 'Comedy' },
+            { genre: 'Drama' },
+            { genre: 'Sci-Fi' },
+          ],
+          rowcount: 5,
+        },
+      ],
+    });
+
+    render(<ResultsPaneOnDashboard {...props} />, { useRedux: true });
+
+    expect(await screen.findByText('Action')).toBeVisible();
+    expect(screen.getByText('Horror')).toBeVisible();
+    expect(screen.queryByText('Comedy')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sci-Fi')).not.toBeInTheDocument();
+    expect(screen.getByText('2 rows')).toBeVisible();
+    expect(mockedGetChartDataRequest).not.toHaveBeenCalled();
+  });
+
+  test('renders an empty (0 rows) result from reused data without an API call', async () => {
+    const props = createResultsPaneOnDashboardProps({
+      sliceId: 205,
+      queriesResponse: [
+        { colnames: ['genre'], coltypes: [1], data: [], rowcount: 0 },
+      ],
+    });
+
+    render(<ResultsPaneOnDashboard {...props} />, { useRedux: true });
+
+    expect(await screen.findByText('0 rows')).toBeVisible();
+    expect(mockedGetChartDataRequest).not.toHaveBeenCalled();
+  });
+
+  test('clears the force-query flag when reusing Redux data', async () => {
+    const props = createResultsPaneOnDashboardProps({
+      sliceId: 206,
+      queryForce: true,
+      queriesResponse: [
+        {
+          colnames: ['genre'],
+          coltypes: [1],
+          data: [{ genre: 'Action' }],
+          rowcount: 1,
+        },
+      ],
+    });
+    const setForceQuery = jest.fn();
+
+    render(
+      <ResultsPaneOnDashboard {...props} setForceQuery={setForceQuery} />,
+      {
+        useRedux: true,
+      },
+    );
+
+    await waitFor(() => expect(setForceQuery).toHaveBeenCalledWith(false));
+    expect(mockedGetChartDataRequest).not.toHaveBeenCalled();
+  });
+});

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { JsonObject, LatestQueryFormData } from '@superset-ui/core';
+import { JsonObject, LatestQueryFormData, QueryData } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import type { ChartStatus, Datasource } from 'src/explore/types';
 
@@ -36,6 +36,7 @@ export interface DataTablesPaneProps {
   errorMessage?: React.ReactNode;
   setForceQuery: SetForceQueryAction;
   canDownload: boolean;
+  queriesResponse?: QueryData[] | null;
 }
 
 export interface ResultsPaneProps {
@@ -51,6 +52,7 @@ export interface ResultsPaneProps {
   canDownload: boolean;
   // Optional map of column/metric name -> verbose label
   columnDisplayNames?: Record<string, string>;
+  queriesResponse?: QueryData[] | null;
 }
 
 export interface SamplesPaneProps {

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
@@ -560,6 +560,7 @@ const ExploreChartPanel = ({
           errorMessage={errorMessage}
           setForceQuery={actions.setForceQuery}
           canDownload={canDownload}
+          queriesResponse={chart.queriesResponse}
         />
       </Split>
       {showDatasetModal && (


### PR DESCRIPTION
## **User description**
The Results tab in DataTablesPane independently fires a separate API request with resultType='results', which produces identical SQL to the chart's resultType='full' request on the backend. This doubles database load on every chart execution when the Results tab is open.

- Reset isRequest.results to false during chart loading to prevent race condition where both requests fire simultaneously
- Pass chart.queriesResponse from Redux through to useResultsPane
- Reuse chart data directly when available (v1 API), falling back to API call for legacy charts

Closes #38152

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The Results tab in the Explore view's DataTablesPane fires an independent API request (`resultType='results'`) every time a chart query runs. On the backend, `_get_results()` is a pure pass-through to `_get_full()` — both produce **identical SQL**. This means every chart execution with the Results tab open sends two duplicate database queries simultaneously.        

**Root cause (two issues):**                                                                                                                           

1. **Race condition in `DataTablesPane`**: `isRequest.results` is not reset to `false` when `chartStatus` transitions to `'loading'`. When`queryFormData` changes during chart loading, `useResultsPane`'s effect fires immediately — sending the Results request at the same time as the chart request.

2. **Redundant API call in `useResultsPane`**: The hook always fetches data via a separate network request, even though identical data is already available in Redux (`chart.queriesResponse`) after the chart query completes.

**Fix:**
- Reset `isRequest.results` to `false` when `chartStatus === 'loading'` to prevent the race condition
- Pass `chart.queriesResponse` from Redux through `ExploreChartPanel` → `DataTablesPane` → `useResultsPane`
- When `queriesResponse` contains v1 API data (has `colnames` field), reuse it directly — skipping the separate API call entirely
- Legacy charts without typed `queriesResponse` fall back to the existing API call

**Result:** One database query instead of two per chart execution. Results tab data appears instantly from Redux without a network round-trip.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="2548" height="1277" alt="스크린샷 2026-02-21 오후 12 44 59" src="https://github.com/user-attachments/assets/2261fdfb-3a02-4b2b-8cfb-ffdad035735d" />

AS-IS duplicated query was submitted to trino

<img width="2426" height="1285" alt="스크린샷 2026-02-21 오후 9 23 49" src="https://github.com/user-attachments/assets/1d4ca034-0d74-41a9-8ff2-6cb3044e993f" />

TO-BE only one query was submitted to trino and the result will be used in chart and result panels.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Build it locally and creating environment with docker-compose and tested it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/38152
- [ ] Required feature flags:
- [ ] Changes UI : No changes in UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Reuse chart query data in Results tab to avoid duplicate backend queries

### What Changed
- Results tab now reuses the chart's query response when available, so opening Results does not send a second identical database query
- Prevents a race where Results and chart requests could fire simultaneously by resetting the Results request flag while the chart is loading
- Legacy charts without the shared response still fetch results from the API as a fallback

### Impact
`✅ Lower database load during chart execution`
`✅ Fewer duplicate queries when viewing Results`
`✅ Faster Results display when chart data is already loaded`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
