### PR TITLE
feat(mcp): register GlobalErrorHandlerMiddleware and LoggingMiddleware

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -30,7 +30,11 @@ import uvicorn
 
 from superset.mcp_service.app import create_mcp_app, init_fastmcp_server
 from superset.mcp_service.mcp_config import get_mcp_factory_config, MCP_STORE_CONFIG
-from superset.mcp_service.middleware import create_response_size_guard_middleware
+from superset.mcp_service.middleware import (
+    create_response_size_guard_middleware,
+    GlobalErrorHandlerMiddleware,
+    LoggingMiddleware,
+)
 from superset.mcp_service.storage import _create_redis_store
 
 logger = logging.getLogger(__name__)
@@ -225,6 +229,12 @@ def run_server(
 
         # Build middleware list
         middleware_list = []
+
+        # Add global error handler (outermost - catches all exceptions)
+        middleware_list.append(GlobalErrorHandlerMiddleware())
+
+        # Add logging middleware (logs all tool calls with duration tracking)
+        middleware_list.append(LoggingMiddleware())
 
         # Add response size guard (protects LLM clients from huge responses)
         if size_guard_middleware := create_response_size_guard_middleware():

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -228,22 +228,24 @@ def run_server(
         auth_provider = _create_auth_provider(flask_app)
 
         # Build middleware list
+        # FastMCP wraps handlers so that the LAST-added middleware is
+        # outermost.  Order here is innermost → outermost.
         middleware_list = []
 
-        # Add global error handler (outermost - catches all exceptions)
-        middleware_list.append(GlobalErrorHandlerMiddleware())
-
-        # Add logging middleware (logs all tool calls with duration tracking)
-        middleware_list.append(LoggingMiddleware())
+        # Add caching middleware (innermost – runs closest to the tool)
+        caching_middleware = create_response_caching_middleware()
+        if caching_middleware:
+            middleware_list.append(caching_middleware)
 
         # Add response size guard (protects LLM clients from huge responses)
         if size_guard_middleware := create_response_size_guard_middleware():
             middleware_list.append(size_guard_middleware)
 
-        # Add caching middleware
-        caching_middleware = create_response_caching_middleware()
-        if caching_middleware:
-            middleware_list.append(caching_middleware)
+        # Add logging middleware (logs all tool calls with duration tracking)
+        middleware_list.append(LoggingMiddleware())
+
+        # Add global error handler (outermost – catches all exceptions)
+        middleware_list.append(GlobalErrorHandlerMiddleware())
 
         mcp_instance = init_fastmcp_server(
             auth=auth_provider,


### PR DESCRIPTION
## **User description**
### SUMMARY

Wires up `GlobalErrorHandlerMiddleware` and `LoggingMiddleware` into the MCP server middleware stack. Both middleware classes were fully implemented in `middleware.py` with unit tests but were never registered in `server.py`. The middleware list previously only included `ResponseSizeGuardMiddleware` and `CachingMiddleware`.

### Problem

The MCP server had no global error handling or request logging. If a tool raised an unhandled exception, it could propagate uncaught, potentially crashing the server or returning raw tracebacks to LLM clients. There was also no observability into tool call durations, user context, or entity IDs being accessed — making debugging and monitoring difficult.

### What Changed

**File: `superset/mcp_service/server.py`**

1. Updated the import to include `GlobalErrorHandlerMiddleware` and `LoggingMiddleware`
2. Added both middleware to the middleware list in the default initialization path

**Middleware ordering** (first = outermost, runs first on request):
1. `GlobalErrorHandlerMiddleware` — outermost, catches all exceptions from inner middleware/tools
2. `LoggingMiddleware` — logs every tool call with duration, user context, entity IDs
3. `ResponseSizeGuardMiddleware` — guards against oversized responses
4. `CachingMiddleware` — caches tool responses

**Why this order:**
- Error handler must be outermost so it catches exceptions from all inner layers (including logging failures)
- Logging should capture the full duration including size guard overhead but not be affected by caching (we want to log cache hits too, which means logging should be outside caching)

### TESTING INSTRUCTIONS

- Existing middleware unit tests pass (`test_middleware.py`, `test_middleware_logging.py`)
- MCP server starts without import errors
- Tool calls produce structured log output with duration and user context
- Unhandled exceptions in tools are caught and returned as structured error responses

### ADDITIONAL INFORMATION

No new dependencies. No configuration changes. The middleware classes already existed with full test coverage — this PR simply registers them in the server startup path.


___

## **CodeAnt-AI Description**
Register global error handler and request logging middleware in MCP server

### What Changed
- The MCP server now includes request logging, response size guarding, response caching, and a global error handler in that execution order (caching innermost, error handler outermost).
- Unhandled tool exceptions are caught and returned as structured error responses instead of propagating raw tracebacks.
- Each tool call is logged with duration and user/context information, and cache behavior is preserved.

### Impact
`✅ Clearer error responses`
`✅ More request-level logs with durations`
`✅ Fewer uncaught server crashes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
