### PR TITLE
refactor(mcp): use serialize_user_object in get_instance_info

### DIFF
--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -30,7 +30,7 @@ from superset.mcp_service.mcp_core import InstanceInfoCore
 from superset.mcp_service.system.schemas import (
     GetSupersetInstanceInfoRequest,
     InstanceInfo,
-    UserInfo,
+    serialize_user_object,
 )
 from superset.mcp_service.system.system_utils import (
     calculate_dashboard_breakdown,
@@ -110,24 +110,7 @@ def get_instance_info(
         # Attach the authenticated user's identity to the response
         user = getattr(g, "user", None)
         if user is not None:
-            raw_roles = getattr(user, "roles", None)
-            user_roles = []
-            if raw_roles is not None:
-                try:
-                    user_roles = [
-                        role.name for role in raw_roles if hasattr(role, "name")
-                    ]
-                except TypeError:
-                    logger.debug("Could not iterate user.roles: %s", type(raw_roles))
-                    user_roles = []
-            result.current_user = UserInfo(
-                id=getattr(user, "id", None),
-                username=getattr(user, "username", None),
-                first_name=getattr(user, "first_name", None),
-                last_name=getattr(user, "last_name", None),
-                email=getattr(user, "email", None),
-                roles=user_roles,
-            )
+            result.current_user = serialize_user_object(user)
 
         return result
 

--- a/tests/unit_tests/mcp_service/system/tool/test_get_current_user.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_current_user.py
@@ -221,6 +221,7 @@ class TestGetInstanceInfoCurrentUserViaMCP:
         mock_g_user.first_name = "Sophie"
         mock_g_user.last_name = "Beaumont"
         mock_g_user.email = "sophie@preset.io"
+        mock_g_user.active = True
         mock_g_user.roles = [mock_role]
 
         with (


### PR DESCRIPTION
### SUMMARY

Follow-up to #38612 per [review comment](https://github.com/apache/superset/pull/38612#issuecomment-2867831266) from @rebenitez1802.

Replaces the inline role-extraction logic in `get_instance_info` with the shared `serialize_user_object()` helper introduced in #38612, reducing code duplication.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - refactor only, no behavior change

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/mcp_service/system/ -x -q
# 67 passed

pytest tests/unit_tests/mcp_service/ -x -q --ignore=tests/unit_tests/mcp_service/test_mcp_tool_registration.py
# 781 passed
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API