### PR TITLE
fix(folders): remove stale column/metric refs from folders on delete

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { debounce } from 'lodash';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {
@@ -32,6 +32,7 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
+import { DatasourceFolder } from 'src/explore/components/DatasourcePanel/types';
 import { FoldersEditorItemType } from '../types';
 import { TreeItem as TreeItemType } from './constants';
 import {
@@ -39,6 +40,7 @@ import {
   buildTree,
   removeChildrenOf,
   serializeForAPI,
+  filterFoldersByValidUuids,
 } from './treeUtils';
 import {
   createFolder,
@@ -79,6 +81,21 @@ export default function FoldersEditor({
     const ensured = ensureDefaultFolders(initialFolders, metrics, columns);
     return ensured;
   });
+
+  // Sync folders when columns/metrics are removed externally
+  useEffect(() => {
+    const validUuids = new Set<string>();
+    columns.forEach(c => {
+      if (c.uuid) validUuids.add(c.uuid);
+    });
+    metrics.forEach(m => {
+      if (m.uuid) validUuids.add(m.uuid);
+    });
+
+    setItems(prevItems =>
+      filterFoldersByValidUuids(prevItems as DatasourceFolder[], validUuids),
+    );
+  }, [columns, metrics]);
 
   const [selectedItemIds, setSelectedItemIds] = useState<Set<string>>(
     new Set(),

--- a/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.test.ts
@@ -29,6 +29,7 @@ import {
   serializeForAPI,
   getProjection,
   countAllFolders,
+  filterFoldersByValidUuids,
 } from './treeUtils';
 import { FoldersEditorItemType } from '../types';
 import { DatasourceFolder } from 'src/explore/components/DatasourcePanel/types';
@@ -725,4 +726,91 @@ test('countAllFolders ignores non-folder children', () => {
   ] as DatasourceFolder[];
 
   expect(countAllFolders(folders)).toBe(1);
+});
+
+test('filterFoldersByValidUuids removes items with invalid UUIDs', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('f1', 'Metrics', [
+      createMetricItem('m1', 'Metric 1'),
+      createMetricItem('m2', 'Metric 2'),
+    ]),
+  ] as DatasourceFolder[];
+
+  const validUuids = new Set(['m1']);
+  const filtered = filterFoldersByValidUuids(folders, validUuids);
+
+  expect(filtered).toHaveLength(1);
+  expect(filtered[0].children).toHaveLength(1);
+  expect(filtered[0].children![0].uuid).toBe('m1');
+});
+
+test('filterFoldersByValidUuids preserves folders even when empty', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('f1', 'Metrics', [
+      createMetricItem('m1', 'Metric 1'),
+    ]),
+  ] as DatasourceFolder[];
+
+  const validUuids = new Set<string>();
+  const filtered = filterFoldersByValidUuids(folders, validUuids);
+
+  expect(filtered).toHaveLength(1);
+  expect(filtered[0].uuid).toBe('f1');
+  expect(filtered[0].children).toHaveLength(0);
+});
+
+test('filterFoldersByValidUuids handles nested folders', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('f1', 'Root', [
+      createFolderItem('f2', 'Nested', [
+        createMetricItem('m1', 'Metric 1'),
+        createColumnItem('c1', 'Column 1'),
+      ]),
+      createColumnItem('c2', 'Column 2'),
+    ]),
+  ] as DatasourceFolder[];
+
+  const validUuids = new Set(['m1', 'c2']);
+  const filtered = filterFoldersByValidUuids(folders, validUuids);
+
+  expect(filtered).toHaveLength(1);
+  expect(filtered[0].children).toHaveLength(2);
+
+  const nestedFolder = filtered[0].children![0] as DatasourceFolder;
+  expect(nestedFolder.uuid).toBe('f2');
+  expect(nestedFolder.children).toHaveLength(1);
+  expect(nestedFolder.children![0].uuid).toBe('m1');
+
+  expect(filtered[0].children![1].uuid).toBe('c2');
+});
+
+test('filterFoldersByValidUuids keeps all items when all UUIDs are valid', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('f1', 'Metrics', [
+      createMetricItem('m1', 'Metric 1'),
+      createMetricItem('m2', 'Metric 2'),
+    ]),
+  ] as DatasourceFolder[];
+
+  const validUuids = new Set(['m1', 'm2']);
+  const filtered = filterFoldersByValidUuids(folders, validUuids);
+
+  expect(filtered).toHaveLength(1);
+  expect(filtered[0].children).toHaveLength(2);
+});
+
+test('filterFoldersByValidUuids returns same reference when nothing changed', () => {
+  const folders: DatasourceFolder[] = [
+    createFolderItem('f1', 'Root', [
+      createFolderItem('f2', 'Nested', [
+        createMetricItem('m1', 'Metric 1'),
+      ]),
+      createColumnItem('c1', 'Column 1'),
+    ]),
+  ] as DatasourceFolder[];
+
+  const validUuids = new Set(['m1', 'c1']);
+  const filtered = filterFoldersByValidUuids(folders, validUuids);
+
+  expect(filtered).toBe(folders);
 });

--- a/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.test.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/treeUtils.test.ts
@@ -746,9 +746,7 @@ test('filterFoldersByValidUuids removes items with invalid UUIDs', () => {
 
 test('filterFoldersByValidUuids preserves folders even when empty', () => {
   const folders: DatasourceFolder[] = [
-    createFolderItem('f1', 'Metrics', [
-      createMetricItem('m1', 'Metric 1'),
-    ]),
+    createFolderItem('f1', 'Metrics', [createMetricItem('m1', 'Metric 1')]),
   ] as DatasourceFolder[];
 
   const validUuids = new Set<string>();
@@ -802,9 +800,7 @@ test('filterFoldersByValidUuids keeps all items when all UUIDs are valid', () =>
 test('filterFoldersByValidUuids returns same reference when nothing changed', () => {
   const folders: DatasourceFolder[] = [
     createFolderItem('f1', 'Root', [
-      createFolderItem('f2', 'Nested', [
-        createMetricItem('m1', 'Metric 1'),
-      ]),
+      createFolderItem('f2', 'Nested', [createMetricItem('m1', 'Metric 1')]),
       createColumnItem('c1', 'Column 1'),
     ]),
   ] as DatasourceFolder[];


### PR DESCRIPTION
### SUMMARY

When a calculated column or metric is removed in the dataset editor, its UUID remains in the folder structure. The backend's `validate_folders` rejects the stale UUID with a 422 error, making it impossible to save the dataset.

This PR filters stale column/metric references from folders when columns or metrics change:

- **`treeUtils.ts`** — Add `filterFoldersByValidUuids()` that recursively removes leaf items whose UUIDs are not in the valid set. Returns the original reference when nothing was removed (avoids unnecessary re-renders).
- **`DatasourceEditor.tsx`** — Use `filterFoldersByValidUuids` in `onChange()` to clean the API payload before propagating to the parent. Also adds missing `uuid` field to the local `Column` interface.
- **`FoldersEditor/index.tsx`** — Add `useEffect` to sync internal folder state when columns/metrics change externally, so the UI immediately reflects removed items.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/6c10edbc-484a-4096-ae0e-0c5ceb69ddda

After:

https://github.com/user-attachments/assets/b627c11a-e48e-4082-bed9-a5483e55165b




### TESTING INSTRUCTIONS

1. Enable the `DATASET_FOLDERS` feature flag
2. Open a dataset in the editor
3. Go to the Calculated Columns tab and add a new calculated column
4. Go to the Folders tab and move the column into a custom folder
5. Save the dataset
6. Go back to the Calculated Columns tab and delete the column
7. Verify the Folders tab no longer shows the deleted column
8. Save the dataset — should succeed without a 422 error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `DATASET_FOLDERS`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API