### PR TITLE
fix(thumbnails): add deduplication to dashboard thumbnail Celery tasks

### DIFF
--- a/superset/commands/distributed_lock/acquire.py
+++ b/superset/commands/distributed_lock/acquire.py
@@ -19,11 +19,10 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
-from functools import partial
 from typing import Any
 
 import redis
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from superset.commands.distributed_lock.base import (
     BaseDistributedLockCommand,
@@ -31,15 +30,30 @@ from superset.commands.distributed_lock.base import (
     get_redis_client,
 )
 from superset.daos.key_value import KeyValueDAO
-from superset.exceptions import AcquireDistributedLockFailedException
+from superset.exceptions import (
+    AcquireDistributedLockFailedException,
+    LockAlreadyHeldException,
+)
 from superset.key_value.exceptions import (
     KeyValueCodecEncodeException,
     KeyValueUpsertFailedError,
 )
 from superset.key_value.types import KeyValueResource
-from superset.utils.decorators import on_error, transaction
+from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
+
+
+def _kv_lock_on_error(ex: Exception) -> None:
+    """Translate KV-backend exceptions into the appropriate lock exception type."""
+    if isinstance(ex, IntegrityError):
+        # Unique-constraint violation: lock is already held by another process.
+        raise LockAlreadyHeldException("KV lock already held") from ex
+    if isinstance(
+        ex, (KeyValueCodecEncodeException, KeyValueUpsertFailedError, SQLAlchemyError)
+    ):
+        raise AcquireDistributedLockFailedException(f"KV lock failed: {ex}") from ex
+    raise ex
 
 
 class AcquireDistributedLock(BaseDistributedLockCommand):
@@ -85,7 +99,7 @@ class AcquireDistributedLock(BaseDistributedLockCommand):
 
             if not acquired:
                 logger.debug("Redis lock on %s already taken", self.redis_lock_key)
-                raise AcquireDistributedLockFailedException("Lock already taken")
+                raise LockAlreadyHeldException("Lock already taken")
 
             logger.debug(
                 "Acquired Redis lock: %s (TTL=%ds)",
@@ -99,17 +113,7 @@ class AcquireDistributedLock(BaseDistributedLockCommand):
                 f"Redis lock failed: {ex}"
             ) from ex
 
-    @transaction(
-        on_error=partial(
-            on_error,
-            catches=(
-                KeyValueCodecEncodeException,
-                KeyValueUpsertFailedError,
-                SQLAlchemyError,
-            ),
-            reraise=AcquireDistributedLockFailedException,
-        ),
-    )
+    @transaction(on_error=_kv_lock_on_error)
     def _acquire_kv(self) -> None:
         """Acquire lock using KeyValue table (database)."""
         # Delete expired entries first to prevent stale locks from blocking

--- a/superset/config.py
+++ b/superset/config.py
@@ -1130,6 +1130,9 @@ THUMBNAIL_CACHE_CONFIG: CacheConfig = {
     "CACHE_NO_NULL_WARNING": True,
 }
 THUMBNAIL_ERROR_CACHE_TTL = int(timedelta(days=1).total_seconds())
+# How long to treat a COMPUTING cache entry as an active lease before considering
+# the worker stuck.  Should exceed the task soft_time_limit (300 s) by a margin.
+THUMBNAIL_COMPUTING_CACHE_TTL = int(timedelta(seconds=360).total_seconds())
 
 # Cache warmup user — must be set explicitly before enabling the cache-warmup
 # Celery task. Intentionally defaults to None so operators pick a dedicated

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1471,11 +1471,6 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
 
         if cache_payload.should_trigger_task(force):
             logger.info("Triggering screenshot ASYNC")
-            # Set status to COMPUTING before enqueuing to prevent duplicate
-            # tasks from concurrent requests seeing PENDING status
-            computing_payload = ScreenshotCachePayload()
-            computing_payload.computing()
-            screenshot_obj.cache.set(cache_key, computing_payload.to_dict())
             cache_dashboard_screenshot.delay(
                 username=get_current_user(),
                 guest_token=(
@@ -1671,11 +1666,6 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
                 "Triggering thumbnail compute (dashboard id: %s) ASYNC",
                 str(dashboard.id),
             )
-            # Set status to COMPUTING before enqueuing to prevent duplicate
-            # tasks from concurrent requests seeing PENDING status
-            computing_payload = ScreenshotCachePayload()
-            computing_payload.computing()
-            screenshot_obj.cache.set(cache_key, computing_payload.to_dict())
             cache_dashboard_thumbnail.delay(
                 current_user=current_user,
                 dashboard_id=dashboard.id,

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1471,7 +1471,11 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
 
         if cache_payload.should_trigger_task(force):
             logger.info("Triggering screenshot ASYNC")
-            screenshot_obj.cache.set(cache_key, ScreenshotCachePayload().to_dict())
+            # Set status to COMPUTING before enqueuing to prevent duplicate
+            # tasks from concurrent requests seeing PENDING status
+            computing_payload = ScreenshotCachePayload()
+            computing_payload.computing()
+            screenshot_obj.cache.set(cache_key, computing_payload.to_dict())
             cache_dashboard_screenshot.delay(
                 username=get_current_user(),
                 guest_token=(
@@ -1667,7 +1671,11 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
                 "Triggering thumbnail compute (dashboard id: %s) ASYNC",
                 str(dashboard.id),
             )
-            screenshot_obj.cache.set(cache_key, ScreenshotCachePayload().to_dict())
+            # Set status to COMPUTING before enqueuing to prevent duplicate
+            # tasks from concurrent requests seeing PENDING status
+            computing_payload = ScreenshotCachePayload()
+            computing_payload.computing()
+            screenshot_obj.cache.set(cache_key, computing_payload.to_dict())
             cache_dashboard_thumbnail.delay(
                 current_user=current_user,
                 dashboard_id=dashboard.id,

--- a/superset/distributed_lock/__init__.py
+++ b/superset/distributed_lock/__init__.py
@@ -46,8 +46,10 @@ def DistributedLock(  # noqa: N802
                         to prevent deadlocks from crashed processes.
     :param kwargs: Additional key parameters to differentiate locks
     :yields: UUID identifying this lock acquisition
-    :raises AcquireDistributedLockFailedException: If lock is already held
-            or Redis connection fails
+    :raises LockAlreadyHeldException: If the lock is already held by another process
+            (subclass of AcquireDistributedLockFailedException)
+    :raises AcquireDistributedLockFailedException: If the lock backend fails
+            (Redis/DB connection error)
     """
     # pylint: disable=import-outside-toplevel
     from superset.commands.distributed_lock.acquire import AcquireDistributedLock

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -441,6 +441,14 @@ class AcquireDistributedLockFailedException(Exception):  # noqa: N818
     """
 
 
+class LockAlreadyHeldException(AcquireDistributedLockFailedException):  # noqa: N818
+    """
+    Raised when a distributed lock is already held by another process (lock contention).
+    Subclass of AcquireDistributedLockFailedException so existing callers that catch
+    the base exception continue to work unchanged.
+    """
+
+
 class ReleaseDistributedLockFailedException(Exception):  # noqa: N818
     """
     Exception to signalize failure to release lock.

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -27,7 +27,11 @@ from superset.extensions import celery_app
 from superset.security.guest_token import GuestToken
 from superset.tasks.utils import get_executor
 from superset.utils.core import override_user
-from superset.utils.screenshots import ChartScreenshot, DashboardScreenshot
+from superset.utils.screenshots import (
+    ChartScreenshot,
+    DashboardScreenshot,
+    StatusValues,
+)
 from superset.utils.urls import get_url_path
 from superset.utils.webdriver import WindowSize
 
@@ -90,6 +94,23 @@ def cache_dashboard_thumbnail(
     dashboard = Dashboard.get(dashboard_id)
     url = get_url_path("Superset.dashboard", dashboard_id_or_slug=dashboard.id)
 
+    screenshot = DashboardScreenshot(url, dashboard.digest)
+    resolved_cache_key = cache_key or screenshot.get_cache_key(window_size, thumb_size)
+
+    # Deduplication: check if another task is already computing this thumbnail.
+    # Skip even for force=True to avoid concurrent Selenium sessions for the
+    # same dashboard, which waste resources without benefit.
+    existing = screenshot.get_from_cache_key(resolved_cache_key)
+    if existing and existing.status == StatusValues.COMPUTING:
+        if not existing.is_computing_stale():
+            logger.info(
+                "Skipping duplicate thumbnail task for dashboard %s "
+                "(already computing, cache_key=%s)",
+                dashboard_id,
+                resolved_cache_key,
+            )
+            return
+
     logger.info("Caching dashboard: %s", url)
     _, username = get_executor(
         executors=current_app.config["THUMBNAIL_EXECUTORS"],
@@ -98,7 +119,6 @@ def cache_dashboard_thumbnail(
     )
     user = security_manager.find_user(username)
     with override_user(user):
-        screenshot = DashboardScreenshot(url, dashboard.digest)
         screenshot.compute_and_cache(
             user=user,
             window_size=window_size,

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -30,7 +30,6 @@ from superset.utils.core import override_user
 from superset.utils.screenshots import (
     ChartScreenshot,
     DashboardScreenshot,
-    StatusValues,
 )
 from superset.utils.urls import get_url_path
 from superset.utils.webdriver import WindowSize
@@ -96,20 +95,6 @@ def cache_dashboard_thumbnail(
 
     screenshot = DashboardScreenshot(url, dashboard.digest)
     resolved_cache_key = cache_key or screenshot.get_cache_key(window_size, thumb_size)
-
-    # Deduplication: check if another task is already computing this thumbnail.
-    # Skip even for force=True to avoid concurrent Selenium sessions for the
-    # same dashboard, which waste resources without benefit.
-    existing = screenshot.get_from_cache_key(resolved_cache_key)
-    if existing and existing.status == StatusValues.COMPUTING:
-        if not existing.is_computing_stale():
-            logger.info(
-                "Skipping duplicate thumbnail task for dashboard %s "
-                "(already computing, cache_key=%s)",
-                dashboard_id,
-                resolved_cache_key,
-            )
-            return
 
     logger.info("Caching dashboard: %s", url)
     _, username = get_executor(

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -93,9 +93,6 @@ def cache_dashboard_thumbnail(
     dashboard = Dashboard.get(dashboard_id)
     url = get_url_path("Superset.dashboard", dashboard_id_or_slug=dashboard.id)
 
-    screenshot = DashboardScreenshot(url, dashboard.digest)
-    resolved_cache_key = cache_key or screenshot.get_cache_key(window_size, thumb_size)
-
     logger.info("Caching dashboard: %s", url)
     _, username = get_executor(
         executors=current_app.config["THUMBNAIL_EXECUTORS"],
@@ -104,6 +101,10 @@ def cache_dashboard_thumbnail(
     )
     user = security_manager.find_user(username)
     with override_user(user):
+        screenshot = DashboardScreenshot(url, dashboard.digest)
+        resolved_cache_key = cache_key or screenshot.get_cache_key(
+            window_size, thumb_size
+        )
         screenshot.compute_and_cache(
             user=user,
             window_size=window_size,

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -109,7 +109,7 @@ def cache_dashboard_thumbnail(
             window_size=window_size,
             thumb_size=thumb_size,
             force=force,
-            cache_key=cache_key,
+            cache_key=resolved_cache_key,
         )
 
 

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -28,7 +28,7 @@ from flask import current_app as app
 from superset import feature_flag_manager, thumbnail_cache
 from superset.distributed_lock import DistributedLock
 from superset.exceptions import (
-    AcquireDistributedLockFailedException,
+    LockAlreadyHeldException,
     ScreenshotImageNotAvailableException,
 )
 from superset.extensions import event_logger
@@ -336,7 +336,7 @@ class BaseScreenshot:
                 logger.info(
                     "Updated thumbnail cache; Status: %s", cache_payload.get_status()
                 )
-        except AcquireDistributedLockFailedException:
+        except LockAlreadyHeldException:
             logger.info(
                 "Skipping duplicate thumbnail task for %s - lock already held",
                 cache_key,

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -26,7 +26,11 @@ from typing import cast, TYPE_CHECKING, TypedDict
 from flask import current_app as app
 
 from superset import feature_flag_manager, thumbnail_cache
-from superset.exceptions import ScreenshotImageNotAvailableException
+from superset.distributed_lock import DistributedLock
+from superset.exceptions import (
+    AcquireDistributedLockFailedException,
+    ScreenshotImageNotAvailableException,
+)
 from superset.extensions import event_logger
 from superset.utils.hashing import hash_from_dict
 from superset.utils.urls import modify_url_query
@@ -276,10 +280,6 @@ class BaseScreenshot:
         :param force: Will force the computation even if it's already cached
         :return: Image payload
         """
-        # pylint: disable=import-outside-toplevel
-        from superset.distributed_lock import DistributedLock
-        from superset.exceptions import AcquireDistributedLockFailedException
-
         cache_key = cache_key or self.get_cache_key(window_size, thumb_size)
         try:
             with DistributedLock(

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -119,7 +119,6 @@ class ScreenshotCachePayload:
 
     def computing(self) -> None:
         self.update_timestamp()
-        self._image = None
         self.status = StatusValues.COMPUTING
 
     def update(self, image: bytes) -> None:
@@ -152,9 +151,7 @@ class ScreenshotCachePayload:
 
     def is_computing_stale(self) -> bool:
         """Check if a COMPUTING status is stale (task likely failed or stuck)."""
-        # Use the same TTL as error cache - if computing takes longer than this,
-        # it's likely stuck and should be retried
-        computing_ttl = app.config["THUMBNAIL_ERROR_CACHE_TTL"]
+        computing_ttl = app.config["THUMBNAIL_COMPUTING_CACHE_TTL"]
         return (
             datetime.now() - datetime.fromisoformat(self.get_timestamp())
         ).total_seconds() >= computing_ttl
@@ -279,45 +276,71 @@ class BaseScreenshot:
         :param force: Will force the computation even if it's already cached
         :return: Image payload
         """
+        # pylint: disable=import-outside-toplevel
+        from superset.distributed_lock import DistributedLock
+        from superset.exceptions import AcquireDistributedLockFailedException
+
         cache_key = cache_key or self.get_cache_key(window_size, thumb_size)
-        cache_payload = self.get_from_cache_key(cache_key) or ScreenshotCachePayload()
-        if not cache_payload.should_trigger_task(force=force):
-            logger.info(
-                "Skipping compute - already processed for thumbnail: %s", cache_key
-            )
-            return
-
-        window_size = window_size or self.window_size
-        thumb_size = thumb_size or self.thumb_size
-        logger.info("Processing url for thumbnail: %s", cache_key)
-        cache_payload.computing()
-        self.cache.set(cache_key, cache_payload.to_dict())
-        image = None
-        # Assuming all sorts of things can go wrong with Selenium
         try:
-            logger.info("trying to generate screenshot")
-            with event_logger.log_context(f"screenshot.compute.{self.thumbnail_type}"):
-                image = self.get_screenshot(user=user, window_size=window_size)
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.warning("Failed at generating thumbnail %s", ex, exc_info=True)
-            cache_payload.error()
-        if image and window_size != thumb_size:
-            try:
-                image = self.resize_image(image, thumb_size=thumb_size)
-            except Exception as ex:  # pylint: disable=broad-except
-                logger.warning("Failed at resizing thumbnail %s", ex, exc_info=True)
-                cache_payload.error()
+            with DistributedLock(
+                namespace="thumbnail",
+                key=cache_key,
+                ttl_seconds=app.config["THUMBNAIL_COMPUTING_CACHE_TTL"],
+            ):
+                cache_payload = (
+                    self.get_from_cache_key(cache_key) or ScreenshotCachePayload()
+                )
+                if not cache_payload.should_trigger_task(force=force):
+                    logger.info(
+                        "Skipping compute - already processed for thumbnail: %s",
+                        cache_key,
+                    )
+                    return
+
+                window_size = window_size or self.window_size
+                thumb_size = thumb_size or self.thumb_size
+                logger.info("Processing url for thumbnail: %s", cache_key)
+                cache_payload.computing()
+                self.cache.set(cache_key, cache_payload.to_dict())
                 image = None
+                # Assuming all sorts of things can go wrong with Selenium
+                try:
+                    logger.info("trying to generate screenshot")
+                    with event_logger.log_context(
+                        f"screenshot.compute.{self.thumbnail_type}"
+                    ):
+                        image = self.get_screenshot(user=user, window_size=window_size)
+                except Exception as ex:  # pylint: disable=broad-except
+                    logger.warning(
+                        "Failed at generating thumbnail %s", ex, exc_info=True
+                    )
+                    cache_payload.error()
+                if image and window_size != thumb_size:
+                    try:
+                        image = self.resize_image(image, thumb_size=thumb_size)
+                    except Exception as ex:  # pylint: disable=broad-except
+                        logger.warning(
+                            "Failed at resizing thumbnail %s", ex, exc_info=True
+                        )
+                        cache_payload.error()
+                        image = None
 
-        # Cache the result (success or error) to avoid immediate retries
-        if image:
-            with event_logger.log_context(f"screenshot.cache.{self.thumbnail_type}"):
-                cache_payload.update(image)
+                if image:
+                    with event_logger.log_context(
+                        f"screenshot.cache.{self.thumbnail_type}"
+                    ):
+                        cache_payload.update(image)
 
-        logger.info("Caching thumbnail: %s", cache_key)
-        self.cache.set(cache_key, cache_payload.to_dict())
-        logger.info("Updated thumbnail cache; Status: %s", cache_payload.get_status())
-        return
+                logger.info("Caching thumbnail: %s", cache_key)
+                self.cache.set(cache_key, cache_payload.to_dict())
+                logger.info(
+                    "Updated thumbnail cache; Status: %s", cache_payload.get_status()
+                )
+        except AcquireDistributedLockFailedException:
+            logger.info(
+                "Skipping duplicate thumbnail task for %s - lock already held",
+                cache_key,
+            )
 
     @classmethod
     def resize_image(

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -291,6 +291,7 @@ class BaseScreenshot:
         thumb_size = thumb_size or self.thumb_size
         logger.info("Processing url for thumbnail: %s", cache_key)
         cache_payload.computing()
+        self.cache.set(cache_key, cache_payload.to_dict())
         image = None
         # Assuming all sorts of things can go wrong with Selenium
         try:

--- a/tests/unit_tests/tasks/test_thumbnails.py
+++ b/tests/unit_tests/tasks/test_thumbnails.py
@@ -1,0 +1,288 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.utils.screenshots import ScreenshotCachePayload
+
+
+@pytest.fixture
+def mock_thumbnail_cache():
+    with patch("superset.tasks.thumbnails.thumbnail_cache", True):
+        yield
+
+
+@pytest.fixture
+def mock_dashboard():
+    dashboard = MagicMock()
+    dashboard.id = 1
+    dashboard.digest = "test_digest"
+    return dashboard
+
+
+@pytest.fixture
+def mock_screenshot():
+    screenshot = MagicMock()
+    screenshot.get_cache_key.return_value = "test_cache_key"
+    return screenshot
+
+
+@patch("superset.tasks.thumbnails.get_executor")
+@patch("superset.tasks.thumbnails.security_manager")
+@patch("superset.tasks.thumbnails.override_user")
+@patch("superset.tasks.thumbnails.get_url_path")
+@patch("superset.tasks.thumbnails.DashboardScreenshot")
+def test_cache_dashboard_thumbnail_skips_when_already_computing(
+    mock_screenshot_cls,
+    mock_get_url_path,
+    mock_override_user,
+    mock_security_manager,
+    mock_get_executor,
+    mock_dashboard,
+    mock_thumbnail_cache,
+):
+    """Task should skip when another task is already computing the same thumbnail."""
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    # Set up a COMPUTING payload that is NOT stale
+    computing_payload = ScreenshotCachePayload()
+    computing_payload.computing()
+
+    mock_screenshot = MagicMock()
+    mock_screenshot.get_cache_key.return_value = "test_cache_key"
+    mock_screenshot.get_from_cache_key.return_value = computing_payload
+    mock_screenshot_cls.return_value = mock_screenshot
+
+    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
+        cache_dashboard_thumbnail(
+            current_user="admin",
+            dashboard_id=1,
+            force=True,
+            cache_key="test_cache_key",
+        )
+
+    # compute_and_cache should NOT be called since another task is computing
+    mock_screenshot.compute_and_cache.assert_not_called()
+
+
+@patch("superset.tasks.thumbnails.get_executor")
+@patch("superset.tasks.thumbnails.security_manager")
+@patch("superset.tasks.thumbnails.override_user")
+@patch("superset.tasks.thumbnails.get_url_path")
+@patch("superset.tasks.thumbnails.DashboardScreenshot")
+def test_cache_dashboard_thumbnail_proceeds_when_computing_is_stale(
+    mock_screenshot_cls,
+    mock_get_url_path,
+    mock_override_user,
+    mock_security_manager,
+    mock_get_executor,
+    mock_dashboard,
+    mock_thumbnail_cache,
+):
+    """Task should proceed when computing status is stale (stuck task)."""
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    # Set up a COMPUTING payload that IS stale
+    computing_payload = ScreenshotCachePayload()
+    computing_payload.computing()
+    computing_payload.is_computing_stale = MagicMock(return_value=True)
+
+    mock_screenshot = MagicMock()
+    mock_screenshot.get_cache_key.return_value = "test_cache_key"
+    mock_screenshot.get_from_cache_key.return_value = computing_payload
+    mock_screenshot_cls.return_value = mock_screenshot
+
+    mock_get_executor.return_value = (None, "admin")
+    mock_security_manager.find_user.return_value = MagicMock()
+
+    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
+        cache_dashboard_thumbnail(
+            current_user="admin",
+            dashboard_id=1,
+            force=True,
+            cache_key="test_cache_key",
+        )
+
+    # compute_and_cache SHOULD be called since the computing status is stale
+    mock_screenshot.compute_and_cache.assert_called_once()
+
+
+@patch("superset.tasks.thumbnails.get_executor")
+@patch("superset.tasks.thumbnails.security_manager")
+@patch("superset.tasks.thumbnails.override_user")
+@patch("superset.tasks.thumbnails.get_url_path")
+@patch("superset.tasks.thumbnails.DashboardScreenshot")
+def test_cache_dashboard_thumbnail_proceeds_when_no_existing_cache(
+    mock_screenshot_cls,
+    mock_get_url_path,
+    mock_override_user,
+    mock_security_manager,
+    mock_get_executor,
+    mock_dashboard,
+    mock_thumbnail_cache,
+):
+    """Task should proceed when there's no existing cache entry."""
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    mock_screenshot = MagicMock()
+    mock_screenshot.get_cache_key.return_value = "test_cache_key"
+    mock_screenshot.get_from_cache_key.return_value = None
+    mock_screenshot_cls.return_value = mock_screenshot
+
+    mock_get_executor.return_value = (None, "admin")
+    mock_security_manager.find_user.return_value = MagicMock()
+
+    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
+        cache_dashboard_thumbnail(
+            current_user="admin",
+            dashboard_id=1,
+            force=False,
+            cache_key="test_cache_key",
+        )
+
+    mock_screenshot.compute_and_cache.assert_called_once()
+
+
+@patch("superset.tasks.thumbnails.get_executor")
+@patch("superset.tasks.thumbnails.security_manager")
+@patch("superset.tasks.thumbnails.override_user")
+@patch("superset.tasks.thumbnails.get_url_path")
+@patch("superset.tasks.thumbnails.DashboardScreenshot")
+def test_cache_dashboard_thumbnail_proceeds_when_status_is_pending(
+    mock_screenshot_cls,
+    mock_get_url_path,
+    mock_override_user,
+    mock_security_manager,
+    mock_get_executor,
+    mock_dashboard,
+    mock_thumbnail_cache,
+):
+    """Task should proceed when cache status is PENDING."""
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    pending_payload = ScreenshotCachePayload()
+
+    mock_screenshot = MagicMock()
+    mock_screenshot.get_cache_key.return_value = "test_cache_key"
+    mock_screenshot.get_from_cache_key.return_value = pending_payload
+    mock_screenshot_cls.return_value = mock_screenshot
+
+    mock_get_executor.return_value = (None, "admin")
+    mock_security_manager.find_user.return_value = MagicMock()
+
+    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
+        cache_dashboard_thumbnail(
+            current_user="admin",
+            dashboard_id=1,
+            force=False,
+            cache_key="test_cache_key",
+        )
+
+    mock_screenshot.compute_and_cache.assert_called_once()
+
+
+@patch("superset.tasks.thumbnails.get_executor")
+@patch("superset.tasks.thumbnails.security_manager")
+@patch("superset.tasks.thumbnails.override_user")
+@patch("superset.tasks.thumbnails.get_url_path")
+@patch("superset.tasks.thumbnails.DashboardScreenshot")
+def test_cache_dashboard_thumbnail_proceeds_when_status_is_error(
+    mock_screenshot_cls,
+    mock_get_url_path,
+    mock_override_user,
+    mock_security_manager,
+    mock_get_executor,
+    mock_dashboard,
+    mock_thumbnail_cache,
+):
+    """Task should proceed when cache status is ERROR."""
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    error_payload = ScreenshotCachePayload()
+    error_payload.error()
+
+    mock_screenshot = MagicMock()
+    mock_screenshot.get_cache_key.return_value = "test_cache_key"
+    mock_screenshot.get_from_cache_key.return_value = error_payload
+    mock_screenshot_cls.return_value = mock_screenshot
+
+    mock_get_executor.return_value = (None, "admin")
+    mock_security_manager.find_user.return_value = MagicMock()
+
+    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
+        cache_dashboard_thumbnail(
+            current_user="admin",
+            dashboard_id=1,
+            force=False,
+            cache_key="test_cache_key",
+        )
+
+    mock_screenshot.compute_and_cache.assert_called_once()
+
+
+@patch("superset.tasks.thumbnails.thumbnail_cache", None)
+def test_cache_dashboard_thumbnail_skips_when_no_cache():
+    """Task should skip when no thumbnail cache is configured."""
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    result = cache_dashboard_thumbnail(
+        current_user="admin",
+        dashboard_id=1,
+        force=True,
+    )
+
+    assert result is None
+
+
+@patch("superset.tasks.thumbnails.get_executor")
+@patch("superset.tasks.thumbnails.security_manager")
+@patch("superset.tasks.thumbnails.override_user")
+@patch("superset.tasks.thumbnails.get_url_path")
+@patch("superset.tasks.thumbnails.DashboardScreenshot")
+def test_cache_dashboard_thumbnail_resolves_cache_key_when_not_provided(
+    mock_screenshot_cls,
+    mock_get_url_path,
+    mock_override_user,
+    mock_security_manager,
+    mock_get_executor,
+    mock_dashboard,
+    mock_thumbnail_cache,
+):
+    """Task should resolve cache_key from screenshot when not explicitly provided."""
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    mock_screenshot = MagicMock()
+    mock_screenshot.get_cache_key.return_value = "resolved_cache_key"
+    mock_screenshot.get_from_cache_key.return_value = None
+    mock_screenshot_cls.return_value = mock_screenshot
+
+    mock_get_executor.return_value = (None, "admin")
+    mock_security_manager.find_user.return_value = MagicMock()
+
+    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
+        cache_dashboard_thumbnail(
+            current_user="admin",
+            dashboard_id=1,
+            force=False,
+            cache_key=None,
+        )
+
+    # Should resolve cache key from screenshot object
+    mock_screenshot.get_cache_key.assert_called_once()
+    mock_screenshot.get_from_cache_key.assert_called_once_with("resolved_cache_key")

--- a/tests/unit_tests/tasks/test_thumbnails.py
+++ b/tests/unit_tests/tasks/test_thumbnails.py
@@ -19,8 +19,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from superset.utils.screenshots import ScreenshotCachePayload
-
 
 @pytest.fixture
 def mock_thumbnail_cache():
@@ -36,268 +34,77 @@ def mock_dashboard():
     return dashboard
 
 
-@pytest.fixture
-def mock_screenshot():
+def _make_screenshot_mock(cache_key: str = "test_cache_key") -> MagicMock:
     screenshot = MagicMock()
-    screenshot.get_cache_key.return_value = "test_cache_key"
+    screenshot.get_cache_key.return_value = cache_key
     return screenshot
 
 
-@patch("superset.tasks.thumbnails.get_executor")
-@patch("superset.tasks.thumbnails.security_manager")
-@patch("superset.tasks.thumbnails.override_user")
-@patch("superset.tasks.thumbnails.get_url_path")
-@patch("superset.tasks.thumbnails.DashboardScreenshot")
-def test_cache_dashboard_thumbnail_skips_when_already_computing(
-    mock_screenshot_cls,
-    mock_get_url_path,
-    mock_override_user,
-    mock_security_manager,
-    mock_get_executor,
-    mock_dashboard,
-    mock_thumbnail_cache,
-):
-    """Task should skip when another task is already computing the same thumbnail."""
-    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
 
-    # Set up a COMPUTING payload that is NOT stale
-    computing_payload = ScreenshotCachePayload()
-    computing_payload.computing()
-
-    mock_screenshot = MagicMock()
-    mock_screenshot.get_cache_key.return_value = "test_cache_key"
-    mock_screenshot.get_from_cache_key.return_value = computing_payload
-    mock_screenshot_cls.return_value = mock_screenshot
-
-    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
-        cache_dashboard_thumbnail(
-            current_user="admin",
-            dashboard_id=1,
-            force=True,
-            cache_key="test_cache_key",
-        )
-
-    # compute_and_cache should NOT be called since another task is computing
-    mock_screenshot.compute_and_cache.assert_not_called()
+_COMMON_PATCHES = [
+    "superset.tasks.thumbnails.get_executor",
+    "superset.tasks.thumbnails.security_manager",
+    "superset.tasks.thumbnails.override_user",
+    "superset.tasks.thumbnails.get_url_path",
+    "superset.tasks.thumbnails.DashboardScreenshot",
+]
 
 
-@patch("superset.tasks.thumbnails.get_executor")
-@patch("superset.tasks.thumbnails.security_manager")
-@patch("superset.tasks.thumbnails.override_user")
-@patch("superset.tasks.thumbnails.get_url_path")
-@patch("superset.tasks.thumbnails.DashboardScreenshot")
-def test_cache_dashboard_thumbnail_proceeds_when_computing_is_stale(
-    mock_screenshot_cls,
-    mock_get_url_path,
-    mock_override_user,
-    mock_security_manager,
-    mock_get_executor,
-    mock_dashboard,
-    mock_thumbnail_cache,
-):
-    """Task should proceed when computing status is stale (stuck task)."""
-    from superset.tasks.thumbnails import cache_dashboard_thumbnail
-
-    # Set up a COMPUTING payload that IS stale
-    computing_payload = ScreenshotCachePayload()
-    computing_payload.computing()
-    computing_payload.is_computing_stale = MagicMock(return_value=True)
-
-    mock_screenshot = MagicMock()
-    mock_screenshot.get_cache_key.return_value = "test_cache_key"
-    mock_screenshot.get_from_cache_key.return_value = computing_payload
-    mock_screenshot_cls.return_value = mock_screenshot
-
-    mock_get_executor.return_value = (None, "admin")
-    mock_security_manager.find_user.return_value = MagicMock()
-
-    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
-        cache_dashboard_thumbnail(
-            current_user="admin",
-            dashboard_id=1,
-            force=True,
-            cache_key="test_cache_key",
-        )
-
-    # compute_and_cache SHOULD be called since the computing status is stale
-    mock_screenshot.compute_and_cache.assert_called_once()
+def _apply_patches(fn):
+    """Stack the five common patches onto a test function."""
+    for p in reversed(_COMMON_PATCHES):
+        fn = patch(p)(fn)
+    return fn
 
 
-@patch("superset.tasks.thumbnails.get_executor")
-@patch("superset.tasks.thumbnails.security_manager")
-@patch("superset.tasks.thumbnails.override_user")
-@patch("superset.tasks.thumbnails.get_url_path")
-@patch("superset.tasks.thumbnails.DashboardScreenshot")
-def test_cache_dashboard_thumbnail_proceeds_when_no_existing_cache(
-    mock_screenshot_cls,
-    mock_get_url_path,
-    mock_override_user,
-    mock_security_manager,
-    mock_get_executor,
-    mock_dashboard,
-    mock_thumbnail_cache,
-):
-    """Task should proceed when there's no existing cache entry."""
-    from superset.tasks.thumbnails import cache_dashboard_thumbnail
-
-    mock_screenshot = MagicMock()
-    mock_screenshot.get_cache_key.return_value = "test_cache_key"
-    mock_screenshot.get_from_cache_key.return_value = None
-    mock_screenshot_cls.return_value = mock_screenshot
-
-    mock_get_executor.return_value = (None, "admin")
-    mock_security_manager.find_user.return_value = MagicMock()
-
-    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
-        cache_dashboard_thumbnail(
-            current_user="admin",
-            dashboard_id=1,
-            force=False,
-            cache_key="test_cache_key",
-        )
-
-    mock_screenshot.compute_and_cache.assert_called_once()
-
-
-@patch("superset.tasks.thumbnails.get_executor")
-@patch("superset.tasks.thumbnails.security_manager")
-@patch("superset.tasks.thumbnails.override_user")
-@patch("superset.tasks.thumbnails.get_url_path")
-@patch("superset.tasks.thumbnails.DashboardScreenshot")
-def test_cache_dashboard_thumbnail_proceeds_when_status_is_pending(
-    mock_screenshot_cls,
-    mock_get_url_path,
-    mock_override_user,
-    mock_security_manager,
-    mock_get_executor,
-    mock_dashboard,
-    mock_thumbnail_cache,
-):
-    """Task should proceed when cache status is PENDING."""
-    from superset.tasks.thumbnails import cache_dashboard_thumbnail
-
-    pending_payload = ScreenshotCachePayload()
-
-    mock_screenshot = MagicMock()
-    mock_screenshot.get_cache_key.return_value = "test_cache_key"
-    mock_screenshot.get_from_cache_key.return_value = pending_payload
-    mock_screenshot_cls.return_value = mock_screenshot
-
-    mock_get_executor.return_value = (None, "admin")
-    mock_security_manager.find_user.return_value = MagicMock()
-
-    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
-        cache_dashboard_thumbnail(
-            current_user="admin",
-            dashboard_id=1,
-            force=False,
-            cache_key="test_cache_key",
-        )
-
-    mock_screenshot.compute_and_cache.assert_called_once()
-
-
-@patch("superset.tasks.thumbnails.get_executor")
-@patch("superset.tasks.thumbnails.security_manager")
-@patch("superset.tasks.thumbnails.override_user")
-@patch("superset.tasks.thumbnails.get_url_path")
-@patch("superset.tasks.thumbnails.DashboardScreenshot")
-def test_cache_dashboard_thumbnail_proceeds_when_status_is_error(
-    mock_screenshot_cls,
-    mock_get_url_path,
-    mock_override_user,
-    mock_security_manager,
-    mock_get_executor,
-    mock_dashboard,
-    mock_thumbnail_cache,
-):
-    """Task should proceed when cache status is ERROR."""
-    from superset.tasks.thumbnails import cache_dashboard_thumbnail
-
-    error_payload = ScreenshotCachePayload()
-    error_payload.error()
-
-    mock_screenshot = MagicMock()
-    mock_screenshot.get_cache_key.return_value = "test_cache_key"
-    mock_screenshot.get_from_cache_key.return_value = error_payload
-    mock_screenshot_cls.return_value = mock_screenshot
-
-    mock_get_executor.return_value = (None, "admin")
-    mock_security_manager.find_user.return_value = MagicMock()
-
-    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
-        cache_dashboard_thumbnail(
-            current_user="admin",
-            dashboard_id=1,
-            force=False,
-            cache_key="test_cache_key",
-        )
-
-    mock_screenshot.compute_and_cache.assert_called_once()
-
-
-@patch("superset.tasks.thumbnails.get_executor")
-@patch("superset.tasks.thumbnails.security_manager")
-@patch("superset.tasks.thumbnails.override_user")
-@patch("superset.tasks.thumbnails.get_url_path")
-@patch("superset.tasks.thumbnails.DashboardScreenshot")
-def test_task_does_not_skip_when_api_enqueued_but_no_prior_computing(
-    mock_screenshot_cls,
-    mock_get_url_path,
-    mock_override_user,
-    mock_security_manager,
-    mock_get_executor,
-    mock_dashboard,
-    mock_thumbnail_cache,
-):
-    """Task must not skip itself when the cache has no COMPUTING marker.
-
-    Previously the API wrote COMPUTING to cache before enqueuing the task,
-    causing the task's dedup guard to treat the marker as a concurrent run
-    and exit before generating any image.  The API no longer writes COMPUTING;
-    the task (via compute_and_cache) owns that transition.
-    """
-    from superset.tasks.thumbnails import cache_dashboard_thumbnail
-
-    mock_screenshot = MagicMock()
-    mock_screenshot.get_cache_key.return_value = "test_cache_key"
-    # No COMPUTING in cache — this is the state left by the API after enqueueing
-    mock_screenshot.get_from_cache_key.return_value = None
-    mock_screenshot_cls.return_value = mock_screenshot
-
-    mock_get_executor.return_value = (None, "admin")
-    mock_security_manager.find_user.return_value = MagicMock()
-
-    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
-        cache_dashboard_thumbnail(
-            current_user="admin",
-            dashboard_id=1,
-            force=False,
-            cache_key="test_cache_key",
-        )
-
-    mock_screenshot.compute_and_cache.assert_called_once()
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 
 @patch("superset.tasks.thumbnails.thumbnail_cache", None)
 def test_cache_dashboard_thumbnail_skips_when_no_cache():
-    """Task should skip when no thumbnail cache is configured."""
+    """Task exits early when no thumbnail cache is configured."""
     from superset.tasks.thumbnails import cache_dashboard_thumbnail
 
-    result = cache_dashboard_thumbnail(
-        current_user="admin",
-        dashboard_id=1,
-        force=True,
-    )
+    result = cache_dashboard_thumbnail(current_user="admin", dashboard_id=1, force=True)
 
     assert result is None
 
 
-@patch("superset.tasks.thumbnails.get_executor")
-@patch("superset.tasks.thumbnails.security_manager")
-@patch("superset.tasks.thumbnails.override_user")
-@patch("superset.tasks.thumbnails.get_url_path")
-@patch("superset.tasks.thumbnails.DashboardScreenshot")
+@_apply_patches
+def test_cache_dashboard_thumbnail_always_delegates_to_compute_and_cache(
+    mock_screenshot_cls,
+    mock_get_url_path,
+    mock_override_user,
+    mock_security_manager,
+    mock_get_executor,
+    mock_dashboard,
+    mock_thumbnail_cache,
+):
+    """Task always calls compute_and_cache; dedup lives inside compute_and_cache."""
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    mock_screenshot = _make_screenshot_mock()
+    mock_screenshot_cls.return_value = mock_screenshot
+    mock_get_executor.return_value = (None, "admin")
+    mock_security_manager.find_user.return_value = MagicMock()
+
+    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
+        cache_dashboard_thumbnail(
+            current_user="admin",
+            dashboard_id=1,
+            force=False,
+            cache_key="test_cache_key",
+        )
+
+    mock_screenshot.compute_and_cache.assert_called_once()
+
+
+@_apply_patches
 def test_cache_dashboard_thumbnail_resolves_cache_key_when_not_provided(
     mock_screenshot_cls,
     mock_get_url_path,
@@ -307,14 +114,11 @@ def test_cache_dashboard_thumbnail_resolves_cache_key_when_not_provided(
     mock_dashboard,
     mock_thumbnail_cache,
 ):
-    """Task should resolve cache_key from screenshot when not explicitly provided."""
+    """Task resolves cache_key from the screenshot object when none is given."""
     from superset.tasks.thumbnails import cache_dashboard_thumbnail
 
-    mock_screenshot = MagicMock()
-    mock_screenshot.get_cache_key.return_value = "resolved_cache_key"
-    mock_screenshot.get_from_cache_key.return_value = None
+    mock_screenshot = _make_screenshot_mock("resolved_cache_key")
     mock_screenshot_cls.return_value = mock_screenshot
-
     mock_get_executor.return_value = (None, "admin")
     mock_security_manager.find_user.return_value = MagicMock()
 
@@ -326,6 +130,5 @@ def test_cache_dashboard_thumbnail_resolves_cache_key_when_not_provided(
             cache_key=None,
         )
 
-    # Should resolve cache key from screenshot object
     mock_screenshot.get_cache_key.assert_called_once()
-    mock_screenshot.get_from_cache_key.assert_called_once_with("resolved_cache_key")
+    mock_screenshot.compute_and_cache.assert_called_once()

--- a/tests/unit_tests/tasks/test_thumbnails.py
+++ b/tests/unit_tests/tasks/test_thumbnails.py
@@ -16,7 +16,8 @@
 # under the License.
 
 from collections.abc import Callable, Iterator
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -55,7 +56,7 @@ _COMMON_PATCHES = [
 ]
 
 
-def _apply_patches(fn: Callable) -> Callable:
+def _apply_patches(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Stack the five common patches onto a test function."""
     for p in reversed(_COMMON_PATCHES):
         fn = patch(p)(fn)
@@ -134,7 +135,7 @@ def test_cache_dashboard_thumbnail_resolves_cache_key_when_not_provided(
 
     mock_screenshot.get_cache_key.assert_called_once()
     mock_screenshot.compute_and_cache.assert_called_once_with(
-        user=mock_security_manager.find_user.return_value,
+        user=ANY,
         window_size=None,
         thumb_size=None,
         force=False,

--- a/tests/unit_tests/tasks/test_thumbnails.py
+++ b/tests/unit_tests/tasks/test_thumbnails.py
@@ -24,12 +24,14 @@ import pytest
 
 @pytest.fixture
 def mock_thumbnail_cache() -> Iterator[None]:
+    """Enable thumbnail cache mocking so tasks don't exit early."""
     with patch("superset.tasks.thumbnails.thumbnail_cache", True):
         yield
 
 
 @pytest.fixture
 def mock_dashboard() -> MagicMock:
+    """Return a mocked Dashboard with id=1 and a fixed digest."""
     dashboard = MagicMock()
     dashboard.id = 1
     dashboard.digest = "test_digest"

--- a/tests/unit_tests/tasks/test_thumbnails.py
+++ b/tests/unit_tests/tasks/test_thumbnails.py
@@ -131,4 +131,10 @@ def test_cache_dashboard_thumbnail_resolves_cache_key_when_not_provided(
         )
 
     mock_screenshot.get_cache_key.assert_called_once()
-    mock_screenshot.compute_and_cache.assert_called_once()
+    mock_screenshot.compute_and_cache.assert_called_once_with(
+        user=mock_security_manager.find_user.return_value,
+        window_size=None,
+        thumb_size=None,
+        force=False,
+        cache_key="resolved_cache_key",
+    )

--- a/tests/unit_tests/tasks/test_thumbnails.py
+++ b/tests/unit_tests/tasks/test_thumbnails.py
@@ -15,19 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from collections.abc import Callable, Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 
 @pytest.fixture
-def mock_thumbnail_cache():
+def mock_thumbnail_cache() -> Iterator[None]:
     with patch("superset.tasks.thumbnails.thumbnail_cache", True):
         yield
 
 
 @pytest.fixture
-def mock_dashboard():
+def mock_dashboard() -> MagicMock:
     dashboard = MagicMock()
     dashboard.id = 1
     dashboard.digest = "test_digest"
@@ -35,6 +36,7 @@ def mock_dashboard():
 
 
 def _make_screenshot_mock(cache_key: str = "test_cache_key") -> MagicMock:
+    """Return a MagicMock screenshot whose get_cache_key returns cache_key."""
     screenshot = MagicMock()
     screenshot.get_cache_key.return_value = cache_key
     return screenshot
@@ -53,7 +55,7 @@ _COMMON_PATCHES = [
 ]
 
 
-def _apply_patches(fn):
+def _apply_patches(fn: Callable) -> Callable:
     """Stack the five common patches onto a test function."""
     for p in reversed(_COMMON_PATCHES):
         fn = patch(p)(fn)
@@ -66,7 +68,7 @@ def _apply_patches(fn):
 
 
 @patch("superset.tasks.thumbnails.thumbnail_cache", None)
-def test_cache_dashboard_thumbnail_skips_when_no_cache():
+def test_cache_dashboard_thumbnail_skips_when_no_cache() -> None:
     """Task exits early when no thumbnail cache is configured."""
     from superset.tasks.thumbnails import cache_dashboard_thumbnail
 
@@ -77,14 +79,14 @@ def test_cache_dashboard_thumbnail_skips_when_no_cache():
 
 @_apply_patches
 def test_cache_dashboard_thumbnail_always_delegates_to_compute_and_cache(
-    mock_screenshot_cls,
-    mock_get_url_path,
-    mock_override_user,
-    mock_security_manager,
-    mock_get_executor,
-    mock_dashboard,
-    mock_thumbnail_cache,
-):
+    mock_screenshot_cls: MagicMock,
+    mock_get_url_path: MagicMock,
+    mock_override_user: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_executor: MagicMock,
+    mock_dashboard: MagicMock,
+    mock_thumbnail_cache: None,
+) -> None:
     """Task always calls compute_and_cache; dedup lives inside compute_and_cache."""
     from superset.tasks.thumbnails import cache_dashboard_thumbnail
 
@@ -106,14 +108,14 @@ def test_cache_dashboard_thumbnail_always_delegates_to_compute_and_cache(
 
 @_apply_patches
 def test_cache_dashboard_thumbnail_resolves_cache_key_when_not_provided(
-    mock_screenshot_cls,
-    mock_get_url_path,
-    mock_override_user,
-    mock_security_manager,
-    mock_get_executor,
-    mock_dashboard,
-    mock_thumbnail_cache,
-):
+    mock_screenshot_cls: MagicMock,
+    mock_get_url_path: MagicMock,
+    mock_override_user: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_executor: MagicMock,
+    mock_dashboard: MagicMock,
+    mock_thumbnail_cache: None,
+) -> None:
     """Task resolves cache_key from the screenshot object when none is given."""
     from superset.tasks.thumbnails import cache_dashboard_thumbnail
 

--- a/tests/unit_tests/tasks/test_thumbnails.py
+++ b/tests/unit_tests/tasks/test_thumbnails.py
@@ -236,6 +236,49 @@ def test_cache_dashboard_thumbnail_proceeds_when_status_is_error(
     mock_screenshot.compute_and_cache.assert_called_once()
 
 
+@patch("superset.tasks.thumbnails.get_executor")
+@patch("superset.tasks.thumbnails.security_manager")
+@patch("superset.tasks.thumbnails.override_user")
+@patch("superset.tasks.thumbnails.get_url_path")
+@patch("superset.tasks.thumbnails.DashboardScreenshot")
+def test_task_does_not_skip_when_api_enqueued_but_no_prior_computing(
+    mock_screenshot_cls,
+    mock_get_url_path,
+    mock_override_user,
+    mock_security_manager,
+    mock_get_executor,
+    mock_dashboard,
+    mock_thumbnail_cache,
+):
+    """Task must not skip itself when the cache has no COMPUTING marker.
+
+    Previously the API wrote COMPUTING to cache before enqueuing the task,
+    causing the task's dedup guard to treat the marker as a concurrent run
+    and exit before generating any image.  The API no longer writes COMPUTING;
+    the task (via compute_and_cache) owns that transition.
+    """
+    from superset.tasks.thumbnails import cache_dashboard_thumbnail
+
+    mock_screenshot = MagicMock()
+    mock_screenshot.get_cache_key.return_value = "test_cache_key"
+    # No COMPUTING in cache — this is the state left by the API after enqueueing
+    mock_screenshot.get_from_cache_key.return_value = None
+    mock_screenshot_cls.return_value = mock_screenshot
+
+    mock_get_executor.return_value = (None, "admin")
+    mock_security_manager.find_user.return_value = MagicMock()
+
+    with patch("superset.models.dashboard.Dashboard.get", return_value=mock_dashboard):
+        cache_dashboard_thumbnail(
+            current_user="admin",
+            dashboard_id=1,
+            force=False,
+            cache_key="test_cache_key",
+        )
+
+    mock_screenshot.compute_and_cache.assert_called_once()
+
+
 @patch("superset.tasks.thumbnails.thumbnail_cache", None)
 def test_cache_dashboard_thumbnail_skips_when_no_cache():
     """Task should skip when no thumbnail cache is configured."""

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -27,7 +27,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pytest_mock import MockerFixture
 
-from superset.exceptions import AcquireDistributedLockFailedException
+from superset.exceptions import LockAlreadyHeldException
 from superset.utils.screenshots import (
     BaseScreenshot,
     ScreenshotCachePayload,
@@ -429,8 +429,8 @@ class TestIntegrationCacheBugFix:
         """compute_and_cache exits without rendering when the distributed lock
         is already held by another worker — atomically preventing duplicate Selenium."""
         mock_lock = mocker.patch(DISTRIBUTED_LOCK_PATH)
-        mock_lock.return_value.__enter__.side_effect = (
-            AcquireDistributedLockFailedException("lock held")
+        mock_lock.return_value.__enter__.side_effect = LockAlreadyHeldException(
+            "lock held"
         )
         get_screenshot = mocker.patch(BASE_SCREENSHOT_PATH + ".get_screenshot")
         BaseScreenshot.cache = MockCache()

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -35,7 +35,7 @@ from superset.utils.screenshots import (
 )
 
 BASE_SCREENSHOT_PATH = "superset.utils.screenshots.BaseScreenshot"
-DISTRIBUTED_LOCK_PATH = "superset.distributed_lock.DistributedLock"
+DISTRIBUTED_LOCK_PATH = "superset.utils.screenshots.DistributedLock"
 
 
 class MockCache:

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -58,7 +58,7 @@ class MockCache:
 
 
 @pytest.fixture
-def mock_user():
+def mock_user() -> MagicMock:
     """Fixture to create a mock user."""
     user = MagicMock()
     user.id = 1
@@ -66,7 +66,7 @@ def mock_user():
 
 
 @pytest.fixture
-def screenshot_obj():
+def screenshot_obj() -> BaseScreenshot:
     """Fixture to create a BaseScreenshot object."""
     url = "http://example.com"
     digest = "sample_digest"
@@ -154,8 +154,8 @@ class TestCacheOnlyOnSuccess:
         assert cached_value["image"] is not None
 
     def test_computing_status_written_to_cache_early(
-        self, mocker: MockerFixture, screenshot_obj, mock_user
-    ):
+        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot, mock_user: MagicMock
+    ) -> None:
         """compute_and_cache writes COMPUTING to cache before taking the screenshot
         so concurrent tasks can detect it and avoid duplicate work."""
         mocker.patch(DISTRIBUTED_LOCK_PATH)
@@ -416,8 +416,8 @@ class TestIntegrationCacheBugFix:
         assert cached_value["image"] is not None
 
     def test_concurrent_task_skips_when_lock_already_held(
-        self, mocker: MockerFixture, screenshot_obj, mock_user
-    ):
+        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot, mock_user: MagicMock
+    ) -> None:
         """compute_and_cache exits without rendering when the distributed lock
         is already held by another worker — atomically preventing duplicate Selenium."""
         mock_lock = mocker.patch(DISTRIBUTED_LOCK_PATH)
@@ -432,8 +432,8 @@ class TestIntegrationCacheBugFix:
         get_screenshot.assert_not_called()
 
     def test_computing_preserves_previous_image(
-        self, mocker: MockerFixture, screenshot_obj, mock_user
-    ):
+        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot, mock_user: MagicMock
+    ) -> None:
         """computing() must not wipe the cached image so a stale thumbnail remains
         visible while a refresh is in progress."""
         old_image = b"old_thumbnail_bytes"

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -383,8 +383,12 @@ class TestIntegrationCacheBugFix:
 
     @patch("superset.utils.screenshots.app")
     def test_stale_computing_triggers_retry(
-        self, mock_app, mocker: MockerFixture, screenshot_obj, mock_user
-    ):
+        self,
+        mock_app: MagicMock,
+        mocker: MockerFixture,
+        screenshot_obj: BaseScreenshot,
+        mock_user: MagicMock,
+    ) -> None:
         """
         Integration test: Stale COMPUTING status should trigger retry
         to recover from stuck tasks.

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -76,7 +76,9 @@ def screenshot_obj() -> BaseScreenshot:
 class TestCacheOnlyOnSuccess:
     """Test that cache is only saved when image generation succeeds."""
 
-    def _setup_mocks(self, mocker: MockerFixture, screenshot_obj):
+    def _setup_mocks(
+        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot
+    ) -> MagicMock:
         """Helper method to set up common mocks."""
         mocker.patch(DISTRIBUTED_LOCK_PATH)
         mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
@@ -194,7 +196,7 @@ class TestShouldTriggerTask:
     """Test the should_trigger_task method improvements."""
 
     @patch("superset.utils.screenshots.app")
-    def test_trigger_on_stale_computing_status(self, mock_app):
+    def test_trigger_on_stale_computing_status(self, mock_app: MagicMock) -> None:
         """Test that stale COMPUTING status triggers recomputation."""
         # Set TTL to 300 seconds
         mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
@@ -263,7 +265,7 @@ class TestShouldTriggerTask:
         assert payload.should_trigger_task(force=False) is True
 
     @patch("superset.utils.screenshots.app")
-    def test_no_trigger_on_fresh_error(self, mock_app):
+    def test_no_trigger_on_fresh_error(self, mock_app: MagicMock) -> None:
         """Test that fresh ERROR status does not trigger task."""
         mock_app.config = {
             "THUMBNAIL_COMPUTING_CACHE_TTL": 300,

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pytest_mock import MockerFixture
 
+from superset.exceptions import AcquireDistributedLockFailedException
 from superset.utils.screenshots import (
     BaseScreenshot,
     ScreenshotCachePayload,
@@ -34,6 +35,7 @@ from superset.utils.screenshots import (
 )
 
 BASE_SCREENSHOT_PATH = "superset.utils.screenshots.BaseScreenshot"
+DISTRIBUTED_LOCK_PATH = "superset.distributed_lock.DistributedLock"
 
 
 class MockCache:
@@ -76,6 +78,7 @@ class TestCacheOnlyOnSuccess:
 
     def _setup_mocks(self, mocker: MockerFixture, screenshot_obj):
         """Helper method to set up common mocks."""
+        mocker.patch(DISTRIBUTED_LOCK_PATH)
         mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         get_screenshot = mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=b"image_data"
@@ -91,6 +94,7 @@ class TestCacheOnlyOnSuccess:
         self, mocker: MockerFixture, screenshot_obj, mock_user
     ):
         """Test that error status is cached when screenshot generation fails."""
+        mocker.patch(DISTRIBUTED_LOCK_PATH)
         mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         get_screenshot = mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot",
@@ -154,6 +158,7 @@ class TestCacheOnlyOnSuccess:
     ):
         """compute_and_cache writes COMPUTING to cache before taking the screenshot
         so concurrent tasks can detect it and avoid duplicate work."""
+        mocker.patch(DISTRIBUTED_LOCK_PATH)
         mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         BaseScreenshot.cache = MockCache()
 
@@ -189,7 +194,7 @@ class TestShouldTriggerTask:
     def test_trigger_on_stale_computing_status(self, mock_app):
         """Test that stale COMPUTING status triggers recomputation."""
         # Set TTL to 300 seconds
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
 
         # Create payload with COMPUTING status from 400 seconds ago (stale)
         old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
@@ -204,7 +209,7 @@ class TestShouldTriggerTask:
     def test_no_trigger_on_fresh_computing_status(self, mock_app):
         """Test that fresh COMPUTING status does not trigger recomputation."""
         # Set TTL to 300 seconds
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
 
         # Create payload with COMPUTING status from 100 seconds ago (fresh)
         fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
@@ -242,7 +247,7 @@ class TestShouldTriggerTask:
     def test_trigger_on_expired_error(self, mock_app):
         """Test that expired ERROR status triggers task."""
         # Set TTL to 300 seconds
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
 
         # Create payload with ERROR status from 400 seconds ago (expired)
         old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
@@ -256,7 +261,7 @@ class TestShouldTriggerTask:
     def test_no_trigger_on_fresh_error(self, mock_app):
         """Test that fresh ERROR status does not trigger task."""
         # Set TTL to 300 seconds
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
 
         # Create payload with ERROR status from 100 seconds ago (fresh)
         fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
@@ -283,7 +288,7 @@ class TestIsComputingStale:
     @patch("superset.utils.screenshots.app")
     def test_computing_is_stale(self, mock_app):
         """Test that old COMPUTING status is detected as stale."""
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
 
         # Timestamp from 400 seconds ago
         old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
@@ -296,7 +301,7 @@ class TestIsComputingStale:
     @patch("superset.utils.screenshots.app")
     def test_computing_is_not_stale(self, mock_app):
         """Test that fresh COMPUTING status is not stale."""
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
 
         # Timestamp from 100 seconds ago
         fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
@@ -309,7 +314,7 @@ class TestIsComputingStale:
     @patch("superset.utils.screenshots.app")
     def test_computing_exactly_at_ttl(self, mock_app):
         """Test boundary condition at exactly TTL."""
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
 
         # Timestamp from exactly 300 seconds ago
         exact_timestamp = (datetime.now() - timedelta(seconds=300)).isoformat()
@@ -323,7 +328,7 @@ class TestIsComputingStale:
     @patch("superset.utils.screenshots.app")
     def test_computing_just_past_ttl(self, mock_app):
         """Test boundary condition just past TTL."""
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
 
         # Timestamp from 301 seconds ago (just past TTL)
         past_ttl_timestamp = (datetime.now() - timedelta(seconds=301)).isoformat()
@@ -345,6 +350,7 @@ class TestIntegrationCacheBugFix:
         Integration test: Failed screenshot should cache error status
         to prevent immediate retries, not leave corrupted cache with image=None.
         """
+        mocker.patch(DISTRIBUTED_LOCK_PATH)
         mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot",
             side_effect=Exception("Network error"),
@@ -374,7 +380,8 @@ class TestIntegrationCacheBugFix:
         Integration test: Stale COMPUTING status should trigger retry
         to recover from stuck tasks.
         """
-        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
+        mocker.patch(DISTRIBUTED_LOCK_PATH)
         BaseScreenshot.cache = MockCache()
 
         # Create stale COMPUTING entry and seed it in the cache
@@ -403,3 +410,33 @@ class TestIntegrationCacheBugFix:
         assert cached_value is not None
         assert cached_value["status"] == "Updated"
         assert cached_value["image"] is not None
+
+    def test_concurrent_task_skips_when_lock_already_held(
+        self, mocker: MockerFixture, screenshot_obj, mock_user
+    ):
+        """compute_and_cache exits without rendering when the distributed lock
+        is already held by another worker — atomically preventing duplicate Selenium."""
+        mock_lock = mocker.patch(DISTRIBUTED_LOCK_PATH)
+        mock_lock.return_value.__enter__.side_effect = (
+            AcquireDistributedLockFailedException("lock held")
+        )
+        get_screenshot = mocker.patch(BASE_SCREENSHOT_PATH + ".get_screenshot")
+        BaseScreenshot.cache = MockCache()
+
+        screenshot_obj.compute_and_cache(user=mock_user, force=False)
+
+        get_screenshot.assert_not_called()
+
+    def test_computing_preserves_previous_image(
+        self, mocker: MockerFixture, screenshot_obj, mock_user
+    ):
+        """computing() must not wipe the cached image so a stale thumbnail remains
+        visible while a refresh is in progress."""
+        old_image = b"old_thumbnail_bytes"
+        payload = ScreenshotCachePayload(image=old_image)
+        assert payload._image == old_image
+
+        payload.computing()
+
+        assert payload._image == old_image
+        assert payload.status == StatusValues.COMPUTING

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -154,7 +154,10 @@ class TestCacheOnlyOnSuccess:
         assert cached_value["image"] is not None
 
     def test_computing_status_written_to_cache_early(
-        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot, mock_user: MagicMock
+        self,
+        mocker: MockerFixture,
+        screenshot_obj: BaseScreenshot,
+        mock_user: MagicMock,
     ) -> None:
         """compute_and_cache writes COMPUTING to cache before taking the screenshot
         so concurrent tasks can detect it and avoid duplicate work."""
@@ -165,9 +168,9 @@ class TestCacheOnlyOnSuccess:
         def check_cache_during_screenshot(*args, **kwargs):
             cache_key = screenshot_obj.get_cache_key()
             cached_value = BaseScreenshot.cache.get(cache_key)
-            assert cached_value is not None, (
-                "Cache should be set to COMPUTING before screenshot starts"
-            )
+            assert (
+                cached_value is not None
+            ), "Cache should be set to COMPUTING before screenshot starts"
             assert cached_value["status"] == "Computing"
             return b"image_data"
 
@@ -416,7 +419,10 @@ class TestIntegrationCacheBugFix:
         assert cached_value["image"] is not None
 
     def test_concurrent_task_skips_when_lock_already_held(
-        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot, mock_user: MagicMock
+        self,
+        mocker: MockerFixture,
+        screenshot_obj: BaseScreenshot,
+        mock_user: MagicMock,
     ) -> None:
         """compute_and_cache exits without rendering when the distributed lock
         is already held by another worker — atomically preventing duplicate Selenium."""
@@ -432,7 +438,10 @@ class TestIntegrationCacheBugFix:
         get_screenshot.assert_not_called()
 
     def test_computing_preserves_previous_image(
-        self, mocker: MockerFixture, screenshot_obj: BaseScreenshot, mock_user: MagicMock
+        self,
+        mocker: MockerFixture,
+        screenshot_obj: BaseScreenshot,
+        mock_user: MagicMock,
     ) -> None:
         """computing() must not wipe the cached image so a stale thumbnail remains
         visible while a refresh is in progress."""

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -165,12 +165,12 @@ class TestCacheOnlyOnSuccess:
         mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         BaseScreenshot.cache = MockCache()
 
-        def check_cache_during_screenshot(*args, **kwargs):
+        def check_cache_during_screenshot(*args: object, **kwargs: object) -> bytes:
             cache_key = screenshot_obj.get_cache_key()
             cached_value = BaseScreenshot.cache.get(cache_key)
-            assert (
-                cached_value is not None
-            ), "Cache should be set to COMPUTING before screenshot starts"
+            assert cached_value is not None, (
+                "Cache should be set to COMPUTING before screenshot starts"
+            )
             assert cached_value["status"] == "Computing"
             return b"image_data"
 

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -246,8 +246,10 @@ class TestShouldTriggerTask:
     @patch("superset.utils.screenshots.app")
     def test_trigger_on_expired_error(self, mock_app):
         """Test that expired ERROR status triggers task."""
-        # Set TTL to 300 seconds
-        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
+        mock_app.config = {
+            "THUMBNAIL_COMPUTING_CACHE_TTL": 300,
+            "THUMBNAIL_ERROR_CACHE_TTL": 300,
+        }
 
         # Create payload with ERROR status from 400 seconds ago (expired)
         old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
@@ -260,8 +262,10 @@ class TestShouldTriggerTask:
     @patch("superset.utils.screenshots.app")
     def test_no_trigger_on_fresh_error(self, mock_app):
         """Test that fresh ERROR status does not trigger task."""
-        # Set TTL to 300 seconds
-        mock_app.config = {"THUMBNAIL_COMPUTING_CACHE_TTL": 300}
+        mock_app.config = {
+            "THUMBNAIL_COMPUTING_CACHE_TTL": 300,
+            "THUMBNAIL_ERROR_CACHE_TTL": 300,
+        }
 
         # Create payload with ERROR status from 100 seconds ago (fresh)
         fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -149,38 +149,33 @@ class TestCacheOnlyOnSuccess:
         assert cached_value["status"] == "Updated"
         assert cached_value["image"] is not None
 
-    def test_no_intermediate_cache_during_computing(
+    def test_computing_status_written_to_cache_early(
         self, mocker: MockerFixture, screenshot_obj, mock_user
     ):
-        """Test that cache is not saved during COMPUTING state."""
+        """compute_and_cache writes COMPUTING to cache before taking the screenshot
+        so concurrent tasks can detect it and avoid duplicate work."""
         mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         BaseScreenshot.cache = MockCache()
 
-        # Mock get_screenshot to check cache state during execution
         def check_cache_during_screenshot(*args, **kwargs):
-            # At this point, we're in COMPUTING state
-            # Cache should NOT be set yet
             cache_key = screenshot_obj.get_cache_key()
             cached_value = BaseScreenshot.cache.get(cache_key)
-            # Cache should be empty during screenshot generation
-            assert cached_value is None, (
-                "Cache should not be saved during COMPUTING state"
+            assert cached_value is not None, (
+                "Cache should be set to COMPUTING before screenshot starts"
             )
+            assert cached_value["status"] == "Computing"
             return b"image_data"
 
         mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot",
             side_effect=check_cache_during_screenshot,
         )
-        # Mock resize to avoid PIL errors with fake image data
         mocker.patch(
             BASE_SCREENSHOT_PATH + ".resize_image", return_value=b"resized_image_data"
         )
 
-        # Execute compute_and_cache
         screenshot_obj.compute_and_cache(user=mock_user, force=True)
 
-        # After completion, cache should be set with UPDATED status
         cache_key = screenshot_obj.get_cache_key()
         cached_value = BaseScreenshot.cache.get(cache_key)
         assert cached_value is not None


### PR DESCRIPTION
### SUMMARY

Fix thumbnail/screenshot task deduplication to prevent concurrent Selenium sessions for the same dashboard or chart.

**Problem:** Multiple thumbnail tasks can be queued and run concurrently for the same dashboard because:
1. The dashboard API set cache status to PENDING before enqueuing, so concurrent requests all see PENDING and each queues a new task
2. The `update_thumbnail()` model method uses `force=True`, which bypasses all cache status checks
3. No atomic dedup existed at the task level

**Solution:**
- **Atomic task-level dedup via `DistributedLock`**: `compute_and_cache` acquires a distributed lock (Redis SET NX EX) before doing any work. Only the first worker to acquire the lock proceeds; others bail immediately on `AcquireDistributedLockFailedException`. The COMPUTING transition and the screenshot are both owned by the task under the lock — no self-skip possible.
- **API-level check is an optimization only**: `should_trigger_task()` in the API avoids unnecessary enqueues, but correctness no longer depends on it. If two requests race past it and enqueue two tasks, the lock ensures only one runs.
- **Stale COMPUTING recovery**: A new `THUMBNAIL_COMPUTING_CACHE_TTL` config (360 s) marks computing leases as stale if the task never finishes. Stale COMPUTING is treated as re-triggerable.
- **Error caching**: Failed screenshots cache an ERROR status with TTL to suppress immediate retries without leaving broken cache entries.
- **Old thumbnail preserved during refresh**: `computing()` no longer clears `_image`, so a stale thumbnail stays visible while a refresh is in progress.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend-only change.

### TESTING INSTRUCTIONS

1. Enable `THUMBNAILS` and `THUMBNAILS_SQLA_LISTENERS` feature flags
2. Visit dashboard list or edit a dashboard — should trigger thumbnail generation
3. Rapid concurrent requests to `/api/v1/dashboard/<id>/thumbnail/<digest>/` should result in only one Selenium task running at a time; additional tasks acquire the lock, see no work to do, and exit cleanly
4. Unit tests: `pytest tests/unit_tests/tasks/test_thumbnails.py tests/unit_tests/utils/test_screenshot_cache_fix.py -v`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `THUMBNAILS`
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API