### PR TITLE
fix(dataset-modal): prevent shift-select from selecting search-hidden items

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -45,23 +45,14 @@ const DatasourceEditor = AsyncEsmComponent(
 );
 
 const StyledDatasourceModal = styled(Modal)`
-  .modal-content {
+  && .ant-modal-content {
     height: 900px;
+  }
+
+  && .ant-modal-body {
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
-    align-items: stretch;
-  }
-
-  .modal-header {
-    flex: 0 1 auto;
-  }
-  .modal-body {
-    flex: 1 1 auto;
-    overflow: auto;
-  }
-
-  .modal-footer {
-    flex: 0 1 auto;
   }
 
   .ant-tabs-top {

--- a/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
@@ -250,7 +250,9 @@ export default function FoldersEditor({
         // Range selection when shift is held and we have a previous selection
         if (shiftKey && selected && lastSelectedId) {
           const selectableItems = flattenedItems.filter(
-            item => item.type !== FoldersEditorItemType.Folder,
+            item =>
+              item.type !== FoldersEditorItemType.Folder &&
+              visibleItemIds.has(item.uuid),
           );
 
           const currentIndex = selectableItems.findIndex(
@@ -277,7 +279,7 @@ export default function FoldersEditor({
         return newSet;
       });
     },
-    [flattenedItems],
+    [flattenedItems, visibleItemIds],
   );
 
   const handleStartEdit = useCallback((folderId: string) => {

--- a/superset-frontend/src/components/Datasource/FoldersEditor/styles.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/styles.tsx
@@ -22,7 +22,7 @@ export const FoldersContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: relative;
-  height: 70vh;
+  height: 100%;
   gap: ${({ theme }) => theme.paddingMD}px;
 `;
 

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -319,6 +319,11 @@ interface OwnersSelectorProps {
 }
 
 const DatasourceContainer = styled.div`
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+
   .change-warning {
     margin: 16px 10px 0;
     color: ${({ theme }) => theme.colorWarning};
@@ -347,9 +352,23 @@ const FlexRowContainer = styled.div`
 `;
 
 const StyledTableTabs = styled(Tabs)`
-  overflow: visible;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+
   .ant-tabs-content-holder {
-    overflow: visible;
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+  }
+
+  .ant-tabs-content {
+    height: 100%;
+  }
+
+  .ant-tabs-tabpane-active {
+    height: 100%;
   }
 `;
 


### PR DESCRIPTION
### SUMMARY

When search is active in the dataset modal's Folders tab, shift-clicking to range-select items would also select items hidden by the search filter. This is because the shift-select logic filtered `flattenedItems` to exclude only folders, but did not exclude items hidden by the search.

The fix adds a `visibleItemIds.has(item.uuid)` check to the selectable items filter, so only items matching the current search query are included in the shift-click range selection.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. Open a dataset modal and go to the Folders tab
2. Type a search term that filters down the list of metrics/columns
3. Click one visible item, then shift-click another visible item
4. Verify that only visible (search-matching) items in the range are selected, not hidden ones

### ADDITIONAL INFORMATION

- [] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API