### PR TITLE
fix(extensions): make LOCAL_EXTENSIONS loading resilient to individual failures

### DIFF
--- a/superset/extensions/utils.py
+++ b/superset/extensions/utils.py
@@ -228,17 +228,20 @@ def get_extensions() -> dict[str, LoadedExtension]:
 
     # Load extensions from LOCAL_EXTENSIONS configuration (filesystem paths)
     for path in current_app.config["LOCAL_EXTENSIONS"]:
-        files = get_bundle_files_from_path(path)
-        # Use absolute filesystem path to dist directory for tracebacks
-        abs_dist_path = str((Path(path) / "dist").resolve())
-        extension = get_loaded_extension(files, source_base_path=abs_dist_path)
-        extension_id = extension.manifest.id
-        extensions[extension_id] = extension
-        logger.info(
-            "Loading extension %s (ID: %s) from local filesystem",
-            extension.name,
-            extension_id,
-        )
+        try:
+            files = get_bundle_files_from_path(path)
+            # Use absolute filesystem path to dist directory for tracebacks
+            abs_dist_path = str((Path(path) / "dist").resolve())
+            extension = get_loaded_extension(files, source_base_path=abs_dist_path)
+            extension_id = extension.manifest.id
+            extensions[extension_id] = extension
+            logger.info(
+                "Loading extension %s (ID: %s) from local filesystem",
+                extension.name,
+                extension_id,
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error("Failed to load extension from %s: %s", path, e)
 
     # Load extensions from discovery path (.supx files)
     if extensions_path := current_app.config.get("EXTENSIONS_PATH"):


### PR DESCRIPTION
### SUMMARY

Previously, a single misconfigured or broken extension in `LOCAL_EXTENSIONS` (e.g. a missing `dist/` directory) would raise an unhandled exception and abort loading of all extensions.

This change wraps each `LOCAL_EXTENSIONS` entry in a `try/except` block so that a failure in one extension is logged and skipped, allowing the remaining extensions to load normally. The error logging pattern matches the one already used in `discover_and_load_extensions`.

**Before:** one bad extension path crashes the entire extension loading pipeline.
**After:** one bad extension path logs an error and is skipped; other extensions load normally.

### TESTING INSTRUCTIONS

1. Add a path to `LOCAL_EXTENSIONS` in `superset_config.py` that does not have a `dist/` directory, e.g.:
   ```python
   LOCAL_EXTENSIONS = ["/path/to/broken-extension", "/path/to/valid-extension"]
   ```
2. Start Superset.
3. **Before:** `GET /api/v1/extensions/` returns a 500 error and no extensions load.
4. **After:** the broken path produces a `logger.error` entry and the valid extension loads successfully.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
