### PR TITLE
feat(mcp): implement RBAC permission checking for MCP tools

### DIFF
--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -48,11 +48,14 @@ def tool(
     description: str | None = None,
     tags: list[str] | None = None,
     protect: bool = True,
+    class_permission_name: str | None = None,
+    method_permission_name: str | None = None,
 ) -> Any:  # Use Any to avoid mypy issues with dependency injection
     """
     Decorator to register an MCP tool with optional authentication.
 
-    This decorator combines FastMCP tool registration with optional authentication.
+    This decorator combines FastMCP tool registration with optional authentication
+    and RBAC permission checking.
 
     Can be used as:
         @tool
@@ -69,6 +72,11 @@ def tool(
         description: Tool description (defaults to function docstring)
         tags: List of tags for categorizing the tool (defaults to empty list)
         protect: Whether to require Superset authentication (defaults to True)
+        class_permission_name: FAB view/resource name for RBAC checking
+            (e.g., "Chart", "Dashboard", "SQLLab"). When set, enables
+            permission checking via security_manager.can_access().
+        method_permission_name: FAB action name (e.g., "read", "write").
+            Defaults to "write" if tags includes "mutate", else "read".
 
     Returns:
         Decorator function that registers and wraps the tool, or the wrapped function
@@ -90,6 +98,16 @@ def tool(
         def public_tool() -> str:
             '''Public tool accessible without auth'''
             return "Hello world"
+
+        @tool(class_permission_name="Chart")  # RBAC: requires can_read on Chart
+        def list_charts() -> list:
+            '''List charts the user can access'''
+            return []
+
+        @tool(tags=["mutate"], class_permission_name="Chart")  # RBAC: can_write on Chart
+        def create_chart(name: str) -> dict:
+            '''Create a new chart'''
+            return {"name": name}
     """
     raise NotImplementedError(
         "MCP tool decorator not initialized. "

--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -104,7 +104,9 @@ def tool(
             '''List charts the user can access'''
             return []
 
-        @tool(tags=["mutate"], class_permission_name="Chart")  # RBAC: can_write on Chart
+        @tool(  # RBAC: can_write on Chart
+            tags=["mutate"], class_permission_name="Chart",
+        )
         def create_chart(name: str) -> dict:
             '''Create a new chart'''
             return {"name": name}

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -60,12 +60,14 @@ def create_tool_decorator(
     description: Optional[str] = None,
     tags: Optional[list[str]] = None,
     protect: bool = True,
+    class_permission_name: Optional[str] = None,
+    method_permission_name: Optional[str] = None,
 ) -> Callable[[F], F] | F:
     """
     Create the concrete MCP tool decorator implementation.
 
-    This combines FastMCP tool registration with optional Superset authentication,
-    replacing the need for separate @mcp.tool and @mcp_auth_hook decorators.
+    This combines FastMCP tool registration with optional Superset authentication
+    and RBAC permission checking.
 
     Supports both @tool and @tool() syntax.
 
@@ -76,6 +78,10 @@ def create_tool_decorator(
         description: Tool description (defaults to function docstring)
         tags: List of tags for categorization (defaults to empty list)
         protect: Whether to apply Superset authentication (defaults to True)
+        class_permission_name: FAB view/resource name for RBAC
+            (e.g., "Chart", "Dashboard", "SQLLab"). Enables permission checking.
+        method_permission_name: FAB action name (e.g., "read", "write").
+            Defaults to "write" if tags has "mutate", else "read".
 
     Returns:
         Decorator that registers and wraps the tool with optional authentication,
@@ -94,6 +100,20 @@ def create_tool_decorator(
 
             # Get prefixed ID based on ambient context
             tool_name, context_type = _get_prefixed_id_with_context(base_tool_name)
+
+            # Store RBAC permission metadata on the function so
+            # mcp_auth_hook can read them at call time.
+            if class_permission_name:
+                from superset.mcp_service.auth import (
+                    CLASS_PERMISSION_ATTR,
+                    METHOD_PERMISSION_ATTR,
+                )
+
+                setattr(func, CLASS_PERMISSION_ATTR, class_permission_name)
+                actual_method = method_permission_name
+                if actual_method is None:
+                    actual_method = "write" if "mutate" in tool_tags else "read"
+                setattr(func, METHOD_PERMISSION_ATTR, actual_method)
 
             # Conditionally apply authentication wrapper
             if protect:

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -77,6 +77,9 @@ def check_tool_permission(func: Callable[..., Any]) -> bool:
     Reads permission metadata stored on the function by the @tool decorator
     and uses Superset's security_manager to verify access.
 
+    Controlled by the ``MCP_RBAC_ENABLED`` config flag (default True).
+    Set to False in superset_config.py to disable RBAC checking.
+
     Args:
         func: The tool function with optional permission attributes.
 
@@ -84,6 +87,11 @@ def check_tool_permission(func: Callable[..., Any]) -> bool:
         True if user has permission or no permission is required.
     """
     try:
+        from flask import current_app
+
+        if not current_app.config.get("MCP_RBAC_ENABLED", True):
+            return True
+
         from superset import security_manager
 
         if not hasattr(g, "user") or not g.user:

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -123,7 +123,7 @@ def check_tool_permission(func: Callable[..., Any]) -> bool:
 
         return has_permission
 
-    except Exception as e:
+    except (AttributeError, ValueError, RuntimeError) as e:
         logger.warning("Error checking tool permission: %s", e)
         return False
 
@@ -352,10 +352,9 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
 
                 # RBAC permission check
                 if not check_tool_permission(tool_func):
+                    method_name = getattr(tool_func, METHOD_PERMISSION_ATTR, "read")
                     raise MCPPermissionDeniedError(
-                        permission_name=getattr(
-                            tool_func, METHOD_PERMISSION_ATTR, "read"
-                        ),
+                        permission_name=f"{PERMISSION_PREFIX}{method_name}",
                         view_name=getattr(tool_func, CLASS_PERMISSION_ATTR, "unknown"),
                         user=user.username,
                         tool_name=tool_func.__name__,
@@ -393,10 +392,9 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
 
                 # RBAC permission check
                 if not check_tool_permission(tool_func):
+                    method_name = getattr(tool_func, METHOD_PERMISSION_ATTR, "read")
                     raise MCPPermissionDeniedError(
-                        permission_name=getattr(
-                            tool_func, METHOD_PERMISSION_ATTR, "read"
-                        ),
+                        permission_name=f"{PERMISSION_PREFIX}{method_name}",
                         view_name=getattr(tool_func, CLASS_PERMISSION_ATTR, "unknown"),
                         user=user.username,
                         tool_name=tool_func.__name__,

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -16,15 +16,16 @@
 # under the License.
 
 """
-Minimal authentication hooks for MCP tools.
-This is a placeholder implementation that provides basic user context.
+Authentication and authorization hooks for MCP tools.
 
-Future enhancements (to be added in separate PRs):
-- JWT token authentication and validation
-- User impersonation support
-- Permission checking with scopes
-- Comprehensive audit logging
-- Field-level permissions
+This module provides:
+- User authentication from JWT or configured dev user
+- RBAC permission checking aligned with Superset's REST API permissions
+- Dataset access validation
+- Session lifecycle management
+
+The RBAC enforcement mirrors Flask-AppBuilder's @protect() decorator,
+ensuring MCP tools respect the same permission model as the REST API.
 """
 
 import logging
@@ -41,6 +42,82 @@ if TYPE_CHECKING:
 F = TypeVar("F", bound=Callable[..., Any])
 
 logger = logging.getLogger(__name__)
+
+# Constants for RBAC permission attributes (mirrors FAB conventions)
+PERMISSION_PREFIX = "can_"
+CLASS_PERMISSION_ATTR = "_class_permission_name"
+METHOD_PERMISSION_ATTR = "_method_permission_name"
+
+
+class MCPPermissionDeniedError(Exception):
+    """Raised when user lacks required RBAC permission for an MCP tool."""
+
+    def __init__(
+        self,
+        permission_name: str,
+        view_name: str,
+        user: str | None = None,
+        tool_name: str | None = None,
+    ):
+        self.permission_name = permission_name
+        self.view_name = view_name
+        self.user = user
+        self.tool_name = tool_name
+        message = (
+            f"Permission denied: {permission_name} on {view_name}"
+            + (f" for user {user}" if user else "")
+            + (f" (tool: {tool_name})" if tool_name else "")
+        )
+        super().__init__(message)
+
+
+def check_tool_permission(func: Callable[..., Any]) -> bool:
+    """Check if the current user has RBAC permission for an MCP tool.
+
+    Reads permission metadata stored on the function by the @tool decorator
+    and uses Superset's security_manager to verify access.
+
+    Args:
+        func: The tool function with optional permission attributes.
+
+    Returns:
+        True if user has permission or no permission is required.
+    """
+    try:
+        from superset import security_manager
+
+        if not hasattr(g, "user") or not g.user:
+            logger.warning(
+                "No user context for permission check on tool: %s", func.__name__
+            )
+            return False
+
+        class_permission_name = getattr(func, CLASS_PERMISSION_ATTR, None)
+        if not class_permission_name:
+            # No RBAC configured for this tool; allow by default.
+            return True
+
+        method_permission_name = getattr(func, METHOD_PERMISSION_ATTR, "read")
+        permission_str = f"{PERMISSION_PREFIX}{method_permission_name}"
+
+        has_permission = security_manager.can_access(
+            permission_str, class_permission_name
+        )
+
+        if not has_permission:
+            logger.warning(
+                "Permission denied for user %s: %s on %s (tool: %s)",
+                g.user.username,
+                permission_str,
+                class_permission_name,
+                func.__name__,
+            )
+
+        return has_permission
+
+    except Exception as e:
+        logger.warning("Error checking tool permission: %s", e)
+        return False
 
 
 def load_user_with_relationships(
@@ -219,14 +296,15 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
     """
     Authentication and authorization decorator for MCP tools.
 
-    This decorator pushes Flask application context and sets up g.user
-    for MCP tool execution.
+    This decorator pushes Flask application context, sets up g.user,
+    and enforces RBAC permission checks for MCP tool execution.
+
+    Permission metadata (class_permission_name, method_permission_name) is
+    stored on tool_func by the @tool decorator in core_mcp_injection.py.
+    If present, check_tool_permission() verifies the user has the required
+    FAB permission before the tool function runs.
 
     Supports both sync and async tool functions.
-
-    TODO (future PR): Add permission checking
-    TODO (future PR): Add JWT scope validation
-    TODO (future PR): Add comprehensive audit logging
     """
     import contextlib
     import functools
@@ -264,6 +342,17 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                     )
                     return await tool_func(*args, **kwargs)
 
+                # RBAC permission check
+                if not check_tool_permission(tool_func):
+                    raise MCPPermissionDeniedError(
+                        permission_name=getattr(
+                            tool_func, METHOD_PERMISSION_ATTR, "read"
+                        ),
+                        view_name=getattr(tool_func, CLASS_PERMISSION_ATTR, "unknown"),
+                        user=user.username,
+                        tool_name=tool_func.__name__,
+                    )
+
                 try:
                     logger.debug(
                         "MCP tool call: user=%s, tool=%s",
@@ -293,6 +382,17 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                         tool_func.__name__,
                     )
                     return tool_func(*args, **kwargs)
+
+                # RBAC permission check
+                if not check_tool_permission(tool_func):
+                    raise MCPPermissionDeniedError(
+                        permission_name=getattr(
+                            tool_func, METHOD_PERMISSION_ATTR, "read"
+                        ),
+                        view_name=getattr(tool_func, CLASS_PERMISSION_ATTR, "unknown"),
+                        user=user.username,
+                        tool_name=tool_func.__name__,
+                    )
 
                 try:
                     logger.debug(

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -118,7 +118,7 @@ def _compile_chart(
         return CompileResult(success=False, error=str(exc))
 
 
-@tool(tags=["mutate"])
+@tool(tags=["mutate"], class_permission_name="Chart")
 @parse_request(GenerateChartRequest)
 async def generate_chart(  # noqa: C901
     request: GenerateChartRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -63,7 +63,7 @@ def _get_cached_form_data(form_data_key: str) -> str | None:
         return None
 
 
-@tool(tags=["data"])
+@tool(tags=["data"], class_permission_name="Chart")
 @parse_request(GetChartDataRequest)
 async def get_chart_data(  # noqa: C901
     request: GetChartDataRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -56,7 +56,7 @@ def _get_cached_form_data(form_data_key: str) -> str | None:
         return None
 
 
-@tool(tags=["discovery"])
+@tool(tags=["discovery"], class_permission_name="Chart")
 @parse_request(GetChartInfoRequest)
 async def get_chart_info(
     request: GetChartInfoRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -2065,7 +2065,7 @@ async def _get_chart_preview_internal(  # noqa: C901
         )
 
 
-@tool(tags=["data"])
+@tool(tags=["data"], class_permission_name="Chart")
 @parse_request(GetChartPreviewRequest)
 async def get_chart_preview(
     request: GetChartPreviewRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -61,7 +61,7 @@ SORTABLE_CHART_COLUMNS = [
 ]
 
 
-@tool(tags=["core"])
+@tool(tags=["core"], class_permission_name="Chart")
 @parse_request(ListChartsRequest)
 async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
     """List charts with filtering and search.

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -45,7 +45,7 @@ from superset.utils import json
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["mutate"])
+@tool(tags=["mutate"], class_permission_name="Chart")
 @parse_request(UpdateChartRequest)
 async def update_chart(
     request: UpdateChartRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -44,7 +44,7 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["mutate"])
+@tool(tags=["mutate"], class_permission_name="Chart")
 @parse_request(UpdateChartPreviewRequest)
 def update_chart_preview(
     request: UpdateChartPreviewRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -44,7 +44,7 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["mutate"], class_permission_name="Chart")
+@tool(tags=["mutate"], class_permission_name="Chart", method_permission_name="write")
 @parse_request(UpdateChartPreviewRequest)
 def update_chart_preview(
     request: UpdateChartPreviewRequest, ctx: Context

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -304,7 +304,7 @@ def _ensure_layout_structure(
         layout["DASHBOARD_VERSION_KEY"] = "v2"
 
 
-@tool(tags=["mutate"])
+@tool(tags=["mutate"], class_permission_name="Dashboard")
 @parse_request(AddChartToDashboardRequest)
 def add_chart_to_existing_dashboard(
     request: AddChartToDashboardRequest, ctx: Context

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -177,7 +177,7 @@ def _generate_title_from_charts(chart_objects: List[Any]) -> str:
     return title
 
 
-@tool(tags=["mutate"])
+@tool(tags=["mutate"], class_permission_name="Dashboard")
 @parse_request(GenerateDashboardRequest)
 def generate_dashboard(
     request: GenerateDashboardRequest, ctx: Context

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -59,7 +59,7 @@ def _get_permalink_state(permalink_key: str) -> DashboardPermalinkValue | None:
         return None
 
 
-@tool(tags=["discovery"])
+@tool(tags=["discovery"], class_permission_name="Dashboard")
 @parse_request(GetDashboardInfoRequest)
 async def get_dashboard_info(
     request: GetDashboardInfoRequest, ctx: Context

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -62,7 +62,7 @@ SORTABLE_DASHBOARD_COLUMNS = [
 ]
 
 
-@tool(tags=["core"])
+@tool(tags=["core"], class_permission_name="Dashboard")
 @parse_request(ListDashboardsRequest)
 async def list_dashboards(
     request: ListDashboardsRequest, ctx: Context

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -42,7 +42,7 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["discovery"])
+@tool(tags=["discovery"], class_permission_name="Dataset")
 @parse_request(GetDatasetInfoRequest)
 async def get_dataset_info(
     request: GetDatasetInfoRequest, ctx: Context

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -61,7 +61,7 @@ SORTABLE_DATASET_COLUMNS = [
 ]
 
 
-@tool(tags=["core"])
+@tool(tags=["core"], class_permission_name="Dataset")
 @parse_request(ListDatasetsRequest)
 async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetList:
     """List datasets with filtering and search.

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -39,7 +39,7 @@ from superset.mcp_service.chart.schemas import (
 from superset.mcp_service.utils.schema_utils import parse_request
 
 
-@tool(tags=["explore"])
+@tool(tags=["explore"], class_permission_name="Explore")
 @parse_request(GenerateExploreLinkRequest)
 async def generate_explore_link(
     request: GenerateExploreLinkRequest, ctx: Context

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -45,6 +45,10 @@ MCP_SERVICE_PORT = 5008
 # MCP Debug mode - shows suppressed initialization output in stdio mode
 MCP_DEBUG = False
 
+# MCP RBAC - when True, tools with class_permission_name are checked
+# against the FAB security_manager before execution.
+MCP_RBAC_ENABLED = True
+
 # MCP JWT Debug Errors - controls server-side JWT debug logging.
 # When False (default), uses the default JWTVerifier with minimal logging.
 # When True, uses DetailedJWTVerifier with tiered logging:

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -323,6 +323,7 @@ def get_mcp_config(app_config: Dict[str, Any] | None = None) -> Dict[str, Any]:
         "MCP_SERVICE_HOST": MCP_SERVICE_HOST,
         "MCP_SERVICE_PORT": MCP_SERVICE_PORT,
         "MCP_DEBUG": MCP_DEBUG,
+        "MCP_RBAC_ENABLED": MCP_RBAC_ENABLED,
         **MCP_SESSION_CONFIG,
         **MCP_CSRF_CONFIG,
     }

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -50,7 +50,11 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["mutate"], class_permission_name="SQLLab")
+@tool(
+    tags=["mutate"],
+    class_permission_name="SQLLab",
+    method_permission_name="execute_sql_query",
+)
 @parse_request(ExecuteSqlRequest)
 async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlResponse:
     """Execute SQL query against database using the unified Database.execute() API."""

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -50,7 +50,7 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["mutate"])
+@tool(tags=["mutate"], class_permission_name="SQLLab")
 @parse_request(ExecuteSqlRequest)
 async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlResponse:
     """Execute SQL query against database using the unified Database.execute() API."""

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -38,7 +38,7 @@ from superset.mcp_service.utils.url_utils import get_superset_base_url
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["explore"])
+@tool(tags=["explore"], class_permission_name="SQLLab")
 @parse_request(OpenSqlLabRequest)
 def open_sql_lab_with_context(
     request: OpenSqlLabRequest, ctx: Context

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -38,7 +38,7 @@ from superset.mcp_service.utils.url_utils import get_superset_base_url
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["explore"], class_permission_name="SQLLab")
+@tool(tags=["explore"], class_permission_name="SQLLab", method_permission_name="read")
 @parse_request(OpenSqlLabRequest)
 def open_sql_lab_with_context(
     request: OpenSqlLabRequest, ctx: Context

--- a/tests/unit_tests/mcp_service/conftest.py
+++ b/tests/unit_tests/mcp_service/conftest.py
@@ -19,5 +19,22 @@
 MCP service test configuration.
 
 Tool imports are handled by app.py, not here.
-This conftest is empty to prevent test pollution.
 """
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_rbac_permission_check():
+    """Allow all RBAC permission checks in MCP integration tests.
+
+    The RBAC permission logic is tested directly in test_auth_rbac.py,
+    which imports check_tool_permission and calls it without going
+    through mcp_auth_hook. This fixture patches the module-level name
+    so that mcp_auth_hook (same module) sees the mock, while direct
+    imports in test_auth_rbac.py still reference the real function.
+    """
+    with patch("superset.mcp_service.auth.check_tool_permission", return_value=True):
+        yield

--- a/tests/unit_tests/mcp_service/conftest.py
+++ b/tests/unit_tests/mcp_service/conftest.py
@@ -18,23 +18,21 @@
 """
 MCP service test configuration.
 
-Tool imports are handled by app.py, not here.
+Disables RBAC permission checks for integration tests.
+RBAC logic is tested directly in test_auth_rbac.py.
 """
-
-from unittest.mock import patch
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_rbac_permission_check():
-    """Allow all RBAC permission checks in MCP integration tests.
+def disable_mcp_rbac(app):
+    """Disable RBAC permission checks for MCP integration tests.
 
-    The RBAC permission logic is tested directly in test_auth_rbac.py,
-    which imports check_tool_permission and calls it without going
-    through mcp_auth_hook. This fixture patches the module-level name
-    so that mcp_auth_hook (same module) sees the mock, while direct
-    imports in test_auth_rbac.py still reference the real function.
+    The RBAC permission logic is tested directly in test_auth_rbac.py.
+    Integration tests use mock users that do not have real FAB roles,
+    so we disable RBAC to let them exercise tool logic.
     """
-    with patch("superset.mcp_service.auth.check_tool_permission", return_value=True):
-        yield
+    app.config["MCP_RBAC_ENABLED"] = False
+    yield
+    app.config.pop("MCP_RBAC_ENABLED", None)

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -119,12 +119,12 @@ def test_check_tool_permission_granted(app_context):
     g.user = MagicMock(username="admin")
     func = _make_tool_func(class_perm="Chart", method_perm="read")
 
-    with patch("superset.extensions.appbuilder") as mock_appbuilder:
-        mock_appbuilder.sm.can_access.return_value = True
+    with patch("superset.security_manager") as mock_sm:
+        mock_sm.can_access.return_value = True
         result = check_tool_permission(func)
 
     assert result is True
-    mock_appbuilder.sm.can_access.assert_called_once_with("can_read", "Chart")
+    mock_sm.can_access.assert_called_once_with("can_read", "Chart")
 
 
 def test_check_tool_permission_denied(app_context):
@@ -132,12 +132,12 @@ def test_check_tool_permission_denied(app_context):
     g.user = MagicMock(username="viewer")
     func = _make_tool_func(class_perm="Dashboard", method_perm="write")
 
-    with patch("superset.extensions.appbuilder") as mock_appbuilder:
-        mock_appbuilder.sm.can_access.return_value = False
+    with patch("superset.security_manager") as mock_sm:
+        mock_sm.can_access.return_value = False
         result = check_tool_permission(func)
 
     assert result is False
-    mock_appbuilder.sm.can_access.assert_called_once_with("can_write", "Dashboard")
+    mock_sm.can_access.assert_called_once_with("can_write", "Dashboard")
 
 
 def test_check_tool_permission_default_method_is_read(app_context):
@@ -146,11 +146,12 @@ def test_check_tool_permission_default_method_is_read(app_context):
     func = _make_tool_func(class_perm="Dataset")
     # No method_perm set - should default to "read"
 
-    with patch("superset.extensions.appbuilder") as mock_appbuilder:
-        mock_appbuilder.sm.can_access.return_value = True
-        check_tool_permission(func)
+    with patch("superset.security_manager") as mock_sm:
+        mock_sm.can_access.return_value = True
+        result = check_tool_permission(func)
 
-    mock_appbuilder.sm.can_access.assert_called_once_with("can_read", "Dataset")
+    assert result is True
+    mock_sm.can_access.assert_called_once_with("can_read", "Dataset")
 
 
 def test_check_tool_permission_disabled_via_config(app_context, app):

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -119,8 +119,9 @@ def test_check_tool_permission_granted(app_context) -> None:
     g.user = MagicMock(username="admin")
     func = _make_tool_func(class_perm="Chart", method_perm="read")
 
-    with patch("superset.security_manager") as mock_sm:
-        mock_sm.can_access.return_value = True
+    mock_sm = MagicMock()
+    mock_sm.can_access = MagicMock(return_value=True)
+    with patch("superset.security_manager", mock_sm):
         result = check_tool_permission(func)
 
     assert result is True
@@ -132,8 +133,9 @@ def test_check_tool_permission_denied(app_context) -> None:
     g.user = MagicMock(username="viewer")
     func = _make_tool_func(class_perm="Dashboard", method_perm="write")
 
-    with patch("superset.security_manager") as mock_sm:
-        mock_sm.can_access.return_value = False
+    mock_sm = MagicMock()
+    mock_sm.can_access = MagicMock(return_value=False)
+    with patch("superset.security_manager", mock_sm):
         result = check_tool_permission(func)
 
     assert result is False
@@ -146,8 +148,9 @@ def test_check_tool_permission_default_method_is_read(app_context) -> None:
     func = _make_tool_func(class_perm="Dataset")
     # No method_perm set - should default to "read"
 
-    with patch("superset.security_manager") as mock_sm:
-        mock_sm.can_access.return_value = True
+    mock_sm = MagicMock()
+    mock_sm.can_access = MagicMock(return_value=True)
+    with patch("superset.security_manager", mock_sm):
         result = check_tool_permission(func)
 
     assert result is True

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -23,11 +23,11 @@ import pytest
 from flask import g
 
 from superset.mcp_service.auth import (
+    check_tool_permission,
     CLASS_PERMISSION_ATTR,
     MCPPermissionDeniedError,
     METHOD_PERMISSION_ATTR,
     PERMISSION_PREFIX,
-    check_tool_permission,
 )
 
 
@@ -184,7 +184,7 @@ def test_method_permission_attr():
 
 
 def test_permission_attrs_read_tag():
-    """core/discovery/data tags with class_permission_name → method_permission = 'read'."""
+    """Tags with class_permission_name set method_permission to read."""
     func = _make_tool_func(class_perm="Chart", method_perm="read")
     assert getattr(func, CLASS_PERMISSION_ATTR) == "Chart"
     assert getattr(func, METHOD_PERMISSION_ATTR) == "read"

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -74,7 +74,7 @@ def _make_tool_func(
 # -- MCPPermissionDeniedError --
 
 
-def test_permission_denied_error_message_basic():
+def test_permission_denied_error_message_basic() -> None:
     err = MCPPermissionDeniedError(
         permission_name="can_read",
         view_name="Chart",
@@ -85,7 +85,7 @@ def test_permission_denied_error_message_basic():
     assert err.view_name == "Chart"
 
 
-def test_permission_denied_error_message_with_user_and_tool():
+def test_permission_denied_error_message_with_user_and_tool() -> None:
     err = MCPPermissionDeniedError(
         permission_name="can_write",
         view_name="Dashboard",
@@ -100,21 +100,21 @@ def test_permission_denied_error_message_with_user_and_tool():
 # -- check_tool_permission --
 
 
-def test_check_tool_permission_no_class_permission_allows(app_context):
+def test_check_tool_permission_no_class_permission_allows(app_context) -> None:
     """Tools without class_permission_name should be allowed by default."""
     g.user = MagicMock(username="admin")
     func = _make_tool_func()  # no class_permission_name
     assert check_tool_permission(func) is True
 
 
-def test_check_tool_permission_no_user_denies(app_context):
+def test_check_tool_permission_no_user_denies(app_context) -> None:
     """If no g.user, permission check should deny."""
     g.user = None
     func = _make_tool_func(class_perm="Chart")
     assert check_tool_permission(func) is False
 
 
-def test_check_tool_permission_granted(app_context):
+def test_check_tool_permission_granted(app_context) -> None:
     """When security_manager.can_access returns True, permission is granted."""
     g.user = MagicMock(username="admin")
     func = _make_tool_func(class_perm="Chart", method_perm="read")
@@ -127,7 +127,7 @@ def test_check_tool_permission_granted(app_context):
     mock_sm.can_access.assert_called_once_with("can_read", "Chart")
 
 
-def test_check_tool_permission_denied(app_context):
+def test_check_tool_permission_denied(app_context) -> None:
     """When security_manager.can_access returns False, permission is denied."""
     g.user = MagicMock(username="viewer")
     func = _make_tool_func(class_perm="Dashboard", method_perm="write")
@@ -140,7 +140,7 @@ def test_check_tool_permission_denied(app_context):
     mock_sm.can_access.assert_called_once_with("can_write", "Dashboard")
 
 
-def test_check_tool_permission_default_method_is_read(app_context):
+def test_check_tool_permission_default_method_is_read(app_context) -> None:
     """When no method_permission_name is set, defaults to 'read'."""
     g.user = MagicMock(username="admin")
     func = _make_tool_func(class_perm="Dataset")
@@ -154,7 +154,7 @@ def test_check_tool_permission_default_method_is_read(app_context):
     mock_sm.can_access.assert_called_once_with("can_read", "Dataset")
 
 
-def test_check_tool_permission_disabled_via_config(app_context, app):
+def test_check_tool_permission_disabled_via_config(app_context, app) -> None:
     """When MCP_RBAC_ENABLED is False, permission checks are skipped."""
     g.user = MagicMock(username="viewer")
     func = _make_tool_func(class_perm="Chart", method_perm="read")
@@ -169,43 +169,43 @@ def test_check_tool_permission_disabled_via_config(app_context, app):
 # -- Permission constants --
 
 
-def test_permission_prefix():
+def test_permission_prefix() -> None:
     assert PERMISSION_PREFIX == "can_"
 
 
-def test_class_permission_attr():
+def test_class_permission_attr() -> None:
     assert CLASS_PERMISSION_ATTR == "_class_permission_name"
 
 
-def test_method_permission_attr():
+def test_method_permission_attr() -> None:
     assert METHOD_PERMISSION_ATTR == "_method_permission_name"
 
 
 # -- create_tool_decorator permission metadata --
 
 
-def test_permission_attrs_read_tag():
+def test_permission_attrs_read_tag() -> None:
     """Tags with class_permission_name set method_permission to read."""
     func = _make_tool_func(class_perm="Chart", method_perm="read")
     assert getattr(func, CLASS_PERMISSION_ATTR) == "Chart"
     assert getattr(func, METHOD_PERMISSION_ATTR) == "read"
 
 
-def test_permission_attrs_write_tag():
+def test_permission_attrs_write_tag() -> None:
     """mutate tag convention → method_permission = 'write'."""
     func = _make_tool_func(class_perm="Chart", method_perm="write")
     assert getattr(func, CLASS_PERMISSION_ATTR) == "Chart"
     assert getattr(func, METHOD_PERMISSION_ATTR) == "write"
 
 
-def test_permission_attrs_custom_method():
+def test_permission_attrs_custom_method() -> None:
     """Explicit method_permission_name overrides tag-based default."""
     func = _make_tool_func(class_perm="SQLLab", method_perm="execute_sql")
     assert getattr(func, CLASS_PERMISSION_ATTR) == "SQLLab"
     assert getattr(func, METHOD_PERMISSION_ATTR) == "execute_sql"
 
 
-def test_no_class_permission_means_no_attrs():
+def test_no_class_permission_means_no_attrs() -> None:
     """Without class_permission_name, no permission attrs are set."""
     func = _make_tool_func()
     assert not hasattr(func, CLASS_PERMISSION_ATTR)

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -23,12 +23,24 @@ import pytest
 from flask import g
 
 from superset.mcp_service.auth import (
-    check_tool_permission,
     CLASS_PERMISSION_ATTR,
     MCPPermissionDeniedError,
     METHOD_PERMISSION_ATTR,
     PERMISSION_PREFIX,
+    check_tool_permission,
 )
+
+
+@pytest.fixture(autouse=True)
+def enable_mcp_rbac(app):
+    """Re-enable RBAC for dedicated RBAC tests.
+
+    The shared conftest disables RBAC for integration tests. This fixture
+    overrides that so we can test the actual permission checking logic.
+    """
+    app.config["MCP_RBAC_ENABLED"] = True
+    yield
+    app.config.pop("MCP_RBAC_ENABLED", None)
 
 
 class _ToolFunc:
@@ -139,6 +151,18 @@ def test_check_tool_permission_default_method_is_read(app_context):
         check_tool_permission(func)
 
     mock_appbuilder.sm.can_access.assert_called_once_with("can_read", "Dataset")
+
+
+def test_check_tool_permission_disabled_via_config(app_context, app):
+    """When MCP_RBAC_ENABLED is False, permission checks are skipped."""
+    g.user = MagicMock(username="viewer")
+    func = _make_tool_func(class_perm="Chart", method_perm="read")
+
+    app.config["MCP_RBAC_ENABLED"] = False
+    try:
+        assert check_tool_permission(func) is True
+    finally:
+        app.config["MCP_RBAC_ENABLED"] = True
 
 
 # -- Permission constants --

--- a/tests/unit_tests/mcp_service/test_auth_rbac.py
+++ b/tests/unit_tests/mcp_service/test_auth_rbac.py
@@ -1,0 +1,197 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for MCP RBAC permission checking (auth.py)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import g
+
+from superset.mcp_service.auth import (
+    check_tool_permission,
+    CLASS_PERMISSION_ATTR,
+    MCPPermissionDeniedError,
+    METHOD_PERMISSION_ATTR,
+    PERMISSION_PREFIX,
+)
+
+
+class _ToolFunc:
+    """Minimal callable stand-in for a tool function in tests.
+
+    Unlike MagicMock, this does NOT auto-create attributes on access,
+    so ``getattr(func, ATTR, None)`` properly returns None when the
+    attribute hasn't been set.
+    """
+
+    def __init__(self, name: str = "test_tool"):
+        self.__name__ = name
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+def _make_tool_func(
+    class_perm: str | None = None,
+    method_perm: str | None = None,
+) -> _ToolFunc:
+    """Create a tool function stub with optional permission attributes."""
+    func = _ToolFunc()
+    if class_perm is not None:
+        setattr(func, CLASS_PERMISSION_ATTR, class_perm)
+    if method_perm is not None:
+        setattr(func, METHOD_PERMISSION_ATTR, method_perm)
+    return func
+
+
+# -- MCPPermissionDeniedError --
+
+
+def test_permission_denied_error_message_basic():
+    err = MCPPermissionDeniedError(
+        permission_name="can_read",
+        view_name="Chart",
+    )
+    assert "can_read" in str(err)
+    assert "Chart" in str(err)
+    assert err.permission_name == "can_read"
+    assert err.view_name == "Chart"
+
+
+def test_permission_denied_error_message_with_user_and_tool():
+    err = MCPPermissionDeniedError(
+        permission_name="can_write",
+        view_name="Dashboard",
+        user="alice",
+        tool_name="generate_dashboard",
+    )
+    assert "alice" in str(err)
+    assert "generate_dashboard" in str(err)
+    assert "Dashboard" in str(err)
+
+
+# -- check_tool_permission --
+
+
+def test_check_tool_permission_no_class_permission_allows(app_context):
+    """Tools without class_permission_name should be allowed by default."""
+    g.user = MagicMock(username="admin")
+    func = _make_tool_func()  # no class_permission_name
+    assert check_tool_permission(func) is True
+
+
+def test_check_tool_permission_no_user_denies(app_context):
+    """If no g.user, permission check should deny."""
+    g.user = None
+    func = _make_tool_func(class_perm="Chart")
+    assert check_tool_permission(func) is False
+
+
+def test_check_tool_permission_granted(app_context):
+    """When security_manager.can_access returns True, permission is granted."""
+    g.user = MagicMock(username="admin")
+    func = _make_tool_func(class_perm="Chart", method_perm="read")
+
+    with patch("superset.extensions.appbuilder") as mock_appbuilder:
+        mock_appbuilder.sm.can_access.return_value = True
+        result = check_tool_permission(func)
+
+    assert result is True
+    mock_appbuilder.sm.can_access.assert_called_once_with("can_read", "Chart")
+
+
+def test_check_tool_permission_denied(app_context):
+    """When security_manager.can_access returns False, permission is denied."""
+    g.user = MagicMock(username="viewer")
+    func = _make_tool_func(class_perm="Dashboard", method_perm="write")
+
+    with patch("superset.extensions.appbuilder") as mock_appbuilder:
+        mock_appbuilder.sm.can_access.return_value = False
+        result = check_tool_permission(func)
+
+    assert result is False
+    mock_appbuilder.sm.can_access.assert_called_once_with("can_write", "Dashboard")
+
+
+def test_check_tool_permission_default_method_is_read(app_context):
+    """When no method_permission_name is set, defaults to 'read'."""
+    g.user = MagicMock(username="admin")
+    func = _make_tool_func(class_perm="Dataset")
+    # No method_perm set - should default to "read"
+
+    with patch("superset.extensions.appbuilder") as mock_appbuilder:
+        mock_appbuilder.sm.can_access.return_value = True
+        check_tool_permission(func)
+
+    mock_appbuilder.sm.can_access.assert_called_once_with("can_read", "Dataset")
+
+
+# -- Permission constants --
+
+
+def test_permission_prefix():
+    assert PERMISSION_PREFIX == "can_"
+
+
+def test_class_permission_attr():
+    assert CLASS_PERMISSION_ATTR == "_class_permission_name"
+
+
+def test_method_permission_attr():
+    assert METHOD_PERMISSION_ATTR == "_method_permission_name"
+
+
+# -- create_tool_decorator permission metadata --
+
+
+def test_permission_attrs_read_tag():
+    """core/discovery/data tags with class_permission_name → method_permission = 'read'."""
+    func = _make_tool_func(class_perm="Chart", method_perm="read")
+    assert getattr(func, CLASS_PERMISSION_ATTR) == "Chart"
+    assert getattr(func, METHOD_PERMISSION_ATTR) == "read"
+
+
+def test_permission_attrs_write_tag():
+    """mutate tag convention → method_permission = 'write'."""
+    func = _make_tool_func(class_perm="Chart", method_perm="write")
+    assert getattr(func, CLASS_PERMISSION_ATTR) == "Chart"
+    assert getattr(func, METHOD_PERMISSION_ATTR) == "write"
+
+
+def test_permission_attrs_custom_method():
+    """Explicit method_permission_name overrides tag-based default."""
+    func = _make_tool_func(class_perm="SQLLab", method_perm="execute_sql")
+    assert getattr(func, CLASS_PERMISSION_ATTR) == "SQLLab"
+    assert getattr(func, METHOD_PERMISSION_ATTR) == "execute_sql"
+
+
+def test_no_class_permission_means_no_attrs():
+    """Without class_permission_name, no permission attrs are set."""
+    func = _make_tool_func()
+    assert not hasattr(func, CLASS_PERMISSION_ATTR)
+    assert not hasattr(func, METHOD_PERMISSION_ATTR)
+
+
+# -- Fixture --
+
+
+@pytest.fixture
+def app_context(app):
+    """Provide Flask app context for tests needing g.user."""
+    with app.app_context():
+        yield


### PR DESCRIPTION
## **User description**
## Summary
- Adds RBAC (Role-Based Access Control) enforcement to MCP tools that mirrors Flask-AppBuilder's `@protect()` decorator pattern
- Each MCP tool now declares its required FAB permission (e.g., `can_read` on `Chart`) via `class_permission_name` on the `@tool` decorator
- `mcp_auth_hook` checks permissions via `security_manager.can_access()` before tool execution, raising `MCPPermissionDeniedError` on denial
- System tools (health_check, get_instance_info, get_schema) remain open to all authenticated users

### Permission Mapping
| Tool Category | class_permission_name | Read Tools | Write Tools |
|---|---|---|---|
| Chart | `Chart` | list_charts, get_chart_info, get_chart_data, get_chart_preview | generate_chart, update_chart, update_chart_preview |
| Dashboard | `Dashboard` | list_dashboards, get_dashboard_info | generate_dashboard, add_chart_to_existing_dashboard |
| Dataset | `Dataset` | list_datasets, get_dataset_info | — |
| Explore | `Explore` | generate_explore_link | — |
| SQL Lab | `SQLLab` | open_sql_lab_with_context | execute_sql |

## Testing Instructions
1. Start MCP server locally (`superset mcp`)
2. Verify admin user can access all tools (no change in behavior)
3. Run unit tests: `pytest tests/unit_tests/mcp_service/test_auth_rbac.py -v` (14 tests)
4. To test permission denial: create a user with limited roles and verify tools return `MCPPermissionDeniedError` for resources they cannot access

## Additional Information
- Mutate-tagged tools (generate_chart, execute_sql, etc.) auto-default to `can_write`; all others default to `can_read`
- Explicit `method_permission_name` can override the default (e.g., for custom SQL Lab permissions)
- No breaking changes: admin users retain full access; tools without `class_permission_name` are allowed by default

## MCP Testing (localhost, 2026-03-04)

### RBAC Permission Checks - Read Operations
- `list_charts` → works for Admin user ✅
- `list_dashboards` → works for Admin user ✅
- `list_datasets` → works for Admin user ✅

### RBAC Permission Checks - Write Operations
- `generate_chart` → works for Admin user ✅
- `generate_explore_link` → works for Admin user ✅

### SQL Lab RBAC Fix
- **Bug found**: `execute_sql` was failing with "Permission denied: write on SQLLab for user admin"
- **Root cause**: FAB's SQLLab view has `can_read`, `can_execute_sql_query`, `can_get_results`, etc. but no `can_write` permission. The default `tags=["mutate"]` → `method_permission_name="write"` mapping was incorrect for SQLLab.
- **Fix applied**: Set explicit `method_permission_name="execute_sql_query"` for `execute_sql` and `method_permission_name="read"` for `open_sql_lab_with_context`
- `execute_sql` after fix → `SELECT 1 as test_rbac_fix` returns `[{"test_rbac_fix": 1}]` ✅


___

## **CodeAnt-AI Description**
Enforce RBAC permission checks for MCP tools with a configurable flag

### What Changed
- MCP tools now declare required FAB permissions; the MCP service checks user permissions before running a tool and raises a clear permission-denied error when access is denied
- 16 resource tools (Chart, Dashboard, Dataset, Explore, SQLLab) now require specific class/method permissions; system tools remain available to authenticated users
- RBAC checking is enabled by default via MCP_RBAC_ENABLED; integration tests disable RBAC via an autouse fixture while 14 dedicated unit tests exercise the RBAC logic
- The tool decorator accepts class_permission_name and method_permission_name; tools tagged "mutate" default to write access when no method is provided

### Impact
`✅ Clearer permission errors for denied MCP tool calls`
`✅ Fewer unauthorized MCP tool executions`
`✅ Fewer RBAC-related integration test failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
