### PR TITLE
fix(mcp): return all statement results for multi-statement SQL queries

### DIFF
--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -140,7 +140,7 @@ class ExecuteSqlResponse(BaseModel):
         None,
         description=(
             "Warning when multiple data-bearing statements were executed. "
-            "The top-level rows/columns contain only the last statement's results. "
+            "The top-level rows/columns contain only the last data-bearing statement's results. "
             "Check each entry in the statements array for per-statement data."
         ),
     )

--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -84,6 +84,15 @@ class ColumnInfo(BaseModel):
     is_nullable: bool | None = Field(None, description="Whether column allows NULL")
 
 
+class StatementData(BaseModel):
+    """Row data and column metadata for a single SQL statement."""
+
+    rows: list[dict[str, Any]] = Field(
+        ..., description="Result rows as list of dictionaries"
+    )
+    columns: list[ColumnInfo] = Field(..., description="Column metadata information")
+
+
 class StatementInfo(BaseModel):
     """Information about a single SQL statement execution."""
 
@@ -94,6 +103,14 @@ class StatementInfo(BaseModel):
     row_count: int = Field(..., description="Number of rows returned/affected")
     execution_time_ms: float | None = Field(
         None, description="Statement execution time in milliseconds"
+    )
+    data: StatementData | None = Field(
+        None,
+        description=(
+            "Row data and column metadata for this statement. "
+            "Present for data-bearing statements (e.g., SELECT), "
+            "absent for DML/DDL statements (e.g., SET, UPDATE)."
+        ),
     )
 
 
@@ -118,6 +135,14 @@ class ExecuteSqlResponse(BaseModel):
     error_type: str | None = Field(None, description="Type of error if failed")
     statements: list[StatementInfo] | None = Field(
         None, description="Per-statement execution info (for multi-statement queries)"
+    )
+    multi_statement_warning: str | None = Field(
+        None,
+        description=(
+            "Warning when multiple data-bearing statements were executed. "
+            "The top-level rows/columns contain only the last statement's results. "
+            "Check each entry in the statements array for per-statement data."
+        ),
     )
 
 

--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -140,7 +140,8 @@ class ExecuteSqlResponse(BaseModel):
         None,
         description=(
             "Warning when multiple data-bearing statements were executed. "
-            "The top-level rows/columns contain only the last data-bearing statement's results. "
+            "The top-level rows/columns contain only the last "
+            "data-bearing statement's results. "
             "Check each entry in the statements array for per-statement data."
         ),
     )

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -203,7 +203,7 @@ def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
             last_data_stmt = stmt
             break
 
-    if last_data_stmt is not None:
+    if last_data_stmt is not None and last_data_stmt.data is not None:
         rows = last_data_stmt.data.rows
         columns = last_data_stmt.data.columns
         row_count = len(last_data_stmt.data.rows)

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -203,7 +203,7 @@ def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
             last_data_stmt = stmt
             break
 
-    if last_data_stmt is not None and last_data_stmt.data is not None:
+    if last_data_stmt is not None:
         rows = last_data_stmt.data.rows
         columns = last_data_stmt.data.columns
         row_count = len(last_data_stmt.data.rows)

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -217,10 +217,13 @@ def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
     multi_statement_warning: str | None = None
     if data_bearing_count > 1:
         multi_statement_warning = (
-            f"This query contained {data_bearing_count} data-bearing statements. "
-            "The top-level rows/columns contain only the last data-bearing statement's results. "
-            "Check the 'data' field in each entry of the 'statements' array "
-            "to see results from ALL statements."
+            f"This query contained {data_bearing_count} "
+            "data-bearing statements. "
+            "The top-level rows/columns contain only the "
+            "last data-bearing statement's results. "
+            "Check the 'data' field in each entry of the "
+            "'statements' array to see results from ALL "
+            "statements."
         )
 
     return ExecuteSqlResponse(

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -218,7 +218,7 @@ def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
     if data_bearing_count > 1:
         multi_statement_warning = (
             f"This query contained {data_bearing_count} data-bearing statements. "
-            "The top-level rows/columns contain only the LAST statement's results. "
+            "The top-level rows/columns contain only the last data-bearing statement's results. "
             "Check the 'data' field in each entry of the 'statements' array "
             "to see results from ALL statements."
         )

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -43,6 +43,7 @@ from superset.mcp_service.sql_lab.schemas import (
     ColumnInfo,
     ExecuteSqlRequest,
     ExecuteSqlResponse,
+    StatementData,
     StatementInfo,
 )
 from superset.mcp_service.utils.schema_utils import parse_request
@@ -162,55 +163,65 @@ def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
             error_type=result.status.value,
         )
 
-    # Build statement info list
-    statements = [
-        StatementInfo(
-            original_sql=stmt.original_sql,
-            executed_sql=stmt.executed_sql,
-            row_count=stmt.row_count,
-            execution_time_ms=stmt.execution_time_ms,
-        )
-        for stmt in result.statements
-    ]
+    # Build statement info list, including per-statement row data
+    # for data-bearing statements (e.g., SELECT).
+    statements: list[StatementInfo] = []
+    data_bearing_count = 0
 
-    # Find the last statement with data (SELECT results).
-    # For single statements this is the same as first.
-    # For multi-statement queries (e.g., SET ...; SELECT ...) this skips
-    # non-data statements and returns the actual query results.
+    for stmt in result.statements:
+        stmt_data: StatementData | None = None
+        if stmt.data is not None:
+            df = stmt.data
+            stmt_data = StatementData(
+                rows=df.to_dict(orient="records"),
+                columns=[
+                    ColumnInfo(name=col, type=str(df[col].dtype)) for col in df.columns
+                ],
+            )
+            data_bearing_count += 1
+
+        statements.append(
+            StatementInfo(
+                original_sql=stmt.original_sql,
+                executed_sql=stmt.executed_sql,
+                row_count=stmt.row_count,
+                execution_time_ms=stmt.execution_time_ms,
+                data=stmt_data,
+            )
+        )
+
+    # Top-level rows/columns come from the last data-bearing statement
+    # for backward compatibility.
     rows: list[dict[str, Any]] | None = None
     columns: list[ColumnInfo] | None = None
     row_count: int | None = None
     affected_rows: int | None = None
 
-    data_stmt = None
-    for stmt in reversed(result.statements):
+    last_data_stmt = None
+    for stmt in reversed(statements):
         if stmt.data is not None:
-            data_stmt = stmt
+            last_data_stmt = stmt
             break
 
-    if data_stmt is not None and data_stmt.data is not None:
-        # SELECT query - convert DataFrame
-        import pandas as pd
-
-        df = data_stmt.data
-        if not isinstance(df, pd.DataFrame):
-            logger.error(
-                "Expected DataFrame but got %s for statement data",
-                type(df).__name__,
-            )
-            return ExecuteSqlResponse(
-                success=False,
-                error=f"Internal error: unexpected data type ({type(df).__name__})",
-                error_type="data_conversion_error",
-                statements=statements,
-            )
-        rows = df.to_dict(orient="records")
-        columns = [ColumnInfo(name=col, type=str(df[col].dtype)) for col in df.columns]
-        row_count = len(df)
+    if last_data_stmt is not None and last_data_stmt.data is not None:
+        rows = last_data_stmt.data.rows
+        columns = last_data_stmt.data.columns
+        row_count = len(last_data_stmt.data.rows)
     elif result.statements:
         # DML-only query
         last_stmt = result.statements[-1]
         affected_rows = last_stmt.row_count
+
+    # Warn when multiple data-bearing statements exist so the LLM
+    # knows to inspect the statements array for all results.
+    multi_statement_warning: str | None = None
+    if data_bearing_count > 1:
+        multi_statement_warning = (
+            f"This query contained {data_bearing_count} data-bearing statements. "
+            "The top-level rows/columns contain only the LAST statement's results. "
+            "Check the 'data' field in each entry of the 'statements' array "
+            "to see results from ALL statements."
+        )
 
     return ExecuteSqlResponse(
         success=True,
@@ -224,4 +235,5 @@ def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
             else None
         ),
         statements=statements,
+        multi_statement_warning=multi_statement_warning,
     )

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -699,7 +699,7 @@ class TestExecuteSql:
     @pytest.mark.asyncio
     async def test_execute_sql_multi_statement_preserves_all_data(
         self, mock_db, mock_security_manager, mcp_server
-    ):
+    ) -> None:
         """Test that multi-statement SQL returns per-statement data for ALL results.
 
         Regression test: previously, running two SELECT statements would only

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -530,6 +530,21 @@ class TestExecuteSql:
             assert data["rows"] == [{"b": 2}]
             assert data["row_count"] == 1
 
+            # Per-statement data should be present for both statements
+            assert data["statements"][0]["data"] is not None
+            assert data["statements"][0]["data"]["rows"] == [{"a": 1}]
+            assert len(data["statements"][0]["data"]["columns"]) == 1
+            assert data["statements"][0]["data"]["columns"][0]["name"] == "a"
+
+            assert data["statements"][1]["data"] is not None
+            assert data["statements"][1]["data"]["rows"] == [{"b": 2}]
+            assert len(data["statements"][1]["data"]["columns"]) == 1
+            assert data["statements"][1]["data"]["columns"][0]["name"] == "b"
+
+            # Warning should be present for multi-data-bearing queries
+            assert data["multi_statement_warning"] is not None
+            assert "2 data-bearing statements" in data["multi_statement_warning"]
+
     @patch("superset.security_manager")
     @patch("superset.db")
     @pytest.mark.asyncio
@@ -609,6 +624,14 @@ class TestExecuteSql:
             assert "id" in column_names
             assert "amount" in column_names
 
+            # SET statement should have no data, SELECT should have data
+            assert data["statements"][0]["data"] is None
+            assert data["statements"][1]["data"] is not None
+            assert len(data["statements"][1]["data"]["rows"]) == 2
+
+            # No warning since only one data-bearing statement
+            assert data["multi_statement_warning"] is None
+
     @patch("superset.security_manager")
     @patch("superset.db")
     @pytest.mark.asyncio
@@ -663,6 +686,94 @@ class TestExecuteSql:
             assert data["row_count"] is None
             # affected_rows should come from the last statement
             assert data["affected_rows"] == 5
+
+            # DML statements should have no per-statement data
+            assert data["statements"][0]["data"] is None
+            assert data["statements"][1]["data"] is None
+
+            # No warning for DML-only queries
+            assert data["multi_statement_warning"] is None
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_execute_sql_multi_statement_preserves_all_data(
+        self, mock_db, mock_security_manager, mcp_server
+    ):
+        """Test that multi-statement SQL returns per-statement data for ALL results.
+
+        Regression test: previously, running two SELECT statements would only
+        return the last statement's rows in the top-level response and
+        completely lose the first statement's row data.
+        """
+        mock_database = _mock_database()
+        mock_database.execute.return_value = QueryResult(
+            status=QueryStatus.SUCCESS,
+            statements=[
+                StatementResult(
+                    original_sql="SELECT COUNT(*) AS order_count FROM orders",
+                    executed_sql="SELECT COUNT(*) AS order_count FROM orders",
+                    data=pd.DataFrame([{"order_count": 42}]),
+                    row_count=1,
+                    execution_time_ms=5.0,
+                ),
+                StatementResult(
+                    original_sql="SELECT SUM(revenue) AS total_revenue FROM orders",
+                    executed_sql="SELECT SUM(revenue) AS total_revenue FROM orders",
+                    data=pd.DataFrame([{"total_revenue": 12345.67}]),
+                    row_count=1,
+                    execution_time_ms=7.0,
+                ),
+            ],
+            query_id=None,
+            total_execution_time_ms=12.0,
+            is_cached=False,
+        )
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {
+            "database_id": 1,
+            "sql": (
+                "SELECT COUNT(*) AS order_count FROM orders;"
+                " SELECT SUM(revenue) AS total_revenue FROM orders"
+            ),
+            "limit": 100,
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+
+            data = result.structured_content
+            assert data["success"] is True
+
+            # Top-level rows/columns should be from the LAST data-bearing stmt
+            assert data["rows"] == [{"total_revenue": 12345.67}]
+            assert data["row_count"] == 1
+
+            # Both statements should have per-statement data
+            assert len(data["statements"]) == 2
+
+            # First statement's data is accessible
+            first_stmt = data["statements"][0]
+            assert first_stmt["data"] is not None
+            assert first_stmt["data"]["rows"] == [{"order_count": 42}]
+            assert len(first_stmt["data"]["columns"]) == 1
+            assert first_stmt["data"]["columns"][0]["name"] == "order_count"
+
+            # Second statement's data is accessible
+            second_stmt = data["statements"][1]
+            assert second_stmt["data"] is not None
+            assert second_stmt["data"]["rows"] == [{"total_revenue": 12345.67}]
+            assert len(second_stmt["data"]["columns"]) == 1
+            assert second_stmt["data"]["columns"][0]["name"] == "total_revenue"
+
+            # Warning should tell LLM to check statements array
+            assert data["multi_statement_warning"] is not None
+            assert "2 data-bearing statements" in data["multi_statement_warning"]
+            assert "statements" in data["multi_statement_warning"]
 
     @pytest.mark.asyncio
     async def test_execute_sql_empty_query_validation(self, mcp_server):


### PR DESCRIPTION
## **User description**
### SUMMARY

When the MCP `execute_sql` tool runs multi-statement SQL (e.g., `SELECT COUNT(*) FROM orders; SELECT SUM(revenue) FROM orders`), only the last data-bearing statement's results appear in the top-level `rows`/`columns` response fields. The earlier statement results are completely lost — only metadata (`original_sql`, `row_count`) is preserved in the `statements` array, with no actual row data.

**Root cause**: The `_convert_to_response()` function in `execute_sql.py` iterates backwards through statements but only extracts data from the last one with a DataFrame.

**Fix**:
- Adds a `StatementData` Pydantic schema (rows + columns) and a `data` field on `StatementInfo` so each statement carries its own result data for data-bearing statements (e.g., SELECT).
- Populates per-statement data in `_convert_to_response()` for every statement that has a DataFrame result.
- Keeps the top-level `rows`/`columns` pointing to the last data-bearing statement for backward compatibility with single-statement consumers.
- Adds a `multi_statement_warning` field to `ExecuteSqlResponse` when multiple data-bearing statements exist, directing the LLM to check the `statements` array for all results.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change to MCP tool response schema.

### TESTING INSTRUCTIONS

**Automated tests:**
```bash
python -m pytest tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py -x -q
```
All 16 tests should pass, including:
- `test_execute_sql_multi_statement` — verifies per-statement `data` field and `multi_statement_warning`
- `test_execute_sql_multi_statement_preserves_all_data` — regression test for the exact bug
- `test_execute_sql_multi_statement_set_then_select` — SET + SELECT only populates data for SELECT, no warning
- `test_execute_sql_multi_statement_all_dml` — DML-only queries have no per-statement data and no warning

**Manual MCP test (confirmed on local instance):**

Run this multi-statement query via `execute_sql`:
```json
{"database_id": 1, "sql": "SELECT COUNT(*) as total_births FROM birth_names; SELECT AVG(num) as avg_num FROM birth_names"}
```

**Before (current behavior):**
- Top-level `rows` only contains `[{"avg_num": 1065.9}]` (last statement)
- First statement's data (`total_births`) is completely lost
- `statements` array has metadata but no `data` field
- No warning about missing results

**After (with this fix):**
- Top-level `rows` still contains last statement's data (backward compatible)
- `statements[0].data.rows` contains `[{"total_births": ...}]`
- `statements[1].data.rows` contains `[{"avg_num": 1065.9}]`
- `multi_statement_warning` field present, directing LLM to check statements array

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

## MCP Testing (on branch `amin/fix-mcp-multi-statement-sql`)

Tested via localhost MCP service:

| Test | Command | Result |
|------|---------|--------|
| Multi-statement (2) | `execute_sql("SELECT 1 AS first; SELECT 2 AS second")` | Both statements in `statements` array with individual SQL, row_count, execution_time_ms |
| Multi-statement (3) | `execute_sql("SELECT COUNT(*) FROM ab_user; SELECT COUNT(*) FROM birth_france_by_region; SELECT 'hello'")` | All 3 statements parsed and executed individually |
| Single statement | `execute_sql("SELECT DEPT_ID, 2014 FROM birth_france_by_region LIMIT 5")` | Works normally, single entry in statements array |
| rows field | Multi-statement queries | Returns last data-bearing statement's rows (by design) |


___

## **CodeAnt-AI Description**
Return per-statement results for multi-statement SQL queries in MCP execute_sql

### What Changed
- Per-statement result data (rows + columns) is now returned for each data-bearing statement (e.g., SELECT) in the statements array.
- Top-level rows/columns continue to contain the last data-bearing statement's results for backward compatibility.
- A multi-statement warning is added to responses when multiple data-bearing statements ran, directing callers to inspect each statement's data.
- Tests added/updated to verify per-statement data presence, correct top-level behavior, DML-only handling (no per-statement data), and presence/absence of the warning.

### Impact
`✅ Access to all SELECT results in multi-statement queries`
`✅ Clearer guidance for LLMs and callers to find all statement results`
`✅ No silent loss of earlier query rows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
