### PR TITLE
fix(mcp): Support form_data_key without chart identifier for unsaved charts

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -112,6 +112,14 @@ class ChartInfo(BaseModel):
     owners: List[UserInfo] = Field(default_factory=list, description="Chart owners")
 
     # Fields for unsaved state support
+    form_data: Dict[str, Any] | None = Field(
+        None,
+        description=(
+            "The chart's form_data configuration. When form_data_key is provided, "
+            "this contains the unsaved (cached) configuration rather than the "
+            "saved version."
+        ),
+    )
     form_data_key: str | None = Field(
         None,
         description=(
@@ -219,26 +227,44 @@ class VersionedResponse(BaseModel):
 
 
 class GetChartInfoRequest(BaseModel):
-    """Request schema for get_chart_info with support for ID or UUID.
+    """Request schema for get_chart_info with support for ID, UUID, or form_data_key.
 
     When form_data_key is provided, the tool will retrieve the unsaved chart state
     from cache, allowing you to explain what the user actually sees (not the saved
     version). This is useful when a user edits a chart in Explore but hasn't saved yet.
+
+    For unsaved charts (no chart ID), provide only form_data_key to retrieve the
+    current chart configuration from cache.
     """
 
     identifier: Annotated[
-        int | str,
-        Field(description="Chart identifier - can be numeric ID or UUID string"),
+        int | str | None,
+        Field(
+            default=None,
+            description=(
+                "Chart identifier - can be numeric ID or UUID string. "
+                "Optional when form_data_key is provided (for unsaved charts)."
+            ),
+        ),
     ]
     form_data_key: str | None = Field(
         default=None,
         description=(
-            "Optional cache key for retrieving unsaved chart state. When a user "
+            "Cache key for retrieving unsaved chart state. When a user "
             "edits a chart in Explore but hasn't saved, the current state is stored "
             "with this key. If provided, the tool returns the current unsaved "
-            "configuration instead of the saved version."
+            "configuration instead of the saved version. "
+            "Can be used alone (without identifier) for unsaved charts."
         ),
     )
+
+    @model_validator(mode="after")
+    def validate_identifier_or_form_data_key(self) -> "GetChartInfoRequest":
+        if not self.identifier and not self.form_data_key:
+            raise ValueError(
+                "At least one of 'identifier' or 'form_data_key' must be provided."
+            )
+        return self
 
 
 def serialize_chart_object(chart: ChartLike | None) -> ChartInfo | None:
@@ -1020,18 +1046,37 @@ class GetChartDataRequest(QueryCacheControl):
     from cache to query data, allowing you to get data for what the user actually sees
     (not the saved version). This is useful when a user edits a chart in Explore but
     hasn't saved yet.
+
+    For unsaved charts (no chart ID), provide only form_data_key to query data using
+    the current chart configuration from cache.
     """
 
-    identifier: int | str = Field(description="Chart identifier (ID, UUID)")
+    identifier: int | str | None = Field(
+        default=None,
+        description=(
+            "Chart identifier (ID, UUID). "
+            "Optional when form_data_key is provided (for unsaved charts)."
+        ),
+    )
     form_data_key: str | None = Field(
         default=None,
         description=(
-            "Optional cache key for retrieving unsaved chart state. When a user "
+            "Cache key for retrieving unsaved chart state. When a user "
             "edits a chart in Explore but hasn't saved, the current state is stored "
             "with this key. If provided, the tool uses this configuration to query "
-            "data instead of the saved chart configuration."
+            "data instead of the saved chart configuration. "
+            "Can be used alone (without identifier) for unsaved charts."
         ),
     )
+
+    @model_validator(mode="after")
+    def validate_identifier_or_form_data_key(self) -> "GetChartDataRequest":
+        if not self.identifier and not self.form_data_key:
+            raise ValueError(
+                "At least one of 'identifier' or 'form_data_key' must be provided."
+            )
+        return self
+
     limit: int | None = Field(
         default=None,
         description=(
@@ -1113,18 +1158,37 @@ class GetChartPreviewRequest(QueryCacheControl):
     chart configuration from cache, allowing you to preview what the user actually sees
     (not the saved version). This is useful when a user edits a chart in Explore but
     hasn't saved yet.
+
+    For unsaved charts (no chart ID), provide only form_data_key to render a preview
+    using the current chart configuration from cache.
     """
 
-    identifier: int | str = Field(description="Chart identifier (ID, UUID)")
+    identifier: int | str | None = Field(
+        default=None,
+        description=(
+            "Chart identifier (ID, UUID). "
+            "Optional when form_data_key is provided (for unsaved charts)."
+        ),
+    )
     form_data_key: str | None = Field(
         default=None,
         description=(
-            "Optional cache key for retrieving unsaved chart state. When a user "
+            "Cache key for retrieving unsaved chart state. When a user "
             "edits a chart in Explore but hasn't saved, the current state is stored "
             "with this key. If provided, the tool renders a preview using this "
-            "configuration instead of the saved chart configuration."
+            "configuration instead of the saved chart configuration. "
+            "Can be used alone (without identifier) for unsaved charts."
         ),
     )
+
+    @model_validator(mode="after")
+    def validate_identifier_or_form_data_key(self) -> "GetChartPreviewRequest":
+        if not self.identifier and not self.form_data_key:
+            raise ValueError(
+                "At least one of 'identifier' or 'form_data_key' must be provided."
+            )
+        return self
+
     format: Literal["url", "ascii", "table", "vega_lite"] = Field(
         default="url",
         description=(

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -109,9 +109,42 @@ async def get_chart_data(  # noqa: C901
         from superset.daos.chart import ChartDAO
         from superset.utils import json as utils_json
 
-        # Find the chart
+        chart = None
+
+        # Handle unsaved chart (form_data_key only, no identifier)
+        if not request.identifier and request.form_data_key:
+            with event_logger.log_context(
+                action="mcp.get_chart_data.unsaved_chart_from_cache"
+            ):
+                await ctx.info(
+                    "No chart identifier - querying data from unsaved chart cache: "
+                    "form_data_key=%s" % (request.form_data_key,)
+                )
+                cached_form_data = _get_cached_form_data(request.form_data_key)
+                if not cached_form_data:
+                    return ChartError(
+                        error="No cached chart data found for form_data_key. "
+                        "The cache may have expired.",
+                        error_type="NotFound",
+                    )
+                try:
+                    cached_form_data_dict = utils_json.loads(cached_form_data)
+                except (TypeError, ValueError) as e:
+                    return ChartError(
+                        error=f"Failed to parse cached form_data: {e}",
+                        error_type="ParseError",
+                    )
+                if not isinstance(cached_form_data_dict, dict):
+                    return ChartError(
+                        error="Cached form_data is not a valid JSON object.",
+                        error_type="ParseError",
+                    )
+
+                # Build query context entirely from cached form_data
+                return await _query_from_form_data(cached_form_data_dict, request, ctx)
+
+        # Find the chart by identifier
         with event_logger.log_context(action="mcp.get_chart_data.chart_lookup"):
-            chart = None
             if isinstance(request.identifier, int) or (
                 isinstance(request.identifier, str) and request.identifier.isdigit()
             ):
@@ -124,7 +157,7 @@ async def get_chart_data(  # noqa: C901
                     "Performing ID-based chart lookup: chart_id=%s" % (chart_id,)
                 )
                 chart = ChartDAO.find_by_id(chart_id)
-            else:
+            elif isinstance(request.identifier, str):
                 await ctx.debug(
                     "Performing UUID-based chart lookup: uuid=%s"
                     % (request.identifier,)
@@ -178,36 +211,40 @@ async def get_chart_data(  # noqa: C901
 
             # Check if form_data_key is provided - use cached form_data instead
             if request.form_data_key:
-                await ctx.info(
-                    "Retrieving unsaved chart state from cache: form_data_key=%s"
-                    % (request.form_data_key,)
-                )
-                if cached_form_data := _get_cached_form_data(request.form_data_key):
-                    try:
-                        parsed_form_data = utils_json.loads(cached_form_data)
-                        # Only use if it's actually a dict (not null, list, etc.)
-                        if isinstance(parsed_form_data, dict):
-                            cached_form_data_dict = parsed_form_data
-                            using_unsaved_state = True
-                            await ctx.info(
-                                "Using cached form_data from form_data_key "
-                                "for data query"
-                            )
-                        else:
-                            await ctx.warning(
-                                "Cached form_data is not a JSON object. "
-                                "Falling back to saved chart configuration."
-                            )
-                    except (TypeError, ValueError) as e:
-                        await ctx.warning(
-                            "Failed to parse cached form_data: %s. "
-                            "Falling back to saved chart configuration." % str(e)
-                        )
-                else:
-                    await ctx.warning(
-                        "form_data_key provided but no cached data found. "
-                        "The cache may have expired. Using saved chart configuration."
+                with event_logger.log_context(
+                    action="mcp.get_chart_data.unsaved_state_override"
+                ):
+                    await ctx.info(
+                        "Retrieving unsaved chart state from cache: form_data_key=%s"
+                        % (request.form_data_key,)
                     )
+                    if cached_form_data := _get_cached_form_data(request.form_data_key):
+                        try:
+                            parsed_form_data = utils_json.loads(cached_form_data)
+                            # Only use if it's actually a dict (not null, list, etc.)
+                            if isinstance(parsed_form_data, dict):
+                                cached_form_data_dict = parsed_form_data
+                                using_unsaved_state = True
+                                await ctx.info(
+                                    "Using cached form_data from form_data_key "
+                                    "for data query"
+                                )
+                            else:
+                                await ctx.warning(
+                                    "Cached form_data is not a JSON object. "
+                                    "Falling back to saved chart configuration."
+                                )
+                        except (TypeError, ValueError) as e:
+                            await ctx.warning(
+                                "Failed to parse cached form_data: %s. "
+                                "Falling back to saved chart configuration." % str(e)
+                            )
+                    else:
+                        await ctx.warning(
+                            "form_data_key provided but no cached data found. "
+                            "The cache may have expired. Using saved chart "
+                            "configuration."
+                        )
 
             # Use the chart's saved query_context - this is the key!
             # The query_context contains all the information needed to reproduce
@@ -704,6 +741,151 @@ async def get_chart_data(  # noqa: C901
         logger.error("Error in get_chart_data: %s", e)
         return ChartError(
             error=f"Failed to get chart data: {str(e)}", error_type="InternalError"
+        )
+
+
+async def _query_from_form_data(
+    form_data: Dict[str, Any],
+    request: GetChartDataRequest,
+    ctx: Context,
+) -> ChartData | ChartError:
+    """Query chart data using only cached form_data (no saved chart).
+
+    Used for unsaved charts where we only have form_data_key.
+    """
+    from superset.commands.chart.data.get_data_command import ChartDataCommand
+    from superset.common.query_context_factory import QueryContextFactory
+
+    datasource_id = form_data.get("datasource_id")
+    datasource_type: str = form_data.get("datasource_type") or "table"
+
+    # Handle combined datasource field (e.g., "1__table")
+    if not datasource_id and form_data.get("datasource"):
+        parts = str(form_data["datasource"]).split("__")
+        if len(parts) == 2:
+            datasource_id, datasource_type = parts[0], parts[1]
+
+    if not datasource_id:
+        return ChartError(
+            error="Cached form_data does not contain datasource information.",
+            error_type="InvalidFormData",
+        )
+
+    viz_type = form_data.get("viz_type", "unknown")
+    row_limit = (
+        request.limit or form_data.get("row_limit") or current_app.config["ROW_LIMIT"]
+    )
+
+    # Extract metrics and groupby based on chart type
+    if viz_type in ("big_number", "big_number_total", "pop_kpi"):
+        metric = form_data.get("metric")
+        metrics = [metric] if metric else []
+        groupby: list[str] = []
+    else:
+        metrics = form_data.get("metrics", [])
+        groupby = list(form_data.get("groupby") or [])
+
+    try:
+        factory = QueryContextFactory()
+        query_context = factory.create(
+            datasource={"id": datasource_id, "type": datasource_type},
+            queries=[
+                {
+                    "filters": form_data.get("filters", []),
+                    "columns": groupby,
+                    "metrics": metrics,
+                    "row_limit": row_limit,
+                    "order_desc": form_data.get("order_desc", True),
+                }
+            ],
+            form_data=form_data,
+            force=request.force_refresh,
+        )
+
+        await ctx.report_progress(3, 4, "Executing data query")
+        with event_logger.log_context(action="mcp.get_chart_data.query_execution"):
+            command = ChartDataCommand(query_context)
+            result = command.run()
+
+        if not result or "queries" not in result or len(result["queries"]) == 0:
+            return ChartError(
+                error="No query results returned for unsaved chart.",
+                error_type="EmptyQuery",
+            )
+
+        query_result = result["queries"][0]
+        data = query_result.get("data", [])
+        raw_columns = query_result.get("colnames", [])
+
+        if not data:
+            return ChartError(
+                error="No data available for unsaved chart.",
+                error_type="NoData",
+            )
+
+        columns = []
+        for col_name in raw_columns:
+            sample_values = [
+                row.get(col_name) for row in data[:3] if row.get(col_name) is not None
+            ]
+            data_type = "string"
+            if sample_values and all(
+                isinstance(v, (int, float)) for v in sample_values
+            ):
+                data_type = "numeric"
+            columns.append(
+                DataColumn(
+                    name=col_name,
+                    display_name=col_name.replace("_", " ").title(),
+                    data_type=data_type,
+                    sample_values=sample_values[:3],
+                    null_count=sum(1 for row in data if row.get(col_name) is None),
+                    unique_count=len({str(row.get(col_name)) for row in data}),
+                )
+            )
+
+        cache_status = get_cache_status_from_result(
+            query_result, force_refresh=request.force_refresh
+        )
+
+        chart_name = form_data.get("slice_name", "Unsaved chart")
+        summary = (
+            f"Unsaved chart ({viz_type}). "
+            f"Contains {len(data)} rows across {len(raw_columns)} columns."
+        )
+
+        await ctx.report_progress(4, 4, "Building response")
+        return ChartData(
+            chart_id=0,
+            chart_name=chart_name,
+            chart_type=viz_type,
+            columns=columns,
+            data=data[: request.limit] if request.limit else data,
+            row_count=len(data),
+            total_rows=query_result.get("rowcount"),
+            summary=summary,
+            insights=["This is an unsaved chart queried from cached form_data."],
+            data_quality={
+                "completeness": 1.0
+                - (
+                    sum(col.null_count for col in columns)
+                    / max(len(data) * len(columns), 1)
+                )
+            },
+            recommended_visualizations=[],
+            data_freshness=None,
+            performance=PerformanceMetadata(
+                query_duration_ms=0,
+                cache_status="fresh_query",
+            ),
+            cache_status=cache_status,
+        )
+
+    except (CommandException, SupersetException, ValueError) as e:
+        logger.error("Error querying unsaved chart data: %s", e)
+        return ChartError(
+            error=f"Error querying unsaved chart data: {e}",
+            error_type="DataError",
         )
 
 

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -805,6 +805,7 @@ async def _query_from_form_data(
         await ctx.report_progress(3, 4, "Executing data query")
         with event_logger.log_context(action="mcp.get_chart_data.query_execution"):
             command = ChartDataCommand(query_context)
+            command.validate()
             result = command.run()
 
         if not result or "queries" not in result or len(result["queries"]) == 0:

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -74,6 +74,11 @@ def _build_unsaved_chart_info(form_data_key: str) -> ChartInfo | ChartError:
             error=f"Failed to parse cached form_data: {e}",
             error_type="ParseError",
         )
+    if not isinstance(form_data, dict):
+        return ChartError(
+            error="Cached form_data is not a valid JSON object.",
+            error_type="ParseError",
+        )
     return ChartInfo(
         viz_type=form_data.get("viz_type"),
         datasource_name=form_data.get("datasource_name"),

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -56,6 +56,60 @@ def _get_cached_form_data(form_data_key: str) -> str | None:
         return None
 
 
+def _build_unsaved_chart_info(form_data_key: str) -> ChartInfo | ChartError:
+    """Build a ChartInfo from cached form_data when no chart identifier exists."""
+    from superset.utils import json as utils_json
+
+    cached_form_data = _get_cached_form_data(form_data_key)
+    if not cached_form_data:
+        return ChartError(
+            error="No cached chart data found for form_data_key. "
+            "The cache may have expired.",
+            error_type="NotFound",
+        )
+    try:
+        form_data = utils_json.loads(cached_form_data)
+    except (TypeError, ValueError) as e:
+        return ChartError(
+            error=f"Failed to parse cached form_data: {e}",
+            error_type="ParseError",
+        )
+    return ChartInfo(
+        viz_type=form_data.get("viz_type"),
+        datasource_name=form_data.get("datasource_name"),
+        datasource_type=form_data.get("datasource_type"),
+        form_data=form_data,
+        form_data_key=form_data_key,
+        is_unsaved_state=True,
+    )
+
+
+def _apply_unsaved_state_override(result: ChartInfo, form_data_key: str) -> None:
+    """Override a ChartInfo's form_data with cached unsaved state."""
+    from superset.utils import json as utils_json
+
+    if cached_form_data := _get_cached_form_data(form_data_key):
+        try:
+            result.form_data = utils_json.loads(cached_form_data)
+            result.form_data_key = form_data_key
+            result.is_unsaved_state = True
+
+            # Update viz_type from cached form_data if present
+            if result.form_data and "viz_type" in result.form_data:
+                result.viz_type = result.form_data["viz_type"]
+        except (TypeError, ValueError) as e:
+            logger.warning(
+                "Failed to parse cached form_data: %s. "
+                "Using saved chart configuration.",
+                e,
+            )
+    else:
+        logger.warning(
+            "form_data_key provided but no cached data found. "
+            "The cache may have expired. Using saved chart configuration."
+        )
+
+
 @tool(tags=["discovery"], class_permission_name="Chart")
 @parse_request(GetChartInfoRequest)
 async def get_chart_info(
@@ -96,12 +150,27 @@ async def get_chart_info(
     """
     from superset.daos.chart import ChartDAO
     from superset.models.slice import Slice
-    from superset.utils import json as utils_json
 
     await ctx.info(
         "Retrieving chart information: identifier=%s, form_data_key=%s"
         % (request.identifier, request.form_data_key)
     )
+
+    # Handle unsaved chart (form_data_key only, no identifier)
+    if not request.identifier and request.form_data_key:
+        with event_logger.log_context(
+            action="mcp.get_chart_info.unsaved_chart_from_cache"
+        ):
+            await ctx.info(
+                "No chart identifier provided - retrieving unsaved chart from cache: "
+                "form_data_key=%s" % (request.form_data_key,)
+            )
+            return _build_unsaved_chart_info(request.form_data_key)
+
+    # At this point identifier must be set (validator ensures at least one
+    # of identifier/form_data_key is provided, and the form_data_key-only
+    # branch returned above).
+    assert request.identifier is not None
 
     # Eager load owners and tags to avoid N+1 queries during serialization
     eager_options = [
@@ -125,35 +194,14 @@ async def get_chart_info(
     if isinstance(result, ChartInfo):
         # If form_data_key is provided, override form_data with cached version
         if request.form_data_key:
-            await ctx.info(
-                "Retrieving unsaved chart state from cache: form_data_key=%s"
-                % (request.form_data_key,)
-            )
-            cached_form_data = _get_cached_form_data(request.form_data_key)
-
-            if cached_form_data:
-                try:
-                    result.form_data = utils_json.loads(cached_form_data)
-                    result.form_data_key = request.form_data_key
-                    result.is_unsaved_state = True
-
-                    # Update viz_type from cached form_data if present
-                    if result.form_data and "viz_type" in result.form_data:
-                        result.viz_type = result.form_data["viz_type"]
-
-                    await ctx.info(
-                        "Chart form_data overridden with unsaved state from cache"
-                    )
-                except (TypeError, ValueError) as e:
-                    await ctx.warning(
-                        "Failed to parse cached form_data: %s. "
-                        "Using saved chart configuration." % (str(e),)
-                    )
-            else:
-                await ctx.warning(
-                    "form_data_key provided but no cached data found. "
-                    "The cache may have expired. Using saved chart configuration."
+            with event_logger.log_context(
+                action="mcp.get_chart_info.unsaved_state_override"
+            ):
+                await ctx.info(
+                    "Retrieving unsaved chart state from cache: form_data_key=%s"
+                    % (request.form_data_key,)
                 )
+                _apply_unsaved_state_override(result, request.form_data_key)
 
         await ctx.info(
             "Chart information retrieved successfully: chart_name=%s, "

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1863,7 +1863,7 @@ async def _get_chart_preview_internal(  # noqa: C901
 
                             class TransientChartFromKey:
                                 def __init__(self, fd: Dict[str, Any]):
-                                    self.id = None
+                                    self.id = 0
                                     self.slice_name = "Unsaved Chart Preview"
                                     self.viz_type = fd.get("viz_type", "table")
                                     ds = fd.get("datasource", "")
@@ -1947,7 +1947,7 @@ async def _get_chart_preview_internal(  # noqa: C901
                             # Create a transient chart object from form data
                             class TransientChart:
                                 def __init__(self, form_data: Dict[str, Any]):
-                                    self.id = None
+                                    self.id = 0
                                     self.slice_name = "Unsaved Chart Preview"
                                     self.viz_type = form_data.get("viz_type", "table")
                                     self.datasource_id = None

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1837,7 +1837,71 @@ async def _get_chart_preview_internal(  # noqa: C901
         # Find the chart
         with event_logger.log_context(action="mcp.get_chart_preview.chart_lookup"):
             chart: Any = None
-            if isinstance(request.identifier, int) or (
+
+            # Handle unsaved chart (form_data_key only, no identifier)
+            if not request.identifier and request.form_data_key:
+                with event_logger.log_context(
+                    action="mcp.get_chart_preview.unsaved_chart_from_cache"
+                ):
+                    await ctx.info(
+                        "No chart identifier - creating transient chart from "
+                        "form_data_key=%s" % (request.form_data_key,)
+                    )
+                    from superset.commands.explore.form_data.get import (
+                        GetFormDataCommand,
+                    )
+                    from superset.commands.explore.form_data.parameters import (
+                        CommandParameters,
+                    )
+                    from superset.utils import json as utils_json
+
+                    try:
+                        cmd_params = CommandParameters(key=request.form_data_key)
+                        form_data_json = GetFormDataCommand(cmd_params).run()
+                        if form_data_json:
+                            form_data = utils_json.loads(form_data_json)
+
+                            class TransientChartFromKey:
+                                def __init__(self, fd: Dict[str, Any]):
+                                    self.id = None
+                                    self.slice_name = "Unsaved Chart Preview"
+                                    self.viz_type = fd.get("viz_type", "table")
+                                    ds = fd.get("datasource", "")
+                                    parts = str(ds).split("__") if ds else []
+                                    self.datasource_id = (
+                                        int(parts[0])
+                                        if len(parts) == 2
+                                        else fd.get("datasource_id")
+                                    )
+                                    self.datasource_type = (
+                                        parts[1]
+                                        if len(parts) == 2
+                                        else fd.get("datasource_type", "table")
+                                    )
+                                    self.params = utils_json.dumps(fd)
+                                    self.form_data = fd
+                                    self.uuid = None
+
+                            chart = TransientChartFromKey(form_data)
+                    except (
+                        CommandException,
+                        ValueError,
+                        KeyError,
+                        AttributeError,
+                        TypeError,
+                    ) as e:
+                        logger.warning(
+                            "Failed to get form data for key %s: %s",
+                            request.form_data_key,
+                            e,
+                        )
+                        return ChartError(
+                            error="No cached chart data found for form_data_key. "
+                            "The cache may have expired.",
+                            error_type="NotFound",
+                        )
+
+            elif isinstance(request.identifier, int) or (
                 isinstance(request.identifier, str) and request.identifier.isdigit()
             ):
                 chart_id = (
@@ -1849,7 +1913,7 @@ async def _get_chart_preview_internal(  # noqa: C901
                     "Performing ID-based chart lookup: chart_id=%s" % (chart_id,)
                 )
                 chart = ChartDAO.find_by_id(chart_id)
-            else:
+            elif isinstance(request.identifier, str):
                 await ctx.debug(
                     "Performing UUID-based chart lookup: uuid=%s"
                     % (request.identifier,)
@@ -1950,6 +2014,48 @@ async def _get_chart_preview_internal(  # noqa: C901
             # Log any warnings (e.g., virtual dataset warnings)
             for warning in validation_result.warnings:
                 await ctx.warning("Dataset warning: %s" % (warning,))
+
+        # If form_data_key is provided, override chart.params with cached
+        # form_data so the preview reflects what the user actually sees
+        if request.form_data_key and getattr(chart, "id", None) is not None:
+            with event_logger.log_context(
+                action="mcp.get_chart_preview.unsaved_state_override"
+            ):
+                await ctx.info(
+                    "Retrieving unsaved chart state from cache: form_data_key=%s"
+                    % (request.form_data_key,)
+                )
+                from superset.commands.explore.form_data.get import (
+                    GetFormDataCommand,
+                )
+                from superset.commands.explore.form_data.parameters import (
+                    CommandParameters,
+                )
+
+                try:
+                    cmd_params = CommandParameters(key=request.form_data_key)
+                    cached_form_data = GetFormDataCommand(cmd_params).run()
+                    if cached_form_data:
+                        chart.params = cached_form_data
+                        from superset.utils import json as utils_json
+
+                        parsed = utils_json.loads(cached_form_data)
+                        if isinstance(parsed, dict) and "viz_type" in parsed:
+                            chart.viz_type = parsed["viz_type"]
+                        await ctx.info(
+                            "Chart params overridden with unsaved state from cache"
+                        )
+                    else:
+                        await ctx.warning(
+                            "form_data_key provided but no cached data found. "
+                            "The cache may have expired. Using saved chart "
+                            "configuration."
+                        )
+                except (CommandException, ValueError, KeyError) as e:
+                    await ctx.warning(
+                        "Failed to retrieve cached form_data: %s. "
+                        "Using saved chart configuration." % (str(e),)
+                    )
 
         import time
 


### PR DESCRIPTION
## **User description**
### SUMMARY
  MCP chart tools (get_chart_info, get_chart_data, get_chart_preview) previously required a chart
  identifier (ID or UUID) even when a form_data_key was provided. This broke the workflow for unsaved/new
  charts in Explore, where no chart ID exists yet but the configuration is cached via form_data_key.

  This change makes the identifier field optional across all three tools when form_data_key is provided,
  and adds handling to query data, retrieve info, and render previews using only the cached form_data. A
  model validator ensures at least one of identifier or form_data_key is provided.

  Key changes:
  - Schemas: Made identifier optional (defaults to None) in GetChartInfoRequest, GetChartDataRequest, and
  GetChartPreviewRequest. Added model_validator to require at least one of identifier or form_data_key.
  Added form_data field to ChartInfo.
  - get_chart_info: Returns a minimal ChartInfo from cached form_data when no identifier is given.
  - get_chart_data: Extracts datasource/metrics/groupby from cached form_data and builds a query context
  to execute against the datasource directly via _query_from_form_data.
  - get_chart_preview: Creates a transient chart object (TransientChartFromKey) from cached form_data to
  render previews without a saved chart. Also adds form_data_key override support for saved charts.
  - Added event_logger context logging for unsaved chart and override paths.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
  1. Open Explore with a new unsaved chart (no chart ID in URL, only form_data_key)
  2. Use MCP get_chart_info with only form_data_key — should return chart config from cache
  3. Use MCP get_chart_data with only form_data_key — should return query results
  4. Use MCP get_chart_preview with only form_data_key — should render a preview
  5. Verify that providing both identifier and form_data_key still works (overrides saved state)
  6. Verify that providing neither returns a validation error
  7. Verify expired/invalid form_data_key returns appropriate error messages

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Support using form_data_key alone to inspect, preview, and query unsaved charts

### What Changed
- get_chart_info: Returns chart metadata built from cached form_data when no chart identifier is provided; can also merge cached unsaved state into a saved chart when form_data_key is present.
- get_chart_data: If only form_data_key is provided, builds a query context from the cached form_data and returns data for the unsaved chart; when form_data_key is provided with a saved chart, cached form_data overrides the saved configuration for the query.
- get_chart_preview: Can render a preview for an unsaved chart by creating a transient chart from cached form_data; when form_data_key is provided for a saved chart, cached form_data overrides the saved params so the preview matches unsaved edits.
- Request schemas for info/data/preview now accept identifier as optional when form_data_key is provided and validate that at least one of identifier or form_data_key is present.

### Impact
`✅ Preview unsaved charts from Explore using form_data_key`
`✅ Query data for unsaved charts using cached configuration`
`✅ Retrieve chart metadata that reflects a user's unsaved edits`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
