### PR TITLE
fix(editor): implement missing methods, fix cursor position clearing

### DIFF
--- a/superset-frontend/packages/superset-core/src/editors/index.ts
+++ b/superset-frontend/packages/superset-core/src/editors/index.ts
@@ -370,6 +370,28 @@ export interface EditorProps {
 }
 
 /**
+ * A single text change expressed as an offset-based replacement.
+ */
+export interface ContentChange {
+  /** Character offset in the document where the replaced range starts */
+  rangeOffset: number;
+  /** Length in characters of the replaced range (0 for pure insertions) */
+  rangeLength: number;
+  /** Text inserted at rangeOffset (empty string for pure deletions) */
+  text: string;
+}
+
+/**
+ * Payload delivered to `onDidChangeContent` listeners.
+ */
+export interface ContentChangeEvent {
+  /** Returns the full current content of the editor */
+  getValue(): string;
+  /** The individual changes that occurred in this event */
+  changes: ReadonlyArray<ContentChange>;
+}
+
+/**
  * Imperative API for controlling the editor programmatically.
  *
  * This handle provides a unified interface for interacting with text editors
@@ -495,20 +517,24 @@ export interface EditorHandle {
 
   /**
    * Subscribe to content changes in the editor.
-   * The listener is called with the full editor content each time it changes.
    *
-   * @param listener Called with the new full content on every change
+   * The listener receives a {@link ContentChangeEvent} with:
+   * - `getValue()` — lazy accessor for the full content (call only when needed
+   *   to avoid unnecessary O(n) string allocation on every keystroke)
+   * - `changes` — the individual edits that occurred, as offset-based replacements
+   *
+   * @param listener Called with a ContentChangeEvent on every change
    * @param thisArgs Optional `this` context for the listener
    * @returns A Disposable that unsubscribes the listener when disposed
    *
    * @example
-   * const disposable = editor.onDidChangeContent(sql => {
-   *   setStatements(parseStatements(sql));
+   * const disposable = editor.onDidChangeContent(e => {
+   *   setStatements(parseStatements(e.getValue()));
    * });
    * // Later, to unsubscribe:
    * disposable.dispose();
    */
-  onDidChangeContent: Event<string>;
+  onDidChangeContent: Event<ContentChangeEvent>;
 }
 
 /**

--- a/superset-frontend/packages/superset-core/src/editors/index.ts
+++ b/superset-frontend/packages/superset-core/src/editors/index.ts
@@ -492,6 +492,23 @@ export interface EditorHandle {
    * - CodeMirror: editor.requestMeasure()
    */
   resize(): void;
+
+  /**
+   * Subscribe to content changes in the editor.
+   * The listener is called with the full editor content each time it changes.
+   *
+   * @param listener Called with the new full content on every change
+   * @param thisArgs Optional `this` context for the listener
+   * @returns A Disposable that unsubscribes the listener when disposed
+   *
+   * @example
+   * const disposable = editor.onDidChangeContent(sql => {
+   *   setStatements(parseStatements(sql));
+   * });
+   * // Later, to unsubscribe:
+   * disposable.dispose();
+   */
+  onDidChangeContent: Event<string>;
 }
 
 /**

--- a/superset-frontend/packages/superset-core/src/sqlLab/index.ts
+++ b/superset-frontend/packages/superset-core/src/sqlLab/index.ts
@@ -253,6 +253,22 @@ export interface QueryResult {
 export declare const getActivePanel: () => Panel;
 
 /**
+ * Switches the active panel in the SQL Lab south pane.
+ * Built-in panel IDs are 'Results' and 'History'.
+ * Pinned table panels use the table's ID as their panel ID.
+ *
+ * @param panelId The ID of the panel to activate
+ * @returns Promise that resolves when the panel is activated
+ *
+ * @example
+ * ```typescript
+ * // Focus the Results panel after running a query
+ * await setActivePanel('Results');
+ * ```
+ */
+export declare function setActivePanel(panelId: string): Promise<void>;
+
+/**
  * Gets the currently active tab in SQL Lab.
  *
  * @returns The current tab object, or undefined if no tab is active.

--- a/superset-frontend/src/core/editors/AceEditorProvider.tsx
+++ b/superset-frontend/src/core/editors/AceEditorProvider.tsx
@@ -55,6 +55,8 @@ type Range = editors.Range;
 type Selection = editors.Selection;
 type EditorAnnotation = editors.EditorAnnotation;
 type CompletionProvider = editors.CompletionProvider;
+type ContentChange = editors.ContentChange;
+type ContentChangeEvent = editors.ContentChangeEvent;
 
 /**
  * Maps EditorLanguage to the corresponding Ace editor component.
@@ -195,9 +197,21 @@ const createAceEditorHandle = (
     const editor = aceEditorRef.current?.editor;
     if (!editor) return new Disposable(() => {});
     const bound = (thisArgs ? listener.bind(thisArgs) : listener) as (
-      value: string,
+      e: ContentChangeEvent,
     ) => void;
-    const handler = () => bound(editor.getValue());
+    const handler = (delta: {
+      action: 'insert' | 'remove';
+      start: { row: number; column: number };
+      lines: string[];
+    }) => {
+      const rangeOffset = editor.session.doc.positionToIndex(delta.start);
+      const changeText = delta.lines.join('\n');
+      const change: ContentChange =
+        delta.action === 'insert'
+          ? { rangeOffset, rangeLength: 0, text: changeText }
+          : { rangeOffset, rangeLength: changeText.length, text: '' };
+      bound({ getValue: () => editor.getValue(), changes: [change] });
+    };
     editor.session.on('change', handler);
     return new Disposable(() => {
       editor.session.off('change', handler);

--- a/superset-frontend/src/core/editors/AceEditorProvider.tsx
+++ b/superset-frontend/src/core/editors/AceEditorProvider.tsx
@@ -194,9 +194,9 @@ const createAceEditorHandle = (
   onDidChangeContent: (listener, thisArgs?) => {
     const editor = aceEditorRef.current?.editor;
     if (!editor) return new Disposable(() => {});
-    const bound = (
-      thisArgs ? listener.bind(thisArgs) : listener
-    ) as (value: string) => void;
+    const bound = (thisArgs ? listener.bind(thisArgs) : listener) as (
+      value: string,
+    ) => void;
     const handler = () => bound(editor.getValue());
     editor.session.on('change', handler);
     return new Disposable(() => {

--- a/superset-frontend/src/core/editors/AceEditorProvider.tsx
+++ b/superset-frontend/src/core/editors/AceEditorProvider.tsx
@@ -205,7 +205,7 @@ const createAceEditorHandle = (
       lines: string[];
     }) => {
       const rangeOffset = editor.session.doc.positionToIndex(delta.start);
-      const changeText = delta.lines.join('\n');
+      const changeText = delta.lines.join(editor.session.doc.getNewLineCharacter());
       const change: ContentChange =
         delta.action === 'insert'
           ? { rangeOffset, rangeLength: 0, text: changeText }

--- a/superset-frontend/src/core/editors/AceEditorProvider.tsx
+++ b/superset-frontend/src/core/editors/AceEditorProvider.tsx
@@ -205,7 +205,9 @@ const createAceEditorHandle = (
       lines: string[];
     }) => {
       const rangeOffset = editor.session.doc.positionToIndex(delta.start);
-      const changeText = delta.lines.join(editor.session.doc.getNewLineCharacter());
+      const changeText = delta.lines.join(
+        editor.session.doc.getNewLineCharacter(),
+      );
       const change: ContentChange =
         delta.action === 'insert'
           ? { rangeOffset, rangeLength: 0, text: changeText }

--- a/superset-frontend/src/core/editors/AceEditorProvider.tsx
+++ b/superset-frontend/src/core/editors/AceEditorProvider.tsx
@@ -117,10 +117,14 @@ const createAceEditorHandle = (
   },
 
   moveCursorToPosition: (position: Position) => {
-    aceEditorRef.current?.editor?.moveCursorToPosition({
-      row: position.line,
-      column: position.column,
-    });
+    const editor = aceEditorRef.current?.editor;
+    if (editor) {
+      editor.clearSelection();
+      editor.moveCursorToPosition({
+        row: position.line,
+        column: position.column,
+      });
+    }
   },
 
   getSelections: (): Selection[] => {
@@ -185,6 +189,19 @@ const createAceEditorHandle = (
 
   resize: () => {
     aceEditorRef.current?.editor?.resize();
+  },
+
+  onDidChangeContent: (listener, thisArgs?) => {
+    const editor = aceEditorRef.current?.editor;
+    if (!editor) return new Disposable(() => {});
+    const bound = (
+      thisArgs ? listener.bind(thisArgs) : listener
+    ) as (value: string) => void;
+    const handler = () => bound(editor.getValue());
+    editor.session.on('change', handler);
+    return new Disposable(() => {
+      editor.session.off('change', handler);
+    });
   },
 });
 

--- a/superset-frontend/src/core/sqlLab/index.ts
+++ b/superset-frontend/src/core/sqlLab/index.ts
@@ -694,6 +694,12 @@ const setSchema: typeof sqlLabApi.setSchema = async (schema: string | null) => {
   store.dispatch(queryEditorSetSchema(queryEditor ?? null, schema));
 };
 
+const setActivePanel: typeof sqlLabApi.setActivePanel = async (
+  panelId: string,
+) => {
+  store.dispatch({ type: SET_ACTIVE_SOUTHPANE_TAB, tabId: panelId });
+};
+
 export const sqlLab: typeof sqlLabApi = {
   CTASMethod,
   getActivePanel,
@@ -719,6 +725,7 @@ export const sqlLab: typeof sqlLabApi = {
   setDatabase,
   setCatalog,
   setSchema,
+  setActivePanel,
 };
 
 // Export all models


### PR DESCRIPTION
## **User description**
### SUMMARY

Adds two missing methods to the extension APIs and corrects a bug in cursor positioning:

1. **`EditorHandle.onDidChangeContent`** — adds a content-change subscription method to `EditorHandle` and implements it in `AceEditorProvider`. Uses `editor.session.on('change', ...)` and returns a `Disposable` for cleanup. The listener receives the full editor content on every change.

2. **`sqlLab.setActivePanel`** — adds a missing `setActivePanel(panelId)` function to the SQL Lab extension API. Dispatches `SET_ACTIVE_SOUTHPANE_TAB` to programmatically switch between south pane panels (`'Results'`, `'History'`, or a pinned table panel ID).

3. **`moveCursorToPosition` fix** — clears any active selection before moving the cursor in `AceEditorProvider`, preventing leftover highlighted text after a programmatic cursor jump.

### TESTING INSTRUCTIONS

**`onDidChangeContent`**
1. In an extension or SQL Lab context, obtain an `EditorHandle` via `onReady`.
2. Subscribe: `const d = editor.onDidChangeContent(sql => console.log(sql));`
3. Type in the editor — the listener should fire with the full content on each keystroke.
4. Call `d.dispose()` and confirm the listener stops firing.

**`setActivePanel`**
1. Open SQL Lab and run a query.
2. From an extension, call `sqlLab.setActivePanel('Results')` — the Results tab should become active.
3. Call `sqlLab.setActivePanel('History')` — the History tab should become active.

**`moveCursorToPosition` fix**
1. Select some text in the SQL editor.
2. Programmatically call `editor.moveCursorToPosition({ line: 0, column: 0 })`.
3. Confirm the selection is cleared and only the cursor moves.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Implement editor content-change subscription, add SQL Lab panel switch, and stop leftover selection when moving the cursor

### What Changed
- EditorHandle exposes onDidChangeContent so callers receive change events with a lazy full-content accessor and precise change details on every edit
- SQL Lab extension API gains setActivePanel(panelId) to programmatically switch the south pane to 'Results', 'History', or a pinned table panel
- Programmatic cursor moves clear any active selection first so only the cursor moves and no text remains highlighted

### Impact
`✅ Immediate content-change notifications for extensions`
`✅ Ability to programmatically focus Results/History/pinned tables`
`✅ No leftover highlighted text after programmatic cursor jumps`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
