### PR TITLE
refactor(extensions): align editors API naming with commands/views, add description to all contribution types

### DIFF
--- a/docs/developer_docs/extensions/extension-points/editors.md
+++ b/docs/developer_docs/extensions/extension-points/editors.md
@@ -41,7 +41,7 @@ Superset uses text editors in various places throughout the application:
 | `python` | Custom Python editor contexts |
 | `text` | Plain text editor contexts |
 
-By registering an editor provider for a language, your extension replaces the default Ace editor in **all** locations that use that language.
+By registering an editor for a language, your extension replaces the default Ace editor in **all** locations that use that language.
 
 ## Implementing an Editor
 

--- a/superset-frontend/packages/superset-core/src/commands/index.ts
+++ b/superset-frontend/packages/superset-core/src/commands/index.ts
@@ -38,7 +38,7 @@ export interface Command {
   /** The icon associated with the command. */
   icon?: string;
   /** A description of what the command does. */
-  description: string;
+  description?: string;
 }
 
 /**

--- a/superset-frontend/packages/superset-core/src/editors/index.ts
+++ b/superset-frontend/packages/superset-core/src/editors/index.ts
@@ -513,17 +513,17 @@ export interface EditorProvider {
 }
 
 /**
- * Event fired when an editor provider is registered.
+ * Event fired when an editor is registered.
  */
-export interface EditorProviderRegisteredEvent {
-  /** The registered provider */
-  provider: EditorProvider;
+export interface EditorRegisteredEvent {
+  /** The descriptor of the editor that was registered */
+  editor: Editor;
 }
 
 /**
- * Event fired when an editor provider is unregistered.
+ * Event fired when an editor is unregistered.
  */
-export interface EditorProviderUnregisteredEvent {
+export interface EditorUnregisteredEvent {
   /** The descriptor of the editor that was unregistered */
   editor: Editor;
 }
@@ -557,7 +557,7 @@ export declare function registerEditor(
  * @param language The language to get an editor for
  * @returns The editor provider or undefined if no extension provides one
  */
-export declare function getEditorProvider(
+export declare function getEditor(
   language: EditorLanguage,
 ): EditorProvider | undefined;
 
@@ -567,21 +567,21 @@ export declare function getEditorProvider(
  * @param language The language to check
  * @returns True if an extension provides an editor for this language
  */
-export declare function hasEditorProvider(language: EditorLanguage): boolean;
+export declare function hasEditor(language: EditorLanguage): boolean;
 
 /**
  * Get all registered editor providers.
  *
  * @returns Array of all registered editor providers
  */
-export declare function getAllEditorProviders(): EditorProvider[];
+export declare function getAllEditors(): EditorProvider[];
 
 /**
- * Event fired when an editor provider is registered.
+ * Event fired when an editor is registered.
  */
-export declare const onDidRegisterEditorProvider: Event<EditorProviderRegisteredEvent>;
+export declare const onDidRegisterEditor: Event<EditorRegisteredEvent>;
 
 /**
- * Event fired when an editor provider is unregistered.
+ * Event fired when an editor is unregistered.
  */
-export declare const onDidUnregisterEditorProvider: Event<EditorProviderUnregisteredEvent>;
+export declare const onDidUnregisterEditor: Event<EditorUnregisteredEvent>;

--- a/superset-frontend/packages/superset-core/src/menus/index.ts
+++ b/superset-frontend/packages/superset-core/src/menus/index.ts
@@ -47,6 +47,8 @@ export interface MenuItem {
   view: string;
   /** The command to execute when this menu item is selected. */
   command: string;
+  /** Optional description of the menu item, for display in contribution manifests. */
+  description?: string;
 }
 
 /**

--- a/superset-frontend/packages/superset-core/src/views/index.ts
+++ b/superset-frontend/packages/superset-core/src/views/index.ts
@@ -46,6 +46,8 @@ export interface View {
   id: string;
   /** The display name of the view. */
   name: string;
+  /** Optional description of the view, for display in contribution manifests. */
+  description?: string;
 }
 
 /**

--- a/superset-frontend/src/core/editors/EditorHost.tsx
+++ b/superset-frontend/src/core/editors/EditorHost.tsx
@@ -61,7 +61,7 @@ const useEditorProvider = (language: EditorLanguage) => {
 
     // Subscribe to provider changes
     const registerDisposable = manager.onDidRegister(event => {
-      if (event.provider.editor.languages.includes(language)) {
+      if (event.editor.languages.includes(language)) {
         updateProvider();
       }
     });

--- a/superset-frontend/src/core/editors/EditorProviders.test.ts
+++ b/superset-frontend/src/core/editors/EditorProviders.test.ts
@@ -204,10 +204,7 @@ test('fires onDidRegister event when provider is registered', () => {
 
   expect(listener).toHaveBeenCalledTimes(1);
   expect(listener).toHaveBeenCalledWith({
-    provider: {
-      editor,
-      component,
-    },
+    editor,
   });
 });
 

--- a/superset-frontend/src/core/editors/EditorProviders.ts
+++ b/superset-frontend/src/core/editors/EditorProviders.ts
@@ -24,8 +24,8 @@ type EditorLanguage = editors.EditorLanguage;
 type EditorProvider = editors.EditorProvider;
 type Editor = editors.Editor;
 type EditorComponent = editors.EditorComponent;
-type EditorProviderRegisteredEvent = editors.EditorProviderRegisteredEvent;
-type EditorProviderUnregisteredEvent = editors.EditorProviderUnregisteredEvent;
+type EditorRegisteredEvent = editors.EditorRegisteredEvent;
+type EditorUnregisteredEvent = editors.EditorUnregisteredEvent;
 
 /**
  * Listener function type for events.
@@ -86,13 +86,12 @@ class EditorProviders {
   /**
    * Event emitter for provider registration events.
    */
-  private registerEmitter = new EventEmitter<EditorProviderRegisteredEvent>();
+  private registerEmitter = new EventEmitter<EditorRegisteredEvent>();
 
   /**
    * Event emitter for provider unregistration events.
    */
-  private unregisterEmitter =
-    new EventEmitter<EditorProviderUnregisteredEvent>();
+  private unregisterEmitter = new EventEmitter<EditorUnregisteredEvent>();
 
   // eslint-disable-next-line no-useless-constructor
   private constructor() {
@@ -145,7 +144,7 @@ class EditorProviders {
     });
 
     // Fire registration event
-    this.registerEmitter.fire({ provider });
+    this.registerEmitter.fire({ editor });
 
     // Return disposable for cleanup
     return new Disposable(() => {
@@ -214,9 +213,7 @@ class EditorProviders {
    * @param listener The listener function.
    * @returns A Disposable to unsubscribe.
    */
-  public onDidRegister(
-    listener: Listener<EditorProviderRegisteredEvent>,
-  ): Disposable {
+  public onDidRegister(listener: Listener<EditorRegisteredEvent>): Disposable {
     return this.registerEmitter.subscribe(listener);
   }
 
@@ -226,7 +223,7 @@ class EditorProviders {
    * @returns A Disposable to unsubscribe.
    */
   public onDidUnregister(
-    listener: Listener<EditorProviderUnregisteredEvent>,
+    listener: Listener<EditorUnregisteredEvent>,
   ): Disposable {
     return this.unregisterEmitter.subscribe(listener);
   }

--- a/superset-frontend/src/core/editors/index.ts
+++ b/superset-frontend/src/core/editors/index.ts
@@ -32,9 +32,8 @@ type EditorLanguage = editorsApi.EditorLanguage;
 type Editor = editorsApi.Editor;
 type EditorProvider = editorsApi.EditorProvider;
 type EditorComponent = editorsApi.EditorComponent;
-type EditorProviderRegisteredEvent = editorsApi.EditorProviderRegisteredEvent;
-type EditorProviderUnregisteredEvent =
-  editorsApi.EditorProviderUnregisteredEvent;
+type EditorRegisteredEvent = editorsApi.EditorRegisteredEvent;
+type EditorUnregisteredEvent = editorsApi.EditorUnregisteredEvent;
 
 /**
  * Register an editor provider as a module-level side effect.
@@ -60,7 +59,7 @@ export const registerEditor = (
  * @param language The language to get an editor for
  * @returns The editor provider or undefined if no extension provides one
  */
-export const getEditorProvider = (
+export const getEditor = (
   language: EditorLanguage,
 ): EditorProvider | undefined => {
   const manager = EditorProviders.getInstance();
@@ -73,7 +72,7 @@ export const getEditorProvider = (
  * @param language The language to check
  * @returns True if an extension provides an editor for this language
  */
-export const hasEditorProvider = (language: EditorLanguage): boolean => {
+export const hasEditor = (language: EditorLanguage): boolean => {
   const manager = EditorProviders.getInstance();
   return manager.hasProvider(language);
 };
@@ -83,28 +82,28 @@ export const hasEditorProvider = (language: EditorLanguage): boolean => {
  *
  * @returns Array of all registered editor providers
  */
-export const getAllEditorProviders = (): EditorProvider[] => {
+export const getAllEditors = (): EditorProvider[] => {
   const manager = EditorProviders.getInstance();
   return manager.getAllProviders();
 };
 
 /**
- * Event fired when an editor provider is registered.
+ * Event fired when an editor is registered.
  * Subscribe to this event to react when extensions register new editors.
  */
-export const onDidRegisterEditorProvider = (
-  listener: (e: EditorProviderRegisteredEvent) => void,
+export const onDidRegisterEditor = (
+  listener: (e: EditorRegisteredEvent) => void,
 ): Disposable => {
   const manager = EditorProviders.getInstance();
   return manager.onDidRegister(listener);
 };
 
 /**
- * Event fired when an editor provider is unregistered.
+ * Event fired when an editor is unregistered.
  * Subscribe to this event to react when extensions unregister editors.
  */
-export const onDidUnregisterEditorProvider = (
-  listener: (e: EditorProviderUnregisteredEvent) => void,
+export const onDidUnregisterEditor = (
+  listener: (e: EditorUnregisteredEvent) => void,
 ): Disposable => {
   const manager = EditorProviders.getInstance();
   return manager.onDidUnregister(listener);
@@ -115,11 +114,11 @@ export const onDidUnregisterEditorProvider = (
  */
 export const editors: typeof editorsApi = {
   registerEditor,
-  getEditorProvider,
-  hasEditorProvider,
-  getAllEditorProviders,
-  onDidRegisterEditorProvider,
-  onDidUnregisterEditorProvider,
+  getEditor,
+  hasEditor,
+  getAllEditors,
+  onDidRegisterEditor,
+  onDidUnregisterEditor,
 };
 
 export { EditorProviders };


### PR DESCRIPTION
## **User description**
### SUMMARY

Cleans up the extensions API for consistency across all contribution types.

**1. Rename editors API functions to drop the "Provider" suffix**

The editors API mixed two naming conventions: `registerEditor` on the write side, but `getEditorProvider` / `hasEditorProvider` / `getAllEditorProviders` / `onDidRegisterEditorProvider` / `onDidUnregisterEditorProvider` on the read side. This diverged from the commands and views APIs, which use the plain noun consistently (`getCommand`, `getViews`, etc.).

All editor-related functions and event types are renamed to use "Editor":

| Before | After |
|---|---|
| `getEditorProvider(language)` | `getEditor(language)` |
| `hasEditorProvider(language)` | `hasEditor(language)` |
| `getAllEditorProviders()` | `getAllEditors()` |
| `onDidRegisterEditorProvider` | `onDidRegisterEditor` |
| `onDidUnregisterEditorProvider` | `onDidUnregisterEditor` |
| `EditorProviderRegisteredEvent` | `EditorRegisteredEvent` |
| `EditorProviderUnregisteredEvent` | `EditorUnregisteredEvent` |

`registerEditor` is unchanged — it was already consistent.

The `EditorRegisteredEvent` payload is also slimmed from `{ provider: EditorProvider }` to `{ editor: Editor }`, matching the shape of `EditorUnregisteredEvent`. The React component remains internal to `EditorProviders` / `EditorHost` and is no longer exposed through the event.

**2. Add optional `description` to all contribution types**

`description` was present on `Command` (required) and `Editor` (optional) but missing from `View` and `MenuItem`. This field is forward-looking for manifest display. It is now optional and consistent across all four types:

- `Command.description?: string` (relaxed from required)
- `Editor.description?: string` (unchanged)
- `View.description?: string` (added)
- `MenuItem.description?: string` (added)

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Align editors API naming with commands/views and add optional descriptions to contribution types

### What Changed
- Editor APIs renamed for consistent public naming: getEditor, hasEditor, getAllEditors, onDidRegisterEditor, onDidUnregisterEditor (replacing the previous *Provider* variants). Extension callers should use the new names.
- Editor lifecycle events now deliver the editor descriptor directly (event.editor) instead of a provider wrapper; consumers of registration/unregistration events receive the editor object.
- Menu items and views now accept an optional description field for contribution manifests; command.description was relaxed from required to optional.
- Internal consumers updated to use the new event shape and API names; tests and documentation updated to reflect wording and API changes.

### Impact
`✅ Consistent editor extension API names across the platform`
`✅ Extension events provide the editor descriptor directly for simpler listeners`
`✅ Contribution manifests can include optional descriptions for views and menu items`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
