### PR TITLE
fix(docs): Use modern driver package for CrateDB

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -244,6 +244,7 @@ See `superset/mcp_service/PRODUCTION.md` for deployment guides.
 
 ---
 
+- [38358](https://github.com/apache/superset/pull/38358): Switched CrateDB PyPI package from `crate[sqlalchemy]` to `sqlalchemy-cratedb`.
 - [35621](https://github.com/apache/superset/pull/35621): The default hash algorithm has changed from MD5 to SHA-256 for improved security and FedRAMP compliance. This affects cache keys for thumbnails, dashboard digests, chart digests, and filter option names. Existing cached data will be invalidated upon upgrade. To opt out of this change and maintain backward compatibility, set `HASH_ALGORITHM = "md5"` in your `superset_config.py`.
 - [35062](https://github.com/apache/superset/pull/35062): Changed the function signature of `setupExtensions` to `setupCodeOverrides` with options as arguments.
 

--- a/docs/src/data/databases.json
+++ b/docs/src/data/databases.json
@@ -1013,7 +1013,7 @@
       "documentation": {
         "description": "CrateDB is a distributed SQL database for machine data and IoT workloads.",
         "logo": "cratedb.svg",
-        "homepage_url": "https://crate.io/",
+        "homepage_url": "https://cratedb.com/",
         "categories": [
           "TIME_SERIES",
           "OPEN_SOURCE"

--- a/docs/src/data/databases.json
+++ b/docs/src/data/databases.json
@@ -1031,7 +1031,7 @@
         "drivers": [
           {
             "name": "crate",
-            "pypi_package": "crate[sqlalchemy]",
+            "pypi_package": "sqlalchemy-cratedb",
             "connection_string": "crate://{host}:{port}",
             "is_recommended": true
           }

--- a/superset/db_engine_specs/crate.py
+++ b/superset/db_engine_specs/crate.py
@@ -37,7 +37,7 @@ class CrateEngineSpec(BaseEngineSpec):
             "CrateDB is a distributed SQL database for machine data and IoT workloads."
         ),
         "logo": "cratedb.svg",
-        "homepage_url": "https://crate.io/",
+        "homepage_url": "https://cratedb.com/",
         "categories": [DatabaseCategory.TIME_SERIES, DatabaseCategory.OPEN_SOURCE],
         "pypi_packages": ["crate", "sqlalchemy-cratedb"],
         "connection_string": "crate://{host}:{port}",

--- a/superset/db_engine_specs/crate.py
+++ b/superset/db_engine_specs/crate.py
@@ -49,7 +49,7 @@ class CrateEngineSpec(BaseEngineSpec):
         "drivers": [
             {
                 "name": "crate",
-                "pypi_package": "crate[sqlalchemy]",
+                "pypi_package": "sqlalchemy-cratedb",
                 "connection_string": "crate://{host}:{port}",
                 "is_recommended": True,
             },


### PR DESCRIPTION
## **User description**
Dear Superset maintainers,

on the [documentation page about CrateDB](https://superset.apache.org/user-docs/databases/supported/cratedb/), we discovered a possible leftover from the migration from `crate[sqlalchemy]` to `sqlalchemy-cratedb` the other day.

Other than merging to `master`, can you possibly commandeer this patch to be backported to earlier releases of Superset? Thank you in advance!

With kind regards,
Andreas.


___

## **CodeAnt-AI Description**
Use sqlalchemy-cratedb as the recommended CrateDB driver and update CrateDB homepage link

### What Changed
- Recommended CrateDB driver package changed from `crate[sqlalchemy]` to `sqlalchemy-cratedb` in engine specs and documentation entries
- CrateDB homepage URL updated from `https://crate.io/` to `https://cratedb.com/`
- Release notes (UPDATING) now mention the PyPI package switch for CrateDB

### Impact
`✅ Clearer CrateDB install instructions`
`✅ Fewer driver installation mismatches`
`✅ Accurate CrateDB homepage link`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
