### PR TITLE
fix(dashboard): fix drop zone vertical shift in tab columns during drag

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -242,6 +242,8 @@ const DashboardContentWrapper = styled.div`
     }
 
     & .dashboard-component-tabs-content {
+      position: relative;
+
       & > div:not(:last-child):not(.empty-droptarget) {
         margin-bottom: ${theme.sizeUnit * 4}px;
       }

--- a/superset-frontend/src/dashboard/components/DashboardGrid.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardGrid.tsx
@@ -81,7 +81,7 @@ const GridContent = styled.div<{ editMode?: boolean }>`
       ${!editMode && `margin-bottom: ${theme.sizeUnit * 4}px`};
     }
 
-    .empty-droptarget {
+    & > .empty-droptarget {
       width: 100%;
       height: ${theme.sizeUnit * 4}px;
       display: flex;

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.tsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.tsx
@@ -102,6 +102,8 @@ const DragDroppableStyles = styled.div`
         display: block;
         background-color: ${theme.colorPrimary};
         position: absolute;
+        top: 0;
+        left: 0;
         z-index: 10;
         opacity: 0.3;
         width: 100%;

--- a/superset-frontend/src/dashboard/components/gridComponents/Column/Column.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column/Column.tsx
@@ -109,6 +109,8 @@ const ColumnStyles = styled.div<{ editMode: boolean }>`
       }
       &:first-child:not(.droptarget-edge) {
         position: absolute;
+        top: 0;
+        left: 0;
         z-index: ${EMPTY_CONTAINER_Z_INDEX};
         width: 100%;
         height: 100%;


### PR DESCRIPTION
### SUMMARY
Drop zones (drop indicators) inside empty columns within tab components were vertically shifted up by ~50px when dragging charts into them. This PR fixes some CSS related to drop indicator positioning

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1728" height="843" alt="Screenshot 2026-02-23 at 17 48 11" src="https://github.com/user-attachments/assets/41d680b1-7d26-4519-80bc-62a751226a9b" />

After:

<img width="1728" height="843" alt="Screenshot 2026-02-23 at 17 47 59" src="https://github.com/user-attachments/assets/23052676-0f93-4d32-a941-7c405d6ee6a7" />


### TESTING INSTRUCTIONS
1. Open a dashboard in edit mode
2. Add a Tabs component
3. Inside the tab, add a Row with two empty Columns
4. Drag a chart from the right panel toward the empty columns
5. Verify the blue drop indicator overlay aligns correctly with the "Empty column" content areas (not shifted above them)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API