### PR TITLE
fix(dataset-modal): prevent shift-select from selecting search-hidden items

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
@@ -250,7 +250,9 @@ export default function FoldersEditor({
         // Range selection when shift is held and we have a previous selection
         if (shiftKey && selected && lastSelectedId) {
           const selectableItems = flattenedItems.filter(
-            item => item.type !== FoldersEditorItemType.Folder,
+            item =>
+              item.type !== FoldersEditorItemType.Folder &&
+              visibleItemIds.has(item.uuid),
           );
 
           const currentIndex = selectableItems.findIndex(
@@ -277,7 +279,7 @@ export default function FoldersEditor({
         return newSet;
       });
     },
-    [flattenedItems],
+    [flattenedItems, visibleItemIds],
   );
 
   const handleStartEdit = useCallback((folderId: string) => {


### PR DESCRIPTION
### SUMMARY

When search is active in the dataset modal's Folders tab, shift-clicking to range-select items would also select items hidden by the search filter. This is because the shift-select logic filtered `flattenedItems` to exclude only folders, but did not exclude items hidden by the search.

The fix adds a `visibleItemIds.has(item.uuid)` check to the selectable items filter, so only items matching the current search query are included in the shift-click range selection.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. Open a dataset modal and go to the Folders tab
2. Type a search term that filters down the list of metrics/columns
3. Click one visible item, then shift-click another visible item
4. Verify that only visible (search-matching) items in the range are selected, not hidden ones

### ADDITIONAL INFORMATION

- [x] Has associated issue: https://app.shortcut.com/preset/story/99964
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API