### PR TITLE
fix(ColorPicker): restore alpha input visibility hidden by geostyler CSS

### DIFF
--- a/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
@@ -98,6 +98,17 @@ export const GlobalStyles = () => {
         [role='button'] {
           cursor: pointer;
         }
+
+        // Override geostyler CSS that hides AntD ColorPicker alpha input
+        // See: https://github.com/apache/superset/issues/34721
+        .ant-color-picker .ant-color-picker-alpha-input {
+          display: block;
+        }
+
+        .ant-color-picker .ant-color-picker-slider-alpha {
+          display: flex;
+          margin-top: ${theme.marginXS}px;
+        }
       `}
     />
   );


### PR DESCRIPTION
## **User description**
### SUMMARY

This PR fixes an issue where the alpha/opacity input field in the AntD ColorPicker component is hidden due to CSS styles from the geostyler library.

**Root Cause**: The geostyler package includes CSS in `node_modules/geostyler/dist/Component/Symbolizer/Field/ColorField/ColorField.css` that sets `display: none` on several AntD ColorPicker elements including `.ant-color-picker-alpha-input` and `.ant-color-picker-slider-alpha`.

**Solution**: Add global CSS overrides in `GlobalStyles.tsx` to restore the visibility of the alpha input and slider with appropriate spacing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**: Alpha input field is hidden (as shown in issue screenshots)

**After**: Alpha input field and slider are visible with proper spacing

Note: The screenshots in the original issue #34721 show the problem clearly.

### TESTING INSTRUCTIONS

1. Navigate to any chart that uses the ColorPicker control (e.g., charts with color customization options)
2. Open the color picker popover
3. Verify that the alpha/opacity input field is visible below the color slider
4. Verify that there is appropriate spacing between the color slider and the alpha slider

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #34721
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

🤖 Generated with [Claude Code](https://claude.ai/code)


___

## **CodeAnt-AI Description**
**Restore alpha/opacity input and spacing in ColorPicker**

### What Changed
- The alpha/opacity numeric input in Ant Design ColorPicker is visible again in color popovers (previously hidden by geostyler CSS)
- The alpha slider now has proper spacing from the color slider so the controls are not cramped

### Impact
`✅ Visible alpha/opacity control in color pickers`
`✅ Easier and more accurate opacity adjustments`
`✅ Fixes hidden alpha input in charts and styling editors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
