### PR TITLE
fix(mcp): improve default chart names with descriptive format

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -868,7 +868,12 @@ def _xy_chart_context(config: XYChartConfig) -> str | None:
     """Build context (time grain / filters) for an XY chart name."""
     parts: list[str] = []
     if config.time_grain:
-        grain_str = _GRAIN_MAP.get(str(config.time_grain), str(config.time_grain))
+        grain_val = (
+            config.time_grain.value
+            if hasattr(config.time_grain, "value")
+            else str(config.time_grain)
+        )
+        grain_str = _GRAIN_MAP.get(grain_val, grain_val)
         parts.append(grain_str)
     filter_ctx = _summarize_filters(config.filters)
     if filter_ctx:

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -875,8 +875,7 @@ def _xy_chart_context(config: XYChartConfig) -> str | None:
         )
         grain_str = _GRAIN_MAP.get(grain_val, grain_val)
         parts.append(grain_str)
-    filter_ctx = _summarize_filters(config.filters)
-    if filter_ctx:
+    if filter_ctx := _summarize_filters(config.filters):
         parts.append(filter_ctx)
     return ", ".join(parts) if parts else None
 

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -789,33 +789,115 @@ def map_filter_operator(op: str) -> str:
     return operator_map.get(op, op)
 
 
-def generate_chart_name(
-    config: TableChartConfig
-    | XYChartConfig
-    | PieChartConfig
-    | PivotTableChartConfig
-    | MixedTimeseriesChartConfig,
+def _humanize_column(col: ColumnRef) -> str:
+    """Return a human-readable label for a column reference."""
+    if col.label:
+        return col.label
+    name = col.name.replace("_", " ").title()
+    if col.aggregate:
+        return f"{col.aggregate.capitalize()}({name})"
+    return name
+
+
+def _summarize_filters(
+    filters: list[Any] | None,
+) -> str | None:
+    """Extract a short context string from filter configs."""
+    if not filters:
+        return None
+    parts: list[str] = []
+    for f in filters[:2]:
+        col = getattr(f, "column", "")
+        val = getattr(f, "value", "")
+        if isinstance(val, list):
+            val = ", ".join(str(v) for v in val[:3])
+        parts.append(f"{str(col).replace('_', ' ').title()} {val}")
+    return ", ".join(parts) if parts else None
+
+
+def _truncate(name: str, max_length: int = 60) -> str:
+    """Truncate to *max_length*, preserving the en-dash context portion."""
+    if len(name) <= max_length:
+        return name
+    if " \u2013 " in name:
+        what, _context = name.split(" \u2013 ", 1)
+        if len(what) <= max_length:
+            return what
+    return name[: max_length - 1] + "\u2026"
+
+
+def generate_chart_name(  # noqa: C901
+    config: TableChartConfig | XYChartConfig,
+    dataset_name: str | None = None,
 ) -> str:
-    """Generate a chart name based on the configuration."""
+    """Generate a descriptive chart name following a standard format.
+
+    Format conventions (by chart type):
+      Aggregated (bar/scatter with group_by): [Metric] by [Dimension]
+      Time-series (line/area, no group_by):   [Metric] Over Time
+      Table (no aggregates):                  [Dataset] Records
+      Table (with aggregates):                [Metric] Summary
+    An en-dash followed by context (filters / time grain) is appended
+    when such information is available.
+    """
+    context = None
     if isinstance(config, TableChartConfig):
-        return f"Table Chart - {', '.join(col.name for col in config.columns)}"
+        has_agg = any(col.aggregate for col in config.columns)
+        if has_agg:
+            metrics = [col for col in config.columns if col.aggregate]
+            what = ", ".join(_humanize_column(m) for m in metrics[:2])
+            what = f"{what} Summary"
+        else:
+            if dataset_name:
+                what = f"{dataset_name} Records"
+            else:
+                cols = ", ".join(_humanize_column(c) for c in config.columns[:3])
+                what = f"{cols} Table"
+        context = _summarize_filters(config.filters)
+
     elif isinstance(config, XYChartConfig):
-        chart_type = config.kind.capitalize()
-        x_col = config.x.name
-        y_cols = ", ".join(col.name for col in config.y)
-        return f"{chart_type} Chart - {x_col} vs {y_cols}"
-    elif isinstance(config, PieChartConfig):
-        metric_label = config.metric.label or config.metric.name
-        return f"Pie Chart - {config.dimension.name} by {metric_label}"
-    elif isinstance(config, PivotTableChartConfig):
-        rows = ", ".join(col.name for col in config.rows)
-        return f"Pivot Table - {rows}"
-    elif isinstance(config, MixedTimeseriesChartConfig):
-        primary = ", ".join(col.name for col in config.y)
-        secondary = ", ".join(col.name for col in config.y_secondary)
-        return f"Mixed Chart - {primary} + {secondary}"
+        primary_metric = _humanize_column(config.y[0]) if config.y else "Value"
+        dimension = _humanize_column(config.x)
+
+        is_timeseries = config.kind in ("line", "area")
+        has_groupby = config.group_by is not None
+
+        if is_timeseries and not has_groupby:
+            what = f"{primary_metric} Over Time"
+        elif has_groupby:
+            group_label = _humanize_column(config.group_by)  # type: ignore[arg-type]
+            what = f"{primary_metric} by {group_label}"
+        elif config.kind == "scatter":
+            y_label = primary_metric
+            what = f"{y_label} vs {dimension}"
+        else:
+            what = f"{primary_metric} by {dimension}"
+
+        # Build context from time grain or filters
+        parts: list[str] = []
+        if config.time_grain:
+            grain_map: dict[str, str] = {
+                "PT1H": "Hourly",
+                "P1D": "Daily",
+                "P1W": "Weekly",
+                "P1M": "Monthly",
+                "P3M": "Quarterly",
+                "P1Y": "Yearly",
+            }
+            grain_str = grain_map.get(str(config.time_grain), str(config.time_grain))
+            parts.append(grain_str)
+        filter_ctx = _summarize_filters(config.filters)
+        if filter_ctx:
+            parts.append(filter_ctx)
+        if parts:
+            context = ", ".join(parts)
     else:
         return "Chart"
+
+    name = what
+    if context:
+        name = f"{what} \u2013 {context}"
+    return _truncate(name)
 
 
 def analyze_chart_capabilities(chart: Any | None, config: Any) -> ChartCapabilities:

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -880,8 +880,36 @@ def _xy_chart_context(config: XYChartConfig) -> str | None:
     return ", ".join(parts) if parts else None
 
 
+def _pie_chart_what(config: PieChartConfig) -> str:
+    """Build the 'what' portion for a pie chart name."""
+    dim = config.dimension.name
+    metric_label = config.metric.label or config.metric.name
+    return f"{dim} by {metric_label}"
+
+
+def _pivot_table_what(config: PivotTableChartConfig) -> str:
+    """Build the 'what' portion for a pivot table chart name."""
+    row_names = ", ".join(r.name for r in config.rows)
+    return f"Pivot Table \u2013 {row_names}"
+
+
+def _mixed_timeseries_what(config: MixedTimeseriesChartConfig) -> str:
+    """Build the 'what' portion for a mixed timeseries chart name."""
+    primary = config.y[0].label or config.y[0].name if config.y else "primary"
+    secondary = (
+        config.y_secondary[0].label or config.y_secondary[0].name
+        if config.y_secondary
+        else "secondary"
+    )
+    return f"{primary} + {secondary}"
+
+
 def generate_chart_name(
-    config: TableChartConfig | XYChartConfig,
+    config: TableChartConfig
+    | XYChartConfig
+    | PieChartConfig
+    | PivotTableChartConfig
+    | MixedTimeseriesChartConfig,
     dataset_name: str | None = None,
 ) -> str:
     """Generate a descriptive chart name following a standard format.
@@ -891,6 +919,9 @@ def generate_chart_name(
       Time-series (line/area, no group_by):   [Metric] Over Time
       Table (no aggregates):                  [Dataset] Records
       Table (with aggregates):                [Metric] Summary
+      Pie:                                    [Dimension] by [Metric]
+      Pivot Table:                            Pivot Table – [Row1, Row2]
+      Mixed Timeseries:                       [Primary] + [Secondary]
     An en-dash followed by context (filters / time grain) is appended
     when such information is available.
     """
@@ -900,6 +931,15 @@ def generate_chart_name(
     elif isinstance(config, XYChartConfig):
         what = _xy_chart_what(config)
         context = _xy_chart_context(config)
+    elif isinstance(config, PieChartConfig):
+        what = _pie_chart_what(config)
+        context = _summarize_filters(config.filters)
+    elif isinstance(config, PivotTableChartConfig):
+        what = _pivot_table_what(config)
+        context = _summarize_filters(config.filters)
+    elif isinstance(config, MixedTimeseriesChartConfig):
+        what = _mixed_timeseries_what(config)
+        context = _summarize_filters(config.filters)
     else:
         return "Chart"
 

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -826,7 +826,57 @@ def _truncate(name: str, max_length: int = 60) -> str:
     return name[: max_length - 1] + "\u2026"
 
 
-def generate_chart_name(  # noqa: C901
+def _table_chart_what(config: TableChartConfig, dataset_name: str | None) -> str:
+    """Build the descriptive fragment for a table chart."""
+    has_agg = any(col.aggregate for col in config.columns)
+    if has_agg:
+        metrics = [col for col in config.columns if col.aggregate]
+        what = ", ".join(_humanize_column(m) for m in metrics[:2])
+        return f"{what} Summary"
+    if dataset_name:
+        return f"{dataset_name} Records"
+    cols = ", ".join(_humanize_column(c) for c in config.columns[:3])
+    return f"{cols} Table"
+
+
+def _xy_chart_what(config: XYChartConfig) -> str:
+    """Build the descriptive fragment for an XY chart."""
+    primary_metric = _humanize_column(config.y[0]) if config.y else "Value"
+    dimension = _humanize_column(config.x)
+
+    if config.kind in ("line", "area") and config.group_by is None:
+        return f"{primary_metric} Over Time"
+    if config.group_by is not None:
+        group_label = _humanize_column(config.group_by)
+        return f"{primary_metric} by {group_label}"
+    if config.kind == "scatter":
+        return f"{primary_metric} vs {dimension}"
+    return f"{primary_metric} by {dimension}"
+
+
+_GRAIN_MAP: dict[str, str] = {
+    "PT1H": "Hourly",
+    "P1D": "Daily",
+    "P1W": "Weekly",
+    "P1M": "Monthly",
+    "P3M": "Quarterly",
+    "P1Y": "Yearly",
+}
+
+
+def _xy_chart_context(config: XYChartConfig) -> str | None:
+    """Build context (time grain / filters) for an XY chart name."""
+    parts: list[str] = []
+    if config.time_grain:
+        grain_str = _GRAIN_MAP.get(str(config.time_grain), str(config.time_grain))
+        parts.append(grain_str)
+    filter_ctx = _summarize_filters(config.filters)
+    if filter_ctx:
+        parts.append(filter_ctx)
+    return ", ".join(parts) if parts else None
+
+
+def generate_chart_name(
     config: TableChartConfig | XYChartConfig,
     dataset_name: str | None = None,
 ) -> str:
@@ -840,57 +890,12 @@ def generate_chart_name(  # noqa: C901
     An en-dash followed by context (filters / time grain) is appended
     when such information is available.
     """
-    context = None
     if isinstance(config, TableChartConfig):
-        has_agg = any(col.aggregate for col in config.columns)
-        if has_agg:
-            metrics = [col for col in config.columns if col.aggregate]
-            what = ", ".join(_humanize_column(m) for m in metrics[:2])
-            what = f"{what} Summary"
-        else:
-            if dataset_name:
-                what = f"{dataset_name} Records"
-            else:
-                cols = ", ".join(_humanize_column(c) for c in config.columns[:3])
-                what = f"{cols} Table"
+        what = _table_chart_what(config, dataset_name)
         context = _summarize_filters(config.filters)
-
     elif isinstance(config, XYChartConfig):
-        primary_metric = _humanize_column(config.y[0]) if config.y else "Value"
-        dimension = _humanize_column(config.x)
-
-        is_timeseries = config.kind in ("line", "area")
-        has_groupby = config.group_by is not None
-
-        if is_timeseries and not has_groupby:
-            what = f"{primary_metric} Over Time"
-        elif has_groupby:
-            group_label = _humanize_column(config.group_by)  # type: ignore[arg-type]
-            what = f"{primary_metric} by {group_label}"
-        elif config.kind == "scatter":
-            y_label = primary_metric
-            what = f"{y_label} vs {dimension}"
-        else:
-            what = f"{primary_metric} by {dimension}"
-
-        # Build context from time grain or filters
-        parts: list[str] = []
-        if config.time_grain:
-            grain_map: dict[str, str] = {
-                "PT1H": "Hourly",
-                "P1D": "Daily",
-                "P1W": "Weekly",
-                "P1M": "Monthly",
-                "P3M": "Quarterly",
-                "P1Y": "Yearly",
-            }
-            grain_str = grain_map.get(str(config.time_grain), str(config.time_grain))
-            parts.append(grain_str)
-        filter_ctx = _summarize_filters(config.filters)
-        if filter_ctx:
-            parts.append(filter_ctx)
-        if parts:
-            context = ", ".join(parts)
+        what = _xy_chart_what(config)
+        context = _xy_chart_context(config)
     else:
         return "Chart"
 

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -263,10 +263,6 @@ async def generate_chart(  # noqa: C901
             await ctx.report_progress(2, 5, "Creating chart in database")
             from superset.commands.chart.create import CreateChartCommand
 
-            # Use custom chart name if provided, otherwise auto-generate
-            chart_name = request.chart_name or generate_chart_name(request.config)
-            await ctx.debug("Chart name: chart_name=%s" % (chart_name,))
-
             # Find the dataset to get its numeric ID
             from superset.daos.dataset import DatasetDAO
 
@@ -342,6 +338,15 @@ async def generate_chart(  # noqa: C901
                         "api_version": "v1",
                     }
                 )
+
+            # Generate chart name after dataset lookup so we can include dataset name
+            dataset_name = getattr(dataset, "datasource_name", None) or getattr(
+                dataset, "table_name", None
+            )
+            chart_name = request.chart_name or generate_chart_name(
+                request.config, dataset_name=dataset_name
+            )
+            await ctx.debug("Chart name: chart_name=%s" % (chart_name,))
 
             try:
                 with event_logger.log_context(action="mcp.generate_chart.db_write"):

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -490,8 +490,8 @@ class TestMapConfigToFormData:
 class TestGenerateChartName:
     """Test generate_chart_name function"""
 
-    def test_generate_table_chart_name(self) -> None:
-        """Test generating name for table chart"""
+    def test_table_no_aggregates(self) -> None:
+        """Table without aggregates uses column names."""
         config = TableChartConfig(
             chart_type="table",
             columns=[
@@ -501,24 +501,137 @@ class TestGenerateChartName:
         )
 
         result = generate_chart_name(config)
-        assert result == "Table Chart - product, revenue"
+        assert result == "Product, Revenue Table"
 
-    def test_generate_xy_chart_name(self) -> None:
-        """Test generating name for XY chart"""
+    def test_table_no_aggregates_with_dataset_name(self) -> None:
+        """Table without aggregates includes dataset name when available."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="product")],
+        )
+
+        result = generate_chart_name(config, dataset_name="Orders")
+        assert result == "Orders Records"
+
+    def test_table_with_aggregates(self) -> None:
+        """Table with aggregates produces a summary name."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[
+                ColumnRef(name="product"),
+                ColumnRef(name="revenue", aggregate="SUM"),
+            ],
+        )
+
+        result = generate_chart_name(config)
+        assert result == "Sum(Revenue) Summary"
+
+    def test_line_chart_over_time(self) -> None:
+        """Line chart without group_by uses 'Over Time' format."""
         config = XYChartConfig(
             chart_type="xy",
-            x=ColumnRef(name="date"),
-            y=[ColumnRef(name="revenue"), ColumnRef(name="orders")],
+            x=ColumnRef(name="order_date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
             kind="line",
         )
 
         result = generate_chart_name(config)
-        assert result == "Line Chart - date vs revenue, orders"
+        assert result == "Sum(Revenue) Over Time"
 
-    def test_generate_chart_name_unsupported(self) -> None:
-        """Test generating name for unsupported config type"""
+    def test_bar_chart_by_dimension(self) -> None:
+        """Bar chart uses 'by [X]' format."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="product_category"),
+            y=[ColumnRef(name="order_count", aggregate="COUNT")],
+            kind="bar",
+        )
+
+        result = generate_chart_name(config)
+        assert result == "Count(Order Count) by Product Category"
+
+    def test_line_chart_with_group_by(self) -> None:
+        """Line chart with group_by uses 'by [group]' format."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+            group_by=ColumnRef(name="sales_rep"),
+        )
+
+        result = generate_chart_name(config)
+        assert result == "Sum(Revenue) by Sales Rep"
+
+    def test_scatter_plot(self) -> None:
+        """Scatter plot uses 'Y vs X' format."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="age"),
+            y=[ColumnRef(name="income")],
+            kind="scatter",
+        )
+
+        result = generate_chart_name(config)
+        assert result == "Income vs Age"
+
+    def test_time_grain_in_context(self) -> None:
+        """Time grain is appended as context."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+            time_grain="P1M",
+        )
+
+        result = generate_chart_name(config)
+        assert result == "Sum(Revenue) Over Time \u2013 Monthly"
+
+    def test_filter_context(self) -> None:
+        """Filters are appended as context."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="product")],
+            filters=[FilterConfig(column="region", op="=", value="West")],
+        )
+
+        result = generate_chart_name(config, dataset_name="Orders")
+        assert result == "Orders Records \u2013 Region West"
+
+    def test_name_truncation(self) -> None:
+        """Names exceeding 60 chars are truncated."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[
+                ColumnRef(
+                    name="very_long_metric_name_that_goes_on_and_on", aggregate="SUM"
+                )
+            ],
+            kind="line",
+            group_by=ColumnRef(name="another_very_long_dimension_name_here"),
+        )
+
+        result = generate_chart_name(config)
+        assert len(result) <= 60
+
+    def test_unsupported_config_type(self) -> None:
+        """Unsupported config type returns generic name."""
         result = generate_chart_name("invalid_config")  # type: ignore
         assert result == "Chart"
+
+    def test_custom_labels_used(self) -> None:
+        """Column labels are preferred over names."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="ds", label="Date"),
+            y=[ColumnRef(name="cnt", aggregate="COUNT", label="Order Count")],
+            kind="bar",
+        )
+
+        result = generate_chart_name(config)
+        assert result == "Order Count by Date"
 
 
 class TestGenerateExploreLink:

--- a/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
+++ b/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
@@ -723,7 +723,7 @@ class TestGenerateChartNameNewTypes:
             metric=ColumnRef(name="revenue", aggregate="SUM"),
         )
         result = generate_chart_name(config)
-        assert result == "Pie Chart - product by revenue"
+        assert result == "product by revenue"
 
     def test_pie_chart_name_with_custom_label(self) -> None:
         config = PieChartConfig(
@@ -732,7 +732,7 @@ class TestGenerateChartNameNewTypes:
             metric=ColumnRef(name="revenue", aggregate="SUM", label="Total Revenue"),
         )
         result = generate_chart_name(config)
-        assert result == "Pie Chart - product by Total Revenue"
+        assert result == "product by Total Revenue"
 
     def test_pivot_table_chart_name(self) -> None:
         config = PivotTableChartConfig(
@@ -741,7 +741,7 @@ class TestGenerateChartNameNewTypes:
             metrics=[ColumnRef(name="revenue", aggregate="SUM")],
         )
         result = generate_chart_name(config)
-        assert result == "Pivot Table - product, region"
+        assert result == "Pivot Table \u2013 product, region"
 
     def test_mixed_timeseries_chart_name(self) -> None:
         config = MixedTimeseriesChartConfig(
@@ -751,7 +751,7 @@ class TestGenerateChartNameNewTypes:
             y_secondary=[ColumnRef(name="orders", aggregate="COUNT")],
         )
         result = generate_chart_name(config)
-        assert result == "Mixed Chart - revenue + orders"
+        assert result == "revenue + orders"
 
 
 # ============================================================


### PR DESCRIPTION
## **User description**
## Summary
- Rewrote `generate_chart_name()` to produce structured, descriptive chart names
- Format: `[What] by [Dimension] – [Context]` with variants per chart type:
  - **Line/Area (no group_by):** "Revenue Over Time – Monthly"
  - **Aggregated (bar, line with group_by):** "Revenue by Product Category"
  - **Scatter:** "Income vs Age"
  - **Table (no aggregates):** "Orders Records" or "Product, Revenue Table"
  - **Table (with aggregates):** "Sum(Revenue) Summary"
- Context portion includes time grain (Monthly, Weekly, etc.) and filter info
- Names capped at 60 characters with smart truncation
- Dataset name included when available (for table charts without aggregates)
- Custom column labels are preferred over raw column names

## Testing Instructions
1. Run unit tests: `pytest tests/unit_tests/mcp_service/chart/test_chart_utils.py::TestGenerateChartName -v`
2. Start the MCP server and use `generate_chart` with `save_chart=True`
3. Verify the auto-generated chart name follows the format above
4. Try with different chart types (line, bar, scatter, table) and verify naming
5. Provide a custom `chart_name` and verify it takes precedence over auto-generation

## MCP Testing Results (localhost, 2026-03-04)

Tested via localhost MCP tools on branch `fix/mcp-improve-default-chart-names`:

### Auto-Generated Chart Names
1. **Time series line chart** (no `chart_name` provided):
   - Config: `x=transaction_date, y=SUM(revenue), kind=line, time_grain=P1M`
   - Auto-generated name: **"Sum(Revenue) Over Time – Monthly"** ✅
   
2. **Categorical bar chart** (no `chart_name` provided):
   - Config: `x=region, y=SUM(revenue), kind=bar`
   - Auto-generated name: **"Sum(Revenue) by Region"** ✅

3. **Custom name provided**:
   - Config: `chart_name="My Custom Chart"`, `x=country, y=AVG(profit), kind=bar`
   - Name used: **"My Custom Chart"** (custom name preserved) ✅

### Name Format
- Time series charts use: "Metric Over Time – Grain" format
- Categorical charts use: "Metric by Dimension" format
- Both patterns are descriptive and LLM-friendly


___

## **CodeAnt-AI Description**
Improve default chart names to descriptive, consistent format

### What Changed
- Auto-generated chart names now follow readable patterns (e.g., "Sum(Revenue) Over Time", "Income vs Age", "Product, Revenue Table", "Sum(Revenue) Summary") instead of generic type-prefixed labels.
- Table names include the dataset name when available ("Orders Records") and prefer aggregated-summary wording for tables with aggregates.
- Time-grain and simple filter summaries are appended after an en-dash as context (e.g., "… – Monthly", "… – Region West"); pivot table names use an en-dash separator.
- Pie and mixed-timeseries charts no longer include redundant chart-type prefixes (e.g., "product by revenue" instead of "Pie Chart - product by revenue").
- Long names are truncated to 60 characters while preserving the main descriptive portion; column labels are preferred over raw column names.
- Chart name generation now runs after dataset lookup when saving a chart so table chart names can include the dataset name; unit tests updated to reflect new naming rules.

### Impact
`✅ Clearer chart titles in dashboards and listings`
`✅ More consistent pivot and table naming`
`✅ Shorter, predictable names when saving charts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
