### PR TITLE
chore: Support specifying app_root via superset_config.py

### DIFF
--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -220,11 +220,12 @@ RequestHeader set X-Forwarded-Proto "https"
 *Please be advised that this feature is in BETA.*
 
 Superset supports running the application under a non-root path. The root path
-prefix can be specified in one of two ways:
+prefix can be specified in one of three ways:
 
-- Setting the `SUPERSET_APP_ROOT` environment variable to the desired prefix.
 - Customizing the [Flask entrypoint](https://github.com/apache/superset/blob/master/superset/app.py#L29)
-  by passing the `superset_app_root` variable.
+  by passing the `superset_app_root` variable; or
+- Setting the `SUPERSET_APP_ROOT` environment variable to the desired prefix; or
+- Setting the `APPLICATION_ROOT` config in your `superset_config.py` file.
 
 Note, the prefix should start with a `/`.
 

--- a/superset/app.py
+++ b/superset/app.py
@@ -60,7 +60,10 @@ def create_app(
         # Allow application to sit on a non-root path
         # *Please be advised that this feature is in BETA.*
         app_root = cast(
-            str, superset_app_root or os.environ.get("SUPERSET_APP_ROOT", "/")
+            str,
+            superset_app_root
+            or os.environ.get("SUPERSET_APP_ROOT")
+            or app.config["APPLICATION_ROOT"],
         )
         if app_root != "/":
             app.wsgi_app = AppRootMiddleware(app.wsgi_app, app_root)


### PR DESCRIPTION
### SUMMARY
Adding docs/support to define `SUPERSET_APP_ROOT` directly from the `superset_config.py`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A
### TESTING INSTRUCTIONS
Unit tests added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
