### PR TITLE
fix: support nested function calls in cache_key_wrapper

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -122,13 +122,13 @@ class ExtraCache:
     # be added to the cache key.
     regex = re.compile(
         r"(\{\{|\{%)[^{}]*?("
-        r"current_user_id\([^()]*\)|"
-        r"current_username\([^()]*\)|"
-        r"current_user_email\([^()]*\)|"
-        r"current_user_rls_rules\([^()]*\)|"
-        r"current_user_roles\([^()]*\)|"
-        r"cache_key_wrapper\([^()]*\)|"
-        r"url_param\([^()]*\)"
+        r"current_user_id\([^)]*\)|"
+        r"current_username\([^)]*\)|"
+        r"current_user_email\([^)]*\)|"
+        r"current_user_rls_rules\([^)]*\)|"
+        r"current_user_roles\([^)]*\)|"
+        r"cache_key_wrapper\([^)]*\)|"
+        r"url_param\([^)]*\)"
         r")"
         r"[^{}]*?(\}\}|\%\})"
     )

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -841,6 +841,15 @@ def test_none_operand_in_filter(login_as_admin, physical_dataset):
             [],
             True,
         ),
+        (
+            "test_has_extra_cache_keys_cache_key_wrapper_with_fn_arg",
+            """
+            SELECT
+            '{{ cache_key_wrapper(my_func()) }}' as user_id
+            """,
+            {1},
+            True,
+        ),
         ("test_has_no_extra_cache_keys_table", "SELECT 'abc' as user", [], False),
     ],
 )

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -841,15 +841,6 @@ def test_none_operand_in_filter(login_as_admin, physical_dataset):
             [],
             True,
         ),
-        (
-            "test_has_extra_cache_keys_cache_key_wrapper_with_fn_arg",
-            """
-            SELECT
-            '{{ cache_key_wrapper(my_func()) }}' as user_id
-            """,
-            {1},
-            True,
-        ),
         ("test_has_no_extra_cache_keys_table", "SELECT 'abc' as user", [], False),
     ],
 )

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -1693,3 +1693,27 @@ def test_undefined_template_variable_not_function(mocker: MockerFixture) -> None
     template = "SELECT {{ undefined_variable.some_method() }}"
     with pytest.raises(UndefinedError):
         processor.process_template(template)
+
+
+@pytest.mark.parametrize(
+    "sql,expected",
+    [
+        ("SELECT {{ cache_key_wrapper(abc) }}", True),
+        ("SELECT {{ cache_key_wrapper(myfunc()) }}", True),
+        (
+            "{% set abc = myfunc() %}\nSELECT {{ cache_key_wrapper(abc) }}",
+            True,
+        ),
+        ("SELECT {{ url_param('foo') }}", True),
+        ("SELECT {{ url_param(get_param('foo')) }}", True),
+        ("SELECT {{ current_user_id() }}", True),
+        ("SELECT {{ current_username() }}", True),
+        ("SELECT {{ current_user_email() }}", True),
+        ("SELECT {{ current_user_roles() }}", True),
+        ("SELECT {{ current_user_rls_rules() }}", True),
+        ("SELECT 1", False),
+        ("SELECT '{{ 1 + 1 }}'", False),
+    ],
+)
+def test_extra_cache_regex(sql: str, expected: bool) -> None:
+    assert bool(ExtraCache.regex.search(sql)) is expected

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -1696,7 +1696,7 @@ def test_undefined_template_variable_not_function(mocker: MockerFixture) -> None
 
 
 @pytest.mark.parametrize(
-    "sql,expected",
+    ("sql", "expected"),
     [
         ("SELECT {{ cache_key_wrapper(abc) }}", True),
         ("SELECT {{ cache_key_wrapper(myfunc()) }}", True),

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -1700,10 +1700,6 @@ def test_undefined_template_variable_not_function(mocker: MockerFixture) -> None
     [
         ("SELECT {{ cache_key_wrapper(abc) }}", True),
         ("SELECT {{ cache_key_wrapper(myfunc()) }}", True),
-        (
-            "{% set abc = myfunc() %}\nSELECT {{ cache_key_wrapper(abc) }}",
-            True,
-        ),
         ("SELECT {{ url_param('foo') }}", True),
         ("SELECT {{ url_param(get_param('foo')) }}", True),
         ("SELECT {{ current_user_id() }}", True),
@@ -1711,6 +1707,7 @@ def test_undefined_template_variable_not_function(mocker: MockerFixture) -> None
         ("SELECT {{ current_user_email() }}", True),
         ("SELECT {{ current_user_roles() }}", True),
         ("SELECT {{ current_user_rls_rules() }}", True),
+        ("SELECT 'cache_key_wrapper(abc)' AS false_positive'", False),
         ("SELECT 1", False),
         ("SELECT '{{ 1 + 1 }}'", False),
     ],

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -1707,7 +1707,7 @@ def test_undefined_template_variable_not_function(mocker: MockerFixture) -> None
         ("SELECT {{ current_user_email() }}", True),
         ("SELECT {{ current_user_roles() }}", True),
         ("SELECT {{ current_user_rls_rules() }}", True),
-        ("SELECT 'cache_key_wrapper(abc)' AS false_positive'", False),
+        ("SELECT 'cache_key_wrapper(abc)' AS false_positive", False),
         ("SELECT 1", False),
         ("SELECT '{{ 1 + 1 }}'", False),
     ],


### PR DESCRIPTION
## **User description**
### SUMMARY

#30549 introduced a regression that caused nested function calls inside `cache_key_wrapper()` to go undetected. This means, that while the following Jinja snippets were functionally identical, only the former was flagged as containing extra cache keys:

```python
{% set abc = myfunc() %}
{{ cache_key_wrapper(abc) }}
```

is the same as

```python
{{ cache_key_wrapper(myfunc()) }}
```

The change relaxes the regex to detect both cases correctly, and adds tests to catch a similar regression going forward.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #33775
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Detect nested templated function calls when computing extra cache keys

### What Changed
- Regex that finds templated helper calls (cache_key_wrapper, url_param, current_user_*) was relaxed so calls wrapped inside other calls are detected (e.g., cache_key_wrapper(myfunc()) and url_param(get_param('x'))).
- Added parametrized unit tests that verify detection of these nested calls and avoid false positives for plain strings or non-templated expressions.

### Impact
`✅ Fewer incorrect cache hits`
`✅ More accurate cache key detection for templated queries`
`✅ Fewer missed extra cache keys from nested function calls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
