### PR TITLE
feat: override UI components from Last queried at to Data as of

### DIFF
--- a/superset-frontend/src/components/LastQueriedLabel/index.tsx
+++ b/superset-frontend/src/components/LastQueriedLabel/index.tsx
@@ -24,13 +24,16 @@ interface LastQueriedLabelProps {
   datasetId?: number;
 }
 
-const LastQueriedLabel: FC<LastQueriedLabelProps> = ({ datasetId, queriedDttm }) => {
+const LastQueriedLabel: FC<LastQueriedLabelProps> = ({
+  datasetId,
+  queriedDttm,
+}) => {
   const theme = useTheme();
   const [dataAsOf, setDataAsOf] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    if (!datasetId) return;
+    if (!datasetId) return undefined;
 
     let cancelled = false;
     setLoading(true);

--- a/superset-frontend/src/components/LastQueriedLabel/index.tsx
+++ b/superset-frontend/src/components/LastQueriedLabel/index.tsx
@@ -16,27 +16,52 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC } from 'react';
-import { t, css, useTheme } from '@superset-ui/core';
-import { extendedDayjs } from 'src/utils/dates';
+import { FC, useEffect, useState } from 'react';
+import { t, css, useTheme, SupersetClient } from '@superset-ui/core';
 
 interface LastQueriedLabelProps {
-  queriedDttm: string | null;
+  queriedDttm?: string | null;
+  datasetId?: number;
 }
 
-const LastQueriedLabel: FC<LastQueriedLabelProps> = ({ queriedDttm }) => {
+const LastQueriedLabel: FC<LastQueriedLabelProps> = ({ datasetId, queriedDttm }) => {
   const theme = useTheme();
+  const [dataAsOf, setDataAsOf] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
-  if (!queriedDttm) {
+  useEffect(() => {
+    if (!datasetId) return;
+
+    let cancelled = false;
+    setLoading(true);
+
+    SupersetClient.get({
+      endpoint: `/api/v1/dataset/${datasetId}/data_as_of`,
+    })
+      .then(({ json }) => {
+        if (!cancelled) {
+          setDataAsOf(json?.result?.data_as_of ?? null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDataAsOf(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, queriedDttm]);
+
+  if (loading || !dataAsOf) {
     return null;
   }
-
-  const parsedDate = extendedDayjs.utc(queriedDttm);
-  if (!parsedDate.isValid()) {
-    return null;
-  }
-
-  const formattedTime = parsedDate.local().format('L LTS');
 
   return (
     <div
@@ -46,9 +71,9 @@ const LastQueriedLabel: FC<LastQueriedLabelProps> = ({ queriedDttm }) => {
         padding: ${theme.gridUnit / 2}px ${theme.gridUnit}px;
         text-align: right;
       `}
-      data-test="last-queried-label"
+      data-test="data-as-of-label"
     >
-      {t('Last queried at')}: {formattedTime}
+      {t('Data as of')}: {dataAsOf}
     </div>
   );
 };

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -699,12 +699,12 @@ const PropertiesModal = ({
                   onChange={setShowChartTimestamps}
                 />
                 <span className="switch-label">
-                  {t('Show chart query timestamps')}
+                  {t('Show chart data as of timestamps')}
                 </span>
               </div>
               <span className="switch-helper">
                 {t(
-                  'Display the last queried timestamp on charts in the dashboard view',
+                  'Display data as of timestamp on charts in the dashboard view',
                 )}
               </span>
             </StyledSwitchContainer>

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -366,7 +366,7 @@ const SliceHeaderControls = (
         data-test="refresh-chart-menu-item"
       >
         <Tooltip
-          title={queriedLabel ? `${t('Last queried at')}: ${queriedLabel}` : ''}
+          title={queriedLabel ? `${t('Data as of')}: ${queriedLabel}` : ''}
           overlayStyle={{ maxWidth: 'none' }}
         >
           <div>

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -553,7 +553,7 @@ const Chart = props => {
       </ChartWrapper>
 
       {!isLoading && showChartTimestamps && queriedDttm != null && (
-        <LastQueriedLabel queriedDttm={queriedDttm} />
+        <LastQueriedLabel datasetId={datasource.id} queriedDttm={queriedDttm} />
       )}
     </SliceContainer>
   );

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.jsx
@@ -382,6 +382,7 @@ const ExploreChartPanel = ({
             `}
           >
             <LastQueriedLabel
+              datasetId={datasource?.id}
               queriedDttm={chart.queriesResponse?.[0]?.queried_dttm ?? null}
             />
           </div>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR overrides the UI part of Last queried to Data as of
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Tested internally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
