### PR TITLE
fix(test): use correct @apache-superset/core/theme import in Menu test

### DIFF
--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -21,12 +21,12 @@ import fetchMock from 'fetch-mock';
 import { render, screen, userEvent } from 'spec/helpers/testing-library';
 import setupCodeOverrides from 'src/setup/setupCodeOverrides';
 import { getExtensionsRegistry } from '@superset-ui/core';
-import * as CoreUI from '@apache-superset/core/ui';
+import * as CoreTheme from '@apache-superset/core/theme';
 import { Menu } from './Menu';
 import * as getBootstrapData from 'src/utils/getBootstrapData';
 
-jest.mock('@apache-superset/core/ui', () => ({
-  ...jest.requireActual('@apache-superset/core/ui'),
+jest.mock('@apache-superset/core/theme', () => ({
+  ...jest.requireActual('@apache-superset/core/theme'),
   useTheme: jest.fn(),
 }));
 
@@ -250,7 +250,7 @@ const staticAssetsPrefixMock = jest.spyOn(
   'staticAssetsPrefix',
 );
 const applicationRootMock = jest.spyOn(getBootstrapData, 'applicationRoot');
-const useThemeMock = CoreUI.useTheme as jest.Mock;
+const useThemeMock = CoreTheme.useTheme as jest.Mock;
 
 fetchMock.get(
   'glob:*api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))',
@@ -264,7 +264,7 @@ beforeEach(() => {
   staticAssetsPrefixMock.mockReturnValue('');
   applicationRootMock.mockReturnValue('');
   // By default useTheme returns the real default theme (brandLogoUrl is falsy)
-  useThemeMock.mockReturnValue(CoreUI.supersetTheme);
+  useThemeMock.mockReturnValue(CoreTheme.supersetTheme);
 });
 
 test('should render', async () => {
@@ -690,7 +690,7 @@ test('should not render the brand text if not available', async () => {
 test('brand logo href should not be prefixed with app root when brandLogoHref is an absolute URL', async () => {
   applicationRootMock.mockReturnValue('/superset');
   useThemeMock.mockReturnValue({
-    ...CoreUI.supersetTheme,
+    ...CoreTheme.supersetTheme,
     brandLogoUrl: '/static/assets/images/custom-logo.png',
     brandLogoHref: 'https://external.example.com',
   });
@@ -712,7 +712,7 @@ test('brand logo href should not be prefixed with app root when brandLogoHref is
 test('brand logo href should not be prefixed with app root when brandLogoHref is protocol-relative', async () => {
   applicationRootMock.mockReturnValue('/superset');
   useThemeMock.mockReturnValue({
-    ...CoreUI.supersetTheme,
+    ...CoreTheme.supersetTheme,
     brandLogoUrl: '/static/assets/images/custom-logo.png',
     brandLogoHref: '//external.example.com',
   });


### PR DESCRIPTION
## **User description**
### SUMMARY

`Menu.test.tsx` was importing from `@apache-superset/core/ui`, a module path that doesn't exist. This caused two CI failures on master:
- **lint-frontend (tsc)**: `TS2307: Cannot find module '@apache-superset/core/ui'`
- **sharded-jest-tests (4)**: Jest `moduleNameMapper` could not resolve the path

The correct module is `@apache-superset/core/theme`, which is where `useTheme` and `supersetTheme` are exported — and what `Menu.tsx` itself imports from.

Introduced when #38316 was merged after #38448 without a rebase.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only fix.

### TESTING INSTRUCTIONS

CI should pass:
- `tsc --noEmit` no longer errors on `Menu.test.tsx`
- Jest shard 4 no longer fails on `Menu.test.tsx`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix Menu.test to import theme utilities from the correct module

### What Changed
- Replaced imports and test mocks that referenced a non-existent module with the correct theme module so tests use the real theme exports.
- Updated mocked theme return values in Menu tests so brand logo and href behavior is validated against the actual theme shape.
- Test-only change; no runtime UI or API behavior altered.

### Impact
`✅ Type-checking no longer fails for Menu.test`
`✅ Jest shard 4 no longer errors resolving the Menu test`
`✅ Fewer CI failures caused by incorrect test imports`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
