### PR TITLE
Fix comment injection inside optimizer hint blocks

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -553,6 +553,9 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
     This class is used for all engines with dialects that can be parsed using sqlglot.
     """
 
+    # Optimizer hints have the form /*+ ... */
+    _OPTIMIZER_HINT_PATTERN = re.compile(r"/\*\+")
+
     def __init__(
         self,
         statement: str | None = None,
@@ -560,6 +563,8 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         ast: exp.Expression | None = None,
     ):
         self._dialect = SQLGLOT_DIALECTS.get(engine)
+        # Store original statement to detect optimizer hints
+        self._original_statement: str | None = statement
         super().__init__(statement, engine, ast)
 
     @classmethod
@@ -721,11 +726,25 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
     def format(self, comments: bool = True) -> str:
         """
         Pretty-format the SQL statement.
+
+        When optimizer hints (/*+ ... */) are present in the original SQL,
+        comment preservation is disabled because sqlglot incorrectly
+        repositions comments inside optimizer hint blocks, breaking syntax.
         """
+        # Detect optimizer hints in the original statement
+        has_optimizer_hints = (
+            self._original_statement
+            and self._OPTIMIZER_HINT_PATTERN.search(self._original_statement)
+        )
+
+        # Disable comment preservation if optimizer hints are present
+        # to prevent sqlglot from injecting comments inside hint blocks
+        effective_comments = comments and not has_optimizer_hints
+
         return Dialect.get_or_raise(self._dialect).generate(
             self._parsed,
             copy=True,
-            comments=comments,
+            comments=effective_comments,
             pretty=True,
         )
 

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -3134,3 +3134,66 @@ def test_backtick_invalid_sql_still_fails() -> None:
     sql = "SELECT * FROM `table` WHERE"
     with pytest.raises(SupersetParseError):
         SQLScript(sql, "base")
+
+
+def test_optimizer_hint_with_comment() -> None:
+    """
+    Test that optimizer hints are not corrupted by inline comments.
+
+    This is a regression test for issue #38189 where sqlglot incorrectly
+    injects converted inline comments (--) inside optimizer hint blocks
+    (/*+ ... */), breaking StarRocks/MySQL syntax.
+
+    The fix detects optimizer hints and disables comment preservation
+    to prevent sqlglot from corrupting the hint syntax.
+    """
+    # SQL with optimizer hint and inline comment
+    sql = """SELECT /*+ SET_VAR(query_timeout = 3000) */ col1, col2
+FROM my_table
+LIMIT 100
+
+-- increase timeout for large scans"""
+
+    script = SQLScript(sql, "mysql")
+    formatted = script.format(comments=True)
+
+    # The optimizer hint should remain intact, not have comments injected inside
+    assert "/*+ SET_VAR(query_timeout = 3000) */" in formatted
+    # The inline comment should be stripped (not converted to /* */ inside hint)
+    assert "query_timeout /* increase timeout" not in formatted
+    assert "3000) */" in formatted  # Hint closing should be intact
+
+
+def test_optimizer_hint_disabled_comments() -> None:
+    """
+    Test that comments are disabled when optimizer hints are present.
+    """
+    sql = "SELECT /*+ SET_VAR(query_timeout = 3000) */ col FROM t"
+
+    script = SQLScript(sql, "mysql")
+    statement = script.statements[0]
+
+    # Check that the optimizer hint pattern is detected
+    assert statement._original_statement is not None
+    assert "/*+ SET_VAR(query_timeout = 3000) */" in statement._original_statement
+
+    # When formatting with comments=True, it should still disable comments
+    # due to optimizer hint detection
+    formatted = statement.format(comments=True)
+    assert "/*+ SET_VAR(query_timeout = 3000) */" in formatted
+
+
+def test_no_optimizer_hint_preserves_comments() -> None:
+    """
+    Test that comments are preserved when no optimizer hints are present.
+    """
+    sql = """SELECT col1, col2
+FROM my_table
+-- this is a comment
+LIMIT 100"""
+
+    script = SQLScript(sql, "mysql")
+    formatted = script.format(comments=True)
+
+    # Comments should be preserved when no optimizer hints are present
+    assert "/* this is a comment */" in formatted


### PR DESCRIPTION
## **User description**
When SQL contains optimizer hints (/*+ ... */) and inline comments (--), sqlglot's comment preservation incorrectly injects converted block comments inside the hint block, breaking StarRocks/MySQL syntax.

This fix detects optimizer hints in the original SQL and disables comment preservation during formatting to prevent the corruption.

Fixes #38189


___

## **CodeAnt-AI Description**
Prevent comment injection inside optimizer hint blocks

### What Changed
- When formatting SQL, optimizer hints (/*+ ... */) in the original statement are detected and comment preservation is turned off to avoid injecting converted comments inside hint blocks.
- Added tests to ensure optimizer hints remain intact after formatting, that comment preservation is disabled when hints are present, and that comments are preserved when no hints exist.

### Impact
`✅ Fewer StarRocks/MySQL syntax errors caused by the formatter`
`✅ Preserved optimizer hints in formatted SQL`
`✅ Correct comment handling when no optimizer hints are present`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
