### PR TITLE
fix(dashboards): remove thumbnail_url from list API to reduce cache cost

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,16 @@ assists people when migrating to a new version.
 
 ## Next
 
+### `thumbnail_url` removed from dashboard list API response
+
+The `thumbnail_url` field has been removed from `GET /api/v1/dashboard/` list responses. External consumers relying on this field must now construct the thumbnail URL client-side using `id` and `changed_on_utc`:
+
+```
+/api/v1/dashboard/{id}/thumbnail/{changed_on_utc}/
+```
+
+The thumbnail endpoint returns a 302 redirect to the cached image regardless of whether the digest is exact, so `changed_on_utc` serves as an effective cache-busting key.
+
 ### Webhook alerts/reports block private/internal hosts by default
 
 Webhook alert/report dispatch (`WebhookNotification.send`) now validates the target URL's host against the same private/internal-IP block applied to dataset import URLs. If the resolved host is in a loopback, link-local, private (RFC-1918), shared-CGNAT, or multicast range, the webhook is rejected with `NotificationParamException`.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -32,7 +32,7 @@ The `thumbnail_url` field has been removed from `GET /api/v1/dashboard/` list re
 /api/v1/dashboard/{id}/thumbnail/{changed_on_utc}/
 ```
 
-The thumbnail endpoint returns a 302 redirect to the cached image regardless of whether the digest is exact, so `changed_on_utc` serves as an effective cache-busting key.
+The thumbnail endpoint redirects to the current digest URL regardless of whether the supplied digest is exact. If the image is not yet cached, that digest URL may return `202` and trigger async generation. Using `changed_on_utc` as the digest is sufficient for cache-busting purposes.
 
 ### Webhook alerts/reports block private/internal hosts by default
 

--- a/superset-frontend/packages/superset-ui-core/src/chart/types/matrixify.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/matrixify.test.ts
@@ -22,6 +22,7 @@ import {
   getMatrixifyConfig,
   getMatrixifyValidationErrors,
   MatrixifyFormData,
+  MatrixifyFilterConstants,
 } from './matrixify';
 import { AdhocMetric } from '../../query/types/Metric';
 
@@ -40,10 +41,10 @@ test('isMatrixifyEnabled should return false when no matrixify configuration exi
 test('isMatrixifyEnabled should return false when layout controls are disabled', () => {
   const formData = {
     viz_type: 'table',
-    matrixify_mode_rows: 'disabled',
-    matrixify_mode_columns: 'disabled',
+    matrixify_mode_rows: 'disabled' as const,
+    matrixify_mode_columns: 'disabled' as const,
     matrixify_rows: [createMetric('Revenue')],
-  } as MatrixifyFormData;
+  } as unknown as MatrixifyFormData;
 
   expect(isMatrixifyEnabled(formData)).toBe(false);
 });
@@ -242,9 +243,9 @@ test('getMatrixifyConfig should preserve ascending topn order when explicitly di
 test('getMatrixifyValidationErrors should return empty array when matrixify is not enabled', () => {
   const formData = {
     viz_type: 'table',
-    matrixify_mode_rows: 'disabled',
-    matrixify_mode_columns: 'disabled',
-  } as MatrixifyFormData;
+    matrixify_mode_rows: 'disabled' as const,
+    matrixify_mode_columns: 'disabled' as const,
+  } as unknown as MatrixifyFormData;
 
   expect(getMatrixifyValidationErrors(formData)).toEqual([]);
 });
@@ -431,4 +432,64 @@ test('should handle partial configuration with one axis only', () => {
   } as MatrixifyFormData;
 
   expect(isMatrixifyEnabled(formData)).toBe(true);
+});
+
+test('MatrixifyFilterConstants has expected values', () => {
+  expect(MatrixifyFilterConstants.ExpressionType.SIMPLE).toBe('SIMPLE');
+  expect(MatrixifyFilterConstants.ExpressionType.SQL).toBe('SQL');
+  expect(MatrixifyFilterConstants.Clause.WHERE).toBe('WHERE');
+  expect(MatrixifyFilterConstants.Clause.HAVING).toBe('HAVING');
+  expect(MatrixifyFilterConstants.Operator.EQUALS).toBe('==');
+  expect(MatrixifyFilterConstants.Operator.NOT_EQUALS).toBe('!=');
+  expect(MatrixifyFilterConstants.Operator.IN).toBe('IN');
+  expect(MatrixifyFilterConstants.Operator.NOT_IN).toBe('NOT IN');
+});
+
+test('isMatrixifyEnabled should return true for all dimension selection mode on rows', () => {
+  const formData = {
+    matrixify_enable: true,
+    matrixify_mode_rows: 'dimensions',
+    matrixify_dimension_selection_mode_rows: 'all',
+    matrixify_dimension_rows: { dimension: 'country', values: [] },
+  } as unknown as MatrixifyFormData;
+
+  expect(isMatrixifyEnabled(formData)).toBe(true);
+});
+
+test('isMatrixifyEnabled should return true for all dimension selection mode on columns', () => {
+  const formData = {
+    matrixify_enable: true,
+    matrixify_mode_columns: 'dimensions',
+    matrixify_dimension_selection_mode_columns: 'all',
+    matrixify_dimension_columns: { dimension: 'product', values: [] },
+  } as unknown as MatrixifyFormData;
+
+  expect(isMatrixifyEnabled(formData)).toBe(true);
+});
+
+test('isMatrixifyEnabled should return true for all selection mode on both axes', () => {
+  const formData = {
+    matrixify_enable: true,
+    matrixify_mode_rows: 'dimensions',
+    matrixify_dimension_selection_mode_rows: 'all',
+    matrixify_dimension_rows: { dimension: 'country', values: [] },
+    matrixify_mode_columns: 'dimensions',
+    matrixify_dimension_selection_mode_columns: 'all',
+    matrixify_dimension_columns: { dimension: 'product', values: [] },
+  } as unknown as MatrixifyFormData;
+
+  expect(isMatrixifyEnabled(formData)).toBe(true);
+});
+
+test('getMatrixifyValidationErrors should return no errors for all selection mode with dimension set', () => {
+  const formData = {
+    matrixify_mode_rows: 'dimensions',
+    matrixify_dimension_selection_mode_rows: 'all',
+    matrixify_dimension_rows: { dimension: 'country', values: [] },
+    matrixify_mode_columns: 'dimensions',
+    matrixify_dimension_selection_mode_columns: 'all',
+    matrixify_dimension_columns: { dimension: 'product', values: [] },
+  } as unknown as MatrixifyFormData;
+
+  expect(getMatrixifyValidationErrors(formData)).toEqual([]);
 });

--- a/superset-frontend/packages/superset-ui-core/src/chart/types/matrixify.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/matrixify.test.ts
@@ -22,7 +22,6 @@ import {
   getMatrixifyConfig,
   getMatrixifyValidationErrors,
   MatrixifyFormData,
-  MatrixifyFilterConstants,
 } from './matrixify';
 import { AdhocMetric } from '../../query/types/Metric';
 
@@ -41,10 +40,10 @@ test('isMatrixifyEnabled should return false when no matrixify configuration exi
 test('isMatrixifyEnabled should return false when layout controls are disabled', () => {
   const formData = {
     viz_type: 'table',
-    matrixify_mode_rows: 'disabled' as const,
-    matrixify_mode_columns: 'disabled' as const,
+    matrixify_mode_rows: 'disabled',
+    matrixify_mode_columns: 'disabled',
     matrixify_rows: [createMetric('Revenue')],
-  } as unknown as MatrixifyFormData;
+  } as MatrixifyFormData;
 
   expect(isMatrixifyEnabled(formData)).toBe(false);
 });
@@ -243,9 +242,9 @@ test('getMatrixifyConfig should preserve ascending topn order when explicitly di
 test('getMatrixifyValidationErrors should return empty array when matrixify is not enabled', () => {
   const formData = {
     viz_type: 'table',
-    matrixify_mode_rows: 'disabled' as const,
-    matrixify_mode_columns: 'disabled' as const,
-  } as unknown as MatrixifyFormData;
+    matrixify_mode_rows: 'disabled',
+    matrixify_mode_columns: 'disabled',
+  } as MatrixifyFormData;
 
   expect(getMatrixifyValidationErrors(formData)).toEqual([]);
 });
@@ -432,64 +431,4 @@ test('should handle partial configuration with one axis only', () => {
   } as MatrixifyFormData;
 
   expect(isMatrixifyEnabled(formData)).toBe(true);
-});
-
-test('MatrixifyFilterConstants has expected values', () => {
-  expect(MatrixifyFilterConstants.ExpressionType.SIMPLE).toBe('SIMPLE');
-  expect(MatrixifyFilterConstants.ExpressionType.SQL).toBe('SQL');
-  expect(MatrixifyFilterConstants.Clause.WHERE).toBe('WHERE');
-  expect(MatrixifyFilterConstants.Clause.HAVING).toBe('HAVING');
-  expect(MatrixifyFilterConstants.Operator.EQUALS).toBe('==');
-  expect(MatrixifyFilterConstants.Operator.NOT_EQUALS).toBe('!=');
-  expect(MatrixifyFilterConstants.Operator.IN).toBe('IN');
-  expect(MatrixifyFilterConstants.Operator.NOT_IN).toBe('NOT IN');
-});
-
-test('isMatrixifyEnabled should return true for all dimension selection mode on rows', () => {
-  const formData = {
-    matrixify_enable: true,
-    matrixify_mode_rows: 'dimensions',
-    matrixify_dimension_selection_mode_rows: 'all',
-    matrixify_dimension_rows: { dimension: 'country', values: [] },
-  } as unknown as MatrixifyFormData;
-
-  expect(isMatrixifyEnabled(formData)).toBe(true);
-});
-
-test('isMatrixifyEnabled should return true for all dimension selection mode on columns', () => {
-  const formData = {
-    matrixify_enable: true,
-    matrixify_mode_columns: 'dimensions',
-    matrixify_dimension_selection_mode_columns: 'all',
-    matrixify_dimension_columns: { dimension: 'product', values: [] },
-  } as unknown as MatrixifyFormData;
-
-  expect(isMatrixifyEnabled(formData)).toBe(true);
-});
-
-test('isMatrixifyEnabled should return true for all selection mode on both axes', () => {
-  const formData = {
-    matrixify_enable: true,
-    matrixify_mode_rows: 'dimensions',
-    matrixify_dimension_selection_mode_rows: 'all',
-    matrixify_dimension_rows: { dimension: 'country', values: [] },
-    matrixify_mode_columns: 'dimensions',
-    matrixify_dimension_selection_mode_columns: 'all',
-    matrixify_dimension_columns: { dimension: 'product', values: [] },
-  } as unknown as MatrixifyFormData;
-
-  expect(isMatrixifyEnabled(formData)).toBe(true);
-});
-
-test('getMatrixifyValidationErrors should return no errors for all selection mode with dimension set', () => {
-  const formData = {
-    matrixify_mode_rows: 'dimensions',
-    matrixify_dimension_selection_mode_rows: 'all',
-    matrixify_dimension_rows: { dimension: 'country', values: [] },
-    matrixify_mode_columns: 'dimensions',
-    matrixify_dimension_selection_mode_columns: 'all',
-    matrixify_dimension_columns: { dimension: 'product', values: [] },
-  } as unknown as MatrixifyFormData;
-
-  expect(getMatrixifyValidationErrors(formData)).toEqual([]);
 });

--- a/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
@@ -100,7 +100,7 @@ test('Renders the modified date', () => {
   expect(modifiedDateElement).toBeInTheDocument();
 });
 
-test('constructs thumbnail URL directly when dashboard has no thumbnail_url', () => {
+test('renders without fetching thumbnail when dashboard has no thumbnail_url', () => {
   render(
     <MemoryRouter>
       <DashboardCard
@@ -125,5 +125,8 @@ test('constructs thumbnail URL directly when dashboard has no thumbnail_url', ()
       />
     </MemoryRouter>,
   );
+  // Component should render without making any API calls to fetch thumbnail.
+  // The thumbnail URL is now constructed directly from dashboard.id and
+  // dashboard.changed_on_utc instead of fetching via SupersetClient.get.
   expect(screen.getByText('No Thumb Dashboard')).toBeInTheDocument();
 });

--- a/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
@@ -18,13 +18,9 @@
  */
 
 import { MemoryRouter } from 'react-router-dom';
-import {
-  JsonResponse,
-  SupersetClient,
-  isFeatureEnabled,
-} from '@superset-ui/core';
+import { isFeatureEnabled } from '@superset-ui/core';
 
-import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { render, screen } from 'spec/helpers/testing-library';
 
 import DashboardCard from './DashboardCard';
 
@@ -104,57 +100,30 @@ test('Renders the modified date', () => {
   expect(modifiedDateElement).toBeInTheDocument();
 });
 
-test('should fetch thumbnail when dashboard has no thumbnail URL and feature flag is enabled', async () => {
-  const mockGet = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
-    json: { result: { thumbnail_url: '/new-thumbnail.png' } },
-  } as unknown as JsonResponse);
-
-  const { rerender } = render(
-    <DashboardCard
-      dashboard={{
-        id: 1,
-        thumbnail_url: '',
-        changed_by_name: '',
-        changed_by: '',
-        dashboard_title: '',
-        published: false,
-        url: '',
-        owners: [],
-      }}
-      hasPerm={() => true}
-      bulkSelectEnabled={false}
-      loading={false}
-      saveFavoriteStatus={() => {}}
-      favoriteStatus={false}
-      handleBulkDashboardExport={() => {}}
-      onDelete={() => {}}
-    />,
+test('constructs thumbnail URL directly when dashboard has no thumbnail_url', () => {
+  render(
+    <MemoryRouter>
+      <DashboardCard
+        dashboard={{
+          id: 2,
+          thumbnail_url: '',
+          changed_by_name: '',
+          changed_by: '',
+          dashboard_title: 'No Thumb Dashboard',
+          published: false,
+          url: '/dashboard/2',
+          owners: [],
+          changed_on_utc: '2024-01-01T00:00:00',
+        }}
+        hasPerm={() => true}
+        bulkSelectEnabled={false}
+        loading={false}
+        saveFavoriteStatus={() => {}}
+        favoriteStatus={false}
+        handleBulkDashboardExport={() => {}}
+        onDelete={() => {}}
+      />
+    </MemoryRouter>,
   );
-  await waitFor(() => {
-    expect(mockGet).toHaveBeenCalledWith({
-      endpoint: '/api/v1/dashboard/1',
-    });
-  });
-  rerender(
-    <DashboardCard
-      dashboard={{
-        id: 1,
-        thumbnail_url: '/new-thumbnail.png',
-        changed_by_name: '',
-        changed_by: '',
-        dashboard_title: '',
-        published: false,
-        url: '',
-        owners: [],
-      }}
-      hasPerm={() => true}
-      bulkSelectEnabled={false}
-      loading={false}
-      saveFavoriteStatus={() => {}}
-      favoriteStatus={false}
-      handleBulkDashboardExport={() => {}}
-      onDelete={() => {}}
-    />,
-  );
-  mockGet.mockRestore();
+  expect(screen.getByText('No Thumb Dashboard')).toBeInTheDocument();
 });

--- a/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
@@ -100,7 +100,13 @@ test('Renders the modified date', () => {
   expect(modifiedDateElement).toBeInTheDocument();
 });
 
-test('renders without fetching thumbnail when dashboard has no thumbnail_url', () => {
+test('constructs thumbnail URL from dashboard id and changed_on_utc when thumbnail_url is empty', () => {
+  const originalFetch = global.fetch;
+  const mockFetch = jest.fn().mockResolvedValue({
+    blob: () => Promise.resolve(new Blob([''], { type: 'image/png' })),
+  });
+  global.fetch = mockFetch;
+
   render(
     <MemoryRouter>
       <DashboardCard
@@ -118,6 +124,7 @@ test('renders without fetching thumbnail when dashboard has no thumbnail_url', (
         hasPerm={() => true}
         bulkSelectEnabled={false}
         loading={false}
+        showThumbnails
         saveFavoriteStatus={() => {}}
         favoriteStatus={false}
         handleBulkDashboardExport={() => {}}
@@ -125,8 +132,14 @@ test('renders without fetching thumbnail when dashboard has no thumbnail_url', (
       />
     </MemoryRouter>,
   );
-  // Component should render without making any API calls to fetch thumbnail.
-  // The thumbnail URL is now constructed directly from dashboard.id and
-  // dashboard.changed_on_utc instead of fetching via SupersetClient.get.
+
   expect(screen.getByText('No Thumb Dashboard')).toBeInTheDocument();
+  // When thumbnail_url is empty, the component constructs the URL directly
+  // from dashboard.id and dashboard.changed_on_utc instead of fetching
+  // via SupersetClient.get.
+  expect(mockFetch).toHaveBeenCalledWith(
+    '/api/v1/dashboard/2/thumbnail/2024-01-01T00%3A00%3A00/',
+  );
+
+  global.fetch = originalFetch;
 });

--- a/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
@@ -31,7 +31,7 @@ const mockDashboard = {
   certification_details: 'Certified on 2022-01-01',
   published: true,
   url: '/dashboard/1',
-  thumbnail_url: '/thumbnails/1.png',
+  changed_on_utc: '2024-01-01T00:00:00',
   changed_on_delta_humanized: '2 days ago',
   owners: [
     { id: 1, name: 'Alice', first_name: 'Alice', last_name: 'Doe' },
@@ -100,46 +100,81 @@ test('Renders the modified date', () => {
   expect(modifiedDateElement).toBeInTheDocument();
 });
 
-test('constructs thumbnail URL from dashboard id and changed_on_utc when thumbnail_url is empty', () => {
-  const originalFetch = global.fetch;
-  const mockFetch = jest.fn().mockResolvedValue({
-    blob: () => Promise.resolve(new Blob([''], { type: 'image/png' })),
+describe('thumbnail URL construction', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      blob: () => Promise.resolve(new Blob([''], { type: 'image/png' })),
+    } as Response);
   });
-  global.fetch = mockFetch;
 
-  render(
-    <MemoryRouter>
-      <DashboardCard
-        dashboard={{
-          id: 2,
-          thumbnail_url: '',
-          changed_by_name: '',
-          changed_by: '',
-          dashboard_title: 'No Thumb Dashboard',
-          published: false,
-          url: '/dashboard/2',
-          owners: [],
-          changed_on_utc: '2024-01-01T00:00:00',
-        }}
-        hasPerm={() => true}
-        bulkSelectEnabled={false}
-        loading={false}
-        showThumbnails
-        saveFavoriteStatus={() => {}}
-        favoriteStatus={false}
-        handleBulkDashboardExport={() => {}}
-        onDelete={() => {}}
-      />
-    </MemoryRouter>,
-  );
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
 
-  expect(screen.getByText('No Thumb Dashboard')).toBeInTheDocument();
-  // When thumbnail_url is empty, the component constructs the URL directly
-  // from dashboard.id and dashboard.changed_on_utc instead of fetching
-  // via SupersetClient.get.
-  expect(mockFetch).toHaveBeenCalledWith(
-    '/api/v1/dashboard/2/thumbnail/2024-01-01T00%3A00%3A00/',
-  );
+  const renderCard = (dashboard: object) =>
+    render(
+      <MemoryRouter>
+        <DashboardCard
+          dashboard={dashboard as any}
+          hasPerm={() => true}
+          bulkSelectEnabled={false}
+          loading={false}
+          showThumbnails
+          saveFavoriteStatus={() => {}}
+          favoriteStatus={false}
+          handleBulkDashboardExport={() => {}}
+          onDelete={() => {}}
+        />
+      </MemoryRouter>,
+    );
 
-  global.fetch = originalFetch;
+  test('constructs thumbnail URL from dashboard id and changed_on_utc', () => {
+    renderCard({
+      id: 2,
+      changed_by_name: '',
+      changed_by: '',
+      dashboard_title: 'UTC Dashboard',
+      published: false,
+      url: '/dashboard/2',
+      owners: [],
+      changed_on_utc: '2024-01-01T00:00:00',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/v1/dashboard/2/thumbnail/2024-01-01T00%3A00%3A00/',
+    );
+  });
+
+  test('falls back to changed_on when changed_on_utc is absent', () => {
+    renderCard({
+      id: 3,
+      changed_by_name: '',
+      changed_by: '',
+      dashboard_title: 'Fallback Dashboard',
+      published: false,
+      url: '/dashboard/3',
+      owners: [],
+      changed_on: '2024-06-01T12:00:00',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/v1/dashboard/3/thumbnail/2024-06-01T12%3A00%3A00/',
+    );
+  });
+
+  test('renders no thumbnail when both changed_on_utc and changed_on are absent', () => {
+    renderCard({
+      id: 4,
+      changed_by_name: '',
+      changed_by: '',
+      dashboard_title: 'No Timestamp Dashboard',
+      published: false,
+      url: '/dashboard/4',
+      owners: [],
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -16,14 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { t } from '@apache-superset/core/translation';
-import {
-  isFeatureEnabled,
-  FeatureFlag,
-  SupersetClient,
-} from '@superset-ui/core';
+import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import { CardStyles } from 'src/views/CRUD/utils';
 import {
   Dropdown,
@@ -69,33 +64,11 @@ function DashboardCard({
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
-  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
-  const [fetchingThumbnail, setFetchingThumbnail] = useState<boolean>(false);
-
-  useEffect(() => {
-    // fetch thumbnail only if it's not already fetched
-    if (
-      !fetchingThumbnail &&
-      dashboard.id &&
-      (thumbnailUrl === undefined || thumbnailUrl === null) &&
-      isFeatureEnabled(FeatureFlag.Thumbnails)
-    ) {
-      // fetch thumbnail
-      if (dashboard.thumbnail_url) {
-        // set to empty string if null so that we don't
-        // keep fetching the thumbnail
-        setThumbnailUrl(dashboard.thumbnail_url || '');
-        return;
-      }
-      setFetchingThumbnail(true);
-      SupersetClient.get({
-        endpoint: `/api/v1/dashboard/${dashboard.id}`,
-      }).then(({ json = {} }) => {
-        setThumbnailUrl(json.result?.thumbnail_url || '');
-        setFetchingThumbnail(false);
-      });
-    }
-  }, [dashboard, thumbnailUrl]);
+  const thumbnailUrl =
+    isFeatureEnabled(FeatureFlag.Thumbnails) && dashboard.id
+      ? dashboard.thumbnail_url ||
+        `/api/v1/dashboard/${dashboard.id}/thumbnail/${encodeURIComponent(dashboard.changed_on_utc || 'default')}/`
+      : '';
 
   const menuItems: MenuItem[] = [];
 

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -67,7 +67,7 @@ function DashboardCard({
   const thumbnailUrl =
     isFeatureEnabled(FeatureFlag.Thumbnails) && dashboard.id
       ? dashboard.thumbnail_url ||
-        `/api/v1/dashboard/${dashboard.id}/thumbnail/${encodeURIComponent(dashboard.changed_on_utc || 'default')}/`
+        `/api/v1/dashboard/${dashboard.id}/thumbnail/${encodeURIComponent(dashboard.changed_on_utc || dashboard.changed_on || 'default')}/`
       : '';
 
   const menuItems: MenuItem[] = [];

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -64,10 +64,10 @@ function DashboardCard({
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
+  const digest = dashboard.changed_on_utc || dashboard.changed_on;
   const thumbnailUrl =
-    isFeatureEnabled(FeatureFlag.Thumbnails) && dashboard.id
-      ? dashboard.thumbnail_url ||
-        `/api/v1/dashboard/${dashboard.id}/thumbnail/${encodeURIComponent(dashboard.changed_on_utc || dashboard.changed_on || 'default')}/`
+    isFeatureEnabled(FeatureFlag.Thumbnails) && dashboard.id && digest
+      ? `/api/v1/dashboard/${dashboard.id}/thumbnail/${encodeURIComponent(digest)}/`
       : '';
 
   const menuItems: MenuItem[] = [];

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -106,11 +106,11 @@ export interface Dashboard {
   changed_by_name: string;
   changed_on_delta_humanized: string;
   changed_by: string;
+  changed_on?: string;
   dashboard_title: string;
   id: number;
   published: boolean;
   url: string;
-  thumbnail_url: string;
   owners: Owner[];
   tags: TagType[];
   created_by: object;

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -55,6 +55,7 @@ export interface Dashboard {
   certified_by?: string;
   certification_details?: string;
   changed_by_name: string;
+  changed_on?: string;
   changed_on_delta_humanized?: string;
   changed_on_utc?: string;
   changed_by: string;

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -64,7 +64,7 @@ export interface Dashboard {
   id: number;
   published: boolean;
   url: string;
-  thumbnail_url?: string;
+  thumbnail_url?: string | null;
   owners: Owner[];
   loading?: boolean;
 }

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -64,7 +64,7 @@ export interface Dashboard {
   id: number;
   published: boolean;
   url: string;
-  thumbnail_url: string;
+  thumbnail_url?: string;
   owners: Owner[];
   loading?: boolean;
 }

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -187,7 +187,6 @@ BASE_LIST_COLUMNS = [
     "status",
     "slug",
     "url",
-    "thumbnail_url",
     "certified_by",
     "certification_details",
     "changed_by.first_name",

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -67,14 +67,14 @@ class TestThumbnailsSeleniumLive(LiveServerTestCase):
         """
         Thumbnails: Simple get async dashboard screenshot
         """
-        with patch("superset.dashboards.api.DashboardRestApi.get") as mock_get:  # noqa: F841
-            rv = self.client.get(DASHBOARD_URL)
-            resp = json.loads(rv.data.decode("utf-8"))
-            obj_id = resp["result"][0]["id"]
-            rv = self.client.get(f"{DASHBOARD_URL}{obj_id}")
-            resp = json.loads(rv.data.decode("utf-8"))
-            thumbnail_url = resp["result"]["thumbnail_url"]
+        rv = self.client.get(DASHBOARD_URL)
+        resp = json.loads(rv.data.decode("utf-8"))
+        obj_id = resp["result"][0]["id"]
+        rv = self.client.get(f"{DASHBOARD_URL}{obj_id}")
+        resp = json.loads(rv.data.decode("utf-8"))
+        thumbnail_url = resp["result"]["thumbnail_url"]
 
+        with patch("superset.dashboards.api.DashboardRestApi.get"):
             response = self.url_open_auth(
                 ADMIN_USERNAME,
                 thumbnail_url,

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -70,7 +70,10 @@ class TestThumbnailsSeleniumLive(LiveServerTestCase):
         with patch("superset.dashboards.api.DashboardRestApi.get") as mock_get:  # noqa: F841
             rv = self.client.get(DASHBOARD_URL)
             resp = json.loads(rv.data.decode("utf-8"))
-            thumbnail_url = resp["result"][0]["thumbnail_url"]
+            obj_id = resp["result"][0]["id"]
+            rv = self.client.get(f"{DASHBOARD_URL}{obj_id}")
+            resp = json.loads(rv.data.decode("utf-8"))
+            thumbnail_url = resp["result"]["thumbnail_url"]
 
             response = self.url_open_auth(
                 ADMIN_USERNAME,
@@ -197,8 +200,12 @@ class TestThumbnails(SupersetTestCase):
     def _get_id_and_thumbnail_url(self, url: str) -> tuple[int, str]:
         rv = self.client.get(url)
         resp = json.loads(rv.data.decode("utf-8"))
-        obj = resp["result"][0]
-        return obj["id"], obj["thumbnail_url"]
+        obj_id = resp["result"][0]["id"]
+        # Fetch thumbnail_url from the detail endpoint since it's
+        # not included in list responses
+        rv = self.client.get(f"{url}{obj_id}")
+        resp = json.loads(rv.data.decode("utf-8"))
+        return obj_id, resp["result"]["thumbnail_url"]
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @with_feature_flags(THUMBNAILS=False)

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -197,6 +197,22 @@ class TestThumbnails(SupersetTestCase):
     # SHA-256 hash of "foo_bar" (default HASH_ALGORITHM is sha256)
     digest_hash = "4928cae8b37b3d1113f5e01e60c967df6c2b9e826dc7d91488d23a62fec715ba"
 
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_dashboard_list_omits_thumbnail_url(self):
+        """
+        Thumbnails: dashboard list response must not include thumbnail_url
+        """
+        self.login(ADMIN_USERNAME)
+        rv = self.client.get(DASHBOARD_URL)
+        resp = json.loads(rv.data.decode("utf-8"))
+        assert rv.status_code == 200
+        assert len(resp["result"]) > 0
+        for dashboard in resp["result"]:
+            assert "thumbnail_url" not in dashboard, (
+                "thumbnail_url should not appear in list responses; "
+                "it is only available on the detail endpoint"
+            )
+
     def _get_id_and_thumbnail_url(self, url: str) -> tuple[int, str]:
         rv = self.client.get(url)
         resp = json.loads(rv.data.decode("utf-8"))


### PR DESCRIPTION
## **User description**
### SUMMARY

Remove `thumbnail_url` from `BASE_LIST_COLUMNS` in the dashboard list API to avoid expensive per-dashboard digest computation on every list request.

**Problem:** When `thumbnail_url` is included in list responses, each dashboard requires computing a cryptographic digest of its configuration. This triggers:
1. Expensive digest computation for every dashboard on every list request (home page, dashboard list)
2. Cache misses due to non-deterministic digest computation (Python set iteration order)
3. Unnecessary Celery thumbnail rendering tasks
4. Audit log entries (`dashboard:view`) for offline users whose dashboards appear in other users' home pages

**Solution:** 
- Remove `thumbnail_url` from `BASE_LIST_COLUMNS` so the list API no longer computes digests
- Update `DashboardCard` to construct the thumbnail URL directly using the dashboard ID and `changed_on_utc` timestamp
- The thumbnail endpoint already handles digest mismatches via 302 redirect, so using `changed_on_utc` as a cache-busting key works without needing the exact digest

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - No visual changes. Thumbnails still load correctly via the redirect mechanism.

### TESTING INSTRUCTIONS

1. Enable the `THUMBNAILS` feature flag
2. Navigate to the home page or dashboard list page
3. Verify dashboard thumbnails still load correctly
4. Check network tab: thumbnails should load via `/api/v1/dashboard/<id>/thumbnail/<changed_on_utc>/` with a 302 redirect to the cached image
5. Verify the dashboard list API response (`/api/v1/dashboard/`) no longer includes `thumbnail_url` in results

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `THUMBNAILS`
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [x] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Show dashboard thumbnails without extra dashboard lookups**

### What Changed
- Dashboard lists no longer include a thumbnail URL in every item, which removes the extra dashboard fetch used just to display thumbnails
- Dashboard cards now build the thumbnail link directly from the dashboard ID and last-updated time, so thumbnails still load on list pages
- If the UTC update time is not available, the card falls back to the regular update time to keep thumbnails working

### Impact
`✅ Faster dashboard list loading`
`✅ Fewer thumbnail-related backend requests`
`✅ Thumbnails still appear on dashboard cards`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

