### PR TITLE
fix(csv): respect CSV_EXPORT config for decimal separator and delimiter

### DIFF
--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -389,7 +389,9 @@ def apply_client_processing(  # noqa: C901
             query["data"] = processed_df.to_dict()
         elif query["result_format"] == ChartDataResultFormat.CSV:
             buf = StringIO()
-            processed_df.to_csv(buf, index=show_default_index)
+            # Apply CSV_EXPORT config for consistent CSV formatting
+            csv_export_config = current_app.config.get("CSV_EXPORT", {})
+            processed_df.to_csv(buf, index=show_default_index, **csv_export_config)
             buf.seek(0)
             query["data"] = buf.getvalue()
 

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -390,7 +390,7 @@ def apply_client_processing(  # noqa: C901
         elif query["result_format"] == ChartDataResultFormat.CSV:
             buf = StringIO()
             # Apply CSV_EXPORT config for consistent CSV formatting
-            csv_export_config = current_app.config.get("CSV_EXPORT", {})
+            csv_export_config = current_app.config["CSV_EXPORT"]
             processed_df.to_csv(buf, index=show_default_index, **csv_export_config)
             buf.seek(0)
             query["data"] = buf.getvalue()

--- a/superset/commands/streaming_export/base.py
+++ b/superset/commands/streaming_export/base.py
@@ -24,6 +24,8 @@ import logging
 import time
 from abc import abstractmethod
 from contextlib import contextmanager
+from decimal import Decimal
+from numbers import Real
 from typing import Any, Callable, Generator
 
 from flask import current_app as app, g, has_app_context
@@ -123,10 +125,16 @@ class BaseStreamingCSVExportCommand(BaseCommand):
         if not decimal_separator or decimal_separator == ".":
             return list(row)
 
-        formatted = []
+        formatted: list[Any] = []
         for value in row:
-            if isinstance(value, float):
-                # Format float with custom decimal separator
+            # Apply the custom decimal separator to any real numeric value
+            # (float, decimal.Decimal, numpy numeric types, ...). Booleans are
+            # technically a numeric type in Python but should never be rewritten
+            # as numbers in CSV output.
+            if isinstance(value, bool):
+                formatted.append(value)
+            elif isinstance(value, (float, Decimal, Real)):
+                # Format numeric values with custom decimal separator
                 formatted.append(str(value).replace(".", decimal_separator))
             else:
                 formatted.append(value)

--- a/superset/commands/streaming_export/base.py
+++ b/superset/commands/streaming_export/base.py
@@ -204,8 +204,18 @@ class BaseStreamingCSVExportCommand(BaseCommand):
         start_time = time.time()
         total_bytes = 0
 
-        # Get CSV export configuration
-        csv_export_config = app.config.get("CSV_EXPORT", {})
+        # Get CSV export configuration. CSV_EXPORT has an explicit default in
+        # config.py, so index directly rather than using .get() with a hardcoded
+        # fallback that would silently mask a misconfiguration removing the key.
+        #
+        # The streaming path only honors the `sep` and `decimal` keys from
+        # CSV_EXPORT. Unlike the non-streaming path in
+        # superset.charts.client_processing (which builds the whole file with a
+        # single DataFrame.to_csv(**CSV_EXPORT) call), this path writes rows
+        # incrementally via csv.writer, so the remaining pandas to_csv kwargs
+        # (e.g. quotechar, lineterminator, encoding) do not map onto it and are
+        # intentionally not applied here.
+        csv_export_config = app.config["CSV_EXPORT"]
         delimiter = csv_export_config.get("sep", ",")
         decimal_separator = csv_export_config.get("decimal", ".")
 

--- a/superset/commands/streaming_export/base.py
+++ b/superset/commands/streaming_export/base.py
@@ -107,15 +107,48 @@ class BaseStreamingCSVExportCommand(BaseCommand):
         buffer.truncate()
         return header_data, total_bytes
 
+    def _format_row_values(
+        self, row: tuple[Any, ...], decimal_separator: str | None
+    ) -> list[Any]:
+        """
+        Format row values, applying custom decimal separator if specified.
+
+        Args:
+            row: Database row as a tuple
+            decimal_separator: Custom decimal separator (e.g., ",") or None
+
+        Returns:
+            List of formatted values
+        """
+        if not decimal_separator or decimal_separator == ".":
+            return list(row)
+
+        formatted = []
+        for value in row:
+            if isinstance(value, float):
+                # Format float with custom decimal separator
+                formatted.append(str(value).replace(".", decimal_separator))
+            else:
+                formatted.append(value)
+        return formatted
+
     def _process_rows(
         self,
         result_proxy: Any,
         csv_writer: Any,
         buffer: io.StringIO,
         limit: int | None,
+        decimal_separator: str | None = None,
     ) -> Generator[tuple[str, int, int], None, None]:
         """
         Process database rows and yield CSV data chunks.
+
+        Args:
+            result_proxy: SQLAlchemy result proxy
+            csv_writer: CSV writer instance
+            buffer: StringIO buffer for CSV data
+            limit: Maximum number of rows to process, or None for unlimited
+            decimal_separator: Custom decimal separator (e.g., ",") or None
 
         Yields tuples of (data_chunk, row_count, byte_count).
         """
@@ -128,7 +161,9 @@ class BaseStreamingCSVExportCommand(BaseCommand):
                 if limit is not None and row_count >= limit:
                     break
 
-                csv_writer.writerow(row)
+                # Format values with custom decimal separator if needed
+                formatted_row = self._format_row_values(row, decimal_separator)
+                csv_writer.writerow(formatted_row)
                 row_count += 1
 
                 # Check buffer size and flush if needed
@@ -161,6 +196,11 @@ class BaseStreamingCSVExportCommand(BaseCommand):
         start_time = time.time()
         total_bytes = 0
 
+        # Get CSV export configuration
+        csv_export_config = app.config.get("CSV_EXPORT", {})
+        delimiter = csv_export_config.get("sep", ",")
+        decimal_separator = csv_export_config.get("decimal", ".")
+
         with db.session() as session:
             # Merge database to prevent DetachedInstanceError
             merged_database = session.merge(database)
@@ -176,8 +216,11 @@ class BaseStreamingCSVExportCommand(BaseCommand):
                     columns = list(result_proxy.keys())
 
                     # Use StringIO with csv.writer for proper escaping
+                    # Apply delimiter from CSV_EXPORT config
                     buffer = io.StringIO()
-                    csv_writer = csv.writer(buffer, quoting=csv.QUOTE_MINIMAL)
+                    csv_writer = csv.writer(
+                        buffer, delimiter=delimiter, quoting=csv.QUOTE_MINIMAL
+                    )
 
                     # Write CSV header
                     header_data, header_bytes = self._write_csv_header(
@@ -189,7 +232,7 @@ class BaseStreamingCSVExportCommand(BaseCommand):
                     # Process rows and yield chunks
                     row_count = 0
                     for data_chunk, rows_processed, chunk_bytes in self._process_rows(
-                        result_proxy, csv_writer, buffer, limit
+                        result_proxy, csv_writer, buffer, limit, decimal_separator
                     ):
                         total_bytes += chunk_bytes
                         row_count = rows_processed

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -2830,10 +2830,15 @@ def test_apply_client_processing_csv_format_custom_separator():
     lines = output_data.strip().split("\n")
 
     # With sep=";", columns should be separated by semicolon
-    assert "name;value" in lines[0]
-    # With decimal=",", decimal values should use comma as separator
-    assert "Alice;1,5" in lines[1] or "Alice;1.5" in lines[1]
-    assert "Bob;2,75" in lines[2] or "Bob;2.75" in lines[2]
+    assert lines[0] == "name;value"
+    # With decimal=",", decimal values must use comma as separator.
+    # Asserting the exact formatted value ensures a regression that drops
+    # the `decimal` option (so floats keep a dot) will be caught.
+    assert "Alice;1,5" in lines[1]
+    assert "Bob;2,75" in lines[2]
+    # Guard explicitly against the dot form slipping through.
+    assert "1.5" not in lines[1]
+    assert "2.75" not in lines[2]
 
 
 @with_config({"CSV_EXPORT": {"sep": ";", "decimal": ","}})
@@ -2883,7 +2888,14 @@ def test_apply_client_processing_csv_pivot_table_custom_separator():
     processed_result = apply_client_processing(result, form_data)
 
     output_data = processed_result["queries"][0]["data"]
+    lines = output_data.strip().split("\n")
 
-    # The output should use semicolon as separator and comma as decimal
-    # After pivoting, the format should reflect CSV_EXPORT settings
-    assert ";" in output_data or "," in output_data
+    # After pivoting a single metric with no groupby rows/columns, the
+    # CSV for the "COUNT(metric)" column and "Total (Sum)" row should
+    # reflect the CSV_EXPORT config: semicolons as field separators and
+    # commas as the decimal separator.
+    assert lines[0] == ";COUNT(metric)"
+    assert "Total (Sum);1234,56" in lines[1]
+    # Guard explicitly against the dot form slipping through, which is
+    # what the previous (broken) implementation produced.
+    assert "1234.56" not in output_data

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -2791,7 +2791,7 @@ def test_apply_client_processing_csv_format_default_na_behavior():
 
 
 @with_config({"CSV_EXPORT": {"sep": ";", "decimal": ","}})
-def test_apply_client_processing_csv_format_custom_separator():
+def test_apply_client_processing_csv_format_custom_separator() -> None:
     """
     Test that apply_client_processing respects CSV_EXPORT config
     for custom separator and decimal character.
@@ -2842,7 +2842,7 @@ def test_apply_client_processing_csv_format_custom_separator():
 
 
 @with_config({"CSV_EXPORT": {"sep": ";", "decimal": ","}})
-def test_apply_client_processing_csv_pivot_table_custom_separator():
+def test_apply_client_processing_csv_pivot_table_custom_separator() -> None:
     """
     Test that apply_client_processing respects CSV_EXPORT config
     for pivot table exports with custom separator and decimal character.

--- a/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
@@ -16,6 +16,7 @@
 # under the License.
 """Unit tests for SQL Lab Streaming CSV Export Command."""
 
+from decimal import Decimal
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -681,3 +682,53 @@ def test_csv_export_config_combined_sep_and_decimal(mocker, mock_query):
     # Verify data uses semicolon separator and comma decimal
     assert "1;Widget;99,99" in csv_data
     assert "2;Gadget;149,5" in csv_data or "2;Gadget;149,50" in csv_data
+
+
+def test_csv_export_config_custom_decimal_for_decimal_type(mocker, mock_query):
+    """
+    Streaming CSV export must respect the custom decimal separator for
+    ``decimal.Decimal`` values too — SQLAlchemy commonly returns NUMERIC /
+    DECIMAL columns as ``Decimal`` rather than ``float``.
+
+    Regression test for GitHub issue #32371 / PR #38170 review feedback.
+    """
+    mock_query.select_sql = "SELECT * FROM test"
+
+    mock_result = MagicMock()
+    mock_result.keys.return_value = ["id", "price"]
+    mock_result.fetchmany.side_effect = [
+        [(1, Decimal("12.34")), (2, Decimal("56.78"))],
+        [],
+    ]
+
+    mock_db, mock_session = _setup_sqllab_mocks(mocker, mock_query)
+
+    mock_connection = MagicMock()
+    mock_connection.execution_options.return_value.execute.return_value = mock_result
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value = mock_connection
+    mock_query.database.get_sqla_engine.return_value.__enter__.return_value = (
+        mock_engine
+    )
+
+    mocker.patch(
+        "superset.commands.streaming_export.base.app.config.get",
+        return_value={"sep": ";", "decimal": ",", "encoding": "utf-8"},
+    )
+
+    command = StreamingSqlResultExportCommand("test_client_123")
+    command.validate()
+
+    csv_generator_callable = command.run()
+    generator = csv_generator_callable()
+    csv_data = "".join(generator)
+
+    # Decimal values must be formatted with the custom separator, not left
+    # with the default ``.`` which would slip through a ``float``-only check.
+    assert "1;12,34" in csv_data
+    assert "2;56,78" in csv_data
+    assert "12.34" not in csv_data
+    assert "56.78" not in csv_data

--- a/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
@@ -16,6 +16,7 @@
 # under the License.
 """Unit tests for SQL Lab Streaming CSV Export Command."""
 
+from decimal import Decimal
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -720,3 +721,53 @@ def test_csv_export_config_combined_sep_and_decimal(mocker, mock_query):
     # Verify data uses semicolon separator and comma decimal
     assert "1;Widget;99,99" in csv_data
     assert "2;Gadget;149,5" in csv_data or "2;Gadget;149,50" in csv_data
+
+
+def test_csv_export_config_custom_decimal_for_decimal_type(mocker, mock_query):
+    """
+    Streaming CSV export must respect the custom decimal separator for
+    ``decimal.Decimal`` values too — SQLAlchemy commonly returns NUMERIC /
+    DECIMAL columns as ``Decimal`` rather than ``float``.
+
+    Regression test for GitHub issue #32371 / PR #38170 review feedback.
+    """
+    mock_query.select_sql = "SELECT * FROM test"
+
+    mock_result = MagicMock()
+    mock_result.keys.return_value = ["id", "price"]
+    mock_result.fetchmany.side_effect = [
+        [(1, Decimal("12.34")), (2, Decimal("56.78"))],
+        [],
+    ]
+
+    mock_db, mock_session = _setup_sqllab_mocks(mocker, mock_query)
+
+    mock_connection = MagicMock()
+    mock_connection.execution_options.return_value.execute.return_value = mock_result
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value = mock_connection
+    mock_query.database.get_sqla_engine.return_value.__enter__.return_value = (
+        mock_engine
+    )
+
+    mocker.patch(
+        "superset.commands.streaming_export.base.app.config.get",
+        return_value={"sep": ";", "decimal": ",", "encoding": "utf-8"},
+    )
+
+    command = StreamingSqlResultExportCommand("test_client_123")
+    command.validate()
+
+    csv_generator_callable = command.run()
+    generator = csv_generator_callable()
+    csv_data = "".join(generator)
+
+    # Decimal values must be formatted with the custom separator, not left
+    # with the default ``.`` which would slip through a ``float``-only check.
+    assert "1;12,34" in csv_data
+    assert "2;56,78" in csv_data
+    assert "12.34" not in csv_data
+    assert "56.78" not in csv_data

--- a/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
@@ -577,3 +577,146 @@ def test_catalog_and_schema_passed_to_engine(mocker, mock_query, mock_result_pro
         catalog="my_catalog",
         schema="my_schema",
     )
+
+
+def test_csv_export_config_custom_separator(mocker, mock_query):
+    """
+    Test that streaming CSV export respects CSV_EXPORT config
+    for custom separator (sep).
+
+    This is a regression test for GitHub issue #32371.
+    """
+    mock_query.select_sql = "SELECT * FROM test"
+
+    mock_result = MagicMock()
+    mock_result.keys.return_value = ["id", "name"]
+    mock_result.fetchmany.side_effect = [
+        [(1, "Alice"), (2, "Bob")],
+        [],
+    ]
+
+    mock_db, mock_session = _setup_sqllab_mocks(mocker, mock_query)
+
+    mock_connection = MagicMock()
+    mock_connection.execution_options.return_value.execute.return_value = mock_result
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value = mock_connection
+    mock_query.database.get_sqla_engine.return_value.__enter__.return_value = (
+        mock_engine
+    )
+
+    # Mock the app config to use semicolon separator
+    mocker.patch(
+        "superset.commands.streaming_export.base.app.config.get",
+        return_value={"sep": ";", "encoding": "utf-8"},
+    )
+
+    command = StreamingSqlResultExportCommand("test_client_123")
+    command.validate()
+
+    csv_generator_callable = command.run()
+    generator = csv_generator_callable()
+    csv_data = "".join(generator)
+
+    # With sep=";", columns should be separated by semicolon
+    assert "id;name" in csv_data
+    assert "1;Alice" in csv_data
+    assert "2;Bob" in csv_data
+
+
+def test_csv_export_config_custom_decimal(mocker, mock_query):
+    """
+    Test that streaming CSV export respects CSV_EXPORT config
+    for custom decimal separator.
+
+    This is a regression test for GitHub issue #32371.
+    """
+    mock_query.select_sql = "SELECT * FROM test"
+
+    mock_result = MagicMock()
+    mock_result.keys.return_value = ["id", "price"]
+    mock_result.fetchmany.side_effect = [
+        [(1, 12.34), (2, 56.78)],
+        [],
+    ]
+
+    mock_db, mock_session = _setup_sqllab_mocks(mocker, mock_query)
+
+    mock_connection = MagicMock()
+    mock_connection.execution_options.return_value.execute.return_value = mock_result
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value = mock_connection
+    mock_query.database.get_sqla_engine.return_value.__enter__.return_value = (
+        mock_engine
+    )
+
+    # Mock the app config to use comma as decimal separator
+    mocker.patch(
+        "superset.commands.streaming_export.base.app.config.get",
+        return_value={"sep": ";", "decimal": ",", "encoding": "utf-8"},
+    )
+
+    command = StreamingSqlResultExportCommand("test_client_123")
+    command.validate()
+
+    csv_generator_callable = command.run()
+    generator = csv_generator_callable()
+    csv_data = "".join(generator)
+
+    # With decimal=",", float values should use comma
+    assert "12,34" in csv_data
+    assert "56,78" in csv_data
+
+
+def test_csv_export_config_combined_sep_and_decimal(mocker, mock_query):
+    """
+    Test that streaming CSV export respects both sep and decimal from CSV_EXPORT.
+
+    This is a regression test for GitHub issue #32371.
+    """
+    mock_query.select_sql = "SELECT * FROM test"
+
+    mock_result = MagicMock()
+    mock_result.keys.return_value = ["id", "name", "price"]
+    mock_result.fetchmany.side_effect = [
+        [(1, "Widget", 99.99), (2, "Gadget", 149.50)],
+        [],
+    ]
+
+    mock_db, mock_session = _setup_sqllab_mocks(mocker, mock_query)
+
+    mock_connection = MagicMock()
+    mock_connection.execution_options.return_value.execute.return_value = mock_result
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value = mock_connection
+    mock_query.database.get_sqla_engine.return_value.__enter__.return_value = (
+        mock_engine
+    )
+
+    # Mock the app config to use European format
+    mocker.patch(
+        "superset.commands.streaming_export.base.app.config.get",
+        return_value={"sep": ";", "decimal": ",", "encoding": "utf-8"},
+    )
+
+    command = StreamingSqlResultExportCommand("test_client_123")
+    command.validate()
+
+    csv_generator_callable = command.run()
+    generator = csv_generator_callable()
+    csv_data = "".join(generator)
+
+    # Verify header uses semicolon separator
+    assert "id;name;price" in csv_data
+    # Verify data uses semicolon separator and comma decimal
+    assert "1;Widget;99,99" in csv_data
+    assert "2;Gadget;149,5" in csv_data or "2;Gadget;149,50" in csv_data

--- a/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
@@ -580,7 +580,7 @@ def test_catalog_and_schema_passed_to_engine(mocker, mock_query, mock_result_pro
     )
 
 
-def test_csv_export_config_custom_separator(mocker, mock_query):
+def test_csv_export_config_custom_separator(mocker, mock_query) -> None:
     """
     Test that streaming CSV export respects CSV_EXPORT config
     for custom separator (sep).
@@ -610,9 +610,9 @@ def test_csv_export_config_custom_separator(mocker, mock_query):
     )
 
     # Mock the app config to use semicolon separator
-    mocker.patch(
-        "superset.commands.streaming_export.base.app.config.get",
-        return_value={"sep": ";", "encoding": "utf-8"},
+    mocker.patch.dict(
+        "superset.commands.streaming_export.base.app.config",
+        {"CSV_EXPORT": {"sep": ";", "encoding": "utf-8"}},
     )
 
     command = StreamingSqlResultExportCommand("test_client_123")
@@ -628,7 +628,7 @@ def test_csv_export_config_custom_separator(mocker, mock_query):
     assert "2;Bob" in csv_data
 
 
-def test_csv_export_config_custom_decimal(mocker, mock_query):
+def test_csv_export_config_custom_decimal(mocker, mock_query) -> None:
     """
     Test that streaming CSV export respects CSV_EXPORT config
     for custom decimal separator.
@@ -658,9 +658,9 @@ def test_csv_export_config_custom_decimal(mocker, mock_query):
     )
 
     # Mock the app config to use comma as decimal separator
-    mocker.patch(
-        "superset.commands.streaming_export.base.app.config.get",
-        return_value={"sep": ";", "decimal": ",", "encoding": "utf-8"},
+    mocker.patch.dict(
+        "superset.commands.streaming_export.base.app.config",
+        {"CSV_EXPORT": {"sep": ";", "decimal": ",", "encoding": "utf-8"}},
     )
 
     command = StreamingSqlResultExportCommand("test_client_123")
@@ -675,7 +675,7 @@ def test_csv_export_config_custom_decimal(mocker, mock_query):
     assert "56,78" in csv_data
 
 
-def test_csv_export_config_combined_sep_and_decimal(mocker, mock_query):
+def test_csv_export_config_combined_sep_and_decimal(mocker, mock_query) -> None:
     """
     Test that streaming CSV export respects both sep and decimal from CSV_EXPORT.
 
@@ -704,9 +704,9 @@ def test_csv_export_config_combined_sep_and_decimal(mocker, mock_query):
     )
 
     # Mock the app config to use European format
-    mocker.patch(
-        "superset.commands.streaming_export.base.app.config.get",
-        return_value={"sep": ";", "decimal": ",", "encoding": "utf-8"},
+    mocker.patch.dict(
+        "superset.commands.streaming_export.base.app.config",
+        {"CSV_EXPORT": {"sep": ";", "decimal": ",", "encoding": "utf-8"}},
     )
 
     command = StreamingSqlResultExportCommand("test_client_123")
@@ -720,10 +720,10 @@ def test_csv_export_config_combined_sep_and_decimal(mocker, mock_query):
     assert "id;name;price" in csv_data
     # Verify data uses semicolon separator and comma decimal
     assert "1;Widget;99,99" in csv_data
-    assert "2;Gadget;149,5" in csv_data or "2;Gadget;149,50" in csv_data
+    assert ";149,5" in csv_data
 
 
-def test_csv_export_config_custom_decimal_for_decimal_type(mocker, mock_query):
+def test_csv_export_config_custom_decimal_for_decimal_type(mocker, mock_query) -> None:
     """
     Streaming CSV export must respect the custom decimal separator for
     ``decimal.Decimal`` values too — SQLAlchemy commonly returns NUMERIC /
@@ -753,9 +753,9 @@ def test_csv_export_config_custom_decimal_for_decimal_type(mocker, mock_query):
         mock_engine
     )
 
-    mocker.patch(
-        "superset.commands.streaming_export.base.app.config.get",
-        return_value={"sep": ";", "decimal": ",", "encoding": "utf-8"},
+    mocker.patch.dict(
+        "superset.commands.streaming_export.base.app.config",
+        {"CSV_EXPORT": {"sep": ";", "decimal": ",", "encoding": "utf-8"}},
     )
 
     command = StreamingSqlResultExportCommand("test_client_123")


### PR DESCRIPTION
### SUMMARY

This PR fixes GitHub issue #32371 where the `CSV_EXPORT` configuration was not being applied correctly in certain CSV export scenarios.

**The issue had two parts:**
1. Custom `decimal` separator (e.g., `decimal: ","`) was ignored in exports
2. Pivoted CSV exports did not respect `CSV_EXPORT` settings

**Root cause:**
- In `superset/charts/client_processing.py`, the `apply_client_processing()` function calls `to_csv()` without passing the `CSV_EXPORT` config when exporting pivoted/processed data
- In `superset/commands/streaming_export/base.py`, the streaming CSV export uses Python's `csv.writer` directly without applying the `sep` or `decimal` config values

**Changes:**
- `superset/charts/client_processing.py`: Pass `CSV_EXPORT` config to `to_csv()` when exporting processed (pivoted) CSV data
- `superset/commands/streaming_export/base.py`: 
  - Use the `sep` parameter as the CSV delimiter for `csv.writer`
  - Add `_format_row_values()` method to format float values with the custom `decimal` separator

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**
With `CSV_EXPORT = {"encoding": "utf-8", "sep": ";", "decimal": ","}`:
- Regular CSV export: Separator works (`;`), but decimal is ignored (still `.`)
- Pivoted CSV export: Neither separator nor decimal config is applied

**After:**
- Both regular and pivoted CSV exports respect the full `CSV_EXPORT` configuration
- Streaming exports also respect the configuration

### TESTING INSTRUCTIONS

1. Add the following to your `superset_config.py`:
   ```python
   CSV_EXPORT = {"encoding": "utf-8", "sep": ";", "decimal": ","}
   ```
2. Restart Superset
3. Create a chart with numeric data (e.g., a table or pivot table)
4. Export to CSV (both regular and pivoted if using pivot table)
5. Verify that:
   - Columns are separated by semicolons (`;`)
   - Decimal values use commas (e.g., `1,5` instead of `1.5`)

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #32371
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>