### PR TITLE
fix(charts): improve minor gridline visibility in dark themes

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -232,6 +232,9 @@ function Echart(
             axisLine: { lineStyle: { color: antdTheme.colorSplit } },
             axisLabel: { color: antdTheme.colorTextSecondary },
             splitLine: { lineStyle: { color: antdTheme.colorSplit } },
+            minorSplitLine: {
+              lineStyle: { color: antdTheme.colorBorderSecondary },
+            },
           };
         }
         if (options?.yAxis) {
@@ -239,6 +242,9 @@ function Echart(
             axisLine: { lineStyle: { color: antdTheme.colorSplit } },
             axisLabel: { color: antdTheme.colorTextSecondary },
             splitLine: { lineStyle: { color: antdTheme.colorSplit } },
+            minorSplitLine: {
+              lineStyle: { color: antdTheme.colorBorderSecondary },
+            },
           };
         }
         return echartsTheme;


### PR DESCRIPTION
## SUMMARY
Fixes #37344 - Minor tick gridlines were overly bright and prominent in dark themes.

## BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The issue reporter provided screenshots showing overly bright minor gridlines in dark theme:
- Issue: https://github.com/apache/superset/issues/37344

## DESCRIPTION OF CHANGE
Minor tick gridlines were using ECharts default colors instead of theme-aware colors, making them overly bright and visually dominant in dark themes. This change applies the theme's `colorBorderSecondary` token to minor gridlines for both x and y axes.

**Changes:**
- Added `minorSplitLine` configuration to `xAxis` theme
- Added `minorSplitLine` configuration to `yAxis` theme
- Uses `colorBorderSecondary` token for appropriate subtlety

This ensures minor gridlines maintain proper visual hierarchy (less prominent than major gridlines) while being theme-aware across both light and dark modes.

## TESTING INSTRUCTIONS
1. Enable dark theme in Superset
2. Create a chart with visible gridlines (e.g., time series, bar chart)
3. Verify minor gridlines are now subtle and appropriately colored
4. Switch to light theme and verify minor gridlines still look good

## ADDITIONAL INFORMATION
- **Type**: Bug fix (cosmetic)
- **Scope**: ECharts-based visualizations
- **Breaking Change**: No