### PR TITLE
fix(bigquery): pass dialect instead of engine to select_star in get_extra_table_metadata

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -438,7 +438,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
                 sql = cls.select_star(
                     database,
                     table,
-                    engine,
+                    engine.dialect,
                     indent=False,
                     show_cols=False,
                     latest_partition=True,


### PR DESCRIPTION
### SUMMARY

`BigQueryEngineSpec.get_extra_table_metadata()` passes an `Engine` object to `select_star()`, but that method's signature expects a `Dialect`. This causes `quote_table()` to fail with:

```
AttributeError: 'Engine' object has no attribute 'identifier_preparer'
```

The fix is a one-character change: pass `engine.dialect` instead of `engine`.

### BEFORE/AFTER SCREENSHOTS OR COVERAGE REPORT

**Before**: Viewing table metadata for partitioned BigQuery tables returns a 500 error.
**After**: Table metadata loads correctly.

### TESTING INSTRUCTIONS

1. Connect a BigQuery database
2. Navigate to a partitioned BigQuery table
3. Verify table metadata (partitions, partition query) loads without error

### ADDITIONAL INFORMATION

The bug is in `superset/db_engine_specs/bigquery.py` line 441. The `get_extra_table_metadata` method opens an engine context and passes `engine` directly to `cls.select_star()`, but `select_star()` declares its third parameter as `dialect: Dialect`. When `select_star()` calls `quote_table(table, dialect)`, it accesses `dialect.identifier_preparer` which doesn't exist on `Engine` objects.