### PR TITLE
fix(ui): remove getPopupContainer to prevent double scrollbar in drop…

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -736,9 +736,7 @@ const Select = forwardRef(
           popupRender={popupRender}
           filterOption={handleFilterOption}
           filterSort={sortComparatorWithSearch}
-          getPopupContainer={
-            getPopupContainer || (triggerNode => triggerNode.parentNode)
-          }
+          getPopupContainer={getPopupContainer || (() => document.body)}
           headerPosition={headerPosition}
           labelInValue={labelInValue}
           maxTagCount={actualMaxTagCount}

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CustomFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CustomFrame.test.tsx
@@ -168,7 +168,7 @@ test('triggers onChange when the anchor changes', async () => {
     store,
   });
   await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
-  userEvent.click(screen.getByRole('radio', { name: 'Date/Time' }));
+  await userEvent.click(screen.getByRole('radio', { name: 'Date/Time' }));
   expect(onChange).toHaveBeenCalled();
 });
 
@@ -178,7 +178,7 @@ test('triggers onChange when the value changes', async () => {
     store,
   });
   await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
-  userEvent.click(screen.getByRole('img', { name: 'up' }));
+  await userEvent.click(screen.getByRole('img', { name: 'up' }));
   expect(onChange).toHaveBeenCalled();
 });
 
@@ -188,14 +188,15 @@ test('triggers onChange when the mode changes', async () => {
     store,
   });
   await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
-  userEvent.click(screen.getByTitle('Midnight'));
+  await userEvent.click(screen.getByTitle('Midnight'));
   expect(await screen.findByTitle('Relative Date/Time')).toBeInTheDocument();
-  userEvent.click(screen.getByTitle('Relative Date/Time'));
-  userEvent.click(screen.getAllByTitle('Now')[1]);
+  await userEvent.click(screen.getByTitle('Relative Date/Time'));
+  await userEvent.click(screen.getAllByTitle('Now')[1]);
   expect(
     await screen.findByText('Configure custom time range'),
   ).toBeInTheDocument();
-  userEvent.click(screen.getAllByTitle('Specific Date/Time')[1]);
+  const buttons = await screen.findAllByTitle('Specific Date/Time');
+  await userEvent.click(buttons[0]);
   await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
 });
 
@@ -205,12 +206,12 @@ test('triggers onChange when the grain changes', async () => {
     store,
   });
   await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
-  userEvent.click(screen.getByText('Days Before'));
+  await userEvent.click(screen.getByText('Days Before'));
   expect(await screen.findByText('Weeks Before')).toBeInTheDocument();
-  userEvent.click(screen.getByText('Weeks Before'));
-  userEvent.click(screen.getByText('Days After'));
+  await userEvent.click(screen.getByText('Weeks Before'));
+  await userEvent.click(screen.getByText('Days After'));
   expect(await screen.findByText('Weeks After')).toBeInTheDocument();
-  userEvent.click(screen.getByText('Weeks After'));
+  await userEvent.click(screen.getByText('Weeks After'));
   await waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
 });
 
@@ -221,10 +222,10 @@ test('triggers onChange when the date changes', async () => {
   });
   await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
   const inputs = screen.getAllByPlaceholderText('Select date');
-  userEvent.click(inputs[0]);
-  userEvent.click(screen.getAllByText('Now')[0]);
-  userEvent.click(inputs[1]);
-  userEvent.click(screen.getAllByText('Now')[1]);
+  await userEvent.click(inputs[0]);
+  await userEvent.click(screen.getAllByText('Now')[0]);
+  await userEvent.click(inputs[1]);
+  await userEvent.click(screen.getAllByText('Now')[1]);
   expect(onChange).toHaveBeenCalledTimes(2);
 });
 
@@ -237,7 +238,7 @@ test('should translate Date Picker', async () => {
     store,
   });
   await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
-  userEvent.click(screen.getAllByRole('img', { name: 'calendar' })[0]);
+  await userEvent.click(screen.getAllByRole('img', { name: 'calendar' })[0]);
   expect(screen.getByText('2021')).toBeInTheDocument();
 
   expect(screen.getByText('lu')).toBeInTheDocument();
@@ -266,13 +267,13 @@ test('calls onChange when START Specific Date/Time is selected', async () => {
   expect(specificDateTimeOptions.length).toBe(2);
 
   const calendarIcons = screen.getAllByRole('img', { name: 'calendar' });
-  userEvent.click(calendarIcons[0]);
+  await userEvent.click(calendarIcons[0]);
 
-  const randomDate = screen.getByTitle('2021-03-11');
-  userEvent.click(randomDate);
+  const randomDate = await screen.findByTitle('2021-03-11');
+  await userEvent.click(randomDate);
 
   const okButton = screen.getByText('OK');
-  userEvent.click(okButton);
+  await userEvent.click(okButton);
 
   expect(onChange).toHaveBeenCalled();
 });
@@ -294,13 +295,13 @@ test('calls onChange when END Specific Date/Time is selected', async () => {
   expect(specificDateTimeOptions.length).toBe(2);
 
   const calendarIcons = screen.getAllByRole('img', { name: 'calendar' });
-  userEvent.click(calendarIcons[1]);
+  await userEvent.click(calendarIcons[1]);
 
-  const randomDate = screen.getByTitle('2021-03-28');
-  userEvent.click(randomDate);
+  const randomDate = await screen.getByTitle('2021-03-28');
+  await userEvent.click(randomDate);
 
   const okButton = screen.getByText('OK');
-  userEvent.click(okButton);
+  await userEvent.click(okButton);
 
   expect(onChange).toHaveBeenCalled();
 });
@@ -330,13 +331,13 @@ test('calls onChange when a date is picked from anchor mode date picker', async 
   expect(dateTimeRadio).toBeChecked();
 
   const calendarIcon = screen.getByRole('img', { name: 'calendar' });
-  userEvent.click(calendarIcon);
+  await userEvent.click(calendarIcon);
 
-  const randomDate = screen.getByTitle('2024-06-05');
-  userEvent.click(randomDate);
+  const randomDate = await screen.getByTitle('2024-06-05');
+  await userEvent.click(randomDate);
 
   const okButton = screen.getByText('OK');
-  userEvent.click(okButton);
+  await userEvent.click(okButton);
 
   expect(onChange).toHaveBeenCalled();
 });

--- a/superset-frontend/src/explore/components/controls/SelectControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.test.tsx
@@ -95,7 +95,7 @@ describe('SelectControl', () => {
       expect(selectorInput).toBeInTheDocument();
     });
 
-    test('renders as mode multiple', () => {
+    test('renders as mode multiple', async () => {
       renderSelectControl({ multi: true });
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
@@ -106,11 +106,13 @@ describe('SelectControl', () => {
       );
       expect(selectorWrapper).toBeInTheDocument();
       expect(selectorInput).toBeInTheDocument();
-      userEvent.click(selectorInput);
-      expect(screen.getByText('Select all (3)')).toBeInTheDocument();
+      await userEvent.click(selectorInput);
+      expect(
+        await within(document.body).findByText('Select all (3)'),
+      ).toBeInTheDocument();
     });
 
-    test('renders with allowNewOptions when freeForm', () => {
+    test('renders with allowNewOptions when freeForm', async () => {
       renderSelectControl({ freeForm: true });
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
@@ -123,16 +125,18 @@ describe('SelectControl', () => {
       expect(selectorInput).toBeInTheDocument();
 
       // Expect a new option to be selectable.
-      userEvent.click(selectorInput);
-      userEvent.type(selectorInput, 'a new option');
-      act(() => jest.runAllTimers());
-      expect(within(selectorWrapper).getByRole('option')).toHaveTextContent(
-        'a new option',
-      );
+      await userEvent.click(selectorInput);
+      await userEvent.type(selectorInput, 'a new option');
+      await act(async () => {
+        jest.runAllTimers();
+      });
+      await screen.findByText('a new option');
+      const option = await within(document.body).findByText('a new option');
+      expect(option).toBeInTheDocument();
     });
 
-    test('renders with allowNewOptions=false when freeForm=false', () => {
-      const container = renderSelectControl({ freeForm: false });
+    test('renders with allowNewOptions=false when freeForm=false', async () => {
+      renderSelectControl({ freeForm: false });
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
       });
@@ -144,19 +148,22 @@ describe('SelectControl', () => {
       expect(selectorInput).toBeInTheDocument();
 
       // Expect no new option to be selectable.
-      userEvent.click(selectorInput);
-      userEvent.type(selectorInput, 'a new option');
-      act(() => jest.advanceTimersByTime(300));
+      await userEvent.click(selectorInput);
+      await userEvent.type(selectorInput, 'a new option');
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
 
       expect(
-        container.querySelector('[role="option"]'),
+        screen.queryByRole('option'),
       ).not.toBeInTheDocument();
+
       expect(
-        within(selectorWrapper).getByText('No data', { selector: 'div' }),
+        await screen.findByText('No data'),
       ).toBeInTheDocument();
     });
 
-    test('renders with tokenSeparators', () => {
+    test('renders with tokenSeparators', async () => {
       renderSelectControl({ tokenSeparators: ['\n', '\t', ';'], multi: true });
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
@@ -168,18 +175,22 @@ describe('SelectControl', () => {
       expect(selectorWrapper).toBeInTheDocument();
       expect(selectorInput).toBeInTheDocument();
 
-      userEvent.click(selectorInput);
+      await userEvent.click(selectorInput);
       const paste = createEvent.paste(selectorInput, {
         clipboardData: {
           getData: () => '1 year ago;1 week ago',
         },
       });
       fireEvent(selectorInput, paste);
-      const yearOption = screen.getByRole('option', { name: /1 year ago/i });
+      const yearOption = await within(document.body).findByRole('option', {
+        name: /1 year ago/i,
+      });
       expect(yearOption).toBeInTheDocument();
       expect(yearOption).toHaveAttribute('aria-selected', 'true');
-      const weekOption = screen.getByRole('option', { name: /1 week ago/ });
-      expect(weekOption?.getAttribute('aria-selected')).toEqual('true');
+      const weekOption = await within(document.body).findByRole('option', {
+        name: /1 week ago/,
+      });
+      expect(weekOption).toHaveAttribute('aria-selected', 'true');
     });
 
     // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -1157,9 +1157,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           // For all other options, sort alphabetically
           return String(a.label).localeCompare(String(b.label));
         }}
-        getPopupContainer={triggerNode =>
-          triggerNode.parentElement || document.body
-        }
         dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
       />
       <Alert


### PR DESCRIPTION
## **User description**
### SUMMARY
Fixes the dual scrollbar issue in dropdown menus by removing custom `getPopupContainer` overrides that forced dropdowns to render inside constrained parent containers.

Allowing Ant Design to render dropdowns in `document.body` (default behavior) prevents nested scroll containers and resolves the double scrollbar problem.

### TESTING INSTRUCTIONS
1. Start Superset locally
2. Navigate to Database configuration modal
3. Open dropdown fields with long option lists
4. Verify only a single scrollbar appears in the dropdown menu.

### ADDITIONAL INFORMATION
Fixes #35833

- [x] Has associated issue: #35833
- [x] Changes UI


___

## **CodeAnt-AI Description**
Render dropdowns into page body to fix double scrollbar in modals

### What Changed
- Dropdown components now render their popup menus into the top-level page body instead of inside parent containers; this removes nested scrollbars in modals and long dropdown lists.
- Database configuration modal no longer forces dropdowns to render inside the modal, so long option lists show a single, correct scrollbar.
- UI tests updated to await interactions and to look for dropdown content in document.body to match the new rendering location and avoid flakiness.

### Impact
`✅ Fewer double scrollbars in dropdowns`
`✅ Clearer dropdown lists in modals with long option sets`
`✅ More reliable UI tests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
