### PR TITLE
fix(world-map): add fallback fill color when colorFn returns null

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.ts
@@ -150,9 +150,15 @@ function WorldMap(element: HTMLElement, props: WorldMapProps): void {
       fillColor: colorFn(d.name, sliceId),
     }));
   } else {
-    colorFn = getSequentialSchemeRegistry()
-      .get(linearColorScheme)
-      .createLinearScale(d3Extent(filteredData, d => d.m1));
+    const rawExtents = d3Extent(filteredData, d => d.m1);
+    const extents: [number, number] =
+      rawExtents[0] != null && rawExtents[1] != null
+        ? [rawExtents[0], rawExtents[1]]
+        : [0, 1];
+    const colorSchemeObj = getSequentialSchemeRegistry().get(linearColorScheme);
+    colorFn = colorSchemeObj
+      ? colorSchemeObj.createLinearScale(extents)
+      : () => theme.colorBorder;
 
     processedData = filteredData.map(d => ({
       ...d,

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.ts
@@ -157,7 +157,7 @@ function WorldMap(element: HTMLElement, props: WorldMapProps): void {
     processedData = filteredData.map(d => ({
       ...d,
       radius: radiusScale(Math.sqrt(d.m2)),
-      fillColor: colorFn(d.m1),
+      fillColor: colorFn(d.m1) ?? theme.colorBorder,
     }));
   }
 

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/test/WorldMap.test.ts
@@ -489,6 +489,59 @@ test('popupTemplate returns tooltip HTML when country data exists', () => {
   expect(tooltipHtml).toContain('hoverinfo');
 });
 
+test('assigns fill colors from sequential scheme when colorBy is metric', () => {
+  WorldMap(container, {
+    ...baseProps,
+    colorBy: ColorBy.Metric,
+  });
+
+  const data = lastDatamapConfig?.data as Record<
+    string,
+    WorldMapDataEntry & { fillColor: string }
+  >;
+  expect(data).toHaveProperty('USA');
+  expect(data).toHaveProperty('CAN');
+  expect(data.USA).toMatchObject({
+    country: 'USA',
+    name: 'United States',
+    m1: 100,
+  });
+  // fillColor should be a valid color string from the sequential scale
+  expect(data.USA.fillColor).toMatch(/^(#|rgb)/);
+  expect(data.CAN.fillColor).toMatch(/^(#|rgb)/);
+});
+
+test('falls back to theme.colorBorder when metric values are null', () => {
+  WorldMap(container, {
+    ...baseProps,
+    colorBy: ColorBy.Metric,
+    data: [
+      {
+        country: 'USA',
+        name: 'United States',
+        m1: null as unknown as number,
+        m2: 200,
+        code: 'US',
+        latitude: 37.0902,
+        longitude: -95.7129,
+      },
+    ],
+  } as any);
+
+  const data = lastDatamapConfig?.data as Record<string, { fillColor: string }>;
+  expect(data.USA.fillColor).toBe('#e0e0e0');
+});
+
+test('does not throw with empty data and metric coloring', () => {
+  expect(() => {
+    WorldMap(container, {
+      ...baseProps,
+      colorBy: ColorBy.Metric,
+      data: [],
+    });
+  }).not.toThrow();
+});
+
 test('popupTemplate handles null/undefined country data gracefully', () => {
   WorldMap(container, baseProps);
 


### PR DESCRIPTION
## **User description**
### SUMMARY
When using metric-based (sequential) coloring in the World Map chart, `colorFn(d.m1)` can return `null` or `undefined` for certain data values, causing countries to render without a fill color. This adds a nullish coalescing fallback to `theme.colorBorder`, consistent with the `defaultFill` used elsewhere in the component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/ece40f1b-471f-4a33-bba2-46be2537ac2f" />
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/f4a51896-c456-48d5-bbdd-4ef7ca12fa5b" />

AFTER

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/3f8e1c78-e03b-43bd-b344-d6b344014e2a" />
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/c57e5dfc-aa79-452e-aeaf-b61ee30cd67d" />

### TESTING INSTRUCTIONS
1. Open World Bank's Data Dashboard (or any other dashboard with WorldMap charts)
2. Verify all countries render with a visible fill color (previously some would appear without fill)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**World map: ensure countries always render with a fill color when metric coloring is used**

### What Changed
- Sequential (metric) coloring now validates data extents and falls back to a safe default when metric values are null/undefined, preventing invalid color scales.
- If the sequential color function is missing or returns null for a country, the map uses the theme border color as the fill so countries never render without a visible fill.
- Map rendering no longer throws on empty data when metric coloring is selected; unit tests added to verify sequential coloring, null-metric fallback, and empty-data handling.

### Impact
`✅ Fewer countries rendered without fill`
`✅ Visible fallback color for countries with missing metric values`
`✅ No crashes when metric-colored map has empty or all-null data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
