### PR TITLE
feat(mcp): add Big Number chart type support to MCP service

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -119,7 +119,8 @@ Chart Types You Can CREATE with generate_chart/generate_explore_link:
 - chart_type="xy", kind="area": Area chart for volume visualization
 - chart_type="xy", kind="scatter": Scatter plot for correlation analysis
 - chart_type="big_number": Big Number display (single metric, header only)
-- chart_type="big_number", show_trendline=True, temporal_column="<date_col>": Big Number with trendline (temporal_column is required when show_trendline=True)
+- chart_type="big_number", show_trendline=True,
+  temporal_column="<date_col>": Big Number with trendline
 - chart_type="table": Data table for detailed views
 - chart_type="table", viz_type="ag-grid-table": Interactive AG Grid table
 - chart_type="pie": Pie chart for proportional data (set donut=True for donut)

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -119,7 +119,7 @@ Chart Types You Can CREATE with generate_chart/generate_explore_link:
 - chart_type="xy", kind="area": Area chart for volume visualization
 - chart_type="xy", kind="scatter": Scatter plot for correlation analysis
 - chart_type="big_number": Big Number display (single metric, header only)
-- chart_type="big_number", show_trendline=True: Big Number with trendline
+- chart_type="big_number", show_trendline=True, temporal_column="<date_col>": Big Number with trendline (temporal_column is required when show_trendline=True)
 - chart_type="table": Data table for detailed views
 - chart_type="table", viz_type="ag-grid-table": Interactive AG Grid table
 - chart_type="pie": Pie chart for proportional data (set donut=True for donut)

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -118,6 +118,8 @@ Chart Types You Can CREATE with generate_chart/generate_explore_link:
 - chart_type="xy", kind="bar": Bar chart for category comparison
 - chart_type="xy", kind="area": Area chart for volume visualization
 - chart_type="xy", kind="scatter": Scatter plot for correlation analysis
+- chart_type="big_number": Big Number display (single metric, header only)
+- chart_type="big_number", show_trendline=True: Big Number with trendline
 - chart_type="table": Data table for detailed views
 - chart_type="table", viz_type="ag-grid-table": Interactive AG Grid table
 - chart_type="pie": Pie chart for proportional data (set donut=True for donut)

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -1023,6 +1023,8 @@ def _handlebars_chart_what(config: HandlebarsChartConfig) -> str:
         metrics = ", ".join(col.name for col in config.metrics[:3])
         return f"Handlebars ({metrics})"
     return "Handlebars Chart"
+
+
 def _big_number_chart_what(config: BigNumberChartConfig) -> str:
     """Build the 'what' portion for a big number chart name.
 

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -649,8 +649,7 @@ def map_pie_config(config: PieChartConfig) -> Dict[str, Any]:
         "date_format": "smart_date",
     }
 
-    time_range = getattr(config, "time_range", None)
-    if time_range:
+    if time_range := getattr(config, "time_range", None):
         form_data["time_range"] = time_range
 
     _add_adhoc_filters(form_data, config.filters)

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -649,9 +649,6 @@ def map_pie_config(config: PieChartConfig) -> Dict[str, Any]:
         "date_format": "smart_date",
     }
 
-    if time_range := getattr(config, "time_range", None):
-        form_data["time_range"] = time_range
-
     _add_adhoc_filters(form_data, config.filters)
 
     return form_data

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -1022,9 +1022,12 @@ def _handlebars_chart_what(config: HandlebarsChartConfig) -> str:
     return "Handlebars Chart"
 def _big_number_chart_what(config: BigNumberChartConfig) -> str:
     """Build the 'what' portion for a big number chart name."""
-    metric_label = (
-        config.metric.label or f"{config.metric.aggregate}({config.metric.name})"
-    )
+    if config.metric.label:
+        metric_label = config.metric.label
+    elif config.metric.aggregate:
+        metric_label = f"{config.metric.aggregate}({config.metric.name})"
+    else:
+        metric_label = config.metric.name
     if config.show_trendline:
         return f"Big Number \u2013 {metric_label} (with trendline)"
     return f"Big Number \u2013 {metric_label}"

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -683,6 +683,7 @@ def map_big_number_config(config: BigNumberChartConfig) -> Dict[str, Any]:
         # (unlike XY charts which use x_axis). This is how Superset's
         # big_number viz determines the time column for the trendline.
         form_data["granularity_sqla"] = config.temporal_column
+        form_data["show_trend_line"] = True
         form_data["start_y_axis_at_zero"] = config.start_y_axis_at_zero
 
         if config.time_grain:
@@ -1020,7 +1021,11 @@ def _handlebars_chart_what(config: HandlebarsChartConfig) -> str:
         return f"Handlebars ({metrics})"
     return "Handlebars Chart"
 def _big_number_chart_what(config: BigNumberChartConfig) -> str:
-    """Build the 'what' portion for a big number chart name."""
+    """Build the 'what' portion for a big number chart name.
+
+    Uses parentheses instead of en-dash to avoid collision with
+    ``generate_chart_name``'s ``\u2013`` context separator.
+    """
     if config.metric.label:
         metric_label = config.metric.label
     elif config.metric.aggregate:
@@ -1028,8 +1033,8 @@ def _big_number_chart_what(config: BigNumberChartConfig) -> str:
     else:
         metric_label = config.metric.name
     if config.show_trendline:
-        return f"Big Number \u2013 {metric_label} (with trendline)"
-    return f"Big Number \u2013 {metric_label}"
+        return f"Big Number ({metric_label}, trendline)"
+    return f"Big Number ({metric_label})"
 
 
 def generate_chart_name(

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 from superset.mcp_service.chart.schemas import (
+    BigNumberChartConfig,
     ChartCapabilities,
     ChartSemantics,
     ColumnRef,
@@ -311,7 +312,8 @@ def map_config_to_form_data(
     | PieChartConfig
     | PivotTableChartConfig
     | MixedTimeseriesChartConfig
-    | HandlebarsChartConfig,
+    | HandlebarsChartConfig
+    | BigNumberChartConfig,
     dataset_id: int | str | None = None,
 ) -> Dict[str, Any]:
     """Map chart config to Superset form_data."""
@@ -327,6 +329,8 @@ def map_config_to_form_data(
         return map_mixed_timeseries_config(config, dataset_id=dataset_id)
     elif isinstance(config, HandlebarsChartConfig):
         return map_handlebars_config(config)
+    elif isinstance(config, BigNumberChartConfig):
+        return map_big_number_config(config)
     else:
         raise ValueError(f"Unsupported config type: {type(config)}")
 
@@ -644,6 +648,46 @@ def map_pie_config(config: PieChartConfig) -> Dict[str, Any]:
         "innerRadius": config.inner_radius,
         "date_format": "smart_date",
     }
+
+    time_range = getattr(config, "time_range", None)
+    if time_range:
+        form_data["time_range"] = time_range
+
+    _add_adhoc_filters(form_data, config.filters)
+
+    return form_data
+
+
+def map_big_number_config(config: BigNumberChartConfig) -> Dict[str, Any]:
+    """Map big number chart config to Superset form_data."""
+    # Determine viz_type: big_number (with trendline) or big_number_total
+    if config.show_trendline and config.temporal_column:
+        viz_type = "big_number"
+    else:
+        viz_type = "big_number_total"
+
+    metric = create_metric_object(config.metric)
+    form_data: Dict[str, Any] = {
+        "viz_type": viz_type,
+        "metric": metric,
+    }
+
+    if config.subheader:
+        form_data["subheader"] = config.subheader
+
+    if config.y_axis_format:
+        form_data["y_axis_format"] = config.y_axis_format
+
+    # Trendline-specific fields
+    if viz_type == "big_number":
+        form_data["x_axis"] = config.temporal_column
+        form_data["start_y_axis_at_zero"] = config.start_y_axis_at_zero
+
+        if config.time_grain:
+            form_data["time_grain_sqla"] = config.time_grain
+
+        if config.compare_lag is not None:
+            form_data["compare_lag"] = config.compare_lag
 
     _add_adhoc_filters(form_data, config.filters)
 
@@ -973,6 +1017,14 @@ def _handlebars_chart_what(config: HandlebarsChartConfig) -> str:
         metrics = ", ".join(col.name for col in config.metrics[:3])
         return f"Handlebars ({metrics})"
     return "Handlebars Chart"
+def _big_number_chart_what(config: BigNumberChartConfig) -> str:
+    """Build the 'what' portion for a big number chart name."""
+    metric_label = (
+        config.metric.label or f"{config.metric.aggregate}({config.metric.name})"
+    )
+    if config.show_trendline:
+        return f"Big Number \u2013 {metric_label} (with trendline)"
+    return f"Big Number \u2013 {metric_label}"
 
 
 def generate_chart_name(
@@ -981,7 +1033,8 @@ def generate_chart_name(
     | PieChartConfig
     | PivotTableChartConfig
     | MixedTimeseriesChartConfig
-    | HandlebarsChartConfig,
+    | HandlebarsChartConfig
+    | BigNumberChartConfig,
     dataset_name: str | None = None,
 ) -> str:
     """Generate a descriptive chart name following a standard format.
@@ -1015,6 +1068,9 @@ def generate_chart_name(
     elif isinstance(config, HandlebarsChartConfig):
         what = _handlebars_chart_what(config)
         context = _summarize_filters(getattr(config, "filters", None))
+    elif isinstance(config, BigNumberChartConfig):
+        what = _big_number_chart_what(config)
+        context = _summarize_filters(getattr(config, "filters", None))
     else:
         return "Chart"
 
@@ -1046,6 +1102,12 @@ def _resolve_viz_type(config: Any) -> str:
         return "mixed_timeseries"
     elif chart_type == "handlebars":
         return "handlebars"
+    elif chart_type == "big_number":
+        show_trendline = getattr(config, "show_trendline", False)
+        temporal_column = getattr(config, "temporal_column", None)
+        return (
+            "big_number" if show_trendline and temporal_column else "big_number_total"
+        )
     return "unknown"
 
 
@@ -1128,6 +1190,13 @@ def analyze_chart_semantics(chart: Any | None, config: Any) -> ChartSemantics:
         "handlebars": (
             "Renders data using a custom Handlebars HTML template for "
             "fully flexible layouts like KPI cards, leaderboards, and reports"
+        ),
+        "big_number": (
+            "Displays a key metric with a trendline showing "
+            "how the value changes over time"
+        ),
+        "big_number_total": (
+            "Highlights a single key metric value as a prominent number"
         ),
     }
 

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -680,9 +680,9 @@ def map_big_number_config(config: BigNumberChartConfig) -> Dict[str, Any]:
 
     # Trendline-specific fields
     if viz_type == "big_number":
-        # Big Number with trendline uses x_axis for the temporal column
-        # (same as XY charts). Also set granularity_sqla for legacy compat.
-        form_data["x_axis"] = config.temporal_column
+        # Big Number with trendline uses granularity_sqla for the temporal column
+        # (unlike XY charts which use x_axis). This is how Superset's
+        # big_number viz determines the time column for the trendline.
         form_data["granularity_sqla"] = config.temporal_column
         form_data["start_y_axis_at_zero"] = config.start_y_axis_at_zero
 

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -330,6 +330,12 @@ def map_config_to_form_data(
     elif isinstance(config, HandlebarsChartConfig):
         return map_handlebars_config(config)
     elif isinstance(config, BigNumberChartConfig):
+        if config.show_trendline and config.temporal_column:
+            if not is_column_truly_temporal(config.temporal_column, dataset_id):
+                raise ValueError(
+                    f"Big Number trendline requires a temporal SQL column; "
+                    f"'{config.temporal_column}' is not temporal."
+                )
         return map_big_number_config(config)
     else:
         raise ValueError(f"Unsupported config type: {type(config)}")

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -680,7 +680,10 @@ def map_big_number_config(config: BigNumberChartConfig) -> Dict[str, Any]:
 
     # Trendline-specific fields
     if viz_type == "big_number":
+        # Big Number with trendline uses x_axis for the temporal column
+        # (same as XY charts). Also set granularity_sqla for legacy compat.
         form_data["x_axis"] = config.temporal_column
+        form_data["granularity_sqla"] = config.temporal_column
         form_data["start_y_axis_at_zero"] = config.start_y_axis_at_zero
 
         if config.time_grain:

--- a/superset/mcp_service/chart/preview_utils.py
+++ b/superset/mcp_service/chart/preview_utils.py
@@ -92,13 +92,23 @@ def generate_preview_from_form_data(
         query_filters = adhoc_filters_to_query_filters(
             form_data.get("adhoc_filters", [])
         )
+
+        # Big Number charts use singular "metric" instead of "metrics"
+        metrics = form_data.get("metrics", [])
+        if not metrics and form_data.get("metric"):
+            metrics = [form_data["metric"]]
+
+        # Big Number with trendline uses granularity_sqla as the time column
+        if not columns and form_data.get("granularity_sqla"):
+            columns = [form_data["granularity_sqla"]]
+
         factory = QueryContextFactory()
         query_context_obj = factory.create(
             datasource={"id": dataset_id, "type": "table"},
             queries=[
                 {
                     "columns": columns,
-                    "metrics": form_data.get("metrics", []),
+                    "metrics": metrics,
                     "orderby": form_data.get("orderby", []),
                     "row_limit": form_data.get("row_limit", 100),
                     "filters": query_filters,

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -947,12 +947,13 @@ class BigNumberChartConfig(UnknownFieldCheckMixin):
 
     @model_validator(mode="after")
     def validate_metric_aggregate(self) -> Self:
-        """Ensure metric has an aggregate function."""
-        if not self.metric.aggregate:
+        """Ensure metric is a valid metric reference (aggregate or saved)."""
+        if not self.metric.is_metric:
             raise ValueError(
-                "Big Number metric must have an aggregate function "
-                "(e.g., SUM, COUNT, AVG). Add 'aggregate' to the "
-                "metric specification."
+                "Big Number metric must be either a saved dataset metric "
+                "or include an aggregate function (e.g., SUM, COUNT, AVG). "
+                "Set 'saved_metric': true to use a saved metric, or add "
+                "'aggregate' to the metric specification."
             )
         return self
 

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -936,6 +936,12 @@ class BigNumberChartConfig(UnknownFieldCheckMixin):
                 "'temporal_column'. Specify a date/time column for "
                 "the trendline x-axis."
             )
+        if self.compare_lag and not self.show_trendline:
+            raise ValueError(
+                "compare_lag requires show_trendline=True. "
+                "Period comparison is only available for "
+                "trendline charts."
+            )
         return self
 
     @model_validator(mode="after")

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -851,6 +851,103 @@ class HandlebarsChartConfig(UnknownFieldCheckMixin):
         return self
 
 
+class BigNumberChartConfig(UnknownFieldCheckMixin):
+    model_config = ConfigDict(extra="ignore")
+
+    chart_type: Literal["big_number"] = Field(
+        ...,
+        description=(
+            "Chart type discriminator - MUST be 'big_number'. "
+            "Creates Big Number charts that display a single prominent "
+            "metric value. Set show_trendline=True with a temporal_column "
+            "for a number with trendline, or leave show_trendline=False "
+            "for a standalone number."
+        ),
+    )
+    metric: ColumnRef = Field(
+        ...,
+        description=(
+            "The metric to display as a big number. "
+            "Must include an aggregate function (e.g., SUM, COUNT)."
+        ),
+    )
+    temporal_column: str | None = Field(
+        None,
+        description=(
+            "Temporal column for the trendline x-axis. "
+            "Required when show_trendline is True."
+        ),
+        max_length=255,
+    )
+    time_grain: TimeGrain | None = Field(
+        None,
+        description=(
+            "Time granularity for trendline data. "
+            "Common values: PT1H (hour), P1D (day), P1W (week), "
+            "P1M (month), P1Y (year)."
+        ),
+    )
+    show_trendline: bool = Field(
+        False,
+        description=(
+            "Show a trendline below the big number. "
+            "Requires 'temporal_column' to be set."
+        ),
+    )
+    subheader: str | None = Field(
+        None,
+        description="Subtitle text displayed below the big number",
+        max_length=500,
+    )
+    y_axis_format: str | None = Field(
+        None,
+        description=(
+            "Number format string for the metric value "
+            "(e.g., '$,.2f' for currency, ',.0f' for integers, "
+            "'.2%' for percentages)"
+        ),
+        max_length=50,
+    )
+    start_y_axis_at_zero: bool = Field(
+        True,
+        description="Anchor trendline y-axis at zero",
+    )
+    compare_lag: int | None = Field(
+        None,
+        description=(
+            "Number of time periods to compare against. "
+            "Displays a percentage change vs the prior period."
+        ),
+        ge=1,
+    )
+    filters: list[FilterConfig] | None = Field(
+        None,
+        description="Filters to apply",
+    )
+
+    @model_validator(mode="after")
+    def validate_trendline_fields(self) -> "BigNumberChartConfig":
+        """Validate trendline requires temporal column."""
+        if self.show_trendline and not self.temporal_column:
+            raise ValueError(
+                "Big Number chart with show_trendline=True requires "
+                "'temporal_column'. Specify a date/time column for "
+                "the trendline x-axis."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_metric_aggregate(self) -> "BigNumberChartConfig":
+        """Ensure metric has an aggregate function."""
+        if not self.metric.aggregate:
+            raise ValueError(
+                "Big Number metric must have an aggregate function "
+                "(e.g., SUM, COUNT, AVG). Add 'aggregate' to the "
+                "metric specification."
+            )
+        return self
+
+
 class TableChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
@@ -1015,12 +1112,14 @@ ChartConfig = Annotated[
     | PieChartConfig
     | PivotTableChartConfig
     | MixedTimeseriesChartConfig
-    | HandlebarsChartConfig,
+    | HandlebarsChartConfig
+    | BigNumberChartConfig,
     Field(
         discriminator="chart_type",
         description=(
             "Chart configuration - specify chart_type as 'xy', 'table', "
-            "'pie', 'pivot_table', 'mixed_timeseries', or 'handlebars'"
+            "'pie', 'pivot_table', 'mixed_timeseries', 'handlebars', "
+            "or 'big_number'"
         ),
     ),
 ]

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -877,7 +877,9 @@ class BigNumberChartConfig(UnknownFieldCheckMixin):
             "Temporal column for the trendline x-axis. "
             "Required when show_trendline is True."
         ),
+        min_length=1,
         max_length=255,
+        pattern=r"^[a-zA-Z0-9_][a-zA-Z0-9_\s\-\.]*$",
     )
     time_grain: TimeGrain | None = Field(
         None,

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import difflib
 from datetime import datetime, timezone
-from typing import Annotated, Any, Dict, List, Literal, Protocol
+from typing import Annotated, Any, Dict, List, Literal, Protocol, Self
 
 from pydantic import (
     AliasChoices,
@@ -928,7 +928,7 @@ class BigNumberChartConfig(UnknownFieldCheckMixin):
     )
 
     @model_validator(mode="after")
-    def validate_trendline_fields(self) -> "BigNumberChartConfig":
+    def validate_trendline_fields(self) -> Self:
         """Validate trendline requires temporal column."""
         if self.show_trendline and not self.temporal_column:
             raise ValueError(
@@ -945,7 +945,7 @@ class BigNumberChartConfig(UnknownFieldCheckMixin):
         return self
 
     @model_validator(mode="after")
-    def validate_metric_aggregate(self) -> "BigNumberChartConfig":
+    def validate_metric_aggregate(self) -> Self:
         """Ensure metric has an aggregate function."""
         if not self.metric.aggregate:
             raise ValueError(

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import difflib
 from datetime import datetime, timezone
-from typing import Annotated, Any, Dict, List, Literal, Protocol, Self
+from typing import Annotated, Any, Dict, List, Literal, Protocol
 
 from pydantic import (
     AliasChoices,
@@ -36,6 +36,7 @@ from pydantic import (
     model_validator,
     PositiveInt,
 )
+from typing_extensions import Self
 
 from superset.constants import TimeGrain
 from superset.daos.base import ColumnOperator, ColumnOperatorEnum

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -89,13 +89,23 @@ def _compile_chart(
         query_filters = adhoc_filters_to_query_filters(
             form_data.get("adhoc_filters", [])
         )
+
+        # Big Number charts use singular "metric" instead of "metrics"
+        metrics = form_data.get("metrics", [])
+        if not metrics and form_data.get("metric"):
+            metrics = [form_data["metric"]]
+
+        # Big Number with trendline uses granularity_sqla as the time column
+        if not columns and form_data.get("granularity_sqla"):
+            columns = [form_data["granularity_sqla"]]
+
         factory = QueryContextFactory()
         query_context = factory.create(
             datasource={"id": dataset_id, "type": "table"},
             queries=[
                 {
                     "columns": columns,
-                    "metrics": form_data.get("metrics", []),
+                    "metrics": metrics,
                     "orderby": form_data.get("orderby", []),
                     "row_limit": 2,
                     "filters": query_filters,

--- a/superset/mcp_service/chart/validation/schema_validator.py
+++ b/superset/mcp_service/chart/validation/schema_validator.py
@@ -134,6 +134,7 @@ class SchemaValidator:
                     "Add 'chart_type': 'pivot_table' for interactive pivot tables",
                     "Add 'chart_type': 'mixed_timeseries' for dual-series time charts",
                     "Add 'chart_type': 'handlebars' for custom HTML template charts",
+                    "Add 'chart_type': 'big_number' for big number display",
                     "Example: 'config': {'chart_type': 'xy', ...}",
                 ],
                 error_code="MISSING_CHART_TYPE",
@@ -154,6 +155,7 @@ class SchemaValidator:
             "pivot_table": SchemaValidator._pre_validate_pivot_table_config,
             "mixed_timeseries": SchemaValidator._pre_validate_mixed_timeseries_config,
             "handlebars": SchemaValidator._pre_validate_handlebars_config,
+            "big_number": SchemaValidator._pre_validate_big_number_config,
         }
 
         if not isinstance(chart_type, str) or chart_type not in chart_type_validators:
@@ -170,12 +172,15 @@ class SchemaValidator:
                     "Use 'chart_type': 'pivot_table' for interactive pivot tables",
                     "Use 'chart_type': 'mixed_timeseries' for dual-series time charts",
                     "Use 'chart_type': 'handlebars' for custom HTML template charts",
+                    "Use 'chart_type': 'big_number' for big number display",
                     "Check spelling and ensure lowercase",
                 ],
                 error_code="INVALID_CHART_TYPE",
             )
 
         return chart_type_validators[chart_type](config)
+
+        return True, None
 
     @staticmethod
     def _pre_validate_xy_config(
@@ -363,6 +368,60 @@ class SchemaValidator:
         return True, None
 
     @staticmethod
+    def _pre_validate_big_number_config(
+        config: Dict[str, Any],
+    ) -> Tuple[bool, ChartGenerationError | None]:
+        """Pre-validate big number chart configuration."""
+        if "metric" not in config:
+            return False, ChartGenerationError(
+                error_type="missing_metric",
+                message="Big Number chart missing required field: metric",
+                details="Big Number charts require a 'metric' field "
+                "specifying the value to display",
+                suggestions=[
+                    "Add 'metric' with name and aggregate: "
+                    "{'name': 'revenue', 'aggregate': 'SUM'}",
+                    "The aggregate function is required (SUM, COUNT, AVG, MIN, MAX)",
+                    "Example: {'chart_type': 'big_number', "
+                    "'metric': {'name': 'sales', 'aggregate': 'SUM'}}",
+                ],
+                error_code="MISSING_BIG_NUMBER_METRIC",
+            )
+
+        metric = config.get("metric", {})
+        if isinstance(metric, dict) and not metric.get("aggregate"):
+            return False, ChartGenerationError(
+                error_type="missing_metric_aggregate",
+                message="Big Number metric must include an aggregate function",
+                details="The metric 'aggregate' field is required "
+                "for Big Number charts",
+                suggestions=[
+                    "Add 'aggregate' to your metric: "
+                    "{'name': 'col', 'aggregate': 'SUM'}",
+                    "Valid aggregates: SUM, COUNT, AVG, MIN, MAX",
+                ],
+                error_code="MISSING_BIG_NUMBER_AGGREGATE",
+            )
+
+        show_trendline = config.get("show_trendline", False)
+        temporal_column = config.get("temporal_column")
+        if show_trendline and not temporal_column:
+            return False, ChartGenerationError(
+                error_type="missing_temporal_column",
+                message="Trendline requires a temporal column",
+                details="When 'show_trendline' is True, a "
+                "'temporal_column' must be specified",
+                suggestions=[
+                    "Add 'temporal_column': 'date_column_name'",
+                    "Or set 'show_trendline': false for number only",
+                    "Use get_dataset_info to find temporal columns",
+                ],
+                error_code="MISSING_TEMPORAL_COLUMN",
+            )
+
+        return True, None
+
+    @staticmethod
     def _pre_validate_pivot_table_config(
         config: Dict[str, Any],
     ) -> Tuple[bool, ChartGenerationError | None]:
@@ -525,6 +584,23 @@ class SchemaValidator:
                             "'metrics': [{'name': 'sales', 'aggregate': 'SUM'}]}",
                         ],
                         error_code="HANDLEBARS_VALIDATION_ERROR",
+                    )
+                elif chart_type == "big_number":
+                    return ChartGenerationError(
+                        error_type="big_number_validation_error",
+                        message="Big Number chart configuration validation failed",
+                        details="The Big Number chart configuration is "
+                        "missing required fields or has invalid "
+                        "structure",
+                        suggestions=[
+                            "Ensure 'metric' field has 'name' and 'aggregate'",
+                            "Example: 'metric': {'name': 'revenue', "
+                            "'aggregate': 'SUM'}",
+                            "For trendline: add 'show_trendline': true "
+                            "and 'temporal_column': 'date_col'",
+                            "Without trendline: just provide the metric",
+                        ],
+                        error_code="BIG_NUMBER_VALIDATION_ERROR",
                     )
 
         # Default enhanced error

--- a/superset/mcp_service/chart/validation/schema_validator.py
+++ b/superset/mcp_service/chart/validation/schema_validator.py
@@ -399,15 +399,18 @@ class SchemaValidator:
                 ],
                 error_code="INVALID_BIG_NUMBER_METRIC_TYPE",
             )
-        if not metric.get("aggregate"):
+        if not metric.get("aggregate") and not metric.get("saved_metric"):
             return False, ChartGenerationError(
                 error_type="missing_metric_aggregate",
-                message="Big Number metric must include an aggregate function",
-                details="The metric 'aggregate' field is required "
-                "for Big Number charts",
+                message="Big Number metric must include an aggregate function "
+                "or reference a saved metric",
+                details="The metric must have an 'aggregate' field "
+                "or 'saved_metric': true",
                 suggestions=[
                     "Add 'aggregate' to your metric: "
                     "{'name': 'col', 'aggregate': 'SUM'}",
+                    "Or use a saved metric: "
+                    "{'name': 'total_sales', 'saved_metric': true}",
                     "Valid aggregates: SUM, COUNT, AVG, MIN, MAX",
                 ],
                 error_code="MISSING_BIG_NUMBER_AGGREGATE",

--- a/superset/mcp_service/chart/validation/schema_validator.py
+++ b/superset/mcp_service/chart/validation/schema_validator.py
@@ -180,8 +180,6 @@ class SchemaValidator:
 
         return chart_type_validators[chart_type](config)
 
-        return True, None
-
     @staticmethod
     def _pre_validate_xy_config(
         config: Dict[str, Any],

--- a/superset/mcp_service/chart/validation/schema_validator.py
+++ b/superset/mcp_service/chart/validation/schema_validator.py
@@ -387,7 +387,19 @@ class SchemaValidator:
             )
 
         metric = config.get("metric", {})
-        if isinstance(metric, dict) and not metric.get("aggregate"):
+        if not isinstance(metric, dict):
+            return False, ChartGenerationError(
+                error_type="invalid_metric_type",
+                message="Big Number metric must be a dict with 'name' and 'aggregate'",
+                details="The 'metric' field must be an object, "
+                f"got {type(metric).__name__}",
+                suggestions=[
+                    "Use a dict: {'name': 'col', 'aggregate': 'SUM'}",
+                    "Valid aggregates: SUM, COUNT, AVG, MIN, MAX",
+                ],
+                error_code="INVALID_BIG_NUMBER_METRIC_TYPE",
+            )
+        if not metric.get("aggregate"):
             return False, ChartGenerationError(
                 error_type="missing_metric_aggregate",
                 message="Big Number metric must include an aggregate function",

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -337,7 +337,9 @@ class TestAnalyzeChartCapabilitiesBigNumber:
             metric=ColumnRef(name="revenue", aggregate="SUM"),
         )
         result = analyze_chart_capabilities(None, config)
-        assert result is not None
+        assert result.supports_export is True
+        assert result.supports_interaction is False
+        assert result.supports_drill_down is False
 
     def test_big_number_trendline_capabilities(self) -> None:
         config = BigNumberChartConfig(
@@ -347,7 +349,9 @@ class TestAnalyzeChartCapabilitiesBigNumber:
             show_trendline=True,
         )
         result = analyze_chart_capabilities(None, config)
-        assert result is not None
+        assert result.supports_export is True
+        assert result.supports_interaction is False
+        assert result.supports_drill_down is False
 
 
 class TestAnalyzeChartSemanticsBigNumber:

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -18,6 +18,7 @@
 """Tests for Big Number chart type support in MCP service."""
 
 import pytest
+from pydantic import ValidationError
 
 from superset.mcp_service.chart.chart_utils import (
     _resolve_viz_type,
@@ -61,7 +62,7 @@ class TestBigNumberChartConfig:
         assert config.temporal_column == "ds"
 
     def test_trendline_without_temporal_column_fails(self) -> None:
-        with pytest.raises(ValueError, match="requires 'temporal_column'"):
+        with pytest.raises(ValidationError, match="requires 'temporal_column'"):
             BigNumberChartConfig(
                 chart_type="big_number",
                 metric=ColumnRef(name="revenue", aggregate="SUM"),
@@ -69,7 +70,7 @@ class TestBigNumberChartConfig:
             )
 
     def test_metric_without_aggregate_fails(self) -> None:
-        with pytest.raises(ValueError, match="must have an aggregate function"):
+        with pytest.raises(ValidationError, match="must have an aggregate function"):
             BigNumberChartConfig(
                 chart_type="big_number",
                 metric=ColumnRef(name="revenue"),
@@ -102,7 +103,7 @@ class TestBigNumberChartConfig:
         assert config.compare_lag == 1
 
     def test_compare_lag_zero_fails(self) -> None:
-        with pytest.raises(ValueError, match="greater than or equal"):
+        with pytest.raises(ValidationError, match="greater than or equal"):
             BigNumberChartConfig(
                 chart_type="big_number",
                 metric=ColumnRef(name="revenue", aggregate="SUM"),
@@ -121,7 +122,7 @@ class TestBigNumberChartConfig:
         assert len(config.filters) == 1
 
     def test_extra_fields_forbidden(self) -> None:
-        with pytest.raises(ValueError, match="Extra inputs"):
+        with pytest.raises(ValidationError, match="Extra inputs"):
             BigNumberChartConfig(
                 chart_type="big_number",
                 metric=ColumnRef(name="revenue", aggregate="SUM"),
@@ -169,6 +170,7 @@ class TestMapBigNumberConfig:
         form_data = map_big_number_config(config)
         assert form_data["viz_type"] == "big_number"
         assert form_data["x_axis"] == "order_date"
+        assert form_data["granularity_sqla"] == "order_date"
         assert form_data["start_y_axis_at_zero"] is True
 
     def test_with_time_grain(self) -> None:
@@ -231,6 +233,7 @@ class TestMapBigNumberConfig:
         )
         form_data = map_big_number_config(config)
         assert "x_axis" not in form_data
+        assert "granularity_sqla" not in form_data
         assert "time_grain_sqla" not in form_data
         assert "start_y_axis_at_zero" not in form_data
 

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -132,7 +132,7 @@ class TestBigNumberChartConfig:
         assert len(config.filters) == 1
 
     def test_extra_fields_forbidden(self) -> None:
-        with pytest.raises(ValidationError, match="Extra inputs"):
+        with pytest.raises(ValueError, match="Unknown field 'unknown_field'"):
             BigNumberChartConfig(
                 chart_type="big_number",
                 metric=ColumnRef(name="revenue", aggregate="SUM"),

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -169,7 +169,7 @@ class TestMapBigNumberConfig:
         )
         form_data = map_big_number_config(config)
         assert form_data["viz_type"] == "big_number"
-        assert form_data["x_axis"] == "order_date"
+        assert "x_axis" not in form_data
         assert form_data["granularity_sqla"] == "order_date"
         assert form_data["start_y_axis_at_zero"] is True
 

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -1,0 +1,469 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Big Number chart type support in MCP service."""
+
+import pytest
+
+from superset.mcp_service.chart.chart_utils import (
+    _resolve_viz_type,
+    analyze_chart_capabilities,
+    analyze_chart_semantics,
+    generate_chart_name,
+    map_big_number_config,
+    map_config_to_form_data,
+)
+from superset.mcp_service.chart.schemas import (
+    BigNumberChartConfig,
+    ColumnRef,
+    FilterConfig,
+)
+from superset.mcp_service.chart.validation.schema_validator import (
+    SchemaValidator,
+)
+
+
+class TestBigNumberChartConfig:
+    """Test BigNumberChartConfig Pydantic schema."""
+
+    def test_minimal_config(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+        )
+        assert config.chart_type == "big_number"
+        assert config.metric.name == "revenue"
+        assert config.metric.aggregate == "SUM"
+        assert config.show_trendline is False
+
+    def test_with_trendline(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+        )
+        assert config.show_trendline is True
+        assert config.temporal_column == "ds"
+
+    def test_trendline_without_temporal_column_fails(self) -> None:
+        with pytest.raises(ValueError, match="requires 'temporal_column'"):
+            BigNumberChartConfig(
+                chart_type="big_number",
+                metric=ColumnRef(name="revenue", aggregate="SUM"),
+                show_trendline=True,
+            )
+
+    def test_metric_without_aggregate_fails(self) -> None:
+        with pytest.raises(ValueError, match="must have an aggregate function"):
+            BigNumberChartConfig(
+                chart_type="big_number",
+                metric=ColumnRef(name="revenue"),
+            )
+
+    def test_with_subheader(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            subheader="Total revenue this quarter",
+        )
+        assert config.subheader == "Total revenue this quarter"
+
+    def test_with_y_axis_format(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            y_axis_format="$,.2f",
+        )
+        assert config.y_axis_format == "$,.2f"
+
+    def test_with_compare_lag(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+            compare_lag=1,
+        )
+        assert config.compare_lag == 1
+
+    def test_compare_lag_zero_fails(self) -> None:
+        with pytest.raises(ValueError, match="greater than or equal"):
+            BigNumberChartConfig(
+                chart_type="big_number",
+                metric=ColumnRef(name="revenue", aggregate="SUM"),
+                compare_lag=0,
+            )
+
+    def test_with_filters(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            filters=[
+                FilterConfig(column="region", op="=", value="US"),
+            ],
+        )
+        assert config.filters is not None
+        assert len(config.filters) == 1
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValueError, match="Extra inputs"):
+            BigNumberChartConfig(
+                chart_type="big_number",
+                metric=ColumnRef(name="revenue", aggregate="SUM"),
+                unknown_field="bad",
+            )
+
+    def test_with_time_grain(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+            time_grain="P1M",
+        )
+        assert config.time_grain == "P1M"
+
+    def test_with_custom_label(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM", label="Total Sales"),
+        )
+        assert config.metric.label == "Total Sales"
+
+
+class TestMapBigNumberConfig:
+    """Test map_big_number_config function."""
+
+    def test_basic_total(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+        )
+        form_data = map_big_number_config(config)
+        assert form_data["viz_type"] == "big_number_total"
+        assert form_data["metric"]["aggregate"] == "SUM"
+        assert form_data["metric"]["column"]["column_name"] == "revenue"
+
+    def test_with_trendline(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="order_date",
+            show_trendline=True,
+        )
+        form_data = map_big_number_config(config)
+        assert form_data["viz_type"] == "big_number"
+        assert form_data["x_axis"] == "order_date"
+        assert form_data["start_y_axis_at_zero"] is True
+
+    def test_with_time_grain(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="order_date",
+            show_trendline=True,
+            time_grain="P1M",
+        )
+        form_data = map_big_number_config(config)
+        assert form_data["time_grain_sqla"] == "P1M"
+
+    def test_with_subheader(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            subheader="Year to date",
+        )
+        form_data = map_big_number_config(config)
+        assert form_data["subheader"] == "Year to date"
+
+    def test_with_y_axis_format(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            y_axis_format="$,.2f",
+        )
+        form_data = map_big_number_config(config)
+        assert form_data["y_axis_format"] == "$,.2f"
+
+    def test_with_compare_lag(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+            compare_lag=7,
+        )
+        form_data = map_big_number_config(config)
+        assert form_data["compare_lag"] == 7
+
+    def test_with_filters(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            filters=[
+                FilterConfig(column="region", op="=", value="US"),
+            ],
+        )
+        form_data = map_big_number_config(config)
+        assert "adhoc_filters" in form_data
+        assert len(form_data["adhoc_filters"]) == 1
+        assert form_data["adhoc_filters"][0]["subject"] == "region"
+
+    def test_no_trendline_fields_for_total(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+        )
+        form_data = map_big_number_config(config)
+        assert "x_axis" not in form_data
+        assert "time_grain_sqla" not in form_data
+        assert "start_y_axis_at_zero" not in form_data
+
+
+class TestMapConfigToFormDataBigNumber:
+    """Test map_config_to_form_data dispatch for big number."""
+
+    def test_dispatches_big_number(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+        )
+        form_data = map_config_to_form_data(config)
+        assert form_data["viz_type"] == "big_number_total"
+
+    def test_dispatches_big_number_trendline(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+        )
+        form_data = map_config_to_form_data(config)
+        assert form_data["viz_type"] == "big_number"
+
+
+class TestGenerateChartNameBigNumber:
+    """Test generate_chart_name for big number configs."""
+
+    def test_basic_total_name(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+        )
+        name = generate_chart_name(config)
+        assert "Big Number" in name
+        assert "SUM(revenue)" in name
+
+    def test_with_trendline_name(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+        )
+        name = generate_chart_name(config)
+        assert "Big Number" in name
+        assert "trendline" in name
+
+    def test_with_custom_label(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(
+                name="revenue",
+                aggregate="SUM",
+                label="Total Sales",
+            ),
+        )
+        name = generate_chart_name(config)
+        assert "Total Sales" in name
+
+
+class TestResolveVizTypeBigNumber:
+    """Test _resolve_viz_type for big number configs."""
+
+    def test_big_number_total(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+        )
+        assert _resolve_viz_type(config) == "big_number_total"
+
+    def test_big_number_with_trendline(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+        )
+        assert _resolve_viz_type(config) == "big_number"
+
+
+class TestAnalyzeChartCapabilitiesBigNumber:
+    """Test analyze_chart_capabilities for big number configs."""
+
+    def test_big_number_total_capabilities(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+        )
+        result = analyze_chart_capabilities(None, config)
+        assert result is not None
+
+    def test_big_number_trendline_capabilities(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+        )
+        result = analyze_chart_capabilities(None, config)
+        assert result is not None
+
+
+class TestAnalyzeChartSemanticsBigNumber:
+    """Test analyze_chart_semantics for big number configs."""
+
+    def test_big_number_total_semantics(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+        )
+        result = analyze_chart_semantics(None, config)
+        assert result is not None
+        assert result.primary_insight != ""
+
+    def test_big_number_trendline_semantics(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="revenue", aggregate="SUM"),
+            temporal_column="ds",
+            show_trendline=True,
+        )
+        result = analyze_chart_semantics(None, config)
+        assert result is not None
+        assert result.primary_insight != ""
+
+
+class TestSchemaValidatorBigNumber:
+    """Test SchemaValidator for big number chart type."""
+
+    def test_valid_big_number_request(self) -> None:
+        data = {
+            "dataset_id": 1,
+            "config": {
+                "chart_type": "big_number",
+                "metric": {"name": "revenue", "aggregate": "SUM"},
+            },
+        }
+        is_valid, request, error = SchemaValidator.validate_request(data)
+        assert is_valid is True
+        assert request is not None
+        assert error is None
+
+    def test_valid_big_number_with_trendline(self) -> None:
+        data = {
+            "dataset_id": 1,
+            "config": {
+                "chart_type": "big_number",
+                "metric": {"name": "revenue", "aggregate": "SUM"},
+                "temporal_column": "ds",
+                "show_trendline": True,
+            },
+        }
+        is_valid, request, error = SchemaValidator.validate_request(data)
+        assert is_valid is True
+        assert request is not None
+
+    def test_missing_metric(self) -> None:
+        data = {
+            "dataset_id": 1,
+            "config": {
+                "chart_type": "big_number",
+            },
+        }
+        is_valid, request, error = SchemaValidator.validate_request(data)
+        assert is_valid is False
+        assert error is not None
+        assert error.error_code == "MISSING_BIG_NUMBER_METRIC"
+
+    def test_missing_metric_aggregate(self) -> None:
+        data = {
+            "dataset_id": 1,
+            "config": {
+                "chart_type": "big_number",
+                "metric": {"name": "revenue"},
+            },
+        }
+        is_valid, request, error = SchemaValidator.validate_request(data)
+        assert is_valid is False
+        assert error is not None
+        assert error.error_code == "MISSING_BIG_NUMBER_AGGREGATE"
+
+    def test_trendline_without_temporal(self) -> None:
+        data = {
+            "dataset_id": 1,
+            "config": {
+                "chart_type": "big_number",
+                "metric": {"name": "revenue", "aggregate": "SUM"},
+                "show_trendline": True,
+            },
+        }
+        is_valid, request, error = SchemaValidator.validate_request(data)
+        assert is_valid is False
+        assert error is not None
+        assert error.error_code == "MISSING_TEMPORAL_COLUMN"
+
+    def test_big_number_accepted_in_chart_type_check(self) -> None:
+        """Verify big_number passes the chart_type validation."""
+        is_valid, error = SchemaValidator._pre_validate(
+            {
+                "dataset_id": 1,
+                "config": {
+                    "chart_type": "big_number",
+                    "metric": {"name": "revenue", "aggregate": "SUM"},
+                },
+            }
+        )
+        assert is_valid is True
+        assert error is None
+
+    def test_invalid_chart_type_still_rejected(self) -> None:
+        """Ensure unknown chart types are still rejected."""
+        is_valid, error = SchemaValidator._pre_validate(
+            {
+                "dataset_id": 1,
+                "config": {"chart_type": "pie"},
+            }
+        )
+        assert is_valid is False
+        assert error is not None
+        assert error.error_code == "INVALID_CHART_TYPE"
+
+    def test_big_number_with_subheader_and_format(self) -> None:
+        data = {
+            "dataset_id": 1,
+            "config": {
+                "chart_type": "big_number",
+                "metric": {"name": "revenue", "aggregate": "SUM"},
+                "subheader": "Year to date",
+                "y_axis_format": "$,.2f",
+            },
+        }
+        is_valid, request, error = SchemaValidator.validate_request(data)
+        assert is_valid is True
+        assert request is not None

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -450,7 +450,7 @@ class TestSchemaValidatorBigNumber:
         is_valid, error = SchemaValidator._pre_validate(
             {
                 "dataset_id": 1,
-                "config": {"chart_type": "pie"},
+                "config": {"chart_type": "nonexistent_chart"},
             }
         )
         assert is_valid is False

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -70,11 +70,19 @@ class TestBigNumberChartConfig:
             )
 
     def test_metric_without_aggregate_fails(self) -> None:
-        with pytest.raises(ValidationError, match="must have an aggregate function"):
+        with pytest.raises(ValidationError, match="saved dataset metric"):
             BigNumberChartConfig(
                 chart_type="big_number",
                 metric=ColumnRef(name="revenue"),
             )
+
+    def test_saved_metric_accepted(self) -> None:
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(name="total_sales", saved_metric=True),
+        )
+        assert config.metric.saved_metric is True
+        assert config.metric.is_metric is True
 
     def test_with_subheader(self) -> None:
         config = BigNumberChartConfig(
@@ -179,6 +187,7 @@ class TestMapBigNumberConfig:
         )
         form_data = map_big_number_config(config)
         assert form_data["viz_type"] == "big_number"
+        assert form_data["show_trend_line"] is True
         assert "x_axis" not in form_data
         assert form_data["granularity_sqla"] == "order_date"
         assert form_data["start_y_axis_at_zero"] is True

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -84,6 +84,16 @@ class TestBigNumberChartConfig:
         assert config.metric.saved_metric is True
         assert config.metric.is_metric is True
 
+    def test_saved_metric_passes_pre_validation(self) -> None:
+        """Verify saved metrics pass through SchemaValidator pre-validation."""
+        data = {
+            "chart_type": "big_number",
+            "metric": {"name": "total_sales", "saved_metric": True},
+        }
+        is_valid, error = SchemaValidator._pre_validate_big_number_config(data)
+        assert is_valid is True
+        assert error is None
+
     def test_with_subheader(self) -> None:
         config = BigNumberChartConfig(
             chart_type="big_number",

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -110,6 +110,16 @@ class TestBigNumberChartConfig:
                 compare_lag=0,
             )
 
+    def test_compare_lag_requires_trendline(self) -> None:
+        with pytest.raises(
+            ValidationError, match="compare_lag requires show_trendline"
+        ):
+            BigNumberChartConfig(
+                chart_type="big_number",
+                metric=ColumnRef(name="revenue", aggregate="SUM"),
+                compare_lag=1,
+            )
+
     def test_with_filters(self) -> None:
         config = BigNumberChartConfig(
             chart_type="big_number",
@@ -225,6 +235,8 @@ class TestMapBigNumberConfig:
         assert "adhoc_filters" in form_data
         assert len(form_data["adhoc_filters"]) == 1
         assert form_data["adhoc_filters"][0]["subject"] == "region"
+        assert form_data["adhoc_filters"][0]["operator"] == "=="
+        assert form_data["adhoc_filters"][0]["comparator"] == "US"
 
     def test_no_trendline_fields_for_total(self) -> None:
         config = BigNumberChartConfig(
@@ -348,7 +360,9 @@ class TestAnalyzeChartSemanticsBigNumber:
         )
         result = analyze_chart_semantics(None, config)
         assert result is not None
-        assert result.primary_insight != ""
+        assert "metric" in result.primary_insight.lower()
+        assert result.data_story != ""
+        assert len(result.recommended_actions) > 0
 
     def test_big_number_trendline_semantics(self) -> None:
         config = BigNumberChartConfig(
@@ -359,7 +373,9 @@ class TestAnalyzeChartSemanticsBigNumber:
         )
         result = analyze_chart_semantics(None, config)
         assert result is not None
-        assert result.primary_insight != ""
+        assert "trend" in result.primary_insight.lower()
+        assert result.data_story != ""
+        assert len(result.recommended_actions) > 0
 
 
 class TestSchemaValidatorBigNumber:
@@ -403,6 +419,19 @@ class TestSchemaValidatorBigNumber:
         assert is_valid is False
         assert error is not None
         assert error.error_code == "MISSING_BIG_NUMBER_METRIC"
+
+    def test_invalid_metric_type(self) -> None:
+        data = {
+            "dataset_id": 1,
+            "config": {
+                "chart_type": "big_number",
+                "metric": "not_a_dict",
+            },
+        }
+        is_valid, request, error = SchemaValidator.validate_request(data)
+        assert is_valid is False
+        assert error is not None
+        assert error.error_code == "INVALID_BIG_NUMBER_METRIC_TYPE"
 
     def test_missing_metric_aggregate(self) -> None:
         data = {


### PR DESCRIPTION
## **User description**
### SUMMARY

Add support for creating Big Number charts via the MCP service. This enables AI assistants to create single-metric display charts with two variants:

- **big_number_total**: A standalone big number display showing a single metric value
- **big_number** (with trendline): A big number with a time-series trendline below it

The implementation includes:
- `BigNumberChartConfig` Pydantic schema with validators for metric aggregates and trendline requirements
- `map_big_number_config()` for converting simplified config to Superset's form_data format
- `_resolve_viz_type()` helper for centralized viz_type resolution across chart types
- Pre-validation in `SchemaValidator` with user-friendly error messages and codes
- Updated MCP instructions to document the new chart type

Supported features:
- Metric with required aggregate function (SUM, COUNT, AVG, MIN, MAX)
- Optional trendline with temporal column and time grain
- Subheader text, number formatting (y_axis_format), and period comparison (compare_lag)
- Filter support

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend MCP service changes only

### TESTING INSTRUCTIONS

1. Run the new test suite:
   ```bash
   pytest tests/unit_tests/mcp_service/chart/test_big_number_chart.py -v
   ```
2. Run the full MCP service test suite to verify no regressions:
   ```bash
   pytest tests/unit_tests/mcp_service/ -x -q
   ```
3. Test via MCP client:
   - Create a big number total: `generate_chart(dataset_id=1, config={"chart_type": "big_number", "metric": {"name": "revenue", "aggregate": "SUM"}})`
   - Create a big number with trendline: `generate_chart(dataset_id=1, config={"chart_type": "big_number", "metric": {"name": "revenue", "aggregate": "SUM"}, "temporal_column": "ds", "show_trendline": true})`

### ADDITIONAL INFORMATION

- [x] Introduces new feature or API
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Removes existing feature or API

## MCP Testing (via localhost MCP service)
1. `health_check` → confirmed service healthy
2. `get_dataset_info(39)` → confirmed birth_names dataset has temporal column `ds` and numeric column `num`
3. Big number form_data now uses `granularity_sqla` (not `x_axis`) for temporal columns, matching Superset's big_number visualization expectations
4. All 39 unit tests pass locally

## MCP Testing Results (localhost, 2026-03-13)

Comprehensive testing via localhost MCP tools on branch `amin/mcp-big-number-chart`:

### Unit Tests
- PR-specific tests: **41/41 passed** (`test_big_number_chart.py`)
- Full MCP test suite: **836/836 passed** (0 failures)

### Live MCP Tool Testing
- `health_check` → healthy (Python 3.12.11)
- `get_instance_info` → admin user, 109 charts, 42 datasets, 18 dashboards
- `list_charts(viz_type in [big_number, big_number_total])` → found 12 existing big_number charts
- `get_chart_info(14)` → "World's Population" (big_number) on wb_health_population dataset
- `get_chart_data(14)` → returned 5 rows with country_code and sum__SP_POP_TOTL columns
- `get_dataset_info(39)` → birth_names dataset with temporal `ds` column and numeric `num` column
- `generate_chart` (line, bar, pie, pivot_table, mixed_timeseries) → all working
- `generate_explore_link` (mixed_timeseries) → explore URL generated
- `execute_sql` → SQL queries executing correctly
- `get_schema(chart)` → schema discovery working with full column/filter metadata

### Edge Cases Tested
- Invalid column name → proper `column_not_found` error with suggestions
- Nonexistent dataset ID → proper `dataset_not_found` error
- `generate_preview=False, save_chart=False` → proper validation error (no-op rejected)

## MCP Tool Testing Results (2026-03-13)

Tested against local Superset MCP service (port 5008) with all tools passing.

### health_check
- **Request**: `health_check()` (no params)
- **Response**: `{"status": "healthy", "service": "Superset OSS MCP Service", "version": "0.0.0-dev", "python_version": "3.12.11"}`

### get_instance_info
- **Request**: `get_instance_info({})`
- **Response**: Admin user (id=1), 18 dashboards, 109 charts, 42 datasets, 1 database (postgresql). `current_user` properly serialized with roles `["Admin"]`. `feature_availability.accessible_menus` returns 25 menu items.

### list_charts
- **Request**: `list_charts({"page": 1, "page_size": 3, "order_column": "changed_on", "order_direction": "desc"})`
- **Response**: 3 charts returned, total_count=109, pagination working correctly.

### list_dashboards
- **Request**: `list_dashboards({"page": 1, "page_size": 3, "order_column": "changed_on", "order_direction": "desc"})`
- **Response**: 3 dashboards returned, total_count=18, pagination working correctly.

### execute_sql
- **Request**: `execute_sql({"database_id": 1, "sql": "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' LIMIT 5"})`
- **Response**: 5 rows returned in 36ms, execution successful.


___

## **CodeAnt-AI Description**
**Add Big Number chart support for single-value displays and trendlines**

### What Changed
- AI assistants can now create Big Number charts for a single metric, either as a standalone number or with a trendline over time
- Big Number charts now accept a subtitle, number formatting, period comparison, and filters
- Validation now catches missing metric, missing aggregate, and missing date column for trendlines with clear error messages
- Chart previews and saved charts now use the right metric and time column for Big Number charts
- Big Number chart types are now included in the MCP usage guide and chart name summaries

### Impact
`✅ Single-metric dashboards`
`✅ Fewer invalid chart requests`
`✅ Clearer chart setup errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
