### PR TITLE
style(metadata-bar): use bold font weight for metadata bar     title      

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/ContentConfig.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/ContentConfig.tsx
@@ -23,7 +23,7 @@ import { Icons } from '@superset-ui/core/components/Icons';
 import { ContentType, MetadataType } from '.';
 
 const Header = styled.div`
-  font-weight: ${({ theme }) => theme.fontWeightStrong};
+  font-weight: bold;
 `;
 
 const Info = ({

--- a/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/ContentConfig.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/MetadataBar/ContentConfig.tsx
@@ -23,7 +23,7 @@ import { Icons } from '@superset-ui/core/components/Icons';
 import { ContentType, MetadataType } from '.';
 
 const Header = styled.div`
-  font-weight: bold;
+  font-weight: ${({ theme }) => theme.fontWeightBold};
 `;
 
 const Info = ({


### PR DESCRIPTION
## **User description**
### SUMMARY

Uses a bolder font for the `MetadataBar` tooltip Header component.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="263" height="202" alt="image" src="https://github.com/user-attachments/assets/27974e23-4498-40a7-a25d-8b6addb23a67" />


AFTER: 
<img width="263" height="202" alt="image" src="https://github.com/user-attachments/assets/5d9557e3-7d97-445d-87eb-1b1712f562b1" />

<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

1. Navigate to any chart or dashboard and hover over the metadata bar.
2. Confirm the metadata bar header/title text appears visually bold.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Make metadata bar header use bold font weight

### What Changed
- Metadata bar header now uses the theme's bold weight token instead of the legacy/undefined strong token
- Metadata bar title renders visually bold and consistent across themes where the previous token could be missing

### Impact
`✅ Bold metadata titles`
`✅ Consistent header weight across themes`
`✅ Improved metadata header readability`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
