### PR TITLE
feat(mcp): add extra_form_data param to get_chart_data for dashboard filters

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1039,6 +1039,14 @@ class GetChartDataRequest(QueryCacheControl):
             "chart's configured row limit."
         ),
     )
+    extra_form_data: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Extra form data to merge into the chart query, typically from "
+            "dashboard native filters. Format: "
+            '{"filters": [{"col": "country", "op": "IN", "val": ["US"]}]}'
+        ),
+    )
     format: Literal["json", "csv", "excel"] = Field(
         default="json", description="Data export format"
     )

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -48,6 +48,16 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
+def _apply_extra_form_data(form_data: dict, extra_form_data: dict | None) -> None:
+    """Merge dashboard native filters into chart form_data in-place."""
+    if not extra_form_data:
+        return
+    form_data["extra_form_data"] = extra_form_data
+    from superset.utils.core import merge_extra_filters
+
+    merge_extra_filters(form_data)
+
+
 def _get_cached_form_data(form_data_key: str) -> str | None:
     """Retrieve form_data from cache using form_data_key.
 
@@ -249,6 +259,8 @@ async def get_chart_data(  # noqa: C901
                     cached_metrics = cached_form_data_dict.get("metrics", [])
                     cached_groupby = cached_form_data_dict.get("groupby", [])
 
+                _apply_extra_form_data(cached_form_data_dict, request.extra_form_data)
+
                 query_context = factory.create(
                     datasource={
                         "id": datasource_id,
@@ -417,6 +429,8 @@ async def get_chart_data(  # noqa: C901
                         error_type="MissingQueryContext",
                     )
 
+                _apply_extra_form_data(form_data, request.extra_form_data)
+
                 query_context = factory.create(
                     datasource={
                         "id": chart.datasource_id,
@@ -442,6 +456,12 @@ async def get_chart_data(  # noqa: C901
                 if request.limit:
                     for query in query_context_json.get("queries", []):
                         query["row_limit"] = request.limit
+
+                # Merge dashboard native filters into query_context's form_data
+                if request.extra_form_data:
+                    qc_form_data = query_context_json.setdefault("form_data", {})
+                    _apply_extra_form_data(qc_form_data, request.extra_form_data)
+                    query_context_json["form_data"] = qc_form_data
 
                 # Create QueryContext from the saved context using the schema
                 # This is exactly how the API does it

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -48,7 +48,9 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-def _apply_extra_form_data(form_data: dict, extra_form_data: dict | None) -> None:
+def _apply_extra_form_data(
+    form_data: dict[str, Any], extra_form_data: dict[str, Any] | None
+) -> None:
     """Merge dashboard native filters into chart form_data in-place."""
     if not extra_form_data:
         return

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -459,10 +459,8 @@ async def get_chart_data(  # noqa: C901
                         query["row_limit"] = request.limit
 
                 # Merge dashboard native filters into query_context's form_data
-                if request.extra_form_data:
-                    qc_form_data = query_context_json.setdefault("form_data", {})
-                    _apply_extra_form_data(qc_form_data, request.extra_form_data)
-                    query_context_json["form_data"] = qc_form_data
+                qc_form_data = query_context_json.setdefault("form_data", {})
+                _apply_extra_form_data(qc_form_data, request.extra_form_data)
 
                 # Create QueryContext from the saved context using the schema
                 # This is exactly how the API does it

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -262,20 +262,24 @@ async def get_chart_data(  # noqa: C901
 
                 _apply_extra_form_data(cached_form_data_dict, request.extra_form_data)
 
+                cached_query: dict[str, Any] = {
+                    "filters": cached_form_data_dict.get("filters", []),
+                    "columns": cached_groupby,
+                    "metrics": cached_metrics,
+                    "row_limit": row_limit,
+                    "order_desc": cached_form_data_dict.get("order_desc", True),
+                }
+                # Include adhoc_filters so dashboard native filters are applied
+                cached_adhoc = cached_form_data_dict.get("adhoc_filters")
+                if cached_adhoc:
+                    cached_query["adhoc_filters"] = cached_adhoc
+
                 query_context = factory.create(
                     datasource={
                         "id": datasource_id,
                         "type": datasource_type,
                     },
-                    queries=[
-                        {
-                            "filters": cached_form_data_dict.get("filters", []),
-                            "columns": cached_groupby,
-                            "metrics": cached_metrics,
-                            "row_limit": row_limit,
-                            "order_desc": cached_form_data_dict.get("order_desc", True),
-                        }
-                    ],
+                    queries=[cached_query],
                     form_data=cached_form_data_dict,
                     force=request.force_refresh,
                 )
@@ -432,20 +436,24 @@ async def get_chart_data(  # noqa: C901
 
                 _apply_extra_form_data(form_data, request.extra_form_data)
 
+                fallback_query: dict[str, Any] = {
+                    "filters": form_data.get("filters", []),
+                    "columns": query_columns,
+                    "metrics": metrics,
+                    "row_limit": row_limit,
+                    "order_desc": True,
+                }
+                # Include adhoc_filters so dashboard native filters are applied
+                fallback_adhoc = form_data.get("adhoc_filters")
+                if fallback_adhoc:
+                    fallback_query["adhoc_filters"] = fallback_adhoc
+
                 query_context = factory.create(
                     datasource={
                         "id": chart.datasource_id,
                         "type": chart.datasource_type,
                     },
-                    queries=[
-                        {
-                            "filters": form_data.get("filters", []),
-                            "columns": query_columns,
-                            "metrics": metrics,
-                            "row_limit": row_limit,
-                            "order_desc": True,
-                        }
-                    ],
+                    queries=[fallback_query],
                     form_data=form_data,
                     force=request.force_refresh,
                 )

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -44,6 +44,7 @@ from superset.mcp_service.chart.schemas import (
 )
 from superset.mcp_service.utils.cache_utils import get_cache_status_from_result
 from superset.mcp_service.utils.schema_utils import parse_request
+from superset.utils.core import merge_extra_filters
 
 logger = logging.getLogger(__name__)
 
@@ -55,8 +56,6 @@ def _apply_extra_form_data(
     if not extra_form_data:
         return
     form_data["extra_form_data"] = extra_form_data
-    from superset.utils.core import merge_extra_filters
-
     merge_extra_filters(form_data)
 
 


### PR DESCRIPTION
## **User description**
### SUMMARY

When an LLM uses the `get_chart_data` MCP tool to fetch data for charts on a dashboard, the data comes back **unfiltered** — it ignores the dashboard's native filters (including defaults). The frontend normally merges `extra_form_data` (containing native filter values) into each chart's `form_data` before querying, but MCP skips this step entirely.

This PR adds an `extra_form_data` parameter to `GetChartDataRequest` so MCP callers (chatbots, LLM agents) can pass dashboard-level filters when querying chart data. The implementation reuses the existing `merge_extra_filters()` / `merge_extra_form_data()` pipeline from `superset/utils/core.py`, injecting filters in all three query-building paths:

1. **Cached form_data path** — when using `form_data_key` for unsaved chart state
2. **Fallback form_data path** — when chart has no saved `query_context`
3. **Saved query_context path** — the most common path for saved charts

**Files changed:**
- `superset/mcp_service/chart/schemas.py` — added `extra_form_data` field to `GetChartDataRequest`
- `superset/mcp_service/chart/tool/get_chart_data.py` — added `_apply_extra_form_data` helper and called it in all 3 query paths

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend-only change, no UI impact.

### TESTING INSTRUCTIONS
1. Run existing MCP unit tests: `pytest tests/unit_tests/mcp_service/ -v` (717 tests pass)
2. Use the `get_chart_data` tool **without** `extra_form_data` — behavior should be unchanged
3. Use the `get_chart_data` tool **with** `extra_form_data` containing filter values, e.g.:
   ```json
   {
     "identifier": 123,
     "extra_form_data": {
       "filters": [{"col": "country", "op": "IN", "val": ["US"]}]
     }
   }
   ```
   Verify that the returned data is filtered by the provided filter values.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Allow dashboard native filters to be applied when MCP callers fetch chart data

### What Changed
- Added an extra_form_data parameter to the get_chart_data request so callers can pass dashboard-level filters.
- Merges provided extra_form_data into chart form_data for all query paths (cached unsaved state, fallback form_data, and saved query_context) so filters affect results.
- Ensures adhoc (native) filters from extra_form_data are included in the built query payloads so returned chart data is filtered correctly.

### Impact
`✅ Filtered chart data returned to LLMs and MCP callers`
`✅ Fewer unfiltered charts when fetching dashboard charts via MCP tools`
`✅ Consistent application of dashboard native filters across saved and unsaved chart states`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
