### PR TITLE
fix(embedded): catch DashboardAccessDeniedError in get_datasets and improve guest token JWT warning

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -225,8 +225,16 @@ Note: Pillow is now a required dependency (previously optional) to support image
 - [31590](https://github.com/apache/superset/pull/31590) Marks the begining of intricate work around supporting dynamic Theming, and breaks support for [THEME_OVERRIDES](https://github.com/apache/superset/blob/732de4ac7fae88e29b7f123b6cbb2d7cd411b0e4/superset/config.py#L671) in favor of a new theming system based on AntD V5. Likely this will be in disrepair until settling over the 5.x lifecycle.
 - [32432](https://github.com/apache/superset/pull/31260) Moves the List Roles FAB view to the frontend and requires `FAB_ADD_SECURITY_API` to be enabled in the configuration and `superset init` to be executed.
 - [34319](https://github.com/apache/superset/pull/34319) Drill to Detail and Drill By is now supported in Embedded mode, and also with the `DASHBOARD_RBAC` FF. If you don't want to expose these features in Embedded / `DASHBOARD_RBAC`, make sure the roles used for Embedded / `DASHBOARD_RBAC`don't have the required permissions to perform D2D actions.
+- [#38185](https://github.com/apache/superset/issues/38185) **Embedded SDK / Guest Token — independent JWT configuration**: The guest token system uses its own JWT configuration keys (`GUEST_TOKEN_JWT_ALGO`, `GUEST_TOKEN_JWT_SECRET`, `GUEST_TOKEN_JWT_EXP_SECONDS`) which are **completely independent** of Flask-JWT-Extended's `JWT_ALGORITHM` setting. If you configure `JWT_ALGORITHM = "RS256"` (or any non-default value) for your login flow, you **must** also explicitly set the guest token keys in `superset_config.py` to avoid `403 Forbidden` errors on the Embedded SDK's `/api/v1/dashboard/{id}/datasets` endpoint:
+  ```python
+  # These are SEPARATE from JWT_ALGORITHM used by Flask-JWT-Extended
+  GUEST_TOKEN_JWT_ALGO = "HS256"
+  GUEST_TOKEN_JWT_SECRET = "your-secret-change-me"  # noqa: S105
+  GUEST_TOKEN_JWT_EXP_SECONDS = 300  # 5 minutes
+  ```
 
 ## 5.0.0
+
 
 - [31976](https://github.com/apache/superset/pull/31976) Removed the `DISABLE_LEGACY_DATASOURCE_EDITOR` feature flag. The previous value of the feature flag was `True` and now the feature is permanently removed.
 - [31959](https://github.com/apache/superset/pull/32000) Removes CSV_UPLOAD_MAX_SIZE config, use your web server to control file upload size.

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -542,6 +542,10 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
             return self.response(200, result=result)
         except (TypeError, ValueError) as err:
             raise DatasetValidationError(err) from err
+        except DashboardAccessDeniedError:
+            return self.response_403()
+        except DashboardNotFoundError:
+            return self.response_404()
 
     @expose("/<id_or_slug>/tabs", methods=("GET",))
     @protect()

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2862,9 +2862,15 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if token.get("type") != "guest":
                 raise ValueError("This is not a guest token.")
         except Exception:  # pylint: disable=broad-except
-            # The login manager will handle sending 401s.
-            # We don't need to send a special error message.
-            logger.warning("Invalid guest token", exc_info=True)
+            logger.warning(
+                "Invalid guest token. If you are using a non-default "
+                "JWT_ALGORITHM (e.g. RS256), ensure GUEST_TOKEN_JWT_ALGO "
+                "and GUEST_TOKEN_JWT_SECRET are explicitly set in "
+                "superset_config.py, as the guest token system uses its "
+                "own separate JWT configuration independent of "
+                "Flask-JWT-Extended.",
+                exc_info=True,
+            )
             return None
 
         return self.get_guest_user_from_token(cast(GuestToken, token))

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -461,8 +461,48 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         response = self.get_assert_metric(uri, "get_datasets")
         assert response.status_code == 404
 
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_get_dashboard_datasets_with_guest_token(self):
+        """
+        Regression test for #38185: a valid guest token must be able to access
+        GET /api/v1/dashboard/{id}/datasets.
+
+        Prior to this fix, get_datasets did not catch DashboardAccessDeniedError,
+        causing an unhandled exception for guest users. Additionally, the endpoint
+        was not handling DashboardNotFoundError unlike get_charts and get_tabs.
+        """
+        from superset.security.guest_token import GuestTokenResourceType
+
+        dashboard = Dashboard.get("world_health")
+
+        # Create a real guest access token (not a mock) and call with the token header
+        token = security_manager.create_guest_access_token(
+            user={
+                "username": "guest",
+                "first_name": "Guest",
+                "last_name": "User",
+            },
+            resources=[
+                {
+                    "type": GuestTokenResourceType.DASHBOARD,
+                    "id": str(dashboard.uuid),
+                }
+            ],
+            rls=[],
+        )
+
+        uri = "api/v1/dashboard/world_health/datasets"
+        response = self.client.get(
+            uri,
+            headers={"X-GuestToken": token},
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data.decode("utf-8"))
+        assert "result" in data
+
     @pytest.mark.usefixtures("create_dashboards")
     def test_get_gamma_dashboard_charts(self):
+
         """
         Check that a gamma user with data access can access dashboard/charts
         """


### PR DESCRIPTION
## Summary

Fixes a regression in Superset v6 where `GET /api/v1/dashboard/{id}/datasets` returns 403 Forbidden for requests authenticated with a valid guest token, breaking embedded dashboard rendering.

## Root Cause

`get_datasets` did not catch `DashboardAccessDeniedError` or `DashboardNotFoundError`, unlike the sibling endpoints `get_charts` and `get_tabs`. Access errors in `DashboardDAO.get_datasets_for_dashboard` → `raise_for_access()` propagated as unhandled exceptions rather than clean HTTP responses.

Additionally, the guest token JWT configuration (`GUEST_TOKEN_JWT_ALGO`, `GUEST_TOKEN_JWT_SECRET`) is independent of Flask-JWT-Extended's `JWT_ALGORITHM`. The warning log now surfaces this explicitly when token parsing fails.

## Changes

- `superset/dashboards/api.py`: catch `DashboardAccessDeniedError` → 403 and `DashboardNotFoundError` → 404 in `get_datasets`, matching `get_charts` and `get_tabs`
- `superset/security/manager.py`: improve guest token parse failure log to call out JWT algorithm misconfiguration
- `tests/integration_tests/dashboards/api_tests.py`: add regression test using real `X-GuestToken` header (prior test mocked `is_guest_user`)
- `UPDATING.md`: document independent guest token JWT config under 6.0.0

## Testing

```bash
pytest tests/integration_tests/dashboards/api_tests.py -k "datasets" -xvs
```

Fixes #38185