### PR TITLE
fix(mcp): make fastmcp truly optional during Superset startup

### DIFF
--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -252,22 +252,33 @@ def initialize_core_mcp_dependencies() -> None:
     Also imports MCP service app to register all host tools BEFORE extension loading.
     """
     try:
-        # Replace the abstract decorators with concrete implementations
-
         import superset_core.mcp.decorators
+    except ImportError:
+        logger.info(
+            "superset-core MCP module not available, skipping MCP initialization"
+        )
+        return
 
-        superset_core.mcp.decorators.tool = create_tool_decorator
-        superset_core.mcp.decorators.prompt = create_prompt_decorator
+    try:
+        from fastmcp.tools import Tool  # noqa: F401
+    except ImportError:
+        logger.info(
+            "fastmcp is not installed, skipping MCP initialization. "
+            "Install it with: pip install 'apache-superset[fastmcp]'"
+        )
+        return
 
-        logger.info("MCP dependency injection initialized successfully")
+    # Replace the abstract decorators with concrete implementations
+    superset_core.mcp.decorators.tool = create_tool_decorator
+    superset_core.mcp.decorators.prompt = create_prompt_decorator
 
+    logger.info("MCP dependency injection initialized successfully")
+
+    try:
         # Import MCP service app to register host tools BEFORE extension loading
         # This prevents host tools from being registered during extension context
-
         from superset.mcp_service import app  # noqa: F401
 
         logger.info("MCP service app imported - host tools registered")
-
     except Exception as e:
-        logger.error("Failed to initialize MCP dependencies: %s", e)
-        raise
+        logger.error("Failed to register MCP host tools: %s", e)

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -251,13 +251,7 @@ def initialize_core_mcp_dependencies() -> None:
 
     Also imports MCP service app to register all host tools BEFORE extension loading.
     """
-    try:
-        import superset_core.mcp.decorators
-    except ImportError:
-        logger.info(
-            "superset-core MCP module not available, skipping MCP initialization"
-        )
-        return
+    import superset_core.mcp.decorators
 
     try:
         from fastmcp.tools import Tool  # noqa: F401

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -544,12 +544,17 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.core.api.core_api_injection import (
             initialize_core_api_dependencies,
         )
-        from superset.core.mcp.core_mcp_injection import (
-            initialize_core_mcp_dependencies,
-        )
 
         initialize_core_api_dependencies()
-        initialize_core_mcp_dependencies()
+
+        try:
+            from superset.core.mcp.core_mcp_injection import (
+                initialize_core_mcp_dependencies,
+            )
+
+            initialize_core_mcp_dependencies()
+        except ImportError:
+            logger.info("MCP dependencies not available, skipping MCP initialization")
 
     def init_all_dependencies_and_extensions(self) -> None:
         """

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -544,17 +544,12 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.core.api.core_api_injection import (
             initialize_core_api_dependencies,
         )
+        from superset.core.mcp.core_mcp_injection import (
+            initialize_core_mcp_dependencies,
+        )
 
         initialize_core_api_dependencies()
-
-        try:
-            from superset.core.mcp.core_mcp_injection import (
-                initialize_core_mcp_dependencies,
-            )
-
-            initialize_core_mcp_dependencies()
-        except ImportError:
-            logger.info("MCP dependencies not available, skipping MCP initialization")
+        initialize_core_mcp_dependencies()
 
     def init_all_dependencies_and_extensions(self) -> None:
         """


### PR DESCRIPTION
## **User description**
### SUMMARY

`fastmcp` is declared as an optional dependency in `pyproject.toml` (under `[project.optional-dependencies]`), but Superset crashes on startup if it is not installed.

The root cause is that `initialize_core_mcp_dependencies()` unconditionally imports `superset.mcp_service.app`, which does `from fastmcp import FastMCP` at module level. This function is called during Superset's `init_core_dependencies()` in `superset/initialization/__init__.py`, making `fastmcp` effectively a hard requirement at startup.

**Fix:** Guard the MCP initialization with early-return checks for both `superset_core.mcp.decorators` and `fastmcp` availability. When either is missing, MCP is simply disabled with an info log and Superset starts normally. Also wraps the call site in `init_core_dependencies()` with a try/except ImportError for defense in depth.

Fixes #38514

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend change

### TESTING INSTRUCTIONS
1. Uninstall fastmcp: `pip uninstall fastmcp`
2. Start Superset: `superset run -p 8088`
3. Verify Superset starts without `ModuleNotFoundError` — should see info log: `fastmcp is not installed, skipping MCP initialization`
4. Reinstall fastmcp: `pip install fastmcp`
5. Restart Superset — MCP tools should register normally

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #38514
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Make fastmcp optional so Superset starts when it's not installed**

### What Changed
- Superset no longer crashes at startup if fastmcp or superset-core MCP module is missing; MCP initialization is skipped with an info log instead.
- When fastmcp is present, MCP decorators are wired and the MCP service app is imported to register host tools as before.
- Import failures while registering MCP host tools are logged as errors but no longer abort overall startup.

### Impact
`✅ Superset starts without fastmcp installed`
`✅ Clear info logs when MCP is disabled`
`✅ Fewer startup crashes caused by missing optional dependency`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
