### PR TITLE
feat(histogram-chart): Enable log scale for Histograms

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
@@ -165,6 +165,20 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'y_axis_log_scale',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Y Axis Log Scale'),
+              renderTrigger: true,
+              default: false,
+              description: t(
+                'Use a logarithmic scale for the Y axis (frequency/count values).',
+              ),
+            },
+          },
+        ],
       ],
     },
   ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
@@ -170,6 +170,7 @@ export default function transformProps(
     },
     yAxis: {
       ...defaultYAxis,
+      ...(yAxisLogScale ? { min: 1 } : {}),
       name: yAxisTitle,
       nameGap: normalize ? 55 : 40,
       type: yAxisLogScale ? 'log' : 'value',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
@@ -63,6 +63,7 @@ export default function transformProps(
     xAxisTitle,
     yAxisTitle,
     yAxisFormat,
+    yAxisLogScale,
   } = formData;
   const { data } = queriesData[0];
   const colorFn = CategoricalColorNamespace.getScale(colorScheme);
@@ -171,7 +172,7 @@ export default function transformProps(
       ...defaultYAxis,
       name: yAxisTitle,
       nameGap: normalize ? 55 : 40,
-      type: 'value',
+      type: yAxisLogScale ? 'log' : 'value',
       nameLocation: 'middle',
       axisLabel: {
         formatter: (value: number) => yAxisFormatter.format(value),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/types.ts
@@ -31,6 +31,7 @@ export type HistogramFormData = QueryFormData & {
   xAxisFormat: string;
   xAxisTitle: string;
   yAxisFormat: string;
+  yAxisLogScale: boolean;
   yAxisTitle: string;
 };
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Enables logarithmic Y-axis scaling as a customization option for histograms to enable a better view of certain data.

### BEFORE/AFTER SCREENSHOTS
<!--- Skip this if not applicable -->

<img width="240" height="746" alt="image" src="https://github.com/user-attachments/assets/7e523ff5-3e4d-492f-b313-c52a7b78c3ce" />

<img width="240" height="746" alt="image" src="https://github.com/user-attachments/assets/7f53b96a-4cda-4586-b24c-a270399fc39d" />

Some data is better represented with a logarithmic axis to make "outliers" more visible in histogram bins.

Consider this chart showing the distribution of files downloaded per day. Through this histogram, it shows that most days in our operations we download 2.22k to 2.67k files. But it's difficult to see how it relates to the other data because it is scaled by value, and most days fall into one bin.

<img width="1709" height="558" alt="image" src="https://github.com/user-attachments/assets/4eb499b3-c417-4ad9-acac-f784e328e73c" />

Now consider the logarithmic scale where we can still see the relationship among the low value bins while it's still clearly visible which bin dominates.

<img width="1712" height="559" alt="image" src="https://github.com/user-attachments/assets/543c692d-3cf9-4b6c-a4dd-b5a30b3e6bb5" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Create a histogram and check/uncheck the log scale box.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
