### PR TITLE
chore(playwright): Using warning for timeouts

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -303,7 +303,7 @@ class WebDriverPlaywright(WebDriverProxy):
                     for loading_element in page.locator(".loading").all():
                         loading_element.wait_for(state="detached")
                 except PlaywrightTimeout:
-                    logger.exception(
+                    logger.warning(
                         "Timed out waiting for charts to load at url %s", url
                     )
                     raise


### PR DESCRIPTION
### SUMMARY

Playwright should use the same log level as selenium does for timeouts, this way we reduce noisy traces marked as errors too.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
