### PR TITLE
fix: Warning toasts when user drops folder item outside of dnd context

### DIFF
--- a/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useDragHandlers.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useDragHandlers.ts
@@ -159,6 +159,19 @@ export function useDragHandlers({
     [childrenByParentId],
   );
 
+  const warnItemsOutsideFolders = useCallback(
+    (hasDraggedColumn: boolean, hasDraggedMetric: boolean) => {
+      if (hasDraggedColumn && hasDraggedMetric) {
+        addWarningToast(t('Columns and metrics should be inside folders'));
+      } else if (hasDraggedColumn) {
+        addWarningToast(t('Columns should be inside folders'));
+      } else if (hasDraggedMetric) {
+        addWarningToast(t('Metrics should be inside folders'));
+      }
+    },
+    [addWarningToast],
+  );
+
   const resetDragState = useCallback(() => {
     setActiveId(null);
     setOverId(null);
@@ -274,14 +287,26 @@ export function useDragHandlers({
     const fallbackOverId = lastValidOverIdRef.current;
     resetDragState();
 
-    // Folder drags only: hidden children create dead zones where over is null.
-    // Regular drags with null over just cancel.
-    const effectiveOver =
-      over ??
-      (folderChildIds.size > 0 && fallbackOverId
-        ? { id: fallbackOverId }
-        : null);
-    if (!effectiveOver || itemsBeingDragged.length === 0) {
+    if (itemsBeingDragged.length === 0) {
+      return;
+    }
+
+    const effectiveOver = over ?? (fallbackOverId ? { id: fallbackOverId } : null);
+
+    if (!effectiveOver) {
+      let hasDraggedColumn = false;
+      let hasDraggedMetric = false;
+      for (const id of itemsBeingDragged) {
+        const item = fullItemsByUuid.get(id);
+        if (item) {
+          if (item.type === FoldersEditorItemType.Column) {
+            hasDraggedColumn = true;
+          } else if (item.type === FoldersEditorItemType.Metric) {
+            hasDraggedMetric = true;
+          }
+        }
+      }
+      warnItemsOutsideFolders(hasDraggedColumn, hasDraggedMetric);
       return;
     }
 
@@ -396,13 +421,7 @@ export function useDragHandlers({
 
     if (hasNonFolderItems) {
       if (!projectedPosition || !projectedPosition.parentId) {
-        if (hasDraggedColumn && hasDraggedMetric) {
-          addWarningToast(t('Columns and metrics should be inside folders'));
-        } else if (hasDraggedColumn) {
-          addWarningToast(t('Columns should be inside folders'));
-        } else {
-          addWarningToast(t('Metrics should be inside folders'));
-        }
+        warnItemsOutsideFolders(hasDraggedColumn, hasDraggedMetric);
         return;
       }
     }

--- a/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useDragHandlers.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/hooks/useDragHandlers.ts
@@ -69,9 +69,6 @@ export function useDragHandlers({
   const [draggedFolderChildIds, setDraggedFolderChildIds] = useState<
     Set<string>
   >(new Set());
-  // Last non-null overId — fallback target when dropping in dead zones
-  const lastValidOverIdRef = useRef<UniqueIdentifier | null>(null);
-
   // Store the flattened items at drag start to keep them stable during drag
   // This prevents react-window from re-rendering due to flattenedItems reference changes
   const dragStartFlattenedItemsRef = useRef<FlattenedTreeItem[] | null>(null);
@@ -176,7 +173,6 @@ export function useDragHandlers({
     setActiveId(null);
     setOverId(null);
     offsetLeftRef.current = 0;
-    lastValidOverIdRef.current = null;
     setCurrentDropTargetId(null);
     setDraggedItemIds(new Set());
     setDraggedFolderChildIds(new Set());
@@ -251,9 +247,6 @@ export function useDragHandlers({
   const handleDragOver = useCallback(
     ({ over }: DragOverEvent) => {
       setOverId(over?.id ?? null);
-      if (over) {
-        lastValidOverIdRef.current = over.id;
-      }
 
       if (activeId && over) {
         if (typeof over.id === 'string' && over.id.endsWith('-empty')) {
@@ -283,17 +276,13 @@ export function useDragHandlers({
     const itemsBeingDragged = Array.from(draggedItemIds);
     const folderChildIds = draggedFolderChildIds;
     const finalOffsetLeft = offsetLeftRef.current;
-    // Capture fallback overId before reset (for dead-zone drops)
-    const fallbackOverId = lastValidOverIdRef.current;
     resetDragState();
 
     if (itemsBeingDragged.length === 0) {
       return;
     }
 
-    const effectiveOver = over ?? (fallbackOverId ? { id: fallbackOverId } : null);
-
-    if (!effectiveOver) {
+    if (!over) {
       let hasDraggedColumn = false;
       let hasDraggedMetric = false;
       for (const id of itemsBeingDragged) {
@@ -310,7 +299,7 @@ export function useDragHandlers({
       return;
     }
 
-    let targetOverId = effectiveOver.id;
+    let targetOverId = over.id;
     let isEmptyDrop = false;
     if (typeof targetOverId === 'string' && targetOverId.endsWith('-empty')) {
       targetOverId = targetOverId.replace('-empty', '');


### PR DESCRIPTION
### SUMMARY
Follow up on https://github.com/apache/superset/pull/38257, the warning toast should pop up also when user drops and item outside of the DND context, i.e. somewhere outside of the modal

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Enable feature flag `DATASET_FOLDERS`
2. Open a dataset with multiple metrics and columns
3. Drag a column and drop it outside of any folder (e.g.,somewhere outside of the dataset modal)
4. Verify a warning toast appears: "Columns should be inside folders"
5. Repeat with a metric — toast should say "Metrics should be inside folders"
6. Select both a column and a metric, drag outside folders — toast should say "Columns and metrics should be inside folders"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

FEATURE_DATASET_FOLDERS=true
