### PR TITLE
feat(mcp): add horizontal bar chart orientation support to generate_chart

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -468,6 +468,17 @@ def add_legend_config(form_data: Dict[str, Any], config: XYChartConfig) -> None:
             form_data["legend_orientation"] = config.legend.position
 
 
+def add_orientation_config(form_data: Dict[str, Any], config: XYChartConfig) -> None:
+    """Add orientation configuration to form_data for bar charts.
+
+    Only applies when kind='bar' and an explicit orientation is set.
+    When orientation is None (the default), Superset uses its own default
+    (vertical bars).
+    """
+    if config.kind == "bar" and getattr(config, "orientation", None):
+        form_data["orientation"] = config.orientation
+
+
 def configure_temporal_handling(
     form_data: Dict[str, Any],
     x_is_temporal: bool,
@@ -576,6 +587,7 @@ def map_xy_config(
     # Add configurations
     add_axis_config(form_data, config)
     add_legend_config(form_data, config)
+    add_orientation_config(form_data, config)
 
     return form_data
 

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -475,7 +475,7 @@ def add_orientation_config(form_data: Dict[str, Any], config: XYChartConfig) -> 
     When orientation is None (the default), Superset uses its own default
     (vertical bars).
     """
-    if config.kind == "bar" and getattr(config, "orientation", None):
+    if config.kind == "bar" and config.orientation:
         form_data["orientation"] = config.orientation
 
 

--- a/superset/mcp_service/chart/resources/chart_configs.py
+++ b/superset/mcp_service/chart/resources/chart_configs.py
@@ -129,6 +129,29 @@ def get_chart_configs_resource() -> str:
             },
             "use_cases": ["Correlation analysis", "Outlier detection"],
         },
+        "horizontal_bar": {
+            "description": "Horizontal bar chart for categories with long names",
+            "config": {
+                "chart_type": "xy",
+                "kind": "bar",
+                "orientation": "horizontal",
+                "x": {"name": "department", "label": "Department"},
+                "y": [
+                    {
+                        "name": "headcount",
+                        "aggregate": "SUM",
+                        "label": "Headcount",
+                    }
+                ],
+                "y_axis": {"title": "Department"},
+                "x_axis": {"title": "Number of Employees"},
+            },
+            "use_cases": [
+                "Long category labels",
+                "Rankings and leaderboards",
+                "Survey results",
+            ],
+        },
         "stacked_area": {
             "description": "Stacked area chart for volume composition over time",
             "config": {
@@ -215,6 +238,7 @@ def get_chart_configs_resource() -> str:
             "Use group_by to split data into series for comparison",
             "Use stacked=true for bar/area charts showing composition",
             "Configure axis format for readability ($,.0f for currency, .2% for pct)",
+            "Use orientation='horizontal' for bar charts with long category names",
         ],
         "table_charts": [
             "Include only essential columns to avoid clutter",

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -749,6 +749,14 @@ class XYChartConfig(BaseModel):
             "If not specified, Superset will use its default behavior."
         ),
     )
+    orientation: Literal["vertical", "horizontal"] | None = Field(
+        None,
+        description=(
+            "Bar chart orientation. Only applies when kind='bar'. "
+            "'vertical' (default): bars extend upward. "
+            "'horizontal': bars extend rightward, useful for long category names."
+        ),
+    )
     stacked: bool = Field(
         False,
         description="Stack bars/areas on top of each other instead of side-by-side",

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -243,6 +243,61 @@ class TestXYChartConfig:
         assert config.group_by is not None
         assert config.group_by.name == "year"
 
+    def test_orientation_horizontal_accepted(self) -> None:
+        """Test that orientation='horizontal' is accepted for bar charts."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="department"),
+            y=[ColumnRef(name="headcount", aggregate="SUM")],
+            kind="bar",
+            orientation="horizontal",
+        )
+        assert config.orientation == "horizontal"
+
+    def test_orientation_vertical_accepted(self) -> None:
+        """Test that orientation='vertical' is accepted for bar charts."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="category"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            kind="bar",
+            orientation="vertical",
+        )
+        assert config.orientation == "vertical"
+
+    def test_orientation_none_by_default(self) -> None:
+        """Test that orientation defaults to None when not specified."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="category"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            kind="bar",
+        )
+        assert config.orientation is None
+
+    def test_orientation_invalid_value_rejected(self) -> None:
+        """Test that invalid orientation values are rejected."""
+        with pytest.raises(ValidationError):
+            XYChartConfig(
+                chart_type="xy",
+                x=ColumnRef(name="category"),
+                y=[ColumnRef(name="sales", aggregate="SUM")],
+                kind="bar",
+                orientation="diagonal",
+            )
+
+    def test_orientation_with_non_bar_chart(self) -> None:
+        """Test that orientation field is accepted on non-bar charts at schema level."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+            orientation="horizontal",
+        )
+        # Schema allows it; the chart_utils layer decides whether to apply it
+        assert config.orientation == "horizontal"
+
 
 class TestTableChartConfigExtraFields:
     """Test TableChartConfig rejects unknown fields."""

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -460,6 +460,84 @@ class TestMapXYConfig:
         assert result["groupby"] == ["category"]
         assert result["x_axis"] == "order_date"
 
+    def test_map_xy_config_bar_horizontal_orientation(self) -> None:
+        """Test XY config mapping for horizontal bar chart"""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="department"),
+            y=[ColumnRef(name="headcount", aggregate="SUM")],
+            kind="bar",
+            orientation="horizontal",
+        )
+
+        result = map_xy_config(config)
+
+        assert result["viz_type"] == "echarts_timeseries_bar"
+        assert result["orientation"] == "horizontal"
+
+    def test_map_xy_config_bar_vertical_orientation(self) -> None:
+        """Test XY config mapping for vertical bar chart (explicit)"""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="category"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            kind="bar",
+            orientation="vertical",
+        )
+
+        result = map_xy_config(config)
+
+        assert result["viz_type"] == "echarts_timeseries_bar"
+        assert result["orientation"] == "vertical"
+
+    def test_map_xy_config_bar_no_orientation(self) -> None:
+        """Test XY config mapping for bar chart without orientation."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="category"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            kind="bar",
+        )
+
+        result = map_xy_config(config)
+
+        assert result["viz_type"] == "echarts_timeseries_bar"
+        assert "orientation" not in result
+
+    def test_map_xy_config_line_orientation_ignored(self) -> None:
+        """Test that orientation is ignored for non-bar chart types"""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+            orientation="horizontal",
+        )
+
+        result = map_xy_config(config)
+
+        assert result["viz_type"] == "echarts_timeseries_line"
+        assert "orientation" not in result
+
+    def test_map_xy_config_bar_horizontal_with_stacked(self) -> None:
+        """Test horizontal bar chart with stacked option"""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="department"),
+            y=[ColumnRef(name="headcount", aggregate="SUM")],
+            kind="bar",
+            orientation="horizontal",
+            stacked=True,
+            group_by=ColumnRef(name="level"),
+        )
+
+        result = map_xy_config(config)
+
+        assert result["viz_type"] == "echarts_timeseries_bar"
+        assert result["orientation"] == "horizontal"
+        assert result["stack"] == "Stack"
+        assert result["groupby"] == ["level"]
+
 
 class TestMapConfigToFormData:
     """Test map_config_to_form_data function"""


### PR DESCRIPTION
## **User description**
### SUMMARY

Add an `orientation` parameter to `XYChartConfig` in the MCP `generate_chart` API, enabling MCP clients to create horizontal bar charts.

- **Schema**: Added `orientation: Literal["vertical", "horizontal"] | None` field to `XYChartConfig` in `schemas.py`. Defaults to `None` (vertical bars). Only applies when `kind="bar"`.
- **Mapping**: Extracted `add_orientation_config()` helper in `chart_utils.py` that passes orientation through to `form_data` when the chart kind is `"bar"`. Non-bar chart types ignore the parameter.
- **Resource**: Added a `horizontal_bar` example to the `chart://configs` resource and updated best practices with an orientation tip.
- **Tests**: Added schema validation tests (accepted values, default, invalid values, non-bar charts) and form_data mapping tests (horizontal, vertical, omitted, ignored for line charts, combined with stacked + group_by).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend-only change to MCP API schema.

### TESTING INSTRUCTIONS

**Automated tests:**
```bash
python -m pytest tests/unit_tests/mcp_service/chart/ -x -q
```
All 254 chart tests should pass.

**Manual MCP test (confirmed on local instance):**

1. Verify the current `XYChartConfig` schema does NOT have an `orientation` field:
```json
{
  "dataset_id": 17,
  "config": {
    "chart_type": "xy",
    "x": {"name": "state"},
    "y": [{"name": "num", "aggregate": "SUM", "label": "Total Births"}],
    "kind": "bar"
  }
}
```
The returned `form_data` has `viz_type: "echarts_timeseries_bar"` but no `orientation` key.

**After (with this fix):**

2. Generate a horizontal bar chart:
```json
{
  "dataset_id": 17,
  "config": {
    "chart_type": "xy",
    "x": {"name": "state"},
    "y": [{"name": "num", "aggregate": "SUM", "label": "Total Births"}],
    "kind": "bar",
    "orientation": "horizontal"
  }
}
```

**Expected**: The returned `form_data` includes `"orientation": "horizontal"` and the chart renders with horizontal bars (bars extending rightward).

3. Verify default behavior unchanged — omitting `orientation` should produce vertical bars as before.

4. Verify non-bar charts ignore orientation:
```json
{
  "chart_type": "xy",
  "x": {"name": "ds"},
  "y": [{"name": "num", "aggregate": "SUM"}],
  "kind": "line",
  "orientation": "horizontal"
}
```
**Expected**: `form_data` should NOT contain an `orientation` key.

### ADDITIONAL INFORMATION

- [x] Introduces new feature or API
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## MCP Testing (via localhost MCP service on branch `amin/feat-mcp-horizontal-bar-chart`)

### Test 1: Horizontal bar chart
- `generate_chart(dataset_id=28, config={chart_type: "xy", x: "product_line", y: [{name: "sales", aggregate: "SUM"}], kind: "bar", orientation: "horizontal"})`
- **Result:** form_data contains `orientation: "horizontal"`, chart generated successfully ✅

### Test 2: Default vertical bar chart (no orientation)
- `generate_chart(dataset_id=28, config={chart_type: "xy", x: "product_line", y: [{name: "sales", aggregate: "SUM"}], kind: "bar"})`
- **Result:** No `orientation` field in form_data (vertical default), chart generated successfully ✅


___

## **CodeAnt-AI Description**
Add horizontal bar chart orientation support to MCP generate_chart

### What Changed
- MCP's XY chart config accepts an orientation setting ("vertical" or "horizontal") for bar charts so clients can request horizontal bar charts.
- When a bar chart orientation is provided, the generate_chart mapping includes an orientation field so the rendered chart uses the requested layout; non-bar chart types ignore the orientation.
- The chart configs resource includes a horizontal_bar example and schema + mapping tests were added to validate accepted values, defaults, invalid inputs, and that orientation is ignored for non-bar charts.

### Impact
`✅ Can create horizontal bar charts`
`✅ Better readability for long category labels`
`✅ Fewer manual workarounds when needing sideways bar layouts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
