### PR TITLE
fix(dashboard): restore filterState prop for cross-filter functionality

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -26,6 +26,7 @@ import {
   SqlaFormData,
   ClientErrorObject,
   DataRecordFilters,
+  type FilterState,
   type JsonObject,
   type AgGridChartState,
 } from '@superset-ui/core';
@@ -89,6 +90,7 @@ export interface ChartProps {
   onChartStateChange?: (chartState: AgGridChartState) => void;
   /** Whether to suppress the loading spinner (during auto-refresh) */
   suppressLoadingSpinner?: boolean;
+  filterState?: FilterState;
 }
 
 export type Actions = {

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
@@ -29,6 +29,15 @@ import chartQueries, {
 } from 'spec/fixtures/mockChartQueries';
 import Chart from './Chart';
 
+let capturedChartContainerProps: Record<string, unknown> = {};
+jest.mock('src/components/Chart/ChartContainer', () => {
+  const MockChartContainer = (props: Record<string, unknown>) => {
+    capturedChartContainerProps = props;
+    return <div data-test="chart-container" />;
+  };
+  return { __esModule: true, default: MockChartContainer };
+});
+
 const props = {
   id: queryId,
   width: 100,
@@ -451,4 +460,25 @@ test('should merge base ownState with converted chart state', () => {
   );
 
   expect(getByTestId('chart-container')).toBeInTheDocument();
+});
+
+test('should pass filterState from dataMask to ChartContainer', () => {
+  const mockFilterState = { value: ['bar'], selectedValues: ['bar'] };
+
+  setup(
+    {},
+    {
+      ...defaultState,
+      dataMask: {
+        [queryId]: {
+          filterState: mockFilterState,
+        },
+      },
+    },
+  );
+
+  expect(capturedChartContainerProps).toHaveProperty(
+    'filterState',
+    mockFilterState,
+  );
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -761,6 +761,7 @@ const Chart = (props: ChartProps) => {
           emitCrossFilters={emitCrossFilters}
           onChartStateChange={handleChartStateChange}
           suppressLoadingSpinner={suppressLoadingSpinner}
+          filterState={dataMask[props.id]?.filterState}
         />
       </ChartWrapper>
 


### PR DESCRIPTION
### SUMMARY

PR #37625 converted the dashboard grid `Chart` component from JSX to TSX. During this conversion, the `filterState` prop was accidentally dropped from the `<ChartContainer>` render call.

This prop passes `dataMask[chartId].filterState` (which contains `selectedValues`) from the Redux store down to chart plugins via `ChartContainer` → `Chart` → `ChartRenderer` → `SuperChart` → plugin `transformProps`. Every ECharts chart relies on `filterState.selectedValues` to:

- **Highlight selected data** via ECharts `highlight`/`downplay` actions
- **Dim non-selected series** via opacity changes in `transformProps`
- **Track selection state** for cross-filter toggling (click to select, click again to deselect)

Without this prop, all three cross-filter behaviors are broken, matching the symptoms reported in #37853.

The fix is a one-line restoration of the dropped prop.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — restores behavior shown in the "Before" GIF of #37853.

### TESTING INSTRUCTIONS

1. Create a dashboard with charts that support cross-filtering (e.g., bar charts, pie charts)
2. Enable cross-filtering
3. Click on a data point — it should highlight and dim non-selected data
4. Click the same data point again — the cross-filter should toggle off
5. Right-click on a data point — should open context menu without retriggering animations

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #37853
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)