### PR TITLE
fix(mcp): convert ValidationError to ToolError in parse_request decorator

### DIFF
--- a/superset/mcp_service/utils/schema_utils.py
+++ b/superset/mcp_service/utils/schema_utils.py
@@ -401,6 +401,22 @@ def _is_parse_request_enabled() -> bool:
     return True
 
 
+def _safe_parse(parse_fn: Callable[..., Any], request: Any) -> Any:
+    """Call parse_fn and convert ValidationError/JSONParseError to ToolError."""
+    from fastmcp.exceptions import ToolError
+
+    try:
+        return parse_fn(request)
+    except ValidationError as e:
+        details = "; ".join(
+            f"{' -> '.join(str(loc) for loc in err['loc'])}: {err['msg']}"
+            for err in e.errors()
+        )
+        raise ToolError(f"Invalid request parameters: {details}") from None
+    except JSONParseError as e:
+        raise ToolError(str(e)) from None
+
+
 def parse_request(
     request_class: Type[BaseModel],
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
@@ -476,7 +492,8 @@ def parse_request(
                 from fastmcp.server.dependencies import get_context
 
                 ctx = get_context()
-                return await func(_maybe_parse(request), ctx, *args, **kwargs)
+                parsed = _safe_parse(_maybe_parse, request)
+                return await func(parsed, ctx, *args, **kwargs)
 
             wrapper = async_wrapper
         else:
@@ -486,7 +503,8 @@ def parse_request(
                 from fastmcp.server.dependencies import get_context
 
                 ctx = get_context()
-                return func(_maybe_parse(request), ctx, *args, **kwargs)
+                parsed = _safe_parse(_maybe_parse, request)
+                return func(parsed, ctx, *args, **kwargs)
 
             wrapper = sync_wrapper
 

--- a/tests/unit_tests/mcp_service/utils/test_schema_utils.py
+++ b/tests/unit_tests/mcp_service/utils/test_schema_utils.py
@@ -481,8 +481,8 @@ class TestParseRequestDecorator:
             result = sync_tool('{"name": "test", "count": 5}', extra="data")
         assert result == "test:5:data"
 
-    def test_decorator_raises_tool_error_for_invalid_data_async(self):
-        """Should raise ToolError with field details for invalid data."""
+    def test_decorator_raises_tool_error_for_validation_error_async(self):
+        """Should raise ToolError (not ValidationError) for invalid data in async."""
         from unittest.mock import MagicMock, patch
 
         from fastmcp.exceptions import ToolError
@@ -495,11 +495,11 @@ class TestParseRequestDecorator:
 
         mock_ctx = MagicMock()
         with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
-            with pytest.raises(ToolError, match="Required fields for RequestModel"):
+            with pytest.raises(ToolError, match="Invalid request parameters"):
                 asyncio.run(async_tool('{"name": "test"}'))  # Missing count
 
-    def test_decorator_raises_tool_error_for_invalid_data_sync(self):
-        """Should raise ToolError with field details for invalid data."""
+    def test_decorator_raises_tool_error_for_validation_error_sync(self):
+        """Should raise ToolError (not ValidationError) for invalid data in sync."""
         from unittest.mock import MagicMock, patch
 
         from fastmcp.exceptions import ToolError
@@ -510,7 +510,7 @@ class TestParseRequestDecorator:
 
         mock_ctx = MagicMock()
         with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
-            with pytest.raises(ToolError, match="Required fields for RequestModel"):
+            with pytest.raises(ToolError, match="Invalid request parameters"):
                 sync_tool('{"name": "test"}')  # Missing count
 
     def test_decorator_with_complex_model_async(self):
@@ -564,3 +564,65 @@ class TestParseRequestDecorator:
         with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
             result = sync_tool(json_str)
         assert result == "test:42"
+
+    def test_tool_error_includes_field_details_sync(self):
+        """ToolError message should include which field is missing."""
+        from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        @parse_request(self.RequestModel)
+        def sync_tool(request, ctx=None):
+            return f"{request.name}:{request.count}"
+
+        mock_ctx = MagicMock()
+        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+            with pytest.raises(ToolError, match="count"):
+                sync_tool({"name": "test"})  # Missing count
+
+    def test_tool_error_includes_field_details_async(self):
+        """ToolError message should include which field is missing (async)."""
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        @parse_request(self.RequestModel)
+        async def async_tool(request, ctx=None):
+            return f"{request.name}:{request.count}"
+
+        mock_ctx = MagicMock()
+        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+            with pytest.raises(ToolError, match="count"):
+                asyncio.run(async_tool({"name": "test"}))  # Missing count
+
+    def test_tool_error_for_invalid_json_sync(self):
+        """Should raise ToolError for unparseable JSON string (sync)."""
+        from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        @parse_request(self.RequestModel)
+        def sync_tool(request, ctx=None):
+            return f"{request.name}:{request.count}"
+
+        mock_ctx = MagicMock()
+        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+            with pytest.raises(ToolError, match="Failed to parse"):
+                sync_tool("not valid json at all")
+
+    def test_tool_error_for_invalid_json_async(self):
+        """Should raise ToolError for unparseable JSON string (async)."""
+        import asyncio
+        from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        @parse_request(self.RequestModel)
+        async def async_tool(request, ctx=None):
+            return f"{request.name}:{request.count}"
+
+        mock_ctx = MagicMock()
+        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+            with pytest.raises(ToolError, match="Failed to parse"):
+                asyncio.run(async_tool("not valid json at all"))


### PR DESCRIPTION
### SUMMARY

When an LLM client calls an MCP tool but forgets a required parameter (e.g., `database_connection_id` for `open_sql_lab_with_context`), the `@parse_request` decorator lets the raw `ValidationError` propagate through the transport layer. Something in the serialization chain then calls `bytes(non_string, encoding)`, producing an unhelpful `TypeError: encoding without a string argument`. The LLM sees this cryptic error and cannot recover or retry because it never learns which parameter was missing.

This PR adds a `_safe_parse()` helper that catches `ValidationError` and `JSONParseError` from `_maybe_parse()` and converts them to `ToolError` (which FastMCP serializes cleanly as an `isError=true` tool result). The error message now includes specific field names and validation details, e.g.:

```
Invalid request parameters: database_connection_id: Field required
```

This lets the LLM understand the error and retry with the correct parameters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - no UI changes

### TESTING INSTRUCTIONS

1. Run the unit tests:
   ```bash
   pytest tests/unit_tests/mcp_service/utils/test_schema_utils.py -v
   ```
2. All 56 tests should pass, including the new error conversion tests.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API