### PR TITLE
fix: Chatbot encoding and bytes errors

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -228,24 +228,25 @@ def run_server(
         auth_provider = _create_auth_provider(flask_app)
 
         # Build middleware list
-        # FastMCP wraps handlers so that the LAST-added middleware is
-        # outermost.  Order here is innermost → outermost.
+        # FastMCP 2.14+ uses reversed(middleware) when building the chain,
+        # so the FIRST-added middleware becomes the outermost wrapper.
+        # Order here is outermost → innermost.
         middleware_list = []
 
-        # Add caching middleware (innermost – runs closest to the tool)
-        caching_middleware = create_response_caching_middleware()
-        if caching_middleware:
-            middleware_list.append(caching_middleware)
+        # Add global error handler (outermost – catches all exceptions)
+        middleware_list.append(GlobalErrorHandlerMiddleware())
+
+        # Add logging middleware (logs all tool calls with duration tracking)
+        middleware_list.append(LoggingMiddleware())
 
         # Add response size guard (protects LLM clients from huge responses)
         if size_guard_middleware := create_response_size_guard_middleware():
             middleware_list.append(size_guard_middleware)
 
-        # Add logging middleware (logs all tool calls with duration tracking)
-        middleware_list.append(LoggingMiddleware())
-
-        # Add global error handler (outermost – catches all exceptions)
-        middleware_list.append(GlobalErrorHandlerMiddleware())
+        # Add caching middleware (innermost – runs closest to the tool)
+        caching_middleware = create_response_caching_middleware()
+        if caching_middleware:
+            middleware_list.append(caching_middleware)
 
         mcp_instance = init_fastmcp_server(
             auth=auth_provider,

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -77,6 +77,7 @@ from superset.sql.parse import SQLScript
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
+    import pandas as pd
     from superset_core.queries.types import (
         AsyncQueryHandle,
         QueryOptions,
@@ -779,6 +780,44 @@ class SQLExecutor:
 
         return query
 
+    @staticmethod
+    def _deserialize_cached_data(raw: Any) -> pd.DataFrame | None:
+        """
+        Deserialize the ``data`` field stored in the query result cache.
+
+        Handles three formats:
+        - **New format** (dict): ``{"records": [...], "columns": [...]}``
+        - **In-memory format** (DataFrame): returned as-is (e.g. SimpleCache)
+        - **None**: DML statements with no result data
+
+        Any other type (e.g. bytes from legacy cache entries) is discarded
+        and treated as a cache miss. We intentionally avoid pickle
+        deserialization to prevent code-execution attacks from a
+        compromised cache backend.
+
+        :param raw: The raw value read from the cache
+        :returns: A pandas DataFrame, or None
+        """
+        import pandas as pd
+
+        if raw is None:
+            return None
+
+        if isinstance(raw, pd.DataFrame):
+            return raw
+
+        if isinstance(raw, dict):
+            return pd.DataFrame(
+                raw["records"],
+                columns=raw["columns"],
+            )
+
+        logger.warning(
+            "Unexpected cached data type %s, discarding cache entry",
+            type(raw).__name__,
+        )
+        return None
+
     def _get_from_cache(self, sql: str, opts: QueryOptions) -> QueryResult | None:
         """
         Check results cache for existing result.
@@ -796,12 +835,14 @@ class SQLExecutor:
         cache_key = self._generate_cache_key(sql, opts)
 
         if (cached := cache_manager.data_cache.get(cache_key)) is not None:
-            # Reconstruct statement results from cached data
+            # Reconstruct statement results from cached data.
+            # New entries store DataFrames as {"records": [...], "columns": [...]}
+            # dicts; legacy entries may contain raw bytes (pickle) or DataFrames.
             statements = [
                 StatementResult(
                     original_sql=stmt_data["original_sql"],
                     executed_sql=stmt_data["executed_sql"],
-                    data=stmt_data["data"],
+                    data=self._deserialize_cached_data(stmt_data.get("data")),
                     row_count=stmt_data["row_count"],
                     execution_time_ms=stmt_data["execution_time_ms"],
                 )
@@ -845,7 +886,14 @@ class SQLExecutor:
                 {
                     "original_sql": stmt.original_sql,
                     "executed_sql": stmt.executed_sql,
-                    "data": stmt.data,
+                    "data": (
+                        {
+                            "records": stmt.data.to_dict(orient="records"),
+                            "columns": list(stmt.data.columns),
+                        }
+                        if stmt.data is not None
+                        else None
+                    ),
                     "row_count": stmt.row_count,
                     "execution_time_ms": stmt.execution_time_ms,
                 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes two issues in the MCP chatbot/SQL execution flow:
1. Cached query results failing with bytes/encoding errors — The result cache was storing raw pandas DataFrames (which get pickled by some cache backends into bytes). On retrieval, the code assumed thedata was always a DataFrame, causing errors when encountering bytes. This PR serializes DataFrames to a JSON-safe dict format ({"records": [...], "columns": [...]}) before caching, and adds a _deserialize_cached_data() method that gracefully handles all formats (dict, DataFrame, None, and bytes as a cache miss) — intentionally avoiding pickle deserialization to prevent code-execution attacks from a compromised cache backend.
2. MCP middleware ordering was reversed — FastMCP 2.14+ changed how middleware is chained (uses reversed(middleware)), so the first-added middleware is now outermost. The middleware list ordering in server.py was updated to reflect this: GlobalErrorHandler → Logging → SizeGuard → Caching (outermost → innermost).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
  1. Start Superset with MCP enabled
  2. Run a SQL query via the MCP chatbot that returns results
  4. Run the same query again — it should hit the cache and return correctly (no bytes/encoding errors)
  5. Verify DML queries (INSERT/UPDATE) that return no data also work from cache
  6. Verify middleware logging shows correct nesting order (error handler outermost)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
