### PR TITLE
fix(mcp): add missing command.validate() to MCP chart data tools

### DIFF
--- a/superset/mcp_service/chart/preview_utils.py
+++ b/superset/mcp_service/chart/preview_utils.py
@@ -103,6 +103,7 @@ def generate_preview_from_form_data(
 
         # Execute query
         command = ChartDataCommand(query_context_obj)
+        command.validate()
         result = command.run()
 
         if not result or not result.get("queries"):

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -101,6 +101,7 @@ def _compile_chart(
         )
 
         command = ChartDataCommand(query_context)
+        command.validate()
         result = command.run()
 
         warnings: List[str] = []

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -462,6 +462,7 @@ async def get_chart_data(  # noqa: C901
             # Execute the query
             with event_logger.log_context(action="mcp.get_chart_data.query_execution"):
                 command = ChartDataCommand(query_context)
+                command.validate()
                 result = command.run()
 
             # Handle empty query results for certain chart types

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -160,6 +160,7 @@ class ASCIIPreviewStrategy(PreviewFormatStrategy):
             )
 
             command = ChartDataCommand(query_context)
+            command.validate()
             result = command.run()
 
             data = []
@@ -234,6 +235,7 @@ class TablePreviewStrategy(PreviewFormatStrategy):
             )
 
             command = ChartDataCommand(query_context)
+            command.validate()
             result = command.run()
 
             data = []
@@ -340,6 +342,7 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
 
             # Execute the query
             command = ChartDataCommand(query_context)
+            command.validate()
             result = command.run()
 
             # Extract data from result

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -671,3 +671,190 @@ class TestGetChartDataRequestSchema:
         assert data["identifier"] == 123
         assert data["limit"] == 50
         assert data["format"] == "json"
+
+
+class TestChartDataCommandValidation:
+    """Tests that ChartDataCommand.validate() is called before run().
+
+    These tests verify the security fix (CWE-862) that adds command.validate()
+    before command.run() in MCP chart data tools. The validate() call enforces
+    row-level security, guest user guards, and schema-level permissions.
+    """
+
+    def test_preview_utils_calls_validate_before_run(self):
+        """Test that generate_preview_from_form_data calls validate() before run()."""
+        from unittest.mock import MagicMock, patch
+
+        call_order: list[str] = []
+        mock_query_result = {"queries": [{"data": [{"col1": "a", "col2": 1}]}]}
+
+        mock_command = MagicMock()
+        mock_command.validate.side_effect = lambda: call_order.append("validate")
+        mock_command.run.side_effect = lambda: (
+            call_order.append("run"),
+            mock_query_result,
+        )[1]
+
+        mock_dataset = MagicMock()
+        mock_dataset.id = 10
+
+        # ChartDataCommand is module-level import in preview_utils;
+        # db and QueryContextFactory are local imports inside the function.
+        with (
+            patch("superset.extensions.db") as mock_db,
+            patch(
+                "superset.mcp_service.chart.preview_utils.ChartDataCommand",
+                return_value=mock_command,
+            ),
+            patch(
+                "superset.common.query_context_factory.QueryContextFactory"
+            ) as mock_factory,
+        ):
+            mock_db.session.query.return_value.get.return_value = mock_dataset
+            mock_factory.return_value.create.return_value = MagicMock()
+
+            from superset.mcp_service.chart.preview_utils import (
+                generate_preview_from_form_data,
+            )
+
+            generate_preview_from_form_data(
+                form_data={"metrics": [{"label": "count"}], "viz_type": "table"},
+                dataset_id=10,
+                preview_format="table",
+            )
+
+            mock_command.validate.assert_called_once()
+            mock_command.run.assert_called_once()
+            assert call_order == ["validate", "run"]
+
+    def test_preview_utils_security_exception_from_validate(self):
+        """Test that SupersetSecurityException from validate() is propagated."""
+        from unittest.mock import MagicMock, patch
+
+        from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+        from superset.exceptions import SupersetSecurityException
+        from superset.mcp_service.chart.schemas import ChartError
+
+        security_error = SupersetSecurityException(
+            SupersetError(
+                message="Access denied",
+                error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                level=ErrorLevel.ERROR,
+            )
+        )
+
+        mock_command = MagicMock()
+        mock_command.validate.side_effect = security_error
+
+        mock_dataset = MagicMock()
+        mock_dataset.id = 10
+
+        with (
+            patch("superset.extensions.db") as mock_db,
+            patch(
+                "superset.mcp_service.chart.preview_utils.ChartDataCommand",
+                return_value=mock_command,
+            ),
+            patch(
+                "superset.common.query_context_factory.QueryContextFactory"
+            ) as mock_factory,
+        ):
+            mock_db.session.query.return_value.get.return_value = mock_dataset
+            mock_factory.return_value.create.return_value = MagicMock()
+
+            from superset.mcp_service.chart.preview_utils import (
+                generate_preview_from_form_data,
+            )
+
+            result = generate_preview_from_form_data(
+                form_data={"metrics": [{"label": "count"}], "viz_type": "table"},
+                dataset_id=10,
+                preview_format="table",
+            )
+
+            # SupersetSecurityException is caught by the broad except and
+            # returned as a ChartError
+            assert isinstance(result, ChartError)
+            assert "Access denied" in result.error
+            mock_command.run.assert_not_called()
+
+    def test_compile_chart_calls_validate_before_run(self):
+        """Test that _compile_chart calls validate() before run()."""
+        from unittest.mock import MagicMock, patch
+
+        call_order: list[str] = []
+        mock_query_result = {"queries": [{"data": [{"col1": 1}]}]}
+
+        mock_command = MagicMock()
+        mock_command.validate.side_effect = lambda: call_order.append("validate")
+        mock_command.run.side_effect = lambda: (
+            call_order.append("run"),
+            mock_query_result,
+        )[1]
+
+        # Both ChartDataCommand and QueryContextFactory are local imports
+        # inside _compile_chart, so patch at source.
+        with (
+            patch(
+                "superset.commands.chart.data.get_data_command.ChartDataCommand",
+                return_value=mock_command,
+            ),
+            patch(
+                "superset.common.query_context_factory.QueryContextFactory"
+            ) as mock_factory,
+        ):
+            mock_factory.return_value.create.return_value = MagicMock()
+
+            from superset.mcp_service.chart.tool.generate_chart import _compile_chart
+
+            result = _compile_chart(
+                form_data={"metrics": [{"label": "count"}], "viz_type": "table"},
+                dataset_id=10,
+            )
+
+            assert result.success is True
+            mock_command.validate.assert_called_once()
+            mock_command.run.assert_called_once()
+            assert call_order == ["validate", "run"]
+
+    def test_compile_chart_security_exception_from_validate(self):
+        """Test that _compile_chart propagates security exception from validate()."""
+        from unittest.mock import MagicMock, patch
+
+        from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+        from superset.exceptions import SupersetSecurityException
+
+        security_error = SupersetSecurityException(
+            SupersetError(
+                message="Row-level security violation",
+                error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                level=ErrorLevel.ERROR,
+            )
+        )
+
+        mock_command = MagicMock()
+        mock_command.validate.side_effect = security_error
+
+        with (
+            patch(
+                "superset.commands.chart.data.get_data_command.ChartDataCommand",
+                return_value=mock_command,
+            ),
+            patch(
+                "superset.common.query_context_factory.QueryContextFactory"
+            ) as mock_factory,
+        ):
+            mock_factory.return_value.create.return_value = MagicMock()
+
+            from superset.mcp_service.chart.tool.generate_chart import _compile_chart
+
+            # SupersetSecurityException is not caught by _compile_chart's
+            # specific except blocks, so it propagates to the caller
+            # (generate_chart's broad except handler).
+            with pytest.raises(SupersetSecurityException):
+                _compile_chart(
+                    form_data={"metrics": [{"label": "count"}], "viz_type": "table"},
+                    dataset_id=10,
+                )
+
+            mock_command.run.assert_not_called()


### PR DESCRIPTION
## **User description**
### SUMMARY

MCP chart data tools called `ChartDataCommand.run()` without first calling `ChartDataCommand.validate()`. The REST API (`charts/data/api.py`) correctly calls `command.validate()` before `command.run()` in all its code paths.

`command.validate()` calls `QueryContext.raise_for_access()` → `QueryContextProcessor.raise_for_access()` → `SecurityManager.raise_for_access()`, which enforces:
- **Row-Level Security (RLS) filters**
- **Guest user payload modification guard** (`query_context_modified`)
- **Dashboard-scoped datasource access**
- **Schema/catalog-level permissions**

Without `validate()`, the MCP tools only relied on `validate_chart_dataset()` — a weaker dataset-level-only check.

**Changes:**
- Added `command.validate()` before `command.run()` in all 6 locations that use `ChartDataCommand`:
  - `get_chart_data.py` — main chart data retrieval
  - `get_chart_preview.py` — ASCII, table, and Vega-Lite preview strategies (3 locations)
  - `preview_utils.py` — preview generation from form data
  - `generate_chart.py` — compile check during chart creation
- Existing `except (CommandException, SupersetException, ...)` handlers already cover `SupersetSecurityException`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — no UI changes

### TESTING INSTRUCTIONS
- `pytest tests/unit_tests/mcp_service/chart/ -x -q` — all 314 tests pass
- New tests in `TestChartDataCommandValidation` verify:
  - `validate()` is called before `run()` (call ordering assertion)
  - `SupersetSecurityException` from `validate()` blocks data access
  - Security exceptions propagate correctly through `_compile_chart`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix missing validation before executing MCP chart data queries

### What Changed
- Calls validation before running chart data commands so row-level security, guest-user guards, and schema/catalog permissions are enforced when generating chart data and previews
- Added validation call in all MCP chart data tool paths: chart data retrieval, three preview strategies, preview-from-form, and compile-time chart checks
- Added unit tests that assert validate() runs before run(), that validation failures block query execution, and that security exceptions surface as errors

### Impact
`✅ Prevents unauthorized data access in chart previews and data endpoints`
`✅ Clearer security failures returned for preview and compile operations`
`✅ Consistent enforcement of row-level security and datasource permissions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
