### PR TITLE
fix(clickhouse): remove _mutate_label workaround and bump clickhouse-connect to >=0.13.0

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,10 @@ assists people when migrating to a new version.
 
 ## Next
 
+### ClickHouse minimum driver version bump
+
+The minimum required version of `clickhouse-connect` has been raised to `>=0.13.0`. If you are using the ClickHouse connector, please upgrade your `clickhouse-connect` package. The `_mutate_label` workaround that appended hash suffixes to column aliases has also been removed, as it is no longer needed with modern versions of the driver.
+
 ### MCP Tool Observability
 
 MCP (Model Context Protocol) tools now include enhanced observability instrumentation for monitoring and debugging:

--- a/docs/src/data/databases.json
+++ b/docs/src/data/databases.json
@@ -751,14 +751,14 @@
           "OPEN_SOURCE"
         ],
         "pypi_packages": [
-          "clickhouse-connect>=0.6.8"
+          "clickhouse-connect>=0.13.0"
         ],
         "connection_string": "clickhousedb://{username}:{password}@{host}:{port}/{database}",
         "default_port": 8123,
         "drivers": [
           {
             "name": "clickhouse-connect (Recommended)",
-            "pypi_package": "clickhouse-connect>=0.6.8",
+            "pypi_package": "clickhouse-connect>=0.13.0",
             "connection_string": "clickhousedb://{username}:{password}@{host}:{port}/{database}",
             "is_recommended": true,
             "notes": "Official ClickHouse Python driver with native protocol support."
@@ -781,7 +781,7 @@
             "connection_string": "clickhousedb://localhost/default"
           }
         ],
-        "install_instructions": "echo \"clickhouse-connect>=0.6.8\" >> ./docker/requirements-local.txt",
+        "install_instructions": "echo \"clickhouse-connect>=0.13.0\" >> ./docker/requirements-local.txt",
         "compatible_databases": [
           {
             "name": "ClickHouse Cloud",
@@ -794,7 +794,7 @@
               "HOSTED_OPEN_SOURCE"
             ],
             "pypi_packages": [
-              "clickhouse-connect>=0.6.8"
+              "clickhouse-connect>=0.13.0"
             ],
             "connection_string": "clickhousedb://{username}:{password}@{host}:8443/{database}?secure=true",
             "parameters": {
@@ -816,7 +816,7 @@
               "HOSTED_OPEN_SOURCE"
             ],
             "pypi_packages": [
-              "clickhouse-connect>=0.6.8"
+              "clickhouse-connect>=0.13.0"
             ],
             "connection_string": "clickhousedb://{username}:{password}@{host}/{database}?secure=true",
             "docs_url": "https://docs.altinity.com/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ bigquery = [
     "sqlalchemy-bigquery>=1.15.0",
     "google-cloud-bigquery>=3.10.0",
 ]
-clickhouse = ["clickhouse-connect>=0.5.14, <1.0"]
+clickhouse = ["clickhouse-connect>=0.13.0, <1.0"]
 cockroachdb = ["cockroachdb>=0.3.5, <0.4"]
 crate = ["sqlalchemy-cratedb>=0.40.1, <1"]
 d1 = [

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -42,7 +42,6 @@ from superset.db_engine_specs.exceptions import SupersetDBAPIDatabaseError
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.extensions import cache_manager
 from superset.utils.core import GenericDataType
-from superset.utils.hashing import hash_from_str
 from superset.utils.network import is_hostname_valid, is_port_open
 
 if TYPE_CHECKING:
@@ -288,13 +287,13 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
             DatabaseCategory.ANALYTICAL_DATABASES,
             DatabaseCategory.OPEN_SOURCE,
         ],
-        "pypi_packages": ["clickhouse-connect>=0.6.8"],
+        "pypi_packages": ["clickhouse-connect>=0.13.0"],
         "connection_string": "clickhousedb://{username}:{password}@{host}:{port}/{database}",
         "default_port": 8123,
         "drivers": [
             {
                 "name": "clickhouse-connect (Recommended)",
-                "pypi_package": "clickhouse-connect>=0.6.8",
+                "pypi_package": "clickhouse-connect>=0.13.0",
                 "connection_string": (
                     "clickhousedb://{username}:{password}@{host}:{port}/{database}"
                 ),
@@ -330,7 +329,7 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
             },
         ],
         "install_instructions": (
-            'echo "clickhouse-connect>=0.6.8" >> ./docker/requirements-local.txt'
+            'echo "clickhouse-connect>=0.13.0" >> ./docker/requirements-local.txt'
         ),
         "compatible_databases": [
             {
@@ -347,7 +346,7 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
                     DatabaseCategory.CLOUD_DATA_WAREHOUSES,
                     DatabaseCategory.HOSTED_OPEN_SOURCE,
                 ],
-                "pypi_packages": ["clickhouse-connect>=0.6.8"],
+                "pypi_packages": ["clickhouse-connect>=0.13.0"],
                 "connection_string": (
                     "clickhousedb://{username}:{password}@{host}:8443/{database}?secure=true"
                 ),
@@ -372,7 +371,7 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
                     DatabaseCategory.CLOUD_DATA_WAREHOUSES,
                     DatabaseCategory.HOSTED_OPEN_SOURCE,
                 ],
-                "pypi_packages": ["clickhouse-connect>=0.6.8"],
+                "pypi_packages": ["clickhouse-connect>=0.13.0"],
                 "connection_string": (
                     "clickhousedb://{username}:{password}@{host}/{database}?secure=true"
                 ),
@@ -517,17 +516,6 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
                 )
             ]
         return []
-
-    @staticmethod
-    def _mutate_label(label: str) -> str:
-        """
-        Suffix with the first six characters from the md5 of the label to avoid
-        collisions with original column names
-
-        :param label: Expected expression label
-        :return: Conditionally mutated label
-        """
-        return f"{label}_{hash_from_str(label)[:6]}"
 
     @classmethod
     def adjust_engine_params(

--- a/tests/unit_tests/db_engine_specs/test_clickhouse.py
+++ b/tests/unit_tests/db_engine_specs/test_clickhouse.py
@@ -212,22 +212,6 @@ def test_connect_get_column_spec(
     assert_column_spec(spec, native_type, sqla_type, attrs, generic_type, is_dttm)
 
 
-@pytest.mark.parametrize(
-    "column_name,expected_result",
-    [
-        # SHA-256 hash suffix (first 6 chars) with default HASH_ALGORITHM
-        ("time", "time_336074"),
-        ("count", "count_6c3549"),
-    ],
-)
-def test_connect_make_label_compatible(column_name: str, expected_result: str) -> None:
-    from superset.db_engine_specs.clickhouse import (
-        ClickHouseConnectEngineSpec as spec,  # noqa: N813
-    )
-
-    label = spec.make_label_compatible(column_name)
-    assert label == expected_result
-
 
 @pytest.mark.parametrize(
     "schema, expected_result",

--- a/tests/unit_tests/db_engine_specs/test_clickhouse.py
+++ b/tests/unit_tests/db_engine_specs/test_clickhouse.py
@@ -212,7 +212,6 @@ def test_connect_get_column_spec(
     assert_column_spec(spec, native_type, sqla_type, attrs, generic_type, is_dttm)
 
 
-
 @pytest.mark.parametrize(
     "schema, expected_result",
     [


### PR DESCRIPTION
### SUMMARY
Removes the `_mutate_label` override from `ClickHouseConnectEngineSpec` that was appending hash suffixes to column aliases as a workaround for column name collision issues in older versions of `clickhouse-connect`. This is no longer needed as of `clickhouse-connect>=0.13.0`.

Also bumps the minimum `clickhouse-connect` version to `>=0.13.0` across all locations including `pyproject.toml`, engine spec metadata, and generated docs for consistency.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
N/A. This change removes a workaround that is no longer needed with modern versions of `clickhouse-connect`. The base class `_mutate_label` already returns the label unchanged, so removing the override is a no-op in terms of behavior.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: Fixes #33551 which is an artifact of the label mutation
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
