### PR TITLE
fix(dev): allow external access to webpack dev server via env var

### DIFF
--- a/.agor.yml
+++ b/.agor.yml
@@ -7,6 +7,6 @@ environment:
   nuke_command: >-
     docker compose -p {{worktree.name}} -f docker-compose-light.yml down -v
   health_check_url: 'http://localhost:{{add 9100 worktree.unique_id}}/health'
-  app_url: 'http://10.33.93.131:{{add 9100 worktree.unique_id}}'
+  app_url: 'http://localhost:{{add 9100 worktree.unique_id}}'
   logs_command: >-
     docker compose -p {{worktree.name}} -f docker-compose-light.yml logs --tail=100 superset-node-light

--- a/.agor.yml
+++ b/.agor.yml
@@ -1,0 +1,12 @@
+environment:
+  up_command: >-
+    NODE_PORT={{add 9100 worktree.unique_id}}
+    docker compose -p {{worktree.name}} -f docker-compose-light.yml up -d
+  down_command: >-
+    docker compose -p {{worktree.name}} -f docker-compose-light.yml down
+  nuke_command: >-
+    docker compose -p {{worktree.name}} -f docker-compose-light.yml down -v
+  health_check_url: 'http://localhost:{{add 9100 worktree.unique_id}}/health'
+  app_url: 'http://10.33.93.131:{{add 9100 worktree.unique_id}}'
+  logs_command: >-
+    docker compose -p {{worktree.name}} -f docker-compose-light.yml logs --tail=100 superset-node-light

--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -162,6 +162,7 @@ services:
       # Webpack dev server must bind to 0.0.0.0 to be accessible from outside the container
       WEBPACK_DEVSERVER_HOST: "${WEBPACK_DEVSERVER_HOST:-0.0.0.0}"
       WEBPACK_DEVSERVER_PORT: "${WEBPACK_DEVSERVER_PORT:-9000}"
+      WEBPACK_ALLOW_ALL_HOSTS: "${WEBPACK_ALLOW_ALL_HOSTS:-true}"
     ports:
       - "${NODE_PORT:-9001}:9000"  # Parameterized port, accessible on all interfaces
     command: ["/app/docker/docker-frontend.sh"]

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -666,16 +666,18 @@ if (isDevMode) {
     liveReload: false,
     host: devserverHost,
     port: devserverPort,
-    allowedHosts: [
-      ...new Set([
-        devserverHost,
-        'localhost',
-        '.localhost',
-        '127.0.0.1',
-        '::1',
-        '.local',
-      ]),
-    ],
+    allowedHosts: process.env.WEBPACK_ALLOW_ALL_HOSTS
+      ? 'all'
+      : [
+          ...new Set([
+            devserverHost,
+            'localhost',
+            '.localhost',
+            '127.0.0.1',
+            '::1',
+            '.local',
+          ]),
+        ],
     proxy: [() => proxyConfig],
     client: {
       overlay: {


### PR DESCRIPTION
### SUMMARY

Adds a `WEBPACK_ALLOW_ALL_HOSTS` env var that, when set, configures webpack-dev-server with `allowedHosts: 'all'`. This enables access from external IPs (e.g. remote dev environments like Agor, Codespaces, or any cloud-based dev setup) without hardcoding host entries.

- **`superset-frontend/webpack.config.js`**: Checks `WEBPACK_ALLOW_ALL_HOSTS` env var; when truthy uses `allowedHosts: 'all'`, otherwise keeps the existing restrictive list
- **`docker-compose-light.yml`**: Passes `WEBPACK_ALLOW_ALL_HOSTS=true` by default since the light compose already binds to `0.0.0.0`
- **`.agor.yml`**: Environment template for multi-worktree development using `docker-compose-light.yml`

Default local development behavior is unchanged — the env var must be explicitly set to opt in.

### TESTING INSTRUCTIONS

1. Start with `docker-compose-light.yml`: `NODE_PORT=9001 docker compose -f docker-compose-light.yml up -d`
2. Access the dev server from an external IP — should work (previously rejected by `allowedHosts`)
3. Without the env var (`WEBPACK_ALLOW_ALL_HOSTS=`), external access should be rejected as before

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)