### PR TITLE
feat(auth): forward Superset login OAuth token to database connections

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -2101,11 +2101,11 @@ DATABASE_OAUTH2_JWT_ALGORITHM = "HS256"
 # by looking at the `default_redirect_uri` attribute in the OAuth2 state object.
 # DATABASE_OAUTH2_REDIRECT_URI = "http://localhost:8088/api/v1/database/oauth2/"
 
-# Map db_engine_spec engine names to OAUTH_PROVIDERS names.
-# For databases with matching engine names, the upstream login token will be used
+# Map Superset database_name values to OAUTH_PROVIDERS names.
+# For databases with a matching database_name, the upstream login token will be used
 # instead of triggering a separate database OAuth2 flow.
 # Requires `save_token: True` to be set in the corresponding OAUTH_PROVIDERS entry.
-# Example: {"trino": "my_keycloak_provider"}
+# Example: {"staging": "my_keycloak_provider"}
 DATABASE_OAUTH2_UPSTREAM_PROVIDERS: dict[str, str] = {}
 
 # Timeout when fetching access and refresh tokens.

--- a/superset/config.py
+++ b/superset/config.py
@@ -2101,6 +2101,13 @@ DATABASE_OAUTH2_JWT_ALGORITHM = "HS256"
 # by looking at the `default_redirect_uri` attribute in the OAuth2 state object.
 # DATABASE_OAUTH2_REDIRECT_URI = "http://localhost:8088/api/v1/database/oauth2/"
 
+# Map db_engine_spec engine names to OAUTH_PROVIDERS names.
+# For databases with matching engine names, the upstream login token will be used
+# instead of triggering a separate database OAuth2 flow.
+# Requires `save_token: True` to be set in the corresponding OAUTH_PROVIDERS entry.
+# Example: {"trino": "my_keycloak_provider"}
+DATABASE_OAUTH2_UPSTREAM_PROVIDERS: dict[str, str] = {}
+
 # Timeout when fetching access and refresh tokens.
 DATABASE_OAUTH2_TIMEOUT = timedelta(seconds=30)
 

--- a/superset/daos/database.py
+++ b/superset/daos/database.py
@@ -28,7 +28,7 @@ from superset.daos.base import BaseDAO
 from superset.databases.filters import DatabaseFilter
 from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.extensions import db
-from superset.models.core import Database, DatabaseUserOAuth2Tokens, UserAuthToken
+from superset.models.core import Database, DatabaseUserOAuth2Tokens, UpstreamOAuthToken
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.models.sql_lab import TabState
@@ -261,7 +261,7 @@ class DatabaseUserOAuth2TokensDAO(BaseDAO[DatabaseUserOAuth2Tokens]):
         return db.session.query(Database).filter_by(id=database_id).one_or_none()
 
 
-class UserAuthTokenDAO(BaseDAO[UserAuthToken]):
+class UpstreamOAuthTokenDAO(BaseDAO[UpstreamOAuthToken]):
     """
     DAO for upstream provider OAuth tokens.
     """
@@ -269,9 +269,9 @@ class UserAuthTokenDAO(BaseDAO[UserAuthToken]):
     @classmethod
     def find_by_user_provider(
         cls, user_id: int, provider: str
-    ) -> UserAuthToken | None:
+    ) -> UpstreamOAuthToken | None:
         return (
-            db.session.query(UserAuthToken)
+            db.session.query(UpstreamOAuthToken)
             .filter_by(user_id=user_id, provider=provider)
             .one_or_none()
         )

--- a/superset/daos/database.py
+++ b/superset/daos/database.py
@@ -28,7 +28,7 @@ from superset.daos.base import BaseDAO
 from superset.databases.filters import DatabaseFilter
 from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.extensions import db
-from superset.models.core import Database, DatabaseUserOAuth2Tokens
+from superset.models.core import Database, DatabaseUserOAuth2Tokens, UserAuthToken
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.models.sql_lab import TabState
@@ -259,3 +259,19 @@ class DatabaseUserOAuth2TokensDAO(BaseDAO[DatabaseUserOAuth2Tokens]):
         database access (which is necessary for OAuth2).
         """
         return db.session.query(Database).filter_by(id=database_id).one_or_none()
+
+
+class UserAuthTokenDAO(BaseDAO[UserAuthToken]):
+    """
+    DAO for upstream provider OAuth tokens.
+    """
+
+    @classmethod
+    def find_by_user_provider(
+        cls, user_id: int, provider: str
+    ) -> UserAuthToken | None:
+        return (
+            db.session.query(UserAuthToken)
+            .filter_by(user_id=user_id, provider=provider)
+            .one_or_none()
+        )

--- a/superset/migrations/versions/2026-03-05_10-00_a1b2c3d4e5f6_add_user_auth_tokens.py
+++ b/superset/migrations/versions/2026-03-05_10-00_a1b2c3d4e5f6_add_user_auth_tokens.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""add_user_auth_tokens
+"""add_upstream_oauth_tokens
 
 Revision ID: a1b2c3d4e5f6
 Revises: f5b5f88d8526
@@ -34,7 +34,7 @@ down_revision = "f5b5f88d8526"
 
 def upgrade() -> None:
     op.create_table(
-        "user_auth_tokens",
+        "upstream_oauth_tokens",
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column(
             "user_id",
@@ -52,12 +52,14 @@ def upgrade() -> None:
         sa.Column("changed_by_fk", sa.Integer, nullable=True),
     )
     op.create_index(
-        "idx_user_auth_tokens_user_provider",
-        "user_auth_tokens",
+        "idx_upstream_oauth_tokens_user_provider",
+        "upstream_oauth_tokens",
         ["user_id", "provider"],
     )
 
 
 def downgrade() -> None:
-    op.drop_index("idx_user_auth_tokens_user_provider", table_name="user_auth_tokens")
-    op.drop_table("user_auth_tokens")
+    op.drop_index(
+        "idx_upstream_oauth_tokens_user_provider", table_name="upstream_oauth_tokens"
+    )
+    op.drop_table("upstream_oauth_tokens")

--- a/superset/migrations/versions/2026-03-05_10-00_a1b2c3d4e5f6_add_user_auth_tokens.py
+++ b/superset/migrations/versions/2026-03-05_10-00_a1b2c3d4e5f6_add_user_auth_tokens.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_user_auth_tokens
+
+Revision ID: a1b2c3d4e5f6
+Revises: f5b5f88d8526
+Create Date: 2026-03-05 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from superset.migrations.shared.utils import add_column_if_not_exists
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "f5b5f88d8526"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_auth_tokens",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("ab_user.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("provider", sa.String(256), nullable=False),
+        sa.Column("access_token", sa.Text, nullable=True),
+        sa.Column("access_token_expiration", sa.DateTime, nullable=True),
+        sa.Column("refresh_token", sa.Text, nullable=True),
+        sa.Column("created_on", sa.DateTime, nullable=True),
+        sa.Column("changed_on", sa.DateTime, nullable=True),
+        sa.Column("created_by_fk", sa.Integer, nullable=True),
+        sa.Column("changed_by_fk", sa.Integer, nullable=True),
+    )
+    op.create_index(
+        "idx_user_auth_tokens_user_provider",
+        "user_auth_tokens",
+        ["user_id", "provider"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_auth_tokens_user_provider", table_name="user_auth_tokens")
+    op.drop_table("user_auth_tokens")

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1367,14 +1367,14 @@ class DatabaseUserOAuth2Tokens(Model, AuditMixinNullable):
     refresh_token = Column(encrypted_field_factory.create(Text), nullable=True)
 
 
-class UserAuthToken(Model, AuditMixinNullable):
+class UpstreamOAuthToken(Model, AuditMixinNullable):
     """
     Store OAuth tokens from the Superset login provider, for forwarding to databases.
     """
 
-    __tablename__ = "user_auth_tokens"
+    __tablename__ = "upstream_oauth_tokens"
     __table_args__ = (
-        sqla.Index("idx_user_auth_tokens_user_provider", "user_id", "provider"),
+        sqla.Index("idx_upstream_oauth_tokens_user_provider", "user_id", "provider"),
     )
 
     id = Column(Integer, primary_key=True)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -512,7 +512,7 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
 
         upstream_provider = app.config.get(
             "DATABASE_OAUTH2_UPSTREAM_PROVIDERS", {}
-        ).get(self.db_engine_spec.engine_name)
+        ).get(self.database_name)
         if upstream_provider and hasattr(g, "user") and hasattr(g.user, "id"):
             access_token = get_upstream_provider_token(upstream_provider, g.user.id)
         else:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -88,6 +88,7 @@ from superset.utils.core import get_query_source_from_request, get_username
 from superset.utils.oauth2 import (
     check_for_oauth2,
     get_oauth2_access_token,
+    get_upstream_provider_token,
     OAuth2ClientConfigSchema,
 )
 
@@ -509,17 +510,23 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             if user and user.email:
                 effective_username = user.email.split("@")[0]
 
-        oauth2_config = self.get_oauth2_config()
-        access_token = (
-            get_oauth2_access_token(
-                oauth2_config,
-                self.id,
-                g.user.id,
-                self.db_engine_spec,
+        upstream_provider = app.config.get(
+            "DATABASE_OAUTH2_UPSTREAM_PROVIDERS", {}
+        ).get(self.db_engine_spec.engine_name)
+        if upstream_provider and hasattr(g, "user") and hasattr(g.user, "id"):
+            access_token = get_upstream_provider_token(upstream_provider, g.user.id)
+        else:
+            oauth2_config = self.get_oauth2_config()
+            access_token = (
+                get_oauth2_access_token(
+                    oauth2_config,
+                    self.id,
+                    g.user.id,
+                    self.db_engine_spec,
+                )
+                if oauth2_config and hasattr(g, "user") and hasattr(g.user, "id")
+                else None
             )
-            if oauth2_config and hasattr(g, "user") and hasattr(g.user, "id")
-            else None
-        )
         masked_url = self.get_password_masked_url(sqlalchemy_url)
         logger.debug("Database._get_sqla_engine(). Masked URL: %s", str(masked_url))
 
@@ -1355,6 +1362,29 @@ class DatabaseUserOAuth2Tokens(Model, AuditMixinNullable):
     )
     database = relationship("Database", foreign_keys=[database_id])
 
+    access_token = Column(encrypted_field_factory.create(Text), nullable=True)
+    access_token_expiration = Column(DateTime, nullable=True)
+    refresh_token = Column(encrypted_field_factory.create(Text), nullable=True)
+
+
+class UserAuthToken(Model, AuditMixinNullable):
+    """
+    Store OAuth tokens from the Superset login provider, for forwarding to databases.
+    """
+
+    __tablename__ = "user_auth_tokens"
+    __table_args__ = (
+        sqla.Index("idx_user_auth_tokens_user_provider", "user_id", "provider"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("ab_user.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user = relationship(security_manager.user_model, foreign_keys=[user_id])
+    provider = Column(String(256), nullable=False)
     access_token = Column(encrypted_field_factory.create(Text), nullable=True)
     access_token_expiration = Column(DateTime, nullable=True)
     refresh_token = Column(encrypted_field_factory.create(Text), nullable=True)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -23,7 +23,7 @@ import time
 from collections import defaultdict
 from typing import Any, Callable, cast, NamedTuple, Optional, TYPE_CHECKING
 
-from flask import current_app, Flask, g, Request
+from flask import current_app, Flask, g, Request, session
 from flask_appbuilder import Model
 from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.security.sqla.apis import RoleApi, UserApi
@@ -1529,6 +1529,41 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         # Exclude all other permissions not explicitly allowed
         return False
+
+    def auth_user_oauth(self, userinfo: dict[str, Any]) -> Any:
+        """
+        Override FAB's auth_user_oauth to persist the upstream login token when the
+        provider is configured with ``save_token: True`` in ``OAUTH_PROVIDERS``.
+
+        The token stored here can later be forwarded to database connections via
+        ``DATABASE_OAUTH2_UPSTREAM_PROVIDERS``, avoiding a separate database OAuth dance.
+        """
+        user = super().auth_user_oauth(userinfo)
+        if user:
+            provider = session.get("oauth_provider")
+            token = session.get("oauth")
+            if token and provider:
+                provider_configs: list[dict[str, Any]] = current_app.config.get(
+                    "OAUTH_PROVIDERS", []
+                )
+                provider_config = next(
+                    (p for p in provider_configs if p.get("name") == provider),
+                    None,
+                )
+                if provider_config and provider_config.get("save_token"):
+                    # pylint: disable=import-outside-toplevel
+                    from superset.utils.oauth2 import save_user_provider_token
+
+                    try:
+                        save_user_provider_token(user.id, provider, token)
+                    except Exception:  # pylint: disable=broad-except
+                        logger.warning(
+                            "Failed to save upstream OAuth token for user=%s provider=%s",
+                            user.id,
+                            provider,
+                            exc_info=True,
+                        )
+        return user
 
     def database_after_insert(
         self,

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -274,7 +274,7 @@ def _refresh_upstream_provider_token(
     from flask_appbuilder import current_app as fab_app  # pylint: disable=import-outside-toplevel
 
     sm = fab_app.appbuilder.sm
-    remote_app = getattr(sm, "oauth_remoteapp", {}).get(provider)
+    remote_app = getattr(sm, "oauth_remotes", {}).get(provider)
     if remote_app is None:
         logger.warning(
             "Cannot refresh upstream token: remote app '%s' not registered", provider

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -37,7 +37,7 @@ from superset.superset_typing import OAuth2ClientConfig, OAuth2State
 
 if TYPE_CHECKING:
     from superset.db_engine_specs.base import BaseEngineSpec
-    from superset.models.core import Database, DatabaseUserOAuth2Tokens, UserAuthToken
+    from superset.models.core import Database, DatabaseUserOAuth2Tokens, UpstreamOAuthToken
 
 JWT_EXPIRATION = timedelta(minutes=5)
 
@@ -182,21 +182,21 @@ def save_user_provider_token(
     token_response: dict[str, Any],
 ) -> None:
     """
-    Upsert a UserAuthToken record for the given user and login provider.
+    Upsert an UpstreamOAuthToken record for the given user and login provider.
 
     Called after a successful Superset OAuth login when the provider has
     ``save_token: True`` set in ``OAUTH_PROVIDERS``.
     """
     # pylint: disable=import-outside-toplevel
-    from superset.models.core import UserAuthToken
+    from superset.models.core import UpstreamOAuthToken
 
     token = (
-        db.session.query(UserAuthToken)
+        db.session.query(UpstreamOAuthToken)
         .filter_by(user_id=user_id, provider=provider)
         .one_or_none()
     )
     if token is None:
-        token = UserAuthToken(user_id=user_id, provider=provider)
+        token = UpstreamOAuthToken(user_id=user_id, provider=provider)
 
     token.access_token = token_response.get("access_token")
     expires_in = token_response.get("expires_in")
@@ -221,10 +221,10 @@ def get_upstream_provider_token(provider: str, user_id: int) -> str | None:
     token is found or when the token cannot be refreshed.
     """
     # pylint: disable=import-outside-toplevel
-    from superset.models.core import UserAuthToken
+    from superset.models.core import UpstreamOAuthToken
 
-    token: UserAuthToken | None = (
-        db.session.query(UserAuthToken)
+    token: UpstreamOAuthToken | None = (
+        db.session.query(UpstreamOAuthToken)
         .filter_by(user_id=user_id, provider=provider)
         .one_or_none()
     )
@@ -247,7 +247,7 @@ def get_upstream_provider_token(provider: str, user_id: int) -> str | None:
 
 
 def _refresh_upstream_provider_token(
-    token: "UserAuthToken",
+    token: "UpstreamOAuthToken",
     provider: str,
 ) -> str | None:
     """

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -37,7 +37,7 @@ from superset.superset_typing import OAuth2ClientConfig, OAuth2State
 
 if TYPE_CHECKING:
     from superset.db_engine_specs.base import BaseEngineSpec
-    from superset.models.core import Database, DatabaseUserOAuth2Tokens
+    from superset.models.core import Database, DatabaseUserOAuth2Tokens, UserAuthToken
 
 JWT_EXPIRATION = timedelta(minutes=5)
 
@@ -172,6 +172,171 @@ def refresh_oauth2_token(
             token.refresh_token = new_refresh_token
 
         db.session.add(token)
+
+    return token.access_token
+
+
+def save_user_provider_token(
+    user_id: int,
+    provider: str,
+    token_response: dict[str, Any],
+) -> None:
+    """
+    Upsert a UserAuthToken record for the given user and login provider.
+
+    Called after a successful Superset OAuth login when the provider has
+    ``save_token: True`` set in ``OAUTH_PROVIDERS``.
+    """
+    # pylint: disable=import-outside-toplevel
+    from superset.models.core import UserAuthToken
+
+    token = (
+        db.session.query(UserAuthToken)
+        .filter_by(user_id=user_id, provider=provider)
+        .one_or_none()
+    )
+    if token is None:
+        token = UserAuthToken(user_id=user_id, provider=provider)
+
+    token.access_token = token_response.get("access_token")
+    expires_in = token_response.get("expires_in")
+    if expires_in is not None:
+        token.access_token_expiration = datetime.now() + timedelta(
+            seconds=int(expires_in)
+        )
+    else:
+        token.access_token_expiration = None
+    token.refresh_token = token_response.get("refresh_token")
+
+    db.session.add(token)
+    db.session.commit()
+
+
+def get_upstream_provider_token(provider: str, user_id: int) -> str | None:
+    """
+    Return a valid access token stored for the given login provider and user.
+
+    If the stored token is expired and a refresh token is available, the token
+    is refreshed and the new access token is returned.  Returns ``None`` when no
+    token is found or when the token cannot be refreshed.
+    """
+    # pylint: disable=import-outside-toplevel
+    from superset.models.core import UserAuthToken
+
+    token: UserAuthToken | None = (
+        db.session.query(UserAuthToken)
+        .filter_by(user_id=user_id, provider=provider)
+        .one_or_none()
+    )
+    if token is None:
+        return None
+
+    if token.access_token and (
+        token.access_token_expiration is None
+        or datetime.now() < token.access_token_expiration
+    ):
+        return token.access_token
+
+    if token.refresh_token:
+        return _refresh_upstream_provider_token(token, provider)
+
+    # Expired with no refresh token — discard stale record
+    db.session.delete(token)
+    db.session.commit()
+    return None
+
+
+def _refresh_upstream_provider_token(
+    token: "UserAuthToken",
+    provider: str,
+) -> str | None:
+    """
+    Refresh an upstream provider token using the stored refresh token.
+
+    Looks up the provider's token endpoint via Flask-AppBuilder's remote app
+    registry, issues a refresh-grant request, persists the new token, and
+    returns the new access token (or ``None`` if the refresh fails).
+    """
+    import requests  # pylint: disable=import-outside-toplevel
+
+    provider_configs: list[dict[str, Any]] = app.config.get("OAUTH_PROVIDERS", [])
+    provider_config = next(
+        (p for p in provider_configs if p.get("name") == provider), None
+    )
+    if not provider_config:
+        logger.warning(
+            "Cannot refresh upstream token: provider '%s' not found in OAUTH_PROVIDERS",
+            provider,
+        )
+        return None
+
+    # Retrieve the token endpoint from the registered remote app's server metadata
+    from flask_appbuilder import current_app as fab_app  # pylint: disable=import-outside-toplevel
+
+    sm = fab_app.appbuilder.sm
+    remote_app = getattr(sm, "oauth_remoteapp", {}).get(provider)
+    if remote_app is None:
+        logger.warning(
+            "Cannot refresh upstream token: remote app '%s' not registered", provider
+        )
+        return None
+
+    try:
+        server_metadata = remote_app.load_server_metadata()
+        token_endpoint = server_metadata.get("token_endpoint")
+    except Exception:  # pylint: disable=broad-except
+        logger.warning(
+            "Cannot refresh upstream token: failed to load server metadata for '%s'",
+            provider,
+            exc_info=True,
+        )
+        return None
+
+    if not token_endpoint:
+        logger.warning(
+            "Cannot refresh upstream token: no token_endpoint in metadata for '%s'",
+            provider,
+        )
+        return None
+
+    client_id = provider_config.get("remote_app", {}).get("client_id")
+    client_secret = provider_config.get("remote_app", {}).get("client_secret")
+
+    try:
+        resp = requests.post(  # noqa: S113
+            token_endpoint,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": token.refresh_token,
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=app.config.get("DATABASE_OAUTH2_TIMEOUT", timedelta(seconds=30)).total_seconds(),
+        )
+        resp.raise_for_status()
+        token_response = resp.json()
+    except Exception:  # pylint: disable=broad-except
+        logger.warning(
+            "Failed to refresh upstream OAuth token for provider '%s'",
+            provider,
+            exc_info=True,
+        )
+        return None
+
+    if "access_token" not in token_response:
+        return None
+
+    token.access_token = token_response["access_token"]
+    expires_in = token_response.get("expires_in")
+    if expires_in is not None:
+        token.access_token_expiration = datetime.now() + timedelta(
+            seconds=int(expires_in)
+        )
+    if new_refresh_token := token_response.get("refresh_token"):
+        token.refresh_token = new_refresh_token
+
+    db.session.add(token)
+    db.session.commit()
 
     return token.access_token
 

--- a/tests/unit_tests/utils/oauth2_tests.py
+++ b/tests/unit_tests/utils/oauth2_tests.py
@@ -28,6 +28,7 @@ from pytest_mock import MockerFixture
 
 from superset.superset_typing import OAuth2ClientConfig
 from superset.utils.oauth2 import (
+    _refresh_upstream_provider_token,
     decode_oauth2_state,
     encode_oauth2_state,
     generate_code_challenge,
@@ -446,3 +447,47 @@ def test_get_upstream_provider_token_expired_calls_refresh(mocker: MockerFixture
 
     refresh_mock.assert_called_once_with(token, "keycloak")
     assert result == "fresh_token"
+
+
+def test_refresh_upstream_provider_token_success(mocker: MockerFixture) -> None:
+    """
+    _refresh_upstream_provider_token refreshes the token via oauth_remotes and persists it.
+    """
+    token = mocker.MagicMock()
+    token.refresh_token = "old_refresh"  # noqa: S105
+
+    # Patch app config
+    app_mock = mocker.patch("superset.utils.oauth2.app")
+    app_mock.config.get.side_effect = lambda key, default=None: {
+        "OAUTH_PROVIDERS": [
+            {
+                "name": "keycloak",
+                "remote_app": {"client_id": "cid", "client_secret": "csecret"},
+            }
+        ],
+        "DATABASE_OAUTH2_TIMEOUT": __import__("datetime").timedelta(seconds=30),
+    }.get(key, default)
+
+    # Patch flask_appbuilder.current_app (imported as fab_app inside the function)
+    remote_app_mock = mocker.MagicMock()
+    remote_app_mock.load_server_metadata.return_value = {
+        "token_endpoint": "https://auth.example.com/token"
+    }
+    fab_current_app_mock = mocker.patch("flask_appbuilder.current_app")
+    fab_current_app_mock.appbuilder.sm.oauth_remotes = {"keycloak": remote_app_mock}
+
+    # Patch requests.post
+    requests_mock = mocker.patch("superset.utils.oauth2.requests")
+    resp_mock = mocker.MagicMock()
+    resp_mock.json.return_value = {"access_token": "new_access", "expires_in": 3600}
+    requests_mock.post.return_value = resp_mock
+
+    # Patch db
+    db_mock = mocker.patch("superset.utils.oauth2.db")
+
+    result = _refresh_upstream_provider_token(token, "keycloak")
+
+    assert result == "new_access"
+    assert token.access_token == "new_access"
+    db_mock.session.add.assert_called_once_with(token)
+    db_mock.session.commit.assert_called_once()

--- a/tests/unit_tests/utils/oauth2_tests.py
+++ b/tests/unit_tests/utils/oauth2_tests.py
@@ -33,7 +33,9 @@ from superset.utils.oauth2 import (
     generate_code_challenge,
     generate_code_verifier,
     get_oauth2_access_token,
+    get_upstream_provider_token,
     refresh_oauth2_token,
+    save_user_provider_token,
 )
 
 DUMMY_OAUTH2_CONFIG = cast(OAuth2ClientConfig, {})
@@ -335,3 +337,112 @@ def test_encode_decode_oauth2_state(
     assert "code_verifier" not in decoded
     assert decoded["database_id"] == 1
     assert decoded["user_id"] == 2
+
+
+# ---------- upstream provider token tests ----------
+
+
+def test_save_user_provider_token_creates_new(mocker: MockerFixture) -> None:
+    """
+    save_user_provider_token should create a new UserAuthToken when none exists.
+    """
+    db_mock = mocker.patch("superset.utils.oauth2.db")
+    mock_token = mocker.MagicMock()
+    mocker.patch("superset.models.core.UserAuthToken", return_value=mock_token)
+    db_mock.session.query().filter_by().one_or_none.return_value = None
+
+    token_response = {
+        "access_token": "tok123",
+        "expires_in": 3600,
+        "refresh_token": "ref456",
+    }
+    save_user_provider_token(user_id=1, provider="keycloak", token_response=token_response)
+
+    db_mock.session.add.assert_called_once()
+    db_mock.session.commit.assert_called_once()
+
+
+def test_save_user_provider_token_updates_existing(mocker: MockerFixture) -> None:
+    """
+    save_user_provider_token should update an existing UserAuthToken in-place.
+    """
+    db_mock = mocker.patch("superset.utils.oauth2.db")
+    existing = mocker.MagicMock()
+    db_mock.session.query().filter_by().one_or_none.return_value = existing
+
+    token_response = {
+        "access_token": "new_tok",
+        "expires_in": 1800,
+        "refresh_token": "new_ref",
+    }
+    save_user_provider_token(user_id=2, provider="keycloak", token_response=token_response)
+
+    assert existing.access_token == "new_tok"
+    assert existing.refresh_token == "new_ref"
+    db_mock.session.add.assert_called_once_with(existing)
+    db_mock.session.commit.assert_called_once()
+
+
+def test_get_upstream_provider_token_no_record(mocker: MockerFixture) -> None:
+    """
+    get_upstream_provider_token returns None when no token record exists.
+    """
+    db_mock = mocker.patch("superset.utils.oauth2.db")
+    db_mock.session.query().filter_by().one_or_none.return_value = None
+
+    result = get_upstream_provider_token(provider="keycloak", user_id=1)
+    assert result is None
+
+
+def test_get_upstream_provider_token_valid(mocker: MockerFixture) -> None:
+    """
+    get_upstream_provider_token returns the access token when it is still valid.
+    """
+    db_mock = mocker.patch("superset.utils.oauth2.db")
+    token = mocker.MagicMock()
+    token.access_token = "valid_token"  # noqa: S105
+    token.access_token_expiration = datetime(2099, 1, 1)
+    db_mock.session.query().filter_by().one_or_none.return_value = token
+
+    result = get_upstream_provider_token(provider="keycloak", user_id=1)
+    assert result == "valid_token"
+
+
+def test_get_upstream_provider_token_expired_no_refresh(mocker: MockerFixture) -> None:
+    """
+    get_upstream_provider_token deletes an expired token with no refresh token and returns None.
+    """
+    db_mock = mocker.patch("superset.utils.oauth2.db")
+    token = mocker.MagicMock()
+    token.access_token = "expired"  # noqa: S105
+    token.access_token_expiration = datetime(2000, 1, 1)
+    token.refresh_token = None
+    db_mock.session.query().filter_by().one_or_none.return_value = token
+
+    result = get_upstream_provider_token(provider="keycloak", user_id=1)
+
+    assert result is None
+    db_mock.session.delete.assert_called_once_with(token)
+    db_mock.session.commit.assert_called_once()
+
+
+def test_get_upstream_provider_token_expired_calls_refresh(mocker: MockerFixture) -> None:
+    """
+    get_upstream_provider_token delegates to refresh when token is expired but has refresh token.
+    """
+    db_mock = mocker.patch("superset.utils.oauth2.db")
+    token = mocker.MagicMock()
+    token.access_token = "expired"  # noqa: S105
+    token.access_token_expiration = datetime(2000, 1, 1)
+    token.refresh_token = "refresh_tok"  # noqa: S105
+    db_mock.session.query().filter_by().one_or_none.return_value = token
+
+    refresh_mock = mocker.patch(
+        "superset.utils.oauth2._refresh_upstream_provider_token",
+        return_value="fresh_token",
+    )
+
+    result = get_upstream_provider_token(provider="keycloak", user_id=1)
+
+    refresh_mock.assert_called_once_with(token, "keycloak")
+    assert result == "fresh_token"

--- a/tests/unit_tests/utils/oauth2_tests.py
+++ b/tests/unit_tests/utils/oauth2_tests.py
@@ -344,11 +344,11 @@ def test_encode_decode_oauth2_state(
 
 def test_save_user_provider_token_creates_new(mocker: MockerFixture) -> None:
     """
-    save_user_provider_token should create a new UserAuthToken when none exists.
+    save_user_provider_token should create a new UpstreamOAuthToken when none exists.
     """
     db_mock = mocker.patch("superset.utils.oauth2.db")
     mock_token = mocker.MagicMock()
-    mocker.patch("superset.models.core.UserAuthToken", return_value=mock_token)
+    mocker.patch("superset.models.core.UpstreamOAuthToken", return_value=mock_token)
     db_mock.session.query().filter_by().one_or_none.return_value = None
 
     token_response = {
@@ -364,7 +364,7 @@ def test_save_user_provider_token_creates_new(mocker: MockerFixture) -> None:
 
 def test_save_user_provider_token_updates_existing(mocker: MockerFixture) -> None:
     """
-    save_user_provider_token should update an existing UserAuthToken in-place.
+    save_user_provider_token should update an existing UpstreamOAuthToken in-place.
     """
     db_mock = mocker.patch("superset.utils.oauth2.db")
     existing = mocker.MagicMock()


### PR DESCRIPTION
## **User description**
Adds a mechanism to persist the upstream OAuth access token (from Superset login) and reuse it for database connections, avoiding a second OAuth dance.

This is particularly useful for Trino deployments that share an identity provider with Superset — and essential for MCP usage where no browser is available to complete a database OAuth flow.

New config:
  OAUTH_PROVIDERS[n].save_token = True  # persist token at login time
  DATABASE_OAUTH2_UPSTREAM_PROVIDERS = {"trino": "provider_name"}  # use it

Changes:
- Add user_auth_tokens table (migration + UserAuthToken model)
- Override auth_user_oauth() in SupersetSecurityManager to save token
- Add save_user_provider_token / get_upstream_provider_token / _refresh_upstream_provider_token to oauth2.py
- Inject upstream token in Database._get_sqla_engine() before falling back to per-database OAuth2
- Add UserAuthTokenDAO
- Add unit tests for new oauth2 utilities

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Forward Superset login OAuth tokens to database connections to reuse upstream access

### What Changed
- Superset now saves OAuth tokens from the login provider (when the provider has save_token: True) and stores them per user.
- Databases mapped in DATABASE_OAUTH2_UPSTREAM_PROVIDERS will use the saved login token for connections instead of triggering a separate database OAuth flow.
- Adds a user_auth_tokens table and migration, login-time token persistence, token refresh logic, and unit tests for the new utilities.

### Impact
`✅ Fewer database OAuth prompts for users sharing an identity provider`
`✅ Works for headless or non-browser database workflows (no second OAuth dance required)`
`✅ Shorter database connection setup when upstream tokens are available`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
