### PR TITLE
fix(mcp): add guardrails to prevent LLM artifact generation

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -156,6 +156,19 @@ CRITICAL RULES - NEVER VIOLATE:
 - Parameter name reminders: open_sql_lab_with_context uses "sql" (not "query"),
   execute_sql uses "sql" (not "query").
 
+IMPORTANT - Tool-Only Interaction:
+- Do NOT generate code artifacts, HTML pages, JavaScript snippets, or any code intended
+  for the user to run. All visualization, data retrieval, and authentication are handled
+  by the provided MCP tools.
+- Always call the appropriate tool directly instead of writing code. For example, use
+  generate_chart to create visualizations rather than generating plotting code.
+- When a tool returns a URL (chart URL, dashboard URL, explore link, SQL Lab link),
+  return that URL to the user. Do NOT attempt to recreate the visualization in code.
+- Do NOT generate HTML dashboards, embed scripts, or custom frontend code. Use
+  generate_dashboard and add_chart_to_existing_dashboard for dashboard operations.
+- If a user asks for something the tools cannot do, explain the limitation and suggest
+  the closest available tool rather than generating code as a workaround.
+
 General usage tips:
 - All listing tools use 1-based pagination (first page is 1)
 - Use get_schema to discover filterable columns, sortable columns, and default columns


### PR DESCRIPTION
## **User description**
### SUMMARY

When LLM clients (e.g., Claude, GPT) connect to the MCP server, they sometimes generate code artifacts (HTML pages, JavaScript snippets, plotting code) instead of calling the provided MCP tools directly. This defeats the purpose of the MCP integration, which is designed to handle all visualization, authentication, and data fetching through its tool API.

This PR adds an explicit "Tool-Only Interaction" guardrail section to the `DEFAULT_INSTRUCTIONS` in the MCP service. The new instructions tell connected LLMs to:

- **Not** generate code artifacts, HTML pages, or JavaScript snippets
- Call the provided tools directly (e.g., `generate_chart` for visualizations)
- Return tool-provided URLs to users instead of recreating visualizations in code
- Use `generate_dashboard` / `add_chart_to_existing_dashboard` instead of generating HTML dashboards
- Explain tool limitations rather than generating code workarounds

The guardrail text is placed between the "Query Examples" and "General usage tips" sections in the system instructions that all LLM clients receive on connection.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — this is a text change to MCP system instructions, not a UI change.

### TESTING INSTRUCTIONS

**Automated tests:**
```bash
python -m pytest tests/unit_tests/mcp_service/ -x -q
```
All 650 MCP service unit tests should pass.

**Manual MCP test (confirmed on local instance):**

1. Connect an LLM client to the MCP server
2. Call `get_instance_info` to verify connectivity
3. Ask the LLM: "Create a chart showing total births by state"

**Before (current behavior):**
- The LLM may generate matplotlib/plotly code or HTML artifacts instead of calling `generate_chart`
- No explicit instruction tells the LLM to avoid code generation

**After (with this fix):**
- System instructions explicitly tell the LLM to call tools directly
- The LLM should call `generate_chart` and return the explore URL
- If asked for something tools can't do, the LLM should explain limitations instead of generating code

**Verification**: Check the MCP system instructions include the "IMPORTANT - Tool-Only Interaction" section by reviewing `superset/mcp_service/app.py` `get_default_instructions()`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## MCP Testing (via localhost MCP service on branch `amin/fix-mcp-artifact-guardrails`)

### Test 1: health_check returns structured JSON
- `health_check()` → Returns `{"status": "healthy", ...}` ✅

### Test 2: get_chart_info returns structured JSON
- `get_chart_info(identifier=59)` → Returns structured chart metadata ✅

### Test 3: All MCP responses are structured data
- Verified multiple tool responses return Pydantic-serialized JSON, no raw HTML/code/artifacts ✅


___

## **CodeAnt-AI Description**
Prevent LLM clients from returning runnable code or HTML instead of using MCP tools

### What Changed
- The MCP system instructions now include a "Tool-Only Interaction" section that instructs connected LLMs to not generate code artifacts, HTML pages, JavaScript snippets, or other runnable code.
- LLMs are explicitly told to call MCP tools (e.g., generate_chart, generate_dashboard, add_chart_to_existing_dashboard) for visualizations and to return tool-provided URLs instead of recreating visuals in code.
- If a requested action is outside the tools' capabilities, LLMs should explain the limitation and suggest the closest available tool-based alternative.

### Impact
`✅ Fewer HTML/JS visualization artifacts returned by LLMs`
`✅ More responses that include tool-provided chart/dashboard URLs`
`✅ Clearer explanations when a request can't be fulfilled by available tools`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
