### PR TITLE
fix(handlebars): add missing currencyformatter.js dependency

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -22324,8 +22324,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/currencyformatter.js/-/currencyformatter.js-1.0.5.tgz",
       "integrity": "sha512-gNhjgPges50sAHOb56BeEOi33w88sED2nSiY0s9niq1S/64IKB8DB1EmJh8wv5PofFXpHWG91yptoDQAj5GI2w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cwd": {
       "version": "0.10.0",
@@ -53502,6 +53501,7 @@
       "version": "0.20.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "currencyformatter.js": "^1.0.5",
         "handlebars-group-by": "^1.0.1",
         "just-handlebars-helpers": "^1.0.19"
       },

--- a/superset-frontend/plugins/plugin-chart-handlebars/package.json
+++ b/superset-frontend/plugins/plugin-chart-handlebars/package.json
@@ -27,6 +27,7 @@
     "access": "public"
   },
   "dependencies": {
+    "currencyformatter.js": "^1.0.5",
     "handlebars-group-by": "^1.0.1",
     "just-handlebars-helpers": "^1.0.19"
   },


### PR DESCRIPTION
## Summary

Adds the missing `currencyformatter.js` dependency to the handlebars plugin.

The `just-handlebars-helpers` package has `currencyformatter.js` as a peer dependency for its `formatCurrency` helper. Without this dependency installed, webpack fails during build with:

```
Module not found: Error: Can't resolve 'currencyformatter.js' in '.../just-handlebars-helpers/lib/helpers'
```

This was blocking PR #37141 and potentially affecting other builds.

## Test plan

- [x] Build completes successfully with `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)