### PR TITLE
fix(mcp): honor target_tab parameter when adding charts to tabbed dashboards

### DIFF
--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -63,17 +63,21 @@ def _find_next_row_position(layout: Dict[str, Any]) -> str:
     return row_key
 
 
-def _find_tab_insert_target(layout: Dict[str, Any]) -> str | None:
+def _find_tab_insert_target(
+    layout: Dict[str, Any], target_tab: str | None = None
+) -> str | None:
     """
-    Detect if the dashboard uses tabs and return the first tab's ID.
+    Detect if the dashboard uses tabs and return the appropriate tab's ID.
 
-    If ``GRID_ID`` has children that are ``TABS`` components, this walks
-    into the first ``TAB`` child so that new rows are placed inside the
-    active tab rather than directly under GRID_ID.
+    If *target_tab* is provided the function first tries to match it against
+    tab ``meta.text`` (display name) or the raw component ID.  When no match
+    is found (or *target_tab* is ``None``) the first ``TAB`` child is used as
+    a fallback so that new rows are still placed inside the tab structure
+    rather than directly under ``GRID_ID``.
 
     Returns:
-        The ID of the first TAB component, or ``None`` if the dashboard
-        does not use top-level tabs.
+        The ID of the matched (or first) TAB component, or ``None`` if the
+        dashboard does not use top-level tabs.
     """
     grid = layout.get("GRID_ID")
     if not grid:
@@ -82,13 +86,25 @@ def _find_tab_insert_target(layout: Dict[str, Any]) -> str | None:
     for child_id in grid.get("children", []):
         child = layout.get(child_id)
         if child and child.get("type") == "TABS":
-            # Found a TABS component; use its first TAB child
             tabs_children = child.get("children", [])
-            if tabs_children:
-                first_tab_id = tabs_children[0]
-                first_tab = layout.get(first_tab_id)
-                if first_tab and first_tab.get("type") == "TAB":
-                    return first_tab_id
+            if not tabs_children:
+                continue
+
+            # When a target_tab is specified, try to resolve it by name or ID
+            if target_tab:
+                for tab_id in tabs_children:
+                    tab = layout.get(tab_id)
+                    if not tab or tab.get("type") != "TAB":
+                        continue
+                    tab_text = (tab.get("meta") or {}).get("text", "")
+                    if target_tab in (tab_id, tab_text):
+                        return tab_id
+
+            # Fallback: return the first TAB child
+            first_tab_id = tabs_children[0]
+            first_tab = layout.get(first_tab_id)
+            if first_tab and first_tab.get("type") == "TAB":
+                return first_tab_id
     return None
 
 
@@ -284,8 +300,10 @@ def add_chart_to_existing_dashboard(
             # Generate a unique ROW ID for the new row
             row_key = _find_next_row_position(current_layout)
 
-            # Detect tabbed dashboards: if GRID has TABS, target the first tab
-            tab_target = _find_tab_insert_target(current_layout)
+            # Detect tabbed dashboards and resolve target_tab by name or ID
+            tab_target = _find_tab_insert_target(
+                current_layout, target_tab=request.target_tab
+            )
             parent_id = tab_target if tab_target else "GRID_ID"
 
             # Add chart, column, and row to layout

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -610,6 +610,107 @@ class TestAddChartToExistingDashboard:
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
+    async def test_add_chart_to_specific_tab_by_name(
+        self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
+    ):
+        """Test adding chart to a specific tab using target_tab name."""
+        mock_dashboard = _mock_dashboard(id=3, title="Tabbed Dashboard")
+        mock_dashboard.slices = [Mock(id=10)]
+        mock_dashboard.position_json = json.dumps(
+            {
+                "ROOT_ID": {
+                    "children": ["GRID_ID"],
+                    "id": "ROOT_ID",
+                    "type": "ROOT",
+                },
+                "GRID_ID": {
+                    "children": ["TABS-abc123"],
+                    "id": "GRID_ID",
+                    "parents": ["ROOT_ID"],
+                    "type": "GRID",
+                },
+                "TABS-abc123": {
+                    "children": ["TAB-tab1", "TAB-tab2"],
+                    "id": "TABS-abc123",
+                    "parents": ["ROOT_ID", "GRID_ID"],
+                    "type": "TABS",
+                },
+                "TAB-tab1": {
+                    "children": ["ROW-existing"],
+                    "id": "TAB-tab1",
+                    "meta": {"text": "Activity Metrics"},
+                    "parents": ["ROOT_ID", "GRID_ID", "TABS-abc123"],
+                    "type": "TAB",
+                },
+                "TAB-tab2": {
+                    "children": [],
+                    "id": "TAB-tab2",
+                    "meta": {"text": "Customers"},
+                    "parents": ["ROOT_ID", "GRID_ID", "TABS-abc123"],
+                    "type": "TAB",
+                },
+                "ROW-existing": {
+                    "children": ["CHART-10"],
+                    "id": "ROW-existing",
+                    "meta": {"background": "BACKGROUND_TRANSPARENT"},
+                    "parents": ["ROOT_ID", "GRID_ID", "TABS-abc123", "TAB-tab1"],
+                    "type": "ROW",
+                },
+                "CHART-10": {
+                    "id": "CHART-10",
+                    "type": "CHART",
+                    "parents": [
+                        "ROOT_ID",
+                        "GRID_ID",
+                        "TABS-abc123",
+                        "TAB-tab1",
+                        "ROW-existing",
+                    ],
+                },
+                "DASHBOARD_VERSION_KEY": "v2",
+            }
+        )
+        mock_find_dashboard.return_value = mock_dashboard
+
+        mock_chart = _mock_chart(id=30, slice_name="Customer Chart")
+        mock_db_session.get.return_value = mock_chart
+
+        updated_dashboard = _mock_dashboard(id=3, title="Tabbed Dashboard")
+        updated_dashboard.slices = [Mock(id=10), Mock(id=30)]
+        mock_update_command.return_value.run.return_value = updated_dashboard
+
+        request = {"dashboard_id": 3, "chart_id": 30, "target_tab": "Customers"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "add_chart_to_existing_dashboard", {"request": request}
+            )
+
+            assert result.structured_content["error"] is None
+
+            call_args = mock_update_command.call_args[0][1]
+            layout = json.loads(call_args["position_json"])
+
+            row_key = result.structured_content["position"]["row_key"]
+            assert row_key in layout
+
+            # Chart should be in TAB-tab2 (Customers), NOT TAB-tab1
+            assert row_key in layout["TAB-tab2"]["children"]
+            assert row_key not in layout["TAB-tab1"]["children"]
+
+            # GRID_ID should still only have TABS, not the new row
+            assert layout["GRID_ID"]["children"] == ["TABS-abc123"]
+
+            # Verify correct parent chain includes TAB-tab2
+            chart_parents = layout["CHART-30"]["parents"]
+            assert "TABS-abc123" in chart_parents
+            assert "TAB-tab2" in chart_parents
+            assert "TAB-tab1" not in chart_parents
+
+    @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+    @patch("superset.db.session")
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -709,6 +810,63 @@ class TestLayoutHelpers:
             "TAB-second": {"children": [], "type": "TAB"},
         }
         assert _find_tab_insert_target(layout) == "TAB-first"
+
+    def test_find_tab_insert_target_by_tab_name(self):
+        """Test _find_tab_insert_target resolves target_tab by display name."""
+        layout = {
+            "GRID_ID": {"children": ["TABS-main"], "type": "GRID"},
+            "TABS-main": {"children": ["TAB-first", "TAB-second"], "type": "TABS"},
+            "TAB-first": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Activity Metrics"},
+            },
+            "TAB-second": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Customers"},
+            },
+        }
+        assert _find_tab_insert_target(layout, target_tab="Customers") == "TAB-second"
+
+    def test_find_tab_insert_target_by_tab_id(self):
+        """Test _find_tab_insert_target resolves target_tab by component ID."""
+        layout = {
+            "GRID_ID": {"children": ["TABS-main"], "type": "GRID"},
+            "TABS-main": {"children": ["TAB-first", "TAB-second"], "type": "TABS"},
+            "TAB-first": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Tab 1"},
+            },
+            "TAB-second": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Tab 2"},
+            },
+        }
+        assert _find_tab_insert_target(layout, target_tab="TAB-second") == "TAB-second"
+
+    def test_find_tab_insert_target_unmatched_falls_back_to_first(self):
+        """Test _find_tab_insert_target falls back to first tab when target_tab
+        doesn't match any tab name or ID."""
+        layout = {
+            "GRID_ID": {"children": ["TABS-main"], "type": "GRID"},
+            "TABS-main": {"children": ["TAB-first", "TAB-second"], "type": "TABS"},
+            "TAB-first": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Tab 1"},
+            },
+            "TAB-second": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Tab 2"},
+            },
+        }
+        assert (
+            _find_tab_insert_target(layout, target_tab="Nonexistent Tab") == "TAB-first"
+        )
 
     def test_find_tab_insert_target_no_grid(self):
         """Test _find_tab_insert_target with missing GRID_ID."""


### PR DESCRIPTION
### SUMMARY

When adding charts to a dashboard that uses tabs via the `add_chart_to_existing_dashboard` MCP tool, the `target_tab` parameter was accepted without error but completely ignored. Charts were always placed in the first tab or under `GRID_ID` at the root level, where they become invisible ghost entries — registered in the dashboard metadata but never rendered in the UI.

**Root cause:** `_find_tab_insert_target()` always returned the first `TAB` child and the `request.target_tab` value was never passed to it.

**Fix:** `_find_tab_insert_target()` now accepts an optional `target_tab` parameter and resolves it by matching against the tab display name (`meta.text`) or the raw component ID. When no match is found it falls back to the first tab to preserve backward compatibility.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend logic change, no UI modifications.

### TESTING INSTRUCTIONS

1. Create a dashboard with multiple tabs (e.g., "Activity Metrics", "Customers")
2. Call `add_chart_to_existing_dashboard` with `target_tab` set to the second tab's name
3. Verify the chart appears inside the specified tab (not the first tab, and not invisible under GRID_ID)
4. Call without `target_tab` — chart should still land in the first tab (backward compat)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API