### PR TITLE
fix(embedded): prevent global guest RLS from being applied to virtual dataset inner tables

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -740,19 +740,19 @@ class BaseDatasource(
     def get_sqla_row_level_filters(
         self,
         template_processor: Optional[BaseTemplateProcessor] = None,
-        include_guest_rls: bool = True,
+        include_global_guest_rls: bool = True,
     ) -> list[TextClause]:
         """
         Return the appropriate row level security filters for this table and the
-        current user. A custom username can be passed when the user is not present in the
-        Flask global namespace.
+        current user.
 
         :param template_processor: The template processor to apply to the filters.
-        :param include_guest_rls: Whether to include guest token RLS filters.
-            Set to False when applying RLS to inner tables of virtual datasets,
-            since guest RLS is applied at the outer query level.
+        :param include_global_guest_rls: Whether to include global (unscoped) guest
+            RLS filters. Set to False for underlying tables in virtual datasets to
+            prevent double application of global guest rules. Dataset-scoped guest
+            rules are always included regardless of this parameter.
         :returns: A list of SQL clauses to be ANDed together.
-        """  # noqa: E501
+        """
         template_processor = template_processor or self.get_template_processor()
 
         all_filters: list[TextClause] = []
@@ -767,8 +767,10 @@ class BaseDatasource(
                 else:
                     all_filters.append(clause)
 
-            if include_guest_rls and is_feature_enabled("EMBEDDED_SUPERSET"):
+            if is_feature_enabled("EMBEDDED_SUPERSET"):
                 for rule in security_manager.get_guest_rls_filters(self):
+                    if not include_global_guest_rls and not rule.get("dataset"):
+                        continue
                     clause = self.text(
                         f"({template_processor.process_template(rule['clause'])})"
                     )

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -740,6 +740,7 @@ class BaseDatasource(
     def get_sqla_row_level_filters(
         self,
         template_processor: Optional[BaseTemplateProcessor] = None,
+        include_guest_rls: bool = True,
     ) -> list[TextClause]:
         """
         Return the appropriate row level security filters for this table and the
@@ -747,6 +748,9 @@ class BaseDatasource(
         Flask global namespace.
 
         :param template_processor: The template processor to apply to the filters.
+        :param include_guest_rls: Whether to include guest token RLS filters.
+            Set to False when applying RLS to inner tables of virtual datasets,
+            since guest RLS is applied at the outer query level.
         :returns: A list of SQL clauses to be ANDed together.
         """  # noqa: E501
         template_processor = template_processor or self.get_template_processor()
@@ -763,7 +767,7 @@ class BaseDatasource(
                 else:
                     all_filters.append(clause)
 
-            if is_feature_enabled("EMBEDDED_SUPERSET"):
+            if include_guest_rls and is_feature_enabled("EMBEDDED_SUPERSET"):
                 for rule in security_manager.get_guest_rls_filters(self):
                     clause = self.text(
                         f"({template_processor.process_template(rule['clause'])})"

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -903,7 +903,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     def get_sqla_row_level_filters(
         self,
         template_processor: Optional[BaseTemplateProcessor] = None,  # pylint: disable=unused-argument
-        include_guest_rls: bool = True,  # pylint: disable=unused-argument
+        include_global_guest_rls: bool = True,  # pylint: disable=unused-argument
     ) -> list[TextClause]:
         # TODO: We should refactor this mixin and remove this method
         # as it exists in the BaseDatasource and is not applicable
@@ -2055,7 +2055,6 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         self.catalog,
                         self.schema or default_schema or "",
                         statement,
-                        include_guest_rls=False,
                     )
                 # Regenerate the SQL after RLS application
                 from_sql = parsed_script.format()

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -903,6 +903,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     def get_sqla_row_level_filters(
         self,
         template_processor: Optional[BaseTemplateProcessor] = None,  # pylint: disable=unused-argument
+        include_guest_rls: bool = True,  # pylint: disable=unused-argument
     ) -> list[TextClause]:
         # TODO: We should refactor this mixin and remove this method
         # as it exists in the BaseDatasource and is not applicable
@@ -2054,6 +2055,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         self.catalog,
                         self.schema or default_schema or "",
                         statement,
+                        include_guest_rls=False,
                     )
                 # Regenerate the SQL after RLS application
                 from_sql = parsed_script.format()

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -34,14 +34,9 @@ def apply_rls(
     catalog: str | None,
     schema: str,
     parsed_statement: BaseSQLStatement[Any],
-    include_guest_rls: bool = True,
 ) -> None:
     """
     Modify statement inplace to ensure RLS rules are applied.
-
-    :param include_guest_rls: Whether to include guest token RLS filters.
-        Set to False when applying RLS to inner tables of virtual datasets,
-        since guest RLS is applied at the outer query level.
     """
     # There are two ways to insert RLS: either replacing the table with a subquery
     # that has the RLS, or appending the RLS to the ``WHERE`` clause. The former is
@@ -58,7 +53,6 @@ def apply_rls(
                 table,
                 database,
                 database.get_default_catalog(),
-                include_guest_rls=include_guest_rls,
             )
             if predicate
         ]
@@ -70,7 +64,6 @@ def get_predicates_for_table(
     table: Table,
     database: Database,
     default_catalog: str | None,
-    include_guest_rls: bool = True,
 ) -> list[str]:
     """
     Get the RLS predicates for a table.
@@ -78,9 +71,6 @@ def get_predicates_for_table(
     This is used to inject RLS rules into SQL statements run in SQL Lab. Note that the
     table must be fully qualified, with catalog (null if the DB doesn't support) and
     schema.
-
-    :param include_guest_rls: Whether to include guest token RLS filters.
-        Set to False when applying RLS to inner tables of virtual datasets.
     """
     from superset.connectors.sqla.models import SqlaTable
 
@@ -108,6 +98,11 @@ def get_predicates_for_table(
     if not dataset:
         return []
 
+    # Exclude global (unscoped) guest RLS to prevent double application in
+    # virtual datasets. Global guest rules will be applied to the outer query
+    # via get_sqla_row_level_filters() on the virtual dataset itself.
+    # Dataset-scoped guest rules are still included here because they target
+    # this specific physical dataset and won't match on the outer query.
     return [
         str(
             predicate.compile(
@@ -116,7 +111,7 @@ def get_predicates_for_table(
             )
         )
         for predicate in dataset.get_sqla_row_level_filters(
-            include_guest_rls=include_guest_rls,
+            include_global_guest_rls=False,
         )
     ]
 

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -34,9 +34,14 @@ def apply_rls(
     catalog: str | None,
     schema: str,
     parsed_statement: BaseSQLStatement[Any],
+    include_guest_rls: bool = True,
 ) -> None:
     """
     Modify statement inplace to ensure RLS rules are applied.
+
+    :param include_guest_rls: Whether to include guest token RLS filters.
+        Set to False when applying RLS to inner tables of virtual datasets,
+        since guest RLS is applied at the outer query level.
     """
     # There are two ways to insert RLS: either replacing the table with a subquery
     # that has the RLS, or appending the RLS to the ``WHERE`` clause. The former is
@@ -53,6 +58,7 @@ def apply_rls(
                 table,
                 database,
                 database.get_default_catalog(),
+                include_guest_rls=include_guest_rls,
             )
             if predicate
         ]
@@ -64,6 +70,7 @@ def get_predicates_for_table(
     table: Table,
     database: Database,
     default_catalog: str | None,
+    include_guest_rls: bool = True,
 ) -> list[str]:
     """
     Get the RLS predicates for a table.
@@ -71,6 +78,9 @@ def get_predicates_for_table(
     This is used to inject RLS rules into SQL statements run in SQL Lab. Note that the
     table must be fully qualified, with catalog (null if the DB doesn't support) and
     schema.
+
+    :param include_guest_rls: Whether to include guest token RLS filters.
+        Set to False when applying RLS to inner tables of virtual datasets.
     """
     from superset.connectors.sqla.models import SqlaTable
 
@@ -105,7 +115,9 @@ def get_predicates_for_table(
                 compile_kwargs={"literal_binds": True},
             )
         )
-        for predicate in dataset.get_sqla_row_level_filters()
+        for predicate in dataset.get_sqla_row_level_filters(
+            include_guest_rls=include_guest_rls,
+        )
     ]
 
 

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -845,3 +845,47 @@ class GuestTokenRowLevelSecurityTests(SupersetTestCase):
         sql = dataset.get_query_str(self.query_obj)
 
         assert re.search(RLS_ALICE_REGEX, sql)
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_global_rls_not_applied_to_virtual_dataset_inner_tables(self):
+        """
+        Global guest RLS (no dataset ID) should only be applied to the outer
+        query of a virtual dataset, not to individual inner tables. This
+        prevents SQL errors when the RLS column doesn't exist on all inner
+        tables (e.g., a virtual dataset JOINing tables where only one has the
+        filtered column).
+        """
+        birth_names = self.get_table(name="birth_names")
+
+        virtual_dataset = SqlaTable(
+            table_name="virtual_birth_names_rls_test",
+            database=birth_names.database,
+            schema=birth_names.schema,
+            sql=f"SELECT * FROM {birth_names.table_name}",  # noqa: S608
+        )
+        db.session.add(virtual_dataset)
+        db.session.commit()
+
+        try:
+            # Global RLS rule (no dataset ID) — should only apply to outer
+            # query, not to the inner birth_names table reference
+            g.user = self.guest_user_with_rls(rules=[{"clause": "name = 'Alice'"}])
+            query_obj = {
+                "groupby": [],
+                "metrics": None,
+                "filter": [],
+                "is_timeseries": False,
+                "columns": ["name"],
+                "granularity": None,
+                "from_dttm": None,
+                "to_dttm": None,
+                "extras": {},
+            }
+            sql = virtual_dataset.get_query_str(query_obj)
+
+            # Guest RLS should appear in the outer WHERE clause
+            assert re.search(RLS_ALICE_REGEX, sql)
+        finally:
+            db.session.delete(virtual_dataset)
+            db.session.commit()

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -326,38 +326,18 @@ def test_get_predicates_for_table(mocker: MockerFixture) -> None:
 
     table = Table("t1", "public", "examples")
     assert get_predicates_for_table(table, database, "examples") == ["c1 = 1"]
-
-
-def test_apply_rls_exclude_guest_rls(mocker: MockerFixture) -> None:
-    """
-    Test that ``apply_rls`` passes ``include_guest_rls`` to
-    ``get_predicates_for_table``.
-    """
-    database = mocker.MagicMock()
-    database.get_default_schema_for_query.return_value = "public"
-    database.get_default_catalog.return_value = "examples"
-    database.db_engine_spec = PostgresEngineSpec
-    mock_get_predicates = mocker.patch(
-        "superset.utils.rls.get_predicates_for_table",
-        return_value=[],
-    )
-
-    parsed_statement = SQLStatement("SELECT * FROM t1", "postgresql")
-
-    apply_rls(database, "examples", "public", parsed_statement, include_guest_rls=False)
-
-    mock_get_predicates.assert_called_once_with(
-        Table("t1", "public", "examples"),
-        database,
-        "examples",
-        include_guest_rls=False,
+    dataset.get_sqla_row_level_filters.assert_called_once_with(
+        include_global_guest_rls=False,
     )
 
 
-def test_get_predicates_for_table_exclude_guest_rls(mocker: MockerFixture) -> None:
+def test_get_predicates_for_table_excludes_global_guest_rls(
+    mocker: MockerFixture,
+) -> None:
     """
-    Test that ``get_predicates_for_table`` passes ``include_guest_rls`` to
-    ``dataset.get_sqla_row_level_filters``.
+    Test that ``get_predicates_for_table`` passes
+    ``include_global_guest_rls=False`` to ``dataset.get_sqla_row_level_filters``
+    to prevent double application of global guest RLS in virtual datasets.
     """
     database = mocker.MagicMock()
     dataset = mocker.MagicMock()
@@ -368,11 +348,9 @@ def test_get_predicates_for_table_exclude_guest_rls(mocker: MockerFixture) -> No
     db.session.query().filter().one_or_none.return_value = dataset
 
     table = Table("t1", "public", "examples")
-    result = get_predicates_for_table(
-        table, database, "examples", include_guest_rls=False
-    )
+    result = get_predicates_for_table(table, database, "examples")
 
     assert result == ["c1 = 1"]
     dataset.get_sqla_row_level_filters.assert_called_once_with(
-        include_guest_rls=False,
+        include_global_guest_rls=False,
     )

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -326,3 +326,53 @@ def test_get_predicates_for_table(mocker: MockerFixture) -> None:
 
     table = Table("t1", "public", "examples")
     assert get_predicates_for_table(table, database, "examples") == ["c1 = 1"]
+
+
+def test_apply_rls_exclude_guest_rls(mocker: MockerFixture) -> None:
+    """
+    Test that ``apply_rls`` passes ``include_guest_rls`` to
+    ``get_predicates_for_table``.
+    """
+    database = mocker.MagicMock()
+    database.get_default_schema_for_query.return_value = "public"
+    database.get_default_catalog.return_value = "examples"
+    database.db_engine_spec = PostgresEngineSpec
+    mock_get_predicates = mocker.patch(
+        "superset.utils.rls.get_predicates_for_table",
+        return_value=[],
+    )
+
+    parsed_statement = SQLStatement("SELECT * FROM t1", "postgresql")
+
+    apply_rls(database, "examples", "public", parsed_statement, include_guest_rls=False)
+
+    mock_get_predicates.assert_called_once_with(
+        Table("t1", "public", "examples"),
+        database,
+        "examples",
+        include_guest_rls=False,
+    )
+
+
+def test_get_predicates_for_table_exclude_guest_rls(mocker: MockerFixture) -> None:
+    """
+    Test that ``get_predicates_for_table`` passes ``include_guest_rls`` to
+    ``dataset.get_sqla_row_level_filters``.
+    """
+    database = mocker.MagicMock()
+    dataset = mocker.MagicMock()
+    predicate = mocker.MagicMock()
+    predicate.compile.return_value = "c1 = 1"
+    dataset.get_sqla_row_level_filters.return_value = [predicate]
+    db = mocker.patch("superset.utils.rls.db")
+    db.session.query().filter().one_or_none.return_value = dataset
+
+    table = Table("t1", "public", "examples")
+    result = get_predicates_for_table(
+        table, database, "examples", include_guest_rls=False
+    )
+
+    assert result == ["c1 = 1"]
+    dataset.get_sqla_row_level_filters.assert_called_once_with(
+        include_guest_rls=False,
+    )


### PR DESCRIPTION
### SUMMARY

Fixes a bug where global guest RLS rules (without a `dataset` ID) for embedded users were being incorrectly applied to the inner physical tables of virtual datasets, in addition to the outer query. When the RLS clause referenced a column that didn't exist on all inner tables (e.g., a virtual dataset with JOINs), this caused SQL errors like `column "channel_name" does not exist`.

**Root cause:** `get_sqla_row_level_filters()` unconditionally includes guest RLS on every call. For virtual datasets, it's called twice:
1. Inner tables via `get_from_clause()` → `apply_rls()` → `get_predicates_for_table()`
2. Outer query via `get_sqla_query()` (line 3213 in helpers.py)

Global guest RLS matches ALL datasets, so it was applied to both inner tables and the outer query — causing errors when inner tables didn't have the filtered column.

**Fix:** Add an `include_guest_rls` parameter (default `True`, fully backward-compatible) threaded through `get_sqla_row_level_filters()` → `get_predicates_for_table()` → `apply_rls()`. In `get_from_clause()`, pass `include_guest_rls=False` so inner tables only get role-based RLS. Guest RLS is applied once at the outer virtual dataset query level.

Fixes #37359
Fixes #37551

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Test dashboard**:

<img width="1718" height="857" alt="image" src="https://github.com/user-attachments/assets/97753558-0d0e-4a7e-a5c9-ed49a53b53d5" />

**Applied guest token RLS**: `"channel_name = 'general'"`


**Before**:

<img width="1720" height="859" alt="image" src="https://github.com/user-attachments/assets/56d906e6-8b42-4360-bf6e-8c48f4d78452" />


**After**:

<img width="1718" height="868" alt="image" src="https://github.com/user-attachments/assets/6321eef0-4771-40f4-b3fe-e2791631def0" />

### TESTING INSTRUCTIONS

1. Create a virtual dataset with a JOIN (e.g., `Slack Members and Channels` from examples)
2. Add a chart using this dataset to a dashboard, enable embedded mode
3. Generate a guest token with a global RLS rule (no `dataset` ID): `{"rls": [{"clause": "channel_name = 'general'"}]}`
4. Access the dashboard with the guest token
5. Verify the chart renders without SQL errors

### ADDITIONAL INFORMATION
- [x] Has associated issue: #37359, #37551
- [x] Required feature flags: `EMBEDDED_SUPERSET`
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API