### PR TITLE
fix(mcp): add missing __init__.py for chart, dashboard, dataset packages

### DIFF
--- a/superset/mcp_service/chart/__init__.py
+++ b/superset/mcp_service/chart/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/mcp_service/dashboard/__init__.py
+++ b/superset/mcp_service/dashboard/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/mcp_service/dataset/__init__.py
+++ b/superset/mcp_service/dataset/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/mcp_service/test_mcp_tool_registration.py
+++ b/tests/unit_tests/mcp_service/test_mcp_tool_registration.py
@@ -37,3 +37,56 @@ def test_mcp_prompts_registered():
 
     prompts = mcp._prompt_manager._prompts
     assert len(prompts) > 0
+
+
+def test_mcp_resources_registered():
+    """Test that MCP resources are registered.
+
+    Resources are registered via @mcp.resource() decorators in resource files.
+    They require __init__.py in parent packages for find_packages() to include
+    them in distributions. This test ensures all expected resources are found.
+    """
+    from superset.mcp_service.app import mcp
+
+    resource_manager = mcp._resource_manager
+    resources = resource_manager._resources
+    assert len(resources) > 0, "No MCP resources registered"
+
+    # Verify the two documented resources are registered
+    resource_uris = set(resources.keys())
+    assert "chart://configs" in resource_uris, (
+        "chart://configs resource not registered - "
+        "check superset/mcp_service/chart/__init__.py exists"
+    )
+    assert "instance://metadata" in resource_uris, (
+        "instance://metadata resource not registered - "
+        "check superset/mcp_service/system/resources/ imports"
+    )
+
+
+def test_mcp_packages_discoverable_by_setuptools():
+    """Test that all MCP sub-packages have __init__.py for setuptools.
+
+    setuptools.find_packages() only discovers directories with __init__.py.
+    Without __init__.py, sub-packages (tool, resources, prompts) are excluded
+    from built distributions, causing missing module errors in deployments.
+    """
+    from pathlib import Path
+
+    mcp_root = Path(__file__).parents[3] / "superset" / "mcp_service"
+    assert mcp_root.is_dir(), f"MCP service root not found: {mcp_root}"
+
+    # All immediate sub-directories that contain Python files should be packages
+    missing = []
+    for subdir in sorted(mcp_root.iterdir()):
+        if not subdir.is_dir() or subdir.name.startswith(("_", ".")):
+            continue
+        # Check if it has any .py files in it or its subdirectories
+        has_py = any(subdir.rglob("*.py"))
+        if has_py and not (subdir / "__init__.py").exists():
+            missing.append(subdir.name)
+
+    assert not missing, (
+        f"MCP sub-packages missing __init__.py (will be excluded from "
+        f"setuptools distributions): {missing}"
+    )


### PR DESCRIPTION
## **User description**
### SUMMARY

The `chart/`, `dashboard/`, and `dataset/` directories under `superset/mcp_service/` were missing `__init__.py` files. Since `setup.py` uses `setuptools.find_packages()`, which only discovers directories that contain `__init__.py`, these packages and all their sub-packages (`resources/`, `prompts/`, `tool/`) were excluded from built distributions.

This caused MCP resources like `chart://configs` and `instance://metadata` to be unavailable in packaged deployments, even though they worked correctly in local development (where Python's namespace package mechanism allows imports without `__init__.py`).

**Root cause**: `find_packages()` requires `__init__.py` to recognize a directory as a Python package. Without it, the entire subtree is skipped during packaging.

**Fix**:
- Added `__init__.py` to `superset/mcp_service/chart/`, `dashboard/`, and `dataset/`
- Added test to verify all MCP resources are properly registered with the FastMCP server
- Added test to verify all MCP sub-packages have `__init__.py` for setuptools discoverability

For reference, these directories already had `__init__.py` and worked correctly:
- `superset/mcp_service/system/` 
- `superset/mcp_service/explore/`
- `superset/mcp_service/sql_lab/`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - no UI changes

### TESTING INSTRUCTIONS

1. Run the new tests:
   ```bash
   pytest tests/unit_tests/mcp_service/test_mcp_tool_registration.py -v
   ```
2. Verify all 4 tests pass, including the new `test_mcp_resources_registered` and `test_mcp_packages_discoverable_by_setuptools`
3. Optionally, verify resources are listed by an MCP client:
   ```
   ListMcpResourcesTool for the connected MCP server should return chart://configs and instance://metadata
   ```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

## MCP Testing Results (localhost, 2026-03-04)

Tested via localhost MCP tools on branch `fix/mcp-missing-init-py-packages`:

### Server Startup
- MCP server started successfully with no import errors ✅
- No tracebacks or import failures in server logs

### Tool Loading Verification
- `health_check` → healthy ✅
- `list_charts` (chart package) → returns 105 charts, page 1, page_size 2 ✅
- `list_dashboards` (dashboard package) → returns 15 dashboards ✅
- `list_datasets` (dataset package) → returns 42 datasets ✅

### Package Import Verification
- `chart/__init__.py` present → chart tools (list_charts, get_chart_info) load correctly ✅
- `dashboard/__init__.py` present → dashboard tools (list_dashboards) load correctly ✅
- `dataset/__init__.py` present → dataset tools (list_datasets) load correctly ✅

All three packages properly importable as Python packages with the `__init__.py` files.


___

## **CodeAnt-AI Description**
Restore MCP chart, dashboard, and dataset packages so resources are present in releases

### What Changed
- Added missing __init__.py files to superset/mcp_service/chart, /dashboard, and /dataset so these packages and their subpackages are included in built Python distributions
- MCP resources that were absent in packaged deployments (for example chart://configs and instance://metadata) are now registered and available when installed from a distribution
- Added unit tests that verify MCP resources are registered and that all MCP sub-packages include __init__.py to prevent packaging regressions

### Impact
`✅ MCP resources available in packaged deployments`
`✅ Fewer missing-module errors when running Superset from wheels`
`✅ Prevents future packaging regressions via unit tests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
