### PR TITLE
fix(dashboard): replace chartsInScope references at import time

### DIFF
--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -175,11 +175,19 @@ def _remap_chart_ids(
 
 
 def _update_cross_filter_scope(
-    cross_filter_config: dict[str, Any],
+    cross_filter_config: Any,
     id_map: dict[int, int],
     uuid_to_new_id: dict[str, int] | None = None,
 ) -> None:
-    """Update scope.excluded and chartsInScope in a cross-filter configuration."""
+    """Update scope.excluded and chartsInScope in a cross-filter configuration.
+
+    Imported dashboard metadata is loosely validated, so malformed payloads may
+    supply ``null`` or non-dict values where a cross-filter config is expected.
+    Skip anything that isn't a dict rather than raising ``AttributeError``.
+    """
+    if not isinstance(cross_filter_config, dict):
+        return
+
     scope = cross_filter_config.get("scope", {})
     if isinstance(scope, dict):
         if excluded := scope.get("excluded", []):

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -143,9 +143,7 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
         # fix chartsInScope references (from PR #26389)
         charts_in_scope = native_filter.get("chartsInScope", [])
         if charts_in_scope:
-            native_filter["chartsInScope"] = _remap_chart_ids(
-                charts_in_scope, id_map
-            )
+            native_filter["chartsInScope"] = _remap_chart_ids(charts_in_scope, id_map)
 
     fixed = update_cross_filter_scoping(fixed, id_map)
     return fixed

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -143,9 +143,9 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
         # fix chartsInScope references (from PR #26389)
         charts_in_scope = native_filter.get("chartsInScope", [])
         if charts_in_scope:
-            native_filter["chartsInScope"] = [
-                id_map[old_id] for old_id in charts_in_scope if old_id in id_map
-            ]
+            native_filter["chartsInScope"] = _remap_chart_ids(
+                charts_in_scope, id_map
+            )
 
     fixed = update_cross_filter_scoping(fixed, id_map)
     return fixed

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -65,11 +65,12 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
     """Update dashboard metadata to use new IDs"""
     fixed = config.copy()
 
-    # build map old_id => new_id
+    # build map old_id => new_id and uuid => new_id
     old_ids = build_uuid_to_id_map(fixed["position"])
     id_map = {
         old_id: chart_ids[uuid] for uuid, old_id in old_ids.items() if uuid in chart_ids
     }
+    uuid_to_new_id = {uuid: chart_ids[uuid] for uuid in old_ids if uuid in chart_ids}
 
     # fix metadata
     metadata = fixed.get("metadata", {})
@@ -143,40 +144,69 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
         # fix chartsInScope references (from PR #26389)
         charts_in_scope = native_filter.get("chartsInScope", [])
         if charts_in_scope:
-            native_filter["chartsInScope"] = _remap_chart_ids(charts_in_scope, id_map)
+            native_filter["chartsInScope"] = _remap_chart_ids(
+                charts_in_scope, id_map, uuid_to_new_id
+            )
 
-    fixed = update_cross_filter_scoping(fixed, id_map)
+    fixed = update_cross_filter_scoping(fixed, id_map, uuid_to_new_id)
     return fixed
 
 
-def _remap_chart_ids(id_list: list[int], id_map: dict[int, int]) -> list[int]:
-    """Remap old chart IDs to new IDs, dropping any that aren't in the map."""
-    return [id_map[old_id] for old_id in id_list if old_id in id_map]
+def _remap_chart_ids(
+    id_list: list[Any],
+    id_map: dict[int, int],
+    uuid_to_new_id: dict[str, int] | None = None,
+) -> list[int]:
+    """Remap old chart IDs (int or UUID string) to new integer IDs.
+
+    Handles both the standard import format (integer IDs) and the example-export
+    format (UUID strings produced by export_example.remap_chart_configuration).
+    """
+    result = []
+    for item in id_list:
+        if isinstance(item, int):
+            if item in id_map:
+                result.append(id_map[item])
+        elif isinstance(item, str) and uuid_to_new_id:
+            new_id = uuid_to_new_id.get(item)
+            if new_id is not None:
+                result.append(new_id)
+    return result
 
 
 def _update_cross_filter_scope(
-    cross_filter_config: dict[str, Any], id_map: dict[int, int]
+    cross_filter_config: dict[str, Any],
+    id_map: dict[int, int],
+    uuid_to_new_id: dict[str, int] | None = None,
 ) -> None:
     """Update scope.excluded and chartsInScope in a cross-filter configuration."""
     scope = cross_filter_config.get("scope", {})
     if isinstance(scope, dict):
         if excluded := scope.get("excluded", []):
-            scope["excluded"] = _remap_chart_ids(excluded, id_map)
+            scope["excluded"] = _remap_chart_ids(excluded, id_map, uuid_to_new_id)
 
     if charts_in_scope := cross_filter_config.get("chartsInScope", []):
-        cross_filter_config["chartsInScope"] = _remap_chart_ids(charts_in_scope, id_map)
+        cross_filter_config["chartsInScope"] = _remap_chart_ids(
+            charts_in_scope, id_map, uuid_to_new_id
+        )
 
 
 def update_cross_filter_scoping(
-    config: dict[str, Any], id_map: dict[int, int]
+    config: dict[str, Any],
+    id_map: dict[int, int],
+    uuid_to_new_id: dict[str, int] | None = None,
 ) -> dict[str, Any]:
-    """Fix cross filter references by remapping chart IDs."""
+    """Fix cross filter references by remapping chart IDs.
+
+    Handles both the standard import format (integer-keyed chart_configuration)
+    and the example-export format (UUID-keyed, produced by export_example).
+    """
     fixed = config.copy()
     metadata = fixed.get("metadata", {})
 
     # Update global_chart_configuration
     global_config = metadata.get("global_chart_configuration", {})
-    _update_cross_filter_scope(global_config, id_map)
+    _update_cross_filter_scope(global_config, id_map, uuid_to_new_id)
 
     # Update chart_configuration entries
     if "chart_configuration" not in metadata:
@@ -186,17 +216,21 @@ def update_cross_filter_scoping(
     for old_id_str, chart_config in metadata["chart_configuration"].items():
         try:
             old_id_int = int(old_id_str)
+            new_id = id_map.get(old_id_int)
+            if new_id is None:
+                continue
         except (TypeError, ValueError):
-            continue
-
-        new_id = id_map.get(old_id_int)
-        if new_id is None:
-            continue
+            # UUID-keyed entry (e.g. from export_example): resolve via chart UUIDs
+            new_id = uuid_to_new_id.get(old_id_str) if uuid_to_new_id else None
+            if new_id is None:
+                # Unknown key — preserve unchanged rather than silently drop
+                new_chart_configuration[old_id_str] = chart_config
+                continue
 
         if isinstance(chart_config, dict):
             chart_config["id"] = new_id
             if cross_filters := chart_config.get("crossFilters", {}):
-                _update_cross_filter_scope(cross_filters, id_map)
+                _update_cross_filter_scope(cross_filters, id_map, uuid_to_new_id)
 
         new_chart_configuration[str(new_id)] = chart_config
 

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -187,59 +187,58 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
     return fixed
 
 
-def update_cross_filter_scoping(  # noqa: C901
+def _remap_chart_ids(id_list: list[int], id_map: dict[int, int]) -> list[int]:
+    """Remap old chart IDs to new IDs, dropping any that aren't in the map."""
+    return [id_map[old_id] for old_id in id_list if old_id in id_map]
+
+
+def _update_cross_filter_scope(
+    cross_filter_config: dict[str, Any], id_map: dict[int, int]
+) -> None:
+    """Update scope.excluded and chartsInScope in a cross-filter configuration."""
+    scope = cross_filter_config.get("scope", {})
+    if isinstance(scope, dict):
+        if excluded := scope.get("excluded", []):
+            scope["excluded"] = _remap_chart_ids(excluded, id_map)
+
+    if charts_in_scope := cross_filter_config.get("chartsInScope", []):
+        cross_filter_config["chartsInScope"] = _remap_chart_ids(charts_in_scope, id_map)
+
+
+def update_cross_filter_scoping(
     config: dict[str, Any], id_map: dict[int, int]
 ) -> dict[str, Any]:
-    # fix cross filter references
+    """Fix cross filter references by remapping chart IDs."""
     fixed = config.copy()
+    metadata = fixed.get("metadata", {})
 
-    cross_filter_global_config = fixed.get("metadata", {}).get(
-        "global_chart_configuration", {}
-    )
-    scope_excluded = cross_filter_global_config.get("scope", {}).get("excluded", [])
-    if scope_excluded:
-        cross_filter_global_config["scope"]["excluded"] = [
-            id_map[old_id] for old_id in scope_excluded if old_id in id_map
-        ]
+    # Update global_chart_configuration
+    global_config = metadata.get("global_chart_configuration", {})
+    _update_cross_filter_scope(global_config, id_map)
 
-    # Global cross-filter chartsInScope mirrors the native-filter case.
-    _remap_charts_in_scope(cross_filter_global_config, id_map)
+    # Update chart_configuration entries
+    if "chart_configuration" not in metadata:
+        return fixed
 
-    if "chart_configuration" in (metadata := fixed.get("metadata", {})):
-        # Build remapped configuration in a single pass for clarity/readability.
-        new_chart_configuration: dict[str, Any] = {}
-        for old_id_str, chart_config in metadata["chart_configuration"].items():
-            try:
-                old_id_int = int(old_id_str)
-            except (TypeError, ValueError):
-                continue
+    new_chart_configuration: dict[str, Any] = {}
+    for old_id_str, chart_config in metadata["chart_configuration"].items():
+        try:
+            old_id_int = int(old_id_str)
+        except (TypeError, ValueError):
+            continue
 
-            new_id = id_map.get(old_id_int)
-            if new_id is None:
-                continue
+        new_id = id_map.get(old_id_int)
+        if new_id is None:
+            continue
 
-            if isinstance(chart_config, dict):
-                chart_config["id"] = new_id
+        if isinstance(chart_config, dict):
+            chart_config["id"] = new_id
+            if cross_filters := chart_config.get("crossFilters", {}):
+                _update_cross_filter_scope(cross_filters, id_map)
 
-                # Update cross filter scope excluded ids
-                scope = chart_config.get("crossFilters", {}).get("scope", {})
-                if isinstance(scope, dict):
-                    excluded_scope = scope.get("excluded", [])
-                    if excluded_scope:
-                        chart_config["crossFilters"]["scope"]["excluded"] = [
-                            id_map[old_id]
-                            for old_id in excluded_scope
-                            if old_id in id_map
-                        ]
+        new_chart_configuration[str(new_id)] = chart_config
 
-                # Cross-filter chartsInScope mirrors the native-filter case.
-                cross_filters = chart_config.get("crossFilters")
-                if isinstance(cross_filters, dict):
-                    _remap_charts_in_scope(cross_filters, id_map)
-
-            new_chart_configuration[str(new_id)] = chart_config
-
-        metadata["chart_configuration"] = new_chart_configuration
+    metadata["chart_configuration"] = new_chart_configuration
     return fixed
 
 

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -215,11 +215,19 @@ def _remap_chart_ids(
 
 
 def _update_cross_filter_scope(
-    cross_filter_config: dict[str, Any],
+    cross_filter_config: Any,
     id_map: dict[int, int],
     uuid_to_new_id: dict[str, int] | None = None,
 ) -> None:
-    """Update scope.excluded and chartsInScope in a cross-filter configuration."""
+    """Update scope.excluded and chartsInScope in a cross-filter configuration.
+
+    Imported dashboard metadata is loosely validated, so malformed payloads may
+    supply ``null`` or non-dict values where a cross-filter config is expected.
+    Skip anything that isn't a dict rather than raising ``AttributeError``.
+    """
+    if not isinstance(cross_filter_config, dict):
+        return
+
     scope = cross_filter_config.get("scope", {})
     if isinstance(scope, dict):
         if excluded := scope.get("excluded", []):

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -85,11 +85,12 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
     """Update dashboard metadata to use new IDs"""
     fixed = config.copy()
 
-    # build map old_id => new_id
+    # build map old_id => new_id and uuid => new_id
     old_ids = build_uuid_to_id_map(fixed["position"])
     id_map = {
         old_id: chart_ids[uuid] for uuid, old_id in old_ids.items() if uuid in chart_ids
     }
+    uuid_to_new_id = {uuid: chart_ids[uuid] for uuid in old_ids if uuid in chart_ids}
 
     # fix metadata
     metadata = fixed.get("metadata", {})
@@ -160,7 +161,11 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
                 id_map[old_id] for old_id in scope_excluded if old_id in id_map
             ]
 
-        _remap_charts_in_scope(native_filter, id_map)
+        charts_in_scope = native_filter.get("chartsInScope", [])
+        if charts_in_scope:
+            native_filter["chartsInScope"] = _remap_chart_ids(
+                charts_in_scope, id_map, uuid_to_new_id
+            )
 
     # fix display control dataset references
     for customization in (
@@ -183,38 +188,65 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
                         dataset_uuid,
                     )
 
-    fixed = update_cross_filter_scoping(fixed, id_map)
+    fixed = update_cross_filter_scoping(fixed, id_map, uuid_to_new_id)
     return fixed
 
 
-def _remap_chart_ids(id_list: list[int], id_map: dict[int, int]) -> list[int]:
-    """Remap old chart IDs to new IDs, dropping any that aren't in the map."""
-    return [id_map[old_id] for old_id in id_list if old_id in id_map]
+def _remap_chart_ids(
+    id_list: list[Any],
+    id_map: dict[int, int],
+    uuid_to_new_id: dict[str, int] | None = None,
+) -> list[int]:
+    """Remap old chart IDs (int or UUID string) to new integer IDs.
+
+    Handles both the standard import format (integer IDs) and the example-export
+    format (UUID strings produced by export_example.remap_chart_configuration).
+    """
+    result = []
+    for item in id_list:
+        if isinstance(item, int):
+            if item in id_map:
+                result.append(id_map[item])
+        elif isinstance(item, str) and uuid_to_new_id:
+            new_id = uuid_to_new_id.get(item)
+            if new_id is not None:
+                result.append(new_id)
+    return result
 
 
 def _update_cross_filter_scope(
-    cross_filter_config: dict[str, Any], id_map: dict[int, int]
+    cross_filter_config: dict[str, Any],
+    id_map: dict[int, int],
+    uuid_to_new_id: dict[str, int] | None = None,
 ) -> None:
     """Update scope.excluded and chartsInScope in a cross-filter configuration."""
     scope = cross_filter_config.get("scope", {})
     if isinstance(scope, dict):
         if excluded := scope.get("excluded", []):
-            scope["excluded"] = _remap_chart_ids(excluded, id_map)
+            scope["excluded"] = _remap_chart_ids(excluded, id_map, uuid_to_new_id)
 
     if charts_in_scope := cross_filter_config.get("chartsInScope", []):
-        cross_filter_config["chartsInScope"] = _remap_chart_ids(charts_in_scope, id_map)
+        cross_filter_config["chartsInScope"] = _remap_chart_ids(
+            charts_in_scope, id_map, uuid_to_new_id
+        )
 
 
 def update_cross_filter_scoping(
-    config: dict[str, Any], id_map: dict[int, int]
+    config: dict[str, Any],
+    id_map: dict[int, int],
+    uuid_to_new_id: dict[str, int] | None = None,
 ) -> dict[str, Any]:
-    """Fix cross filter references by remapping chart IDs."""
+    """Fix cross filter references by remapping chart IDs.
+
+    Handles both the standard import format (integer-keyed chart_configuration)
+    and the example-export format (UUID-keyed, produced by export_example).
+    """
     fixed = config.copy()
     metadata = fixed.get("metadata", {})
 
     # Update global_chart_configuration
     global_config = metadata.get("global_chart_configuration", {})
-    _update_cross_filter_scope(global_config, id_map)
+    _update_cross_filter_scope(global_config, id_map, uuid_to_new_id)
 
     # Update chart_configuration entries
     if "chart_configuration" not in metadata:
@@ -224,17 +256,21 @@ def update_cross_filter_scoping(
     for old_id_str, chart_config in metadata["chart_configuration"].items():
         try:
             old_id_int = int(old_id_str)
+            new_id = id_map.get(old_id_int)
+            if new_id is None:
+                continue
         except (TypeError, ValueError):
-            continue
-
-        new_id = id_map.get(old_id_int)
-        if new_id is None:
-            continue
+            # UUID-keyed entry (e.g. from export_example): resolve via chart UUIDs
+            new_id = uuid_to_new_id.get(old_id_str) if uuid_to_new_id else None
+            if new_id is None:
+                # Unknown key — preserve unchanged rather than silently drop
+                new_chart_configuration[old_id_str] = chart_config
+                continue
 
         if isinstance(chart_config, dict):
             chart_config["id"] = new_id
             if cross_filters := chart_config.get("crossFilters", {}):
-                _update_cross_filter_scope(cross_filters, id_map)
+                _update_cross_filter_scope(cross_filters, id_map, uuid_to_new_id)
 
         new_chart_configuration[str(new_id)] = chart_config
 

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -62,21 +62,6 @@ def build_uuid_to_id_map(position: dict[str, Any]) -> dict[str, int]:
     }
 
 
-def _remap_charts_in_scope(container: dict[str, Any], id_map: dict[int, int]) -> None:
-    """Remap source-env chart IDs in ``container["chartsInScope"]`` in place.
-
-    ``chartsInScope`` is a denormalized cache of the charts a filter (native
-    or cross-filter) currently applies to. Both surfaces share this contract,
-    so they share this remap. Unresolvable IDs are dropped rather than
-    passed through, matching the convention used for ``scope.excluded``.
-    """
-    charts_in_scope = container.get("chartsInScope")
-    if isinstance(charts_in_scope, list):
-        container["chartsInScope"] = [
-            id_map[old_id] for old_id in charts_in_scope if old_id in id_map
-        ]
-
-
 def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
     config: dict[str, Any],
     chart_ids: dict[str, int],

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -333,6 +333,107 @@ def test_update_id_refs_handles_missing_time_grains():
     assert "time_grains" not in filter_config
 
 
+def test_update_id_refs_cross_filter_uuid_keyed_config_remapped():
+    """
+    Test that UUID-keyed chart_configuration entries (from example exports) are
+    properly remapped to new integer IDs during import, including UUID values in
+    chartsInScope.
+
+    export_example.remap_chart_configuration produces chart_configuration keyed by
+    chart UUIDs with UUID values in crossFilters.chartsInScope.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+            "CHART2": {
+                "id": "CHART2",
+                "meta": {"chartId": 102, "uuid": "uuid2"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "chart_configuration": {
+                # UUID-keyed format from export_example
+                "uuid1": {
+                    "id": "uuid1",
+                    "crossFilters": {
+                        "chartsInScope": ["uuid2"],  # UUID reference
+                        "scope": {"excluded": []},
+                    },
+                },
+                "uuid2": {
+                    "id": "uuid2",
+                    "crossFilters": {
+                        "chartsInScope": ["uuid1"],  # UUID reference
+                        "scope": {"excluded": []},
+                    },
+                },
+            }
+        },
+    }
+
+    chart_ids = {"uuid1": 1, "uuid2": 2}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    chart_cfg = fixed["metadata"]["chart_configuration"]
+    # UUID keys should be remapped to new integer keys
+    assert "1" in chart_cfg
+    assert "2" in chart_cfg
+    assert "uuid1" not in chart_cfg
+    assert "uuid2" not in chart_cfg
+    # Inner id fields should be new integer IDs
+    assert chart_cfg["1"]["id"] == 1
+    assert chart_cfg["2"]["id"] == 2
+    # chartsInScope UUIDs should be remapped to new integer IDs
+    assert chart_cfg["1"]["crossFilters"]["chartsInScope"] == [2]
+    assert chart_cfg["2"]["crossFilters"]["chartsInScope"] == [1]
+
+
+def test_update_id_refs_cross_filter_uuid_keyed_unknown_preserved():
+    """
+    Test that UUID-keyed chart_configuration entries with no matching position
+    entry are preserved unchanged rather than silently dropped.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    unknown_uuid = "ffffffff-0000-0000-0000-000000000000"
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "chart_configuration": {
+                "101": {"id": 101, "crossFilters": {"scope": {"excluded": []}}},
+                unknown_uuid: {"id": unknown_uuid, "crossFilters": {}},
+            }
+        },
+    }
+
+    chart_ids = {"uuid1": 1}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    chart_cfg = fixed["metadata"]["chart_configuration"]
+    # Integer-keyed entry should be remapped
+    assert "1" in chart_cfg
+    assert "101" not in chart_cfg
+    # Unknown UUID-keyed entry should be preserved unchanged
+    assert unknown_uuid in chart_cfg
+
+
 def test_update_id_refs_cross_filter_charts_in_scope():
     """
     Test that chartsInScope references in cross-filter configurations are updated.

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -123,7 +123,7 @@ def test_update_native_filter_config_scope_excluded():
     }
 
 
-def test_update_native_filter_charts_in_scope():
+def test_update_native_filter_charts_in_scope() -> None:
     """
     Test that chartsInScope references in native filters are updated during import.
 
@@ -333,7 +333,7 @@ def test_update_id_refs_handles_missing_time_grains():
     assert "time_grains" not in filter_config
 
 
-def test_update_id_refs_cross_filter_uuid_keyed_config_remapped():
+def test_update_id_refs_cross_filter_uuid_keyed_config_remapped() -> None:
     """
     Test that UUID-keyed chart_configuration entries (from example exports) are
     properly remapped to new integer IDs during import, including UUID values in
@@ -397,7 +397,7 @@ def test_update_id_refs_cross_filter_uuid_keyed_config_remapped():
     assert chart_cfg["2"]["crossFilters"]["chartsInScope"] == [1]
 
 
-def test_update_id_refs_cross_filter_uuid_keyed_unknown_preserved():
+def test_update_id_refs_cross_filter_uuid_keyed_unknown_preserved() -> None:
     """
     Test that UUID-keyed chart_configuration entries with no matching position
     entry are preserved unchanged rather than silently dropped.
@@ -434,7 +434,7 @@ def test_update_id_refs_cross_filter_uuid_keyed_unknown_preserved():
     assert unknown_uuid in chart_cfg
 
 
-def test_update_id_refs_cross_filter_charts_in_scope():
+def test_update_id_refs_cross_filter_charts_in_scope() -> None:
     """
     Test that chartsInScope references in cross-filter configurations are updated.
 

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -123,6 +123,53 @@ def test_update_native_filter_config_scope_excluded():
     }
 
 
+def test_update_native_filter_charts_in_scope():
+    """
+    Test that chartsInScope references in native filters are updated during import.
+
+    This is a fix for issue #26338 - chartsInScope references were not being
+    updated to use new chart IDs during dashboard import.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+            "CHART2": {
+                "id": "CHART2",
+                "meta": {"chartId": 102, "uuid": "uuid2"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "native_filter_configuration": [{"chartsInScope": [101, 102, 103]}],
+        },
+    }
+    chart_ids = {"uuid1": 1, "uuid2": 2}
+    dataset_info: dict[str, dict[str, Any]] = {}  # not used
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+    assert fixed == {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 1, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+            "CHART2": {
+                "id": "CHART2",
+                "meta": {"chartId": 2, "uuid": "uuid2"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {"native_filter_configuration": [{"chartsInScope": [1, 2]}]},
+    }
+
+
 def test_update_id_refs_cross_filter_chart_configuration_key_and_excluded_mapping():
     from superset.commands.dashboard.importers.v1.utils import update_id_refs
 
@@ -284,3 +331,76 @@ def test_update_id_refs_handles_missing_time_grains():
     filter_config = fixed["metadata"]["native_filter_configuration"][0]
     assert filter_config.get("filterType") == "filter_timegrain"
     assert "time_grains" not in filter_config
+
+
+def test_update_id_refs_cross_filter_charts_in_scope():
+    """
+    Test that chartsInScope references in cross-filter configurations are updated.
+
+    This is a fix for issue #26338 - chartsInScope references in chart_configuration
+    and global_chart_configuration were not being updated during dashboard import.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+            "CHART2": {
+                "id": "CHART2",
+                "meta": {"chartId": 102, "uuid": "uuid2"},
+                "type": "CHART",
+            },
+            "CHART3": {
+                "id": "CHART3",
+                "meta": {"chartId": 103, "uuid": "uuid3"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "chart_configuration": {
+                "101": {
+                    "id": 101,
+                    "crossFilters": {
+                        "chartsInScope": [102, 103],
+                        "scope": {"excluded": [101]},
+                    },
+                },
+                "102": {
+                    "id": 102,
+                    "crossFilters": {
+                        "chartsInScope": [101, 103, 999],  # 999 should be dropped
+                        "scope": {"excluded": []},
+                    },
+                },
+            },
+            "global_chart_configuration": {
+                "chartsInScope": [101, 102, 103, 999],  # 999 should be dropped
+                "scope": {"excluded": [103]},
+            },
+        },
+    }
+
+    chart_ids = {"uuid1": 1, "uuid2": 2, "uuid3": 3}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    metadata = fixed["metadata"]
+
+    # Check chart_configuration chartsInScope is updated
+    assert metadata["chart_configuration"]["1"]["crossFilters"]["chartsInScope"] == [
+        2,
+        3,
+    ]
+    assert metadata["chart_configuration"]["2"]["crossFilters"]["chartsInScope"] == [
+        1,
+        3,
+    ]
+
+    # Check global_chart_configuration chartsInScope is updated
+    assert metadata["global_chart_configuration"]["chartsInScope"] == [1, 2, 3]
+    assert metadata["global_chart_configuration"]["scope"]["excluded"] == [3]

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -666,3 +666,76 @@ def test_update_id_refs_handles_missing_time_grains():
     filter_config = fixed["metadata"]["native_filter_configuration"][0]
     assert filter_config.get("filterType") == "filter_timegrain"
     assert "time_grains" not in filter_config
+
+
+def test_update_id_refs_cross_filter_charts_in_scope():
+    """
+    Test that chartsInScope references in cross-filter configurations are updated.
+
+    This is a fix for issue #26338 - chartsInScope references in chart_configuration
+    and global_chart_configuration were not being updated during dashboard import.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+            "CHART2": {
+                "id": "CHART2",
+                "meta": {"chartId": 102, "uuid": "uuid2"},
+                "type": "CHART",
+            },
+            "CHART3": {
+                "id": "CHART3",
+                "meta": {"chartId": 103, "uuid": "uuid3"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "chart_configuration": {
+                "101": {
+                    "id": 101,
+                    "crossFilters": {
+                        "chartsInScope": [102, 103],
+                        "scope": {"excluded": [101]},
+                    },
+                },
+                "102": {
+                    "id": 102,
+                    "crossFilters": {
+                        "chartsInScope": [101, 103, 999],  # 999 should be dropped
+                        "scope": {"excluded": []},
+                    },
+                },
+            },
+            "global_chart_configuration": {
+                "chartsInScope": [101, 102, 103, 999],  # 999 should be dropped
+                "scope": {"excluded": [103]},
+            },
+        },
+    }
+
+    chart_ids = {"uuid1": 1, "uuid2": 2, "uuid3": 3}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    metadata = fixed["metadata"]
+
+    # Check chart_configuration chartsInScope is updated
+    assert metadata["chart_configuration"]["1"]["crossFilters"]["chartsInScope"] == [
+        2,
+        3,
+    ]
+    assert metadata["chart_configuration"]["2"]["crossFilters"]["chartsInScope"] == [
+        1,
+        3,
+    ]
+
+    # Check global_chart_configuration chartsInScope is updated
+    assert metadata["global_chart_configuration"]["chartsInScope"] == [1, 2, 3]
+    assert metadata["global_chart_configuration"]["scope"]["excluded"] == [3]

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -668,7 +668,7 @@ def test_update_id_refs_handles_missing_time_grains():
     assert "time_grains" not in filter_config
 
 
-def test_update_id_refs_cross_filter_uuid_keyed_config_remapped():
+def test_update_id_refs_cross_filter_uuid_keyed_config_remapped() -> None:
     """
     Test that UUID-keyed chart_configuration entries (from example exports) are
     properly remapped to new integer IDs during import, including UUID values in
@@ -732,7 +732,7 @@ def test_update_id_refs_cross_filter_uuid_keyed_config_remapped():
     assert chart_cfg["2"]["crossFilters"]["chartsInScope"] == [1]
 
 
-def test_update_id_refs_cross_filter_uuid_keyed_unknown_preserved():
+def test_update_id_refs_cross_filter_uuid_keyed_unknown_preserved() -> None:
     """
     Test that UUID-keyed chart_configuration entries with no matching position
     entry are preserved unchanged rather than silently dropped.
@@ -769,7 +769,7 @@ def test_update_id_refs_cross_filter_uuid_keyed_unknown_preserved():
     assert unknown_uuid in chart_cfg
 
 
-def test_update_id_refs_cross_filter_charts_in_scope():
+def test_update_id_refs_cross_filter_charts_in_scope() -> None:
     """
     Test that chartsInScope references in cross-filter configurations are updated.
 

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -668,6 +668,107 @@ def test_update_id_refs_handles_missing_time_grains():
     assert "time_grains" not in filter_config
 
 
+def test_update_id_refs_cross_filter_uuid_keyed_config_remapped():
+    """
+    Test that UUID-keyed chart_configuration entries (from example exports) are
+    properly remapped to new integer IDs during import, including UUID values in
+    chartsInScope.
+
+    export_example.remap_chart_configuration produces chart_configuration keyed by
+    chart UUIDs with UUID values in crossFilters.chartsInScope.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+            "CHART2": {
+                "id": "CHART2",
+                "meta": {"chartId": 102, "uuid": "uuid2"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "chart_configuration": {
+                # UUID-keyed format from export_example
+                "uuid1": {
+                    "id": "uuid1",
+                    "crossFilters": {
+                        "chartsInScope": ["uuid2"],  # UUID reference
+                        "scope": {"excluded": []},
+                    },
+                },
+                "uuid2": {
+                    "id": "uuid2",
+                    "crossFilters": {
+                        "chartsInScope": ["uuid1"],  # UUID reference
+                        "scope": {"excluded": []},
+                    },
+                },
+            }
+        },
+    }
+
+    chart_ids = {"uuid1": 1, "uuid2": 2}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    chart_cfg = fixed["metadata"]["chart_configuration"]
+    # UUID keys should be remapped to new integer keys
+    assert "1" in chart_cfg
+    assert "2" in chart_cfg
+    assert "uuid1" not in chart_cfg
+    assert "uuid2" not in chart_cfg
+    # Inner id fields should be new integer IDs
+    assert chart_cfg["1"]["id"] == 1
+    assert chart_cfg["2"]["id"] == 2
+    # chartsInScope UUIDs should be remapped to new integer IDs
+    assert chart_cfg["1"]["crossFilters"]["chartsInScope"] == [2]
+    assert chart_cfg["2"]["crossFilters"]["chartsInScope"] == [1]
+
+
+def test_update_id_refs_cross_filter_uuid_keyed_unknown_preserved():
+    """
+    Test that UUID-keyed chart_configuration entries with no matching position
+    entry are preserved unchanged rather than silently dropped.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    unknown_uuid = "ffffffff-0000-0000-0000-000000000000"
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "chart_configuration": {
+                "101": {"id": 101, "crossFilters": {"scope": {"excluded": []}}},
+                unknown_uuid: {"id": unknown_uuid, "crossFilters": {}},
+            }
+        },
+    }
+
+    chart_ids = {"uuid1": 1}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    chart_cfg = fixed["metadata"]["chart_configuration"]
+    # Integer-keyed entry should be remapped
+    assert "1" in chart_cfg
+    assert "101" not in chart_cfg
+    # Unknown UUID-keyed entry should be preserved unchanged
+    assert unknown_uuid in chart_cfg
+
+
 def test_update_id_refs_cross_filter_charts_in_scope():
     """
     Test that chartsInScope references in cross-filter configurations are updated.


### PR DESCRIPTION
## **User description**
### SUMMARY

**Originally authored by @rdubois-kh in #26389** - This PR adopts and rebases the original contribution.

This PR fixes issue #26338: `chartsInScope` references are not fixed during a Dashboard import.

When a dashboard is imported using the `ImportDashboardsCommand` (v1), the chart ID references need to be updated to use the IDs of the newly created charts in the target instance. The original code was missing updates for `chartsInScope` references in several places:

1. **Native filter configuration** - `chartsInScope` in `native_filter_configuration` entries
2. **Global chart configuration** - `chartsInScope` in `global_chart_configuration`
3. **Per-chart cross-filter configuration** - `chartsInScope` in `chart_configuration[id].crossFilters`

This resulted in broken filter scoping after dashboard imports, where filters would reference old chart IDs that don't exist in the target instance.

**Changes made:**
- Added `chartsInScope` remapping in `update_id_refs()` for native filters
- Added `chartsInScope` remapping in `update_cross_filter_scoping()` for global and per-chart configurations
- Refactored `update_cross_filter_scoping()` to extract helper functions `_remap_chart_ids()` and `_update_cross_filter_scope()` to reduce complexity
- Added comprehensive unit tests for the new functionality

Fixes #26338

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend-only change

### TESTING INSTRUCTIONS

1. Create a dashboard with charts and configure native filters with specific charts in scope
2. Export the dashboard
3. Modify the exported ZIP to change chart UUIDs (simulating import to a different instance)
4. Import the modified dashboard
5. Verify that `chartsInScope` in the imported dashboard's `json_metadata` contains the correct new chart IDs

Or run the unit tests:
```bash
pytest tests/unit_tests/dashboards/commands/importers/v1/utils_test.py -v
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: #26338
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

**Attribution:** This PR adopts the work from #26389 by @rdubois-kh. The original PR needed a rebase due to conflicts with recent changes to the cross-filter scoping code.


___

## **CodeAnt-AI Description**
Fix chartsInScope references during dashboard import

### What Changed
- During dashboard import, chart ID references stored in native filters, global chart configuration, and per-chart cross-filter configuration (chartsInScope) are updated to the newly created chart IDs in the target instance; any unknown/removed IDs are dropped.
- Cross-filter scope exclusions are remapped consistently alongside chartsInScope, and per-chart configuration keys are renamed to the new chart IDs.
- Added unit tests covering native filters, chart_configuration, and global_chart_configuration chartsInScope remapping.

### Impact
`✅ Filters scope preserved after dashboard import`
`✅ Fewer broken filter references when importing dashboards between instances`
`✅ Clearer import failures by dropping unknown chart IDs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
