### PR TITLE
fix(i18n): preserve locale territory in bootstrap data

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -477,7 +477,13 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
     )
 
     if isinstance(locale, Locale):
-        language = locale.language
+        # Use language + territory to support locales like zh_TW.
+        # locale.language alone strips the territory (e.g. zh_TW → zh).
+        language = (
+            f"{locale.language}_{locale.territory}"
+            if locale.territory
+            else locale.language
+        )
     elif isinstance(locale, str):
         language = locale
     else:


### PR DESCRIPTION
### SUMMARY

`locale.language` strips the territory component from locale identifiers (e.g. `zh_TW` → `zh`), causing the frontend to receive `zh` instead of `zh_TW`. This makes locale-specific translations like Traditional Chinese (`zh_TW`) fall back to Simplified Chinese (`zh`).

This fix includes the territory when available, so the frontend receives the full locale tag (e.g. `zh_TW`, `pt_BR`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** `locale = zh_TW` → frontend receives `language: "zh"` → wrong translations
**After:** `locale = zh_TW` → frontend receives `language: "zh_TW"` → correct translations

### TESTING INSTRUCTIONS

1. Set `BABEL_DEFAULT_LOCALE = "zh_TW"` in `superset_config.py` (or another territory-specific locale like `pt_BR`)
2. Restart Superset and load any page
3. Verify the frontend bootstrap data contains `"language": "zh_TW"` (not `"zh"`)
4. Confirm that locale-specific translations are correctly applied

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API