### PR TITLE
fix(theme): persist local theme id so "Local" tag remains after navigation

### DIFF
--- a/superset-frontend/src/theme/ThemeProvider.tsx
+++ b/superset-frontend/src/theme/ThemeProvider.tsx
@@ -79,7 +79,8 @@ export function SupersetThemeProvider({
   // setCrudTheme removed - dashboards should NOT modify the global controller
 
   const setTemporaryTheme = useCallback(
-    (config: AnyThemeConfig) => themeController.setTemporaryTheme(config),
+    (config: AnyThemeConfig, themeId?: number | null) =>
+      themeController.setTemporaryTheme(config, themeId),
     [themeController],
   );
 

--- a/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
+++ b/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
@@ -81,6 +81,15 @@ describe('SupersetThemeProvider', () => {
       onChange: jest.fn().mockReturnValue(jest.fn()),
       canUpdateTheme: jest.fn().mockReturnValue(true),
       canUpdateMode: jest.fn().mockReturnValue(true),
+      setTemporaryTheme: jest.fn(),
+      clearLocalOverrides: jest.fn(),
+      getCurrentCrudThemeId: jest.fn().mockReturnValue(null),
+      hasDevOverride: jest.fn().mockReturnValue(false),
+      canSetMode: jest.fn().mockReturnValue(true),
+      canSetTheme: jest.fn().mockReturnValue(true),
+      canDetectOSPreference: jest.fn().mockReturnValue(true),
+      createDashboardThemeProvider: jest.fn(),
+      getAppliedThemeId: jest.fn().mockReturnValue(null),
       destroy: jest.fn(),
     } as unknown as jest.Mocked<ThemeController>;
 
@@ -241,6 +250,30 @@ describe('SupersetThemeProvider', () => {
       });
 
       expect(mockThemeController.resetTheme).toHaveBeenCalled();
+    });
+
+    test('should call setTemporaryTheme with config and themeId when invoked', () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      const { result } = renderHook((): ThemeContextType => useThemeContext(), {
+        wrapper,
+      });
+
+      const tempTheme = {
+        token: {
+          colorPrimary: '#00ff00',
+          colorBgBase: '#ffffff',
+        },
+      };
+
+      act(() => {
+        result.current.setTemporaryTheme(tempTheme, 42);
+      });
+
+      expect(mockThemeController.setTemporaryTheme).toHaveBeenCalledWith(
+        tempTheme,
+        42,
+      );
     });
   });
 });


### PR DESCRIPTION
## **User description**
<!---
fix(theme): persist local theme id so "Local" tag remains after navigation
-->

### SUMMARY
This PR fixes an issue where the “Local” tag disappears after navigating away from the Themes page.ThemeProvider.tsx was updated so the context wrapper forwards the optional themeId to ThemeController.setTemporaryTheme.
This ensures the ID is persisted in localStorage, allowing the Themes page to correctly restore the “Local” tag when the page is revisited.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:

https://github.com/user-attachments/assets/892a9b29-e552-4484-8db1-931aa9422471


AFTER:

https://github.com/user-attachments/assets/bb504cb5-90ca-4516-b0a4-2931cf92850d



### TESTING INSTRUCTIONS
1) Go to Settings → Themes.
2) Select any theme and click “Set local theme for testing”.
3) Confirm the “Local” tag appears on the selected theme.
4) Navigate to another page (e.g., Dashboards or Charts).
5) Return to Settings → Themes.
6) Verify that the “Local” tag still appears for the applied theme.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Persist local theme ID so the "Local" tag remains after navigation

### What Changed
- The theme provider now forwards an optional theme ID when applying a temporary theme, ensuring the selected local theme ID is persisted.
- Tests added to verify that applying a temporary theme passes both the theme config and the theme ID to the theme controller; test mocks updated accordingly.

### Impact
`✅ Local theme tag persists after navigation`
`✅ Fewer missing "Local" labels on the Themes page`
`✅ Clearer test coverage for temporary theme application`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
