### PR TITLE
feat(mcp): Add tool annotations for MCP directory compliance

### DIFF
--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -37,7 +37,12 @@ Usage:
 
 from typing import Any, Callable, TypeVar
 
-from mcp.types import ToolAnnotations
+try:
+    from mcp.types import ToolAnnotations
+except (
+    ImportError
+):  # MCP extras may not be installed in superset-core-only environments
+    ToolAnnotations = Any  # type: ignore[assignment,misc]
 
 # Type variable for decorated functions
 F = TypeVar("F", bound=Callable[..., Any])

--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -42,7 +42,7 @@ try:
 except (
     ImportError
 ):  # MCP extras may not be installed in superset-core-only environments
-    ToolAnnotations = Any  # type: ignore[assignment]
+    ToolAnnotations = Any
 
 # Type variable for decorated functions
 F = TypeVar("F", bound=Callable[..., Any])

--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -42,7 +42,7 @@ try:
 except (
     ImportError
 ):  # MCP extras may not be installed in superset-core-only environments
-    ToolAnnotations = Any  # type: ignore[assignment,misc]
+    ToolAnnotations = Any  # type: ignore[assignment]
 
 # Type variable for decorated functions
 F = TypeVar("F", bound=Callable[..., Any])

--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -37,6 +37,8 @@ Usage:
 
 from typing import Any, Callable, TypeVar
 
+from mcp.types import ToolAnnotations
+
 # Type variable for decorated functions
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -50,6 +52,7 @@ def tool(
     protect: bool = True,
     class_permission_name: str | None = None,
     method_permission_name: str | None = None,
+    annotations: ToolAnnotations | None = None,
 ) -> Any:  # Use Any to avoid mypy issues with dependency injection
     """
     Decorator to register an MCP tool with optional authentication.
@@ -77,6 +80,8 @@ def tool(
             permission checking via security_manager.can_access().
         method_permission_name: FAB action name (e.g., "read", "write").
             Defaults to "write" if tags includes "mutate", else "read".
+        annotations: MCP tool annotations (title, readOnlyHint, destructiveHint, etc.)
+            These hints help MCP clients understand tool behavior and safety.
 
     Returns:
         Decorator function that registers and wraps the tool, or the wrapped function
@@ -178,4 +183,5 @@ def prompt(
 __all__ = [
     "tool",
     "prompt",
+    "ToolAnnotations",
 ]

--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -42,7 +42,7 @@ try:
 except (
     ImportError
 ):  # MCP extras may not be installed in superset-core-only environments
-    ToolAnnotations = Any
+    ToolAnnotations = dict
 
 # Type variable for decorated functions
 F = TypeVar("F", bound=Callable[..., Any])

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -25,6 +25,8 @@ that replaces the abstract functions in superset-core during initialization.
 import logging
 from typing import Any, Callable, Optional, TypeVar
 
+from mcp.types import ToolAnnotations
+
 from superset.extensions.context import get_current_extension_context
 
 # Type variable for decorated functions
@@ -62,6 +64,7 @@ def create_tool_decorator(
     protect: bool = True,
     class_permission_name: Optional[str] = None,
     method_permission_name: Optional[str] = None,
+    annotations: Optional[ToolAnnotations] = None,
 ) -> Callable[[F], F] | F:
     """
     Create the concrete MCP tool decorator implementation.
@@ -82,6 +85,7 @@ def create_tool_decorator(
             (e.g., "Chart", "Dashboard", "SQLLab"). Enables permission checking.
         method_permission_name: FAB action name (e.g., "read", "write").
             Defaults to "write" if tags has "mutate", else "read".
+        annotations: MCP tool annotations (title, readOnlyHint, destructiveHint, etc.)
 
     Returns:
         Decorator that registers and wraps the tool with optional authentication,
@@ -130,6 +134,7 @@ def create_tool_decorator(
                 name=tool_name,
                 description=tool_description,
                 tags=tool_tags,
+                annotations=annotations,
             )
             mcp.add_tool(tool)
 

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -67,7 +67,7 @@ def create_tool_decorator(
     protect: bool = True,
     class_permission_name: Optional[str] = None,
     method_permission_name: Optional[str] = None,
-    annotations: Optional[ToolAnnotations] = None,
+    annotations: ToolAnnotations | None = None,
 ) -> Callable[[F], F] | F:
     """
     Create the concrete MCP tool decorator implementation.

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Optional, TypeVar
 try:
     from mcp.types import ToolAnnotations
 except ImportError:
-    ToolAnnotations = Any
+    ToolAnnotations = dict
 
 from superset.extensions.context import get_current_extension_context
 

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Optional, TypeVar
 try:
     from mcp.types import ToolAnnotations
 except ImportError:
-    ToolAnnotations = Any  # type: ignore[assignment,misc]
+    ToolAnnotations = Any  # type: ignore[assignment]
 
 from superset.extensions.context import get_current_extension_context
 

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Optional, TypeVar
 try:
     from mcp.types import ToolAnnotations
 except ImportError:
-    ToolAnnotations = Any  # type: ignore[assignment]
+    ToolAnnotations = Any
 
 from superset.extensions.context import get_current_extension_context
 

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -25,7 +25,10 @@ that replaces the abstract functions in superset-core during initialization.
 import logging
 from typing import Any, Callable, Optional, TypeVar
 
-from mcp.types import ToolAnnotations
+try:
+    from mcp.types import ToolAnnotations
+except ImportError:
+    ToolAnnotations = Any  # type: ignore[assignment,misc]
 
 from superset.extensions.context import get_current_extension_context
 

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List
 from urllib.parse import parse_qs, urlparse
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException
 from superset.extensions import event_logger
@@ -119,7 +119,15 @@ def _compile_chart(
         return CompileResult(success=False, error=str(exc))
 
 
-@tool(tags=["mutate"], class_permission_name="Chart")
+@tool(
+    tags=["mutate"],
+    class_permission_name="Chart",
+    annotations=ToolAnnotations(
+        title="Create chart",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GenerateChartRequest)
 async def generate_chart(  # noqa: C901
     request: GenerateChartRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, TYPE_CHECKING
 
 from fastmcp import Context
 from flask import current_app
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.models.slice import Slice
@@ -74,7 +74,15 @@ def _get_cached_form_data(form_data_key: str) -> str | None:
         return None
 
 
-@tool(tags=["data"], class_permission_name="Chart")
+@tool(
+    tags=["data"],
+    class_permission_name="Chart",
+    annotations=ToolAnnotations(
+        title="Get chart data",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GetChartDataRequest)
 async def get_chart_data(  # noqa: C901
     request: GetChartDataRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -23,7 +23,7 @@ import logging
 
 from fastmcp import Context
 from sqlalchemy.orm import subqueryload
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
@@ -115,7 +115,15 @@ def _apply_unsaved_state_override(result: ChartInfo, form_data_key: str) -> None
         )
 
 
-@tool(tags=["discovery"], class_permission_name="Chart")
+@tool(
+    tags=["discovery"],
+    class_permission_name="Chart",
+    annotations=ToolAnnotations(
+        title="Get chart info",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GetChartInfoRequest)
 async def get_chart_info(
     request: GetChartInfoRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -23,7 +23,7 @@ import logging
 from typing import Any, Dict, List, Protocol
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException
 from superset.exceptions import SupersetException
@@ -2177,7 +2177,15 @@ async def _get_chart_preview_internal(  # noqa: C901
         )
 
 
-@tool(tags=["data"], class_permission_name="Chart")
+@tool(
+    tags=["data"],
+    class_permission_name="Chart",
+    annotations=ToolAnnotations(
+        title="Get chart preview",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GetChartPreviewRequest)
 async def get_chart_preview(
     request: GetChartPreviewRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -23,7 +23,7 @@ import logging
 from typing import cast, TYPE_CHECKING
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.models.slice import Slice
@@ -62,7 +62,15 @@ SORTABLE_CHART_COLUMNS = [
 ]
 
 
-@tool(tags=["core"], class_permission_name="Chart")
+@tool(
+    tags=["core"],
+    class_permission_name="Chart",
+    annotations=ToolAnnotations(
+        title="List charts",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(ListChartsRequest)
 async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
     """List charts with filtering and search.

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -23,7 +23,7 @@ import logging
 import time
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import (
@@ -45,7 +45,15 @@ from superset.utils import json
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["mutate"], class_permission_name="Chart")
+@tool(
+    tags=["mutate"],
+    class_permission_name="Chart",
+    annotations=ToolAnnotations(
+        title="Update chart",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
 @parse_request(UpdateChartRequest)
 async def update_chart(
     request: UpdateChartRequest, ctx: Context

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
     annotations=ToolAnnotations(
         title="Update chart",
         readOnlyHint=False,
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @parse_request(UpdateChartRequest)

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
     annotations=ToolAnnotations(
         title="Update chart preview",
         readOnlyHint=False,
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @parse_request(UpdateChartPreviewRequest)

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -24,7 +24,7 @@ import time
 from typing import Any, Dict
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import (
@@ -44,7 +44,16 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["mutate"], class_permission_name="Chart", method_permission_name="write")
+@tool(
+    tags=["mutate"],
+    class_permission_name="Chart",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Update chart preview",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
 @parse_request(UpdateChartPreviewRequest)
 def update_chart_preview(
     request: UpdateChartPreviewRequest, ctx: Context

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -311,7 +311,7 @@ def _ensure_layout_structure(
     annotations=ToolAnnotations(
         title="Add chart to dashboard",
         readOnlyHint=False,
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @parse_request(AddChartToDashboardRequest)

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -26,7 +26,7 @@ import re
 from typing import Any, Dict
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.chart.schemas import serialize_chart_object
@@ -305,7 +305,15 @@ def _ensure_layout_structure(
         layout["DASHBOARD_VERSION_KEY"] = "v2"
 
 
-@tool(tags=["mutate"], class_permission_name="Dashboard")
+@tool(
+    tags=["mutate"],
+    class_permission_name="Dashboard",
+    annotations=ToolAnnotations(
+        title="Add chart to dashboard",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
 @parse_request(AddChartToDashboardRequest)
 def add_chart_to_existing_dashboard(
     request: AddChartToDashboardRequest, ctx: Context

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -311,7 +311,7 @@ def _ensure_layout_structure(
     annotations=ToolAnnotations(
         title="Add chart to dashboard",
         readOnlyHint=False,
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @parse_request(AddChartToDashboardRequest)

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -25,7 +25,7 @@ import logging
 from typing import Any, Dict, List
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.chart.schemas import serialize_chart_object
@@ -178,7 +178,15 @@ def _generate_title_from_charts(chart_objects: List[Any]) -> str:
     return title
 
 
-@tool(tags=["mutate"], class_permission_name="Dashboard")
+@tool(
+    tags=["mutate"],
+    class_permission_name="Dashboard",
+    annotations=ToolAnnotations(
+        title="Create dashboard",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GenerateDashboardRequest)
 def generate_dashboard(
     request: GenerateDashboardRequest, ctx: Context

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 
 from fastmcp import Context
 from sqlalchemy.orm import subqueryload
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.dashboards.permalink.exceptions import DashboardPermalinkGetFailedError
 from superset.dashboards.permalink.types import DashboardPermalinkValue
@@ -59,7 +59,15 @@ def _get_permalink_state(permalink_key: str) -> DashboardPermalinkValue | None:
         return None
 
 
-@tool(tags=["discovery"], class_permission_name="Dashboard")
+@tool(
+    tags=["discovery"],
+    class_permission_name="Dashboard",
+    annotations=ToolAnnotations(
+        title="Get dashboard info",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GetDashboardInfoRequest)
 async def get_dashboard_info(
     request: GetDashboardInfoRequest, ctx: Context

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -26,7 +26,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.models.dashboard import Dashboard
@@ -63,7 +63,15 @@ SORTABLE_DASHBOARD_COLUMNS = [
 ]
 
 
-@tool(tags=["core"], class_permission_name="Dashboard")
+@tool(
+    tags=["core"],
+    class_permission_name="Dashboard",
+    annotations=ToolAnnotations(
+        title="List dashboards",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(ListDashboardsRequest)
 async def list_dashboards(
     request: ListDashboardsRequest, ctx: Context

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 
 from fastmcp import Context
 from sqlalchemy.orm import joinedload, subqueryload
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.dataset.schemas import (
@@ -42,7 +42,15 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["discovery"], class_permission_name="Dataset")
+@tool(
+    tags=["discovery"],
+    class_permission_name="Dataset",
+    annotations=ToolAnnotations(
+        title="Get dataset info",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GetDatasetInfoRequest)
 async def get_dataset_info(
     request: GetDatasetInfoRequest, ctx: Context

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -26,7 +26,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
@@ -61,7 +61,15 @@ SORTABLE_DATASET_COLUMNS = [
 ]
 
 
-@tool(tags=["core"], class_permission_name="Dataset")
+@tool(
+    tags=["core"],
+    class_permission_name="Dataset",
+    annotations=ToolAnnotations(
+        title="List datasets",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(ListDatasetsRequest)
 async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetList:
     """List datasets with filtering and search.

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -44,7 +44,7 @@ from superset.mcp_service.utils.schema_utils import parse_request
     class_permission_name="Explore",
     annotations=ToolAnnotations(
         title="Generate explore link",
-        readOnlyHint=True,
+        readOnlyHint=False,
         destructiveHint=False,
     ),
 )

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -26,7 +26,7 @@ from typing import Any, Dict
 from urllib.parse import parse_qs, urlparse
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import (
@@ -39,7 +39,15 @@ from superset.mcp_service.chart.schemas import (
 from superset.mcp_service.utils.schema_utils import parse_request
 
 
-@tool(tags=["explore"], class_permission_name="Explore")
+@tool(
+    tags=["explore"],
+    class_permission_name="Explore",
+    annotations=ToolAnnotations(
+        title="Generate explore link",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GenerateExploreLinkRequest)
 async def generate_explore_link(
     request: GenerateExploreLinkRequest, ctx: Context

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
     annotations=ToolAnnotations(
         title="Execute SQL query",
         readOnlyHint=False,
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @parse_request(ExecuteSqlRequest)

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -28,7 +28,7 @@ import logging
 from typing import Any
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 from superset_core.queries.types import (
     CacheOptions,
     QueryOptions,
@@ -55,6 +55,11 @@ logger = logging.getLogger(__name__)
     tags=["mutate"],
     class_permission_name="SQLLab",
     method_permission_name="execute_sql_query",
+    annotations=ToolAnnotations(
+        title="Execute SQL query",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
 )
 @parse_request(ExecuteSqlRequest)
 async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlResponse:

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -25,7 +25,7 @@ import logging
 from urllib.parse import urlencode
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.sql_lab.schemas import (
@@ -38,7 +38,16 @@ from superset.mcp_service.utils.url_utils import get_superset_base_url
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["explore"], class_permission_name="SQLLab", method_permission_name="read")
+@tool(
+    tags=["explore"],
+    class_permission_name="SQLLab",
+    method_permission_name="read",
+    annotations=ToolAnnotations(
+        title="Open SQL Lab with context",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(OpenSqlLabRequest)
 def open_sql_lab_with_context(
     request: OpenSqlLabRequest, ctx: Context

--- a/superset/mcp_service/sql_lab/tool/save_sql_query.py
+++ b/superset/mcp_service/sql_lab/tool/save_sql_query.py
@@ -45,6 +45,8 @@ logger = logging.getLogger(__name__)
 
 @tool(
     tags=["mutate"],
+    class_permission_name="SQLLab",
+    method_permission_name="write",
     annotations=ToolAnnotations(
         title="Save SQL query",
         readOnlyHint=False,

--- a/superset/mcp_service/sql_lab/tool/save_sql_query.py
+++ b/superset/mcp_service/sql_lab/tool/save_sql_query.py
@@ -29,7 +29,7 @@ import logging
 
 from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetErrorException, SupersetSecurityException
@@ -43,7 +43,14 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-@tool(tags=["mutate"])
+@tool(
+    tags=["mutate"],
+    annotations=ToolAnnotations(
+        title="Save SQL query",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
 @parse_request(SaveSqlQueryRequest)
 async def save_sql_query(
     request: SaveSqlQueryRequest, ctx: Context

--- a/superset/mcp_service/sql_lab/tool/save_sql_query.py
+++ b/superset/mcp_service/sql_lab/tool/save_sql_query.py
@@ -138,7 +138,7 @@ async def save_sql_query(
     except SQLAlchemyError as e:
         from superset import db
 
-        db.session.rollback()
+        db.session.rollback()  # pylint: disable=consider-using-transaction
         await ctx.error(
             "Failed to save SQL query: error=%s, database_id=%s"
             % (str(e), request.database_id)

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -23,7 +23,7 @@ InstanceInfoCore for flexible, extensible metrics calculation.
 import logging
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.mcp_core import InstanceInfoCore
@@ -73,7 +73,14 @@ _instance_info_core = InstanceInfoCore(
 )
 
 
-@tool(tags=["core"])
+@tool(
+    tags=["core"],
+    annotations=ToolAnnotations(
+        title="Get instance info",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GetSupersetInstanceInfoRequest)
 def get_instance_info(
     request: GetSupersetInstanceInfoRequest, ctx: Context

--- a/superset/mcp_service/system/tool/get_schema.py
+++ b/superset/mcp_service/system/tool/get_schema.py
@@ -27,7 +27,7 @@ import logging
 from typing import Callable, Literal
 
 from fastmcp import Context
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.common.schema_discovery import (
@@ -121,7 +121,14 @@ _SCHEMA_CORE_FACTORIES: dict[
 }
 
 
-@tool(tags=["discovery"])
+@tool(
+    tags=["discovery"],
+    annotations=ToolAnnotations(
+        title="Get schema",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 @parse_request(GetSchemaRequest)
 async def get_schema(request: GetSchemaRequest, ctx: Context) -> GetSchemaResponse:
     """

--- a/superset/mcp_service/system/tool/health_check.py
+++ b/superset/mcp_service/system/tool/health_check.py
@@ -23,7 +23,7 @@ import platform
 import time
 
 from flask import current_app
-from superset_core.mcp.decorators import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.system.schemas import HealthCheckResponse
@@ -34,7 +34,14 @@ logger = logging.getLogger(__name__)
 _start_time = time.monotonic()
 
 
-@tool(tags=["core"])
+@tool(
+    tags=["core"],
+    annotations=ToolAnnotations(
+        title="Health check",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
 async def health_check() -> HealthCheckResponse:
     """
     Simple health check tool for testing the MCP service.


### PR DESCRIPTION
## **User description**
### SUMMARY

Add `ToolAnnotations` (`title`, `readOnlyHint`, `destructiveHint`) to all 20 MCP tools so that MCP directory services and clients can surface human-readable titles and understand each tool's safety profile.

**What changed:**

1. **Abstract decorator** (`superset-core/src/superset_core/mcp/decorators.py`): Added `annotations: ToolAnnotations | None = None` parameter and re-exported `ToolAnnotations` from `mcp.types` in `__all__`.

2. **Concrete decorator** (`superset/core/mcp/core_mcp_injection.py`): Added `annotations` parameter that gets passed through to `Tool.from_function()`.

3. **All 20 tool files**: Added `ToolAnnotations` import and `annotations=ToolAnnotations(title=..., readOnlyHint=..., destructiveHint=False)` to each `@tool(...)` decorator:
   - **14 read-only tools** (`readOnlyHint=True`): health_check, get_instance_info, get_schema, list_charts, get_chart_info, get_chart_preview, get_chart_data, list_dashboards, get_dashboard_info, list_datasets, get_dataset_info, execute_sql, open_sql_lab_with_context, generate_explore_link
   - **6 mutating tools** (`readOnlyHint=False`): generate_chart, update_chart, update_chart_preview, generate_dashboard, add_chart_to_existing_dashboard, save_sql_query

**Why:**

The MCP spec defines `ToolAnnotations` to help clients and directory services understand tool behavior. Adding `title` provides human-readable display names, `readOnlyHint` tells clients which tools only read data, and `destructiveHint=False` signals that no tool performs irreversible destructive operations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (backend-only change, no UI impact).

### TESTING INSTRUCTIONS

1. Verify all 20 tool files have `ToolAnnotations` in their `@tool()` decorator
2. Verify read-only tools have `readOnlyHint=True` and mutating tools have `readOnlyHint=False`
3. Verify all tools have `destructiveHint=False`
4. Run `ruff check` and `ruff format --check` on all changed files to confirm linting passes

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Add MCP tool annotations so directory clients see titles and safety hints

### What Changed
- All MCP tools now include human-readable titles and safety hints (readOnlyHint and destructiveHint) surfaced to MCP directory clients.
- The tool decorator implementations accept annotations and gracefully fall back when MCP types are not installed, preventing import errors in environments without MCP extras.
- Several tools that modify data are now flagged as destructive (for example: Execute SQL, Update chart, Update chart preview, Add chart to dashboard); Generate explore link is marked as mutating since it writes cache state; Save SQL query now has proper RBAC settings.

### Impact
`✅ Clearer tool display names in MCP directories`
`✅ Clearer destructive warnings for SQL and mutating tools`
`✅ Correct RBAC for saving SQL queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
