### PR TITLE
fix(nativeFilters): Native filters not applied when ALERT_REPORT_TABS disabled

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -261,11 +261,16 @@ class BaseReportState:
         Retrieve the URL for the dashboard tabs, or return the dashboard URL if no tabs are available.
         """  # noqa: E501
         force = "true" if self._report_schedule.force_screenshot else "false"
+        dashboard_state = self._report_schedule.extra.get("dashboard")
 
-        if (
-            dashboard_state := self._report_schedule.extra.get("dashboard")
-        ) and feature_flag_manager.is_feature_enabled("ALERT_REPORT_TABS"):
+        # Compute native filters when the ALERT_REPORTS_FILTER feature is enabled
+        native_filter_params: str | None = None
+        if feature_flag_manager.is_feature_enabled("ALERT_REPORTS_FILTER"):
             native_filter_params = self._report_schedule.get_native_filters_params()
+
+        if dashboard_state and feature_flag_manager.is_feature_enabled(
+            "ALERT_REPORT_TABS"
+        ):
             if anchor := dashboard_state.get("anchor"):
                 try:
                     anchor_list: list[str] = json.loads(anchor)
@@ -301,6 +306,7 @@ class BaseReportState:
                 user_friendly=user_friendly,
                 dashboard_id_or_slug=dashboard_id_or_slug,
                 force=force,
+                native_filters=native_filter_params,
                 **kwargs,
             )
         ]

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -582,3 +582,96 @@ def test_update_recipient_to_slack_v2_missing_channels(mocker: MockerFixture):
     )
     with pytest.raises(UpdateFailedError):
         mock_cmmd.update_report_schedule_slack_v2()
+
+
+@with_feature_flags(ALERT_REPORT_TABS=False, ALERT_REPORTS_FILTER=True)
+def test_get_dashboard_urls_with_native_filters_without_tabs_feature(
+    mocker: MockerFixture,
+    app,
+) -> None:
+    """
+    Test that native filters are applied to dashboard URLs when
+    ALERT_REPORTS_FILTER is enabled but ALERT_REPORT_TABS is disabled.
+    """
+    import urllib.parse
+
+    mock_dashboard = mocker.Mock()
+    mock_dashboard.uuid = "test-uuid-123"
+    mock_dashboard.id = 123
+
+    mock_report_schedule = mocker.Mock()
+    mock_report_schedule.chart = False
+    mock_report_schedule.dashboard = mock_dashboard
+    mock_report_schedule.force_screenshot = False
+    mock_report_schedule.extra = {
+        "dashboard": {
+            "nativeFilters": [
+                {
+                    "nativeFilterId": "filter_id",
+                    "columnName": "column_name",
+                    "filterType": "filter_select",
+                    "filterValues": ["value1", "value2"],
+                }
+            ]
+        }
+    }
+    mock_report_schedule.get_native_filters_params.return_value = "(filter_id:test)"
+
+    class_instance: BaseReportState = BaseReportState(
+        mock_report_schedule, "January 1, 2021", "execution_id_example"
+    )
+
+    result: list[str] = class_instance.get_dashboard_urls()
+
+    # Verify native_filters param is in the URL
+    assert len(result) == 1
+    parsed_url = urllib.parse.urlparse(result[0])
+    query_params = urllib.parse.parse_qs(parsed_url.query)
+    assert "native_filters" in query_params
+    assert query_params["native_filters"][0] == "(filter_id:test)"
+
+
+@with_feature_flags(ALERT_REPORT_TABS=False, ALERT_REPORTS_FILTER=False)
+def test_get_dashboard_urls_without_filter_feature(
+    mocker: MockerFixture,
+    app,
+) -> None:
+    """
+    Test that native filters are NOT applied when ALERT_REPORTS_FILTER is disabled.
+    """
+    import urllib.parse
+
+    mock_dashboard = mocker.Mock()
+    mock_dashboard.uuid = "test-uuid-123"
+    mock_dashboard.id = 123
+
+    mock_report_schedule = mocker.Mock()
+    mock_report_schedule.chart = False
+    mock_report_schedule.dashboard = mock_dashboard
+    mock_report_schedule.force_screenshot = False
+    mock_report_schedule.extra = {
+        "dashboard": {
+            "nativeFilters": [
+                {
+                    "nativeFilterId": "filter_id",
+                    "columnName": "column_name",
+                    "filterType": "filter_select",
+                    "filterValues": ["value1", "value2"],
+                }
+            ]
+        }
+    }
+
+    class_instance: BaseReportState = BaseReportState(
+        mock_report_schedule, "January 1, 2021", "execution_id_example"
+    )
+
+    result: list[str] = class_instance.get_dashboard_urls()
+
+    # Verify native_filters param is NOT in the URL
+    assert len(result) == 1
+    parsed_url = urllib.parse.urlparse(result[0])
+    query_params = urllib.parse.parse_qs(parsed_url.query)
+    assert "native_filters" not in query_params
+    # Verify get_native_filters_params was not called
+    mock_report_schedule.get_native_filters_params.assert_not_called()


### PR DESCRIPTION
### SUMMARY

When `ALERT_REPORTS_FILTER=True` but `ALERT_REPORT_TABS=False`, native filters configured on dashboard reports were silently ignored during screenshot capture.

**Root Cause**: In `get_dashboard_urls()`, native filter params were only computed inside the `ALERT_REPORT_TABS` feature flag branch, so the else branch returned URLs without filters.

**Fix**: Moved the native filter computation outside the `ALERT_REPORT_TABS` conditional, gated by `ALERT_REPORTS_FILTER` instead. Now filters are applied to dashboard URLs regardless of whether the tabs feature is enabled

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
