### PR TITLE
fix(heatmap): correct tooltip display to show axis values instead of indices

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
@@ -370,20 +370,32 @@ export default function transformProps(
           metricLabel,
         );
         const paramsValue = params.value as (string | number)[];
-        const x = paramsValue?.[0];
-        const y = paramsValue?.[1];
+        // paramsValue contains [xIndex, yIndex, metricValue, rankValue?]
+        // We need to look up the actual axis values from the sorted arrays
+        const xIndex = paramsValue?.[0] as number;
+        const yIndex = paramsValue?.[1] as number;
         const value = paramsValue?.[2] as number | null | undefined;
-        const formattedX = xAxisFormatter(x);
-        const formattedY = yAxisFormatter(y);
+        const xValue = sortedXAxisValues[xIndex];
+        const yValue = sortedYAxisValues[yIndex];
+        // Format the axis values for display (handle null/undefined with empty string fallback)
+        // Convert to string/number for formatter compatibility
+        const formattedX =
+          xValue !== null && xValue !== undefined
+            ? xAxisFormatter(xValue as string | number)
+            : '';
+        const formattedY =
+          yValue !== null && yValue !== undefined
+            ? yAxisFormatter(yValue as string | number)
+            : '';
         const formattedValue = valueFormatter(value);
         let percentage = 0;
         let suffix = 'heatmap';
         if (typeof value === 'number') {
           if (normalizeAcross === 'x') {
-            percentage = value / totals.x[x];
+            percentage = value / totals.x[String(xValue)];
             suffix = formattedX;
           } else if (normalizeAcross === 'y') {
-            percentage = value / totals.y[y];
+            percentage = value / totals.y[String(yValue)];
             suffix = formattedY;
           } else {
             percentage = value / totals.total;


### PR DESCRIPTION
### SUMMARY
Fixes a bug where heatmap tooltips display numeric indices (0, 1, 2...) instead of the actual axis values.

**Root cause:** PR #36302 changed the heatmap data structure to use axis indices for proper sorting, but the tooltip formatter was not updated to look up the actual values from the sorted arrays.

**Changes:**
- Updated tooltip formatter to look up actual x/y axis values from `sortedXAxisValues` and `sortedYAxisValues` arrays using the indices
- Fixed percentage calculation when `normalizeAcross` is enabled to use actual values instead of indices as lookup keys

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Tooltip shows `0 (1)` or similar numeric indices  
<img width="887" height="447" alt="image" src="https://github.com/user-attachments/assets/de2f564f-47bd-49b7-86fa-1ed1e910e8a6" />

**After:** Tooltip shows actual axis labels like `Mon (Morning)`
<img width="864" height="679" alt="image" src="https://github.com/user-attachments/assets/5da658e4-d218-4536-8c35-4bf62e51288a" />


### TESTING INSTRUCTIONS
1. Create a heatmap chart with text labels on both axes (e.g., days of week vs. time of day)
2. Hover over cells and verify the tooltip header shows actual axis labels, not indices
3. Test with different sort options (X Axis Sort / Y Axis Sort):
   - Alphabetical ascending/descending
   - Metric value ascending/descending
4. Enable "Show percentage" and verify percentages calculate correctly
5. Test normalization mode (`normalizeAcross` = 'x', 'y', or 'heatmap') - tooltips should still show correct values
6. Test with numeric and temporal axes to ensure formatters work correctly

### ADDITIONAL INFORMATION
- [x] Changes UI
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
