### PR TITLE
fix(mcp): wrap LoggingMiddleware.on_message event_logger in try/except

### DIFF
--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -213,23 +213,27 @@ class LoggingMiddleware(Middleware):
         agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
             self._extract_context_info(context)
         )
-        event_logger.log(
-            user_id=user_id,
-            action="mcp_message",
-            dashboard_id=dashboard_id,
-            duration_ms=None,
-            slice_id=slice_id,
-            referrer=None,
-            curated_payload={
-                "tool": getattr(context.message, "name", None),
-                "agent_id": agent_id,
-                "params": _sanitize_params(params),
-                "method": context.method,
-                "dashboard_id": dashboard_id,
-                "slice_id": slice_id,
-                "dataset_id": dataset_id,
-            },
-        )
+        try:
+            event_logger.log(
+                user_id=user_id,
+                action="mcp_message",
+                dashboard_id=dashboard_id,
+                duration_ms=None,
+                slice_id=slice_id,
+                referrer=None,
+                curated_payload={
+                    "tool": getattr(context.message, "name", None),
+                    "agent_id": agent_id,
+                    "params": _sanitize_params(params),
+                    "method": context.method,
+                    "dashboard_id": dashboard_id,
+                    "slice_id": slice_id,
+                    "dataset_id": dataset_id,
+                },
+            )
+        except RuntimeError:
+            # No Flask app context (e.g., during MCP initialize handshake)
+            pass
         logger.info(
             "MCP message: tool=%s, agent_id=%s, user_id=%s, method=%s",
             getattr(context.message, "name", None),

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -171,24 +171,28 @@ class LoggingMiddleware(Middleware):
             return result
         finally:
             duration_ms = int((time.time() - start_time) * 1000)
-            event_logger.log(
-                user_id=user_id,
-                action="mcp_tool_call",
-                dashboard_id=dashboard_id,
-                duration_ms=duration_ms,
-                slice_id=slice_id,
-                referrer=None,
-                curated_payload={
-                    "tool": tool_name,
-                    "agent_id": agent_id,
-                    "params": _sanitize_params(params),
-                    "method": context.method,
-                    "dashboard_id": dashboard_id,
-                    "slice_id": slice_id,
-                    "dataset_id": dataset_id,
-                    "success": success,
-                },
-            )
+            try:
+                event_logger.log(
+                    user_id=user_id,
+                    action="mcp_tool_call",
+                    dashboard_id=dashboard_id,
+                    duration_ms=duration_ms,
+                    slice_id=slice_id,
+                    referrer=None,
+                    curated_payload={
+                        "tool": tool_name,
+                        "agent_id": agent_id,
+                        "params": _sanitize_params(params),
+                        "method": context.method,
+                        "dashboard_id": dashboard_id,
+                        "slice_id": slice_id,
+                        "dataset_id": dataset_id,
+                        "success": success,
+                    },
+                )
+            except RuntimeError:
+                # No Flask app context (middleware runs after tool pops context)
+                pass
             logger.info(
                 "MCP tool call: tool=%s, agent_id=%s, user_id=%s, method=%s, "
                 "dashboard_id=%s, slice_id=%s, dataset_id=%s, duration_ms=%s, "

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -22,6 +22,7 @@ from typing import Any, Awaitable, Callable, Dict, Protocol
 
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
+from flask import has_app_context
 from pydantic import ValidationError
 from sqlalchemy.exc import OperationalError, TimeoutError
 from starlette.exceptions import HTTPException
@@ -171,7 +172,7 @@ class LoggingMiddleware(Middleware):
             return result
         finally:
             duration_ms = int((time.time() - start_time) * 1000)
-            try:
+            if has_app_context():
                 event_logger.log(
                     user_id=user_id,
                     action="mcp_tool_call",
@@ -190,9 +191,6 @@ class LoggingMiddleware(Middleware):
                         "success": success,
                     },
                 )
-            except RuntimeError:
-                # No Flask app context (middleware runs after tool pops context)
-                pass
             logger.info(
                 "MCP tool call: tool=%s, agent_id=%s, user_id=%s, method=%s, "
                 "dashboard_id=%s, slice_id=%s, dataset_id=%s, duration_ms=%s, "
@@ -217,7 +215,7 @@ class LoggingMiddleware(Middleware):
         agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
             self._extract_context_info(context)
         )
-        try:
+        if has_app_context():
             event_logger.log(
                 user_id=user_id,
                 action="mcp_message",
@@ -235,9 +233,6 @@ class LoggingMiddleware(Middleware):
                     "dataset_id": dataset_id,
                 },
             )
-        except RuntimeError:
-            # No Flask app context (e.g., during MCP initialize handshake)
-            pass
         logger.info(
             "MCP message: tool=%s, agent_id=%s, user_id=%s, method=%s",
             getattr(context.message, "name", None),


### PR DESCRIPTION
### SUMMARY

After registering `LoggingMiddleware` in the MCP server startup, the MCP server started failing the `initialize` handshake with clients (e.g. Claude Code) with:

```
WARNING:root:Failed to validate request: Working outside of application context.
```

**Root cause**: `LoggingMiddleware` fires on ALL MCP messages including the protocol-level `initialize` handshake and the `on_call_tool()` finally block (which runs after `mcp_auth_hook` pops Flask context). Both `on_message()` and `on_call_tool()` call `event_logger.log()` which requires Flask app context, but:

1. During `initialize` there is no Flask app context (`mcp_auth_hook` only pushes context for tool calls, not protocol messages)
2. In `on_call_tool()`'s finally block, the Flask app context has already been popped by `mcp_auth_hook`

**Fix**: Use `flask.has_app_context()` guard check before `event_logger.log()` calls in both `on_call_tool()` and `on_message()`. This is explicit about intent, avoids exception-driven control flow, and won't accidentally swallow unrelated `RuntimeError`s.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - backend fix

### TESTING INSTRUCTIONS

1. Start the MCP server locally: `superset mcp run --port 5008 --debug`
2. Connect with an MCP client (e.g. Claude Code `/mcp`)
3. Verify the `initialize` handshake completes successfully (no `Working outside of application context` error)
4. Verify all 19 MCP tools work correctly (health_check, list_charts, list_dashboards, list_datasets, get_instance_info, get_schema, get_chart_info, get_dashboard_info, get_dataset_info, execute_sql, open_sql_lab_with_context, generate_explore_link, generate_chart, get_chart_data, get_chart_preview, update_chart, update_chart_preview, generate_dashboard, add_chart_to_existing_dashboard)
5. Verify tool calls still log properly via `event_logger` when Flask app context is available

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API