### PR TITLE
fix(templates): restore css_bundle calls in spa.html for production builds

### DIFF
--- a/superset/templates/superset/spa.html
+++ b/superset/templates/superset/spa.html
@@ -67,6 +67,11 @@
 
     {% endblock %}
 
+    {{ css_bundle(assets_prefix, 'theme') }}
+    {% if entry %}
+      {{ css_bundle(assets_prefix, entry) }}
+    {% endif %}
+
     {{ js_bundle(assets_prefix, 'theme') }}
 
     {% block head_js %}

--- a/tests/unit_tests/extension_tests.py
+++ b/tests/unit_tests/extension_tests.py
@@ -14,12 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from os.path import dirname
+from os.path import dirname, join
 from unittest.mock import Mock
 
 from superset.extensions import UIManifestProcessor
 
 APP_DIR = f"{dirname(__file__)}/fixtures"
+SUPERSET_DIR = join(dirname(__file__), "..", "..", "superset")
 
 
 def test_get_manifest_with_prefix():
@@ -49,3 +50,21 @@ def test_get_manifest_no_prefix():
     assert manifest["js_manifest"]("styles") == ["/static/dist/styles-js.js"]
     assert manifest["css_manifest"]("styles") == []
     assert manifest["assets_prefix"] == ""
+
+
+def test_spa_template_includes_css_bundles():
+    """
+    Verify spa.html loads CSS bundles for production builds.
+    """
+    template_path = join(SUPERSET_DIR, "templates", "superset", "spa.html")
+    with open(template_path) as f:
+        template_content = f.read()
+
+    assert "css_bundle(assets_prefix, 'theme')" in template_content, (
+        "spa.html must call css_bundle for the 'theme' entry to load "
+        "extracted CSS (including font @font-face declarations) in production builds"
+    )
+    assert "css_bundle(assets_prefix, entry)" in template_content, (
+        "spa.html must call css_bundle for the page entry to load "
+        "entry-specific extracted CSS in production builds"
+    )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Restores `css_bundle()` calls in `spa.html` that were accidentally dropped during the Ant Design v5 overhaul. Without them, webpack-extracted CSS files (including @font-face declarations for Inter) are never loaded via `<link>` tags in production builds, causing the browser to fall back to `Helvetica`.

Dev mode was unaffected since style-loader injects CSS inline.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Reproduce the bug with the pre-built 6.0.0 image. Run:
 ```bash
TAG=6.0.0 docker compose -f docker-compose-image-tag.yml up
```
2. Open http://localhost:8088, inspect any text in DevTools --> "Rendered Fonts" shows `Helvetica`
3. Stop the container.
4. Test the fix by mounting the updated template. Create a `docker-compose.override.yml` file in the repository root
```bash
services:
  superset:
    volumes:
      - ./superset/templates:/app/superset/templates
```
5. Then run:
```bash
TAG=6.0.0 docker compose -f docker-compose-image-tag.yml -f docker-compose.override.yml up
```
6. Finally, open http://localhost:8088, inspect any text --> "Rendered Fonts" now shows `Inter`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #37226
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
