### PR TITLE
fix(mcp): wrap LoggingMiddleware.on_message event_logger in try/except

### DIFF
--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -213,23 +213,27 @@ class LoggingMiddleware(Middleware):
         agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
             self._extract_context_info(context)
         )
-        event_logger.log(
-            user_id=user_id,
-            action="mcp_message",
-            dashboard_id=dashboard_id,
-            duration_ms=None,
-            slice_id=slice_id,
-            referrer=None,
-            curated_payload={
-                "tool": getattr(context.message, "name", None),
-                "agent_id": agent_id,
-                "params": _sanitize_params(params),
-                "method": context.method,
-                "dashboard_id": dashboard_id,
-                "slice_id": slice_id,
-                "dataset_id": dataset_id,
-            },
-        )
+        try:
+            event_logger.log(
+                user_id=user_id,
+                action="mcp_message",
+                dashboard_id=dashboard_id,
+                duration_ms=None,
+                slice_id=slice_id,
+                referrer=None,
+                curated_payload={
+                    "tool": getattr(context.message, "name", None),
+                    "agent_id": agent_id,
+                    "params": _sanitize_params(params),
+                    "method": context.method,
+                    "dashboard_id": dashboard_id,
+                    "slice_id": slice_id,
+                    "dataset_id": dataset_id,
+                },
+            )
+        except RuntimeError:
+            # No Flask app context (e.g., during MCP initialize handshake)
+            pass
         logger.info(
             "MCP message: tool=%s, agent_id=%s, user_id=%s, method=%s",
             getattr(context.message, "name", None),


### PR DESCRIPTION
### SUMMARY

After registering `LoggingMiddleware` in the MCP server startup, the MCP server started failing the `initialize` handshake with clients (e.g. Claude Code) with:

```
WARNING:root:Failed to validate request: Working outside of application context.
```

**Root cause**: `LoggingMiddleware.on_message()` fires on ALL MCP messages including the protocol-level `initialize` handshake. It calls `event_logger.log()` which requires Flask app context, but during `initialize` there is no Flask app context pushed (`mcp_auth_hook` only pushes context for tool calls, not protocol messages).

**Fix**: Wrap the `event_logger.log()` call in `on_message()` with `try/except RuntimeError` to gracefully skip logging when no Flask app context is available.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - backend fix

### TESTING INSTRUCTIONS

1. Start the MCP server locally: `python -m superset.mcp_service.server`
2. Connect with an MCP client (e.g. Claude Code `/mcp`)
3. Verify the `initialize` handshake completes successfully (no `Working outside of application context` error)
4. Verify tool calls still log properly via `event_logger`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API