### PR TITLE
fix(map-box): prevent clusters from being smaller than individual points

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -242,6 +242,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest-dom": "^5.5.0",
         "eslint-plugin-lodash": "^7.4.0",
+        "eslint-plugin-no-only-tests": "^3.3.0",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-react-prefer-function-component": "^5.0.0",
         "eslint-plugin-react-you-might-not-need-an-effect": "^0.9.2",
@@ -24331,6 +24332,16 @@
       },
       "peerDependencies": {
         "eslint": ">=2"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -323,6 +323,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-lodash": "^7.4.0",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react-prefer-function-component": "^5.0.0",
     "eslint-plugin-react-you-might-not-need-an-effect": "^0.9.2",

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
@@ -239,8 +239,12 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
             const safeNumericLabel = Number.isFinite(numericLabel)
               ? numericLabel
               : 0;
+            const minClusterRadius = radius / 6;
+            const clampedLabel = Math.max(0, safeNumericLabel);
             const scaledRadius = roundDecimal(
-              (safeNumericLabel / safeMaxLabel) ** 0.5 * radius,
+              minClusterRadius +
+                (clampedLabel / safeMaxLabel) ** 0.5 *
+                  (radius - minClusterRadius),
               1,
             );
             const fontHeight = roundDecimal(scaledRadius * 0.5, 1);

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
@@ -190,7 +190,10 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
       .filter(value => Number.isFinite(value));
     const safeMaxAbsLabel =
       finiteClusterLabels.length > 0
-        ? Math.max(...finiteClusterLabels.map(value => Math.abs(value)))
+        ? Math.max(
+            Math.max(...finiteClusterLabels.map(value => Math.abs(value))),
+            1,
+          )
         : 1;
 
     // Calculate min/max radius values for Pixels mode scaling

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
@@ -246,11 +246,9 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
               ? numericLabel
               : 0;
             const minClusterRadius = radius * MIN_CLUSTER_RADIUS_RATIO;
-            const ratio =
-              Math.abs(safeNumericLabel) / safeMaxAbsLabel;
+            const ratio = Math.abs(safeNumericLabel) / safeMaxAbsLabel;
             const scaledRadius = roundDecimal(
-              minClusterRadius +
-                ratio ** 0.5 * (radius - minClusterRadius),
+              minClusterRadius + ratio ** 0.5 * (radius - minClusterRadius),
               1,
             );
             const fontHeight = roundDecimal(scaledRadius * 0.5, 1);

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
@@ -185,16 +185,13 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
       }
     });
 
-    const filteredLabels = clusterLabelMap.filter(
-      v => !Number.isNaN(v),
-    ) as number[];
-    // Guard against empty array or zero max to prevent NaN from division
-    const maxLabel =
-      filteredLabels.length > 0 ? Math.max(...filteredLabels) : 1;
-    const minLabel =
-      filteredLabels.length > 0 ? Math.min(...filteredLabels) : 0;
-    const maxAbsLabel = Math.max(Math.abs(maxLabel), Math.abs(minLabel));
-    const safeMaxAbsLabel = maxAbsLabel > 0 ? maxAbsLabel : 1;
+    const finiteClusterLabels = clusterLabelMap
+      .map(value => Number(value))
+      .filter(value => Number.isFinite(value));
+    const safeMaxAbsLabel =
+      finiteClusterLabels.length > 0
+        ? Math.max(...finiteClusterLabels.map(value => Math.abs(value)))
+        : 1;
 
     // Calculate min/max radius values for Pixels mode scaling
     let minRadiusValue = Infinity;
@@ -207,8 +204,11 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
           location.properties.radius != null
         ) {
           const radiusValueRaw = location.properties.radius;
-          const radiusValue = Number(radiusValueRaw);
-          if (Number.isFinite(radiusValue)) {
+          const radiusValue =
+            typeof radiusValueRaw === 'string' && radiusValueRaw.trim() === ''
+              ? null
+              : Number(radiusValueRaw);
+          if (radiusValue != null && Number.isFinite(radiusValue)) {
             minRadiusValue = Math.min(minRadiusValue, radiusValue);
             maxRadiusValue = Math.max(maxRadiusValue, radiusValue);
           }
@@ -305,7 +305,10 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
             const defaultRadius = radius * MIN_CLUSTER_RADIUS_RATIO;
             const rawRadius = location.properties.radius;
             const numericRadiusProperty =
-              rawRadius != null ? Number(rawRadius) : null;
+              rawRadius != null &&
+              !(typeof rawRadius === 'string' && rawRadius.trim() === '')
+                ? Number(rawRadius)
+                : null;
             const radiusProperty =
               numericRadiusProperty != null &&
               Number.isFinite(numericRadiusProperty)

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
@@ -24,6 +24,7 @@ import roundDecimal from './utils/roundDecimal';
 import luminanceFromRGB from './utils/luminanceFromRGB';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
+// Shared radius bounds keep cluster and point sizing in sync.
 export const MIN_CLUSTER_RADIUS_RATIO = 1 / 6;
 export const MAX_POINT_RADIUS_RATIO = 1 / 3;
 

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
@@ -24,6 +24,8 @@ import roundDecimal from './utils/roundDecimal';
 import luminanceFromRGB from './utils/luminanceFromRGB';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
+export const MIN_CLUSTER_RADIUS_RATIO = 1 / 6;
+
 interface GeoJSONLocation {
   geometry: {
     coordinates: [number, number];
@@ -239,7 +241,7 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
             const safeNumericLabel = Number.isFinite(numericLabel)
               ? numericLabel
               : 0;
-            const minClusterRadius = radius / 6;
+            const minClusterRadius = radius * MIN_CLUSTER_RADIUS_RATIO;
             const clampedLabel = Math.max(0, safeNumericLabel);
             const scaledRadius = roundDecimal(
               minClusterRadius +

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
@@ -246,7 +246,10 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
             const safeNumericLabel = Number.isFinite(numericLabel)
               ? numericLabel
               : 0;
-            const minClusterRadius = radius * MIN_CLUSTER_RADIUS_RATIO;
+            const minClusterRadius =
+              pointRadiusUnit === 'Pixels'
+                ? radius * MAX_POINT_RADIUS_RATIO
+                : radius * MIN_CLUSTER_RADIUS_RATIO;
             const ratio = Math.abs(safeNumericLabel) / safeMaxAbsLabel;
             const scaledRadius = roundDecimal(
               minClusterRadius + ratio ** 0.5 * (radius - minClusterRadius),
@@ -301,8 +304,13 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
           } else {
             const defaultRadius = radius * MIN_CLUSTER_RADIUS_RATIO;
             const rawRadius = location.properties.radius;
+            const numericRadiusProperty =
+              rawRadius != null ? Number(rawRadius) : null;
             const radiusProperty =
-              typeof rawRadius === 'number' ? rawRadius : null;
+              numericRadiusProperty != null &&
+              Number.isFinite(numericRadiusProperty)
+                ? numericRadiusProperty
+                : null;
             const pointMetric = location.properties.metric ?? null;
             let pointRadius: number = radiusProperty ?? defaultRadius;
             let pointLabel: string | number | undefined;

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/ScatterPlotGlowOverlay.tsx
@@ -25,6 +25,7 @@ import luminanceFromRGB from './utils/luminanceFromRGB';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
 export const MIN_CLUSTER_RADIUS_RATIO = 1 / 6;
+export const MAX_POINT_RADIUS_RATIO = 1 / 3;
 
 interface GeoJSONLocation {
   geometry: {
@@ -189,7 +190,10 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
     // Guard against empty array or zero max to prevent NaN from division
     const maxLabel =
       filteredLabels.length > 0 ? Math.max(...filteredLabels) : 1;
-    const safeMaxLabel = maxLabel > 0 ? maxLabel : 1;
+    const minLabel =
+      filteredLabels.length > 0 ? Math.min(...filteredLabels) : 0;
+    const maxAbsLabel = Math.max(Math.abs(maxLabel), Math.abs(minLabel));
+    const safeMaxAbsLabel = maxAbsLabel > 0 ? maxAbsLabel : 1;
 
     // Calculate min/max radius values for Pixels mode scaling
     let minRadiusValue = Infinity;
@@ -242,11 +246,11 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
               ? numericLabel
               : 0;
             const minClusterRadius = radius * MIN_CLUSTER_RADIUS_RATIO;
-            const clampedLabel = Math.max(0, safeNumericLabel);
+            const ratio =
+              Math.abs(safeNumericLabel) / safeMaxAbsLabel;
             const scaledRadius = roundDecimal(
               minClusterRadius +
-                (clampedLabel / safeMaxLabel) ** 0.5 *
-                  (radius - minClusterRadius),
+                ratio ** 0.5 * (radius - minClusterRadius),
               1,
             );
             const fontHeight = roundDecimal(scaledRadius * 0.5, 1);
@@ -280,10 +284,12 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
 
             if (Number.isFinite(safeNumericLabel)) {
               let label: string | number = clusterLabel;
-              if (safeNumericLabel >= 10000) {
-                label = `${Math.round(safeNumericLabel / 1000)}k`;
-              } else if (safeNumericLabel >= 1000) {
-                label = `${Math.round(safeNumericLabel / 100) / 10}k`;
+              const absLabel = Math.abs(safeNumericLabel);
+              const sign = safeNumericLabel < 0 ? '-' : '';
+              if (absLabel >= 10000) {
+                label = `${sign}${Math.round(absLabel / 1000)}k`;
+              } else if (absLabel >= 1000) {
+                label = `${sign}${Math.round(absLabel / 100) / 10}k`;
               }
               this.drawText(ctx, pixelRounded, {
                 fontHeight,
@@ -294,7 +300,7 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
               });
             }
           } else {
-            const defaultRadius = radius / 6;
+            const defaultRadius = radius * MIN_CLUSTER_RADIUS_RATIO;
             const rawRadius = location.properties.radius;
             const radiusProperty =
               typeof rawRadius === 'number' ? rawRadius : null;
@@ -317,8 +323,8 @@ class ScatterPlotGlowOverlay extends PureComponent<ScatterPlotGlowOverlayProps> 
               } else if (pointRadiusUnit === 'Pixels') {
                 // Scale pixel values to a reasonable range (radius/6 to radius/3)
                 // This ensures points are visible and proportional to their values
-                const MIN_POINT_RADIUS = radius / 6;
-                const MAX_POINT_RADIUS = radius / 3;
+                const MIN_POINT_RADIUS = radius * MIN_CLUSTER_RADIUS_RATIO;
+                const MAX_POINT_RADIUS = radius * MAX_POINT_RADIUS_RATIO;
 
                 if (
                   Number.isFinite(minRadiusValue) &&

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -344,3 +344,155 @@ test('renders successfully with mixed extreme and negative radius values', () =>
     (global as any).mockRedraw(redrawParams);
   }).not.toThrow();
 });
+
+test('cluster radius is always >= individual point radius', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 2,
+      sum: 1,
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 50,
+      sum: 100,
+    }),
+    createLocation([300, 300], { cluster: false }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const singlePointRadius = defaultProps.dotRadius / 6;
+
+  // cluster with label=1 (index 0)
+  expect(arcCalls[0][2]).toBeGreaterThanOrEqual(singlePointRadius);
+  // cluster with label=100 (index 1)
+  expect(arcCalls[1][2]).toBeGreaterThanOrEqual(singlePointRadius);
+  // single point (index 2) gets defaultRadius
+  expect(arcCalls[2][2]).toBe(singlePointRadius);
+});
+
+test('largest cluster gets full dotRadius', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 10,
+      sum: 50,
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 50,
+      sum: 100,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  // The largest cluster (label=100, maxLabel=100) should get full radius
+  expect(arcCalls[1][2]).toBe(defaultProps.dotRadius);
+});
+
+test('cluster radii preserve proportional ordering', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 5,
+      sum: 10,
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 25,
+      sum: 50,
+    }),
+    createLocation([300, 300], {
+      cluster: true,
+      point_count: 50,
+      sum: 100,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const r10 = arcCalls[0][2];
+  const r50 = arcCalls[1][2];
+  const r100 = arcCalls[2][2];
+
+  expect(r10).toBeLessThan(r50);
+  expect(r50).toBeLessThan(r100);
+});
+
+test('negative cluster label produces valid finite radius', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 3,
+      sum: -5,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const radiusValue = arcCalls[0][2];
+  expect(Number.isFinite(radiusValue)).toBe(true);
+  expect(radiusValue).toBeGreaterThanOrEqual(defaultProps.dotRadius / 6);
+});
+
+test('single cluster with small maxLabel gets full dotRadius', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 1,
+      sum: 1,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  // When there's only one cluster, label=maxLabel, so it gets full radius
+  expect(arcCalls[0][2]).toBe(defaultProps.dotRadius);
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -18,7 +18,9 @@
  */
 
 import { render } from '@testing-library/react';
-import ScatterPlotGlowOverlay from '../src/ScatterPlotGlowOverlay';
+import ScatterPlotGlowOverlay, {
+  MIN_CLUSTER_RADIUS_RATIO,
+} from '../src/ScatterPlotGlowOverlay';
 
 // Mock react-map-gl's CanvasOverlay
 jest.mock('react-map-gl', () => ({
@@ -371,14 +373,15 @@ test('cluster radius is always >= individual point radius', () => {
   (global as any).mockRedraw(redrawParams);
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
-  const singlePointRadius = defaultProps.dotRadius / 6;
+  const minClusterRadius =
+    defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
 
   // cluster with label=1 (index 0)
-  expect(arcCalls[0][2]).toBeGreaterThanOrEqual(singlePointRadius);
+  expect(arcCalls[0][2]).toBeGreaterThanOrEqual(minClusterRadius);
   // cluster with label=100 (index 1)
-  expect(arcCalls[1][2]).toBeGreaterThanOrEqual(singlePointRadius);
-  // single point (index 2) gets defaultRadius
-  expect(arcCalls[2][2]).toBe(singlePointRadius);
+  expect(arcCalls[1][2]).toBeGreaterThanOrEqual(minClusterRadius);
+  // single point (index 2) gets minimum cluster radius as default
+  expect(arcCalls[2][2]).toBe(minClusterRadius);
 });
 
 test('largest cluster gets full dotRadius', () => {
@@ -470,7 +473,9 @@ test('negative cluster label produces valid finite radius', () => {
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const radiusValue = arcCalls[0][2];
   expect(Number.isFinite(radiusValue)).toBe(true);
-  expect(radiusValue).toBeGreaterThanOrEqual(defaultProps.dotRadius / 6);
+  expect(radiusValue).toBeGreaterThanOrEqual(
+    defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO,
+  );
 });
 
 test('single cluster with small maxLabel gets full dotRadius', () => {
@@ -495,4 +500,37 @@ test('single cluster with small maxLabel gets full dotRadius', () => {
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   // When there's only one cluster, label=maxLabel, so it gets full radius
   expect(arcCalls[0][2]).toBe(defaultProps.dotRadius);
+});
+
+test('zero-value cluster is visible with minimum radius', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 5,
+      sum: 0,
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 10,
+      sum: 100,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const zeroClusterRadius = arcCalls[0][2];
+
+  expect(Number.isFinite(zeroClusterRadius)).toBe(true);
+  expect(zeroClusterRadius).toBeGreaterThanOrEqual(
+    defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO,
+  );
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -20,6 +20,7 @@
 import { render } from '@testing-library/react';
 import ScatterPlotGlowOverlay, {
   MIN_CLUSTER_RADIUS_RATIO,
+  MAX_POINT_RADIUS_RATIO,
 } from '../src/ScatterPlotGlowOverlay';
 
 // Mock react-map-gl's CanvasOverlay
@@ -92,17 +93,29 @@ test('renders map with varying radius values in Pixels mode', () => {
     createLocation([300, 300], { radius: 100, cluster: false }),
   ];
 
-  expect(() => {
-    render(
-      <ScatterPlotGlowOverlay
-        {...defaultProps}
-        locations={locations}
-        pointRadiusUnit="Pixels"
-      />,
-    );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
-  }).not.toThrow();
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      pointRadiusUnit="Pixels"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const minPointRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
+  const maxPointRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
+
+  // All point radii should be within [MIN_CLUSTER_RADIUS_RATIO, MAX_POINT_RADIUS_RATIO] * dotRadius
+  arcCalls.forEach((call: any) => {
+    expect(call[2]).toBeGreaterThanOrEqual(minPointRadius);
+    expect(call[2]).toBeLessThanOrEqual(maxPointRadius);
+  });
+
+  // Ordering should be preserved: radius 10 < 50 < 100
+  expect(arcCalls[0][2]).toBeLessThan(arcCalls[1][2]);
+  expect(arcCalls[1][2]).toBeLessThan(arcCalls[2][2]);
 });
 
 test('handles dataset with uniform radius values', () => {
@@ -499,6 +512,179 @@ test('single cluster with small maxLabel gets full dotRadius', () => {
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   // When there's only one cluster, label=maxLabel, so it gets full radius
   expect(arcCalls[0][2]).toBe(defaultProps.dotRadius);
+});
+
+test('all-negative cluster labels produce differentiated radii by magnitude', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 3,
+      sum: -100,
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 3,
+      sum: -10,
+    }),
+    createLocation([300, 300], {
+      cluster: true,
+      point_count: 3,
+      sum: -1,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const rNeg100 = arcCalls[0][2];
+  const rNeg10 = arcCalls[1][2];
+  const rNeg1 = arcCalls[2][2];
+  const minClusterRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
+
+  // Higher magnitude = bigger circle: |-100| > |-10| > |-1|
+  expect(rNeg1).toBeLessThan(rNeg10);
+  expect(rNeg10).toBeLessThan(rNeg100);
+  expect(Number.isFinite(rNeg100)).toBe(true);
+  expect(Number.isFinite(rNeg10)).toBe(true);
+  expect(Number.isFinite(rNeg1)).toBe(true);
+  expect(rNeg1).toBeGreaterThanOrEqual(minClusterRadius);
+  expect(rNeg100).toBe(defaultProps.dotRadius);
+});
+
+test('mixed positive-and-negative cluster labels size by magnitude', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 3,
+      sum: -50,
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 3,
+      sum: 0,
+    }),
+    createLocation([300, 300], {
+      cluster: true,
+      point_count: 3,
+      sum: 100,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const rNeg50 = arcCalls[0][2];
+  const rZero = arcCalls[1][2];
+  const r100 = arcCalls[2][2];
+  const minClusterRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
+
+  // Magnitude ordering: |0| < |-50| < |100|
+  expect(rZero).toBeLessThan(rNeg50);
+  expect(rNeg50).toBeLessThan(r100);
+  expect(rZero).toBeGreaterThanOrEqual(minClusterRadius);
+  expect(r100).toBe(defaultProps.dotRadius);
+});
+
+test('all-identical negative labels get equal full radii', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 3,
+      sum: -5,
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 3,
+      sum: -5,
+    }),
+    createLocation([300, 300], {
+      cluster: true,
+      point_count: 3,
+      sum: -5,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const r1 = arcCalls[0][2];
+  const r2 = arcCalls[1][2];
+  const r3 = arcCalls[2][2];
+
+  expect(r1).toBe(r2);
+  expect(r2).toBe(r3);
+  expect(r1).toBe(defaultProps.dotRadius);
+});
+
+test('single negative cluster gets full radius', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 3,
+      sum: -5,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  expect(arcCalls[0][2]).toBe(defaultProps.dotRadius);
+});
+
+test('large negative cluster labels are abbreviated', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 3,
+      sum: -50000,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+    />,
+  );
+  const redrawParams = createMockRedrawParams();
+  (global as any).mockRedraw(redrawParams);
+
+  const fillTextCalls = redrawParams.ctx.fillText.mock.calls;
+  const labelArg = fillTextCalls[0][0];
+  expect(labelArg).toBe('-50k');
 });
 
 test('zero-value cluster is visible with minimum radius', () => {

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -23,11 +23,58 @@ import ScatterPlotGlowOverlay, {
   MAX_POINT_RADIUS_RATIO,
 } from '../src/ScatterPlotGlowOverlay';
 
+type MockGradient = {
+  addColorStop: jest.Mock<void, [number, string]>;
+};
+
+type MockCanvasContext = {
+  clearRect: jest.Mock<void, [number, number, number, number]>;
+  beginPath: jest.Mock<void, []>;
+  arc: jest.Mock<void, [number, number, number, number, number]>;
+  fill: jest.Mock<void, []>;
+  fillText: jest.Mock<void, [string, number, number]>;
+  measureText: jest.Mock<{ width: number }, [string]>;
+  createRadialGradient: jest.Mock<
+    MockGradient,
+    [number, number, number, number, number, number]
+  >;
+  globalCompositeOperation: string;
+  fillStyle: string | CanvasGradient;
+  font: string;
+  textAlign: CanvasTextAlign;
+  textBaseline: CanvasTextBaseline;
+  shadowBlur: number;
+  shadowColor: string;
+};
+
+type LocationProperties = Record<
+  string,
+  number | string | boolean | null | undefined
+>;
+
+type TestLocation = {
+  geometry: { coordinates: [number, number] };
+  properties: LocationProperties;
+};
+
+type MockRedrawParams = {
+  width: number;
+  height: number;
+  ctx: MockCanvasContext;
+  isDragging: boolean;
+  project: (lngLat: [number, number]) => [number, number];
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var mockRedraw: unknown;
+}
+
 // Mock react-map-gl's CanvasOverlay
 jest.mock('react-map-gl', () => ({
-  CanvasOverlay: ({ redraw }: { redraw: Function }) => {
+  CanvasOverlay: ({ redraw }: { redraw: unknown }) => {
     // Store the redraw function so tests can call it
-    (global as any).mockRedraw = redraw;
+    global.mockRedraw = redraw;
     return <div data-testid="canvas-overlay" />;
   },
 }));
@@ -40,21 +87,30 @@ jest.mock('../src/utils/luminanceFromRGB', () => ({
 
 // Test helpers
 const createMockCanvas = () => {
-  const ctx: any = {
+  const ctx: MockCanvasContext = {
     clearRect: jest.fn(),
     beginPath: jest.fn(),
     arc: jest.fn(),
     fill: jest.fn(),
     fillText: jest.fn(),
-    measureText: jest.fn(() => ({ width: 10 })),
-    createRadialGradient: jest.fn(() => ({
-      addColorStop: jest.fn(),
-    })),
+    measureText: jest.fn((_: string) => ({ width: 10 })),
+    createRadialGradient: jest.fn(
+      (
+        _x0: number,
+        _y0: number,
+        _r0: number,
+        _x1: number,
+        _y1: number,
+        _r1: number,
+      ) => ({
+        addColorStop: jest.fn<void, [number, string]>(),
+      }),
+    ),
     globalCompositeOperation: '',
     fillStyle: '',
     font: '',
-    textAlign: '',
-    textBaseline: '',
+    textAlign: 'center',
+    textBaseline: 'middle',
     shadowBlur: 0,
     shadowColor: '',
   };
@@ -62,7 +118,9 @@ const createMockCanvas = () => {
   return ctx;
 };
 
-const createMockRedrawParams = (overrides = {}) => ({
+const createMockRedrawParams = (
+  overrides: Partial<MockRedrawParams> = {},
+): MockRedrawParams => ({
   width: 800,
   height: 600,
   ctx: createMockCanvas(),
@@ -73,16 +131,27 @@ const createMockRedrawParams = (overrides = {}) => ({
 
 const createLocation = (
   coordinates: [number, number],
-  properties: Record<string, any>,
-) => ({
+  properties: LocationProperties,
+): TestLocation => ({
   geometry: { coordinates },
   properties,
 });
 
+const triggerRedraw = (
+  overrides: Partial<MockRedrawParams> = {},
+): MockRedrawParams => {
+  const redrawParams = createMockRedrawParams(overrides);
+  if (typeof global.mockRedraw !== 'function') {
+    throw new Error('CanvasOverlay redraw callback was not registered');
+  }
+  (global.mockRedraw as (params: MockRedrawParams) => void)(redrawParams);
+  return redrawParams;
+};
+
 const defaultProps = {
-  lngLatAccessor: (loc: any) => loc.geometry.coordinates,
+  lngLatAccessor: (loc: TestLocation) => loc.geometry.coordinates,
   dotRadius: 60,
-  rgb: ['', 255, 0, 0] as any,
+  rgb: ['', 255, 0, 0] as [string, number, number, number],
   globalOpacity: 1,
 };
 
@@ -100,15 +169,14 @@ test('renders map with varying radius values in Pixels mode', () => {
       pointRadiusUnit="Pixels"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const minPointRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
   const maxPointRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
 
   // All point radii should be within [MIN_CLUSTER_RADIUS_RATIO, MAX_POINT_RADIUS_RATIO] * dotRadius
-  arcCalls.forEach((call: any) => {
+  arcCalls.forEach(call => {
     expect(call[2]).toBeGreaterThanOrEqual(minPointRadius);
     expect(call[2]).toBeLessThanOrEqual(maxPointRadius);
   });
@@ -133,8 +201,7 @@ test('handles dataset with uniform radius values', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -153,8 +220,7 @@ test('renders successfully when data contains non-finite values', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -173,8 +239,7 @@ test('handles radius values provided as strings', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -193,8 +258,7 @@ test('renders points when radius values are missing', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -218,8 +282,7 @@ test('renders both cluster and non-cluster points correctly', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -238,8 +301,7 @@ test('renders map with multiple points with different radius values', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -258,8 +320,7 @@ test('renders map with Kilometers mode', () => {
         zoom={10}
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -278,8 +339,7 @@ test('renders map with Miles mode', () => {
         zoom={10}
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -296,8 +356,7 @@ test('displays metric property labels on points', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -310,8 +369,7 @@ test('handles empty dataset without errors', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -330,8 +388,7 @@ test('handles extreme outlier radius values without breaking', () => {
         pointRadiusUnit="Pixels"
       />,
     );
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -355,8 +412,7 @@ test('renders successfully with mixed extreme and negative radius values', () =>
   }).not.toThrow();
 
   expect(() => {
-    const redrawParams = createMockRedrawParams();
-    (global as any).mockRedraw(redrawParams);
+    triggerRedraw();
   }).not.toThrow();
 });
 
@@ -382,8 +438,7 @@ test('cluster radius is always >= individual point radius', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const minClusterRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
@@ -417,8 +472,7 @@ test('largest cluster gets full dotRadius', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   // The largest cluster (label=100, maxLabel=100) should get full radius
@@ -451,8 +505,7 @@ test('cluster radii preserve proportional ordering', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const r10 = arcCalls[0][2];
@@ -479,8 +532,7 @@ test('negative cluster label produces valid finite radius', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const radiusValue = arcCalls[0][2];
@@ -506,8 +558,7 @@ test('single cluster with small maxLabel gets full dotRadius', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   // When there's only one cluster, label=maxLabel, so it gets full radius
@@ -540,8 +591,7 @@ test('all-negative cluster labels produce differentiated radii by magnitude', ()
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const rNeg100 = arcCalls[0][2];
@@ -585,8 +635,7 @@ test('mixed positive-and-negative cluster labels size by magnitude', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const rNeg50 = arcCalls[0][2];
@@ -627,8 +676,7 @@ test('all-identical negative labels get equal full radii', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const r1 = arcCalls[0][2];
@@ -656,8 +704,7 @@ test('single negative cluster gets full radius', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   expect(arcCalls[0][2]).toBe(defaultProps.dotRadius);
@@ -679,13 +726,58 @@ test('large negative cluster labels are abbreviated', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const fillTextCalls = redrawParams.ctx.fillText.mock.calls;
   const labelArg = fillTextCalls[0][0];
   expect(labelArg).toBe('-50k');
 });
+
+test.each([
+  ['sum', [{ sum: -100 }, { sum: -10 }, { sum: -1 }]],
+  ['min', [{ min: -100 }, { min: -10 }, { min: -1 }]],
+  ['max', [{ max: -100 }, { max: -10 }, { max: -1 }]],
+  ['mean', [{ sum: -300 }, { sum: -30 }, { sum: -3 }]],
+])(
+  'negative %s cluster labels preserve magnitude-based ordering',
+  (aggregation, labelProps) => {
+    const locations = [
+      createLocation([100, 100], {
+        cluster: true,
+        point_count: 3,
+        ...labelProps[0],
+      }),
+      createLocation([200, 200], {
+        cluster: true,
+        point_count: 3,
+        ...labelProps[1],
+      }),
+      createLocation([300, 300], {
+        cluster: true,
+        point_count: 3,
+        ...labelProps[2],
+      }),
+    ];
+
+    render(
+      <ScatterPlotGlowOverlay
+        {...defaultProps}
+        locations={locations}
+        aggregation={aggregation}
+      />,
+    );
+    const redrawParams = triggerRedraw();
+
+    const arcCalls = redrawParams.ctx.arc.mock.calls;
+    const largestRadius = arcCalls[0][2];
+    const middleRadius = arcCalls[1][2];
+    const smallestRadius = arcCalls[2][2];
+
+    expect(smallestRadius).toBeLessThan(middleRadius);
+    expect(middleRadius).toBeLessThan(largestRadius);
+    expect(largestRadius).toBe(defaultProps.dotRadius);
+  },
+);
 
 test('zero-value cluster is visible with minimum radius', () => {
   const locations = [
@@ -708,8 +800,7 @@ test('zero-value cluster is visible with minimum radius', () => {
       aggregation="sum"
     />,
   );
-  const redrawParams = createMockRedrawParams();
-  (global as any).mockRedraw(redrawParams);
+  const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const zeroClusterRadius = arcCalls[0][2];

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -248,6 +248,29 @@ test('handles radius values provided as strings', () => {
   expect(arcCalls[1][2]).toBeLessThan(arcCalls[2][2]);
 });
 
+test('treats blank radius strings as missing values', () => {
+  const locations = [
+    createLocation([100, 100], { radius: '', cluster: false }),
+    createLocation([200, 200], { radius: '   ', cluster: false }),
+    createLocation([300, 300], { radius: '100', cluster: false }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      pointRadiusUnit="Pixels"
+    />,
+  );
+  const redrawParams = triggerRedraw();
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+
+  expect(arcCalls[0][2]).toBe(MIN_VISIBLE_POINT_RADIUS);
+  expect(arcCalls[1][2]).toBe(MIN_VISIBLE_POINT_RADIUS);
+  expect(arcCalls[2][2]).toBe(15);
+});
+
 test('renders points when radius values are missing', () => {
   const locations = [
     createLocation([100, 100], { radius: null, cluster: false }),
@@ -541,6 +564,36 @@ test('negative cluster label produces valid finite radius', () => {
   const radiusValue = arcCalls[0][2];
   expect(Number.isFinite(radiusValue)).toBe(true);
   expect(radiusValue).toBeGreaterThanOrEqual(MIN_VISIBLE_POINT_RADIUS);
+});
+
+test('ignores non-finite cluster labels when computing cluster scaling bounds', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 3,
+      sum: 'invalid',
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 3,
+      sum: 100,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+      pointRadiusUnit="Pixels"
+    />,
+  );
+  const redrawParams = triggerRedraw();
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+
+  expect(arcCalls[0][2]).toBeGreaterThanOrEqual(MAX_VISIBLE_POINT_RADIUS);
+  expect(arcCalls[1][2]).toBe(defaultProps.dotRadius);
 });
 
 test('single cluster with small maxLabel gets full dotRadius', () => {

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -18,10 +18,7 @@
  */
 
 import { render } from '@testing-library/react';
-import ScatterPlotGlowOverlay, {
-  MIN_CLUSTER_RADIUS_RATIO,
-  MAX_POINT_RADIUS_RATIO,
-} from '../src/ScatterPlotGlowOverlay';
+import ScatterPlotGlowOverlay from '../src/ScatterPlotGlowOverlay';
 
 type MockGradient = {
   addColorStop: jest.Mock<void, [number, string]>;
@@ -154,6 +151,8 @@ const defaultProps = {
   rgb: ['', 255, 0, 0] as [string, number, number, number],
   globalOpacity: 1,
 };
+const MIN_VISIBLE_POINT_RADIUS = 10;
+const MAX_VISIBLE_POINT_RADIUS = 20;
 
 test('renders map with varying radius values in Pixels mode', () => {
   const locations = [
@@ -172,13 +171,11 @@ test('renders map with varying radius values in Pixels mode', () => {
   const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
-  const minPointRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
-  const maxPointRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
 
-  // All point radii should be within [MIN_CLUSTER_RADIUS_RATIO, MAX_POINT_RADIUS_RATIO] * dotRadius
+  // With dotRadius=60, pixel-sized points should map to the visible 10-20 range.
   arcCalls.forEach(call => {
-    expect(call[2]).toBeGreaterThanOrEqual(minPointRadius);
-    expect(call[2]).toBeLessThanOrEqual(maxPointRadius);
+    expect(call[2]).toBeGreaterThanOrEqual(MIN_VISIBLE_POINT_RADIUS);
+    expect(call[2]).toBeLessThanOrEqual(MAX_VISIBLE_POINT_RADIUS);
   });
 
   // Ordering should be preserved: radius 10 < 50 < 100
@@ -241,12 +238,10 @@ test('handles radius values provided as strings', () => {
   const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
-  const minPointRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
-  const maxPointRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
 
   arcCalls.forEach(call => {
-    expect(call[2]).toBeGreaterThanOrEqual(minPointRadius);
-    expect(call[2]).toBeLessThanOrEqual(maxPointRadius);
+    expect(call[2]).toBeGreaterThanOrEqual(MIN_VISIBLE_POINT_RADIUS);
+    expect(call[2]).toBeLessThanOrEqual(MAX_VISIBLE_POINT_RADIUS);
   });
 
   expect(arcCalls[0][2]).toBeLessThan(arcCalls[1][2]);
@@ -448,16 +443,12 @@ test('cluster radius is always >= max individual point radius in Pixels mode', (
   const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
-  const minClusterRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
-  const largestPointRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
 
   // cluster with label=1 (index 0) should not be smaller than the largest point bubble
-  expect(arcCalls[0][2]).toBeGreaterThanOrEqual(minClusterRadius);
+  expect(arcCalls[0][2]).toBeGreaterThanOrEqual(MAX_VISIBLE_POINT_RADIUS);
   // point radii span the configured pixel range
-  expect(arcCalls[1][2]).toBe(
-    defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO,
-  );
-  expect(arcCalls[2][2]).toBe(largestPointRadius);
+  expect(arcCalls[1][2]).toBe(MIN_VISIBLE_POINT_RADIUS);
+  expect(arcCalls[2][2]).toBe(MAX_VISIBLE_POINT_RADIUS);
   expect(arcCalls[0][2]).toBeGreaterThanOrEqual(arcCalls[2][2]);
 });
 
@@ -549,9 +540,7 @@ test('negative cluster label produces valid finite radius', () => {
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const radiusValue = arcCalls[0][2];
   expect(Number.isFinite(radiusValue)).toBe(true);
-  expect(radiusValue).toBeGreaterThanOrEqual(
-    defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO,
-  );
+  expect(radiusValue).toBeGreaterThanOrEqual(MIN_VISIBLE_POINT_RADIUS);
 });
 
 test('single cluster with small maxLabel gets full dotRadius', () => {
@@ -609,7 +598,6 @@ test('all-negative cluster labels produce differentiated radii by magnitude', ()
   const rNeg100 = arcCalls[0][2];
   const rNeg10 = arcCalls[1][2];
   const rNeg1 = arcCalls[2][2];
-  const minClusterRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
 
   // Higher magnitude = bigger circle: |-100| > |-10| > |-1|
   expect(rNeg1).toBeLessThan(rNeg10);
@@ -617,7 +605,7 @@ test('all-negative cluster labels produce differentiated radii by magnitude', ()
   expect(Number.isFinite(rNeg100)).toBe(true);
   expect(Number.isFinite(rNeg10)).toBe(true);
   expect(Number.isFinite(rNeg1)).toBe(true);
-  expect(rNeg1).toBeGreaterThanOrEqual(minClusterRadius);
+  expect(rNeg1).toBeGreaterThanOrEqual(MIN_VISIBLE_POINT_RADIUS);
   expect(rNeg100).toBe(defaultProps.dotRadius);
 });
 
@@ -653,12 +641,11 @@ test('mixed positive-and-negative cluster labels size by magnitude', () => {
   const rNeg50 = arcCalls[0][2];
   const rZero = arcCalls[1][2];
   const r100 = arcCalls[2][2];
-  const minClusterRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
 
   // Magnitude ordering: |0| < |-50| < |100|
   expect(rZero).toBeLessThan(rNeg50);
   expect(rNeg50).toBeLessThan(r100);
-  expect(rZero).toBeGreaterThanOrEqual(minClusterRadius);
+  expect(rZero).toBeGreaterThanOrEqual(MIN_VISIBLE_POINT_RADIUS);
   expect(r100).toBe(defaultProps.dotRadius);
 });
 
@@ -817,9 +804,7 @@ test('zero-value cluster is visible with minimum radius', () => {
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const zeroClusterRadius = arcCalls[0][2];
-  const minVisibleClusterRadius =
-    defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
 
   expect(Number.isFinite(zeroClusterRadius)).toBe(true);
-  expect(zeroClusterRadius).toBeGreaterThanOrEqual(minVisibleClusterRadius);
+  expect(zeroClusterRadius).toBeGreaterThanOrEqual(MAX_VISIBLE_POINT_RADIUS);
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -373,8 +373,7 @@ test('cluster radius is always >= individual point radius', () => {
   (global as any).mockRedraw(redrawParams);
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
-  const minClusterRadius =
-    defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
+  const minClusterRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
 
   // cluster with label=1 (index 0)
   expect(arcCalls[0][2]).toBeGreaterThanOrEqual(minClusterRadius);

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -231,16 +231,26 @@ test('handles radius values provided as strings', () => {
     createLocation([300, 300], { radius: '100', cluster: false }),
   ];
 
-  expect(() => {
-    render(
-      <ScatterPlotGlowOverlay
-        {...defaultProps}
-        locations={locations}
-        pointRadiusUnit="Pixels"
-      />,
-    );
-    triggerRedraw();
-  }).not.toThrow();
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      pointRadiusUnit="Pixels"
+    />,
+  );
+  const redrawParams = triggerRedraw();
+
+  const arcCalls = redrawParams.ctx.arc.mock.calls;
+  const minPointRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
+  const maxPointRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
+
+  arcCalls.forEach(call => {
+    expect(call[2]).toBeGreaterThanOrEqual(minPointRadius);
+    expect(call[2]).toBeLessThanOrEqual(maxPointRadius);
+  });
+
+  expect(arcCalls[0][2]).toBeLessThan(arcCalls[1][2]);
+  expect(arcCalls[1][2]).toBeLessThan(arcCalls[2][2]);
 });
 
 test('renders points when radius values are missing', () => {
@@ -416,19 +426,15 @@ test('renders successfully with mixed extreme and negative radius values', () =>
   }).not.toThrow();
 });
 
-test('cluster radius is always >= individual point radius', () => {
+test('cluster radius is always >= max individual point radius in Pixels mode', () => {
   const locations = [
     createLocation([100, 100], {
       cluster: true,
       point_count: 2,
       sum: 1,
     }),
-    createLocation([200, 200], {
-      cluster: true,
-      point_count: 50,
-      sum: 100,
-    }),
-    createLocation([300, 300], { cluster: false }),
+    createLocation([200, 200], { cluster: false, radius: 1 }),
+    createLocation([300, 300], { cluster: false, radius: 100 }),
   ];
 
   render(
@@ -436,19 +442,23 @@ test('cluster radius is always >= individual point radius', () => {
       {...defaultProps}
       locations={locations}
       aggregation="sum"
+      pointRadiusUnit="Pixels"
     />,
   );
   const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
-  const minClusterRadius = defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
+  const minClusterRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
+  const largestPointRadius = defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
 
-  // cluster with label=1 (index 0)
+  // cluster with label=1 (index 0) should not be smaller than the largest point bubble
   expect(arcCalls[0][2]).toBeGreaterThanOrEqual(minClusterRadius);
-  // cluster with label=100 (index 1)
-  expect(arcCalls[1][2]).toBeGreaterThanOrEqual(minClusterRadius);
-  // single point (index 2) gets minimum cluster radius as default
-  expect(arcCalls[2][2]).toBe(minClusterRadius);
+  // point radii span the configured pixel range
+  expect(arcCalls[1][2]).toBe(
+    defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO,
+  );
+  expect(arcCalls[2][2]).toBe(largestPointRadius);
+  expect(arcCalls[0][2]).toBeGreaterThanOrEqual(arcCalls[2][2]);
 });
 
 test('largest cluster gets full dotRadius', () => {
@@ -470,6 +480,7 @@ test('largest cluster gets full dotRadius', () => {
       {...defaultProps}
       locations={locations}
       aggregation="sum"
+      pointRadiusUnit="Pixels"
     />,
   );
   const redrawParams = triggerRedraw();
@@ -503,6 +514,7 @@ test('cluster radii preserve proportional ordering', () => {
       {...defaultProps}
       locations={locations}
       aggregation="sum"
+      pointRadiusUnit="Pixels"
     />,
   );
   const redrawParams = triggerRedraw();
@@ -798,15 +810,16 @@ test('zero-value cluster is visible with minimum radius', () => {
       {...defaultProps}
       locations={locations}
       aggregation="sum"
+      pointRadiusUnit="Pixels"
     />,
   );
   const redrawParams = triggerRedraw();
 
   const arcCalls = redrawParams.ctx.arc.mock.calls;
   const zeroClusterRadius = arcCalls[0][2];
+  const minVisibleClusterRadius =
+    defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
 
   expect(Number.isFinite(zeroClusterRadius)).toBe(true);
-  expect(zeroClusterRadius).toBeGreaterThanOrEqual(
-    defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO,
-  );
+  expect(zeroClusterRadius).toBeGreaterThanOrEqual(minVisibleClusterRadius);
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
@@ -861,3 +861,33 @@ test('zero-value cluster is visible with minimum radius', () => {
   expect(Number.isFinite(zeroClusterRadius)).toBe(true);
   expect(zeroClusterRadius).toBeGreaterThanOrEqual(MAX_VISIBLE_POINT_RADIUS);
 });
+
+test('all-zero clusters use a finite radius', () => {
+  const locations = [
+    createLocation([100, 100], {
+      cluster: true,
+      point_count: 5,
+      sum: 0,
+    }),
+    createLocation([200, 200], {
+      cluster: true,
+      point_count: 10,
+      sum: 0,
+    }),
+  ];
+
+  render(
+    <ScatterPlotGlowOverlay
+      {...defaultProps}
+      locations={locations}
+      aggregation="sum"
+      pointRadiusUnit="Pixels"
+    />,
+  );
+  const redrawParams = triggerRedraw();
+
+  redrawParams.ctx.arc.mock.calls.forEach(call => {
+    expect(Number.isFinite(call[2])).toBe(true);
+    expect(call[2]).toBeGreaterThanOrEqual(MAX_VISIBLE_POINT_RADIUS);
+  });
+});


### PR DESCRIPTION
## **User description**
### SUMMARY

This PR fixes cluster and point sizing inconsistencies in the legacy MapBox chart overlay.

Before this change, cluster bubbles and individual point bubbles in `Pixels` mode used disconnected sizing ranges, which caused several problems:
- Small clusters could render smaller than visible point bubbles
- Zero-value clusters could collapse to an invisible radius
- Negative cluster labels could produce invalid sizing behavior
- Numeric-string point radius values were handled inconsistently between scaling and rendering

The updated behavior is:
- In `Pixels` mode, cluster radii are remapped to a visible range whose floor is at least the maximum individual point bubble radius, so clusters do not render smaller than points
- Zero-value clusters remain visible with a finite minimum radius
- Negative cluster labels size by absolute magnitude while keeping signed labels in the bubble text
- Numeric-string point radius values are coerced consistently during point scaling and rendering
- Point radii in `Pixels` mode remain bounded and preserve ordering across the dataset

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
- Small clusters could render smaller than visible individual points
- Zero-value clusters could disappear
- Negative labels could produce invalid radius calculations

After:
- Clusters in `Pixels` mode stay at least as large as point bubbles
- Zero-value clusters stay visible
- Negative labels render with finite, magnitude-based sizing

### TESTING INSTRUCTIONS

1. Create a MapBox chart with clustered geospatial data.
2. Set `Clustering Radius` to `60` and `Point Radius Unit` to `Pixels`.
3. Zoom to a level where both clusters and individual points are visible.
4. Verify that small clusters do not render smaller than visible point bubbles.
5. Verify that zero-value clusters remain visible.
6. Verify that larger-magnitude cluster values render larger circles, including negative values.
7. Verify that point radii continue to scale proportionally in `Pixels` mode.

```bash
cd superset-frontend
npm run test -- --runTestsByPath plugins/legacy-plugin-chart-map-box/test/ScatterPlotGlowOverlay.test.tsx
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #38314
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Ensure cluster circles are not smaller than individual points and handle negative/zero/string radii**

### What Changed
- Cluster circle sizes in Pixels mode are never smaller than individual point bubbles; the smallest cluster radius is tied to the maximum point radius so clusters remain visible and comparable to points.
- Zero-value clusters are rendered with a finite visible radius instead of collapsing to invisible.
- Negative cluster labels are sized by their absolute magnitude while keeping the negative sign in the displayed label; ordering by magnitude is preserved across positive, negative, and mixed datasets.
- Point radius inputs provided as numeric strings are coerced consistently; blank or whitespace-only radius strings are treated as missing values and fall back to a minimum visible radius.
- Tests added and updated to assert visible bounds, ordering, negative-label behavior, zero-value visibility, and robust handling of non-finite or missing radius values.

### Impact
`✅ No invisible zero-value clusters`
`✅ Consistent point sizing from numeric-string radius inputs`
`✅ Clear, magnitude-ordered cluster sizes for negative labels`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
