### PR TITLE
fix(security): fix Guest Token API 422 error by disabling JWT sub claim verification

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -2445,6 +2445,12 @@ EXTRA_DYNAMIC_QUERY_FILTERS: ExtraDynamicQueryFilters = {}
 # connection via the UI (without downtime).
 CATALOGS_SIMPLIFIED_MIGRATION: bool = False
 
+# Configure JWT subsystem to not enforce that the sub claim is a string
+# Set this variable to avoid breaking `/api/security` endpoints
+# TODO: remove this variable once pyjwt resolved the issue.
+# https://github.com/jpadilla/pyjwt/issues/1017
+# https://github.com/dpgaspar/Flask-AppBuilder/issues/2287
+JWT_VERIFY_SUB: bool = False
 
 # When updating a DB connection or manually triggering a perm sync, the command
 # happens in sync mode. If you have a celery worker configured, it's recommended


### PR DESCRIPTION
## Summary

PyJWT >= 2.10 enforces that the 'sub' claim must be a string, which breaks the `/api/v1/security/guest_token` and `/api/v1/security/csrf_token` endpoints when the subject is not a string, resulting in a 422 error with message "Subject must be string".

This adds `JWT_VERIFY_SUB = False` to the default config to disable this verification until the upstream issue is resolved.

**This is an adoption of #32244 by @hainenber**, rebased on current master.

## References

- https://github.com/jpadilla/pyjwt/issues/1017
- https://github.com/dpgaspar/Flask-AppBuilder/issues/2287

## Test plan

- [ ] Verify Guest Token API works without 422 error
- [ ] Verify CSRF token endpoint works correctly

Closes #32241
Supersedes #32244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: hainenber <dotronghai96@gmail.com>