### PR TITLE
fix(dashboard): prevent x-axis clipping when toggling chart description

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
@@ -379,6 +379,79 @@ test('should fallback to formData state when runtime state not available', () =>
   expect(getByTestId('chart-container')).toBeInTheDocument();
 });
 
+test('chart height is reduced on first render in expanded state (guards against useEffect regression)', () => {
+  const DESCRIPTION_HEIGHT = 60;
+  const CHART_HEIGHT = 300;
+  // Matches the DEFAULT_HEADER_HEIGHT constant in Chart.tsx.
+  const DEFAULT_HEADER_HEIGHT = 22;
+
+  // Stabilise getHeaderHeight(): emotion injects margin-bottom CSS during
+  // React's commit phase, so getComputedStyle returns different values in
+  // initial renders vs re-renders. Mock it to always return empty so
+  // getHeaderHeight() consistently falls back to DEFAULT_HEADER_HEIGHT.
+  const getComputedStyleSpy = jest
+    .spyOn(window, 'getComputedStyle')
+    .mockReturnValue({
+      getPropertyValue: () => '',
+    } as unknown as CSSStyleDeclaration);
+
+  // JSDOM doesn't compute layout, so mock offsetHeight to simulate a real
+  // description element with height.
+  const offsetHeightSpy = jest
+    .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+    .mockImplementation(function (this: HTMLElement) {
+      return this.classList.contains('slice_description')
+        ? DESCRIPTION_HEIGHT
+        : 0;
+    });
+
+  // Suppress all passive effects to simulate the first-paint moment — the
+  // point at which the original useEffect bug caused clipping. useLayoutEffect
+  // (the fix) runs synchronously before paint and is intentionally NOT mocked
+  // here. If the implementation were reverted to useEffect, this spy would
+  // prevent the height measurement and the assertion below would fail.
+  const useEffectSpy = jest
+    .spyOn(global.React, 'useEffect')
+    .mockImplementation(() => {});
+
+  const { container } = setup(
+    { height: CHART_HEIGHT },
+    {
+      charts: {
+        ...defaultState.charts,
+        [queryId]: {
+          ...defaultState.charts[queryId],
+          // ChartOverlay renders with an inline height style when loading —
+          // this is the observable proxy for getChartHeight() without real layout.
+          chartStatus: 'loading',
+        },
+      },
+      dashboardState: {
+        ...defaultState.dashboardState,
+        expandedSlices: { [queryId]: true },
+      },
+    },
+  );
+
+  const chartHeight = parseInt(
+    container.querySelector<HTMLDivElement>('.dashboard-chart > div[style]')!
+      .style.height,
+    10,
+  );
+
+  // useLayoutEffect must have measured and applied descriptionHeight
+  // synchronously. If useEffect were used instead, descriptionHeight would
+  // still be 0 here (suppressed by useEffectSpy) and chartHeight would equal
+  // CHART_HEIGHT - DEFAULT_HEADER_HEIGHT rather than the value below.
+  expect(chartHeight).toBe(
+    CHART_HEIGHT - DEFAULT_HEADER_HEIGHT - DESCRIPTION_HEIGHT,
+  );
+
+  useEffectSpy.mockRestore();
+  getComputedStyleSpy.mockRestore();
+  offsetHeightSpy.mockRestore();
+});
+
 test('should not show a close button on chart error banners', () => {
   const { queryByRole } = setup(
     {},

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
@@ -370,6 +370,79 @@ test('should fallback to formData state when runtime state not available', () =>
   expect(getByTestId('chart-container')).toBeInTheDocument();
 });
 
+test('chart height is reduced on first render in expanded state (guards against useEffect regression)', () => {
+  const DESCRIPTION_HEIGHT = 60;
+  const CHART_HEIGHT = 300;
+  // Matches the DEFAULT_HEADER_HEIGHT constant in Chart.tsx.
+  const DEFAULT_HEADER_HEIGHT = 22;
+
+  // Stabilise getHeaderHeight(): emotion injects margin-bottom CSS during
+  // React's commit phase, so getComputedStyle returns different values in
+  // initial renders vs re-renders. Mock it to always return empty so
+  // getHeaderHeight() consistently falls back to DEFAULT_HEADER_HEIGHT.
+  const getComputedStyleSpy = jest
+    .spyOn(window, 'getComputedStyle')
+    .mockReturnValue({
+      getPropertyValue: () => '',
+    } as unknown as CSSStyleDeclaration);
+
+  // JSDOM doesn't compute layout, so mock offsetHeight to simulate a real
+  // description element with height.
+  const offsetHeightSpy = jest
+    .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+    .mockImplementation(function (this: HTMLElement) {
+      return this.classList.contains('slice_description')
+        ? DESCRIPTION_HEIGHT
+        : 0;
+    });
+
+  // Suppress all passive effects to simulate the first-paint moment — the
+  // point at which the original useEffect bug caused clipping. useLayoutEffect
+  // (the fix) runs synchronously before paint and is intentionally NOT mocked
+  // here. If the implementation were reverted to useEffect, this spy would
+  // prevent the height measurement and the assertion below would fail.
+  const useEffectSpy = jest
+    .spyOn(global.React, 'useEffect')
+    .mockImplementation(() => {});
+
+  const { container } = setup(
+    { height: CHART_HEIGHT },
+    {
+      charts: {
+        ...defaultState.charts,
+        [queryId]: {
+          ...defaultState.charts[queryId],
+          // ChartOverlay renders with an inline height style when loading —
+          // this is the observable proxy for getChartHeight() without real layout.
+          chartStatus: 'loading',
+        },
+      },
+      dashboardState: {
+        ...defaultState.dashboardState,
+        expandedSlices: { [queryId]: true },
+      },
+    },
+  );
+
+  const chartHeight = parseInt(
+    container.querySelector<HTMLDivElement>('.dashboard-chart > div[style]')!
+      .style.height,
+    10,
+  );
+
+  // useLayoutEffect must have measured and applied descriptionHeight
+  // synchronously. If useEffect were used instead, descriptionHeight would
+  // still be 0 here (suppressed by useEffectSpy) and chartHeight would equal
+  // CHART_HEIGHT - DEFAULT_HEADER_HEIGHT rather than the value below.
+  expect(chartHeight).toBe(
+    CHART_HEIGHT - DEFAULT_HEADER_HEIGHT - DESCRIPTION_HEIGHT,
+  );
+
+  useEffectSpy.mockRestore();
+  getComputedStyleSpy.mockRestore();
+  offsetHeightSpy.mockRestore();
+});
+
 test('should not show a close button on chart error banners', () => {
   const { queryByRole } = setup(
     {},

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -17,7 +17,15 @@
  * under the License.
  */
 import cx from 'classnames';
-import { useCallback, useEffect, useRef, useMemo, useState, memo } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useMemo,
+  useState,
+  memo,
+} from 'react';
 import type { ChartCustomization, JsonObject } from '@superset-ui/core';
 import { styled, t } from '@apache-superset/core/ui';
 import { debounce } from 'lodash';
@@ -303,13 +311,9 @@ const Chart = (props: ChartProps) => {
     [dispatch, props.id, sliceVizType],
   );
 
-  useEffect(() => {
-    if (isExpanded) {
-      const descHeight =
-        isExpanded && descriptionRef.current
-          ? descriptionRef.current?.offsetHeight
-          : 0;
-      setDescriptionHeight(descHeight);
+  useLayoutEffect(() => {
+    if (isExpanded && descriptionRef.current) {
+      setDescriptionHeight(descriptionRef.current.offsetHeight);
     } else {
       setDescriptionHeight(0);
     }

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -20,6 +20,7 @@ import cx from 'classnames';
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useMemo,
   useState,
@@ -318,13 +319,9 @@ const Chart = (props: ChartProps) => {
     [dispatch, props.id, sliceVizType],
   );
 
-  useEffect(() => {
-    if (isExpanded) {
-      const descHeight =
-        isExpanded && descriptionRef.current
-          ? descriptionRef.current?.offsetHeight
-          : 0;
-      setDescriptionHeight(descHeight);
+  useLayoutEffect(() => {
+    if (isExpanded && descriptionRef.current) {
+      setDescriptionHeight(descriptionRef.current.offsetHeight);
     } else {
       setDescriptionHeight(0);
     }


### PR DESCRIPTION
## **User description**
## SUMMARY

When toggling **“Show chart description”** on a dashboard chart, the bottom portion of the **x-axis** was being cut off. This was a regression introduced after **4.1.2**, most noticeably affecting **heatmap charts**.

**Root Cause**

The description height was measured inside a `useEffect`, which executes after the browser has already painted the UI.

On the first render where `isExpanded = true`:

* `descriptionHeight` is still `0`
* `getChartHeight()` calculates chart dimensions without accounting for the description
* The chart canvas renders too tall
* `ChartWrapper` has `overflow: hidden`
* The bottom of the chart (including x-axis labels) becomes clipped

**Fix**

Replaced `useEffect` with `useLayoutEffect` for measuring the description height.

`useLayoutEffect` runs synchronously after React commits DOM updates but **before the browser paints**. This ensures:

* The description height is measured immediately
* State is updated before paint
* The chart receives correct dimensions on the first visible render
* No clipping occurs

---
## Before
<img width="1071" height="750" alt="image" src="https://github.com/user-attachments/assets/2223d5e6-b510-44a4-9bce-5e5753efb489" />

## After the fix
<img width="626" height="434" alt="image" src="https://github.com/user-attachments/assets/cdba0ab4-5bf2-4dde-b986-7189eb2a7de9" />

## TESTING INSTRUCTIONS

1. Open any dashboard
2. Add or locate a chart with a description

   * Set description via:
     **Explore → Chart tab → Description field**
3. On the dashboard, open the chart’s ⋮ menu
4. Click **Show chart description**
5. Verify:

   * The full chart, including the x-axis, is visible
   * No clipping occurs
6. Toggle the description off and on multiple times

   * Confirm layout remains stable
7. Test specifically with **heatmap charts**, as they most reliably reproduced the original issue

---

## ADDITIONAL INFORMATION

Fixes #33737


___

## **CodeAnt-AI Description**
Prevent chart x-axis from being clipped when showing chart descriptions

### What Changed
- When a chart's "Show chart description" is toggled open, the chart now measures the description height before the browser paints so the chart layout includes the description on first render; this prevents the bottom of the chart (including x-axis labels) from being cut off.
- Added a unit test that simulates the first-paint moment to ensure the synchronous measurement behavior remains; the test fails if the measurement is delayed until after paint.

### Impact
`✅ No clipped x-axis when toggling chart descriptions`
`✅ Stable dashboard chart layout immediately after toggling descriptions`
`✅ Fewer visual regressions in dashboard chart rendering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
