### PR TITLE
fix(dynamodb): strip leading SQL comments to prevent PartiQL parse errors

### DIFF
--- a/superset/db_engine_specs/dynamodb.py
+++ b/superset/db_engine_specs/dynamodb.py
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
+import re
 from datetime import datetime
 from typing import Any, Optional
 
@@ -26,6 +29,7 @@ from superset.db_engine_specs.base import BaseEngineSpec, DatabaseCategory
 class DynamoDBEngineSpec(BaseEngineSpec):
     engine = "dynamodb"
     engine_name = "Amazon DynamoDB"
+    allows_sql_comments = False
 
     metadata = {
         "description": (
@@ -75,6 +79,42 @@ class DynamoDBEngineSpec(BaseEngineSpec):
             "DATETIME({col}, 'start of day', 'weekday 1', '-7 days')"
         ),
     }
+
+    # Regex to match leading single-line (--) and multi-line (/* */) SQL comments,
+    # including any surrounding whitespace.
+    _leading_comments_re = re.compile(
+        r"^(\s*(--[^\n]*(\n|$)|/\*.*?\*/\s*))+",
+        re.DOTALL,
+    )
+
+    @classmethod
+    def execute(
+        cls,
+        cursor: Any,
+        query: str,
+        database: Any,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Execute a SQL query against DynamoDB via PyDynamoDB.
+
+        PyDynamoDB uses regex patterns (e.g. ``r"^\\s*(SELECT).*"``) to identify
+        query types. Leading SQL comments—such as those injected by
+        ``SQL_QUERY_MUTATOR``—break this detection and cause
+        "Expected nested_select_statement" errors.
+
+        This override strips leading comments so the query always starts with
+        the actual SQL keyword that PyDynamoDB expects.
+        """
+        query = cls._strip_leading_comments(query)
+        if cls.arraysize:
+            cursor.arraysize = cls.arraysize
+        cursor.execute(query)
+
+    @classmethod
+    def _strip_leading_comments(cls, sql: str) -> str:
+        """Remove leading SQL comments (``--`` and ``/* */``) from a query."""
+        return cls._leading_comments_re.sub("", sql).lstrip()
 
     @classmethod
     def epoch_to_dttm(cls) -> str:

--- a/tests/unit_tests/db_engine_specs/test_dynamodb.py
+++ b/tests/unit_tests/db_engine_specs/test_dynamodb.py
@@ -17,9 +17,11 @@
 
 from datetime import datetime
 from typing import Optional
+from unittest.mock import MagicMock
 
 import pytest
 
+from superset.db_engine_specs.dynamodb import DynamoDBEngineSpec
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm  # noqa: F401
 
@@ -42,3 +44,99 @@ def test_convert_dttm(
     )
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_allows_sql_comments_is_false() -> None:
+    assert DynamoDBEngineSpec.allows_sql_comments is False
+
+
+@pytest.mark.parametrize(
+    "sql,expected",
+    [
+        # No comments — unchanged
+        ("SELECT * FROM t", "SELECT * FROM t"),
+        # Single leading -- comment
+        ("-- tracking key\nSELECT * FROM t", "SELECT * FROM t"),
+        # Multiple leading -- comments
+        (
+            "-- user: alice\n-- workspace: ws-123\nSELECT * FROM t",
+            "SELECT * FROM t",
+        ),
+        # Block /* */ comment
+        ("/* metadata */\nSELECT * FROM t", "SELECT * FROM t"),
+        # Mixed -- and /* */ leading comments
+        (
+            "-- key\n/* block */\n-- another\nSELECT * FROM t",
+            "SELECT * FROM t",
+        ),
+        # Trailing comments preserved
+        ("SELECT * FROM t -- inline", "SELECT * FROM t -- inline"),
+        # Leading whitespace + comments
+        ("  \n-- comment\n  SELECT * FROM t", "SELECT * FROM t"),
+        # Empty string
+        ("", ""),
+        # Only comments
+        ("-- just a comment\n-- another", ""),
+        # Multi-line block comment
+        (
+            "/* line1\nline2\nline3 */\nSELECT 1",
+            "SELECT 1",
+        ),
+        # Realistic SQL_QUERY_MUTATOR output with tracking key and metadata
+        (
+            "-- 6dcd92a04feb50f14bbcf07c661680ba\n"
+            'SELECT entityId FROM "sandbox-EntityContextsTable"\n'
+            "-- workspace_slug: superset\n"
+            "-- 6dcd92a04feb50f14bbcf07c661680ba",
+            'SELECT entityId FROM "sandbox-EntityContextsTable"\n'
+            "-- workspace_slug: superset\n"
+            "-- 6dcd92a04feb50f14bbcf07c661680ba",
+        ),
+        # Realistic: metadata at top (non-DynamoDB-aware mutator)
+        (
+            "-- 6dcd92a04feb50f14bbcf07c661680ba\n"
+            "-- user: alice@example.com\n"
+            "-- workspace_slug: superset\n"
+            "SELECT * FROM users\n"
+            "-- 6dcd92a04feb50f14bbcf07c661680ba",
+            "SELECT * FROM users\n-- 6dcd92a04feb50f14bbcf07c661680ba",
+        ),
+    ],
+)
+def test_strip_leading_comments(sql: str, expected: str) -> None:
+    assert DynamoDBEngineSpec._strip_leading_comments(sql) == expected
+
+
+def test_execute_strips_comments() -> None:
+    cursor = MagicMock()
+    database = MagicMock()
+    query = "-- tracking comment\nSELECT * FROM my_table"
+
+    DynamoDBEngineSpec.execute(cursor, query, database)
+
+    cursor.execute.assert_called_once_with("SELECT * FROM my_table")
+
+
+def test_execute_plain_query() -> None:
+    cursor = MagicMock()
+    database = MagicMock()
+    query = "SELECT * FROM my_table"
+
+    DynamoDBEngineSpec.execute(cursor, query, database)
+
+    cursor.execute.assert_called_once_with("SELECT * FROM my_table")
+
+
+def test_execute_non_select_queries() -> None:
+    cursor = MagicMock()
+    database = MagicMock()
+
+    for query_template in [
+        "-- comment\nINSERT INTO t VALUES (1, 2)",
+        "-- comment\nUPDATE t SET col = 1",
+        "-- comment\nDELETE FROM t WHERE id = 1",
+    ]:
+        cursor.reset_mock()
+        DynamoDBEngineSpec.execute(cursor, query_template, database)
+        executed = cursor.execute.call_args[0][0]
+        assert not executed.startswith("--")


### PR DESCRIPTION
### SUMMARY

PyDynamoDB uses regex patterns like `r"^\s*(SELECT).*"` to identify query types (SELECT, INSERT, UPDATE, DELETE). When `SQL_QUERY_MUTATOR` or other middleware prepends comment metadata (tracking keys, user info, workspace context) to queries, the regex matching fails because the query no longer starts with a SQL keyword. This produces `"Expected nested_select_statement"` errors.

**Changes:**
- Set `allows_sql_comments = False` on `DynamoDBEngineSpec` (same pattern as Kusto and Elasticsearch engine specs) to prevent Superset's SQL parser from including comments when formatting statements
- Override `execute()` to strip any leading `--` and `/* */` comments before they reach PyDynamoDB's parser, providing defense-in-depth against any `SQL_QUERY_MUTATOR` that adds comment headers
- Add 19 unit tests covering comment stripping, execute behavior, and edge cases

**Root cause:** PartiQL (DynamoDB's SQL dialect) does not support SQL-style comments. Any leading comments break PyDynamoDB's regex-based query type detection.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend-only change, no UI impact.

### TESTING INSTRUCTIONS
1. Configure a `SQL_QUERY_MUTATOR` that prepends comments to queries (e.g., `-- user: alice`)
2. Connect a DynamoDB database
3. Run a query in SQL Lab: `SELECT * FROM your_table`
4. **Before fix:** "Expected nested_select_statement" error
5. **After fix:** Query executes successfully

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API