### PR TITLE
fix(mcp): suppress third-party deprecation warnings from client responses

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -314,6 +314,24 @@ from superset.core.mcp.core_mcp_injection import (  # noqa: E402
 
 initialize_core_mcp_dependencies()
 
+# Suppress known third-party deprecation warnings that leak to MCP clients.
+# The MCP SDK captures Python warnings and forwards them to clients via
+# server log entries, wasting LLM tokens and causing clients to act on
+# irrelevant internal warnings. These warnings come from transitive imports
+# triggered by tool/schema registration below.
+import warnings  # noqa: E402
+
+warnings.filterwarnings(
+    "ignore",
+    category=DeprecationWarning,
+    module=r"marshmallow\..*",
+)
+warnings.filterwarnings(
+    "ignore",
+    category=FutureWarning,
+    module=r"google\..*",
+)
+
 # Import all MCP tools to register them with the mcp instance
 # NOTE: Always add new tool imports here when creating new MCP tools.
 # Tools use the @tool decorator from `superset-core` and register automatically

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -36,6 +36,32 @@ from superset.mcp_service.storage import _create_redis_store
 logger = logging.getLogger(__name__)
 
 
+def _suppress_third_party_warnings() -> None:
+    """Suppress known third-party deprecation warnings from MCP responses.
+
+    The MCP SDK captures Python warnings and forwards them to clients via
+    ``mcp.server.lowlevel.server:Warning:`` log entries.  This wastes LLM
+    tokens and causes clients to try to "fix" irrelevant internal warnings.
+
+    Suppressed warnings:
+    - marshmallow ``RemovedInMarshmallow4Warning`` (triggered during
+      database engine schema instantiation)
+    - google.api_core ``FutureWarning`` (Python version support notices)
+    """
+    import warnings
+
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        module=r"marshmallow\..*",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        category=FutureWarning,
+        module=r"google\..*",
+    )
+
+
 def configure_logging(debug: bool = False) -> None:
     """Configure logging for the MCP service."""
     import sys
@@ -179,6 +205,7 @@ def run_server(
     """
 
     configure_logging(debug)
+    _suppress_third_party_warnings()
 
     # DO NOT IMPORT TOOLS HERE!! IMPORT THEM IN app.py!!!!!
 

--- a/tests/unit_tests/mcp_service/test_mcp_server.py
+++ b/tests/unit_tests/mcp_service/test_mcp_server.py
@@ -109,6 +109,40 @@ def test_create_event_store_uses_default_config_values():
             )
 
 
+def test_suppress_third_party_warnings():
+    """Third-party deprecation warnings filters are installed."""
+    import re
+    import warnings
+
+    from superset.mcp_service.server import _suppress_third_party_warnings
+
+    _suppress_third_party_warnings()
+
+    # Verify marshmallow DeprecationWarning filter is installed
+    marshmallow_filters = [
+        f
+        for f in warnings.filters
+        if f[0] == "ignore"
+        and f[2] is DeprecationWarning
+        and isinstance(f[3], re.Pattern)
+        and f[3].pattern == r"marshmallow\..*"
+    ]
+    assert len(marshmallow_filters) >= 1, (
+        "Expected marshmallow DeprecationWarning filter"
+    )
+
+    # Verify google FutureWarning filter is installed
+    google_filters = [
+        f
+        for f in warnings.filters
+        if f[0] == "ignore"
+        and f[2] is FutureWarning
+        and isinstance(f[3], re.Pattern)
+        and f[3].pattern == r"google\..*"
+    ]
+    assert len(google_filters) >= 1, "Expected google FutureWarning filter"
+
+
 def test_create_event_store_returns_none_when_redis_store_fails():
     """EventStore returns None when Redis store creation fails."""
     config = {


### PR DESCRIPTION
## **User description**
### SUMMARY

The MCP SDK captures Python warnings via the `warnings` module and forwards them to clients as `mcp.server.lowlevel.server:Warning:` log entries. This caused marshmallow `RemovedInMarshmallow4Warning` and google.api_core `FutureWarning` deprecation warnings to leak into MCP tool responses.

**Impact:**
- Pollutes MCP tool responses with irrelevant internal warnings
- Wastes LLM tokens processing these warnings  
- LLM clients may try to "fix" or act on these warnings
- Happens on code paths that trigger marshmallow schema instantiation (e.g., `get_chart_preview` when database connection schemas are loaded)

**Fix:**
Added `warnings.filterwarnings()` calls in two places:
1. **`app.py`** (before tool imports) - Suppresses import-time warnings triggered during tool/schema registration
2. **`server.py`** (`_suppress_third_party_warnings()` called at server startup) - Suppresses runtime warnings during tool execution

Suppressed warning categories:
- `DeprecationWarning` from `marshmallow.*` modules (marshmallow 4 migration notices)
- `FutureWarning` from `google.*` modules (Python version support notices)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before** (server logs during `get_chart_preview`):
```
2026-02-26 13:37:00,082:INFO:mcp.server.lowlevel.server:Warning: FutureWarning: You are using a Python version (3.10.16) which Google will stop supporting...
2026-02-26 13:37:00,083:INFO:mcp.server.lowlevel.server:Warning: RemovedInMarshmallow4Warning: Passing field metadata as keyword arguments is deprecated...
(7 more marshmallow warnings)
```

**After**: No deprecation warnings in MCP client responses.

### TESTING INSTRUCTIONS

1. Run the new test:
   ```bash
   pytest tests/unit_tests/mcp_service/test_mcp_server.py::test_suppress_third_party_warnings -v
   ```
2. Start the MCP server and call `get_chart_preview` - verify no `mcp.server.lowlevel.server:Warning:` entries for marshmallow or google warnings in the response

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

## MCP Testing Results (localhost, 2026-03-04)

Tested via localhost MCP tools on branch `fix/mcp-suppress-deprecation-warnings`:

### Tool Responses - No Warnings
- `health_check` → clean JSON response, no deprecation warnings ✅
- `list_charts` → clean JSON response, no warnings ✅
- `get_chart_info` (ID: 1) → clean JSON response, no warnings ✅

### Warning Suppression Verification
- Server logs show NO Marshmallow `RemovedInMarshmallow4Warning` in responses ✅
- Server logs show NO google.api_core `FutureWarning` in responses ✅
- Warning filters in both `app.py` (import-time) and `server.py` (runtime) work correctly

### Note
- `datetime.utcnow()` DeprecationWarning still appears in server logs (from Python stdlib/MCP SDK), but this is a separate issue not in scope for this PR - it doesn't come from Marshmallow or google.api_core

All tool responses are clean structured JSON without any third-party deprecation warnings leaking through.


___

## **CodeAnt-AI Description**
**Suppress third‑party deprecation warnings from MCP client responses**

### What Changed
- MCP no longer forwards marshmallow DeprecationWarning and google FutureWarning messages to client responses; these warnings are filtered during app import and at server startup
- A unit test verifies the warning filters for marshmallow and google are installed

### Impact
`✅ Fewer irrelevant warnings in MCP tool outputs`
`✅ Fewer wasted LLM tokens processing internal deprecation notices`
`✅ Clearer tool responses for users`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
