### PR TITLE
fix(mcp): honor target_tab parameter when adding charts to tabbed dashboards

### DIFF
--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -63,17 +63,21 @@ def _find_next_row_position(layout: Dict[str, Any]) -> str:
     return row_key
 
 
-def _find_tab_insert_target(layout: Dict[str, Any]) -> str | None:
+def _find_tab_insert_target(
+    layout: Dict[str, Any], target_tab: str | None = None
+) -> str | None:
     """
-    Detect if the dashboard uses tabs and return the first tab's ID.
+    Detect if the dashboard uses tabs and return the appropriate tab's ID.
 
-    If ``GRID_ID`` has children that are ``TABS`` components, this walks
-    into the first ``TAB`` child so that new rows are placed inside the
-    active tab rather than directly under GRID_ID.
+    If *target_tab* is provided the function first tries to match it against
+    tab ``meta.text`` (display name) or the raw component ID.  When no match
+    is found (or *target_tab* is ``None``) the first ``TAB`` child is used as
+    a fallback so that new rows are still placed inside the tab structure
+    rather than directly under ``GRID_ID``.
 
     Returns:
-        The ID of the first TAB component, or ``None`` if the dashboard
-        does not use top-level tabs.
+        The ID of the matched (or first) TAB component, or ``None`` if the
+        dashboard does not use top-level tabs.
     """
     grid = layout.get("GRID_ID")
     if not grid:
@@ -82,13 +86,25 @@ def _find_tab_insert_target(layout: Dict[str, Any]) -> str | None:
     for child_id in grid.get("children", []):
         child = layout.get(child_id)
         if child and child.get("type") == "TABS":
-            # Found a TABS component; use its first TAB child
             tabs_children = child.get("children", [])
-            if tabs_children:
-                first_tab_id = tabs_children[0]
-                first_tab = layout.get(first_tab_id)
-                if first_tab and first_tab.get("type") == "TAB":
-                    return first_tab_id
+            if not tabs_children:
+                continue
+
+            # When a target_tab is specified, try to resolve it by name or ID
+            if target_tab:
+                for tab_id in tabs_children:
+                    tab = layout.get(tab_id)
+                    if not tab or tab.get("type") != "TAB":
+                        continue
+                    tab_text = (tab.get("meta") or {}).get("text", "")
+                    if target_tab in (tab_id, tab_text):
+                        return tab_id
+
+            # Fallback: return the first TAB child
+            first_tab_id = tabs_children[0]
+            first_tab = layout.get(first_tab_id)
+            if first_tab and first_tab.get("type") == "TAB":
+                return first_tab_id
     return None
 
 
@@ -284,8 +300,10 @@ def add_chart_to_existing_dashboard(
             # Generate a unique ROW ID for the new row
             row_key = _find_next_row_position(current_layout)
 
-            # Detect tabbed dashboards: if GRID has TABS, target the first tab
-            tab_target = _find_tab_insert_target(current_layout)
+            # Detect tabbed dashboards and resolve target_tab by name or ID
+            tab_target = _find_tab_insert_target(
+                current_layout, target_tab=request.target_tab
+            )
             parent_id = tab_target if tab_target else "GRID_ID"
 
             # Add chart, column, and row to layout

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -49,9 +49,11 @@ logger = logging.getLogger(__name__)
 # Not exhaustive (omits flags, skin-tone modifiers, etc.) but sufficient for
 # flexible matching of dashboard tab labels.
 _EMOJI_RE = re.compile(
-    "[\U0001f300-\U0001f9ff\U00002600-\U000027bf\U0000fe00-\U0000fe0f"
-    "\U0001fa00-\U0001fa6f\U0001fa70-\U0001faff\U00002702-\U000027b0"
-    "\U0000200d\U0000fe0f]+"
+    "[\U0001f300-\U0001f9ff"
+    "\U0001fa00-\U0001faff"
+    "\U00002600-\U000027bf"
+    "\U0000fe00-\U0000fe0f"
+    "\U0000200d]+"
 )
 
 
@@ -73,8 +75,10 @@ def _find_next_row_position(layout: Dict[str, Any]) -> str:
     return row_key
 
 
-def _normalize_tab_text(text: str) -> str:
+def _normalize_tab_text(text: str | None) -> str:
     """Strip emoji and extra whitespace from tab text for flexible matching."""
+    if not text:
+        return ""
     cleaned = _EMOJI_RE.sub("", text)
     return cleaned.strip().lower()
 

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -63,19 +63,76 @@ def _find_next_row_position(layout: Dict[str, Any]) -> str:
     return row_key
 
 
+def _normalize_tab_text(text: str) -> str:
+    """Strip emoji and extra whitespace from tab text for flexible matching."""
+    import re
+
+    # Remove emoji characters (Unicode emoji ranges)
+    cleaned = re.sub(
+        r"[\U0001F300-\U0001F9FF\U00002600-\U000027BF\U0000FE00-\U0000FE0F"
+        r"\U0001FA00-\U0001FA6F\U0001FA70-\U0001FAFF\U00002702-\U000027B0"
+        r"\U0000200D\U0000FE0F]+",
+        "",
+        text,
+    )
+    return cleaned.strip().lower()
+
+
 def _match_tab_in_children(
     layout: Dict[str, Any],
     tabs_children: list[str],
     target_tab: str,
 ) -> str | None:
-    """Search tabs_children for a tab matching target_tab by ID or name."""
+    """Search tabs_children for a tab matching target_tab by ID or name.
+
+    Matching is flexible: exact ID match, exact text match, or
+    case-insensitive text match after stripping emoji characters.
+    """
+    target_normalized = _normalize_tab_text(target_tab)
     for tab_id in tabs_children:
         tab = layout.get(tab_id)
         if not tab or tab.get("type") != "TAB":
             continue
         tab_text = (tab.get("meta") or {}).get("text", "")
+        # Exact match on ID or text
         if target_tab in (tab_id, tab_text):
             return tab_id
+        # Flexible match: case-insensitive, emoji-stripped
+        if target_normalized and _normalize_tab_text(tab_text) == target_normalized:
+            return tab_id
+    return None
+
+
+def _collect_tabs_groups(layout: Dict[str, Any]) -> list[list[str]]:
+    """Collect all TABS groups from ROOT_ID and GRID_ID children.
+
+    Superset dashboards can place TABS under either ROOT_ID or GRID_ID
+    depending on how the layout was constructed.
+    """
+    groups: list[list[str]] = []
+    for parent_key in ("ROOT_ID", "GRID_ID"):
+        parent = layout.get(parent_key)
+        if not parent:
+            continue
+        for child_id in parent.get("children", []):
+            child = layout.get(child_id)
+            if not child or child.get("type") != "TABS":
+                continue
+            tabs_children = child.get("children", [])
+            if tabs_children:
+                groups.append(tabs_children)
+    return groups
+
+
+def _first_tab_from_groups(
+    layout: Dict[str, Any], groups: list[list[str]]
+) -> str | None:
+    """Return the first valid TAB ID from the collected groups."""
+    for tabs_children in groups:
+        first_tab_id = tabs_children[0]
+        first_tab = layout.get(first_tab_id)
+        if first_tab and first_tab.get("type") == "TAB":
+            return first_tab_id
     return None
 
 
@@ -95,33 +152,15 @@ def _find_tab_insert_target(
         The ID of the matched (or first) TAB component, or ``None`` if the
         dashboard does not use top-level tabs.
     """
-    grid = layout.get("GRID_ID")
-    if not grid:
-        return None
+    groups = _collect_tabs_groups(layout)
 
-    first_tab_fallback: str | None = None
-
-    for child_id in grid.get("children", []):
-        child = layout.get(child_id)
-        if not child or child.get("type") != "TABS":
-            continue
-        tabs_children = child.get("children", [])
-        if not tabs_children:
-            continue
-
-        if target_tab:
+    if target_tab:
+        for tabs_children in groups:
             matched = _match_tab_in_children(layout, tabs_children, target_tab)
             if matched:
                 return matched
 
-        # Remember the first TAB as fallback but keep searching
-        if first_tab_fallback is None:
-            first_tab_id = tabs_children[0]
-            first_tab = layout.get(first_tab_id)
-            if first_tab and first_tab.get("type") == "TAB":
-                first_tab_fallback = first_tab_id
-
-    return first_tab_fallback
+    return _first_tab_from_groups(layout, groups)
 
 
 def _add_chart_to_layout(

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -46,14 +46,19 @@ from superset.utils import json
 logger = logging.getLogger(__name__)
 
 # Compiled regex for stripping common emoji Unicode ranges from tab text.
-# Not exhaustive (omits flags, skin-tone modifiers, etc.) but sufficient for
-# flexible matching of dashboard tab labels.
+# Uses specific Unicode blocks to avoid overly permissive ranges.
 _EMOJI_RE = re.compile(
-    "[\U0001f300-\U0001f9ff"
-    "\U0001fa00-\U0001faff"
-    "\U00002600-\U000027bf"
-    "\U0000fe00-\U0000fe0f"
-    "\U0000200d]+"
+    "["
+    "\U0001f300-\U0001f5ff"  # Misc Symbols and Pictographs
+    "\U0001f600-\U0001f64f"  # Emoticons
+    "\U0001f680-\U0001f6ff"  # Transport and Map Symbols
+    "\U0001f900-\U0001f9ff"  # Supplemental Symbols and Pictographs
+    "\U0001fa70-\U0001faff"  # Symbols and Pictographs Extended-A
+    "\u2600-\u26ff"  # Misc Symbols
+    "\u2700-\u27bf"  # Dingbats
+    "\ufe00-\ufe0f"  # Variation Selectors
+    "\u200d"  # Zero-width joiner
+    "]+"
 )
 
 

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -22,6 +22,7 @@ This tool adds a chart to an existing dashboard with automatic layout positionin
 """
 
 import logging
+import re
 from typing import Any, Dict
 
 from fastmcp import Context
@@ -44,6 +45,15 @@ from superset.utils import json
 
 logger = logging.getLogger(__name__)
 
+# Compiled regex for stripping common emoji Unicode ranges from tab text.
+# Not exhaustive (omits flags, skin-tone modifiers, etc.) but sufficient for
+# flexible matching of dashboard tab labels.
+_EMOJI_RE = re.compile(
+    "[\U0001f300-\U0001f9ff\U00002600-\U000027bf\U0000fe00-\U0000fe0f"
+    "\U0001fa00-\U0001fa6f\U0001fa70-\U0001faff\U00002702-\U000027b0"
+    "\U0000200d\U0000fe0f]+"
+)
+
 
 def _find_next_row_position(layout: Dict[str, Any]) -> str:
     """
@@ -65,17 +75,7 @@ def _find_next_row_position(layout: Dict[str, Any]) -> str:
 
 def _normalize_tab_text(text: str) -> str:
     """Strip emoji and extra whitespace from tab text for flexible matching."""
-    import re
-
-    # Remove emoji characters (Unicode emoji ranges)
-    # Note: using regular strings (not raw) so Python processes \U escapes
-    cleaned = re.sub(
-        "[\U0001f300-\U0001f9ff\U00002600-\U000027bf\U0000fe00-\U0000fe0f"
-        "\U0001fa00-\U0001fa6f\U0001fa70-\U0001faff\U00002702-\U000027b0"
-        "\U0000200d\U0000fe0f]+",
-        "",
-        text,
-    )
+    cleaned = _EMOJI_RE.sub("", text)
     return cleaned.strip().lower()
 
 

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -63,6 +63,22 @@ def _find_next_row_position(layout: Dict[str, Any]) -> str:
     return row_key
 
 
+def _match_tab_in_children(
+    layout: Dict[str, Any],
+    tabs_children: list[str],
+    target_tab: str,
+) -> str | None:
+    """Search tabs_children for a tab matching target_tab by ID or name."""
+    for tab_id in tabs_children:
+        tab = layout.get(tab_id)
+        if not tab or tab.get("type") != "TAB":
+            continue
+        tab_text = (tab.get("meta") or {}).get("text", "")
+        if target_tab in (tab_id, tab_text):
+            return tab_id
+    return None
+
+
 def _find_tab_insert_target(
     layout: Dict[str, Any], target_tab: str | None = None
 ) -> str | None:
@@ -83,29 +99,29 @@ def _find_tab_insert_target(
     if not grid:
         return None
 
+    first_tab_fallback: str | None = None
+
     for child_id in grid.get("children", []):
         child = layout.get(child_id)
-        if child and child.get("type") == "TABS":
-            tabs_children = child.get("children", [])
-            if not tabs_children:
-                continue
+        if not child or child.get("type") != "TABS":
+            continue
+        tabs_children = child.get("children", [])
+        if not tabs_children:
+            continue
 
-            # When a target_tab is specified, try to resolve it by name or ID
-            if target_tab:
-                for tab_id in tabs_children:
-                    tab = layout.get(tab_id)
-                    if not tab or tab.get("type") != "TAB":
-                        continue
-                    tab_text = (tab.get("meta") or {}).get("text", "")
-                    if target_tab in (tab_id, tab_text):
-                        return tab_id
+        if target_tab:
+            matched = _match_tab_in_children(layout, tabs_children, target_tab)
+            if matched:
+                return matched
 
-            # Fallback: return the first TAB child
+        # Remember the first TAB as fallback but keep searching
+        if first_tab_fallback is None:
             first_tab_id = tabs_children[0]
             first_tab = layout.get(first_tab_id)
             if first_tab and first_tab.get("type") == "TAB":
-                return first_tab_id
-    return None
+                first_tab_fallback = first_tab_id
+
+    return first_tab_fallback
 
 
 def _add_chart_to_layout(

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -68,10 +68,11 @@ def _normalize_tab_text(text: str) -> str:
     import re
 
     # Remove emoji characters (Unicode emoji ranges)
+    # Note: using regular strings (not raw) so Python processes \U escapes
     cleaned = re.sub(
-        r"[\U0001F300-\U0001F9FF\U00002600-\U000027BF\U0000FE00-\U0000FE0F"
-        r"\U0001FA00-\U0001FA6F\U0001FA70-\U0001FAFF\U00002702-\U000027B0"
-        r"\U0000200D\U0000FE0F]+",
+        "[\U0001f300-\U0001f9ff\U00002600-\U000027bf\U0000fe00-\U0000fe0f"
+        "\U0001fa00-\U0001fa6f\U0001fa70-\U0001faff\U00002702-\U000027b0"
+        "\U0000200d\U0000fe0f]+",
         "",
         text,
     )

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -610,6 +610,107 @@ class TestAddChartToExistingDashboard:
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
+    async def test_add_chart_to_specific_tab_by_name(
+        self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
+    ):
+        """Test adding chart to a specific tab using target_tab name."""
+        mock_dashboard = _mock_dashboard(id=3, title="Tabbed Dashboard")
+        mock_dashboard.slices = [Mock(id=10)]
+        mock_dashboard.position_json = json.dumps(
+            {
+                "ROOT_ID": {
+                    "children": ["GRID_ID"],
+                    "id": "ROOT_ID",
+                    "type": "ROOT",
+                },
+                "GRID_ID": {
+                    "children": ["TABS-abc123"],
+                    "id": "GRID_ID",
+                    "parents": ["ROOT_ID"],
+                    "type": "GRID",
+                },
+                "TABS-abc123": {
+                    "children": ["TAB-tab1", "TAB-tab2"],
+                    "id": "TABS-abc123",
+                    "parents": ["ROOT_ID", "GRID_ID"],
+                    "type": "TABS",
+                },
+                "TAB-tab1": {
+                    "children": ["ROW-existing"],
+                    "id": "TAB-tab1",
+                    "meta": {"text": "Activity Metrics"},
+                    "parents": ["ROOT_ID", "GRID_ID", "TABS-abc123"],
+                    "type": "TAB",
+                },
+                "TAB-tab2": {
+                    "children": [],
+                    "id": "TAB-tab2",
+                    "meta": {"text": "Customers"},
+                    "parents": ["ROOT_ID", "GRID_ID", "TABS-abc123"],
+                    "type": "TAB",
+                },
+                "ROW-existing": {
+                    "children": ["CHART-10"],
+                    "id": "ROW-existing",
+                    "meta": {"background": "BACKGROUND_TRANSPARENT"},
+                    "parents": ["ROOT_ID", "GRID_ID", "TABS-abc123", "TAB-tab1"],
+                    "type": "ROW",
+                },
+                "CHART-10": {
+                    "id": "CHART-10",
+                    "type": "CHART",
+                    "parents": [
+                        "ROOT_ID",
+                        "GRID_ID",
+                        "TABS-abc123",
+                        "TAB-tab1",
+                        "ROW-existing",
+                    ],
+                },
+                "DASHBOARD_VERSION_KEY": "v2",
+            }
+        )
+        mock_find_dashboard.return_value = mock_dashboard
+
+        mock_chart = _mock_chart(id=30, slice_name="Customer Chart")
+        mock_db_session.get.return_value = mock_chart
+
+        updated_dashboard = _mock_dashboard(id=3, title="Tabbed Dashboard")
+        updated_dashboard.slices = [Mock(id=10), Mock(id=30)]
+        mock_update_command.return_value.run.return_value = updated_dashboard
+
+        request = {"dashboard_id": 3, "chart_id": 30, "target_tab": "Customers"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "add_chart_to_existing_dashboard", {"request": request}
+            )
+
+            assert result.structured_content["error"] is None
+
+            call_args = mock_update_command.call_args[0][1]
+            layout = json.loads(call_args["position_json"])
+
+            row_key = result.structured_content["position"]["row_key"]
+            assert row_key in layout
+
+            # Chart should be in TAB-tab2 (Customers), NOT TAB-tab1
+            assert row_key in layout["TAB-tab2"]["children"]
+            assert row_key not in layout["TAB-tab1"]["children"]
+
+            # GRID_ID should still only have TABS, not the new row
+            assert layout["GRID_ID"]["children"] == ["TABS-abc123"]
+
+            # Verify correct parent chain includes TAB-tab2
+            chart_parents = layout["CHART-30"]["parents"]
+            assert "TABS-abc123" in chart_parents
+            assert "TAB-tab2" in chart_parents
+            assert "TAB-tab1" not in chart_parents
+
+    @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+    @patch("superset.db.session")
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -709,6 +810,63 @@ class TestLayoutHelpers:
             "TAB-second": {"children": [], "type": "TAB"},
         }
         assert _find_tab_insert_target(layout) == "TAB-first"
+
+    def test_find_tab_insert_target_by_tab_name(self):
+        """Test _find_tab_insert_target resolves target_tab by display name."""
+        layout = {
+            "GRID_ID": {"children": ["TABS-main"], "type": "GRID"},
+            "TABS-main": {"children": ["TAB-first", "TAB-second"], "type": "TABS"},
+            "TAB-first": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Activity Metrics"},
+            },
+            "TAB-second": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Customers"},
+            },
+        }
+        assert _find_tab_insert_target(layout, target_tab="Customers") == "TAB-second"
+
+    def test_find_tab_insert_target_by_tab_id(self):
+        """Test _find_tab_insert_target resolves target_tab by component ID."""
+        layout = {
+            "GRID_ID": {"children": ["TABS-main"], "type": "GRID"},
+            "TABS-main": {"children": ["TAB-first", "TAB-second"], "type": "TABS"},
+            "TAB-first": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Tab 1"},
+            },
+            "TAB-second": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Tab 2"},
+            },
+        }
+        assert _find_tab_insert_target(layout, target_tab="TAB-second") == "TAB-second"
+
+    def test_find_tab_insert_target_unmatched_falls_back_to_first(self):
+        """Test _find_tab_insert_target falls back to first tab when target_tab
+        doesn't match any tab name or ID."""
+        layout = {
+            "GRID_ID": {"children": ["TABS-main"], "type": "GRID"},
+            "TABS-main": {"children": ["TAB-first", "TAB-second"], "type": "TABS"},
+            "TAB-first": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Tab 1"},
+            },
+            "TAB-second": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Tab 2"},
+            },
+        }
+        assert (
+            _find_tab_insert_target(layout, target_tab="Nonexistent Tab") == "TAB-first"
+        )
 
     def test_find_tab_insert_target_no_grid(self):
         """Test _find_tab_insert_target with missing GRID_ID."""


### PR DESCRIPTION
## **User description**
### SUMMARY

When adding charts to a dashboard that uses tabs via the `add_chart_to_existing_dashboard` MCP tool, the `target_tab` parameter was accepted without error but completely ignored. Charts were always placed in the first tab or under `GRID_ID` at the root level, where they become invisible ghost entries — registered in the dashboard metadata but never rendered in the UI.

**Root causes fixed:**

1. **`target_tab` was never passed** to `_find_tab_insert_target()` — the parameter was accepted but silently discarded
2. **TABS search only checked GRID_ID children** — Superset dashboards can place TABS under ROOT_ID (which is the common pattern), so TABS were never found
3. **Exact tab name matching failed with emoji** — tab text like `🧭 Exploratory` wouldn't match when user passes `"Exploratory"`, added flexible emoji-stripped case-insensitive matching

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend logic change, no UI modifications.

### TESTING INSTRUCTIONS

1. Create a dashboard with multiple tabs (e.g., "Sales Overview", "Exploratory")
2. Call `add_chart_to_existing_dashboard` with `target_tab` set to the second tab's name (without emoji)
3. Verify the chart appears inside the specified tab (not the first tab, and not invisible under GRID_ID)
4. Call without `target_tab` — chart should still land in the first tab (backward compat)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

## MCP Testing (via localhost MCP service on branch `amin/fix-target-tab-placement`)

### Test 1: Target tab with emoji text — "Exploratory" matches "🧭 Exploratory"
- `get_dashboard_info(6)` → Sales Dashboard has tabs: "🎯 Sales Overview" (TAB-d-E0Zc1cTH) and "🧭 Exploratory" (TAB-4fthLQmdX)
- `add_chart_to_existing_dashboard(dashboard_id=6, chart_id=2, target_tab="Exploratory")`
- **Result:** CHART-2 parents = `["ROOT_ID", "TABS-e5Ruro0cjP", "TAB-4fthLQmdX", ...]` — correctly placed in Exploratory tab ✅

### Test 2: Target tab with emoji text — "Sales Overview" matches "🎯 Sales Overview"
- `add_chart_to_existing_dashboard(dashboard_id=6, chart_id=3, target_tab="Sales Overview")`
- **Result:** CHART-3 parents = `["ROOT_ID", "TABS-e5Ruro0cjP", "TAB-d-E0Zc1cTH", ...]` — correctly placed in Sales Overview tab ✅

### Test 3: ROOT_ID TABS search (bug found & fixed)
- Before fix: TABS under ROOT_ID were missed because `_find_tab_insert_target` only searched GRID_ID children
- After fix: Both ROOT_ID and GRID_ID children are searched for TABS components ✅

### Test 4: Unit tests
- `pytest tests/unit_tests/mcp_service/dashboard/ -x -q` → 45 passed ✅


___

## **CodeAnt-AI Description**
**Respect target_tab when adding charts to tabbed dashboards**

### What Changed
- When adding a chart to a dashboard, the requested target_tab (by display name or component ID) is honored and the chart is placed inside that tab instead of the first tab or under GRID_ID.
- Tab name matching is flexible: matches by exact ID, exact display text, or case-insensitive display text after stripping common emoji prefixes (e.g., "🧭 Exploratory" can be targeted with "Exploratory").
- The tool now searches for TABS placed under both ROOT_ID and GRID_ID so tabs are found regardless of dashboard layout; if no target_tab is provided or no match is found, placement falls back to the first tab.
- New unit tests cover placing charts into a specified tab by name and ensure charts are not left invisible under GRID_ID.

### Impact
`✅ Charts land in the intended dashboard tab`
`✅ No invisible/ghost charts under GRID_ID`
`✅ Tab selection works with emoji-prefixed tab names`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
