### PR TITLE
fix: SQL Lab tab content padding

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -118,7 +118,7 @@ export interface ResultSetProps {
 const ResultContainer = styled.div`
   display: flex;
   flex-direction: column;
-  row-gap: ${({ theme }) => theme.sizeUnit * 2}px;
+  row-gap: ${({ theme }) => theme.sizeUnit * 4}px;
   height: 100%;
 `;
 

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -118,7 +118,7 @@ export interface ResultSetProps {
 const ResultContainer = styled.div`
   display: flex;
   flex-direction: column;
-  row-gap: ${({ theme }) => theme.sizeUnit * 4}px;
+  row-gap: ${({ theme }) => theme.sizeUnit * 3}px;
   height: 100%;
 `;
 

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -80,7 +80,7 @@ const StyledPane = styled.div`
       ${({ theme }) => theme.sizeUnit * 2}px;
   }
   .ant-tabs-tabpane {
-    padding-top: ${({ theme }) => theme.sizeUnit * 4}px;
+    padding-top: ${({ theme }) => theme.sizeUnit * 3}px;
     .scrollable {
       overflow-y: auto;
     }

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -63,6 +63,7 @@ const TABS_KEYS = {
 const StyledPane = styled.div`
   width: 100%;
   height: 100%;
+
   .ant-tabs .ant-tabs-content-holder {
     overflow: visible;
   }
@@ -79,6 +80,7 @@ const StyledPane = styled.div`
       ${({ theme }) => theme.sizeUnit * 2}px;
   }
   .ant-tabs-tabpane {
+    padding-top: ${({ theme }) => theme.sizeUnit * 4}px;
     .scrollable {
       overflow-y: auto;
     }


### PR DESCRIPTION
## **User description**
### SUMMARY
Adding top padding to SQL Lab tabs to match left/right padding.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1125" height="800" alt="Screenshot 2026-03-10 at 10 50 25" src="https://github.com/user-attachments/assets/b6344665-58b5-40e4-83f4-e9232a8b0618" />
<img width="1508" height="805" alt="Screenshot 2026-03-10 at 11 18 04" src="https://github.com/user-attachments/assets/748f84b5-014a-4937-820d-4cda4cf47e3d" />

### TESTING INSTRUCTIONS
Check the padding.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix SQL Lab tab padding and increase vertical spacing in result view

### What Changed
- SQL Lab tab content now has consistent top padding so tab panels align with left/right padding
- Rows inside the query result area have increased vertical spacing, making table sections and messages easier to scan

### Impact
`✅ Consistent SQL Lab tab padding`
`✅ Easier-to-scan query results`
`✅ Fewer layout misalignments in SQL Lab`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
