### PR TITLE
feat(mcp): add popularity_score computed field for charts, dashboards, datasets

### DIFF
--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -313,6 +313,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         model_ids: Sequence[str | int],
         skip_base_filter: bool = False,
         id_column: str | None = None,
+        query_options: list[Any] | None = None,
     ) -> list[T]:
         """
         Find a List of models by a list of ids, if defined applies `base_filter`
@@ -321,6 +322,8 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         :param skip_base_filter: If true, skip applying the base filter
         :param id_column: Optional column name to use for ID lookup
                          (defaults to id_column_name)
+        :param query_options: SQLAlchemy query options (e.g., joinedload,
+                             subqueryload) to apply to the query for eager loading
         """
         column = id_column or cls.id_column_name
         id_col = getattr(cls.model_cls, column, None)
@@ -349,6 +352,9 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
 
         query = db.session.query(cls.model_cls).filter(id_col.in_(converted_ids))
         query = cls._apply_base_filter(query, skip_base_filter)
+
+        if query_options:
+            query = query.options(*query_options)
 
         try:
             results = query.all()

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -126,6 +126,13 @@ class ChartInfo(BaseModel):
     tags: List[TagInfo] = Field(default_factory=list, description="Chart tags")
     owners: List[UserInfo] = Field(default_factory=list, description="Chart owners")
 
+    popularity_score: float | None = Field(
+        None,
+        description="Popularity score based on views, favorites, dashboard usage, "
+        "and recency. Request via select_columns=['popularity_score'] or sort "
+        "via order_column='popularity_score'.",
+    )
+
     # Fields for unsaved state support
     form_data: Dict[str, Any] | None = Field(
         None,

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -243,9 +243,18 @@ def _list_charts_by_popularity(
     start = page * page_size
     end = start + page_size
 
-    # Fetch full models for page IDs
+    # Fetch full models for page IDs with eager loading to avoid N+1
+    # lazy loads during serialization (tags, owners).
     if page_ids := sorted_ids[start:end]:
-        items = dao_class.find_by_ids(page_ids)
+        from sqlalchemy.orm import subqueryload
+
+        from superset.models.slice import Slice
+
+        eager_options = [
+            subqueryload(Slice.tags),
+            subqueryload(Slice.owners),
+        ]
+        items = dao_class.find_by_ids(page_ids, query_options=eager_options)
         # Preserve popularity sort order
         id_to_item = {item.id: item for item in items}
         ordered_items = [id_to_item[pid] for pid in page_ids if pid in id_to_item]

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -122,6 +122,8 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
         )
     )
 
+    # Avoid circular imports: DAO and schema_discovery depend on models
+    # that import from mcp_service during app initialization
     from superset.daos.chart import ChartDAO
     from superset.mcp_service.common.schema_discovery import (
         CHART_SORTABLE_COLUMNS,

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -166,6 +166,13 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
             dao_columns = request.select_columns
             if dao_columns:
                 dao_columns = [c for c in dao_columns if c != "popularity_score"]
+                # Ensure id is loaded when popularity_score was requested
+                # (scores are keyed by id)
+                if (
+                    "popularity_score" in request.select_columns
+                    and "id" not in dao_columns
+                ):
+                    dao_columns = ["id"] + dao_columns
 
             with event_logger.log_context(action="mcp.list_charts.query"):
                 result = list_core.run_tool(
@@ -193,6 +200,15 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
 
         # Apply field filtering via serialization context
         columns_to_filter = result.columns_requested
+        # Re-add popularity_score if it was originally requested
+        # (it was stripped before the DAO query since it's computed)
+        if (
+            request.select_columns
+            and "popularity_score" in request.select_columns
+            and columns_to_filter
+            and "popularity_score" not in columns_to_filter
+        ):
+            columns_to_filter = list(columns_to_filter) + ["popularity_score"]
         await ctx.debug(
             "Applying field filtering via serialization context: columns=%s"
             % (columns_to_filter,)

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -20,6 +20,7 @@ MCP tool: list_charts (advanced filtering with metadata cache control)
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import cast, TYPE_CHECKING
 
 from fastmcp import Context
@@ -62,7 +63,31 @@ SORTABLE_CHART_COLUMNS = [
     "description",
     "changed_on",
     "created_on",
+    "popularity_score",
 ]
+
+CHART_SEARCH_COLUMNS = [
+    "slice_name",
+    "description",
+]
+
+
+def _needs_popularity(request: ListChartsRequest) -> bool:
+    """Check if popularity_score computation is needed."""
+    if request.order_column == "popularity_score":
+        return True
+    if request.select_columns and "popularity_score" in request.select_columns:
+        return True
+    return False
+
+
+def _attach_popularity_scores(
+    charts: list[ChartInfo], scores: dict[int, float]
+) -> None:
+    """Attach popularity scores to serialized chart objects in-place."""
+    for chart in charts:
+        if chart.id is not None and chart.id in scores:
+            chart.popularity_score = scores[chart.id]
 
 
 @tool(
@@ -81,7 +106,7 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
     modified time.
 
     Sortable columns for order_column: id, slice_name, viz_type,
-    datasource_name, description, changed_on, created_on
+    datasource_name, description, changed_on, created_on, popularity_score
     """
     await ctx.info(
         "Listing charts: page=%s, page_size=%s, search=%s"
@@ -116,34 +141,50 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
         """Serialize chart object (field filtering handled by model_serializer)."""
         return serialize_chart_object(cast(ChartLike | None, obj))
 
-    tool = ModelListCore(
-        dao_class=ChartDAO,
-        output_schema=ChartInfo,
-        item_serializer=_serialize_chart,
-        filter_type=ChartFilter,
-        default_columns=DEFAULT_CHART_COLUMNS,
-        search_columns=[
-            "slice_name",
-            "description",
-        ],
-        list_field_name="charts",
-        output_list_schema=ChartList,
-        all_columns=all_columns,
-        sortable_columns=CHART_SORTABLE_COLUMNS,
-        logger=logger,
-    )
-
     try:
-        with event_logger.log_context(action="mcp.list_charts.query"):
-            result = tool.run_tool(
-                filters=request.filters,
-                search=request.search,
-                select_columns=request.select_columns,
-                order_column=request.order_column,
-                order_direction=request.order_direction,
-                page=max(request.page - 1, 0),
-                page_size=request.page_size,
+        # Two-pass approach when sorting by popularity_score
+        if request.order_column == "popularity_score":
+            with event_logger.log_context(action="mcp.list_charts.popularity_sort"):
+                result = _list_charts_by_popularity(
+                    request, ChartDAO, _serialize_chart, all_columns, ctx
+                )
+        else:
+            list_core = ModelListCore(
+                dao_class=ChartDAO,
+                output_schema=ChartInfo,
+                item_serializer=_serialize_chart,
+                filter_type=ChartFilter,
+                default_columns=DEFAULT_CHART_COLUMNS,
+                search_columns=CHART_SEARCH_COLUMNS,
+                list_field_name="charts",
+                output_list_schema=ChartList,
+                all_columns=all_columns,
+                sortable_columns=CHART_SORTABLE_COLUMNS,
+                logger=logger,
             )
+
+            with event_logger.log_context(action="mcp.list_charts.query"):
+                result = list_core.run_tool(
+                    filters=request.filters,
+                    search=request.search,
+                    select_columns=request.select_columns,
+                    order_column=request.order_column,
+                    order_direction=request.order_direction,
+                    page=max(request.page - 1, 0),
+                    page_size=request.page_size,
+                )
+
+            # Attach popularity scores if requested in select_columns
+            if request.select_columns and "popularity_score" in request.select_columns:
+                from superset.mcp_service.common.popularity import (
+                    compute_chart_popularity,
+                )
+
+                chart_ids = [c.id for c in result.charts if c.id is not None]
+                if chart_ids:
+                    scores = compute_chart_popularity(chart_ids)
+                    _attach_popularity_scores(result.charts, scores)
+
         count = len(result.charts) if hasattr(result, "charts") else 0
         total_pages = getattr(result, "total_pages", None)
         await ctx.info(
@@ -152,8 +193,6 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
         )
 
         # Apply field filtering via serialization context
-        # Always use columns_requested (either explicit select_columns or defaults)
-        # This triggers ChartInfo._filter_fields_by_context for each chart
         columns_to_filter = result.columns_requested
         await ctx.debug(
             "Applying field filtering via serialization context: columns=%s"
@@ -166,3 +205,87 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
     except Exception as e:
         await ctx.error("Failed to list charts: %s" % (str(e),))
         raise
+
+
+def _list_charts_by_popularity(
+    request: ListChartsRequest,
+    dao_class: type,
+    serializer: callable,
+    all_columns: list[str],
+    ctx: Context,
+) -> ChartList:
+    """Two-pass listing: sort all matching charts by popularity score."""
+    from superset.mcp_service.common.popularity import (
+        compute_chart_popularity,
+        get_popularity_sorted_ids,
+    )
+    from superset.mcp_service.common.schema_discovery import CHART_SORTABLE_COLUMNS
+    from superset.mcp_service.system.schemas import PaginationInfo
+
+    sorted_ids, scores, total_count = get_popularity_sorted_ids(
+        compute_fn=compute_chart_popularity,
+        dao_class=dao_class,
+        filters=request.filters,
+        search=request.search,
+        search_columns=CHART_SEARCH_COLUMNS,
+        order_direction=request.order_direction,
+    )
+
+    # Apply pagination to sorted IDs
+    page = max(request.page - 1, 0)
+    page_size = request.page_size
+    start = page * page_size
+    end = start + page_size
+    page_ids = sorted_ids[start:end]
+
+    # Fetch full models for page IDs
+    if page_ids:
+        items = dao_class.find_by_ids(page_ids)
+        # Preserve popularity sort order
+        id_to_item = {item.id: item for item in items}
+        ordered_items = [id_to_item[pid] for pid in page_ids if pid in id_to_item]
+    else:
+        ordered_items = []
+
+    # Serialize
+    select_columns = request.select_columns or DEFAULT_CHART_COLUMNS
+    # Ensure popularity_score is in the select_columns
+    if "popularity_score" not in select_columns:
+        select_columns = list(select_columns) + ["popularity_score"]
+
+    chart_objs = []
+    for item in ordered_items:
+        obj = serializer(item, select_columns)
+        if obj is not None:
+            chart_objs.append(obj)
+
+    # Attach scores
+    _attach_popularity_scores(chart_objs, scores)
+
+    total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
+    pagination_info = PaginationInfo(
+        page=page,
+        page_size=page_size,
+        total_count=total_count,
+        total_pages=total_pages,
+        has_next=page < total_pages - 1,
+        has_previous=page > 0,
+    )
+
+    return ChartList(
+        charts=chart_objs,
+        count=len(chart_objs),
+        total_count=total_count,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+        has_previous=page > 0,
+        has_next=page < total_pages - 1,
+        columns_requested=select_columns,
+        columns_loaded=select_columns,
+        columns_available=all_columns,
+        sortable_columns=CHART_SORTABLE_COLUMNS,
+        filters_applied=request.filters if isinstance(request.filters, list) else [],
+        pagination=pagination_info,
+        timestamp=datetime.now(timezone.utc),
+    )

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -71,22 +71,6 @@ CHART_SEARCH_COLUMNS = [
 ]
 
 
-def _needs_popularity(request: ListChartsRequest) -> bool:
-    """Check if popularity_score computation is needed."""
-    if request.order_column == "popularity_score":
-        return True
-    if request.select_columns and "popularity_score" in request.select_columns:
-        return True
-    return False
-
-
-def _attach_popularity_scores(charts: list[Any], scores: dict[int, float]) -> None:
-    """Attach popularity scores to serialized chart objects in-place."""
-    for chart in charts:
-        if chart.id is not None and chart.id in scores:
-            chart.popularity_score = scores[chart.id]
-
-
 @tool(
     tags=["core"],
     class_permission_name="Chart",

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -162,11 +162,16 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
                 logger=logger,
             )
 
+            # Strip computed fields before passing to DAO query
+            dao_columns = request.select_columns
+            if dao_columns:
+                dao_columns = [c for c in dao_columns if c != "popularity_score"]
+
             with event_logger.log_context(action="mcp.list_charts.query"):
                 result = list_core.run_tool(
                     filters=request.filters,
                     search=request.search,
-                    select_columns=request.select_columns,
+                    select_columns=dao_columns,
                     order_column=request.order_column,
                     order_direction=request.order_direction,
                     page=max(request.page - 1, 0),

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -180,6 +180,11 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
                     scores = compute_chart_popularity(chart_ids)
                     attach_popularity_scores(result.charts, scores)
 
+            # Overwrite columns_requested so the metadata reflects the user's
+            # original request, not the internally-mutated dao_columns.
+            if original_select_columns:
+                result.columns_requested = original_select_columns
+
         count = len(result.charts) if hasattr(result, "charts") else 0
         total_pages = getattr(result, "total_pages", None)
         await ctx.info(

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -19,8 +19,6 @@
 MCP tool: list_charts (advanced filtering with metadata cache control)
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Callable
 from datetime import datetime, timezone

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -19,9 +19,12 @@
 MCP tool: list_charts (advanced filtering with metadata cache control)
 """
 
+from __future__ import annotations
+
 import logging
+from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import cast, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
@@ -209,8 +212,8 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
 
 def _list_charts_by_popularity(
     request: ListChartsRequest,
-    dao_class: type,
-    serializer: callable,
+    dao_class: Any,
+    serializer: Callable[..., dict[str, Any] | None],
     all_columns: list[str],
     ctx: Context,
 ) -> ChartList:
@@ -236,10 +239,9 @@ def _list_charts_by_popularity(
     page_size = request.page_size
     start = page * page_size
     end = start + page_size
-    page_ids = sorted_ids[start:end]
 
     # Fetch full models for page IDs
-    if page_ids:
+    if page_ids := sorted_ids[start:end]:
         items = dao_class.find_by_ids(page_ids)
         # Preserve popularity sort order
         id_to_item = {item.id: item for item in items}

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -140,6 +140,11 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
         """Serialize chart object (field filtering handled by model_serializer)."""
         return serialize_chart_object(cast(ChartLike | None, obj))
 
+    # Preserve original select_columns before any mutation for response filtering
+    original_select_columns = (
+        list(request.select_columns) if request.select_columns else None
+    )
+
     try:
         # Two-pass approach when sorting by popularity_score
         if request.order_column == "popularity_score":
@@ -198,17 +203,11 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
             % (count, total_pages)
         )
 
-        # Apply field filtering via serialization context
-        columns_to_filter = result.columns_requested
-        # Re-add popularity_score if it was originally requested
-        # (it was stripped before the DAO query since it's computed)
-        if (
-            request.select_columns
-            and "popularity_score" in request.select_columns
-            and columns_to_filter
-            and "popularity_score" not in columns_to_filter
-        ):
-            columns_to_filter = list(columns_to_filter) + ["popularity_score"]
+        # Build response filtering from the original request columns when the
+        # user explicitly specified select_columns (to avoid leaking internally
+        # injected columns like 'id'). Fall back to result.columns_requested
+        # (which holds DAO defaults) when no explicit columns were requested.
+        columns_to_filter = original_select_columns or result.columns_requested
         await ctx.debug(
             "Applying field filtering via serialization context: columns=%s"
             % (columns_to_filter,)
@@ -256,11 +255,13 @@ def _list_charts_by_popularity(
     else:
         ordered_items = []
 
-    # Serialize
-    select_columns = request.select_columns or DEFAULT_CHART_COLUMNS
-    # Ensure popularity_score is in the select_columns
+    # Serialize - preserve the original request columns for response filtering
+    columns_requested = request.select_columns or DEFAULT_CHART_COLUMNS
+    # Expand select_columns for internal loading (need popularity_score for
+    # attach step), but keep columns_requested reflecting what was asked for
+    select_columns = list(columns_requested)
     if "popularity_score" not in select_columns:
-        select_columns = list(select_columns) + ["popularity_score"]
+        select_columns = select_columns + ["popularity_score"]
 
     chart_objs = []
     for item in ordered_items:
@@ -290,7 +291,7 @@ def _list_charts_by_popularity(
         total_pages=total_pages,
         has_previous=page > 0,
         has_next=page < total_pages - 1,
-        columns_requested=select_columns,
+        columns_requested=columns_requested,
         columns_loaded=select_columns,
         columns_available=all_columns,
         sortable_columns=CHART_SORTABLE_COLUMNS,

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -103,7 +103,7 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
     modified time.
 
     Sortable columns for order_column: id, slice_name, viz_type,
-    datasource_name, description, changed_on, created_on, popularity_score
+    description, changed_on, created_on, popularity_score
     """
     await ctx.info(
         "Listing charts: page=%s, page_size=%s, search=%s"
@@ -257,11 +257,12 @@ def _list_charts_by_popularity(
 
     # Serialize - preserve the original request columns for response filtering
     columns_requested = request.select_columns or DEFAULT_CHART_COLUMNS
-    # Expand select_columns for internal loading (need popularity_score for
-    # attach step), but keep columns_requested reflecting what was asked for
+    # Include popularity_score in response when sorting by it, even if not
+    # explicitly in select_columns (so clients can see the sort key)
+    if "popularity_score" not in columns_requested:
+        columns_requested = list(columns_requested) + ["popularity_score"]
+    # Expand select_columns for internal loading
     select_columns = list(columns_requested)
-    if "popularity_score" not in select_columns:
-        select_columns = select_columns + ["popularity_score"]
 
     chart_objs = []
     for item in ordered_items:

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -41,7 +41,14 @@ from superset.mcp_service.chart.schemas import (
     ListChartsRequest,
     serialize_chart_object,
 )
+from superset.mcp_service.common.popularity import (
+    attach_popularity_scores,
+    compute_chart_popularity,
+    get_popularity_sorted_ids,
+)
 from superset.mcp_service.mcp_core import ModelListCore
+from superset.mcp_service.system.schemas import PaginationInfo
+from superset.mcp_service.utils.schema_utils import parse_request
 
 logger = logging.getLogger(__name__)
 
@@ -56,17 +63,6 @@ DEFAULT_CHART_COLUMNS = [
     "url",
     "changed_on",
     "changed_on_humanized",
-]
-
-SORTABLE_CHART_COLUMNS = [
-    "id",
-    "slice_name",
-    "viz_type",
-    "datasource_name",
-    "description",
-    "changed_on",
-    "created_on",
-    "popularity_score",
 ]
 
 CHART_SEARCH_COLUMNS = [
@@ -177,14 +173,9 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
 
             # Attach popularity scores if requested in select_columns
             if request.select_columns and "popularity_score" in request.select_columns:
-                from superset.mcp_service.common.popularity import (
-                    compute_chart_popularity,
-                )
-
-                chart_ids = [c.id for c in result.charts if c.id is not None]
-                if chart_ids:
+                if chart_ids := [c.id for c in result.charts if c.id is not None]:
                     scores = compute_chart_popularity(chart_ids)
-                    _attach_popularity_scores(result.charts, scores)
+                    attach_popularity_scores(result.charts, scores)
 
         count = len(result.charts) if hasattr(result, "charts") else 0
         total_pages = getattr(result, "total_pages", None)
@@ -216,12 +207,7 @@ def _list_charts_by_popularity(
     ctx: Context,
 ) -> ChartList:
     """Two-pass listing: sort all matching charts by popularity score."""
-    from superset.mcp_service.common.popularity import (
-        compute_chart_popularity,
-        get_popularity_sorted_ids,
-    )
     from superset.mcp_service.common.schema_discovery import CHART_SORTABLE_COLUMNS
-    from superset.mcp_service.system.schemas import PaginationInfo
 
     sorted_ids, scores, total_count = get_popularity_sorted_ids(
         compute_fn=compute_chart_popularity,
@@ -260,7 +246,7 @@ def _list_charts_by_popularity(
             chart_objs.append(obj)
 
     # Attach scores
-    _attach_popularity_scores(chart_objs, scores)
+    attach_popularity_scores(chart_objs, scores)
 
     total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
     pagination_info = PaginationInfo(

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -41,14 +41,8 @@ from superset.mcp_service.chart.schemas import (
     ListChartsRequest,
     serialize_chart_object,
 )
-from superset.mcp_service.common.popularity import (
-    attach_popularity_scores,
-    compute_chart_popularity,
-    get_popularity_sorted_ids,
-)
 from superset.mcp_service.mcp_core import ModelListCore
 from superset.mcp_service.system.schemas import PaginationInfo
-from superset.mcp_service.utils.schema_utils import parse_request
 
 logger = logging.getLogger(__name__)
 
@@ -106,9 +100,13 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
         )
     )
 
-    # Avoid circular imports: DAO and schema_discovery depend on models
-    # that import from mcp_service during app initialization
+    # Avoid circular imports: DAO, schema_discovery, and popularity depend
+    # on models that import from mcp_service during app initialization
     from superset.daos.chart import ChartDAO
+    from superset.mcp_service.common.popularity import (
+        attach_popularity_scores,
+        compute_chart_popularity,
+    )
     from superset.mcp_service.common.schema_discovery import (
         CHART_SORTABLE_COLUMNS,
         get_all_column_names,
@@ -225,6 +223,11 @@ def _list_charts_by_popularity(
     ctx: Context,
 ) -> ChartList:
     """Two-pass listing: sort all matching charts by popularity score."""
+    from superset.mcp_service.common.popularity import (
+        attach_popularity_scores,
+        compute_chart_popularity,
+        get_popularity_sorted_ids,
+    )
     from superset.mcp_service.common.schema_discovery import CHART_SORTABLE_COLUMNS
 
     sorted_ids, scores, total_count = get_popularity_sorted_ids(

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -274,24 +274,26 @@ def _list_charts_by_popularity(
     attach_popularity_scores(chart_objs, scores)
 
     total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
+    # Convert back to 1-based page for the response (request uses 1-based)
+    page_1based = page + 1
     pagination_info = PaginationInfo(
-        page=page,
+        page=page_1based,
         page_size=page_size,
         total_count=total_count,
         total_pages=total_pages,
-        has_next=page < total_pages - 1,
-        has_previous=page > 0,
+        has_next=page_1based < total_pages,
+        has_previous=page_1based > 1,
     )
 
     return ChartList(
         charts=chart_objs,
         count=len(chart_objs),
         total_count=total_count,
-        page=page,
+        page=page_1based,
         page_size=page_size,
         total_pages=total_pages,
-        has_previous=page > 0,
-        has_next=page < total_pages - 1,
+        has_previous=page_1based > 1,
+        has_next=page_1based < total_pages,
         columns_requested=columns_requested,
         columns_loaded=select_columns,
         columns_available=all_columns,

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -84,9 +84,7 @@ def _needs_popularity(request: ListChartsRequest) -> bool:
     return False
 
 
-def _attach_popularity_scores(
-    charts: list[ChartInfo], scores: dict[int, float]
-) -> None:
+def _attach_popularity_scores(charts: list[Any], scores: dict[int, float]) -> None:
     """Attach popularity scores to serialized chart objects in-place."""
     for chart in charts:
         if chart.id is not None and chart.id in scores:

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -192,6 +192,13 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
         # injected columns like 'id'). Fall back to result.columns_requested
         # (which holds DAO defaults) when no explicit columns were requested.
         columns_to_filter = original_select_columns or result.columns_requested
+        # When sorting by popularity_score, ensure it stays in the response
+        # even when the user's explicit select_columns didn't include it
+        if (
+            request.order_column == "popularity_score"
+            and "popularity_score" not in columns_to_filter
+        ):
+            columns_to_filter = list(columns_to_filter) + ["popularity_score"]
         await ctx.debug(
             "Applying field filtering via serialization context: columns=%s"
             % (columns_to_filter,)

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -104,6 +104,7 @@ def _add_view_scores(
             .all()
         )
     except sa.exc.SQLAlchemyError:
+        db.session.rollback()
         logger.warning(
             "Failed to query logs table for view counts (action=%s). "
             "Scoring will proceed without view data.",
@@ -301,6 +302,8 @@ def compute_dataset_popularity(
             if ds.extra:
                 try:
                     extra_dict = json_utils.loads(ds.extra)
+                    if not isinstance(extra_dict, dict):
+                        continue
                     certification = extra_dict.get("certification", {})
                     if isinstance(certification, dict) and certification.get(
                         "certified_by"

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -263,7 +263,7 @@ def compute_dataset_popularity(
     # Datasets use CertificationMixin where certification is in the extra JSON
     datasets = (
         db.session.query(SqlaTable.id, SqlaTable.extra, SqlaTable.changed_on)
-        .filter(SqlaTable.id.in_(dataset_ids))
+        .filter(SqlaTable.id.in_(dataset_ids))  # type: ignore[attr-defined,unused-ignore]
         .all()
     )
     for ds in datasets:

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -31,9 +31,32 @@ from typing import Any
 
 import sqlalchemy as sa
 
+from superset.connectors.sqla.models import SqlaTable
 from superset.extensions import db
+from superset.models.core import FavStar, Log
+from superset.models.dashboard import Dashboard, dashboard_slices
+from superset.models.slice import Slice
+from superset.utils import json as json_utils
 
 logger = logging.getLogger(__name__)
+
+# Scoring weights
+VIEW_WEIGHT = 3
+FAV_WEIGHT = 5
+DASHBOARD_COUNT_WEIGHT = 2
+CHART_COUNT_WEIGHT_DASHBOARD = 1
+CHART_COUNT_WEIGHT_DATASET = 3
+CERTIFICATION_BONUS = 10
+PUBLISHED_BONUS = 3
+
+# Recency thresholds and bonuses
+RECENCY_RECENT_DAYS = 7
+RECENCY_MODERATE_DAYS = 30
+RECENCY_RECENT_BONUS = 5.0
+RECENCY_MODERATE_BONUS = 2.0
+
+# Two-pass query limit
+MAX_POPULARITY_SORT_PAGE_SIZE = 100_000
 
 
 def _recency_bonus(changed_on: datetime | None) -> float:
@@ -45,10 +68,10 @@ def _recency_bonus(changed_on: datetime | None) -> float:
     if changed_on.tzinfo is None:
         changed_on = changed_on.replace(tzinfo=timezone.utc)
     delta = now - changed_on
-    if delta <= timedelta(days=7):
-        return 5.0
-    if delta <= timedelta(days=30):
-        return 2.0
+    if delta <= timedelta(days=RECENCY_RECENT_DAYS):
+        return RECENCY_RECENT_BONUS
+    if delta <= timedelta(days=RECENCY_MODERATE_DAYS):
+        return RECENCY_MODERATE_BONUS
     return 0.0
 
 
@@ -66,8 +89,6 @@ def _add_view_scores(
     weight: int,
 ) -> None:
     """Add view count scores from the logs table."""
-    from superset.models.core import Log
-
     view_counts = (
         db.session.query(id_column, sa.func.count(Log.id).label("view_count"))
         .filter(Log.action == action, id_column.in_(entity_ids), Log.dttm >= cutoff)
@@ -87,8 +108,6 @@ def _add_fav_scores(
     weight: int,
 ) -> None:
     """Add favorite count scores from the favstar table."""
-    from superset.models.core import FavStar
-
     fav_counts = (
         db.session.query(FavStar.obj_id, sa.func.count(FavStar.id).label("fav_count"))
         .filter(FavStar.class_name == class_name, FavStar.obj_id.in_(entity_ids))
@@ -116,15 +135,13 @@ def compute_chart_popularity(chart_ids: list[int], days: int = 30) -> dict[int, 
     if not chart_ids:
         return {}
 
-    from superset.models.core import Log
-    from superset.models.dashboard import dashboard_slices
-    from superset.models.slice import Slice
-
     scores = _init_scores(chart_ids)
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
-    _add_view_scores(scores, "mount_explorer", Log.slice_id, chart_ids, cutoff, 3)
-    _add_fav_scores(scores, "slice", chart_ids, 5)
+    _add_view_scores(
+        scores, "mount_explorer", Log.slice_id, chart_ids, cutoff, VIEW_WEIGHT
+    )
+    _add_fav_scores(scores, "slice", chart_ids, FAV_WEIGHT)
 
     # Dashboard count (how many dashboards contain each chart)
     dash_counts = (
@@ -138,7 +155,7 @@ def compute_chart_popularity(chart_ids: list[int], days: int = 30) -> dict[int, 
     )
     for row in dash_counts:
         if row.slice_id in scores:
-            scores[row.slice_id] += row.dash_count * 2
+            scores[row.slice_id] += row.dash_count * DASHBOARD_COUNT_WEIGHT
 
     # Certification and recency from chart objects
     charts = (
@@ -149,7 +166,7 @@ def compute_chart_popularity(chart_ids: list[int], days: int = 30) -> dict[int, 
     for chart in charts:
         if chart.id in scores:
             if chart.certified_by:
-                scores[chart.id] += 10
+                scores[chart.id] += CERTIFICATION_BONUS
             scores[chart.id] += _recency_bonus(chart.changed_on)
 
     return scores
@@ -173,16 +190,13 @@ def compute_dashboard_popularity(
     if not dashboard_ids:
         return {}
 
-    from superset.models.core import Log
-    from superset.models.dashboard import Dashboard, dashboard_slices
-
     scores = _init_scores(dashboard_ids)
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
     _add_view_scores(
-        scores, "mount_dashboard", Log.dashboard_id, dashboard_ids, cutoff, 3
+        scores, "mount_dashboard", Log.dashboard_id, dashboard_ids, cutoff, VIEW_WEIGHT
     )
-    _add_fav_scores(scores, "Dashboard", dashboard_ids, 5)
+    _add_fav_scores(scores, "Dashboard", dashboard_ids, FAV_WEIGHT)
 
     # Chart count per dashboard
     chart_counts = (
@@ -196,9 +210,9 @@ def compute_dashboard_popularity(
     )
     for row in chart_counts:
         if row.dashboard_id in scores:
-            scores[row.dashboard_id] += row.chart_count * 1
+            scores[row.dashboard_id] += row.chart_count * CHART_COUNT_WEIGHT_DASHBOARD
 
-    # 4. Published, certification, and recency from dashboard objects
+    # Published, certification, and recency from dashboard objects
     dashboards = (
         db.session.query(
             Dashboard.id,
@@ -212,9 +226,9 @@ def compute_dashboard_popularity(
     for dash in dashboards:
         if dash.id in scores:
             if dash.published:
-                scores[dash.id] += 3
+                scores[dash.id] += PUBLISHED_BONUS
             if dash.certified_by:
-                scores[dash.id] += 10
+                scores[dash.id] += CERTIFICATION_BONUS
             scores[dash.id] += _recency_bonus(dash.changed_on)
 
     return scores
@@ -237,9 +251,6 @@ def compute_dataset_popularity(
     if not dataset_ids:
         return {}
 
-    from superset.connectors.sqla.models import SqlaTable
-    from superset.models.slice import Slice
-
     scores = _init_scores(dataset_ids)
 
     # 1. Chart count per dataset (how many charts use each dataset)
@@ -257,7 +268,7 @@ def compute_dataset_popularity(
     )
     for row in chart_counts:
         if row.datasource_id in scores:
-            scores[row.datasource_id] += row.chart_count * 3
+            scores[row.datasource_id] += row.chart_count * CHART_COUNT_WEIGHT_DATASET
 
     # 2. Certification and recency from dataset objects
     # Datasets use CertificationMixin where certification is in the extra JSON
@@ -270,12 +281,10 @@ def compute_dataset_popularity(
         if ds.id in scores:
             # Check certification from extra JSON
             if ds.extra:
-                from superset.utils import json as json_utils
-
                 try:
                     extra_dict = json_utils.loads(ds.extra)
                     if extra_dict.get("certification"):
-                        scores[ds.id] += 10
+                        scores[ds.id] += CERTIFICATION_BONUS
                 except (TypeError, ValueError):
                     pass
             scores[ds.id] += _recency_bonus(ds.changed_on)
@@ -310,13 +319,12 @@ def get_popularity_sorted_ids(
         Tuple of (sorted_ids, scores_dict, total_count)
     """
     # Use a large page_size to get all matching IDs in one query
-    max_page_size = 100_000
     all_items, total_count = dao_class.list(
         column_operators=filters,
         order_column="changed_on",
         order_direction="desc",
         page=0,
-        page_size=max_page_size,
+        page_size=MAX_POPULARITY_SORT_PAGE_SIZE,
         search=search,
         search_columns=search_columns,
         columns=["id"],
@@ -342,3 +350,10 @@ def get_popularity_sorted_ids(
     sorted_ids = sorted(all_ids, key=lambda x: scores.get(x, 0.0), reverse=reverse)
 
     return sorted_ids, scores, total_count
+
+
+def attach_popularity_scores(items: list[Any], scores: dict[int, float]) -> None:
+    """Attach popularity scores to serialized objects in-place."""
+    for item in items:
+        if item.id is not None and item.id in scores:
+            item.popularity_score = scores[item.id]

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -55,6 +55,9 @@ RECENCY_MODERATE_DAYS = 30
 RECENCY_RECENT_BONUS = 5.0
 RECENCY_MODERATE_BONUS = 2.0
 
+# Default time window for view counts
+DEFAULT_VIEW_WINDOW_DAYS = 30
+
 # Two-pass query limit
 MAX_POPULARITY_SORT_PAGE_SIZE = 100_000
 
@@ -119,7 +122,9 @@ def _add_fav_scores(
             scores[row.obj_id] += row.fav_count * weight
 
 
-def compute_chart_popularity(chart_ids: list[int], days: int = 30) -> dict[int, float]:
+def compute_chart_popularity(
+    chart_ids: list[int], days: int = DEFAULT_VIEW_WINDOW_DAYS
+) -> dict[int, float]:
     """Compute popularity scores for charts.
 
     Formula: view_count_30d * 3 + fav_count * 5 + dashboard_count * 2
@@ -173,7 +178,7 @@ def compute_chart_popularity(chart_ids: list[int], days: int = 30) -> dict[int, 
 
 
 def compute_dashboard_popularity(
-    dashboard_ids: list[int], days: int = 30
+    dashboard_ids: list[int], days: int = DEFAULT_VIEW_WINDOW_DAYS
 ) -> dict[int, float]:
     """Compute popularity scores for dashboards.
 
@@ -235,7 +240,7 @@ def compute_dashboard_popularity(
 
 
 def compute_dataset_popularity(
-    dataset_ids: list[int], days: int = 30
+    dataset_ids: list[int], days: int = DEFAULT_VIEW_WINDOW_DAYS
 ) -> dict[int, float]:
     """Compute popularity scores for datasets.
 
@@ -299,7 +304,7 @@ def get_popularity_sorted_ids(
     search: str | None,
     search_columns: list[str],
     order_direction: str = "desc",
-    days: int = 30,
+    days: int = DEFAULT_VIEW_WINDOW_DAYS,
 ) -> tuple[list[int], dict[int, float], int]:
     """Fetch all matching IDs, compute popularity scores, return sorted IDs.
 

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -339,6 +339,10 @@ def get_popularity_sorted_ids(
         if (item_id := getattr(item, "id", None)) is not None
     ]
 
+    # Cap total_count to the number of IDs actually loaded to keep pagination
+    # consistent when the result set exceeds MAX_POPULARITY_SORT_PAGE_SIZE
+    total_count = len(all_ids)
+
     if not all_ids:
         return [], {}, total_count
 

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -25,7 +25,9 @@ relationships, certification, and recency.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import sqlalchemy as sa
 
@@ -261,7 +263,7 @@ def compute_dataset_popularity(
     # Datasets use CertificationMixin where certification is in the extra JSON
     datasets = (
         db.session.query(SqlaTable.id, SqlaTable.extra, SqlaTable.changed_on)
-        .filter(SqlaTable.id.in_(dataset_ids))
+        .filter(SqlaTable.id.in_(dataset_ids))  # type: ignore[union-attr]
         .all()
     )
     for ds in datasets:
@@ -282,9 +284,9 @@ def compute_dataset_popularity(
 
 
 def get_popularity_sorted_ids(
-    compute_fn: callable,
-    dao_class: type,
-    filters: list | None,
+    compute_fn: Callable[..., dict[int, float]],
+    dao_class: Any,
+    filters: list[Any] | None,
     search: str | None,
     search_columns: list[str],
     order_direction: str = "desc",
@@ -323,8 +325,11 @@ def get_popularity_sorted_ids(
     if not all_items:
         return [], {}, 0
 
-    all_ids = [getattr(item, "id", None) for item in all_items]
-    all_ids = [i for i in all_ids if i is not None]
+    all_ids: list[int] = [
+        item_id
+        for item in all_items
+        if (item_id := getattr(item, "id", None)) is not None
+    ]
 
     if not all_ids:
         return [], {}, total_count

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -1,0 +1,339 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Popularity scoring for charts, dashboards, and datasets.
+
+Computes a composite popularity score based on views, favorites,
+relationships, certification, and recency.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+import sqlalchemy as sa
+
+from superset.extensions import db
+
+logger = logging.getLogger(__name__)
+
+
+def _recency_bonus(changed_on: datetime | None) -> float:
+    """Compute recency bonus based on changed_on timestamp."""
+    if not changed_on:
+        return 0.0
+    now = datetime.now(timezone.utc)
+    # Ensure changed_on is timezone-aware for comparison
+    if changed_on.tzinfo is None:
+        changed_on = changed_on.replace(tzinfo=timezone.utc)
+    delta = now - changed_on
+    if delta <= timedelta(days=7):
+        return 5.0
+    if delta <= timedelta(days=30):
+        return 2.0
+    return 0.0
+
+
+def _init_scores(ids: list[int]) -> dict[int, float]:
+    """Initialize a score dict with 0.0 for each ID."""
+    return {i: 0.0 for i in ids}  # noqa: C420
+
+
+def _add_view_scores(
+    scores: dict[int, float],
+    action: str,
+    id_column: sa.Column,
+    entity_ids: list[int],
+    cutoff: datetime,
+    weight: int,
+) -> None:
+    """Add view count scores from the logs table."""
+    from superset.models.core import Log
+
+    view_counts = (
+        db.session.query(id_column, sa.func.count(Log.id).label("view_count"))
+        .filter(Log.action == action, id_column.in_(entity_ids), Log.dttm >= cutoff)
+        .group_by(id_column)
+        .all()
+    )
+    for row in view_counts:
+        entity_id = row[0]
+        if entity_id in scores:
+            scores[entity_id] += row.view_count * weight
+
+
+def _add_fav_scores(
+    scores: dict[int, float],
+    class_name: str,
+    entity_ids: list[int],
+    weight: int,
+) -> None:
+    """Add favorite count scores from the favstar table."""
+    from superset.models.core import FavStar
+
+    fav_counts = (
+        db.session.query(FavStar.obj_id, sa.func.count(FavStar.id).label("fav_count"))
+        .filter(FavStar.class_name == class_name, FavStar.obj_id.in_(entity_ids))
+        .group_by(FavStar.obj_id)
+        .all()
+    )
+    for row in fav_counts:
+        if row.obj_id in scores:
+            scores[row.obj_id] += row.fav_count * weight
+
+
+def compute_chart_popularity(chart_ids: list[int], days: int = 30) -> dict[int, float]:
+    """Compute popularity scores for charts.
+
+    Formula: view_count_30d * 3 + fav_count * 5 + dashboard_count * 2
+             + is_certified * 10 + recency_bonus
+
+    Args:
+        chart_ids: List of chart IDs to score
+        days: Number of days for view count window
+
+    Returns:
+        Dict mapping chart_id -> popularity score
+    """
+    if not chart_ids:
+        return {}
+
+    from superset.models.core import Log
+    from superset.models.dashboard import dashboard_slices
+    from superset.models.slice import Slice
+
+    scores = _init_scores(chart_ids)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    _add_view_scores(scores, "mount_explorer", Log.slice_id, chart_ids, cutoff, 3)
+    _add_fav_scores(scores, "slice", chart_ids, 5)
+
+    # Dashboard count (how many dashboards contain each chart)
+    dash_counts = (
+        db.session.query(
+            dashboard_slices.c.slice_id,
+            sa.func.count(dashboard_slices.c.dashboard_id).label("dash_count"),
+        )
+        .filter(dashboard_slices.c.slice_id.in_(chart_ids))
+        .group_by(dashboard_slices.c.slice_id)
+        .all()
+    )
+    for row in dash_counts:
+        if row.slice_id in scores:
+            scores[row.slice_id] += row.dash_count * 2
+
+    # Certification and recency from chart objects
+    charts = (
+        db.session.query(Slice.id, Slice.certified_by, Slice.changed_on)
+        .filter(Slice.id.in_(chart_ids))
+        .all()
+    )
+    for chart in charts:
+        if chart.id in scores:
+            if chart.certified_by:
+                scores[chart.id] += 10
+            scores[chart.id] += _recency_bonus(chart.changed_on)
+
+    return scores
+
+
+def compute_dashboard_popularity(
+    dashboard_ids: list[int], days: int = 30
+) -> dict[int, float]:
+    """Compute popularity scores for dashboards.
+
+    Formula: view_count_30d * 3 + fav_count * 5 + chart_count * 1
+             + is_published * 3 + is_certified * 10 + recency_bonus
+
+    Args:
+        dashboard_ids: List of dashboard IDs to score
+        days: Number of days for view count window
+
+    Returns:
+        Dict mapping dashboard_id -> popularity score
+    """
+    if not dashboard_ids:
+        return {}
+
+    from superset.models.core import Log
+    from superset.models.dashboard import Dashboard, dashboard_slices
+
+    scores = _init_scores(dashboard_ids)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    _add_view_scores(
+        scores, "mount_dashboard", Log.dashboard_id, dashboard_ids, cutoff, 3
+    )
+    _add_fav_scores(scores, "Dashboard", dashboard_ids, 5)
+
+    # Chart count per dashboard
+    chart_counts = (
+        db.session.query(
+            dashboard_slices.c.dashboard_id,
+            sa.func.count(dashboard_slices.c.slice_id).label("chart_count"),
+        )
+        .filter(dashboard_slices.c.dashboard_id.in_(dashboard_ids))
+        .group_by(dashboard_slices.c.dashboard_id)
+        .all()
+    )
+    for row in chart_counts:
+        if row.dashboard_id in scores:
+            scores[row.dashboard_id] += row.chart_count * 1
+
+    # 4. Published, certification, and recency from dashboard objects
+    dashboards = (
+        db.session.query(
+            Dashboard.id,
+            Dashboard.published,
+            Dashboard.certified_by,
+            Dashboard.changed_on,
+        )
+        .filter(Dashboard.id.in_(dashboard_ids))
+        .all()
+    )
+    for dash in dashboards:
+        if dash.id in scores:
+            if dash.published:
+                scores[dash.id] += 3
+            if dash.certified_by:
+                scores[dash.id] += 10
+            scores[dash.id] += _recency_bonus(dash.changed_on)
+
+    return scores
+
+
+def compute_dataset_popularity(
+    dataset_ids: list[int], days: int = 30
+) -> dict[int, float]:
+    """Compute popularity scores for datasets.
+
+    Formula: chart_count * 3 + is_certified * 10 + recency_bonus
+
+    Args:
+        dataset_ids: List of dataset IDs to score
+        days: Number of days (unused for datasets, kept for API consistency)
+
+    Returns:
+        Dict mapping dataset_id -> popularity score
+    """
+    if not dataset_ids:
+        return {}
+
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.slice import Slice
+
+    scores = _init_scores(dataset_ids)
+
+    # 1. Chart count per dataset (how many charts use each dataset)
+    chart_counts = (
+        db.session.query(
+            Slice.datasource_id,
+            sa.func.count(Slice.id).label("chart_count"),
+        )
+        .filter(
+            Slice.datasource_id.in_(dataset_ids),
+            Slice.datasource_type == "table",
+        )
+        .group_by(Slice.datasource_id)
+        .all()
+    )
+    for row in chart_counts:
+        if row.datasource_id in scores:
+            scores[row.datasource_id] += row.chart_count * 3
+
+    # 2. Certification and recency from dataset objects
+    # Datasets use CertificationMixin where certification is in the extra JSON
+    datasets = (
+        db.session.query(SqlaTable.id, SqlaTable.extra, SqlaTable.changed_on)
+        .filter(SqlaTable.id.in_(dataset_ids))
+        .all()
+    )
+    for ds in datasets:
+        if ds.id in scores:
+            # Check certification from extra JSON
+            if ds.extra:
+                from superset.utils import json as json_utils
+
+                try:
+                    extra_dict = json_utils.loads(ds.extra)
+                    if extra_dict.get("certification"):
+                        scores[ds.id] += 10
+                except (TypeError, ValueError):
+                    pass
+            scores[ds.id] += _recency_bonus(ds.changed_on)
+
+    return scores
+
+
+def get_popularity_sorted_ids(
+    compute_fn: callable,
+    dao_class: type,
+    filters: list | None,
+    search: str | None,
+    search_columns: list[str],
+    order_direction: str = "desc",
+    days: int = 30,
+) -> tuple[list[int], dict[int, float], int]:
+    """Fetch all matching IDs, compute popularity scores, return sorted IDs.
+
+    This is the "two-pass" approach: first get all matching IDs (lightweight),
+    then compute scores and sort by popularity.
+
+    Args:
+        compute_fn: One of compute_chart/dashboard/dataset_popularity
+        dao_class: DAO class to query
+        filters: Column operator filters
+        search: Search string
+        search_columns: Columns to search
+        order_direction: "asc" or "desc"
+        days: Days window for view counts
+
+    Returns:
+        Tuple of (sorted_ids, scores_dict, total_count)
+    """
+    # Use a large page_size to get all matching IDs in one query
+    max_page_size = 100_000
+    all_items, total_count = dao_class.list(
+        column_operators=filters,
+        order_column="changed_on",
+        order_direction="desc",
+        page=0,
+        page_size=max_page_size,
+        search=search,
+        search_columns=search_columns,
+        columns=["id"],
+    )
+
+    if not all_items:
+        return [], {}, 0
+
+    all_ids = [getattr(item, "id", None) for item in all_items]
+    all_ids = [i for i in all_ids if i is not None]
+
+    if not all_ids:
+        return [], {}, total_count
+
+    # Compute popularity scores
+    scores = compute_fn(all_ids, days=days)
+
+    # Sort by score
+    reverse = order_direction == "desc"
+    sorted_ids = sorted(all_ids, key=lambda x: scores.get(x, 0.0), reverse=reverse)
+
+    return sorted_ids, scores, total_count

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -288,7 +288,10 @@ def compute_dataset_popularity(
             if ds.extra:
                 try:
                     extra_dict = json_utils.loads(ds.extra)
-                    if extra_dict.get("certification"):
+                    certification = extra_dict.get("certification", {})
+                    if isinstance(certification, dict) and certification.get(
+                        "certified_by"
+                    ):
                         scores[ds.id] += CERTIFICATION_BONUS
                 except (TypeError, ValueError):
                     pass

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -263,7 +263,7 @@ def compute_dataset_popularity(
     # Datasets use CertificationMixin where certification is in the extra JSON
     datasets = (
         db.session.query(SqlaTable.id, SqlaTable.extra, SqlaTable.changed_on)
-        .filter(SqlaTable.id.in_(dataset_ids))  # type: ignore[union-attr]
+        .filter(SqlaTable.id.in_(dataset_ids))
         .all()
     )
     for ds in datasets:

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -354,8 +354,14 @@ def get_popularity_sorted_ids(
     if not all_ids:
         return [], {}, total_count
 
-    # Compute popularity scores
-    scores = compute_fn(all_ids, days=days)
+    # Compute popularity scores in chunks to avoid oversized SQL IN lists
+    # (some DB engines, like SQLite, have bind-variable limits)
+    scores: dict[int, float] = {}
+    chunk_size = 900
+    for i in range(0, len(all_ids), chunk_size):
+        chunk = all_ids[i : i + chunk_size]
+        chunk_scores = compute_fn(chunk, days=days)
+        scores.update(chunk_scores)
 
     # Sort by score
     reverse = order_direction == "desc"

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -302,13 +302,12 @@ def compute_dataset_popularity(
             if ds.extra:
                 try:
                     extra_dict = json_utils.loads(ds.extra)
-                    if not isinstance(extra_dict, dict):
-                        continue
-                    certification = extra_dict.get("certification", {})
-                    if isinstance(certification, dict) and certification.get(
-                        "certified_by"
-                    ):
-                        scores[ds.id] += CERTIFICATION_BONUS
+                    if isinstance(extra_dict, dict):
+                        certification = extra_dict.get("certification", {})
+                        if isinstance(certification, dict) and certification.get(
+                            "certified_by"
+                        ):
+                            scores[ds.id] += CERTIFICATION_BONUS
                 except (TypeError, ValueError):
                     pass
             scores[ds.id] += _recency_bonus(ds.changed_on)

--- a/superset/mcp_service/common/popularity.py
+++ b/superset/mcp_service/common/popularity.py
@@ -91,13 +91,26 @@ def _add_view_scores(
     cutoff: datetime,
     weight: int,
 ) -> None:
-    """Add view count scores from the logs table."""
-    view_counts = (
-        db.session.query(id_column, sa.func.count(Log.id).label("view_count"))
-        .filter(Log.action == action, id_column.in_(entity_ids), Log.dttm >= cutoff)
-        .group_by(id_column)
-        .all()
-    )
+    """Add view count scores from the logs table.
+
+    Degrades gracefully when the logs table is empty (e.g. Preset production
+    where events are routed to external systems) or inaccessible.
+    """
+    try:
+        view_counts = (
+            db.session.query(id_column, sa.func.count(Log.id).label("view_count"))
+            .filter(Log.action == action, id_column.in_(entity_ids), Log.dttm >= cutoff)
+            .group_by(id_column)
+            .all()
+        )
+    except sa.exc.SQLAlchemyError:
+        logger.warning(
+            "Failed to query logs table for view counts (action=%s). "
+            "Scoring will proceed without view data.",
+            action,
+            exc_info=True,
+        )
+        return
     for row in view_counts:
         entity_id = row[0]
         if entity_id in scores:

--- a/superset/mcp_service/common/schema_discovery.py
+++ b/superset/mcp_service/common/schema_discovery.py
@@ -519,7 +519,7 @@ DASHBOARD_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
     "popularity_score": ColumnMetadata(
         name="popularity_score",
         description="Popularity score based on views, favorites, chart count, "
-        "and recency",
+        "certification, published status, and recency",
         type="float",
         is_default=False,
     ),

--- a/superset/mcp_service/common/schema_discovery.py
+++ b/superset/mcp_service/common/schema_discovery.py
@@ -363,7 +363,7 @@ DATASET_SORTABLE_COLUMNS = [
     "created_on",
     "popularity_score",
 ]
-DATASET_SEARCH_COLUMNS = ["table_name", "description"]
+DATASET_SEARCH_COLUMNS = ["schema", "sql", "table_name", "uuid"]
 DATASET_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
     "database_name": ColumnMetadata(
         name="database_name",

--- a/superset/mcp_service/common/schema_discovery.py
+++ b/superset/mcp_service/common/schema_discovery.py
@@ -256,6 +256,7 @@ CHART_SORTABLE_COLUMNS = [
     "description",
     "changed_on",
     "created_on",
+    "popularity_score",
 ]
 CHART_SEARCH_COLUMNS = ["slice_name", "description"]
 CHART_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
@@ -334,6 +335,13 @@ CHART_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
     "owners": ColumnMetadata(
         name="owners", description="Chart owners", type="list", is_default=False
     ),
+    "popularity_score": ColumnMetadata(
+        name="popularity_score",
+        description="Popularity score based on views, favorites, dashboard usage, "
+        "and recency",
+        type="float",
+        is_default=False,
+    ),
 }
 
 # Dataset configuration
@@ -353,6 +361,7 @@ DATASET_SORTABLE_COLUMNS = [
     "schema",
     "changed_on",
     "created_on",
+    "popularity_score",
 ]
 DATASET_SEARCH_COLUMNS = ["table_name", "description"]
 DATASET_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
@@ -428,6 +437,12 @@ DATASET_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
     "owners": ColumnMetadata(
         name="owners", description="Dataset owners", type="list", is_default=False
     ),
+    "popularity_score": ColumnMetadata(
+        name="popularity_score",
+        description="Popularity score based on chart usage, certification, and recency",
+        type="float",
+        is_default=False,
+    ),
 }
 
 # Dashboard configuration
@@ -449,6 +464,7 @@ DASHBOARD_SORTABLE_COLUMNS = [
     "published",
     "changed_on",
     "created_on",
+    "popularity_score",
 ]
 DASHBOARD_SEARCH_COLUMNS = ["dashboard_title", "slug"]
 DASHBOARD_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
@@ -499,6 +515,13 @@ DASHBOARD_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
     ),
     "charts": ColumnMetadata(
         name="charts", description="Charts in dashboard", type="list", is_default=False
+    ),
+    "popularity_score": ColumnMetadata(
+        name="popularity_score",
+        description="Popularity score based on views, favorites, chart count, "
+        "and recency",
+        type="float",
+        is_default=False,
     ),
 }
 

--- a/superset/mcp_service/common/schema_discovery.py
+++ b/superset/mcp_service/common/schema_discovery.py
@@ -363,7 +363,7 @@ DATASET_SORTABLE_COLUMNS = [
     "created_on",
     "popularity_score",
 ]
-DATASET_SEARCH_COLUMNS = ["schema", "sql", "table_name", "uuid"]
+DATASET_SEARCH_COLUMNS = ["table_name", "description", "schema", "sql", "uuid"]
 DATASET_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
     "database_name": ColumnMetadata(
         name="database_name",
@@ -466,7 +466,7 @@ DASHBOARD_SORTABLE_COLUMNS = [
     "created_on",
     "popularity_score",
 ]
-DASHBOARD_SEARCH_COLUMNS = ["dashboard_title", "slug"]
+DASHBOARD_SEARCH_COLUMNS = ["dashboard_title", "slug", "uuid"]
 DASHBOARD_EXTRA_COLUMNS: dict[str, ColumnMetadata] = {
     "url": ColumnMetadata(
         name="url", description="Dashboard URL", type="str", is_default=True

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -386,6 +386,13 @@ class DashboardInfo(BaseModel):
         ),
     )
 
+    popularity_score: float | None = Field(
+        None,
+        description="Popularity score based on views, favorites, chart count, "
+        "and recency. Request via select_columns=['popularity_score'] or sort "
+        "via order_column='popularity_score'.",
+    )
+
     # Fields for permalink/filter state support
     permalink_key: str | None = Field(
         None,

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -180,6 +180,11 @@ async def list_dashboards(
                 scores = compute_dashboard_popularity(dash_ids)
                 attach_popularity_scores(result.dashboards, scores)
 
+        # Overwrite columns_requested so the metadata reflects the user's
+        # original request, not the internally-mutated dao_columns.
+        if original_select_columns:
+            result.columns_requested = original_select_columns
+
     count = len(result.dashboards) if hasattr(result, "dashboards") else 0
     total_pages = getattr(result, "total_pages", None)
     await ctx.info(

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -22,8 +22,6 @@ This module contains the FastMCP tool for listing dashboards using
 advanced filtering with clear, unambiguous request schema and metadata cache control.
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Callable
 from datetime import datetime, timezone

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -242,9 +242,20 @@ def _list_dashboards_by_popularity(
     start = page * page_size
     end = start + page_size
 
-    # Fetch full models for page IDs
+    # Fetch full models for page IDs with eager loading to avoid N+1
+    # lazy loads during serialization (owners, tags, roles, slices).
     if page_ids := sorted_ids[start:end]:
-        items = dao_class.find_by_ids(page_ids)
+        from sqlalchemy.orm import subqueryload
+
+        from superset.models.dashboard import Dashboard
+
+        eager_options = [
+            subqueryload(Dashboard.owners),
+            subqueryload(Dashboard.tags),
+            subqueryload(Dashboard.roles),
+            subqueryload(Dashboard.slices),
+        ]
+        items = dao_class.find_by_ids(page_ids, query_options=eager_options)
         id_to_item = {item.id: item for item in items}
         ordered_items = [id_to_item[pid] for pid in page_ids if pid in id_to_item]
     else:

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -192,6 +192,13 @@ async def list_dashboards(
     # injected columns like 'id'). Fall back to result.columns_requested
     # (which holds DAO defaults) when no explicit columns were requested.
     columns_to_filter = original_select_columns or result.columns_requested
+    # When sorting by popularity_score, ensure it stays in the response
+    # even when the user's explicit select_columns didn't include it
+    if (
+        request.order_column == "popularity_score"
+        and "popularity_score" not in columns_to_filter
+    ):
+        columns_to_filter = list(columns_to_filter) + ["popularity_score"]
     await ctx.debug(
         "Applying field filtering via serialization context: columns=%s"
         % (columns_to_filter,)

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -77,9 +77,7 @@ DASHBOARD_SEARCH_COLUMNS = [
 ]
 
 
-def _attach_popularity_scores(
-    dashboards: list[DashboardInfo], scores: dict[int, float]
-) -> None:
+def _attach_popularity_scores(dashboards: list[Any], scores: dict[int, float]) -> None:
     """Attach popularity scores to serialized dashboard objects in-place."""
     for dash in dashboards:
         if dash.id is not None and dash.id in scores:

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -246,11 +246,13 @@ def _list_dashboards_by_popularity(
 
     # Serialize - preserve the original request columns for response filtering
     columns_requested = request.select_columns or DEFAULT_DASHBOARD_COLUMNS
+    # Include popularity_score in response when sorting by it, even if not
+    # explicitly in select_columns (so clients can see the sort key)
+    if "popularity_score" not in columns_requested:
+        columns_requested = list(columns_requested) + ["popularity_score"]
     # Expand select_columns for internal loading (need popularity_score for
-    # attach step), but keep columns_requested reflecting what was asked for
+    # attach step)
     select_columns = list(columns_requested)
-    if "popularity_score" not in select_columns:
-        select_columns = select_columns + ["popularity_score"]
 
     dash_objs = []
     for item in ordered_items:

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -117,6 +117,8 @@ async def list_dashboards(
         )
     )
 
+    # Avoid circular imports: DAO and schema_discovery depend on models
+    # that import from mcp_service during app initialization
     from superset.daos.dashboard import DashboardDAO
     from superset.mcp_service.common.schema_discovery import (
         DASHBOARD_SORTABLE_COLUMNS,

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -22,9 +22,12 @@ This module contains the FastMCP tool for listing dashboards using
 advanced filtering with clear, unambiguous request schema and metadata cache control.
 """
 
+from __future__ import annotations
+
 import logging
+from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
@@ -199,8 +202,8 @@ async def list_dashboards(
 
 def _list_dashboards_by_popularity(
     request: ListDashboardsRequest,
-    dao_class: type,
-    serializer: callable,
+    dao_class: Any,
+    serializer: Callable[..., dict[str, Any] | None],
     all_columns: list[str],
     ctx: Context,
 ) -> DashboardList:
@@ -228,10 +231,9 @@ def _list_dashboards_by_popularity(
     page_size = request.page_size
     start = page * page_size
     end = start + page_size
-    page_ids = sorted_ids[start:end]
 
     # Fetch full models for page IDs
-    if page_ids:
+    if page_ids := sorted_ids[start:end]:
         items = dao_class.find_by_ids(page_ids)
         id_to_item = {item.id: item for item in items}
         ordered_items = [id_to_item[pid] for pid in page_ids if pid in id_to_item]

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -23,6 +23,7 @@ advanced filtering with clear, unambiguous request schema and metadata cache con
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from fastmcp import Context
@@ -63,7 +64,23 @@ SORTABLE_DASHBOARD_COLUMNS = [
     "published",
     "changed_on",
     "created_on",
+    "popularity_score",
 ]
+
+DASHBOARD_SEARCH_COLUMNS = [
+    "dashboard_title",
+    "slug",
+    "uuid",
+]
+
+
+def _attach_popularity_scores(
+    dashboards: list[DashboardInfo], scores: dict[int, float]
+) -> None:
+    """Attach popularity scores to serialized dashboard objects in-place."""
+    for dash in dashboards:
+        if dash.id is not None and dash.id in scores:
+            dash.popularity_score = scores[dash.id]
 
 
 @tool(
@@ -83,7 +100,7 @@ async def list_dashboards(
     request additional fields.
 
     Sortable columns for order_column: id, dashboard_title, slug, published,
-    changed_on, created_on
+    changed_on, created_on, popularity_score
     """
     await ctx.info(
         "Listing dashboards: page=%s, page_size=%s, search=%s"
@@ -118,34 +135,49 @@ async def list_dashboards(
         """Serialize dashboard object (field filtering handled by model_serializer)."""
         return serialize_dashboard_object(obj)
 
-    tool = ModelListCore(
-        dao_class=DashboardDAO,
-        output_schema=DashboardInfo,
-        item_serializer=_serialize_dashboard,
-        filter_type=DashboardFilter,
-        default_columns=DEFAULT_DASHBOARD_COLUMNS,
-        search_columns=[
-            "dashboard_title",
-            "slug",
-            "uuid",
-        ],
-        list_field_name="dashboards",
-        output_list_schema=DashboardList,
-        all_columns=all_columns,
-        sortable_columns=DASHBOARD_SORTABLE_COLUMNS,
-        logger=logger,
-    )
-
-    with event_logger.log_context(action="mcp.list_dashboards.query"):
-        result = tool.run_tool(
-            filters=request.filters,
-            search=request.search,
-            select_columns=request.select_columns,
-            order_column=request.order_column,
-            order_direction=request.order_direction,
-            page=max(request.page - 1, 0),
-            page_size=request.page_size,
+    # Two-pass approach when sorting by popularity_score
+    if request.order_column == "popularity_score":
+        with event_logger.log_context(action="mcp.list_dashboards.popularity_sort"):
+            result = _list_dashboards_by_popularity(
+                request, DashboardDAO, _serialize_dashboard, all_columns, ctx
+            )
+    else:
+        list_core = ModelListCore(
+            dao_class=DashboardDAO,
+            output_schema=DashboardInfo,
+            item_serializer=_serialize_dashboard,
+            filter_type=DashboardFilter,
+            default_columns=DEFAULT_DASHBOARD_COLUMNS,
+            search_columns=DASHBOARD_SEARCH_COLUMNS,
+            list_field_name="dashboards",
+            output_list_schema=DashboardList,
+            all_columns=all_columns,
+            sortable_columns=DASHBOARD_SORTABLE_COLUMNS,
+            logger=logger,
         )
+
+        with event_logger.log_context(action="mcp.list_dashboards.query"):
+            result = list_core.run_tool(
+                filters=request.filters,
+                search=request.search,
+                select_columns=request.select_columns,
+                order_column=request.order_column,
+                order_direction=request.order_direction,
+                page=max(request.page - 1, 0),
+                page_size=request.page_size,
+            )
+
+        # Attach popularity scores if requested in select_columns
+        if request.select_columns and "popularity_score" in request.select_columns:
+            from superset.mcp_service.common.popularity import (
+                compute_dashboard_popularity,
+            )
+
+            dash_ids = [d.id for d in result.dashboards if d.id is not None]
+            if dash_ids:
+                scores = compute_dashboard_popularity(dash_ids)
+                _attach_popularity_scores(result.dashboards, scores)
+
     count = len(result.dashboards) if hasattr(result, "dashboards") else 0
     total_pages = getattr(result, "total_pages", None)
     await ctx.info(
@@ -154,8 +186,6 @@ async def list_dashboards(
     )
 
     # Apply field filtering via serialization context
-    # Always use columns_requested (either explicit select_columns or defaults)
-    # This triggers DashboardInfo._filter_fields_by_context for each dashboard
     columns_to_filter = result.columns_requested
     await ctx.debug(
         "Applying field filtering via serialization context: columns=%s"
@@ -165,3 +195,86 @@ async def list_dashboards(
         return result.model_dump(
             mode="json", context={"select_columns": columns_to_filter}
         )
+
+
+def _list_dashboards_by_popularity(
+    request: ListDashboardsRequest,
+    dao_class: type,
+    serializer: callable,
+    all_columns: list[str],
+    ctx: Context,
+) -> DashboardList:
+    """Two-pass listing: sort all matching dashboards by popularity score."""
+    from superset.mcp_service.common.popularity import (
+        compute_dashboard_popularity,
+        get_popularity_sorted_ids,
+    )
+    from superset.mcp_service.common.schema_discovery import (
+        DASHBOARD_SORTABLE_COLUMNS,
+    )
+    from superset.mcp_service.system.schemas import PaginationInfo
+
+    sorted_ids, scores, total_count = get_popularity_sorted_ids(
+        compute_fn=compute_dashboard_popularity,
+        dao_class=dao_class,
+        filters=request.filters,
+        search=request.search,
+        search_columns=DASHBOARD_SEARCH_COLUMNS,
+        order_direction=request.order_direction,
+    )
+
+    # Apply pagination to sorted IDs
+    page = max(request.page - 1, 0)
+    page_size = request.page_size
+    start = page * page_size
+    end = start + page_size
+    page_ids = sorted_ids[start:end]
+
+    # Fetch full models for page IDs
+    if page_ids:
+        items = dao_class.find_by_ids(page_ids)
+        id_to_item = {item.id: item for item in items}
+        ordered_items = [id_to_item[pid] for pid in page_ids if pid in id_to_item]
+    else:
+        ordered_items = []
+
+    # Serialize
+    select_columns = request.select_columns or DEFAULT_DASHBOARD_COLUMNS
+    if "popularity_score" not in select_columns:
+        select_columns = list(select_columns) + ["popularity_score"]
+
+    dash_objs = []
+    for item in ordered_items:
+        obj = serializer(item, select_columns)
+        if obj is not None:
+            dash_objs.append(obj)
+
+    _attach_popularity_scores(dash_objs, scores)
+
+    total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
+    pagination_info = PaginationInfo(
+        page=page,
+        page_size=page_size,
+        total_count=total_count,
+        total_pages=total_pages,
+        has_next=page < total_pages - 1,
+        has_previous=page > 0,
+    )
+
+    return DashboardList(
+        dashboards=dash_objs,
+        count=len(dash_objs),
+        total_count=total_count,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+        has_previous=page > 0,
+        has_next=page < total_pages - 1,
+        columns_requested=select_columns,
+        columns_loaded=select_columns,
+        columns_available=all_columns,
+        sortable_columns=DASHBOARD_SORTABLE_COLUMNS,
+        filters_applied=request.filters if isinstance(request.filters, list) else [],
+        pagination=pagination_info,
+        timestamp=datetime.now(timezone.utc),
+    )

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -36,6 +36,11 @@ if TYPE_CHECKING:
     from superset.models.dashboard import Dashboard
 
 from superset.extensions import event_logger
+from superset.mcp_service.common.popularity import (
+    attach_popularity_scores,
+    compute_dashboard_popularity,
+    get_popularity_sorted_ids,
+)
 from superset.mcp_service.dashboard.schemas import (
     DashboardFilter,
     DashboardInfo,
@@ -44,6 +49,8 @@ from superset.mcp_service.dashboard.schemas import (
     serialize_dashboard_object,
 )
 from superset.mcp_service.mcp_core import ModelListCore
+from superset.mcp_service.system.schemas import PaginationInfo
+from superset.mcp_service.utils.schema_utils import parse_request
 
 logger = logging.getLogger(__name__)
 
@@ -58,16 +65,6 @@ DEFAULT_DASHBOARD_COLUMNS = [
     "url",
     "changed_on",
     "changed_on_humanized",
-]
-
-SORTABLE_DASHBOARD_COLUMNS = [
-    "id",
-    "dashboard_title",
-    "slug",
-    "published",
-    "changed_on",
-    "created_on",
-    "popularity_score",
 ]
 
 DASHBOARD_SEARCH_COLUMNS = [
@@ -170,14 +167,9 @@ async def list_dashboards(
 
         # Attach popularity scores if requested in select_columns
         if request.select_columns and "popularity_score" in request.select_columns:
-            from superset.mcp_service.common.popularity import (
-                compute_dashboard_popularity,
-            )
-
-            dash_ids = [d.id for d in result.dashboards if d.id is not None]
-            if dash_ids:
+            if dash_ids := [d.id for d in result.dashboards if d.id is not None]:
                 scores = compute_dashboard_popularity(dash_ids)
-                _attach_popularity_scores(result.dashboards, scores)
+                attach_popularity_scores(result.dashboards, scores)
 
     count = len(result.dashboards) if hasattr(result, "dashboards") else 0
     total_pages = getattr(result, "total_pages", None)
@@ -206,14 +198,9 @@ def _list_dashboards_by_popularity(
     ctx: Context,
 ) -> DashboardList:
     """Two-pass listing: sort all matching dashboards by popularity score."""
-    from superset.mcp_service.common.popularity import (
-        compute_dashboard_popularity,
-        get_popularity_sorted_ids,
-    )
     from superset.mcp_service.common.schema_discovery import (
         DASHBOARD_SORTABLE_COLUMNS,
     )
-    from superset.mcp_service.system.schemas import PaginationInfo
 
     sorted_ids, scores, total_count = get_popularity_sorted_ids(
         compute_fn=compute_dashboard_popularity,
@@ -249,7 +236,7 @@ def _list_dashboards_by_popularity(
         if obj is not None:
             dash_objs.append(obj)
 
-    _attach_popularity_scores(dash_objs, scores)
+    attach_popularity_scores(dash_objs, scores)
 
     total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
     pagination_info = PaginationInfo(

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -263,24 +263,26 @@ def _list_dashboards_by_popularity(
     attach_popularity_scores(dash_objs, scores)
 
     total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
+    # Convert back to 1-based page for the response (request uses 1-based)
+    page_1based = page + 1
     pagination_info = PaginationInfo(
-        page=page,
+        page=page_1based,
         page_size=page_size,
         total_count=total_count,
         total_pages=total_pages,
-        has_next=page < total_pages - 1,
-        has_previous=page > 0,
+        has_next=page_1based < total_pages,
+        has_previous=page_1based > 1,
     )
 
     return DashboardList(
         dashboards=dash_objs,
         count=len(dash_objs),
         total_count=total_count,
-        page=page,
+        page=page_1based,
         page_size=page_size,
         total_pages=total_pages,
-        has_previous=page > 0,
-        has_next=page < total_pages - 1,
+        has_previous=page_1based > 1,
+        has_next=page_1based < total_pages,
         columns_requested=columns_requested,
         columns_loaded=select_columns,
         columns_available=all_columns,

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -135,6 +135,11 @@ async def list_dashboards(
         """Serialize dashboard object (field filtering handled by model_serializer)."""
         return serialize_dashboard_object(obj)
 
+    # Preserve original select_columns before any mutation for response filtering
+    original_select_columns = (
+        list(request.select_columns) if request.select_columns else None
+    )
+
     # Two-pass approach when sorting by popularity_score
     if request.order_column == "popularity_score":
         with event_logger.log_context(action="mcp.list_dashboards.popularity_sort"):
@@ -189,17 +194,11 @@ async def list_dashboards(
         % (count, total_pages)
     )
 
-    # Apply field filtering via serialization context
-    columns_to_filter = result.columns_requested
-    # Re-add popularity_score if it was originally requested
-    # (it was stripped before the DAO query since it's computed)
-    if (
-        request.select_columns
-        and "popularity_score" in request.select_columns
-        and columns_to_filter
-        and "popularity_score" not in columns_to_filter
-    ):
-        columns_to_filter = list(columns_to_filter) + ["popularity_score"]
+    # Build response filtering from the original request columns when the
+    # user explicitly specified select_columns (to avoid leaking internally
+    # injected columns like 'id'). Fall back to result.columns_requested
+    # (which holds DAO defaults) when no explicit columns were requested.
+    columns_to_filter = original_select_columns or result.columns_requested
     await ctx.debug(
         "Applying field filtering via serialization context: columns=%s"
         % (columns_to_filter,)
@@ -245,10 +244,13 @@ def _list_dashboards_by_popularity(
     else:
         ordered_items = []
 
-    # Serialize
-    select_columns = request.select_columns or DEFAULT_DASHBOARD_COLUMNS
+    # Serialize - preserve the original request columns for response filtering
+    columns_requested = request.select_columns or DEFAULT_DASHBOARD_COLUMNS
+    # Expand select_columns for internal loading (need popularity_score for
+    # attach step), but keep columns_requested reflecting what was asked for
+    select_columns = list(columns_requested)
     if "popularity_score" not in select_columns:
-        select_columns = list(select_columns) + ["popularity_score"]
+        select_columns = select_columns + ["popularity_score"]
 
     dash_objs = []
     for item in ordered_items:
@@ -277,7 +279,7 @@ def _list_dashboards_by_popularity(
         total_pages=total_pages,
         has_previous=page > 0,
         has_next=page < total_pages - 1,
-        columns_requested=select_columns,
+        columns_requested=columns_requested,
         columns_loaded=select_columns,
         columns_available=all_columns,
         sortable_columns=DASHBOARD_SORTABLE_COLUMNS,

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -156,11 +156,16 @@ async def list_dashboards(
             logger=logger,
         )
 
+        # Strip computed fields before passing to DAO query
+        dao_columns = request.select_columns
+        if dao_columns:
+            dao_columns = [c for c in dao_columns if c != "popularity_score"]
+
         with event_logger.log_context(action="mcp.list_dashboards.query"):
             result = list_core.run_tool(
                 filters=request.filters,
                 search=request.search,
-                select_columns=request.select_columns,
+                select_columns=dao_columns,
                 order_column=request.order_column,
                 order_direction=request.order_direction,
                 page=max(request.page - 1, 0),

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -160,6 +160,10 @@ async def list_dashboards(
         dao_columns = request.select_columns
         if dao_columns:
             dao_columns = [c for c in dao_columns if c != "popularity_score"]
+            # Ensure id is loaded when popularity_score was requested
+            # (scores are keyed by id)
+            if "popularity_score" in request.select_columns and "id" not in dao_columns:
+                dao_columns = ["id"] + dao_columns
 
         with event_logger.log_context(action="mcp.list_dashboards.query"):
             result = list_core.run_tool(
@@ -187,6 +191,15 @@ async def list_dashboards(
 
     # Apply field filtering via serialization context
     columns_to_filter = result.columns_requested
+    # Re-add popularity_score if it was originally requested
+    # (it was stripped before the DAO query since it's computed)
+    if (
+        request.select_columns
+        and "popularity_score" in request.select_columns
+        and columns_to_filter
+        and "popularity_score" not in columns_to_filter
+    ):
+        columns_to_filter = list(columns_to_filter) + ["popularity_score"]
     await ctx.debug(
         "Applying field filtering via serialization context: columns=%s"
         % (columns_to_filter,)

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -74,13 +74,6 @@ DASHBOARD_SEARCH_COLUMNS = [
 ]
 
 
-def _attach_popularity_scores(dashboards: list[Any], scores: dict[int, float]) -> None:
-    """Attach popularity scores to serialized dashboard objects in-place."""
-    for dash in dashboards:
-        if dash.id is not None and dash.id in scores:
-            dash.popularity_score = scores[dash.id]
-
-
 @tool(
     tags=["core"],
     class_permission_name="Dashboard",

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -36,11 +36,6 @@ if TYPE_CHECKING:
     from superset.models.dashboard import Dashboard
 
 from superset.extensions import event_logger
-from superset.mcp_service.common.popularity import (
-    attach_popularity_scores,
-    compute_dashboard_popularity,
-    get_popularity_sorted_ids,
-)
 from superset.mcp_service.dashboard.schemas import (
     DashboardFilter,
     DashboardInfo,
@@ -50,7 +45,6 @@ from superset.mcp_service.dashboard.schemas import (
 )
 from superset.mcp_service.mcp_core import ModelListCore
 from superset.mcp_service.system.schemas import PaginationInfo
-from superset.mcp_service.utils.schema_utils import parse_request
 
 logger = logging.getLogger(__name__)
 
@@ -110,9 +104,13 @@ async def list_dashboards(
         )
     )
 
-    # Avoid circular imports: DAO and schema_discovery depend on models
-    # that import from mcp_service during app initialization
+    # Avoid circular imports: DAO, schema_discovery, and popularity depend
+    # on models that import from mcp_service during app initialization
     from superset.daos.dashboard import DashboardDAO
+    from superset.mcp_service.common.popularity import (
+        attach_popularity_scores,
+        compute_dashboard_popularity,
+    )
     from superset.mcp_service.common.schema_discovery import (
         DASHBOARD_SORTABLE_COLUMNS,
         get_all_column_names,
@@ -222,6 +220,11 @@ def _list_dashboards_by_popularity(
     ctx: Context,
 ) -> DashboardList:
     """Two-pass listing: sort all matching dashboards by popularity score."""
+    from superset.mcp_service.common.popularity import (
+        attach_popularity_scores,
+        compute_dashboard_popularity,
+        get_popularity_sorted_ids,
+    )
     from superset.mcp_service.common.schema_discovery import (
         DASHBOARD_SORTABLE_COLUMNS,
     )

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -310,6 +310,15 @@ class GetDatasetInfoRequest(MetadataCacheControl):
         int | str,
         Field(description="Dataset identifier - can be numeric ID or UUID string"),
     ]
+    select_columns: Annotated[
+        List[str],
+        Field(
+            default_factory=list,
+            description="List of columns to include in the response. When empty or "
+            "omitted, all columns are returned. Use 'popularity_score' to include "
+            "computed popularity scoring.",
+        ),
+    ]
 
 
 def _parse_json_field(obj: Any, field_name: str) -> Dict[str, Any] | None:

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -151,6 +151,12 @@ class DatasetInfo(BaseModel):
     is_favorite: bool | None = Field(
         None, description="Whether this dataset is favorited by the current user"
     )
+    popularity_score: float | None = Field(
+        None,
+        description="Popularity score based on chart usage, certification, "
+        "and recency. Request via select_columns=['popularity_score'] or sort "
+        "via order_column='popularity_score'.",
+    )
     model_config = ConfigDict(
         from_attributes=True,
         ser_json_timedelta="iso8601",

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -30,6 +30,7 @@ from sqlalchemy.orm import joinedload, subqueryload
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
+from superset.mcp_service.common.popularity import compute_dataset_popularity
 from superset.mcp_service.dataset.schemas import (
     DatasetError,
     DatasetInfo,
@@ -120,6 +121,11 @@ async def get_dataset_info(
             result = tool.run_tool(request.identifier)
 
         if isinstance(result, DatasetInfo):
+            # Compute popularity_score for single dataset retrieval
+            if result.id is not None:
+                scores = compute_dataset_popularity([result.id])
+                result.popularity_score = scores.get(result.id, 0.0)
+
             await ctx.info(
                 "Dataset information retrieved successfully: "
                 "dataset_id=%s, table_name=%s, columns_count=%s, metrics_count=%s"

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -122,9 +122,15 @@ async def get_dataset_info(
 
         if isinstance(result, DatasetInfo):
             # Compute popularity_score for single dataset retrieval
+            # Isolated so a failure here doesn't prevent returning dataset info
             if result.id is not None:
-                scores = compute_dataset_popularity([result.id])
-                result.popularity_score = scores.get(result.id, 0.0)
+                try:
+                    scores = compute_dataset_popularity([result.id])
+                    result.popularity_score = scores.get(result.id, 0.0)
+                except (ValueError, TypeError, AttributeError) as e:
+                    await ctx.warning(
+                        "Failed to compute popularity score: %s" % (str(e),)
+                    )
 
             await ctx.info(
                 "Dataset information retrieved successfully: "

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -26,6 +26,7 @@ import logging
 from datetime import datetime, timezone
 
 from fastmcp import Context
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import joinedload, subqueryload
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
@@ -121,13 +122,23 @@ async def get_dataset_info(
             result = tool.run_tool(request.identifier)
 
         if isinstance(result, DatasetInfo):
-            # Compute popularity_score for single dataset retrieval
-            # Isolated so a failure here doesn't prevent returning dataset info
-            if result.id is not None:
+            # Compute popularity_score only when explicitly requested via
+            # select_columns (opt-in). Isolated so a failure here does not
+            # prevent returning dataset info.
+            if (
+                result.id is not None
+                and request.select_columns
+                and "popularity_score" in request.select_columns
+            ):
                 try:
                     scores = compute_dataset_popularity([result.id])
                     result.popularity_score = scores.get(result.id, 0.0)
-                except (ValueError, TypeError, AttributeError) as e:
+                except (
+                    ValueError,
+                    TypeError,
+                    AttributeError,
+                    SQLAlchemyError,
+                ) as e:
                     await ctx.warning(
                         "Failed to compute popularity score: %s" % (str(e),)
                     )

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -122,14 +122,15 @@ async def get_dataset_info(
             result = tool.run_tool(request.identifier)
 
         if isinstance(result, DatasetInfo):
-            # Compute popularity_score only when explicitly requested via
-            # select_columns (opt-in). Isolated so a failure here does not
-            # prevent returning dataset info.
-            if (
-                result.id is not None
-                and request.select_columns
-                and "popularity_score" in request.select_columns
-            ):
+            # Only compute popularity_score when select_columns is empty/None
+            # (meaning "return everything") or when it explicitly includes
+            # "popularity_score". This avoids unnecessary DB queries when a
+            # caller requests a specific column subset that excludes it.
+            should_compute_popularity = (
+                not request.select_columns
+                or "popularity_score" in request.select_columns
+            )
+            if should_compute_popularity and result.id is not None:
                 try:
                     scores = compute_dataset_popularity([result.id])
                     result.popularity_score = scores.get(result.id, 0.0)

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -194,6 +194,11 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
                     scores = compute_dataset_popularity(ds_ids)
                     attach_popularity_scores(result.datasets, scores)
 
+            # Overwrite columns_requested so the metadata reflects the user's
+            # original request, not the internally-mutated dao_columns.
+            if original_select_columns:
+                result.columns_requested = original_select_columns
+
         await ctx.info(
             "Datasets listed successfully: count=%s, total_count=%s, total_pages=%s"
             % (
@@ -263,9 +268,19 @@ def _list_datasets_by_popularity(
     start = page * page_size
     end = start + page_size
 
-    # Fetch full models for page IDs
+    # Fetch full models for page IDs with eager loading to avoid N+1
+    # lazy loads during serialization (columns, metrics, database).
     if page_ids := sorted_ids[start:end]:
-        items = dao_class.find_by_ids(page_ids)
+        from sqlalchemy.orm import joinedload, subqueryload
+
+        from superset.connectors.sqla.models import SqlaTable
+
+        eager_options = [
+            subqueryload(SqlaTable.columns),
+            subqueryload(SqlaTable.metrics),
+            joinedload(SqlaTable.database),
+        ]
+        items = dao_class.find_by_ids(page_ids, query_options=eager_options)
         id_to_item = {item.id: item for item in items}
         ordered_items = [id_to_item[pid] for pid in page_ids if pid in id_to_item]
     else:

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -145,6 +145,11 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
             """Serialize dataset (filtering via model_serializer)."""
             return serialize_dataset_object(obj)
 
+        # Preserve original select_columns before any mutation for response filtering
+        original_select_columns = (
+            list(request.select_columns) if request.select_columns else None
+        )
+
         # Two-pass approach when sorting by popularity_score
         if request.order_column == "popularity_score":
             with event_logger.log_context(action="mcp.list_datasets.popularity_sort"):
@@ -205,17 +210,11 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
             )
         )
 
-        # Apply field filtering via serialization context
-        columns_to_filter = result.columns_requested
-        # Re-add popularity_score if it was originally requested
-        # (it was stripped before the DAO query since it's computed)
-        if (
-            request.select_columns
-            and "popularity_score" in request.select_columns
-            and columns_to_filter
-            and "popularity_score" not in columns_to_filter
-        ):
-            columns_to_filter = list(columns_to_filter) + ["popularity_score"]
+        # Build response filtering from the original request columns when the
+        # user explicitly specified select_columns (to avoid leaking internally
+        # injected columns like 'id'). Fall back to result.columns_requested
+        # (which holds DAO defaults) when no explicit columns were requested.
+        columns_to_filter = original_select_columns or result.columns_requested
         await ctx.debug(
             "Applying field filtering via serialization context: columns=%s"
             % (columns_to_filter,)
@@ -272,10 +271,13 @@ def _list_datasets_by_popularity(
     else:
         ordered_items = []
 
-    # Serialize
-    select_columns = request.select_columns or DEFAULT_DATASET_COLUMNS
+    # Serialize - preserve the original request columns for response filtering
+    columns_requested = request.select_columns or DEFAULT_DATASET_COLUMNS
+    # Expand select_columns for internal loading (need popularity_score for
+    # attach step), but keep columns_requested reflecting what was asked for
+    select_columns = list(columns_requested)
     if "popularity_score" not in select_columns:
-        select_columns = list(select_columns) + ["popularity_score"]
+        select_columns = select_columns + ["popularity_score"]
 
     ds_objs = []
     for item in ordered_items:
@@ -304,7 +306,7 @@ def _list_datasets_by_popularity(
         total_pages=total_pages,
         has_previous=page > 0,
         has_next=page < total_pages - 1,
-        columns_requested=select_columns,
+        columns_requested=columns_requested,
         columns_loaded=select_columns,
         columns_available=all_columns,
         sortable_columns=DATASET_SORTABLE_COLUMNS,

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -273,11 +273,12 @@ def _list_datasets_by_popularity(
 
     # Serialize - preserve the original request columns for response filtering
     columns_requested = request.select_columns or DEFAULT_DATASET_COLUMNS
-    # Expand select_columns for internal loading (need popularity_score for
-    # attach step), but keep columns_requested reflecting what was asked for
+    # Include popularity_score in response when sorting by it, even if not
+    # explicitly in select_columns (so clients can see the sort key)
+    if "popularity_score" not in columns_requested:
+        columns_requested = list(columns_requested) + ["popularity_score"]
+    # Expand select_columns for internal loading
     select_columns = list(columns_requested)
-    if "popularity_score" not in select_columns:
-        select_columns = select_columns + ["popularity_score"]
 
     ds_objs = []
     for item in ordered_items:

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -36,6 +36,11 @@ if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
 
 from superset.extensions import event_logger
+from superset.mcp_service.common.popularity import (
+    attach_popularity_scores,
+    compute_dataset_popularity,
+    get_popularity_sorted_ids,
+)
 from superset.mcp_service.dataset.schemas import (
     DatasetFilter,
     DatasetInfo,
@@ -44,6 +49,8 @@ from superset.mcp_service.dataset.schemas import (
     serialize_dataset_object,
 )
 from superset.mcp_service.mcp_core import ModelListCore
+from superset.mcp_service.system.schemas import PaginationInfo
+from superset.mcp_service.utils.schema_utils import parse_request
 
 logger = logging.getLogger(__name__)
 
@@ -62,15 +69,6 @@ DEFAULT_DATASET_COLUMNS = [
     "certification_details",
     "changed_on",
     "changed_on_humanized",
-]
-
-SORTABLE_DATASET_COLUMNS = [
-    "id",
-    "table_name",
-    "schema",
-    "changed_on",
-    "created_on",
-    "popularity_score",
 ]
 
 DATASET_SEARCH_COLUMNS = ["schema", "sql", "table_name", "uuid"]
@@ -180,14 +178,9 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
 
             # Attach popularity scores if requested in select_columns
             if request.select_columns and "popularity_score" in request.select_columns:
-                from superset.mcp_service.common.popularity import (
-                    compute_dataset_popularity,
-                )
-
-                ds_ids = [d.id for d in result.datasets if d.id is not None]
-                if ds_ids:
+                if ds_ids := [d.id for d in result.datasets if d.id is not None]:
                     scores = compute_dataset_popularity(ds_ids)
-                    _attach_popularity_scores(result.datasets, scores)
+                    attach_popularity_scores(result.datasets, scores)
 
         await ctx.info(
             "Datasets listed successfully: count=%s, total_count=%s, total_pages=%s"
@@ -231,12 +224,7 @@ def _list_datasets_by_popularity(
     ctx: Context,
 ) -> DatasetList:
     """Two-pass listing: sort all matching datasets by popularity score."""
-    from superset.mcp_service.common.popularity import (
-        compute_dataset_popularity,
-        get_popularity_sorted_ids,
-    )
     from superset.mcp_service.common.schema_discovery import DATASET_SORTABLE_COLUMNS
-    from superset.mcp_service.system.schemas import PaginationInfo
 
     sorted_ids, scores, total_count = get_popularity_sorted_ids(
         compute_fn=compute_dataset_popularity,
@@ -272,7 +260,7 @@ def _list_datasets_by_popularity(
         if obj is not None:
             ds_objs.append(obj)
 
-    _attach_popularity_scores(ds_objs, scores)
+    attach_popularity_scores(ds_objs, scores)
 
     total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
     pagination_info = PaginationInfo(

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -127,6 +127,8 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
     )
 
     try:
+        # Avoid circular imports: DAO and schema_discovery depend on models
+        # that import from mcp_service during app initialization
         from superset.daos.dataset import DatasetDAO
         from superset.mcp_service.common.schema_discovery import (
             DATASET_SORTABLE_COLUMNS,

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -208,6 +208,13 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
         # injected columns like 'id'). Fall back to result.columns_requested
         # (which holds DAO defaults) when no explicit columns were requested.
         columns_to_filter = original_select_columns or result.columns_requested
+        # When sorting by popularity_score, ensure it stays in the response
+        # even when the user's explicit select_columns didn't include it
+        if (
+            request.order_column == "popularity_score"
+            and "popularity_score" not in columns_to_filter
+        ):
+            columns_to_filter = list(columns_to_filter) + ["popularity_score"]
         await ctx.debug(
             "Applying field filtering via serialization context: columns=%s"
             % (columns_to_filter,)

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -63,7 +63,7 @@ DEFAULT_DATASET_COLUMNS = [
     "changed_on_humanized",
 ]
 
-DATASET_SEARCH_COLUMNS = ["schema", "sql", "table_name", "uuid"]
+DATASET_SEARCH_COLUMNS = ["table_name", "description", "schema", "sql", "uuid"]
 
 
 @tool(

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -23,6 +23,7 @@ advanced filtering with clear, unambiguous request schema and metadata cache con
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from fastmcp import Context
@@ -66,7 +67,19 @@ SORTABLE_DATASET_COLUMNS = [
     "schema",
     "changed_on",
     "created_on",
+    "popularity_score",
 ]
+
+DATASET_SEARCH_COLUMNS = ["schema", "sql", "table_name", "uuid"]
+
+
+def _attach_popularity_scores(
+    datasets: list[DatasetInfo], scores: dict[int, float]
+) -> None:
+    """Attach popularity scores to serialized dataset objects in-place."""
+    for ds in datasets:
+        if ds.id is not None and ds.id in scores:
+            ds.popularity_score = scores[ds.id]
 
 
 @tool(
@@ -85,7 +98,7 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
     time.
 
     Sortable columns for order_column: id, table_name, schema, changed_on,
-    created_on
+    created_on, popularity_score
     """
     await ctx.info(
         "Listing datasets: page=%s, page_size=%s, search=%s"
@@ -131,31 +144,49 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
             """Serialize dataset (filtering via model_serializer)."""
             return serialize_dataset_object(obj)
 
-        # Create tool with standard serialization
-        tool = ModelListCore(
-            dao_class=DatasetDAO,
-            output_schema=DatasetInfo,
-            item_serializer=_serialize_dataset,
-            filter_type=DatasetFilter,
-            default_columns=DEFAULT_DATASET_COLUMNS,
-            search_columns=["schema", "sql", "table_name", "uuid"],
-            list_field_name="datasets",
-            output_list_schema=DatasetList,
-            all_columns=all_columns,
-            sortable_columns=DATASET_SORTABLE_COLUMNS,
-            logger=logger,
-        )
-
-        with event_logger.log_context(action="mcp.list_datasets.query"):
-            result = tool.run_tool(
-                filters=request.filters,
-                search=request.search,
-                select_columns=request.select_columns,
-                order_column=request.order_column,
-                order_direction=request.order_direction,
-                page=max(request.page - 1, 0),
-                page_size=request.page_size,
+        # Two-pass approach when sorting by popularity_score
+        if request.order_column == "popularity_score":
+            with event_logger.log_context(action="mcp.list_datasets.popularity_sort"):
+                result = _list_datasets_by_popularity(
+                    request, DatasetDAO, _serialize_dataset, all_columns, ctx
+                )
+        else:
+            # Create tool with standard serialization
+            list_core = ModelListCore(
+                dao_class=DatasetDAO,
+                output_schema=DatasetInfo,
+                item_serializer=_serialize_dataset,
+                filter_type=DatasetFilter,
+                default_columns=DEFAULT_DATASET_COLUMNS,
+                search_columns=DATASET_SEARCH_COLUMNS,
+                list_field_name="datasets",
+                output_list_schema=DatasetList,
+                all_columns=all_columns,
+                sortable_columns=DATASET_SORTABLE_COLUMNS,
+                logger=logger,
             )
+
+            with event_logger.log_context(action="mcp.list_datasets.query"):
+                result = list_core.run_tool(
+                    filters=request.filters,
+                    search=request.search,
+                    select_columns=request.select_columns,
+                    order_column=request.order_column,
+                    order_direction=request.order_direction,
+                    page=max(request.page - 1, 0),
+                    page_size=request.page_size,
+                )
+
+            # Attach popularity scores if requested in select_columns
+            if request.select_columns and "popularity_score" in request.select_columns:
+                from superset.mcp_service.common.popularity import (
+                    compute_dataset_popularity,
+                )
+
+                ds_ids = [d.id for d in result.datasets if d.id is not None]
+                if ds_ids:
+                    scores = compute_dataset_popularity(ds_ids)
+                    _attach_popularity_scores(result.datasets, scores)
 
         await ctx.info(
             "Datasets listed successfully: count=%s, total_count=%s, total_pages=%s"
@@ -167,8 +198,6 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
         )
 
         # Apply field filtering via serialization context
-        # Always use columns_requested (either explicit select_columns or defaults)
-        # This triggers DatasetInfo._filter_fields_by_context for each dataset
         columns_to_filter = result.columns_requested
         await ctx.debug(
             "Applying field filtering via serialization context: columns=%s"
@@ -191,3 +220,84 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
             )
         )
         raise
+
+
+def _list_datasets_by_popularity(
+    request: ListDatasetsRequest,
+    dao_class: type,
+    serializer: callable,
+    all_columns: list[str],
+    ctx: Context,
+) -> DatasetList:
+    """Two-pass listing: sort all matching datasets by popularity score."""
+    from superset.mcp_service.common.popularity import (
+        compute_dataset_popularity,
+        get_popularity_sorted_ids,
+    )
+    from superset.mcp_service.common.schema_discovery import DATASET_SORTABLE_COLUMNS
+    from superset.mcp_service.system.schemas import PaginationInfo
+
+    sorted_ids, scores, total_count = get_popularity_sorted_ids(
+        compute_fn=compute_dataset_popularity,
+        dao_class=dao_class,
+        filters=request.filters,
+        search=request.search,
+        search_columns=DATASET_SEARCH_COLUMNS,
+        order_direction=request.order_direction,
+    )
+
+    # Apply pagination to sorted IDs
+    page = max(request.page - 1, 0)
+    page_size = request.page_size
+    start = page * page_size
+    end = start + page_size
+    page_ids = sorted_ids[start:end]
+
+    # Fetch full models for page IDs
+    if page_ids:
+        items = dao_class.find_by_ids(page_ids)
+        id_to_item = {item.id: item for item in items}
+        ordered_items = [id_to_item[pid] for pid in page_ids if pid in id_to_item]
+    else:
+        ordered_items = []
+
+    # Serialize
+    select_columns = request.select_columns or DEFAULT_DATASET_COLUMNS
+    if "popularity_score" not in select_columns:
+        select_columns = list(select_columns) + ["popularity_score"]
+
+    ds_objs = []
+    for item in ordered_items:
+        obj = serializer(item, select_columns)
+        if obj is not None:
+            ds_objs.append(obj)
+
+    _attach_popularity_scores(ds_objs, scores)
+
+    total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
+    pagination_info = PaginationInfo(
+        page=page,
+        page_size=page_size,
+        total_count=total_count,
+        total_pages=total_pages,
+        has_next=page < total_pages - 1,
+        has_previous=page > 0,
+    )
+
+    return DatasetList(
+        datasets=ds_objs,
+        count=len(ds_objs),
+        total_count=total_count,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+        has_previous=page > 0,
+        has_next=page < total_pages - 1,
+        columns_requested=select_columns,
+        columns_loaded=select_columns,
+        columns_available=all_columns,
+        sortable_columns=DATASET_SORTABLE_COLUMNS,
+        filters_applied=request.filters if isinstance(request.filters, list) else [],
+        pagination=pagination_info,
+        timestamp=datetime.now(timezone.utc),
+    )

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -74,13 +74,6 @@ DEFAULT_DATASET_COLUMNS = [
 DATASET_SEARCH_COLUMNS = ["schema", "sql", "table_name", "uuid"]
 
 
-def _attach_popularity_scores(datasets: list[Any], scores: dict[int, float]) -> None:
-    """Attach popularity scores to serialized dataset objects in-place."""
-    for ds in datasets:
-        if ds.id is not None and ds.id in scores:
-            ds.popularity_score = scores[ds.id]
-
-
 @tool(
     tags=["core"],
     class_permission_name="Dataset",

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -22,8 +22,6 @@ This module contains the FastMCP tool for listing datasets using
 advanced filtering with clear, unambiguous request schema and metadata cache control.
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Callable
 from datetime import datetime, timezone

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -76,9 +76,7 @@ SORTABLE_DATASET_COLUMNS = [
 DATASET_SEARCH_COLUMNS = ["schema", "sql", "table_name", "uuid"]
 
 
-def _attach_popularity_scores(
-    datasets: list[DatasetInfo], scores: dict[int, float]
-) -> None:
+def _attach_popularity_scores(datasets: list[Any], scores: dict[int, float]) -> None:
     """Attach popularity scores to serialized dataset objects in-place."""
     for ds in datasets:
         if ds.id is not None and ds.id in scores:

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -36,11 +36,6 @@ if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
 
 from superset.extensions import event_logger
-from superset.mcp_service.common.popularity import (
-    attach_popularity_scores,
-    compute_dataset_popularity,
-    get_popularity_sorted_ids,
-)
 from superset.mcp_service.dataset.schemas import (
     DatasetFilter,
     DatasetInfo,
@@ -50,7 +45,6 @@ from superset.mcp_service.dataset.schemas import (
 )
 from superset.mcp_service.mcp_core import ModelListCore
 from superset.mcp_service.system.schemas import PaginationInfo
-from superset.mcp_service.utils.schema_utils import parse_request
 
 logger = logging.getLogger(__name__)
 
@@ -120,9 +114,13 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
     )
 
     try:
-        # Avoid circular imports: DAO and schema_discovery depend on models
-        # that import from mcp_service during app initialization
+        # Avoid circular imports: DAO, schema_discovery, and popularity depend
+        # on models that import from mcp_service during app initialization
         from superset.daos.dataset import DatasetDAO
+        from superset.mcp_service.common.popularity import (
+            attach_popularity_scores,
+            compute_dataset_popularity,
+        )
         from superset.mcp_service.common.schema_discovery import (
             DATASET_SORTABLE_COLUMNS,
             get_all_column_names,
@@ -251,6 +249,11 @@ def _list_datasets_by_popularity(
     ctx: Context,
 ) -> DatasetList:
     """Two-pass listing: sort all matching datasets by popularity score."""
+    from superset.mcp_service.common.popularity import (
+        attach_popularity_scores,
+        compute_dataset_popularity,
+        get_popularity_sorted_ids,
+    )
     from superset.mcp_service.common.schema_discovery import DATASET_SORTABLE_COLUMNS
 
     sorted_ids, scores, total_count = get_popularity_sorted_ids(

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -22,9 +22,12 @@ This module contains the FastMCP tool for listing datasets using
 advanced filtering with clear, unambiguous request schema and metadata cache control.
 """
 
+from __future__ import annotations
+
 import logging
+from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
@@ -224,8 +227,8 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
 
 def _list_datasets_by_popularity(
     request: ListDatasetsRequest,
-    dao_class: type,
-    serializer: callable,
+    dao_class: Any,
+    serializer: Callable[..., dict[str, Any] | None],
     all_columns: list[str],
     ctx: Context,
 ) -> DatasetList:
@@ -251,10 +254,9 @@ def _list_datasets_by_popularity(
     page_size = request.page_size
     start = page * page_size
     end = start + page_size
-    page_ids = sorted_ids[start:end]
 
     # Fetch full models for page IDs
-    if page_ids:
+    if page_ids := sorted_ids[start:end]:
         items = dao_class.find_by_ids(page_ids)
         id_to_item = {item.id: item for item in items}
         ordered_items = [id_to_item[pid] for pid in page_ids if pid in id_to_item]

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -167,11 +167,16 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
                 logger=logger,
             )
 
+            # Strip computed fields before passing to DAO query
+            dao_columns = request.select_columns
+            if dao_columns:
+                dao_columns = [c for c in dao_columns if c != "popularity_score"]
+
             with event_logger.log_context(action="mcp.list_datasets.query"):
                 result = list_core.run_tool(
                     filters=request.filters,
                     search=request.search,
-                    select_columns=request.select_columns,
+                    select_columns=dao_columns,
                     order_column=request.order_column,
                     order_direction=request.order_direction,
                     page=max(request.page - 1, 0),

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -289,24 +289,26 @@ def _list_datasets_by_popularity(
     attach_popularity_scores(ds_objs, scores)
 
     total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 0
+    # Convert back to 1-based page for the response (request uses 1-based)
+    page_1based = page + 1
     pagination_info = PaginationInfo(
-        page=page,
+        page=page_1based,
         page_size=page_size,
         total_count=total_count,
         total_pages=total_pages,
-        has_next=page < total_pages - 1,
-        has_previous=page > 0,
+        has_next=page_1based < total_pages,
+        has_previous=page_1based > 1,
     )
 
     return DatasetList(
         datasets=ds_objs,
         count=len(ds_objs),
         total_count=total_count,
-        page=page,
+        page=page_1based,
         page_size=page_size,
         total_pages=total_pages,
-        has_previous=page > 0,
-        has_next=page < total_pages - 1,
+        has_previous=page_1based > 1,
+        has_next=page_1based < total_pages,
         columns_requested=columns_requested,
         columns_loaded=select_columns,
         columns_available=all_columns,

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -171,6 +171,13 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
             dao_columns = request.select_columns
             if dao_columns:
                 dao_columns = [c for c in dao_columns if c != "popularity_score"]
+                # Ensure id is loaded when popularity_score was requested
+                # (scores are keyed by id)
+                if (
+                    "popularity_score" in request.select_columns
+                    and "id" not in dao_columns
+                ):
+                    dao_columns = ["id"] + dao_columns
 
             with event_logger.log_context(action="mcp.list_datasets.query"):
                 result = list_core.run_tool(
@@ -200,6 +207,15 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
 
         # Apply field filtering via serialization context
         columns_to_filter = result.columns_requested
+        # Re-add popularity_score if it was originally requested
+        # (it was stripped before the DAO query since it's computed)
+        if (
+            request.select_columns
+            and "popularity_score" in request.select_columns
+            and columns_to_filter
+            and "popularity_score" not in columns_to_filter
+        ):
+            columns_to_filter = list(columns_to_filter) + ["popularity_score"]
         await ctx.debug(
             "Applying field filtering via serialization context: columns=%s"
             % (columns_to_filter,)

--- a/tests/unit_tests/mcp_service/common/test_popularity.py
+++ b/tests/unit_tests/mcp_service/common/test_popularity.py
@@ -366,6 +366,7 @@ class TestGetPopularitySortedIds:
         )
 
         assert sorted_ids == [2, 1]
+        assert scores == {1: 30.0, 2: 10.0}
         assert total == 2
 
     def test_empty_results(self):

--- a/tests/unit_tests/mcp_service/common/test_popularity.py
+++ b/tests/unit_tests/mcp_service/common/test_popularity.py
@@ -1,0 +1,386 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for the popularity scoring module.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from superset.mcp_service.common.popularity import (
+    _recency_bonus,
+    compute_chart_popularity,
+    compute_dashboard_popularity,
+    compute_dataset_popularity,
+    get_popularity_sorted_ids,
+)
+
+# Named tuples to simulate SQLAlchemy query results
+ViewRow = namedtuple("ViewRow", ["slice_id", "view_count"])
+DashViewRow = namedtuple("DashViewRow", ["dashboard_id", "view_count"])
+FavRow = namedtuple("FavRow", ["obj_id", "fav_count"])
+DashCountRow = namedtuple("DashCountRow", ["slice_id", "dash_count"])
+ChartCountRow = namedtuple("ChartCountRow", ["dashboard_id", "chart_count"])
+DatasetChartCountRow = namedtuple(
+    "DatasetChartCountRow", ["datasource_id", "chart_count"]
+)
+ChartMeta = namedtuple("ChartMeta", ["id", "certified_by", "changed_on"])
+DashMeta = namedtuple("DashMeta", ["id", "published", "certified_by", "changed_on"])
+DatasetMeta = namedtuple("DatasetMeta", ["id", "extra", "changed_on"])
+
+
+class TestRecencyBonus:
+    def test_within_7_days(self):
+        recent = datetime.now(timezone.utc) - timedelta(days=3)
+        assert _recency_bonus(recent) == 5.0
+
+    def test_within_30_days(self):
+        moderate = datetime.now(timezone.utc) - timedelta(days=15)
+        assert _recency_bonus(moderate) == 2.0
+
+    def test_older_than_30_days(self):
+        old = datetime.now(timezone.utc) - timedelta(days=60)
+        assert _recency_bonus(old) == 0.0
+
+    def test_none_changed_on(self):
+        assert _recency_bonus(None) == 0.0
+
+    def test_naive_datetime_treated_as_utc(self):
+        # Naive datetime (no tzinfo) should be treated as UTC
+        recent = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=3)
+        assert _recency_bonus(recent) == 5.0
+
+
+class TestComputeChartPopularity:
+    def test_empty_ids_returns_empty(self):
+        assert compute_chart_popularity([]) == {}
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_chart_scoring_formula(self, mock_db):
+        """Test: view_count*3 + fav_count*5 + dash_count*2 + certified*10 + recency"""
+        recent = datetime.now(timezone.utc) - timedelta(days=2)  # +5 recency
+
+        # Setup mock query chain
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        # Each db.session.query() call returns a different chain
+        query_chains = [
+            # 1. View counts query
+            self._mock_query_chain([ViewRow(slice_id=1, view_count=10)]),
+            # 2. Fav counts query
+            self._mock_query_chain([FavRow(obj_id=1, fav_count=3)]),
+            # 3. Dashboard counts query
+            self._mock_query_chain([DashCountRow(slice_id=1, dash_count=4)]),
+            # 4. Chart metadata query
+            self._mock_query_chain(
+                [ChartMeta(id=1, certified_by="admin", changed_on=recent)]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_chart_popularity([1])
+
+        # views: 10*3=30, favs: 3*5=15, dashes: 4*2=8, certified: 10, recency: 5
+        expected = 30 + 15 + 8 + 10 + 5
+        assert scores[1] == expected
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_chart_no_activity_only_recency(self, mock_db):
+        """Chart with no views/favs/dashboards gets only recency + certification."""
+        old = datetime.now(timezone.utc) - timedelta(days=60)  # 0 recency
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        query_chains = [
+            self._mock_query_chain([]),  # No views
+            self._mock_query_chain([]),  # No favs
+            self._mock_query_chain([]),  # No dashboards
+            self._mock_query_chain(
+                [ChartMeta(id=1, certified_by=None, changed_on=old)]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_chart_popularity([1])
+        assert scores[1] == 0.0
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_multiple_charts(self, mock_db):
+        """Multiple charts scored independently."""
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        old = datetime.now(timezone.utc) - timedelta(days=60)
+
+        query_chains = [
+            # Views
+            self._mock_query_chain(
+                [
+                    ViewRow(slice_id=1, view_count=5),
+                    ViewRow(slice_id=2, view_count=20),
+                ]
+            ),
+            # Favs
+            self._mock_query_chain([FavRow(obj_id=2, fav_count=2)]),
+            # Dashboard counts
+            self._mock_query_chain([]),
+            # Metadata
+            self._mock_query_chain(
+                [
+                    ChartMeta(id=1, certified_by=None, changed_on=old),
+                    ChartMeta(id=2, certified_by=None, changed_on=old),
+                ]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_chart_popularity([1, 2])
+
+        # Chart 1: views=5*3=15
+        assert scores[1] == 15.0
+        # Chart 2: views=20*3=60, favs=2*5=10
+        assert scores[2] == 70.0
+
+    def _mock_query_chain(self, results):
+        """Create a mock query chain that returns results at the end."""
+        chain = MagicMock()
+        chain.filter.return_value = chain
+        chain.group_by.return_value = chain
+        chain.all.return_value = results
+        return chain
+
+
+class TestComputeDashboardPopularity:
+    def test_empty_ids_returns_empty(self):
+        assert compute_dashboard_popularity([]) == {}
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_dashboard_scoring_formula(self, mock_db):
+        """Test: view_count*3 + fav_count*5 + chart_count*1 + published*3
+        + certified*10 + recency"""
+        recent = datetime.now(timezone.utc) - timedelta(days=2)  # +5 recency
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        query_chains = [
+            # Views
+            self._mock_query_chain([DashViewRow(dashboard_id=1, view_count=8)]),
+            # Favs
+            self._mock_query_chain([FavRow(obj_id=1, fav_count=2)]),
+            # Chart counts
+            self._mock_query_chain([ChartCountRow(dashboard_id=1, chart_count=5)]),
+            # Metadata
+            self._mock_query_chain(
+                [
+                    DashMeta(
+                        id=1, published=True, certified_by="admin", changed_on=recent
+                    )
+                ]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_dashboard_popularity([1])
+
+        # views=8*3=24, favs=2*5=10, charts=5*1=5, published=3,
+        # certified=10, recency=5
+        expected = 24 + 10 + 5 + 3 + 10 + 5
+        assert scores[1] == expected
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_unpublished_no_certification(self, mock_db):
+        """Dashboard that is not published and not certified."""
+        old = datetime.now(timezone.utc) - timedelta(days=60)
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        query_chains = [
+            self._mock_query_chain([]),  # No views
+            self._mock_query_chain([]),  # No favs
+            self._mock_query_chain([]),  # No charts
+            self._mock_query_chain(
+                [DashMeta(id=1, published=False, certified_by=None, changed_on=old)]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_dashboard_popularity([1])
+        assert scores[1] == 0.0
+
+    def _mock_query_chain(self, results):
+        chain = MagicMock()
+        chain.filter.return_value = chain
+        chain.group_by.return_value = chain
+        chain.all.return_value = results
+        return chain
+
+
+class TestComputeDatasetPopularity:
+    def test_empty_ids_returns_empty(self):
+        assert compute_dataset_popularity([]) == {}
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_dataset_scoring_formula(self, mock_db):
+        """Test: chart_count*3 + certified*10 + recency"""
+        recent = datetime.now(timezone.utc) - timedelta(days=2)  # +5 recency
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        query_chains = [
+            # Chart counts
+            self._mock_query_chain(
+                [DatasetChartCountRow(datasource_id=1, chart_count=7)]
+            ),
+            # Metadata
+            self._mock_query_chain(
+                [
+                    DatasetMeta(
+                        id=1,
+                        extra='{"certification": {"certified_by": "admin"}}',
+                        changed_on=recent,
+                    )
+                ]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_dataset_popularity([1])
+
+        # charts=7*3=21, certified=10, recency=5
+        expected = 21 + 10 + 5
+        assert scores[1] == expected
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_dataset_no_certification(self, mock_db):
+        """Dataset with empty extra JSON is not certified."""
+        old = datetime.now(timezone.utc) - timedelta(days=60)
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        query_chains = [
+            self._mock_query_chain([]),
+            self._mock_query_chain([DatasetMeta(id=1, extra="{}", changed_on=old)]),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_dataset_popularity([1])
+        assert scores[1] == 0.0
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_dataset_invalid_extra_json(self, mock_db):
+        """Dataset with invalid extra JSON doesn't crash."""
+        old = datetime.now(timezone.utc) - timedelta(days=60)
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        query_chains = [
+            self._mock_query_chain([]),
+            self._mock_query_chain(
+                [DatasetMeta(id=1, extra="not valid json", changed_on=old)]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_dataset_popularity([1])
+        assert scores[1] == 0.0
+
+    def _mock_query_chain(self, results):
+        chain = MagicMock()
+        chain.filter.return_value = chain
+        chain.group_by.return_value = chain
+        chain.all.return_value = results
+        return chain
+
+
+class TestGetPopularitySortedIds:
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_sorts_by_score_desc(self, mock_db):
+        """IDs are returned sorted by score in descending order."""
+        mock_dao = MagicMock()
+        # Return 3 items with IDs 1, 2, 3
+        item1 = MagicMock(id=1)
+        item2 = MagicMock(id=2)
+        item3 = MagicMock(id=3)
+        mock_dao.list.return_value = ([item1, item2, item3], 3)
+
+        # Mock compute function: item 2 has highest score
+        def mock_compute(ids, days=30):
+            return {1: 10.0, 2: 50.0, 3: 25.0}
+
+        sorted_ids, scores, total = get_popularity_sorted_ids(
+            compute_fn=mock_compute,
+            dao_class=mock_dao,
+            filters=None,
+            search=None,
+            search_columns=["name"],
+            order_direction="desc",
+        )
+
+        assert sorted_ids == [2, 3, 1]
+        assert total == 3
+        assert scores == {1: 10.0, 2: 50.0, 3: 25.0}
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_sorts_by_score_asc(self, mock_db):
+        """IDs are returned sorted by score in ascending order."""
+        mock_dao = MagicMock()
+        item1 = MagicMock(id=1)
+        item2 = MagicMock(id=2)
+        mock_dao.list.return_value = ([item1, item2], 2)
+
+        def mock_compute(ids, days=30):
+            return {1: 30.0, 2: 10.0}
+
+        sorted_ids, scores, total = get_popularity_sorted_ids(
+            compute_fn=mock_compute,
+            dao_class=mock_dao,
+            filters=None,
+            search=None,
+            search_columns=["name"],
+            order_direction="asc",
+        )
+
+        assert sorted_ids == [2, 1]
+        assert total == 2
+
+    def test_empty_results(self):
+        """Empty result set returns empty list."""
+        mock_dao = MagicMock()
+        mock_dao.list.return_value = ([], 0)
+
+        sorted_ids, scores, total = get_popularity_sorted_ids(
+            compute_fn=lambda ids, days=30: {},
+            dao_class=mock_dao,
+            filters=None,
+            search=None,
+            search_columns=["name"],
+        )
+
+        assert sorted_ids == []
+        assert scores == {}
+        assert total == 0

--- a/tests/unit_tests/mcp_service/common/test_popularity.py
+++ b/tests/unit_tests/mcp_service/common/test_popularity.py
@@ -385,3 +385,103 @@ class TestGetPopularitySortedIds:
         assert sorted_ids == []
         assert scores == {}
         assert total == 0
+
+
+class TestLogsTableDegradation:
+    """Tests for graceful degradation when the logs table is empty or inaccessible."""
+
+    def _mock_query_chain(self, results):
+        chain = MagicMock()
+        chain.filter.return_value = chain
+        chain.group_by.return_value = chain
+        chain.all.return_value = results
+        return chain
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_chart_scoring_without_view_data(self, mock_db):
+        """Charts still score on favs, dashboard count, certification, and recency
+        when the logs table returns no view data (e.g. Preset production)."""
+        recent = datetime.now(timezone.utc) - timedelta(days=2)  # +5 recency
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        query_chains = [
+            self._mock_query_chain([]),  # No views (empty logs table)
+            self._mock_query_chain([FavRow(obj_id=1, fav_count=3)]),
+            self._mock_query_chain([DashCountRow(slice_id=1, dash_count=4)]),
+            self._mock_query_chain(
+                [ChartMeta(id=1, certified_by="admin", changed_on=recent)]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_chart_popularity([1])
+
+        # No views, favs: 3*5=15, dashes: 4*2=8, certified: 10, recency: 5
+        assert scores[1] == 15 + 8 + 10 + 5
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_chart_scoring_when_logs_query_raises(self, mock_db):
+        """Charts still score when the logs table query raises SQLAlchemyError."""
+        import sqlalchemy as sa
+
+        recent = datetime.now(timezone.utc) - timedelta(days=2)
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        # First query (views) raises, remaining queries succeed
+        error_chain = MagicMock()
+        error_chain.filter.return_value = error_chain
+        error_chain.group_by.return_value = error_chain
+        error_chain.all.side_effect = sa.exc.OperationalError(
+            "SELECT", {}, Exception("logs table does not exist")
+        )
+
+        query_chains = [
+            error_chain,  # Views query fails
+            self._mock_query_chain([FavRow(obj_id=1, fav_count=2)]),
+            self._mock_query_chain([DashCountRow(slice_id=1, dash_count=1)]),
+            self._mock_query_chain(
+                [ChartMeta(id=1, certified_by=None, changed_on=recent)]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_chart_popularity([1])
+
+        # No views (error), favs: 2*5=10, dashes: 1*2=2, no cert, recency: 5
+        assert scores[1] == 10 + 2 + 5
+
+    @patch("superset.mcp_service.common.popularity.db")
+    def test_dashboard_scoring_when_logs_query_raises(self, mock_db):
+        """Dashboards still score when the logs table query raises."""
+        import sqlalchemy as sa
+
+        old = datetime.now(timezone.utc) - timedelta(days=60)
+
+        mock_session = MagicMock()
+        mock_db.session = mock_session
+
+        error_chain = MagicMock()
+        error_chain.filter.return_value = error_chain
+        error_chain.group_by.return_value = error_chain
+        error_chain.all.side_effect = sa.exc.OperationalError(
+            "SELECT", {}, Exception("logs table does not exist")
+        )
+
+        query_chains = [
+            error_chain,  # Views query fails
+            self._mock_query_chain([FavRow(obj_id=1, fav_count=4)]),
+            self._mock_query_chain([ChartCountRow(dashboard_id=1, chart_count=3)]),
+            self._mock_query_chain(
+                [DashMeta(id=1, published=True, certified_by="admin", changed_on=old)]
+            ),
+        ]
+        mock_session.query.side_effect = query_chains
+
+        scores = compute_dashboard_popularity([1])
+
+        # No views, favs: 4*5=20, charts: 3*1=3, published: 3, certified: 10
+        assert scores[1] == 20 + 3 + 3 + 10

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -613,10 +613,11 @@ class TestDashboardSortableColumns:
 
     def test_dashboard_sortable_columns_definition(self):
         """Test that dashboard sortable columns are properly defined."""
-        from superset.mcp_service.dashboard.tool.list_dashboards import (
-            SORTABLE_DASHBOARD_COLUMNS,
+        from superset.mcp_service.common.schema_discovery import (
+            DASHBOARD_SORTABLE_COLUMNS,
         )
 
+        SORTABLE_DASHBOARD_COLUMNS = DASHBOARD_SORTABLE_COLUMNS
         assert SORTABLE_DASHBOARD_COLUMNS == [
             "id",
             "dashboard_title",
@@ -658,10 +659,14 @@ class TestDashboardSortableColumns:
 
     def test_sortable_columns_in_docstring(self):
         """Test that sortable columns are documented in tool docstring."""
+        from superset.mcp_service.common.schema_discovery import (
+            DASHBOARD_SORTABLE_COLUMNS,
+        )
         from superset.mcp_service.dashboard.tool.list_dashboards import (
             list_dashboards,
-            SORTABLE_DASHBOARD_COLUMNS,
         )
+
+        SORTABLE_DASHBOARD_COLUMNS = DASHBOARD_SORTABLE_COLUMNS
 
         # Check list_dashboards docstring for sortable columns documentation
         assert list_dashboards.__doc__ is not None

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -624,6 +624,7 @@ class TestDashboardSortableColumns:
             "published",
             "changed_on",
             "created_on",
+            "popularity_score",
         ]
         # Ensure no computed properties are included
         assert "changed_on_delta_humanized" not in SORTABLE_DASHBOARD_COLUMNS

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -617,8 +617,8 @@ class TestDashboardSortableColumns:
             DASHBOARD_SORTABLE_COLUMNS,
         )
 
-        SORTABLE_DASHBOARD_COLUMNS = DASHBOARD_SORTABLE_COLUMNS
-        assert SORTABLE_DASHBOARD_COLUMNS == [
+        sortable_dashboard_columns = DASHBOARD_SORTABLE_COLUMNS
+        assert sortable_dashboard_columns == [
             "id",
             "dashboard_title",
             "slug",
@@ -628,9 +628,9 @@ class TestDashboardSortableColumns:
             "popularity_score",
         ]
         # Ensure no computed properties are included
-        assert "changed_on_delta_humanized" not in SORTABLE_DASHBOARD_COLUMNS
-        assert "changed_by_name" not in SORTABLE_DASHBOARD_COLUMNS
-        assert "uuid" not in SORTABLE_DASHBOARD_COLUMNS
+        assert "changed_on_delta_humanized" not in sortable_dashboard_columns
+        assert "changed_by_name" not in sortable_dashboard_columns
+        assert "uuid" not in sortable_dashboard_columns
 
     @patch("superset.daos.dashboard.DashboardDAO.list")
     @pytest.mark.asyncio
@@ -666,10 +666,10 @@ class TestDashboardSortableColumns:
             list_dashboards,
         )
 
-        SORTABLE_DASHBOARD_COLUMNS = DASHBOARD_SORTABLE_COLUMNS
+        sortable_dashboard_columns = DASHBOARD_SORTABLE_COLUMNS
 
         # Check list_dashboards docstring for sortable columns documentation
         assert list_dashboards.__doc__ is not None
         assert "Sortable columns for order_column:" in list_dashboards.__doc__
-        for col in SORTABLE_DASHBOARD_COLUMNS:
+        for col in sortable_dashboard_columns:
             assert col in list_dashboards.__doc__

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -1425,10 +1425,11 @@ class TestDatasetSortableColumns:
 
     def test_dataset_sortable_columns_definition(self):
         """Test that dataset sortable columns are properly defined."""
-        from superset.mcp_service.dataset.tool.list_datasets import (
-            SORTABLE_DATASET_COLUMNS,
+        from superset.mcp_service.common.schema_discovery import (
+            DATASET_SORTABLE_COLUMNS,
         )
 
+        SORTABLE_DATASET_COLUMNS = DATASET_SORTABLE_COLUMNS
         assert SORTABLE_DATASET_COLUMNS == [
             "id",
             "table_name",
@@ -1473,10 +1474,14 @@ class TestDatasetSortableColumns:
 
     def test_sortable_columns_in_docstring(self):
         """Test that sortable columns are documented in tool docstring."""
+        from superset.mcp_service.common.schema_discovery import (
+            DATASET_SORTABLE_COLUMNS,
+        )
         from superset.mcp_service.dataset.tool.list_datasets import (
             list_datasets,
-            SORTABLE_DATASET_COLUMNS,
         )
+
+        SORTABLE_DATASET_COLUMNS = DATASET_SORTABLE_COLUMNS
 
         # Check list_datasets docstring for sortable columns documentation
         assert list_datasets.__doc__ is not None

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -1429,8 +1429,8 @@ class TestDatasetSortableColumns:
             DATASET_SORTABLE_COLUMNS,
         )
 
-        SORTABLE_DATASET_COLUMNS = DATASET_SORTABLE_COLUMNS
-        assert SORTABLE_DATASET_COLUMNS == [
+        sortable_dataset_columns = DATASET_SORTABLE_COLUMNS
+        assert sortable_dataset_columns == [
             "id",
             "table_name",
             "schema",
@@ -1439,10 +1439,10 @@ class TestDatasetSortableColumns:
             "popularity_score",
         ]
         # Ensure no computed properties are included
-        assert "changed_on_delta_humanized" not in SORTABLE_DATASET_COLUMNS
-        assert "changed_by_name" not in SORTABLE_DATASET_COLUMNS
-        assert "database_name" not in SORTABLE_DATASET_COLUMNS
-        assert "uuid" not in SORTABLE_DATASET_COLUMNS
+        assert "changed_on_delta_humanized" not in sortable_dataset_columns
+        assert "changed_by_name" not in sortable_dataset_columns
+        assert "database_name" not in sortable_dataset_columns
+        assert "uuid" not in sortable_dataset_columns
 
     @patch("superset.daos.dataset.DatasetDAO.list")
     @pytest.mark.asyncio
@@ -1481,12 +1481,12 @@ class TestDatasetSortableColumns:
             list_datasets,
         )
 
-        SORTABLE_DATASET_COLUMNS = DATASET_SORTABLE_COLUMNS
+        sortable_dataset_columns = DATASET_SORTABLE_COLUMNS
 
         # Check list_datasets docstring for sortable columns documentation
         assert list_datasets.__doc__ is not None
         assert "Sortable columns for order_column:" in list_datasets.__doc__
-        for col in SORTABLE_DATASET_COLUMNS:
+        for col in sortable_dataset_columns:
             assert col in list_datasets.__doc__
 
     @patch("superset.daos.dataset.DatasetDAO.list")

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -1435,6 +1435,7 @@ class TestDatasetSortableColumns:
             "schema",
             "changed_on",
             "created_on",
+            "popularity_score",
         ]
         # Ensure no computed properties are included
         assert "changed_on_delta_humanized" not in SORTABLE_DATASET_COLUMNS

--- a/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
@@ -235,6 +235,7 @@ class TestGetSchemaToolViaClient:
 
             # Check search columns match list_datasets actual search columns
             assert "table_name" in info["search_columns"]
+            assert "description" in info["search_columns"]
             assert "schema" in info["search_columns"]
             assert "sql" in info["search_columns"]
             assert "uuid" in info["search_columns"]

--- a/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
@@ -233,9 +233,11 @@ class TestGetSchemaToolViaClient:
             required_columns = {"id", "table_name", "schema", "changed_on_humanized"}
             assert required_columns.issubset(set(info["default_select"]))
 
-            # Check search columns
+            # Check search columns match list_datasets actual search columns
             assert "table_name" in info["search_columns"]
-            assert "description" in info["search_columns"]
+            assert "schema" in info["search_columns"]
+            assert "sql" in info["search_columns"]
+            assert "uuid" in info["search_columns"]
 
     @patch("superset.daos.dashboard.DashboardDAO.get_filterable_columns_and_operators")
     @pytest.mark.asyncio


### PR DESCRIPTION
## **User description**
## Summary

Adds a `popularity_score` computed field to all three MCP list tools (charts, dashboards, datasets) so MCP clients can rank results by relevance.

- Scores are computed **lazily** — only when requested via `select_columns` or `order_column`
- Supports sorting via `order_column="popularity_score"` using a two-pass approach (fetch IDs → score → sort → paginate → fetch full models)
- No performance impact on normal list calls that don't request the field

### Scoring Formulas

| Asset | Formula |
|-------|---------|
| **Charts** | `view_count_30d * 3 + fav_count * 5 + dashboard_count * 2 + is_certified * 10 + recency_bonus` |
| **Dashboards** | `view_count_30d * 3 + fav_count * 5 + chart_count * 1 + is_published * 3 + is_certified * 10 + recency_bonus` |
| **Datasets** | `chart_count * 3 + is_certified * 10 + recency_bonus` |

Recency bonus: +5 if modified in last 7 days, +2 if last 30 days, +0 otherwise.

### Files Changed

- **New:** `superset/mcp_service/common/popularity.py` — core scoring module
- **New:** `tests/unit_tests/mcp_service/common/test_popularity.py` — 19 unit tests
- **Modified:** Chart/Dashboard/Dataset schemas — added `popularity_score` field
- **Modified:** `schema_discovery.py` — added popularity_score to sortable/extra columns
- **Modified:** List tool files — handle popularity sorting and selection

## Test plan

- [x] 19 unit tests covering scoring formulas, recency bonus, two-pass sorting, and edge cases
- [ ] Manual verification via MCP: `list_charts(select_columns=["id", "slice_name", "popularity_score"])`
- [ ] Manual verification via MCP: `list_charts(order_column="popularity_score", order_direction="desc")`

## MCP Testing Results (localhost, 2026-03-13)

Comprehensive testing via localhost MCP tools on branch `feat/mcp-popularity-score`:

### Unit Tests
- PR-specific tests: **65/65 passed** (`test_popularity.py`, `test_dashboard_tools.py`, `test_dataset_tools.py`)
- Full MCP test suite: **814/814 passed** (0 failures)

### Live MCP Tool Testing
- `health_check` → healthy
- `list_charts` → charts listed with pagination working
- `list_dashboards` → 18 dashboards with correct pagination
- `list_datasets` → 42 datasets listed
- `execute_sql` → SQL query on birth_names returned 250 rows correctly
- `generate_chart` (pie chart by gender) → chart preview with explore URL generated
- All chart types working correctly via generate_chart and generate_explore_link

## MCP Tool Testing Results (2026-03-13)

Tested against local Superset MCP service (port 5008) with all tools passing.

### health_check
- **Request**: `health_check()` (no params)
- **Response**: `{"status": "healthy", "service": "Superset OSS MCP Service", "version": "0.0.0-dev", "python_version": "3.12.11"}`

### get_instance_info
- **Request**: `get_instance_info({})`
- **Response**: Admin user (id=1), 18 dashboards, 109 charts, 42 datasets, 1 database (postgresql). `current_user` properly serialized with roles `["Admin"]`. `feature_availability.accessible_menus` returns 25 menu items.

### list_charts
- **Request**: `list_charts({"page": 1, "page_size": 3, "order_column": "changed_on", "order_direction": "desc"})`
- **Response**: 3 charts returned, total_count=109, pagination working correctly.

### list_dashboards
- **Request**: `list_dashboards({"page": 1, "page_size": 3, "order_column": "changed_on", "order_direction": "desc"})`
- **Response**: 3 dashboards returned, total_count=18, pagination working correctly.

### list_datasets
- **Request**: `list_datasets({"page": 1, "page_size": 3})`
- **Response**: 3 datasets returned, total_count=42, pagination working correctly.

### execute_sql
- **Request**: `execute_sql({"database_id": 1, "sql": "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' LIMIT 5"})`
- **Response**: 5 rows returned in 36ms, execution successful.

### get_chart_info
- **Request**: `get_chart_info({"identifier": 107})`
- **Response**: Chart "Sum(Revenue) by Region" (echarts_timeseries_bar), with full metadata including owners with roles.


___

## **CodeAnt-AI Description**
**Add popularity scores and ranking to MCP charts, dashboards, and datasets**

### What Changed
- Chart, dashboard, and dataset lists can now return a `popularity_score` and sort results by it.
- When sorting by popularity, results are ordered by a score that reflects views, favorites, related usage, certification, published status, and recent updates.
- `popularity_score` can also be requested as part of the returned fields, and dataset detail responses now include it as well.
- Dataset search now matches more useful fields, including schema, SQL, and UUID.
- Tests were updated to cover the new score behavior, sorting, and schema expectations.

### Impact
`✅ Faster relevance ranking in MCP search results`
`✅ Easier discovery of frequently used charts, dashboards, and datasets`
`✅ Clearer dataset details with popularity scores`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
