### PR TITLE
feat(pivot-table): rename subtotal labels to subvalue with aggregator

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -1073,7 +1073,9 @@ export function TableRenderer(props: TableRendererProps) {
                 true,
               )}
             >
-              {t('Subtotal')}
+              {t('Subvalue (%(aggregatorName)s)', {
+                aggregatorName: t(aggregatorName),
+              })}
             </th>,
           );
         }
@@ -1333,7 +1335,9 @@ export function TableRenderer(props: TableRendererProps) {
               true,
             )}
           >
-            {t('Subtotal')}
+            {t('Subvalue (%(aggregatorName)s)', {
+              aggregatorName: t(aggregatorName),
+            })}
           </th>
         ) : null;
 


### PR DESCRIPTION
## Summary
- update pivot table subtotal labels to include the active aggregator name
- replace static `Subtotal` with `Subvalue (%(aggregatorName)s)` in row and column subtotal headers

## Context
- addresses https://github.com/apache/superset/issues/35089

## Notes
- this keeps total labels unchanged and only updates subtotal header wording
