### PR TITLE
fix(dataset-modal): fix drag overlay shift caused by modal transform containing block

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useContainingBlockModifier.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useContainingBlockModifier.ts
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { Modifier } from '@dnd-kit/core';
+
+/**
+ * Finds the nearest ancestor element that creates a containing block for
+ * position:fixed elements. Per CSS spec, an ancestor with transform,
+ * will-change:transform, filter, perspective, or contain:paint establishes
+ * a new containing block for fixed-position descendants.
+ */
+function findContainingBlockAncestor(
+  element: HTMLElement,
+): HTMLElement | null {
+  let ancestor = element.parentElement;
+  while (ancestor && ancestor !== document.documentElement) {
+    const style = window.getComputedStyle(ancestor);
+    if (
+      (style.transform && style.transform !== 'none') ||
+      style.willChange === 'transform' ||
+      (style.filter && style.filter !== 'none') ||
+      (style.perspective && style.perspective !== 'none')
+    ) {
+      return ancestor;
+    }
+    ancestor = ancestor.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Hook that returns a DragOverlay modifier to compensate for CSS transform
+ * on ancestor elements. When the FoldersEditor is rendered inside a draggable
+ * modal (react-draggable), the modal's transform: translate() creates a new
+ * containing block for position:fixed elements. dnd-kit's DragOverlay uses
+ * position:fixed with viewport-relative coordinates, causing it to be offset
+ * by the ancestor's position. This modifier subtracts that offset.
+ */
+export function useContainingBlockModifier(
+  containerRef: React.RefObject<HTMLElement | null>,
+): Modifier[] {
+  const containingBlockRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containingBlockRef.current = findContainingBlockAncestor(
+        containerRef.current,
+      );
+    }
+  }, [containerRef]);
+
+  const modifier: Modifier = useCallback(({ transform }) => {
+    if (!containingBlockRef.current) return transform;
+    const rect = containingBlockRef.current.getBoundingClientRect();
+    return {
+      ...transform,
+      x: transform.x - rect.left,
+      y: transform.y - rect.top,
+    };
+  }, []);
+
+  return useMemo(() => [modifier], [modifier]);
+}

--- a/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useContainingBlockModifier.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useContainingBlockModifier.ts
@@ -26,9 +26,7 @@ import type { Modifier } from '@dnd-kit/core';
  * will-change:transform, filter, perspective, or contain:paint establishes
  * a new containing block for fixed-position descendants.
  */
-function findContainingBlockAncestor(
-  element: HTMLElement,
-): HTMLElement | null {
+function findContainingBlockAncestor(element: HTMLElement): HTMLElement | null {
   let ancestor = element.parentElement;
   while (ancestor && ancestor !== document.documentElement) {
     const style = window.getComputedStyle(ancestor);

--- a/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
@@ -55,6 +55,7 @@ import { FoldersContainer, FoldersContent } from './styles';
 import { FoldersEditorProps } from './types';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { useDragHandlers } from './hooks/useDragHandlers';
+import { useContainingBlockModifier } from './hooks/useContainingBlockModifier';
 import { useItemHeights } from './hooks/useItemHeights';
 import { useHeightCache } from './hooks/useHeightCache';
 import {
@@ -89,6 +90,8 @@ export default function FoldersEditor({
   const [showResetConfirm, setShowResetConfirm] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor, pointerSensorOptions));
+  const contentRef = useRef<HTMLDivElement>(null);
+  const dragOverlayModifiers = useContainingBlockModifier(contentRef);
 
   const fullFlattenedItems = useMemo(() => flattenTree(items), [items]);
 
@@ -408,7 +411,7 @@ export default function FoldersEditor({
         onResetToDefault={handleResetToDefault}
         allVisibleSelected={allVisibleSelected}
       />
-      <FoldersContent>
+      <FoldersContent ref={contentRef}>
         <DndContext
           sensors={sensors}
           measuring={measuringConfig}
@@ -453,7 +456,7 @@ export default function FoldersEditor({
             </AutoSizer>
           </SortableContext>
 
-          <DragOverlay>
+          <DragOverlay modifiers={dragOverlayModifiers}>
             <DragOverlayContent
               dragOverlayItems={dragOverlayItems}
               dragOverlayWidth={dragOverlayWidth}


### PR DESCRIPTION
### SUMMARY
PR #37555 added `draggable` and `resizable` to the DatasourceModal. The `draggable` prop wraps the modal in `react-draggable`, which applies `transform: translate(0px, 0px)` to a wrapper element. Per CSS spec, any ancestor with a CSS `transform` creates a new containing block for `position: fixed` descendants.

dnd-kit's `DragOverlay` uses `position: fixed` with viewport-relative coordinates from `getBoundingClientRect()`, so it gets offset by the modal's position within the viewport (~200px to the right).

This adds a custom dnd-kit modifier (`useContainingBlockModifier`) that detects the nearest ancestor creating a containing block and subtracts its viewport offset from the overlay transform, restoring correct positioning.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/3407405d-7a7a-494a-843b-3d5820f350e9

After:

https://github.com/user-attachments/assets/9778f17a-202d-4a74-bba8-286a3780e5a8



### TESTING INSTRUCTIONS
1. Open the dataset editor modal (Edit Dataset)
2. Go to the Folders tab
3. Select one or more items
4. Drag them — the overlay should follow the cursor correctly, not be shifted to the right

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)