### PR TITLE
fix(excel): remove unwanted index column from Excel exports

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -259,7 +259,9 @@ class QueryContextProcessor:
                 )
             elif self._query_context.result_format == ChartDataResultFormat.XLSX:
                 excel.apply_column_types(df, coltypes)
-                result = excel.df_to_excel(df, **current_app.config["EXCEL_EXPORT"])
+                result = excel.df_to_excel(
+                    df, index=include_index, **current_app.config["EXCEL_EXPORT"]
+                )
             return result or ""
 
         return df.to_dict(orient="records")

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -126,7 +126,7 @@ def test_get_data_xlsx(
     result = processor.get_data(df, coltypes)
     assert result == b"binary data"
     mock_apply_column_types.assert_called_once_with(df, coltypes)
-    mock_df_to_excel.assert_called_once_with(df)
+    mock_df_to_excel.assert_called_once_with(df, index=False)
 
 
 def test_get_data_json(processor, mock_query_context):
@@ -201,7 +201,7 @@ def test_get_data_empty_dataframe_xlsx(
     result = processor.get_data(df, coltypes)
     assert result == b"binary data empty"
     mock_apply_column_types.assert_called_once_with(df, coltypes)
-    mock_df_to_excel.assert_called_once_with(df)
+    mock_df_to_excel.assert_called_once_with(df, index=False)
 
 
 def test_get_data_nan_values_json(processor, mock_query_context):


### PR DESCRIPTION
## Summary

The Excel export was including an unwanted index column (row numbers 0, 1, 2...) because `df.to_excel()` defaults to `index=True`. CSV export already handled this correctly by passing `index=include_index`.

This fix applies the same logic to Excel exports: only include the index column if the DataFrame has a custom index (not a RangeIndex).

**Before:**
![Image](https://github.com/user-attachments/assets/063a8240-2fe2-4939-9725-6f022dd4202b)

**After:** The first column with row numbers will no longer appear.

## Test plan

- [ ] Export a chart to Excel and verify no unwanted index column appears
- [ ] Verify CSV export still works correctly
- [ ] Verify DataFrames with custom indices still export the index

Closes #32113
Related: #22981, #29717

🤖 Generated with [Claude Code](https://claude.com/claude-code)