### PR TITLE
fix(mcp): use broad Exception in outermost tool-level handlers

### DIFF
--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -26,7 +26,6 @@ from fastmcp import Context
 from superset_core.mcp import tool
 
 from superset.commands.exceptions import CommandException
-from superset.exceptions import SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.auth import has_dataset_access
 from superset.mcp_service.chart.chart_utils import (
@@ -545,7 +544,7 @@ async def generate_chart(  # noqa: C901
         )
         return GenerateChartResponse.model_validate(result)
 
-    except (CommandException, SupersetException, ValueError, KeyError) as e:
+    except Exception as e:
         await ctx.error(
             "Chart generation failed: error=%s, execution_time_ms=%s"
             % (

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -691,7 +691,7 @@ async def get_chart_data(  # noqa: C901
                 error_type="DataError",
             )
 
-    except (CommandException, SupersetException, ValueError, KeyError) as e:
+    except Exception as e:
         await ctx.error(
             "Chart data retrieval failed: identifier=%s, error=%s, error_type=%s"
             % (

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -2110,14 +2110,7 @@ async def get_chart_preview(
             )
 
         return result
-    except (
-        CommandException,
-        SupersetException,
-        ValueError,
-        KeyError,
-        AttributeError,
-        TypeError,
-    ) as e:
+    except Exception as e:
         await ctx.error(
             "Chart preview generation failed: identifier=%s, error=%s, error_type=%s"
             % (


### PR DESCRIPTION
### SUMMARY

The MCP tool functions (`generate_chart`, `get_chart_data`, `get_chart_preview`) are the outermost boundary for MCP requests. If an unexpected exception escapes these handlers, the MCP client receives an unhandled crash instead of a structured error response.

This changes the outermost `except` clause in each tool function from a specific exception tuple to `except Exception`, ensuring all errors are caught and returned as clean error responses. Inner/utility handlers continue to catch specific exception types for proper error categorization.

Follow-up to #37185.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - no UI changes

### TESTING INSTRUCTIONS
1. All 624 MCP service unit tests pass
2. Verify that unexpected exceptions in tool functions return structured error responses instead of crashing

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API