### PR TITLE
fix(embedded): add box-sizing and font-size reset for embedded dashboards

### DIFF
--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -21,10 +21,16 @@ import 'src/public-path';
 import { lazy, Suspense } from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { Global } from '@emotion/react';
 import { t } from '@apache-superset/core';
 import { makeApi } from '@superset-ui/core';
 import { logging } from '@apache-superset/core';
-import { type SupersetThemeConfig, ThemeMode } from '@apache-superset/core/ui';
+import {
+  type SupersetThemeConfig,
+  ThemeMode,
+  css,
+  useTheme,
+} from '@apache-superset/core/ui';
 import Switchboard from '@superset-ui/switchboard';
 import getBootstrapData, { applicationRoot } from 'src/utils/getBootstrapData';
 import setupClient from 'src/setup/setupClient';
@@ -88,8 +94,34 @@ const EmbededLazyDashboardPage = () => {
   return <LazyDashboardPage idOrSlug={bootstrapData.embedded!.dashboard_id} />;
 };
 
+/**
+ * Global CSS reset for embedded dashboards.
+ *
+ * In standalone mode, antd's <Layout> component injects box-sizing and
+ * font-size via CSS-in-JS. Embedded mode does not render <Layout>, so
+ * these rules are never injected. This component fills that gap.
+ */
+const EmbeddedGlobalStyles = () => {
+  const theme = useTheme();
+  return (
+    <Global
+      styles={css`
+        *,
+        *::before,
+        *::after {
+          box-sizing: border-box;
+        }
+        body {
+          font-size: ${theme.fontSize}px;
+        }
+      `}
+    />
+  );
+};
+
 const EmbeddedRoute = () => (
   <EmbeddedContextProviders>
+    <EmbeddedGlobalStyles />
     <Suspense fallback={<Loading />}>
       <ErrorBoundary>
         <EmbededLazyDashboardPage />


### PR DESCRIPTION
## **User description**
## Summary

Embedded dashboards rendered via `superset-embedded-sdk` are missing CSS rules that the standalone mode gets from antd's `<Layout>` component via CSS-in-JS. This causes:

1. **Chart gaps disappear** — missing `box-sizing: border-box` means padding is added outside element width, causing adjacent panels to overlap
2. **Larger fonts, less visible content** — browser defaults to `font-size: 16px` instead of the `14px` that antd's `<Layout>` provides in standalone mode (~14% larger)

### Root Cause

In **standalone mode**, the component tree is:
```
App.tsx → RootContextProviders → <Layout> → <Layout.Content> → DashboardPage
```

In **embedded mode**, the component tree is:
```
embedded/index.tsx → EmbeddedContextProviders → DashboardPage
```

antd v5 uses CSS-in-JS with on-demand injection — component-level CSS is only injected when the component renders. Since embedded mode never renders `<Layout>`, the following CSS rules are never injected:

```css
:where(.css-hash).ant-layout,
:where(.css-hash).ant-layout * {
    box-sizing: border-box;
}
.ant-layout {
    font-size: 14px;
}
```

### Fix

Added an `EmbeddedGlobalStyles` component that injects the missing CSS rules using Emotion's `<Global>` component, using the theme's `fontSize` token for consistency:

- `box-sizing: border-box` on `*, *::before, *::after`
- `font-size` on `body` using `theme.fontSize` (default 14px from antd)

### Related PRs

- #38351 — fixes only `box-sizing` (approved, on hold for testing)
- #36375 — fixes only `box-sizing` (maintainer requested scoping)
- #37528 — fixes only `box-sizing` on `.dashboard-component-chart-holder`

This PR extends the approach of #38351 to **also fix the font-size discrepancy**, which none of the existing PRs address.

Fixes #37493

## Test Plan

- [ ] Embed a dashboard using `superset-embedded-sdk`
- [ ] Verify no horizontal scrollbar / chart overlap (box-sizing fix)
- [ ] Verify font size matches standalone mode (~14px, not 16px)
- [ ] Verify standalone dashboard rendering is unaffected
- [ ] Verify embedded dashboard with custom theme still works


🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Restore layout box-sizing and font size in embedded dashboards

### What Changed
- Embedded dashboards now include a global CSS reset that applies box-sizing: border-box to all elements
- The page font size in embedded mode is set to the theme's font size (matching standalone dashboards)
- Chart panel spacing and text density in embedded dashboards match standalone rendering, preventing overlap and oversized text

### Impact
`✅ Restored chart gaps and spacing in embedded dashboards`
`✅ Consistent font size between embedded and standalone dashboards`
`✅ Fewer layout overlaps in embedded embeds`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
