### PR TITLE
fix(embedded): default to light theme instead of system preference

### DIFF
--- a/superset-frontend/packages/superset-core/src/theme/types.ts
+++ b/superset-frontend/packages/superset-core/src/theme/types.ts
@@ -426,6 +426,7 @@ export interface ThemeControllerOptions {
   canUpdateTheme?: () => boolean;
   canUpdateMode?: () => boolean;
   isGlobalContext?: boolean;
+  initialMode?: ThemeMode;
 }
 
 export interface ThemeContextType {

--- a/superset-frontend/src/embedded/EmbeddedContextProviders.tsx
+++ b/superset-frontend/src/embedded/EmbeddedContextProviders.tsx
@@ -26,7 +26,7 @@ import { DynamicPluginProvider } from 'src/components';
 import { EmbeddedUiConfigProvider } from 'src/components/UiConfigContext';
 import { SupersetThemeProvider } from 'src/theme/ThemeProvider';
 import { ThemeController } from 'src/theme/ThemeController';
-import { type ThemeStorage } from '@apache-superset/core/theme';
+import { type ThemeStorage, ThemeMode } from '@apache-superset/core/theme';
 import { store } from 'src/views/store';
 import querystring from 'query-string';
 
@@ -52,6 +52,7 @@ class ThemeMemoryStorageAdapter implements ThemeStorage {
 
 const themeController = new ThemeController({
   storage: new ThemeMemoryStorageAdapter(),
+  initialMode: ThemeMode.DEFAULT,
 });
 
 export const getThemeController = (): ThemeController => themeController;

--- a/superset-frontend/src/theme/ThemeController.ts
+++ b/superset-frontend/src/theme/ThemeController.ts
@@ -102,15 +102,19 @@ export class ThemeController {
   // Track loaded font URLs to avoid duplicate injections
   private loadedFontUrls: Set<string> = new Set();
 
+  private initialMode: ThemeMode | undefined;
+
   constructor({
     storage = new LocalStorageAdapter(),
     modeStorageKey = STORAGE_KEYS.THEME_MODE,
     themeObject = supersetThemeObject,
     defaultTheme = (supersetThemeObject.theme as AnyThemeConfig) ?? {},
     onChange = undefined,
+    initialMode = undefined,
   }: ThemeControllerOptions = {}) {
     this.storage = storage;
     this.modeStorageKey = modeStorageKey;
+    this.initialMode = initialMode;
 
     // Controller creates and owns the global theme
     this.globalTheme = themeObject;
@@ -742,6 +746,9 @@ export class ThemeController {
       this.storage.removeItem(this.modeStorageKey);
       return ThemeMode.DEFAULT;
     }
+
+    // Use explicit initial mode if provided (e.g. embedded dashboards default to light)
+    if (this.initialMode !== undefined) return this.initialMode;
 
     // Default to system preference when both themes are available
     return ThemeMode.SYSTEM;

--- a/superset-frontend/src/theme/ThemeController.ts
+++ b/superset-frontend/src/theme/ThemeController.ts
@@ -748,7 +748,11 @@ export class ThemeController {
     }
 
     // Use explicit initial mode if provided (e.g. embedded dashboards default to light)
-    if (this.initialMode !== undefined) return this.initialMode;
+    if (
+      this.initialMode !== undefined &&
+      this.isValidThemeMode(this.initialMode)
+    )
+      return this.initialMode;
 
     // Default to system preference when both themes are available
     return ThemeMode.SYSTEM;

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -1687,8 +1687,6 @@ test('font loading: adds new font URLs when switching themes', () => {
     .forEach(el => el.remove());
 });
 
-// initialMode option tests (embedded dashboard fix: sc-101450)
-
 test('ThemeController uses initialMode when provided and no saved mode exists', () => {
   mockGetBootstrapData.mockReturnValue(
     createMockBootstrapData({

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -1781,3 +1781,20 @@ test('ThemeController initialMode is ignored when no dark theme exists', () => {
   // Should still be DEFAULT because there's no dark theme available
   expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
 });
+
+test('ThemeController invalid initialMode falls back to SYSTEM', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  const controller = createController({
+    initialMode: 'invalid' as ThemeMode,
+  });
+
+  // Invalid initialMode should be rejected by isValidThemeMode,
+  // falling through to the default SYSTEM mode
+  expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
+});

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -1686,3 +1686,100 @@ test('font loading: adds new font URLs when switching themes', () => {
     .querySelectorAll('style[data-superset-fonts]')
     .forEach(el => el.remove());
 });
+
+// initialMode option tests (embedded dashboard fix: sc-101450)
+
+test('ThemeController uses initialMode when provided and no saved mode exists', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  const controller = createController({ initialMode: ThemeMode.DEFAULT });
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+});
+
+test('ThemeController defaults to SYSTEM when initialMode is not provided', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  const controller = createController();
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
+});
+
+test('ThemeController saved mode takes precedence over initialMode', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  mockLocalStorage.getItem.mockReturnValue(ThemeMode.DARK);
+
+  const controller = createController({ initialMode: ThemeMode.DEFAULT });
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
+});
+
+test('ThemeController with initialMode DEFAULT applies light theme even when system prefers dark', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  mockMatchMedia.mockReturnValue({
+    matches: true, // system prefers dark
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  });
+
+  const controller = createController({ initialMode: ThemeMode.DEFAULT });
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+  const lastCall =
+    mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+  expect(lastCall.token.colorBgBase).toBe(DEFAULT_THEME.token!.colorBgBase);
+});
+
+test('ThemeController with initialMode still allows setThemeMode after init', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  const controller = createController({ initialMode: ThemeMode.DEFAULT });
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+
+  controller.setThemeMode(ThemeMode.DARK);
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
+
+  controller.setThemeMode(ThemeMode.SYSTEM);
+  expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
+});
+
+test('ThemeController initialMode is ignored when no dark theme exists', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: {},
+    }),
+  );
+
+  const controller = createController({ initialMode: ThemeMode.SYSTEM });
+
+  // Should still be DEFAULT because there's no dark theme available
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+});


### PR DESCRIPTION
### SUMMARY

Embedded dashboards were inheriting the user's OS dark/light mode preference instead of defaulting to light mode. When both default and dark themes are available via bootstrap data, `ThemeController.determineInitialMode()` defaults to `ThemeMode.SYSTEM`, which reads `prefers-color-scheme` from the user's OS. The SDK's `setThemeMode()` fires after initial render via postMessage, so the wrong theme is shown first.

**Fix**: Add `initialMode` option to `ThemeControllerOptions`. Embedded contexts pass `ThemeMode.DEFAULT` so they start in light mode. Main app behavior is unchanged (still defaults to SYSTEM when both themes exist). The SDK can still override the mode after init. Invalid `initialMode` values are validated with `isValidThemeMode()` and fall back to SYSTEM, matching the existing `savedMode` check.

**Files changed:**
- `packages/superset-core/src/theme/types.ts` — Added `initialMode?: ThemeMode` to `ThemeControllerOptions`
- `src/theme/ThemeController.ts` — Store and use `initialMode` as fallback in `determineInitialMode()`, with `isValidThemeMode()` validation
- `src/embedded/EmbeddedContextProviders.tsx` — Pass `initialMode: ThemeMode.DEFAULT`
- `src/theme/tests/ThemeController.test.ts` — 7 new tests (73/73 passing)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**: Embedded dashboard renders in dark mode if user's OS is set to dark mode, ignoring SDK theme setting.
**After**: Embedded dashboard renders in light mode by default. SDK `setThemeMode()` can still switch to dark/system.

### TESTING INSTRUCTIONS

1. Set your OS to dark mode
2. Load an embedded dashboard (via the Superset Embedded SDK)
3. Verify the dashboard renders in **light mode** by default
4. Call `setThemeMode('dark')` via the SDK — verify it switches to dark mode
5. Call `setThemeMode('system')` via the SDK — verify it follows OS preference
6. Verify non-embedded Superset still follows system theme preference

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API