### PR TITLE
fix(mcp): Improve validation errors and field aliases to reduce failed LLM tool calls

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -70,7 +70,7 @@ Chart Management:
 
 SQL Lab Integration:
 - execute_sql: Execute SQL queries and get results (requires database_id)
-- open_sql_lab_with_context: Generate SQL Lab URL with pre-filled query
+- open_sql_lab_with_context: Generate SQL Lab URL with pre-filled sql
 
 Schema Discovery:
 - get_schema: Get schema metadata for chart/dataset/dashboard (columns, filters)
@@ -103,7 +103,7 @@ To find your own charts/dashboards:
    "opr": "eq", "value": current_user.id}}])
 
 To explore data with SQL:
-1. get_instance_info -> find database_id
+1. list_datasets -> find a dataset and note its database_id
 2. execute_sql(database_id, sql) -> run query
 3. open_sql_lab_with_context(database_id) -> open SQL Lab UI
 

--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -19,7 +19,7 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 
 class ExecuteSqlRequest(BaseModel):
@@ -119,7 +119,9 @@ class OpenSqlLabRequest(BaseModel):
     """Request schema for opening SQL Lab with context."""
 
     database_connection_id: int = Field(
-        ..., description="Database connection ID to use in SQL Lab"
+        ...,
+        description="Database connection ID to use in SQL Lab",
+        validation_alias=AliasChoices("database_connection_id", "database_id"),
     )
     schema_name: str | None = Field(
         None, description="Default schema to select in SQL Lab", alias="schema"
@@ -127,7 +129,11 @@ class OpenSqlLabRequest(BaseModel):
     dataset_in_context: str | None = Field(
         None, description="Dataset name/table to provide as context"
     )
-    sql: str | None = Field(None, description="SQL query to pre-populate in the editor")
+    sql: str | None = Field(
+        None,
+        description="SQL to pre-populate in the editor",
+        validation_alias=AliasChoices("sql", "query"),
+    )
     title: str | None = Field(None, description="Title for the SQL Lab tab/query")
 
 

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -190,7 +190,20 @@ def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
 
     if data_stmt is not None and data_stmt.data is not None:
         # SELECT query - convert DataFrame
+        import pandas as pd
+
         df = data_stmt.data
+        if not isinstance(df, pd.DataFrame):
+            logger.error(
+                "Expected DataFrame but got %s for statement data",
+                type(df).__name__,
+            )
+            return ExecuteSqlResponse(
+                success=False,
+                error=f"Internal error: unexpected data type ({type(df).__name__})",
+                error_type="data_conversion_error",
+                statements=statements,
+            )
         rows = df.to_dict(orient="records")
         columns = [ColumnInfo(name=col, type=str(df[col].dtype)) for col in df.columns]
         row_count = len(df)

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -18,7 +18,7 @@
 """
 Open SQL Lab with Context MCP Tool
 
-Tool for generating SQL Lab URLs with pre-populated query and context.
+Tool for generating SQL Lab URLs with pre-populated sql and context.
 """
 
 import logging
@@ -43,9 +43,9 @@ logger = logging.getLogger(__name__)
 def open_sql_lab_with_context(
     request: OpenSqlLabRequest, ctx: Context
 ) -> SqlLabResponse:
-    """Generate SQL Lab URL with pre-populated query and context.
+    """Generate SQL Lab URL with pre-populated sql and context.
 
-    Returns URL for direct navigation.
+    Pass the sql parameter to pre-fill the editor. Returns URL for direct navigation.
     """
     try:
         from superset.daos.database import DatabaseDAO

--- a/superset/mcp_service/utils/schema_utils.py
+++ b/superset/mcp_service/utils/schema_utils.py
@@ -448,7 +448,25 @@ def parse_request(
 
         def _maybe_parse(request: Any) -> Any:
             if _is_parse_request_enabled():
-                return parse_json_or_model(request, request_class, "request")
+                try:
+                    return parse_json_or_model(request, request_class, "request")
+                except ValidationError as e:
+                    from fastmcp.exceptions import ToolError
+
+                    details = []
+                    for err in e.errors():
+                        field = " -> ".join(str(loc) for loc in err["loc"])
+                        details.append(f"{field}: {err['msg']}")
+                    required_fields = [
+                        f.alias or name
+                        for name, f in request_class.model_fields.items()
+                        if f.is_required()
+                    ]
+                    raise ToolError(
+                        f"Invalid request parameters: {'; '.join(details)}. "
+                        f"Required fields for {request_class.__name__}: "
+                        f"{', '.join(required_fields)}"
+                    ) from None
             return request
 
         if asyncio.iscoroutinefunction(func):

--- a/tests/unit_tests/mcp_service/utils/test_schema_utils.py
+++ b/tests/unit_tests/mcp_service/utils/test_schema_utils.py
@@ -481,9 +481,11 @@ class TestParseRequestDecorator:
             result = sync_tool('{"name": "test", "count": 5}', extra="data")
         assert result == "test:5:data"
 
-    def test_decorator_raises_validation_error_async(self):
-        """Should raise ValidationError for invalid data in async function."""
+    def test_decorator_raises_tool_error_for_invalid_data_async(self):
+        """Should raise ToolError with field details for invalid data."""
         from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
 
         @parse_request(self.RequestModel)
         async def async_tool(request, ctx=None):
@@ -493,12 +495,14 @@ class TestParseRequestDecorator:
 
         mock_ctx = MagicMock()
         with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
-            with pytest.raises(ValidationError):
+            with pytest.raises(ToolError, match="Required fields for RequestModel"):
                 asyncio.run(async_tool('{"name": "test"}'))  # Missing count
 
-    def test_decorator_raises_validation_error_sync(self):
-        """Should raise ValidationError for invalid data in sync function."""
+    def test_decorator_raises_tool_error_for_invalid_data_sync(self):
+        """Should raise ToolError with field details for invalid data."""
         from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
 
         @parse_request(self.RequestModel)
         def sync_tool(request, ctx=None):
@@ -506,7 +510,7 @@ class TestParseRequestDecorator:
 
         mock_ctx = MagicMock()
         with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
-            with pytest.raises(ValidationError):
+            with pytest.raises(ToolError, match="Required fields for RequestModel"):
                 sync_tool('{"name": "test"}')  # Missing count
 
     def test_decorator_with_complex_model_async(self):


### PR DESCRIPTION
## **User description**
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Reduces failed MCP tool calls by giving LLMs better error messages and accepting common field name
  variations:

  1. Actionable validation errors — The parse_request decorator now catches Pydantic ValidationError and
  re-raises it as a ToolError with field-level details and a list of required fields, so the LLM can
  self-correct on retry instead of getting raw Pydantic internals.
  2. Field alias tolerance — Adds AliasChoices to OpenSqlLabRequest so both
  database_id/database_connection_id and sql/query are accepted, since LLMs frequently use these
  interchangeably.
  3. Defensive type check in execute_sql — Validates that statement data is a DataFrame before calling
  .to_dict(), returning a proper error response instead of an unhandled exception.

  Also updates MCP app instructions to guide LLMs toward list_datasets for finding database_id and uses
  consistent sql terminology.

### TESTING INSTRUCTIONS
  - Run the updated unit tests: pytest tests/unit_tests/mcp_service/utils/test_schema_utils.py
  - Verify validation errors now raise ToolError with required field names
  - Test open_sql_lab_with_context with both database_id and database_connection_id, and both sql and
  query

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @aminghadersohi


___

## **CodeAnt-AI Description**
**Improve MCP tool request validation, field aliasing, and SQL result handling**

### What Changed
- Validation errors from MCP tool requests are converted into clear ToolError messages that list which fields failed and which fields are required, enabling LLMs to self-correct on retry.
- Open SQL Lab tool accepts common field name variations: database_id or database_connection_id for the database, and sql or query for the pre-filled SQL; instructions now guide LLMs to use list_datasets to find a dataset's database_id.
- SQL execution now detects when returned statement data is not a table and returns a controlled error with an explanation instead of raising an internal exception.
- Unit tests updated to expect ToolError with field details for invalid tool requests.

### Impact
`✅ Fewer failed LLM tool calls due to unclear validation errors`
`✅ Clearer request error messages for LLM retries`
`✅ Fewer internal crashes when SQL returns unexpected data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
