### PR TITLE
fix(docker-compose-light): revert/light-compose and fix init scripts (examples & cy…

### DIFF
--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -87,6 +87,8 @@ services:
         required: false
     image: postgres:17
     restart: unless-stopped
+    ports:
+      - "${DATABASE_PORT:-5432}:5432"  # Parameterized port, accessible on all interfaces
     volumes:
       - db_home_light:/var/lib/postgresql/data
       - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
@@ -114,6 +116,8 @@ services:
     environment:
       DATABASE_HOST: db-light
       DATABASE_DB: superset_light
+      EXAMPLES_HOST: db-light
+      EXAMPLES_DB: examples
       POSTGRES_DB: superset_light
       SUPERSET_CONFIG_PATH: /app/docker/pythonpath_dev/superset_config_docker_light.py
       GITHUB_HEAD_REF: ${GITHUB_HEAD_REF:-}
@@ -136,6 +140,8 @@ services:
     environment:
       DATABASE_HOST: db-light
       DATABASE_DB: superset_light
+      EXAMPLES_HOST: db-light
+      EXAMPLES_DB: examples
       POSTGRES_DB: superset_light
       SUPERSET_CONFIG_PATH: /app/docker/pythonpath_dev/superset_config_docker_light.py
     healthcheck:

--- a/docker/docker-entrypoint-initdb.d/cypress-init.sh
+++ b/docker/docker-entrypoint-initdb.d/cypress-init.sh
@@ -23,6 +23,6 @@
 # ------------------------------------------------------------------------
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<-EOSQL
   CREATE DATABASE superset_cypress;
 EOSQL

--- a/docker/docker-entrypoint-initdb.d/examples-init.sh
+++ b/docker/docker-entrypoint-initdb.d/examples-init.sh
@@ -23,7 +23,7 @@
 # ------------------------------------------------------------------------
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<-EOSQL
   CREATE USER ${EXAMPLES_USER} WITH PASSWORD '${EXAMPLES_PASSWORD}';
   CREATE DATABASE ${EXAMPLES_DB};
   GRANT ALL PRIVILEGES ON DATABASE ${EXAMPLES_DB} TO ${EXAMPLES_USER};


### PR DESCRIPTION
## **User description**
…press init)

- restore expected EXAMPLES env usage in docker-compose-light.yml
- ensure psql uses -d "" in cypress-init.sh and examples-init.sh

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Fixes #38491


___

## **CodeAnt-AI Description**
**Restore example DB init and expose light DB port in docker-compose-light**

### What Changed
- Database initialization scripts now target the intended Postgres database explicitly, so example and Cypress databases are created against the configured POSTGRES_DB instead of relying on psql defaults
- The light compose Postgres service now publishes the database port to the host (configurable via DATABASE_PORT), making the DB reachable from the host machine
- Superset light services receive EXAMPLES_HOST and EXAMPLES_DB environment variables so example-data setup can connect to the correct database host and name

### Impact
`✅ Clearer example DB initialization`
`✅ Accessible local DB port for development`
`✅ Reliable test/example database creation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
