### PR TITLE
fix(charts): set reasonable default y-axis title margin to prevent label overlap

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
@@ -158,7 +158,7 @@ const defaultFormData: EchartsTimeseriesFormData & {
   xAxisTitle: '',
   xAxisTitleMargin: 0,
   yAxisTitle: '',
-  yAxisTitleMargin: 0,
+  yAxisTitleMargin: 15,
   yAxisTitlePosition: '',
   time_range: 'No filter',
   granularity: undefined,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -46,7 +46,7 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   xAxisTitle: '',
   xAxisTitleMargin: 0,
   yAxisTitle: '',
-  yAxisTitleMargin: 0,
+  yAxisTitleMargin: 15,
   yAxisTitlePosition: 'Top',
   // Now that the weird bug workaround is over, here's the rest...
   ...DEFAULT_SORT_SERIES_DATA,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -104,7 +104,7 @@ export const DEFAULT_TITLE_FORM_DATA: TitleFormData = {
   xAxisTitle: '',
   xAxisTitleMargin: 0,
   yAxisTitle: '',
-  yAxisTitleMargin: 0,
+  yAxisTitleMargin: 15,
   yAxisTitlePosition: 'Top',
 };
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -112,7 +112,7 @@ const formData: EchartsMixedTimeseriesFormData = {
   yAxisBounds: [undefined, undefined],
   yAxisBoundsSecondary: [undefined, undefined],
   yAxisTitle: '',
-  yAxisTitleMargin: 0,
+  yAxisTitleMargin: 15,
   yAxisTitlePosition: '',
   yAxisTitleSecondary: '',
   zoomable: false,


### PR DESCRIPTION
## **User description**
### SUMMARY

Several ECharts-based chart types (Timeseries, MixedTimeseries, BoxPlot, etc.) default `yAxisTitleMargin` to `0`. This value feeds directly into ECharts' `nameGap` configuration, which controls the spacing between the y-axis title and its tick labels. With `nameGap: 0`, whenever a user adds a y-axis title the text renders on top of the tick labels, making both unreadable.

This PR changes the default `yAxisTitleMargin` from `0` to `15` in:

- `DEFAULT_TITLE_FORM_DATA` (shared across multiple chart types)
- `DEFAULT_FORM_DATA` in the Timeseries constants (which inlines the same defaults)

A value of 15 provides enough spacing to prevent overlap without being excessive. For reference, the Histogram chart already hardcodes `nameGap: 40`/`55`, and the Bubble chart defaults to `yAxisTitleMargin: 30`.

Test fixtures that hardcoded the old default of `0` as form data input have been updated to match.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**: Y-axis title text overlaps with tick labels when `yAxisTitleMargin` defaults to 0.
**After**: Y-axis title text has 15px of spacing from tick labels, making both legible.

### TESTING INSTRUCTIONS

**Automated tests:**
```bash
cd superset-frontend && npx jest --no-coverage plugins/plugin-chart-echarts/test --passWithNoTests
```

**Manual test via MCP (confirmed on local instance):**

1. Generate a bar chart with a y-axis title via MCP `generate_chart`:
```json
{
  "dataset_id": 17,
  "config": {
    "chart_type": "xy",
    "x": {"name": "state"},
    "y": [{"name": "num", "aggregate": "SUM", "label": "Total Births"}],
    "kind": "bar",
    "y_axis": {"title": "Number of Births"}
  }
}
```
2. Open the explore URL returned by the tool
3. Verify the y-axis title "Number of Births" has visible spacing from the tick labels (not overlapping)

**Before (current behavior):**
- The `form_data` returned by `generate_chart` includes `y_axis_title: "Number of Births"` but `yAxisTitleMargin` defaults to 0
- On the frontend, the title overlaps with the axis tick labels

**After (with this fix):**
- `yAxisTitleMargin` defaults to 15, giving enough spacing between the title and tick labels
- Users can still override this value via the Customize tab

**Additional manual test:**
1. Open any Timeseries, MixedTimeseries, or BoxPlot chart in Explore
2. In the Customize tab, set a Y-Axis Title (e.g. "Revenue")
3. Verify the title no longer overlaps with the axis tick labels
4. Verify that manually adjusting the Y-Axis Title Margin control still works as expected

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Set default y-axis title margin to 15px to prevent overlap with tick labels**

### What Changed
- Default y-axis title margin was changed from 0 to 15 across shared chart defaults and Timeseries/MixedTimeseries test fixtures so y-axis titles no longer render on top of tick labels
- Updated test fixtures to reflect the new default so generated charts and snapshots match the visible spacing

### Impact
`✅ Clearer y-axis titles without manual adjustments`
`✅ Fewer charts with unreadable overlapping axis text`
`✅ Less need to tweak axis spacing when adding y-axis titles`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
