### PR TITLE
fix: make MCP tests FastMCP 2.x/3.x compatible and quote ag-grid column names

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -534,7 +534,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (
               expression.includes('\n');
             const wrappedExpression = isExpression
               ? `(${expression})`
-              : expression;
+              : `"${expression}"`;
             resolved = resolved.replace(
               new RegExp(`\\b${escapedLabel}\\b`, 'g'),
               wrappedExpression,

--- a/tests/unit_tests/mcp_service/test_mcp_tool_registration.py
+++ b/tests/unit_tests/mcp_service/test_mcp_tool_registration.py
@@ -17,25 +17,27 @@
 
 """Test MCP app imports and tool/prompt registration."""
 
+import asyncio
+
 
 def test_mcp_app_imports_successfully():
     """Test that the MCP app can be imported without errors."""
     from superset.mcp_service.app import mcp
 
     assert mcp is not None
-    assert hasattr(mcp, "_tool_manager")
 
-    tools = mcp._tool_manager._tools
-    assert len(tools) > 0
-    assert "health_check" in tools
-    assert "list_charts" in tools
+    tools = asyncio.run(mcp.list_tools())
+    tool_names = {t.name for t in tools}
+    assert len(tool_names) > 0
+    assert "health_check" in tool_names
+    assert "list_charts" in tool_names
 
 
 def test_mcp_prompts_registered():
     """Test that MCP prompts are registered."""
     from superset.mcp_service.app import mcp
 
-    prompts = mcp._prompt_manager._prompts
+    prompts = asyncio.run(mcp.list_prompts())
     assert len(prompts) > 0
 
 
@@ -48,12 +50,10 @@ def test_mcp_resources_registered():
     """
     from superset.mcp_service.app import mcp
 
-    resource_manager = mcp._resource_manager
-    resources = resource_manager._resources
-    assert len(resources) > 0, "No MCP resources registered"
+    resources = asyncio.run(mcp.list_resources())
+    resource_uris = {str(r.uri) for r in resources}
+    assert len(resource_uris) > 0, "No MCP resources registered"
 
-    # Verify the two documented resources are registered
-    resource_uris = set(resources.keys())
     assert "chart://configs" in resource_uris, (
         "chart://configs resource not registered - "
         "check superset/mcp_service/chart/__init__.py exists"

--- a/tests/unit_tests/mcp_service/test_mcp_tool_registration.py
+++ b/tests/unit_tests/mcp_service/test_mcp_tool_registration.py
@@ -15,9 +15,34 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Test MCP app imports and tool/prompt registration."""
+"""Test MCP app imports and tool/prompt registration.
+
+Compatible with both FastMCP 2.x (private _tool_manager API)
+and FastMCP 3.x (public async list_tools API).
+"""
 
 import asyncio
+
+
+def _get_tool_names(mcp):
+    """Get registered tool names, compatible with FastMCP 2.x and 3.x."""
+    if hasattr(mcp, "_tool_manager"):
+        return set(mcp._tool_manager._tools.keys())
+    return {t.name for t in asyncio.run(mcp.list_tools())}
+
+
+def _get_prompt_count(mcp):
+    """Get registered prompt count, compatible with FastMCP 2.x and 3.x."""
+    if hasattr(mcp, "_prompt_manager"):
+        return len(mcp._prompt_manager._prompts)
+    return len(asyncio.run(mcp.list_prompts()))
+
+
+def _get_resource_uris(mcp):
+    """Get registered resource URIs, compatible with FastMCP 2.x and 3.x."""
+    if hasattr(mcp, "_resource_manager"):
+        return set(mcp._resource_manager._resources.keys())
+    return {str(r.uri) for r in asyncio.run(mcp.list_resources())}
 
 
 def test_mcp_app_imports_successfully():
@@ -26,8 +51,7 @@ def test_mcp_app_imports_successfully():
 
     assert mcp is not None
 
-    tools = asyncio.run(mcp.list_tools())
-    tool_names = {t.name for t in tools}
+    tool_names = _get_tool_names(mcp)
     assert len(tool_names) > 0
     assert "health_check" in tool_names
     assert "list_charts" in tool_names
@@ -37,8 +61,7 @@ def test_mcp_prompts_registered():
     """Test that MCP prompts are registered."""
     from superset.mcp_service.app import mcp
 
-    prompts = asyncio.run(mcp.list_prompts())
-    assert len(prompts) > 0
+    assert _get_prompt_count(mcp) > 0
 
 
 def test_mcp_resources_registered():
@@ -50,8 +73,7 @@ def test_mcp_resources_registered():
     """
     from superset.mcp_service.app import mcp
 
-    resources = asyncio.run(mcp.list_resources())
-    resource_uris = {str(r.uri) for r in resources}
+    resource_uris = _get_resource_uris(mcp)
     assert len(resource_uris) > 0, "No MCP resources registered"
 
     assert "chart://configs" in resource_uris, (


### PR DESCRIPTION
### SUMMARY

Two CI fixes for issues broken on master:

1. **MCP tool registration tests** (`test_mcp_tool_registration.py`): CI pins FastMCP 2.14.3 which uses private `_tool_manager` API, while local dev may use FastMCP 3.x which removed those privates and added public `list_tools()` etc. Added compatibility helpers that detect the FastMCP version via `hasattr` and use the appropriate API.

2. **ag-grid buildQuery** (`buildQuery.ts`): When resolving label names to their underlying SQL column expressions, simple column identifiers were not being double-quoted. The test expects `"user_status"` but the code produced `user_status`. Fixed by wrapping simple (non-expression) column names in SQL double-quotes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - test fix and minor code fix

### TESTING INSTRUCTIONS
```bash
# MCP tests (Python)
pytest tests/unit_tests/mcp_service/test_mcp_tool_registration.py -x -q

# ag-grid tests (Jest shard 7 in CI)
# The buildQuery.test.ts "should quote simple column names without parentheses" test should pass
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API