### PR TITLE
fix(docs): swizzle MethodEndpoint to fix SSG crash on all API pages

### DIFF
--- a/docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
+++ b/docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
@@ -1,0 +1,94 @@
+/* ============================================================================
+ * Swizzled from docusaurus-theme-openapi-docs to fix SSG crash.
+ *
+ * The original component calls useTypedSelector (Redux) at the top level,
+ * which fails during static site generation because no Redux store is
+ * available. This version moves the hook into a browser-only child component
+ * so SSG can render the page without a store context.
+ * ========================================================================== */
+
+import React from "react";
+
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import { useTypedSelector } from "@theme/ApiItem/hooks";
+
+function colorForMethod(method: string) {
+  switch (method.toLowerCase()) {
+    case "get":
+      return "primary";
+    case "post":
+      return "success";
+    case "delete":
+      return "danger";
+    case "put":
+      return "info";
+    case "patch":
+      return "warning";
+    case "head":
+      return "secondary";
+    case "event":
+      return "secondary";
+    default:
+      return undefined;
+  }
+}
+
+export interface Props {
+  method: string;
+  path: string;
+  context?: "endpoint" | "callback";
+}
+
+interface ServerState {
+  server: { value: { url: string; variables?: Record<string, { default?: string }> } | null };
+}
+
+// Inner component rendered only in the browser, where the Redux store exists.
+function ServerUrl() {
+  const serverValue = useTypedSelector((state: ServerState) => state.server.value);
+
+  if (serverValue && serverValue.variables) {
+    let serverUrlWithVariables = serverValue.url.replace(/\/$/, "");
+    Object.keys(serverValue.variables).forEach((variable) => {
+      serverUrlWithVariables = serverUrlWithVariables.replace(
+        `{${variable}}`,
+        serverValue.variables?.[variable].default ?? ""
+      );
+    });
+    return <>{serverUrlWithVariables}</>;
+  }
+
+  if (serverValue && serverValue.url) {
+    return <>{serverValue.url}</>;
+  }
+
+  return null;
+}
+
+function MethodEndpoint({ method, path, context }: Props) {
+  const renderServerUrl = () => {
+    if (context === "callback") {
+      return "";
+    }
+    return <BrowserOnly>{() => <ServerUrl />}</BrowserOnly>;
+  };
+
+  return (
+    <>
+      <pre className="openapi__method-endpoint">
+        <span className={"badge badge--" + colorForMethod(method)}>
+          {method === "event" ? "Webhook" : method.toUpperCase()}
+        </span>{" "}
+        {method !== "event" && (
+          <h2 className="openapi__method-endpoint-path">
+            {renderServerUrl()}
+            {`${path.replace(/{([a-z0-9-_]+)}/gi, ":$1")}`}
+          </h2>
+        )}
+      </pre>
+      <div className="openapi__divider" />
+    </>
+  );
+}
+
+export default MethodEndpoint;

--- a/docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
+++ b/docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
@@ -1,16 +1,46 @@
-/* ============================================================================
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  * Swizzled from docusaurus-theme-openapi-docs to fix SSG crash.
  *
  * The original component calls useTypedSelector (Redux) at the top level,
  * which fails during static site generation because no Redux store is
  * available. This version moves the hook into a browser-only child component
  * so SSG can render the page without a store context.
- * ========================================================================== */
+ */
 
 import React from "react";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
-import { useTypedSelector } from "@theme/ApiItem/hooks";
+import { useSelector } from "react-redux";
+
+interface ServerVariable {
+  default?: string;
+}
+
+interface ServerValue {
+  url: string;
+  variables?: Record<string, ServerVariable>;
+}
+
+interface StoreState {
+  server: { value: ServerValue | null };
+}
 
 function colorForMethod(method: string) {
   switch (method.toLowerCase()) {
@@ -39,13 +69,9 @@ export interface Props {
   context?: "endpoint" | "callback";
 }
 
-interface ServerState {
-  server: { value: { url: string; variables?: Record<string, { default?: string }> } | null };
-}
-
 // Inner component rendered only in the browser, where the Redux store exists.
 function ServerUrl() {
-  const serverValue = useTypedSelector((state: ServerState) => state.server.value);
+  const serverValue = useSelector((state: StoreState) => state.server.value);
 
   if (serverValue && serverValue.variables) {
     let serverUrlWithVariables = serverValue.url.replace(/\/$/, "");


### PR DESCRIPTION
## **User description**
### SUMMARY

All 242 API doc pages were failing to build on Netlify with:

```
TypeError: Cannot destructure property 'store' of 'i' as it is null.
    at MethodEndpoint
```

**Root cause:** `docusaurus-theme-openapi-docs` v4.7.1 (resolved from `^4.6.0` in `package.json`) calls `useTypedSelector` (a Redux hook) at the top level of `MethodEndpoint`. During Docusaurus static site generation (SSG), no Redux `Provider` is available, so the store is `null` and destructuring crashes.

**Fix:** Swizzle `MethodEndpoint` in `docs/src/theme/` to extract the Redux hook into a `ServerUrl` child component that only renders inside `<BrowserOnly>`, where the Redux store is available. The server URL display is browser-only behavior anyway — it was already rendered inside `<BrowserOnly>` in the original code.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — build fix only.

### TESTING INSTRUCTIONS

- Netlify deploy preview on this PR should build successfully
- All `/user-docs/api/...` pages should render

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix SSG crash on API docs by rendering server URL only in the browser

### What Changed
- Static site generation no longer crashes on API pages caused by attempting to read Redux state during build; Netlify and other SSG environments can build the API docs successfully
- Server URL for endpoints is now resolved and inserted only in the browser, preserving the same endpoint path display for users visiting the site
- Callback endpoints omit the server URL as before; visual output for endpoints in the browser remains consistent with prior behavior

### Impact
`✅ Successful Netlify (SSG) builds for API docs`
`✅ All /user-docs/api/... pages render instead of failing`
`✅ Unchanged browser-visible endpoint paths and badges`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
