### PR TITLE
feat(auth): add SAML login support to frontend

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -120,7 +120,7 @@ flask==2.3.3
     #   flask-session
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==5.0.2
+flask-appbuilder==5.1.0
     # via
     #   apache-superset (pyproject.toml)
     #   apache-superset-core

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -262,7 +262,7 @@ flask==2.3.3
     #   flask-sqlalchemy
     #   flask-testing
     #   flask-wtf
-flask-appbuilder==5.0.2
+flask-appbuilder==5.1.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/superset-frontend/src/pages/Login/Login.test.tsx
+++ b/superset-frontend/src/pages/Login/Login.test.tsx
@@ -17,20 +17,30 @@
  * under the License.
  */
 import { render, screen } from 'spec/helpers/testing-library';
+import getBootstrapData from 'src/utils/getBootstrapData';
 import Login from './index';
+
+const defaultBootstrapData = {
+  common: {
+    conf: {
+      AUTH_TYPE: 1,
+      AUTH_PROVIDERS: [],
+      AUTH_USER_REGISTRATION: false,
+    },
+    feature_flags: {},
+  },
+};
 
 jest.mock('src/utils/getBootstrapData', () => ({
   __esModule: true,
-  default: () => ({
-    common: {
-      conf: {
-        AUTH_TYPE: 1,
-        AUTH_PROVIDERS: [],
-        AUTH_USER_REGISTRATION: false,
-      },
-    },
-  }),
+  default: jest.fn(() => defaultBootstrapData),
 }));
+
+const mockGetBootstrapData = getBootstrapData as jest.Mock;
+
+beforeEach(() => {
+  mockGetBootstrapData.mockReturnValue(defaultBootstrapData);
+});
 
 test('should render login form elements', () => {
   render(<Login />, { useRedux: true });
@@ -52,4 +62,22 @@ test('should render form instruction text', () => {
   expect(
     screen.getByText('Enter your login and password below:'),
   ).toBeInTheDocument();
+});
+
+test('should render SAML provider buttons', () => {
+  mockGetBootstrapData.mockReturnValue({
+    common: {
+      conf: {
+        AUTH_TYPE: 5,
+        AUTH_PROVIDERS: [
+          { name: 'okta', icon: 'okta' },
+          { name: 'onelogin', icon: 'onelogin' },
+        ],
+        AUTH_USER_REGISTRATION: false,
+      },
+    },
+  });
+  render(<Login />, { useRedux: true });
+  expect(screen.getByText('Sign in with Okta')).toBeInTheDocument();
+  expect(screen.getByText('Sign in with Onelogin')).toBeInTheDocument();
 });

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -57,6 +57,7 @@ enum AuthType {
   AuthDB = 1,
   AuthLDAP = 2,
   AuthOauth = 4,
+  AuthSAML = 5,
 }
 
 const StyledCard = styled(Card)`
@@ -180,7 +181,8 @@ export default function Login() {
             </Form>
           </Flex>
         )}
-        {authType === AuthType.AuthOauth && (
+        {(authType === AuthType.AuthOauth ||
+          authType === AuthType.AuthSAML) && (
           <Flex justify="center" gap={0} vertical>
             <Form layout="vertical" requiredMark="optional" form={form}>
               {providers.map((provider: OAuthProvider) => (

--- a/superset/config.py
+++ b/superset/config.py
@@ -311,6 +311,7 @@ WTF_CSRF_EXEMPT_LIST = [
     "superset.views.core.explore_json",
     "superset.views.core.log",
     "superset.views.datasource.views.samples",
+    "flask_appbuilder.security.views.acs",
 ]
 
 # Whether to run the web server in debug mode or not

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -36,7 +36,7 @@ from flask import (
 )
 from flask_appbuilder import BaseView, Model, ModelView
 from flask_appbuilder.actions import action
-from flask_appbuilder.const import AUTH_OAUTH
+from flask_appbuilder.const import AUTH_OAUTH, AUTH_SAML
 from flask_appbuilder.forms import DynamicForm
 from flask_appbuilder.models.sqla.filters import BaseFilter
 from flask_appbuilder.security.sqla.models import User
@@ -485,7 +485,9 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
     auth_type = app.config["AUTH_TYPE"]
     auth_user_registration = app.config["AUTH_USER_REGISTRATION"]
     frontend_config["AUTH_USER_REGISTRATION"] = auth_user_registration
-    should_show_recaptcha = auth_user_registration and (auth_type != AUTH_OAUTH)
+    should_show_recaptcha = auth_user_registration and (
+        auth_type not in (AUTH_OAUTH, AUTH_SAML)
+    )
 
     if auth_user_registration:
         frontend_config["AUTH_USER_REGISTRATION_ROLE"] = app.config[
@@ -505,6 +507,16 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
                 }
             )
         frontend_config["AUTH_PROVIDERS"] = oauth_providers
+    elif auth_type == AUTH_SAML:
+        saml_providers = []
+        for provider in appbuilder.sm.saml_providers:
+            saml_providers.append(
+                {
+                    "name": provider["name"],
+                    "icon": provider.get("icon", "fa-sign-in"),
+                }
+            )
+        frontend_config["AUTH_PROVIDERS"] = saml_providers
 
     bootstrap_data = {
         "application_root": app.config["APPLICATION_ROOT"],

--- a/tests/unit_tests/views/test_bootstrap_auth.py
+++ b/tests/unit_tests/views/test_bootstrap_auth.py
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import g
+from flask_appbuilder.const import (
+    AUTH_DB,
+    AUTH_LDAP,
+    AUTH_OAUTH,
+    AUTH_SAML,
+)
+
+from superset.views.base import cached_common_bootstrap_data
+
+
+@pytest.fixture(autouse=True)
+def mock_user() -> None:
+    g.user = MagicMock()
+
+
+def _get_bootstrap(user_id: int = 1) -> dict[str, Any]:
+    with patch("superset.views.base.menu_data", return_value={}):
+        return cached_common_bootstrap_data(user_id=user_id, locale=None)
+
+
+def test_bootstrap_saml_providers(app_context: None) -> None:
+    """SAML providers are included in bootstrap data."""
+    from flask import current_app
+
+    current_app.config["AUTH_TYPE"] = AUTH_SAML
+    current_app.config["AUTH_USER_REGISTRATION"] = False
+    current_app.config["SAML_PROVIDERS"] = [
+        {"name": "okta", "icon": "fa-okta"},
+        {"name": "entra_id", "icon": "fa-microsoft"},
+    ]
+
+    payload = _get_bootstrap()
+
+    assert payload["conf"]["AUTH_TYPE"] == AUTH_SAML
+    providers = payload["conf"]["AUTH_PROVIDERS"]
+    assert len(providers) == 2
+    assert providers[0] == {"name": "okta", "icon": "fa-okta"}
+    assert providers[1] == {"name": "entra_id", "icon": "fa-microsoft"}
+
+
+def test_bootstrap_saml_provider_default_icon(app_context: None) -> None:
+    """SAML providers without an icon get a default icon."""
+    from flask import current_app
+
+    current_app.config["AUTH_TYPE"] = AUTH_SAML
+    current_app.config["AUTH_USER_REGISTRATION"] = False
+    current_app.config["SAML_PROVIDERS"] = [
+        {"name": "onelogin"},
+    ]
+
+    payload = _get_bootstrap()
+
+    providers = payload["conf"]["AUTH_PROVIDERS"]
+    assert providers[0] == {"name": "onelogin", "icon": "fa-sign-in"}
+
+
+def test_bootstrap_oauth_providers(app_context: None) -> None:
+    """OAuth providers are included in bootstrap data."""
+    from flask import current_app
+
+    current_app.config["AUTH_TYPE"] = AUTH_OAUTH
+    current_app.config["AUTH_USER_REGISTRATION"] = False
+    current_app.config["OAUTH_PROVIDERS"] = [
+        {"name": "github", "icon": "fa-github"},
+    ]
+
+    payload = _get_bootstrap()
+
+    assert payload["conf"]["AUTH_TYPE"] == AUTH_OAUTH
+    providers = payload["conf"]["AUTH_PROVIDERS"]
+    assert len(providers) == 1
+    assert providers[0] == {"name": "github", "icon": "fa-github"}
+
+
+@pytest.mark.parametrize(
+    "auth_type",
+    [AUTH_OAUTH, AUTH_SAML],
+)
+def test_recaptcha_not_shown_for_federated_auth(
+    app_context: None,
+    auth_type: int,
+) -> None:
+    """Recaptcha should not be shown for OAuth or SAML auth types."""
+    from flask import current_app
+
+    current_app.config["AUTH_TYPE"] = auth_type
+    current_app.config["AUTH_USER_REGISTRATION"] = True
+    current_app.config["AUTH_USER_REGISTRATION_ROLE"] = "Public"
+    current_app.config.pop("RECAPTCHA_PUBLIC_KEY", None)
+
+    payload = _get_bootstrap()
+
+    assert "RECAPTCHA_PUBLIC_KEY" not in payload["conf"]
+
+
+@pytest.mark.parametrize(
+    "auth_type",
+    [AUTH_DB, AUTH_LDAP],
+)
+def test_recaptcha_shown_for_non_federated_auth(
+    app_context: None,
+    auth_type: int,
+) -> None:
+    """Recaptcha should be shown for DB and LDAP auth types when registration is on."""
+    from flask import current_app
+
+    current_app.config["AUTH_TYPE"] = auth_type
+    current_app.config["AUTH_USER_REGISTRATION"] = True
+    current_app.config["AUTH_USER_REGISTRATION_ROLE"] = "Public"
+    current_app.config["RECAPTCHA_PUBLIC_KEY"] = "test-key"
+
+    payload = _get_bootstrap()
+
+    assert payload["conf"]["RECAPTCHA_PUBLIC_KEY"] == "test-key"


### PR DESCRIPTION
## **User description**
### SUMMARY

Flask-AppBuilder 5.1.0 added SAML authentication (`AuthSAMLView`). The Superset backend already passes SAML providers to the frontend via bootstrap data (`superset/views/base.py`), but the React Login component didn't handle `AUTH_TYPE = 5` (`AUTH_SAML`), so the login page rendered empty — just "Sign in" with no provider buttons.

This PR adds full SAML login support:

- **Frontend**: Add `AuthSAML = 5` to the `AuthType` enum and render SAML provider buttons using the same pattern as OAuth (same provider shape `{name, icon}` and `/login/<provider>` URL pattern)
- **Dependency**: Add `python3-saml` via `flask-appbuilder[saml]` extra in `pyproject.toml` and pinned requirements
- **CSRF**: Exempt FAB's SAML ACS endpoint (`/saml/acs/`) from CSRF protection — the IdP POSTs the SAML response cross-site without a CSRF token
- **Recaptcha**: Exclude SAML from the recaptcha check (like OAuth, SAML users don't go through a self-registration form)
- **Tests**: Backend tests for SAML/OAuth bootstrap data and recaptcha logic; frontend test for SAML provider button rendering

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**: With `AUTH_TYPE = AUTH_SAML`, the login page shows only "Sign in" with no buttons.

**After**: SAML provider buttons render correctly, matching the OAuth provider button style.

### TESTING INSTRUCTIONS

1. Configure SAML authentication in `superset_config.py`:
   ```python
   from flask_appbuilder.const import AUTH_SAML

   AUTH_TYPE = AUTH_SAML
   AUTH_USER_REGISTRATION = True
   AUTH_USER_REGISTRATION_ROLE = "Admin"

   SAML_PROVIDERS = [
       {
           "name": "entra_id",
           "icon": "fa-microsoft",
           "idp": { ... },
           "attribute_mapping": { ... },
       },
   ]
   SAML_CONFIG = { "sp": { ... }, "security": { ... } }
   ```
2. Verify the login page shows SAML provider buttons
3. Click a provider button and complete the SAML flow
4. Verify successful login and redirect to the welcome page
5. Run backend tests: `pytest tests/unit_tests/views/test_bootstrap_auth.py -v`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Add SAML login support and ensure SAML providers and recaptcha behavior are exposed to the frontend

### What Changed
- Login page now shows SAML provider buttons (e.g., "Sign in with Okta") when server is configured for SAML
- Server bootstrap data includes SAML providers and uses a default icon when none is provided, so the frontend can render provider buttons
- Recaptcha is not included for SAML (same behavior as OAuth), preventing unnecessary captcha prompts for federated sign-ins
- The SAML ACS endpoint is exempted from CSRF protection so IdP-posted SAML responses are accepted
- Tests added to verify SAML provider bootstrap data and frontend rendering of SAML buttons

### Impact
`✅ Login page shows SAML providers`
`✅ No recaptcha prompt for SAML sign-ins`
`✅ Successful SAML ACS posts accepted without CSRF rejections`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
