### PR TITLE
fix(dataset-modal): show warning toast when dropping items outside folders

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useDragHandlers.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useDragHandlers.ts
@@ -297,6 +297,8 @@ export function useDragHandlers({
     let hasNonFolderItems = false;
     let hasDraggedFolder = false;
     let hasDraggedDefaultFolder = false;
+    let hasDraggedColumn = false;
+    let hasDraggedMetric = false;
     for (const item of draggedItems) {
       if (item.type === FoldersEditorItemType.Folder) {
         hasDraggedFolder = true;
@@ -305,11 +307,24 @@ export function useDragHandlers({
         }
       } else {
         hasNonFolderItems = true;
+        if (item.type === FoldersEditorItemType.Column) {
+          hasDraggedColumn = true;
+        }
+        if (item.type === FoldersEditorItemType.Metric) {
+          hasDraggedMetric = true;
+        }
       }
     }
 
     if (hasNonFolderItems) {
       if (!projectedPosition || !projectedPosition.parentId) {
+        if (hasDraggedColumn && hasDraggedMetric) {
+          addWarningToast(t('Columns and metrics should be inside folders'));
+        } else if (hasDraggedColumn) {
+          addWarningToast(t('Columns should be inside folders'));
+        } else {
+          addWarningToast(t('Metrics should be inside folders'));
+        }
         return;
       }
     }


### PR DESCRIPTION
### SUMMARY

When dragging columns or metrics outside of any folder in the dataset folders editor, the drop was silently rejected with no feedback. This adds a warning toast to inform users that items should be placed inside folders.

The message is context-aware:
- **Columns only**: "Columns should be inside folders"
- **Metrics only**: "Metrics should be inside folders"
- **Both**: "Columns and metrics should be inside folders"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**: Dropping items outside folders silently does nothing.
**After**: A warning toast appears explaining that items should be inside folders.

### TESTING INSTRUCTIONS
1. Enable feature flag `DATASET_FOLDERS`
2. Open a dataset with multiple metrics and columns
3. Drag a column and drop it outside of any folder (e.g., in the empty space between folders or at root level)
4. Verify a warning toast appears: "Columns should be inside folders"
5. Repeat with a metric — toast should say "Metrics should be inside folders"
6. Select both a column and a metric, drag outside folders — toast should say "Columns and metrics should be inside folders"

### ADDITIONAL INFORMATION
- [ ] Has associated issue: 
- [x] Required feature flags: `DATASET_FOLDERS`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

FEATURE_DATASET_FOLDERS=true