### PR TITLE
feat(mcp): add user roles to MCP response and permission-aware instructions

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -156,6 +156,23 @@ Feature Availability:
 - Call get_instance_info to discover accessible menus for the current user.
 - Do NOT assume features exist; always check get_instance_info first.
 
+Permission Awareness:
+- get_instance_info returns current_user.roles (e.g., ["Admin"], ["Alpha"], ["Viewer"]).
+- ALWAYS check the user's roles BEFORE suggesting write operations (creating datasets,
+  charts, dashboards, or running SQL).
+- Common roles and their typical capabilities:
+  - Admin: Full access to all features
+  - Alpha: Can create and modify charts, dashboards, datasets, and run SQL
+  - Gamma: Can view charts and dashboards they have been granted access to
+  - Viewer: Read-only access to shared dashboards and charts
+- If a user has a read-only role (Viewer, Gamma) and a listing tool returns 0 results,
+  do NOT suggest they create resources. Instead:
+  1. Explain that they may not have access to the requested resources
+  2. Suggest they ask a workspace admin to grant them access or share content with them
+  3. Offer to help with what they CAN do (e.g., viewing dashboards they have access to)
+- If you are unsure about a user's capabilities, check their accessible_menus in
+  feature_availability from get_instance_info.
+
 If you are unsure which tool to use, start with get_instance_info
 or use the quickstart prompt for an interactive guide.
 

--- a/superset/mcp_service/system/schemas.py
+++ b/superset/mcp_service/system/schemas.py
@@ -161,6 +161,13 @@ class UserInfo(BaseModel):
     last_name: str | None = None
     email: str | None = None
     active: bool | None = None
+    roles: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Role names assigned to the user (e.g., Admin, Alpha, Gamma, Viewer). "
+            "Use this to determine what actions the user can perform."
+        ),
+    )
 
 
 class TagInfo(BaseModel):

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -110,11 +110,16 @@ def get_instance_info(
         # Attach the authenticated user's identity to the response
         user = getattr(g, "user", None)
         if user is not None:
-            user_roles = [
-                role.name
-                for role in getattr(user, "roles", [])
-                if hasattr(role, "name")
-            ]
+            raw_roles = getattr(user, "roles", None)
+            user_roles = []
+            if raw_roles is not None:
+                try:
+                    user_roles = [
+                        role.name for role in raw_roles if hasattr(role, "name")
+                    ]
+                except TypeError:
+                    logger.debug("Could not iterate user.roles: %s", type(raw_roles))
+                    user_roles = []
             result.current_user = UserInfo(
                 id=getattr(user, "id", None),
                 username=getattr(user, "username", None),

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -110,12 +110,18 @@ def get_instance_info(
         # Attach the authenticated user's identity to the response
         user = getattr(g, "user", None)
         if user is not None:
+            user_roles = [
+                role.name
+                for role in getattr(user, "roles", [])
+                if hasattr(role, "name")
+            ]
             result.current_user = UserInfo(
                 id=getattr(user, "id", None),
                 username=getattr(user, "username", None),
                 first_name=getattr(user, "first_name", None),
                 last_name=getattr(user, "last_name", None),
                 email=getattr(user, "email", None),
+                roles=user_roles,
             )
 
         return result

--- a/tests/unit_tests/mcp_service/system/tool/test_get_current_user.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_current_user.py
@@ -213,12 +213,15 @@ class TestGetInstanceInfoCurrentUserViaMCP:
         # and breaks mock resolution on Python 3.10.
         from superset.mcp_service.mcp_core import InstanceInfoCore
 
+        mock_role = Mock()
+        mock_role.name = "Alpha"
         mock_g_user = Mock()
         mock_g_user.id = 5
         mock_g_user.username = "sophie"
         mock_g_user.first_name = "Sophie"
         mock_g_user.last_name = "Beaumont"
         mock_g_user.email = "sophie@preset.io"
+        mock_g_user.roles = [mock_role]
 
         with (
             patch.object(
@@ -241,6 +244,7 @@ class TestGetInstanceInfoCurrentUserViaMCP:
         assert cu["first_name"] == "Sophie"
         assert cu["last_name"] == "Beaumont"
         assert cu["email"] == "sophie@preset.io"
+        assert cu["roles"] == ["Alpha"]
 
     @pytest.mark.asyncio
     async def test_get_instance_info_no_user_returns_null(self, mcp_server):
@@ -295,6 +299,7 @@ class TestGetInstanceInfoCurrentUserViaMCP:
         assert cu["first_name"] is None
         assert cu["last_name"] is None
         assert cu["email"] is None
+        assert cu["roles"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## SUMMARY

When a viewer user asks the AI assistant to create charts or dashboards, the assistant suggests creating datasets even though the viewer lacks permissions. This happens because the MCP service does not expose the user's roles, so the LLM has no way to know the user's permission level.

### Changes:
- **Add `roles` field to `UserInfo` schema** — the LLM now receives role names (e.g., `["Viewer"]`, `["Admin"]`) in the `get_instance_info` response
- **Populate roles from `user.roles`** in the `get_instance_info` tool
- **Add "Permission Awareness" section to `DEFAULT_INSTRUCTIONS`** — guides the LLM to check user roles before suggesting write operations and provides appropriate alternatives for read-only users

### Before
LLM receives `current_user` with only `id`, `username`, `first_name`, `last_name`, `email` — no role info. When `list_datasets` returns 0 results for a Viewer, the LLM suggests "create a dataset" which the user cannot do.

### After
LLM receives `current_user.roles = ["Viewer"]` and instructions tell it to check roles before suggesting write operations. For read-only users with empty results, it explains access limitations and suggests asking an admin for help.

## BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend-only change to MCP service tool responses and instructions.

## TESTING INSTRUCTIONS
1. Connect to the MCP service as a Viewer user
2. Call `get_instance_info` — verify `current_user.roles` is populated with the user's role names
3. Ask the assistant to create a chart when no datasets are accessible — verify it explains the permission limitation instead of suggesting "create a dataset"

## ADDITIONAL INFORMATION
- [ ] Required feature flags — none
- [ ] Changes UI — no
- [ ] Includes DB Migration — no
- [ ] Introduces new feature or API — adds `roles` field to existing `UserInfo` schema
- [ ] Removes existing feature or API — no

## MCP Testing Results (localhost, 2026-03-04)

Tested via localhost MCP tools on branch `amin/ch100265/improve-mcp-permission-awareness`:

### get_instance_info - User Roles
- Called `get_instance_info` with no parameters
- Result: `current_user.roles` returns `["Admin"]` for admin user ✅
- Verified: `roles` field is a list of role name strings (not full role objects)

### Feature Availability
- `feature_availability.accessible_menus` returns full list of accessible menus for Admin role ✅
- Includes: SQL Editor, Dashboards, Charts, Datasets, Databases, Security, Tags, etc.
- Menu list reflects actual FAB permissions for the authenticated user

### Permission-Aware Instructions
- Verified `DEFAULT_INSTRUCTIONS` in `app.py` includes "Permission Awareness" section
- Instructions guide LLMs to check `current_user.roles` before suggesting write operations
- Role capabilities documented: Admin (full), Alpha (create/modify), Gamma (view granted), Viewer (read-only)

### Error Handling
- `get_instance_info` handles non-iterable `user.roles` gracefully (catches TypeError) ✅
- Falls back to empty list if roles cannot be iterated