### PR TITLE
fix(charts): revert: improve negative stacked bar label positioning and accessibility (#37405)

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -31,7 +31,6 @@ import {
   ValueFormatter,
 } from '@superset-ui/core';
 import { SupersetTheme, isThemeDark } from '@apache-superset/core/theme';
-import { getContrastingColor } from '@superset-ui/core';
 import type {
   CallbackDataParams,
   DefaultStatesMixin,
@@ -143,39 +142,28 @@ export const getBaselineSeriesForStream = (
   };
 };
 
-export function optimizeBarLabelPlacement(
+export function transformNegativeLabelsPosition(
   series: SeriesOption,
   isHorizontal: boolean,
 ): TimeseriesDataRecord[] {
   /*
-   * Adjusts label position for all values in bar series
-   * Positions labels inside bars at appropriate edges to avoid axis overlap
+   * Adjusts label position for negative values in bar series
    * @param series - Array of series options
    * @param isHorizontal - Whether chart is horizontal
-   * @returns data with adjusted label positions for all values
+   * @returns data with adjusted label positions for negative values
    */
   const transformValue = (value: any) => {
     const [xValue, yValue] = Array.isArray(value) ? value : [null, null];
     const axisValue = isHorizontal ? xValue : yValue;
 
-    if (axisValue === null || axisValue === undefined) {
-      return value;
-    }
-
-    // Use inside positioning for all bar charts to avoid axis overlap
-    const labelPosition =
-      axisValue < 0
-        ? isHorizontal
-          ? 'insideLeft'
-          : 'insideBottom'
-        : isHorizontal
-          ? 'insideRight'
-          : 'insideTop';
-
-    return {
-      value,
-      label: { position: labelPosition },
-    };
+    return axisValue < 0
+      ? {
+          value,
+          label: {
+            position: 'outside',
+          },
+        }
+      : value;
   };
 
   return (series.data as TimeseriesDataRecord[]).map(transformValue);
@@ -376,20 +364,8 @@ export function transformSeries(
 
   return {
     ...series,
-    ...(Array.isArray(data)
-      ? colorByPrimaryAxis
-        ? {
-            data: applyColorByPrimaryAxis(
-              series,
-              colorScale,
-              sliceId,
-              opacity,
-              isHorizontal,
-            ),
-          }
-        : seriesType === 'bar' && !stack
-          ? { data: optimizeBarLabelPlacement(series, isHorizontal) }
-          : null
+    ...(Array.isArray(data) && seriesType === 'bar' && !stack
+      ? { data: transformNegativeLabelsPosition(series, isHorizontal) }
       : null),
     connectNulls,
     queryIndex,
@@ -422,11 +398,8 @@ export function transformSeries(
     symbolSize: markerSize,
     label: {
       show: !!showValue,
-      position: stack ? 'inside' : isHorizontal ? 'right' : 'top',
-      color:
-        stack || seriesType === 'bar'
-          ? getContrastingColor(String(itemStyle.color))
-          : theme?.colorText,
+      position: isHorizontal ? 'right' : 'top',
+      color: theme?.colorText,
       textBorderWidth: 0,
       formatter: (params: any) => {
         // don't show confidence band value labels, as they're already visible on the tooltip

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -364,8 +364,20 @@ export function transformSeries(
 
   return {
     ...series,
-    ...(Array.isArray(data) && seriesType === 'bar' && !stack
-      ? { data: transformNegativeLabelsPosition(series, isHorizontal) }
+    ...(Array.isArray(data)
+      ? colorByPrimaryAxis
+        ? {
+            data: applyColorByPrimaryAxis(
+              series,
+              colorScale,
+              sliceId,
+              opacity,
+              isHorizontal,
+            ),
+          }
+        : seriesType === 'bar' && !stack
+          ? { data: transformNegativeLabelsPosition(series, isHorizontal) }
+          : null
       : null),
     connectNulls,
     queryIndex,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -22,24 +22,20 @@ import { supersetTheme } from '@apache-superset/core/theme';
 import type { SeriesOption } from 'echarts';
 import { EchartsTimeseriesSeriesType } from '../../src';
 import { TIMESERIES_CONSTANTS } from '../../src/constants';
-import {
-  LegendOrientation,
-  EchartsTimeseriesChartProps,
-} from '../../src/types';
+import { LegendOrientation } from '../../src/types';
 import {
   transformSeries,
-  optimizeBarLabelPlacement,
+  transformNegativeLabelsPosition,
   getPadding,
 } from '../../src/Timeseries/transformers';
 import transformProps from '../../src/Timeseries/transformProps';
+import { EchartsTimeseriesChartProps } from '../../src/types';
 import * as seriesUtils from '../../src/utils/series';
 
-// Mock the colorScale function to return different colors based on key
-const mockColorScale = jest.fn((key: string) => {
-  if (key === 'test-key') return '#1f77b4'; // blue
-  if (key === 'series-key') return '#ff7f0e'; // orange
-  return '#2ca02c'; // green for any other key
-}) as unknown as CategoricalColorScale;
+// Mock the colorScale function
+const mockColorScale = jest.fn(
+  (key: string, sliceId?: number) => `color-for-${key}-${sliceId}`,
+) as unknown as CategoricalColorScale;
 
 describe('transformSeries', () => {
   const series = { name: 'test-series' };
@@ -53,8 +49,7 @@ describe('transformSeries', () => {
 
     const result = transformSeries(series, mockColorScale, 'test-key', opts);
 
-    expect(mockColorScale).toHaveBeenCalledWith('test-key', 1);
-    expect((result as any)?.itemStyle.color).toBe('#1f77b4');
+    expect((result as any)?.itemStyle.color).toBe('color-for-test-key-1');
   });
 
   test('should use seriesKey if timeShiftColor is not enabled', () => {
@@ -66,8 +61,7 @@ describe('transformSeries', () => {
 
     const result = transformSeries(series, mockColorScale, 'test-key', opts);
 
-    expect(mockColorScale).toHaveBeenCalledWith('series-key', 2);
-    expect((result as any)?.itemStyle.color).toBe('#ff7f0e');
+    expect((result as any)?.itemStyle.color).toBe('color-for-series-key-2');
   });
 
   test('should apply border styles for bar series with connectNulls', () => {
@@ -129,8 +123,8 @@ describe('transformSeries', () => {
   });
 });
 
-describe('optimizeBarLabelPlacement', () => {
-  test('label position for non-stacked vertical charts', () => {
+describe('transformNegativeLabelsPosition', () => {
+  test('label position bottom of negative value no Horizontal', () => {
     const isHorizontal = false;
     const series: SeriesOption = {
       data: [
@@ -143,12 +137,15 @@ describe('optimizeBarLabelPlacement', () => {
       type: EchartsTimeseriesSeriesType.Bar,
       stack: undefined,
     };
-    const result = optimizeBarLabelPlacement(series, isHorizontal);
-    expect((result as any)[0].label.position).toBe('insideTop');
-    expect((result as any)[1].label.position).toBe('insideTop');
-    expect((result as any)[2].label.position).toBe('insideBottom');
-    expect((result as any)[3].label.position).toBe('insideBottom');
-    expect((result as any)[4].label.position).toBe('insideTop');
+    const result =
+      Array.isArray(series.data) && series.type === 'bar' && !series.stack
+        ? transformNegativeLabelsPosition(series, isHorizontal)
+        : series.data;
+    expect((result as any)[0].label).toBe(undefined);
+    expect((result as any)[1].label).toBe(undefined);
+    expect((result as any)[2].label.position).toBe('outside');
+    expect((result as any)[3].label.position).toBe('outside');
+    expect((result as any)[4].label).toBe(undefined);
   });
 
   test('label position left of negative value is Horizontal', () => {
@@ -165,12 +162,15 @@ describe('optimizeBarLabelPlacement', () => {
       stack: undefined,
     };
 
-    const result = optimizeBarLabelPlacement(series, isHorizontal);
-    expect((result as any)[0].label.position).toBe('insideRight');
-    expect((result as any)[1].label.position).toBe('insideLeft');
-    expect((result as any)[2].label.position).toBe('insideRight');
-    expect((result as any)[3].label.position).toBe('insideLeft');
-    expect((result as any)[4].label.position).toBe('insideLeft');
+    const result =
+      Array.isArray(series.data) && series.type === 'bar' && !series.stack
+        ? transformNegativeLabelsPosition(series, isHorizontal)
+        : series.data;
+    expect((result as any)[0].label).toBe(undefined);
+    expect((result as any)[1].label.position).toBe('outside');
+    expect((result as any)[2].label).toBe(undefined);
+    expect((result as any)[3].label.position).toBe('outside');
+    expect((result as any)[4].label.position).toBe('outside');
   });
 
   test('label position to line type', () => {
@@ -192,7 +192,7 @@ describe('optimizeBarLabelPlacement', () => {
       !series.stack &&
       series.type !== 'line' &&
       series.type === 'bar'
-        ? optimizeBarLabelPlacement(series, isHorizontal)
+        ? transformNegativeLabelsPosition(series, isHorizontal)
         : series.data;
     expect((result as any)[0].label).toBe(undefined);
     expect((result as any)[1].label).toBe(undefined);
@@ -215,34 +215,15 @@ describe('optimizeBarLabelPlacement', () => {
       stack: 'obs',
     };
 
-    const result = optimizeBarLabelPlacement(series, isHorizontal);
-    expect((result as any)[0].label.position).toBe('insideTop');
-    expect((result as any)[1].label.position).toBe('insideTop');
-    expect((result as any)[2].label.position).toBe('insideBottom');
-    expect((result as any)[3].label.position).toBe('insideBottom');
-    expect((result as any)[4].label.position).toBe('insideTop');
-  });
-
-  test('label position for horizontal stacked charts', () => {
-    const isHorizontal = true;
-    const series: SeriesOption = {
-      data: [
-        [1, 2020],
-        [-3, 2021],
-        [2, 2022],
-        [-4, 2023],
-        [-6, 2024],
-      ],
-      type: EchartsTimeseriesSeriesType.Bar,
-      stack: 'obs',
-    };
-
-    const result = optimizeBarLabelPlacement(series, isHorizontal);
-    expect((result as any)[0].label.position).toBe('insideRight');
-    expect((result as any)[1].label.position).toBe('insideLeft');
-    expect((result as any)[2].label.position).toBe('insideRight');
-    expect((result as any)[3].label.position).toBe('insideLeft');
-    expect((result as any)[4].label.position).toBe('insideLeft');
+    const result =
+      Array.isArray(series.data) && series.type === 'bar' && !series.stack
+        ? transformNegativeLabelsPosition(series, isHorizontal)
+        : series.data;
+    expect((result as any)[0].label).toBe(undefined);
+    expect((result as any)[1].label).toBe(undefined);
+    expect((result as any)[2].label).toBe(undefined);
+    expect((result as any)[3].label).toBe(undefined);
+    expect((result as any)[4].label).toBe(undefined);
   });
 });
 


### PR DESCRIPTION
## **User description**
This reverts commit 77148277b96b1a3b1a60b11d364d2f92659cbd04.
There were some problems with narrow bars and labels being cut off, reverting the fix for now and can look into a longer term improvement as a follow up
### SUMMARY

Reverts PR #37405 which introduced issues with negative stacked bar label positioning. It's easier to revert now and re-implement with improvements later than to fix all the edge cases in the current implementation.

**Reverted PR**: #37405 - "feat(charts): improve negative stacked bar label positioning and accessibility"

**Conflict Resolution**: This revert had merge conflicts with two subsequent PRs:
- **PR #37531** (color by primary axis) - ✅ Retained the new feature
- **PR #38448** (import path refactor) - ✅ Kept the new import structure

Both features were preserved during the revert.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before Revert** (PR #37405 behavior):
- Stacked bars were more understandable and the label was in the right section of the bar but non stacked bars (especially thin ones) with labels became unreadable 
- Labels positioned at edge inside bars with contrasting colors
- Introduced issues that need to be addressed before re-implementation
<img width="890" height="613" alt="image" src="https://github.com/user-attachments/assets/2f4628a4-4884-4617-a789-48b15ff69ee7" />
<img width="904" height="594" alt="image" src="https://github.com/user-attachments/assets/7d7c7cca-32d9-4c4d-8505-4d3034062e1e" />



**After Revert** (restores pre-#37405 behavior):
- Labels with non stacked bars that are thin are more readable again, but went back to the confusing label location on stacked bars. Will work on a better solution for all cases in the future 
- Labels for negative stacked bars positioned outside bars (original behavior)
<img width="892" height="727" alt="image" src="https://github.com/user-attachments/assets/4aed5526-998d-40f7-9cd7-9d2d18bf81d5" />
<img width="906" height="713" alt="image" src="https://github.com/user-attachments/assets/63f426c8-205e-4330-8f50-0711d7c2b568" />


### TESTING INSTRUCTIONS

**1. Verify the revert worked (negative stacked bars):**
```sql
-- SQL Lab query for negative stacked bars
WITH chart_data AS (
  SELECT * FROM (VALUES
    ('Bar 1', 'Segment A', -10),
    ('Bar 1', 'Segment B', -5),
    ('Bar 2', 'Segment A', -7),
    ('Bar 2', 'Segment B', -3)
  ) AS t(bar, segment, value)
)
SELECT * FROM chart_data;


___

## **CodeAnt-AI Description**
Place negative labels outside non-stacked bar series and use theme text color for value labels

### What Changed
- Negative values in non-stacked bar series now show labels outside the bar; positive values keep no explicit inside positioning
- Value label color is unified to the theme text color across series (no contrasting color by bar color)
- Stacked bars and non-bar series behavior remains unchanged (no forced label repositioning)
- Unit tests and test mocks updated to reflect the new label positioning and color behavior

### Impact
`✅ Clearer negative bar labels`
`✅ Consistent value label color`
`✅ Tests aligned with visible label behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
