### PR TITLE
fix(docs): guard window reference in logging.ts for SSR compatibility

### DIFF
--- a/superset-frontend/packages/superset-core/src/utils/logging.ts
+++ b/superset-frontend/packages/superset-core/src/utils/logging.ts
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-const console = window.console || {};
+const console =
+  typeof window !== 'undefined' ? window.console || {} : globalThis.console;
 const log = console.log || (() => {});
 
 const logger = {


### PR DESCRIPTION
### SUMMARY

Fixes the Netlify docs build failure (`window is not defined`) that's been breaking deploy previews on all PRs.

**Root cause:** `superset-frontend/packages/superset-core/src/utils/logging.ts` references `window.console` at module initialization with no SSR guard. During Docusaurus SSG, this module gets evaluated in Node.js via the import chain:

```
alert.mdx → StorybookWrapper → @apache-superset/core/ui → Alert → translation → Translator → logging.ts
                                                                                                  ↑
                                                                              window.console (💥 in Node.js)
```

**Fix:** Add a `typeof window !== 'undefined'` guard with `globalThis.console` fallback for Node.js.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Every PR's Netlify deploy preview fails with:
```
Error: Can't render static file for pathname "/developer_portal/extensions/components/alert"
ReferenceError: window is not defined
```

**After:** SSG renders the page successfully with Node.js `globalThis.console` as fallback.

### TESTING INSTRUCTIONS

1. Build the docs site:
   ```bash
   cd docs
   npm install
   npm run build
   ```
2. Verify the build completes without `window is not defined` errors
3. Verify `/developer_portal/extensions/components/alert` renders correctly in the build output

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)