### PR TITLE
fix(mcp): resolve chatbot tool call flakiness with URL and instruction fixes

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -142,6 +142,20 @@ Query Examples:
 - My dashboards:
   filters=[{{"col": "created_by_fk", "opr": "eq", "value": <user_id>}}]
 
+To modify an existing chart (add filters, change metrics, change dimensions, etc.):
+1. get_chart_info(chart_id) -> examine current configuration
+2. update_chart(chart_id, config) -> apply changes (filters, metrics, dimensions)
+Do NOT use execute_sql for chart modifications. Use update_chart instead.
+
+CRITICAL RULES - NEVER VIOLATE:
+- NEVER fabricate or invent URLs. ALL URLs must come from tool call results.
+  If you need a link, call the appropriate tool (generate_explore_link, generate_chart,
+  open_sql_lab_with_context, etc.) and use the URL it returns.
+- To modify an existing chart's filters, metrics, or dimensions, use update_chart.
+  Do NOT use execute_sql for chart modifications.
+- Parameter name reminders: open_sql_lab_with_context uses "sql" (not "query"),
+  execute_sql uses "sql" (not "query").
+
 General usage tips:
 - All listing tools use 1-based pagination (first page is 1)
 - Use get_schema to discover filterable columns, sortable columns, and default columns

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -28,6 +28,7 @@ from fastmcp import Context
 from superset_core.mcp.decorators import tool
 
 from superset.extensions import event_logger
+from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.mcp_service.sql_lab.schemas import (
     OpenSqlLabRequest,
     SqlLabResponse,
@@ -95,7 +96,7 @@ def open_sql_lab_with_context(
 
         # Construct SQL Lab URL
         query_string = urlencode(params)
-        url = f"/sqllab?{query_string}"
+        url = f"{get_superset_base_url()}/sqllab?{query_string}"
 
         logger.info(
             "Generated SQL Lab URL for database %s", request.database_connection_id

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -28,12 +28,12 @@ from fastmcp import Context
 from superset_core.mcp.decorators import tool
 
 from superset.extensions import event_logger
-from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.mcp_service.sql_lab.schemas import (
     OpenSqlLabRequest,
     SqlLabResponse,
 )
 from superset.mcp_service.utils.schema_utils import parse_request
+from superset.mcp_service.utils.url_utils import get_superset_base_url
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes three issues with MCP tool calls reported when using external MCP clients (Grok, etc.):

1. **`open_sql_lab_with_context` returned relative URLs** (`/sqllab?...`) while every other tool returns absolute URLs via `get_superset_base_url()`. This forced LLMs to guess the base URL, leading to hallucinated `{{ preset_base_url }}` template syntax or broken links.

2. **LLMs fabricate URLs** instead of calling chart tools — the `DEFAULT_INSTRUCTIONS` lacked explicit guardrails telling LLMs to never invent URLs and always use tool results.

3. **LLMs call `execute_sql` instead of `update_chart`** when asked to modify chart filters — the instructions didn't include a "modify an existing chart" workflow or parameter name reminders.

**Changes:**
- `open_sql_lab_with_context.py`: Import `get_superset_base_url` and use it to construct absolute SQL Lab URLs, matching the pattern used by `generate_chart`, `generate_dashboard`, `add_chart_to_existing_dashboard`, etc.
- `app.py` (`DEFAULT_INSTRUCTIONS`): Add anti-hallucination guardrails (never fabricate URLs, use `update_chart` for chart modifications, correct parameter names) and a "modify an existing chart" workflow section.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend-only change to MCP tool output and instructions text.

### TESTING INSTRUCTIONS
1. Connect an MCP client (e.g., Claude Desktop, Grok) to the Superset MCP service
2. Ask the chatbot to "open SQL Lab for database X" — verify the returned URL is absolute (starts with `http://...`) not relative (`/sqllab?...`)
3. Ask "add a filter to chart 123" — verify it uses `update_chart`, not `execute_sql`
4. Ask "show me a chart of sales data" — verify it calls `generate_explore_link` or `generate_chart` instead of fabricating a URL

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix MCP tool outputs and chatbot instructions to stop broken links and incorrect chart edits

### What Changed
- SQL Lab links returned by the tool are now absolute (include the Superset base URL) instead of relative paths, so links work when returned to external MCP clients.
- Chatbot instructions now explicitly forbid inventing URLs and require calling the appropriate tool for any link; added a clear "modify an existing chart" workflow that tells the bot to fetch chart info then call the chart-update tool.
- Instructions clarify parameter names and emphasize using the chart update tool (not SQL execution) for changing chart filters, metrics, or dimensions.

### Impact
`✅ Absolute SQL Lab links in chatbot responses`
`✅ Fewer fabricated or hallucinated URLs returned to external clients`
`✅ Chart edits use the correct update flow instead of execute_sql`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
