### PR TITLE
fix(FilterBar): reduce padded space between filter header and first filter

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -33,6 +33,7 @@ const TitleArea = styled.div`
     justify-content: space-between;
     margin: 0;
     padding: 0 ${theme.sizeUnit * 2}px ${theme.sizeUnit * 2}px;
+    padding-bottom: 0;
 
     & > span {
       font-size: ${theme.fontSizeLG}px;
@@ -56,9 +57,7 @@ const HeaderButton = styled(Button)`
 
 const Wrapper = styled.div`
   ${({ theme }) => `
-    padding: ${theme.sizeUnit * 3}px ${theme.sizeUnit * 2}px ${
-      theme.sizeUnit
-    }px;
+    padding: ${theme.sizeUnit * 3}px ${theme.sizeUnit * 2}px 0px;
   `}
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -33,7 +33,7 @@ const TitleArea = styled.div`
     justify-content: space-between;
     margin: 0;
     padding: 0 ${theme.sizeUnit * 2}px ${theme.sizeUnit * 2}px;
-    padding-bottom: 0;
+    padding-bottom: 0; /* Works with other changes in PR https://github.com/apache/superset/pull/38646 to reduces space between filter header and 1st filter */
 
     & > span {
       font-size: ${theme.fontSizeLG}px;
@@ -57,7 +57,8 @@ const HeaderButton = styled(Button)`
 
 const Wrapper = styled.div`
   ${({ theme }) => `
-    padding: ${theme.sizeUnit * 3}px ${theme.sizeUnit * 2}px 0px;
+    padding: ${theme.sizeUnit * 3}px ${theme.sizeUnit * 2}px;
+    padding-bottom: 0; /* Works with other changes in PR https://github.com/apache/superset/pull/38646 to reduces space between filter header and 1st filter */
   `}
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -119,6 +119,7 @@ const FilterControlsWrapper = styled.div`
     flex-direction: column;
     gap: ${theme.sizeUnit * 2}px;
     padding: ${theme.sizeUnit * 4}px;
+    padding-top: 0;
     // 108px padding to make room for buttons with position: absolute
     padding-bottom: ${theme.sizeUnit * 27}px;
   `}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -119,7 +119,7 @@ const FilterControlsWrapper = styled.div`
     flex-direction: column;
     gap: ${theme.sizeUnit * 2}px;
     padding: ${theme.sizeUnit * 4}px;
-    padding-top: 0;
+    padding-top: 0; /* Works with other changes in PR https://github.com/apache/superset/pull/38646 to reduces space between filter header and 1st filter */
     // 108px padding to make room for buttons with position: absolute
     padding-bottom: ${theme.sizeUnit * 27}px;
   `}


### PR DESCRIPTION
## **User description**
fix(FilterBar): reduce padded space between filter header and first filter
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #38600 

Reduces ~24px of space buffering filter header and first filter. All modified components are of Vertical type so no changes to Horizontal mode. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="1487" height="887" alt="image" src="https://github.com/user-attachments/assets/81b603e3-0828-4c8a-aae2-82de55ad8609" />


After
<img width="1487" height="887" alt="image" src="https://github.com/user-attachments/assets/7fca5083-3670-4320-885a-5fec46e6421e" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Reduce excessive vertical gap between filter header and first filter in vertical filter bar

### What Changed
- Removed extra bottom/top padding so the header sits closer to the first filter in vertical filter bars
- Reduced overall top padding in the filter panel wrapper so content starts higher without affecting horizontal mode
- Visual spacing between header and first filter decreased by ~24px in vertical layout

### Impact
`✅ Less empty space in filter panels`
`✅ Shorter vertical filter bars on dashboards`
`✅ Clearer, tighter filter layout`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
