### PR TITLE
fix(query): normalize ad-hoc SQL expressions in QueryObject.cache_key

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name
 from __future__ import annotations
 
+import copy
 import logging
 from datetime import datetime
 from pprint import pformat
@@ -420,9 +421,38 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         the use-provided inputs to bounds, which may be time-relative (as in
         "5 days ago" or "now").
         """
-        # Cast to dict[str, Any] for mutation operations
-        cache_dict: dict[str, Any] = dict(self.to_dict())
+        # Use deepcopy to prevent mutation of original objects (nested metrics/columns)
+        cache_dict: dict[str, Any] = copy.deepcopy(self.to_dict())  # type: ignore[arg-type]
         cache_dict.update(extra)
+
+        def _normalize_sql(value: Any) -> Any:
+            if isinstance(value, str):
+                return value.replace("\r\n", "\n").strip()
+            return value
+
+        # Normalize SQL expressions to ensure deterministic cache keys
+        for metric in cache_dict.get("metrics") or []:
+            if isinstance(metric, dict) and metric.get("expressionType") == "SQL":
+                metric["sqlExpression"] = _normalize_sql(metric.get("sqlExpression"))
+
+        for column in cache_dict.get("columns") or []:
+            if isinstance(column, dict) and column.get("expressionType") == "SQL":
+                column["sqlExpression"] = _normalize_sql(column.get("sqlExpression"))
+
+        for order in cache_dict.get("orderby") or []:
+            if (
+                isinstance(order, (list, tuple))
+                and len(order) > 0
+                and isinstance(order[0], dict)
+                and order[0].get("expressionType") == "SQL"
+            ):
+                order[0]["sqlExpression"] = _normalize_sql(
+                    order[0].get("sqlExpression")
+                )
+
+        # NOTE: Only normalize ad-hoc SQL expressions here.
+        # where and having clauses are already sanitized in validate() during
+        # the query execution lifecycle.
 
         # TODO: the below KVs can all be cleaned up and moved to `to_dict()` at some
         #  predetermined point in time when orgs are aware that the previously

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -450,6 +450,15 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                     order[0].get("sqlExpression")
                 )
 
+        series_limit_metric = cache_dict.get("series_limit_metric")
+        if (
+            isinstance(series_limit_metric, dict)
+            and series_limit_metric.get("expressionType") == "SQL"
+        ):
+            series_limit_metric["sqlExpression"] = _normalize_sql(
+                series_limit_metric.get("sqlExpression")
+            )
+
         # NOTE: Only normalize ad-hoc SQL expressions here.
         # where and having clauses are already sanitized in validate() during
         # the query execution lifecycle.

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import copy
 from unittest.mock import call, patch
 
 from flask_appbuilder.security.sqla.models import User
@@ -386,3 +387,127 @@ def test_cache_key_cache_impersonation_on_with_different_user_and_db_impersonati
         ],
         any_order=True,
     )
+
+
+def test_cache_key_normalization_metrics_crlf():
+    """Verify CRLF vs LF parity in Metrics"""
+    metric_crlf = {
+        "expressionType": "SQL",
+        "sqlExpression": "SELECT *\r\nFROM table\r\nWHERE x = 1",
+    }
+    metric_lf = {
+        "expressionType": "SQL",
+        "sqlExpression": "SELECT *\nFROM table\nWHERE x = 1",
+    }
+
+    qo_crlf = QueryObject(metrics=[metric_crlf])
+    qo_lf = QueryObject(metrics=[metric_lf])
+
+    assert qo_crlf.cache_key() == qo_lf.cache_key()
+
+
+def test_cache_key_normalization_columns_crlf():
+    """Verify CRLF vs LF parity in Columns"""
+    column_crlf = {
+        "expressionType": "SQL",
+        "sqlExpression": "CASE WHEN x THEN 1\r\nELSE 0 END",
+    }
+    column_lf = {
+        "expressionType": "SQL",
+        "sqlExpression": "CASE WHEN x THEN 1\nELSE 0 END",
+    }
+
+    qo_crlf = QueryObject(columns=[column_crlf])
+    qo_lf = QueryObject(columns=[column_lf])
+
+    assert qo_crlf.cache_key() == qo_lf.cache_key()
+
+
+def test_cache_key_normalization_whitespace():
+    """Verify whitespace stripping in SQL expressions"""
+    metric_space = {"expressionType": "SQL", "sqlExpression": "  SELECT * FROM table  "}
+    metric_no_space = {"expressionType": "SQL", "sqlExpression": "SELECT * FROM table"}
+
+    qo_space = QueryObject(metrics=[metric_space])
+    qo_no_space = QueryObject(metrics=[metric_no_space])
+
+    assert qo_space.cache_key() == qo_no_space.cache_key()
+
+
+def test_cache_key_normalization_orderby_defensive():
+    """Verify defensive normalization of OrderBy structures"""
+    metric_sql = {"expressionType": "SQL", "sqlExpression": "col\r\n"}
+    # Standard orderby structure: [(metric_dict, ascend_bool)]
+    qo1 = QueryObject(orderby=[(metric_sql, True)])
+
+    metric_sql_clean = {"expressionType": "SQL", "sqlExpression": "col"}
+    qo2 = QueryObject(orderby=[(metric_sql_clean, True)])
+
+    assert qo1.cache_key() == qo2.cache_key()
+
+
+def test_cache_key_no_side_effects():
+    """Verify that cache_key generation does not mutate the original object"""
+    metric_sql = {"expressionType": "SQL", "sqlExpression": "SELECT *\r\nFROM table "}
+    qo = QueryObject(metrics=[metric_sql])
+    original_dict = copy.deepcopy(qo.to_dict())
+
+    # Generate cache key multiple times
+    key1 = qo.cache_key()
+    key2 = qo.cache_key()
+
+    assert key1 == key2
+    # Ensure original object is not mutated
+    assert qo.to_dict() == original_dict
+    assert qo.metrics[0]["sqlExpression"] == "SELECT *\r\nFROM table "
+
+
+def test_cache_key_non_sql_metrics_unchanged():
+    """Verify that non-SQL metrics are handled without modification"""
+    metrics = ["count", {"expressionType": "SIMPLE", "column": {"column_name": "x"}}]
+    qo = QueryObject(metrics=metrics)
+    # Should not crash and should work normally
+    key = qo.cache_key()
+    assert key is not None
+
+
+def test_cache_key_mixed_metrics():
+    """Verify that mixed metrics (names and ad-hoc SQL) are handled correctly"""
+    metric_sql = {"expressionType": "SQL", "sqlExpression": "SELECT 1\r\n"}
+    metric_name = "count"
+    qo = QueryObject(metrics=[metric_sql, metric_name])
+
+    # Normalization should happen for the SQL one
+    key1 = qo.cache_key()
+
+    metric_sql_clean = {"expressionType": "SQL", "sqlExpression": "SELECT 1"}
+    qo_clean = QueryObject(metrics=[metric_sql_clean, metric_name])
+    key2 = qo_clean.cache_key()
+
+    assert key1 == key2
+
+
+def test_cache_key_normalization_mixed_newlines():
+    """Verify that expressions with mixed \\r\\n and \\n are unified"""
+    metric_mixed = {
+        "expressionType": "SQL",
+        "sqlExpression": "SELECT 1\r\nFROM t\nWHERE 1=1\r\n",
+    }
+    metric_clean = {
+        "expressionType": "SQL",
+        "sqlExpression": "SELECT 1\nFROM t\nWHERE 1=1",
+    }
+
+    qo_mixed = QueryObject(metrics=[metric_mixed])
+    qo_clean = QueryObject(metrics=[metric_clean])
+
+    assert qo_mixed.cache_key() == qo_clean.cache_key()
+
+
+def test_cache_key_orderby_malformed_defensive():
+    """Verify that malformed OrderBy structures do not cause crashes"""
+    qo = QueryObject(
+        orderby=[None, ("not_a_dict", True), ({"no_expression_type": "x"}, False)]
+    )
+    key = qo.cache_key()
+    assert key is not None


### PR DESCRIPTION
## **User description**
### SUMMARY

When `GLOBAL_ASYNC_QUERIES` is enabled, the web server and Celery workers independently generate cache keys for the same query. Formatting differences in ad-hoc SQL expressions (e.g., `\r\n` vs `\n`, leading/trailing whitespace) can result in different `QueryObject.cache_key()` values, leading to HTTP 422 errors due to async cache mismatches.

While `where` and `having` clauses are sanitized during `validate()`, ad-hoc SQL expressions in the following fields were not normalized prior to hashing:

* `metrics` (adhoc SQL)
* `columns` (adhoc SQL)
* `orderby` (adhoc SQL)

This patch introduces a minimal normalization step inside `QueryObject.cache_key()` to ensure deterministic hash generation:

* Uses `copy.deepcopy(self.to_dict())` to prevent mutation.
* Normalizes CRLF (`\r\n`) to LF (`\n`).
* Strips leading/trailing whitespace.
* Applies normalization only when `expressionType == "SQL"` (defensive guard).
* Does **not** render Jinja or modify execution lifecycle.

This change is strictly limited to formatting normalization in the hashing layer and does not alter query semantics or template processing.

Fixes #37114

---

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (backend-only change).

---

### TESTING INSTRUCTIONS

#### Automated Tests

Run:

```
pytest tests/unit_tests/queries/query_object_test.py
```

Test coverage includes:

* CRLF vs LF parity
* Mixed newline normalization
* Leading/trailing whitespace normalization
* Mixed metric types (string + adhoc SQL)
* Defensive `orderby` structure handling
* No mutation of original `QueryObject`

#### Manual Verification

1. Enable `GLOBAL_ASYNC_QUERIES = True` in `superset_config.py`.
2. Create or edit a chart with:

   * An ad-hoc SQL metric containing multiple lines (including CRLF if possible).
   * Or a custom SQL expression in `Sort by`.
3. Load the chart/dashboard.
4. Confirm:

   * No HTTP 422 error occurs.
   * Async query executes successfully.
   * Cache key remains consistent between web and worker processes.

---

### ADDITIONAL INFORMATION

* [x] Has associated issue: #37114
* [ ] Required feature flags
* [ ] Changes UI
* [ ] Includes DB Migration
* [ ] Introduces new feature or API
* [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Normalize ad-hoc SQL in query cache keys to prevent async cache mismatches

### What Changed
- Query cache key generation now normalizes ad-hoc SQL expressions by converting CRLF to LF and trimming surrounding whitespace for metrics, columns, order-by entries, and series_limit_metric
- Cache key generation uses a deep copy of the query object to avoid mutating the original QueryObject
- Added tests covering CRLF vs LF, mixed newlines, leading/trailing whitespace, mixed metric types, defensive order-by handling, malformed order-by entries, and no side effects

### Impact
`✅ Fewer async cache mismatches between web server and workers`
`✅ Fewer HTTP 422 errors caused by cache-key formatting differences`
`✅ Deterministic cache keys without mutating query objects`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
