### PR TITLE
fix(build): restore automatic .d.ts generation in dev mode

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -217,24 +217,31 @@ if (!isDevMode) {
   );
 }
 
-// TypeScript type checking configuration
-// SWC handles transpilation. In production, type checking is done by:
-// 1. `npm run plugins:build` which generates .d.ts files
-// 2. `npm run type` which runs full TypeScript checking
-// We skip ForkTsCheckerWebpackPlugin in production because:
-// - Story files import from @storybook-shared which causes rootDir errors
-// - The above commands already provide comprehensive type checking
+// TypeScript type checking and .d.ts generation
+// SWC handles transpilation; this plugin handles type checking separately.
+// build: true enables project references so .d.ts files are auto-generated.
+// mode: 'write-references' writes .d.ts output (no manual `npm run plugins:build` needed).
+// Story files are excluded because they import @storybook-shared which resolves
+// outside plugin rootDir ("src"), causing errors in --build mode.
 if (isDevMode) {
   plugins.push(
     new ForkTsCheckerWebpackPlugin({
       async: true,
       typescript: {
+        build: true,
+        mode: 'write-references',
         memoryLimit: TYPESCRIPT_MEMORY_LIMIT,
         configOverwrite: {
           compilerOptions: {
             skipLibCheck: true,
             incremental: true,
           },
+          exclude: [
+            'src/**/*.js',
+            'src/**/*.jsx',
+            '**/*.test.*',
+            '**/*.stories.*',
+          ],
         },
       },
     }),


### PR DESCRIPTION
### SUMMARY

Re-enables `build: true` and `mode: 'write-references'` on `ForkTsCheckerWebpackPlugin` so that `.d.ts` files are generated automatically during webpack dev builds. This removes the need for developers to manually run `npm run plugins:build` after every change.

**Background:** PR #35946 (SWC migration) originally added these settings as essential for the dev workflow. PR #37771 had to remove them because story files that import from `@storybook-shared` (a webpack alias to `.storybook/shared/`) cause `rootDir` errors — each plugin tsconfig has `rootDir: "src"`, but `@storybook-shared` resolves outside that directory.

**Fix:** `ForkTsCheckerWebpackPlugin` supports `configOverwrite.exclude`, which is applied per-project during `--build` traversal. By excluding `**/*.stories.*` (and `**/*.test.*`), TypeScript never processes story files and thus never attempts to resolve `@storybook-shared`, eliminating the `rootDir` conflict. The existing plugin tsconfigs already exclude stories via their own `exclude` arrays — this change ensures the webpack plugin respects the same exclusion.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — build tooling change, no UI impact.

### TESTING INSTRUCTIONS

1. Run `npm run dev-server` (or `npm run dev`) in `superset-frontend/`
2. Verify the dev server starts without TypeScript rootDir errors
3. Modify a TypeScript file in a plugin (e.g., `plugins/plugin-chart-echarts/src/`)
4. Verify `.d.ts` files are generated in the plugin's `lib/` directory without needing to run `npm run plugins:build`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)