### PR TITLE
feat: add PDF export for Superset chart exports and introduce new PDF…

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -80,7 +80,7 @@ case "${1}" in
     ;;
   app)
     echo "Starting web app (using development server)..."
-    flask run -p $PORT --reload --debugger --without-threads --host=0.0.0.0 --exclude-patterns "*/node_modules/*:*/.venv/*:*/build/*:*/__pycache__/*"
+    flask run -p $PORT --reload --debugger --without-threads --host=0.0.0.0 --exclude-patterns "*/node_modules/*:*/.venv/*:*/build/*:*/__pycache__/*:*/superset_home/*"
     ;;
   app-gunicorn)
     echo "Starting web app..."

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -144,6 +144,7 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
       logEvent,
       exportCSV = () => ({}),
       exportXLSX = () => ({}),
+      exportPDF = () => ({}),
       editMode = false,
       annotationQuery = {},
       annotationError = {},
@@ -358,6 +359,7 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
                   exportPivotCSV={exportPivotCSV}
                   exportFullCSV={exportFullCSV}
                   exportXLSX={exportXLSX}
+                  exportPDF={exportPDF}
                   exportFullXLSX={exportFullXLSX}
                   supersetCanExplore={supersetCanExplore}
                   supersetCanShare={supersetCanShare}

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -38,6 +38,7 @@ const createProps = (viz_type = VizType.Sunburst) =>
     exportCSV: jest.fn(),
     exportFullCSV: jest.fn(),
     exportXLSX: jest.fn(),
+    exportPDF: jest.fn(),
     exportFullXLSX: jest.fn(),
     exportPivotExcel: jest.fn(),
     forceRefresh: jest.fn(),
@@ -193,6 +194,17 @@ test('Should "export to Excel"', async () => {
   userEvent.click(await screen.findByText('Export to Excel'));
   expect(props.exportXLSX).toHaveBeenCalledTimes(1);
   expect(props.exportXLSX).toHaveBeenCalledWith(371);
+});
+
+test('Should "export to PDF"', async () => {
+  const props = createProps();
+  renderWrapper(props);
+  openMenu();
+  expect(props.exportPDF).toHaveBeenCalledTimes(0);
+  userEvent.hover(screen.getByText('Download'));
+  userEvent.click(await screen.findByText('Export to PDF'));
+  expect(props.exportPDF).toHaveBeenCalledTimes(1);
+  expect(props.exportPDF).toHaveBeenCalledWith(371);
 });
 
 test('Export full CSV is under featureflag', async () => {

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -127,6 +127,7 @@ export interface SliceHeaderControlsProps {
   exportPivotCSV?: (sliceId: number) => void;
   exportFullCSV?: (sliceId: number) => void;
   exportXLSX?: (sliceId: number) => void;
+  exportPDF?: (sliceId: number) => void;
   exportFullXLSX?: (sliceId: number) => void;
   handleToggleFullSize: () => void;
   exportPivotExcel?: (tableSelector: string, sliceName: string) => void;
@@ -245,6 +246,10 @@ const SliceHeaderControls = (
       case MenuKeys.ExportXlsx:
         // eslint-disable-next-line no-unused-expressions
         props.exportXLSX?.(props.slice.slice_id);
+        break;
+      case MenuKeys.ExportPdf:
+        // eslint-disable-next-line no-unused-expressions
+        props.exportPDF?.(props.slice.slice_id);
         break;
       case MenuKeys.DownloadAsImage: {
         // menu closes with a delay, we need to hide it manually,
@@ -527,6 +532,11 @@ const SliceHeaderControls = (
         {
           key: MenuKeys.ExportXlsx,
           label: t('Export to Excel'),
+          icon: <Icons.FileOutlined css={dropdownIconsStyles} />,
+        },
+        {
+          key: MenuKeys.ExportPdf,
+          label: t('Export to PDF'),
           icon: <Icons.FileOutlined css={dropdownIconsStyles} />,
         },
         ...(isFeatureEnabled(FeatureFlag.AllowFullCsvExport) &&

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/types.ts
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/types.ts
@@ -49,6 +49,7 @@ export interface SliceHeaderControlsProps {
   exportPivotCSV?: (sliceId: number) => void;
   exportFullCSV?: (sliceId: number) => void;
   exportXLSX?: (sliceId: number) => void;
+  exportPDF?: (sliceId: number) => void;
   exportFullXLSX?: (sliceId: number) => void;
   handleToggleFullSize: () => void;
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.tsx
@@ -256,6 +256,30 @@ test('should call exportChart when exportXLSX is clicked', async () => {
   stubbedExportXLSX.mockRestore();
 });
 
+test('should call exportChart when exportPDF is clicked', async () => {
+  const stubbedExportPDF = jest
+    .spyOn(exploreUtils, 'exportChart')
+    .mockImplementation((() => {}) as any);
+  const { findByText, getByRole } = setup(
+    {},
+    {
+      dashboardInfo: { ...defaultState.dashboardInfo, superset_can_csv: true },
+    },
+  );
+  fireEvent.click(getByRole('button', { name: 'More Options' }));
+  fireEvent.mouseOver(getByRole('menuitem', { name: 'Download right' }));
+  const exportAction = await findByText('Export to PDF');
+  fireEvent.click(exportAction);
+  expect(stubbedExportPDF).toHaveBeenCalledTimes(1);
+  expect(stubbedExportPDF).toHaveBeenCalledWith(
+    expect.objectContaining({
+      resultType: 'full',
+      resultFormat: 'pdf',
+    }),
+  );
+  stubbedExportPDF.mockRestore();
+});
+
 test('should call exportChart with row_limit props.maxRows when exportFullXLSX is clicked', async () => {
   (global as any).featureFlags = {
     [FeatureFlag.AllowFullCsvExport]: true,

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -36,6 +36,7 @@ import {
   LOG_ACTIONS_CHANGE_DASHBOARD_FILTER,
   LOG_ACTIONS_EXPLORE_DASHBOARD_CHART,
   LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART,
+  LOG_ACTIONS_CHART_DOWNLOAD_AS_PDF,
   LOG_ACTIONS_EXPORT_XLSX_DASHBOARD_CHART,
   LOG_ACTIONS_FORCE_REFRESH_CHART,
 } from 'src/logger/LogUtils';
@@ -474,7 +475,9 @@ const Chart = (props: ChartProps) => {
       const logAction =
         format === 'csv'
           ? LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART
-          : LOG_ACTIONS_EXPORT_XLSX_DASHBOARD_CHART;
+          : format === 'pdf'
+            ? LOG_ACTIONS_CHART_DOWNLOAD_AS_PDF
+            : LOG_ACTIONS_EXPORT_XLSX_DASHBOARD_CHART;
       boundActionCreators.logEvent(logAction, {
         slice_id: sliceSliceId,
         is_cached: isCached,
@@ -599,6 +602,10 @@ const Chart = (props: ChartProps) => {
     exportTable('xlsx', true);
   }, [exportTable]);
 
+  const exportPDF = useCallback(() => {
+    exportTable('pdf', false);
+  }, [exportTable]);
+
   const forceRefresh = useCallback(() => {
     boundActionCreators.logEvent(LOG_ACTIONS_FORCE_REFRESH_CHART, {
       slice_id: sliceSliceId,
@@ -664,6 +671,7 @@ const Chart = (props: ChartProps) => {
         exportCSV={exportCSV}
         exportPivotCSV={exportPivotCSV}
         exportXLSX={exportXLSX}
+        exportPDF={exportPDF}
         exportFullCSV={exportFullCSV}
         exportFullXLSX={exportFullXLSX}
         updateSliceName={(name: string) =>

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -370,6 +370,7 @@ export enum MenuKeys {
   ExportPivotCsv = 'export_pivot_csv',
   ExportFullCsv = 'export_full_csv',
   ExportXlsx = 'export_xlsx',
+  ExportPdf = 'export_pdf',
   ExportFullXlsx = 'export_full_xlsx',
   ForceRefresh = 'force_refresh',
   Fullscreen = 'fullscreen',

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
@@ -58,6 +58,7 @@ import {
   LOG_ACTIONS_CHART_DOWNLOAD_AS_JSON,
   LOG_ACTIONS_CHART_DOWNLOAD_AS_CSV,
   LOG_ACTIONS_CHART_DOWNLOAD_AS_CSV_PIVOTED,
+  LOG_ACTIONS_CHART_DOWNLOAD_AS_PDF,
   LOG_ACTIONS_CHART_DOWNLOAD_AS_XLS,
 } from 'src/logger/LogUtils';
 import exportPivotExcel from 'src/utils/downloadAsPivotExcel';
@@ -85,10 +86,12 @@ const MENU_KEYS = {
   EXPORT_TO_PIVOT_XLSX: 'export_to_pivot_xlsx',
   EXPORT_TO_CSV: 'export_to_csv',
   EXPORT_TO_JSON: 'export_to_json',
+  EXPORT_TO_PDF: 'export_to_pdf',
   EXPORT_TO_XLSX: 'export_to_xlsx',
   EXPORT_ALL_SCREENSHOT: 'export_all_screenshot',
   EXPORT_CURRENT_TO_CSV: 'export_current_to_csv',
   EXPORT_CURRENT_TO_JSON: 'export_current_to_json',
+  EXPORT_CURRENT_PDF: 'export_current_pdf',
   EXPORT_CURRENT_SCREENSHOT: 'export_current_screenshot',
   EXPORT_CURRENT_XLSX: 'export_current_xlsx',
   SHARE_SUBMENU: 'share_submenu',
@@ -418,6 +421,19 @@ export const useExploreAdditionalActionsMenu = (
     [canDownloadCSV, latestQueryFormData, ownState],
   );
 
+  const exportPdf = useCallback(
+    () =>
+      canDownloadCSV
+        ? exportChart({
+            formData: latestQueryFormData as QueryFormData,
+            ownState,
+            resultType: 'results',
+            resultFormat: 'pdf',
+          })
+        : null,
+    [canDownloadCSV, latestQueryFormData, ownState],
+  );
+
   const copyLink = useCallback(async () => {
     try {
       if (!latestQueryFormData?.datasource) {
@@ -732,6 +748,22 @@ export const useExploreAdditionalActionsMenu = (
         },
       },
       {
+        key: MENU_KEYS.EXPORT_TO_PDF,
+        label: t('Export to PDF'),
+        icon: <Icons.FileOutlined />,
+        disabled: !canDownloadCSV,
+        onClick: () => {
+          exportPdf();
+          setIsDropdownVisible(false);
+          dispatch(
+            logEvent(LOG_ACTIONS_CHART_DOWNLOAD_AS_PDF, {
+              chartId: slice?.slice_id,
+              chartName: slice?.slice_name,
+            }),
+          );
+        },
+      },
+      {
         key: MENU_KEYS.EXPORT_ALL_SCREENSHOT,
         label: t('Export screenshot (jpeg)'),
         icon: <Icons.FileImageOutlined />,
@@ -829,6 +861,27 @@ export const useExploreAdditionalActionsMenu = (
           setIsDropdownVisible(false);
           dispatch(
             logEvent(LOG_ACTIONS_CHART_DOWNLOAD_AS_JSON, {
+              chartId: slice?.slice_id,
+              chartName: slice?.slice_name,
+            }),
+          );
+        },
+      },
+      {
+        key: MENU_KEYS.EXPORT_CURRENT_PDF,
+        label: t('Export to PDF'),
+        icon: <Icons.FileOutlined />,
+        disabled: !canDownloadCSV,
+        onClick: () => {
+          exportChart({
+            formData: latestQueryFormData as QueryFormData,
+            ownState,
+            resultType: 'results',
+            resultFormat: 'pdf',
+          });
+          setIsDropdownVisible(false);
+          dispatch(
+            logEvent(LOG_ACTIONS_CHART_DOWNLOAD_AS_PDF, {
               chartId: slice?.slice_id,
               chartName: slice?.slice_name,
             }),
@@ -1026,6 +1079,7 @@ export const useExploreAdditionalActionsMenu = (
     exportCSV,
     exportCSVPivoted,
     exportExcel,
+    exportPdf,
     exportJson,
     latestQueryFormData,
     onOpenInEditor,

--- a/superset-frontend/src/explore/exploreUtils/exportChart.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/exportChart.test.ts
@@ -143,6 +143,22 @@ test('exportChart passes xlsx exportType for Excel exports', async () => {
   );
 });
 
+test('exportChart passes pdf exportType for PDF exports', async () => {
+  const onStartStreamingExport = jest.fn();
+
+  await exportChart({
+    formData: baseFormData,
+    resultFormat: 'pdf',
+    onStartStreamingExport: onStartStreamingExport as unknown as null,
+  });
+
+  expect(onStartStreamingExport).toHaveBeenCalledWith(
+    expect.objectContaining({
+      exportType: 'pdf',
+    }),
+  );
+});
+
 test('exportChart legacy API (useLegacyApi=true) passes prefixed URL with app root configured', async () => {
   const appRoot = '/superset';
   ensureAppRoot.mockImplementation((path: string) => `${appRoot}${path}`);
@@ -216,6 +232,31 @@ test('exportChart legacy API builds relative URL for xlsx export', async () => {
   expect(onStartStreamingExport).toHaveBeenCalledTimes(1);
   const callArgs = onStartStreamingExport.mock.calls[0][0];
   expect(callArgs.url).toBe('/superset/explore_json/?xlsx=true');
+});
+
+test('exportChart legacy API builds relative URL for pdf export', async () => {
+  ensureAppRoot.mockImplementation((path: string) => path);
+
+  getChartMetadataRegistry.mockReturnValue({
+    get: jest.fn().mockReturnValue({ useLegacyApi: true, parseMethod: 'json' }),
+  });
+
+  const onStartStreamingExport = jest.fn();
+  const legacyFormData = {
+    datasource: '1__table',
+    viz_type: 'bubble',
+  };
+
+  await exportChart({
+    formData: legacyFormData,
+    resultFormat: 'pdf',
+    resultType: 'results',
+    onStartStreamingExport: onStartStreamingExport as unknown as null,
+  });
+
+  expect(onStartStreamingExport).toHaveBeenCalledTimes(1);
+  const callArgs = onStartStreamingExport.mock.calls[0][0];
+  expect(callArgs.url).toBe('/superset/explore_json/?pdf=true');
 });
 
 test('exportChart legacy API calls postForm with relative URL', async () => {

--- a/superset-frontend/src/explore/exploreUtils/getExploreUrl.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getExploreUrl.test.ts
@@ -64,6 +64,13 @@ test('Get relative ExploreUrl with endpointType:xlsx', () => {
   ).toBe('/superset/explore_json/?xlsx=true');
 });
 
+test('Get relative ExploreUrl with endpointType:pdf', () => {
+  const params = createParams();
+  expect(
+    getExploreUrl({ ...params, endpointType: 'pdf', relative: true }),
+  ).toBe('/superset/explore_json/?pdf=true');
+});
+
 test('Get relative ExploreUrl with force:true', () => {
   const params = createParams();
   expect(

--- a/superset-frontend/src/explore/exploreUtils/getLegacyEndpointType.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getLegacyEndpointType.test.ts
@@ -38,3 +38,9 @@ test('Should return resultFormat when resultFormat:xlsx', () => {
     getLegacyEndpointType({ ...createParams(), resultFormat: 'xlsx' }),
   ).toBe('xlsx');
 });
+
+test('Should return resultFormat when resultFormat:pdf', () => {
+  expect(
+    getLegacyEndpointType({ ...createParams(), resultFormat: 'pdf' }),
+  ).toBe('pdf');
+});

--- a/superset-frontend/src/explore/exploreUtils/getURIDirectory.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getURIDirectory.test.ts
@@ -19,9 +19,11 @@
 import { getURIDirectory } from '.';
 
 test('Cases in which the "explore_json" will be returned', () => {
-  ['full', 'json', 'csv', 'query', 'results', 'samples'].forEach(name => {
-    expect(getURIDirectory(name)).toBe('/superset/explore_json/');
-  });
+  ['full', 'json', 'csv', 'pdf', 'xlsx', 'query', 'results', 'samples'].forEach(
+    name => {
+      expect(getURIDirectory(name)).toBe('/superset/explore_json/');
+    },
+  );
 });
 
 test('Cases in which the "explore" will be returned', () => {

--- a/superset-frontend/src/explore/exploreUtils/index.ts
+++ b/superset-frontend/src/explore/exploreUtils/index.ts
@@ -51,6 +51,8 @@ export type EndpointType =
   | 'full'
   | 'json'
   | 'csv'
+  | 'pdf'
+  | 'xlsx'
   | 'query'
   | 'results'
   | 'samples'
@@ -158,6 +160,7 @@ export function getURIDirectory(
     'full',
     'json',
     'csv',
+    'pdf',
     'xlsx',
     'query',
     'results',
@@ -269,6 +272,9 @@ export function getExploreUrl({
   if (endpointType === 'xlsx') {
     search.xlsx = 'true';
   }
+  if (endpointType === 'pdf') {
+    search.pdf = 'true';
+  }
   if (endpointType === URL_PARAMS.standalone.name) {
     search.standalone = '1';
   }
@@ -349,7 +355,9 @@ export const getLegacyEndpointType = ({
   resultType: string;
   resultFormat: string;
 }): string =>
-  resultFormat === 'csv' || resultFormat === 'xlsx' ? resultFormat : resultType;
+  resultFormat === 'csv' || resultFormat === 'xlsx' || resultFormat === 'pdf'
+    ? resultFormat
+    : resultType;
 
 export const exportChart = async ({
   formData,

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -660,6 +660,29 @@ test('shows screenshot width when PDF is selected', async () => {
   expect(screen.getByRole('spinbutton')).toBeInTheDocument();
 });
 
+test('does not show screenshot width when PDF NEW is selected', async () => {
+  render(<AlertReportModal {...generateMockedProps(false, true, false)} />, {
+    useRedux: true,
+  });
+  userEvent.click(screen.getByTestId('contents-panel'));
+  await screen.findByText(/test chart/i);
+  const contentTypeSelector = screen.getByRole('combobox', {
+    name: /select content type/i,
+  });
+  await comboboxSelect(contentTypeSelector, 'Chart', () =>
+    screen.getByText(/select chart/i),
+  );
+  const reportFormatSelector = screen.getByRole('combobox', {
+    name: /select format/i,
+  });
+  await comboboxSelect(
+    reportFormatSelector,
+    'PDF NEW',
+    () => screen.getAllByText(/Send as PDF NEW/i)[0],
+  );
+  expect(screen.queryByText(/screenshot width/i)).not.toBeInTheDocument();
+});
+
 // Schedule Section
 test('opens Schedule Section on click', async () => {
   render(<AlertReportModal {...generateMockedProps(false, true, false)} />, {

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -213,6 +213,10 @@ const FORMAT_OPTIONS = {
     label: t('Send as PDF'),
     value: 'PDF',
   },
+  pdfNew: {
+    label: t('Send as PDF NEW'),
+    value: 'PDF_NEW',
+  },
   png: {
     label: t('Send as PNG'),
     value: 'PNG',
@@ -2374,7 +2378,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   </StyledInputContainer>
                   <StyledInputContainer
                     css={
-                      ['PDF', 'TEXT', 'CSV'].includes(reportFormat) &&
+                      ['PDF', 'PDF_NEW', 'TEXT', 'CSV'].includes(reportFormat) &&
                       noMarginBottom
                     }
                   >
@@ -2400,7 +2404,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                                     chartVizType,
                                   )
                                 ? Object.values(FORMAT_OPTIONS)
-                                : ['pdf', 'png', 'csv'].map(
+                                : ['pdf', 'pdfNew', 'png', 'csv'].map(
                                     key =>
                                       FORMAT_OPTIONS[key as FORMAT_OPTIONS_KEY],
                                   )

--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -273,6 +273,14 @@ function ReportModal({
               value: NotificationFormats.Text,
             },
             {
+              label: t('PDF attached in email'),
+              value: NotificationFormats.PDF,
+            },
+            {
+              label: t('PDF NEW attached in email'),
+              value: NotificationFormats.PDFNew,
+            },
+            {
               label: t('Image (PNG) embedded in email'),
               value: NotificationFormats.PNG,
             },

--- a/superset-frontend/src/features/reports/types.ts
+++ b/superset-frontend/src/features/reports/types.ts
@@ -32,6 +32,8 @@ export enum ReportType {
 
 export enum NotificationFormats {
   Text = 'TEXT',
+  PDF = 'PDF',
+  PDFNew = 'PDF_NEW',
   PNG = 'PNG',
   CSV = 'CSV',
 }

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -59,6 +59,7 @@ export const LOG_ACTIONS_CHART_DOWNLOAD_AS_CSV_PIVOTED =
   'chart_download_as_csv_pivoted';
 export const LOG_ACTIONS_CHART_DOWNLOAD_AS_XLS = 'chart_download_as_xls';
 export const LOG_ACTIONS_CHART_DOWNLOAD_AS_JSON = 'chart_download_as_json';
+export const LOG_ACTIONS_CHART_DOWNLOAD_AS_PDF = 'chart_download_as_pdf';
 export const LOG_ACTIONS_SQLLAB_WARN_LOCAL_STORAGE_USAGE =
   'sqllab_warn_local_storage_usage';
 export const LOG_ACTIONS_SQLLAB_FETCH_FAILED_QUERY =
@@ -112,6 +113,7 @@ export const LOG_EVENT_TYPE_USER = new Set([
   LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE,
   LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_PDF,
   LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE,
+  LOG_ACTIONS_CHART_DOWNLOAD_AS_PDF,
 ]);
 
 export const LOG_EVENT_DATASET_TYPE_DATASET_CREATION = [

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -58,6 +58,7 @@ from superset.utils.core import (
     get_user_id,
 )
 from superset.utils.decorators import logs_context
+from superset.utils.pdf import build_pdf_from_chart_data
 from superset.views.base import CsvResponse, generate_download_headers, XlsxResponse
 from superset.views.base_api import statsd_metrics
 
@@ -404,7 +405,10 @@ class ChartDataRestApi(ChartRestApi):
         if result_type == ChartDataResultType.POST_PROCESSED:
             result = apply_client_processing(result, form_data, datasource)
 
-        if result_format in ChartDataResultFormat.table_like():
+        export_result_formats = ChartDataResultFormat.table_like() | {
+            ChartDataResultFormat.PDF
+        }
+        if result_format in export_result_formats:
             # Verify user has permission to export file
             if is_feature_enabled("GRANULAR_EXPORT_CONTROLS"):
                 has_export_perm = security_manager.can_access(
@@ -419,6 +423,18 @@ class ChartDataRestApi(ChartRestApi):
                 return self.response_400(_("Empty query result"))
 
             is_csv_format = result_format == ChartDataResultFormat.CSV
+            is_pdf_format = result_format == ChartDataResultFormat.PDF
+
+            def _normalize_pdf_rows(query_data: Any) -> list[dict[str, Any]]:
+                if not isinstance(query_data, list):
+                    return []
+                rows: list[dict[str, Any]] = []
+                for row in query_data:
+                    if isinstance(row, dict):
+                        rows.append({str(key): value for key, value in row.items()})
+                    else:
+                        rows.append({"value": row})
+                return rows
 
             # Check if we should use streaming for large datasets
             if is_csv_format and self._should_use_streaming(result, form_data):
@@ -431,6 +447,13 @@ class ChartDataRestApi(ChartRestApi):
                 data = result["queries"][0]["data"]
                 if is_csv_format:
                     return CsvResponse(data, headers=generate_download_headers("csv"))
+                if is_pdf_format:
+                    pdf_data = build_pdf_from_chart_data(_normalize_pdf_rows(data))
+                    return Response(
+                        pdf_data,
+                        headers=generate_download_headers("pdf"),
+                        mimetype="application/pdf",
+                    )
 
                 return XlsxResponse(data, headers=generate_download_headers("xlsx"))
 
@@ -439,6 +462,8 @@ class ChartDataRestApi(ChartRestApi):
                 if result_format == ChartDataResultFormat.CSV:
                     encoding = app.config["CSV_EXPORT"].get("encoding", "utf-8")
                     return query_data.encode(encoding)
+                if result_format == ChartDataResultFormat.PDF:
+                    return build_pdf_from_chart_data(_normalize_pdf_rows(query_data))
                 return query_data
 
             files = {

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -58,7 +58,7 @@ from superset.utils.core import (
     get_user_id,
 )
 from superset.utils.decorators import logs_context
-from superset.utils.pdf import build_pdf_from_chart_data
+from superset.utils.pdf import apply_column_labels_to_rows, build_pdf_from_chart_data
 from superset.views.base import CsvResponse, generate_download_headers, XlsxResponse
 from superset.views.base_api import statsd_metrics
 
@@ -425,16 +425,26 @@ class ChartDataRestApi(ChartRestApi):
             is_csv_format = result_format == ChartDataResultFormat.CSV
             is_pdf_format = result_format == ChartDataResultFormat.PDF
 
+            def _get_pdf_column_labels() -> dict[str, str]:
+                query_context = result.get("query_context")
+                resolved_datasource = datasource or getattr(
+                    query_context, "datasource", None
+                )
+                datasource_data = getattr(resolved_datasource, "data", None)
+                if not isinstance(datasource_data, dict):
+                    return {}
+                verbose_map = datasource_data.get("verbose_map")
+                if not isinstance(verbose_map, dict):
+                    return {}
+                return {
+                    str(column_name): str(label) if label else str(column_name)
+                    for column_name, label in verbose_map.items()
+                }
+
+            pdf_column_labels = _get_pdf_column_labels() if is_pdf_format else {}
+
             def _normalize_pdf_rows(query_data: Any) -> list[dict[str, Any]]:
-                if not isinstance(query_data, list):
-                    return []
-                rows: list[dict[str, Any]] = []
-                for row in query_data:
-                    if isinstance(row, dict):
-                        rows.append({str(key): value for key, value in row.items()})
-                    else:
-                        rows.append({"value": row})
-                return rows
+                return apply_column_labels_to_rows(query_data, pdf_column_labels)
 
             # Check if we should use streaming for large datasets
             if is_csv_format and self._should_use_streaming(result, form_data):

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -37,6 +37,7 @@ from superset.commands.report.exceptions import (
     ReportScheduleDataFrameTimeout,
     ReportScheduleExecuteUnexpectedError,
     ReportScheduleNotFoundError,
+    ReportSchedulePdfFailedError,
     ReportSchedulePreviousWorkingError,
     ReportScheduleScreenshotFailedError,
     ReportScheduleScreenshotTimeout,
@@ -221,12 +222,18 @@ class BaseReportState:
             if result_format in {
                 ChartDataResultFormat.CSV,
                 ChartDataResultFormat.JSON,
+                ChartDataResultFormat.PDF,
             }:
+                result_type = (
+                    ChartDataResultType.FULL.value
+                    if result_format == ChartDataResultFormat.PDF
+                    else ChartDataResultType.POST_PROCESSED.value
+                )
                 return get_url_path(
                     "ChartDataRestApi.get_data",
                     pk=self._report_schedule.chart_id,
                     format=result_format.value,
-                    type=ChartDataResultType.POST_PROCESSED.value,
+                    type=result_type,
                     force=force,
                 )
             return get_url_path(
@@ -436,6 +443,64 @@ class BaseReportState:
 
         return pdf
 
+    def _get_chart_data_pdf(self) -> bytes:
+        """
+        Get chart-data based pdf for chart reports.
+        :raises: ReportSchedulePdfFailedError
+        """
+        if not self._report_schedule.chart:
+            raise ReportSchedulePdfFailedError(
+                "Chart data pdf export is only supported for chart reports"
+            )
+
+        start_time = datetime.utcnow()
+        url = self._get_url(result_format=ChartDataResultFormat.PDF)
+        _, username = get_executor(
+            executors=app.config["ALERT_REPORTS_EXECUTORS"],
+            model=self._report_schedule,
+        )
+        user = security_manager.find_user(username)
+        auth_cookies = machine_auth_provider_factory.instance.get_auth_cookies(user)
+
+        if self._report_schedule.chart.query_context is None:
+            logger.warning("No query context found, taking a screenshot to generate it")
+            self._update_query_context()
+
+        try:
+            chart_data = get_chart_csv_data(chart_url=url, auth_cookies=auth_cookies)
+            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            logger.info(
+                "Chart data PDF generation from %s as user %s took %.2fs - execution_id: %s",  # noqa: E501
+                url,
+                username,
+                elapsed_seconds,
+                self._execution_id,
+            )
+        except SoftTimeLimitExceeded as ex:
+            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            logger.warning(
+                "Chart data PDF generation timeout after %.2fs - execution_id: %s",
+                elapsed_seconds,
+                self._execution_id,
+            )
+            raise ReportSchedulePdfFailedError(
+                "A timeout occurred while generating a pdf."
+            ) from ex
+        except Exception as ex:
+            elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
+            logger.error(
+                "Chart data PDF generation failed after %.2fs - execution_id: %s",
+                elapsed_seconds,
+                self._execution_id,
+            )
+            raise ReportSchedulePdfFailedError(
+                f"Failed generating pdf {str(ex)}"
+            ) from ex
+
+        if not chart_data:
+            raise ReportSchedulePdfFailedError()
+        return chart_data
+
     def _get_csv_data(self) -> bytes:
         start_time = datetime.utcnow()
         url = self._get_url(result_format=ChartDataResultFormat.CSV)
@@ -611,6 +676,13 @@ class BaseReportState:
                 pdf_data = self._get_pdf()
                 if not pdf_data:
                     error_text = "Unexpected missing pdf"
+            elif self._report_schedule.report_format == ReportDataFormat.PDF_NEW:
+                if self._report_schedule.chart:
+                    pdf_data = self._get_chart_data_pdf()
+                    if not pdf_data:
+                        error_text = "Unexpected missing pdf"
+                else:
+                    error_text = "PDF NEW is only supported for chart reports"
             elif (
                 self._report_schedule.chart
                 and self._report_schedule.report_format == ReportDataFormat.CSV

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -79,6 +79,7 @@ class ReportState(StrEnum):
 
 class ReportDataFormat(StrEnum):
     PDF = "PDF"
+    PDF_NEW = "PDF_NEW"
     PNG = "PNG"
     CSV = "CSV"
     TEXT = "TEXT"

--- a/superset/utils/pdf.py
+++ b/superset/utils/pdf.py
@@ -42,6 +42,7 @@ MAX_PAGE_WIDTH = 4096
 HEADER_BG_COLOR = (244, 244, 244)
 GRID_COLOR = (210, 210, 210)
 TEXT_COLOR = (0, 0, 0)
+TURKISH_GLYPH_PROBE = "ĞÜŞİÖÇğüşıöç"
 
 
 def build_pdf_from_screenshots(snapshots: list[bytes]) -> bytes:
@@ -135,18 +136,48 @@ def apply_column_labels_to_rows(
 
 def _load_table_font() -> Any:
     """
-    Load a monospaced font when available, with a safe fallback.
+    Load a Unicode-capable font for table rendering, with a safe fallback.
     """
     font_candidates = [
+        "/app/.venv/lib/python3.11/site-packages/matplotlib/mpl-data/fonts/ttf/DejaVuSansMono.ttf",
+        "/app/.venv/lib/python3.11/site-packages/matplotlib/mpl-data/fonts/ttf/DejaVuSans.ttf",
         "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
         "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
         "/usr/share/fonts/dejavu/DejaVuSansMono.ttf",
+        "/usr/share/fonts/dejavu/DejaVuSans.ttf",
     ]
+
+    def _supports_glyphs(font: Any, probe: str) -> bool:
+        """
+        Return False when unsupported chars are silently rendered as '?' glyph.
+        """
+        def _mask_bytes(char: str) -> bytes:
+            # Pillow may return ImagingCore which supports bytes() but not tobytes().
+            return bytes(font.getmask(char))
+
+        try:
+            fallback_mask = _mask_bytes("?")
+            for char in probe:
+                if char.isspace():
+                    continue
+                if _mask_bytes(char) == fallback_mask and char != "?":
+                    return False
+            return True
+        except Exception:
+            return False
+
     for font_path in font_candidates:
         try:
-            return ImageFont.truetype(font_path, 15)
+            font = ImageFont.truetype(font_path, 15)
+            if _supports_glyphs(font, TURKISH_GLYPH_PROBE):
+                return font
         except OSError:
             continue
+    logger.warning(
+        "Could not load a Unicode-capable table font; falling back to default font."
+    )
     return ImageFont.load_default()
 
 

--- a/superset/utils/pdf.py
+++ b/superset/utils/pdf.py
@@ -31,13 +31,14 @@ except ModuleNotFoundError:
 
 
 NEWLINE_PATTERN = re.compile(r"\r\n|\r|\n")
-DEFAULT_PAGE_WIDTH = 1240
 DEFAULT_PAGE_HEIGHT = 1754
 PAGE_MARGIN = 48
 CELL_PADDING_X = 8
 CELL_PADDING_Y = 6
 MIN_COLUMN_CHARS = 10
-MAX_COLUMN_CHARS = 60
+MAX_COLUMN_CHARS = 120
+MIN_PAGE_WIDTH = 360
+MAX_PAGE_WIDTH = 4096
 HEADER_BG_COLOR = (244, 244, 244)
 GRID_COLOR = (210, 210, 210)
 TEXT_COLOR = (0, 0, 0)
@@ -76,6 +77,60 @@ def _normalize_chart_row_value(value: Any) -> str:
         value_str = str(value)
     value_str = NEWLINE_PATTERN.sub(" ", value_str).replace("\t", "    ")
     return value_str
+
+
+def apply_column_labels_to_rows(
+    query_data: Any,
+    column_labels: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Apply human-friendly column labels to row keys while preserving row values.
+
+    If multiple source columns resolve to the same label, unique suffixes are
+    applied to prevent key collisions and data loss.
+    """
+    if not isinstance(query_data, list):
+        return []
+
+    normalized_labels = {
+        str(column_name): str(label) if label else str(column_name)
+        for column_name, label in (column_labels or {}).items()
+    }
+
+    header_map: dict[str, str] = {}
+    used_headers: set[str] = set()
+    for row in query_data:
+        if not isinstance(row, dict):
+            continue
+        for key in row:
+            source_key = str(key)
+            if source_key in header_map:
+                continue
+
+            preferred = normalized_labels.get(source_key, source_key)
+            candidate = preferred
+            if candidate in used_headers:
+                candidate = f"{preferred} ({source_key})"
+            suffix = 2
+            while candidate in used_headers:
+                candidate = f"{preferred} ({suffix})"
+                suffix += 1
+
+            header_map[source_key] = candidate
+            used_headers.add(candidate)
+
+    rows: list[dict[str, Any]] = []
+    for row in query_data:
+        if isinstance(row, dict):
+            rows.append(
+                {
+                    header_map.get(str(key), str(key)): value
+                    for key, value in row.items()
+                }
+            )
+        else:
+            rows.append({"value": row})
+    return rows
 
 
 def _load_table_font() -> Any:
@@ -128,6 +183,13 @@ def _estimate_column_width_chars(
             max_length = max(max_length, len(cell_value))
         widths.append(min(max(max_length, MIN_COLUMN_CHARS), MAX_COLUMN_CHARS))
     return widths
+
+
+def _calculate_page_width(table_width: int) -> int:
+    """
+    Calculate page width based on table content width with safe bounds.
+    """
+    return min(max((PAGE_MARGIN * 2) + table_width, MIN_PAGE_WIDTH), MAX_PAGE_WIDTH)
 
 
 def _wrap_cell(value: str, width_chars: int) -> list[str]:
@@ -204,7 +266,7 @@ def build_pdf_from_chart_data(rows: list[dict[str, Any]]) -> bytes:  # noqa: C90
             for width_chars in column_widths_chars
         ]
         table_width = sum(column_widths_px)
-        page_width = max(DEFAULT_PAGE_WIDTH, (PAGE_MARGIN * 2) + table_width)
+        page_width = _calculate_page_width(table_width)
         page_height = DEFAULT_PAGE_HEIGHT
         x_origin = PAGE_MARGIN
 

--- a/superset/utils/pdf.py
+++ b/superset/utils/pdf.py
@@ -16,15 +16,31 @@
 # under the License.
 
 import logging
+import re
+import textwrap
 from io import BytesIO
+from typing import Any
 
 from superset.commands.report.exceptions import ReportSchedulePdfFailedError
 
 logger = logging.getLogger(__name__)
 try:
-    from PIL import Image
+    from PIL import Image, ImageDraw, ImageFont
 except ModuleNotFoundError:
     logger.info("No PIL installation found")
+
+
+NEWLINE_PATTERN = re.compile(r"\r\n|\r|\n")
+DEFAULT_PAGE_WIDTH = 1240
+DEFAULT_PAGE_HEIGHT = 1754
+PAGE_MARGIN = 48
+CELL_PADDING_X = 8
+CELL_PADDING_Y = 6
+MIN_COLUMN_CHARS = 10
+MAX_COLUMN_CHARS = 60
+HEADER_BG_COLOR = (244, 244, 244)
+GRID_COLOR = (210, 210, 210)
+TEXT_COLOR = (0, 0, 0)
 
 
 def build_pdf_from_screenshots(snapshots: list[bytes]) -> bytes:
@@ -46,3 +62,249 @@ def build_pdf_from_screenshots(snapshots: list[bytes]) -> bytes:
         ) from ex
 
     return new_pdf.read()
+
+
+def _normalize_chart_row_value(value: Any) -> str:
+    """
+    Convert chart row values into printable text for PDF export.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple, dict, set)):
+        value_str = str(value)
+    else:
+        value_str = str(value)
+    value_str = NEWLINE_PATTERN.sub(" ", value_str).replace("\t", "    ")
+    return value_str
+
+
+def _load_table_font() -> Any:
+    """
+    Load a monospaced font when available, with a safe fallback.
+    """
+    font_candidates = [
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+        "/usr/share/fonts/dejavu/DejaVuSansMono.ttf",
+    ]
+    for font_path in font_candidates:
+        try:
+            return ImageFont.truetype(font_path, 15)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _measure_text_metrics(font: Any) -> tuple[int, int]:
+    """
+    Return approximate single-character width and line height for the font.
+    """
+    probe = Image.new("RGB", (1, 1), "white")
+    draw = ImageDraw.Draw(probe)
+    char_bbox = draw.textbbox((0, 0), "0", font=font)
+    line_bbox = draw.textbbox((0, 0), "Ag", font=font)
+    char_width = max(char_bbox[2] - char_bbox[0], 1)
+    line_height = max((line_bbox[3] - line_bbox[1]) + 2, 12)
+    return char_width, line_height
+
+
+def _extract_columns(rows: list[dict[str, str]]) -> list[str]:
+    columns: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in columns:
+                columns.append(key)
+    return columns
+
+
+def _estimate_column_width_chars(
+    columns: list[str], rows: list[dict[str, str]]
+) -> list[int]:
+    widths: list[int] = []
+    for column in columns:
+        max_length = len(column)
+        for row in rows:
+            cell_value = row.get(column, "")
+            max_length = max(max_length, len(cell_value))
+        widths.append(min(max(max_length, MIN_COLUMN_CHARS), MAX_COLUMN_CHARS))
+    return widths
+
+
+def _wrap_cell(value: str, width_chars: int) -> list[str]:
+    wrapped = textwrap.wrap(
+        value,
+        width=width_chars,
+        replace_whitespace=False,
+        drop_whitespace=False,
+        break_long_words=True,
+        break_on_hyphens=False,
+    )
+    return wrapped or [""]
+
+
+def _draw_row_chunk(
+    draw: Any,
+    x_origin: int,
+    y_origin: int,
+    row_cells: list[list[str]],
+    chunk_start: int,
+    chunk_line_count: int,
+    column_widths_px: list[int],
+    font: Any,
+    line_height: int,
+    header: bool = False,
+) -> int:
+    row_height = (chunk_line_count * line_height) + (CELL_PADDING_Y * 2)
+    x_position = x_origin
+    for idx, cell_lines in enumerate(row_cells):
+        cell_width = column_widths_px[idx]
+        draw.rectangle(
+            (
+                x_position,
+                y_origin,
+                x_position + cell_width,
+                y_origin + row_height,
+            ),
+            fill=HEADER_BG_COLOR if header else "white",
+            outline=GRID_COLOR,
+        )
+        line_cursor = y_origin + CELL_PADDING_Y
+        for line_index in range(chunk_start, chunk_start + chunk_line_count):
+            text_line = cell_lines[line_index] if line_index < len(cell_lines) else ""
+            draw.text(
+                (x_position + CELL_PADDING_X, line_cursor),
+                text_line,
+                fill=TEXT_COLOR,
+                font=font,
+            )
+            line_cursor += line_height
+        x_position += cell_width
+    return row_height
+
+
+def build_pdf_from_chart_data(rows: list[dict[str, Any]]) -> bytes:  # noqa: C901
+    """
+    Build a paginated table PDF document from chart row data.
+    """
+    try:
+        normalized_rows = [
+            {str(key): _normalize_chart_row_value(value) for key, value in row.items()}
+            for row in rows
+        ]
+        columns = _extract_columns(normalized_rows)
+        if not columns:
+            columns = ["message"]
+            normalized_rows = [{"message": "No data available."}]
+
+        font = _load_table_font()
+        char_width, line_height = _measure_text_metrics(font)
+        column_widths_chars = _estimate_column_width_chars(columns, normalized_rows)
+        column_widths_px = [
+            (width_chars * char_width) + (CELL_PADDING_X * 2)
+            for width_chars in column_widths_chars
+        ]
+        table_width = sum(column_widths_px)
+        page_width = max(DEFAULT_PAGE_WIDTH, (PAGE_MARGIN * 2) + table_width)
+        page_height = DEFAULT_PAGE_HEIGHT
+        x_origin = PAGE_MARGIN
+
+        header_cells = [
+            _wrap_cell(column_name, column_widths_chars[idx])
+            for idx, column_name in enumerate(columns)
+        ]
+        header_line_count = max(len(cell) for cell in header_cells)
+        for cell in header_cells:
+            if len(cell) < header_line_count:
+                cell.extend([""] * (header_line_count - len(cell)))
+
+        pages: list[Any] = []
+        page = Image.new("RGB", (page_width, page_height), "white")
+        draw = ImageDraw.Draw(page)
+        y_cursor = PAGE_MARGIN
+
+        def begin_new_page() -> tuple[Any, Any, int]:
+            next_page = Image.new("RGB", (page_width, page_height), "white")
+            next_draw = ImageDraw.Draw(next_page)
+            next_y = PAGE_MARGIN
+            next_y += _draw_row_chunk(
+                draw=next_draw,
+                x_origin=x_origin,
+                y_origin=next_y,
+                row_cells=header_cells,
+                chunk_start=0,
+                chunk_line_count=header_line_count,
+                column_widths_px=column_widths_px,
+                font=font,
+                line_height=line_height,
+                header=True,
+            )
+            return next_page, next_draw, next_y
+
+        # Draw header on the first page.
+        y_cursor += _draw_row_chunk(
+            draw=draw,
+            x_origin=x_origin,
+            y_origin=y_cursor,
+            row_cells=header_cells,
+            chunk_start=0,
+            chunk_line_count=header_line_count,
+            column_widths_px=column_widths_px,
+            font=font,
+            line_height=line_height,
+            header=True,
+        )
+
+        for row in normalized_rows:
+            row_cells = [
+                _wrap_cell(row.get(column_name, ""), column_widths_chars[idx])
+                for idx, column_name in enumerate(columns)
+            ]
+            total_row_lines = max(len(cell) for cell in row_cells)
+            for cell in row_cells:
+                if len(cell) < total_row_lines:
+                    cell.extend([""] * (total_row_lines - len(cell)))
+
+            line_start = 0
+            while line_start < total_row_lines:
+                available_height = page_height - PAGE_MARGIN - y_cursor
+                max_lines_for_chunk = max(
+                    (available_height - (CELL_PADDING_Y * 2)) // line_height,
+                    0,
+                )
+
+                if max_lines_for_chunk <= 0:
+                    pages.append(page)
+                    page, draw, y_cursor = begin_new_page()
+                    continue
+
+                chunk_line_count = min(
+                    max_lines_for_chunk,
+                    total_row_lines - line_start,
+                )
+                y_cursor += _draw_row_chunk(
+                    draw=draw,
+                    x_origin=x_origin,
+                    y_origin=y_cursor,
+                    row_cells=row_cells,
+                    chunk_start=line_start,
+                    chunk_line_count=chunk_line_count,
+                    column_widths_px=column_widths_px,
+                    font=font,
+                    line_height=line_height,
+                )
+                line_start += chunk_line_count
+
+                if line_start < total_row_lines:
+                    pages.append(page)
+                    page, draw, y_cursor = begin_new_page()
+
+        pages.append(page)
+        output = BytesIO()
+        pages[0].save(output, "PDF", save_all=True, append_images=pages[1:])
+        output.seek(0)
+    except Exception as ex:
+        raise ReportSchedulePdfFailedError(
+            f"Failed converting chart data to pdf {str(ex)}"
+        ) from ex
+
+    return output.read()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -90,6 +90,7 @@ from superset.utils.core import (
     get_user_id,
     ReservedUrlParameters,
 )
+from superset.utils.pdf import build_pdf_from_chart_data
 from superset.views.base import (
     api,
     BaseSupersetView,
@@ -199,6 +200,9 @@ class Superset(BaseSupersetView):
         if response_type == ChartDataResultFormat.XLSX:
             return self._generate_xlsx(viz_obj)
 
+        if response_type == ChartDataResultFormat.PDF:
+            return self._generate_pdf(viz_obj)
+
         if response_type == ChartDataResultType.QUERY:
             return self.get_query_string_response(viz_obj)
 
@@ -228,6 +232,18 @@ class Superset(BaseSupersetView):
                 df = apply_column_types(df, coltypes)
         xlsx_data = df_to_excel(df, index=False)
         return XlsxResponse(xlsx_data, headers=generate_download_headers("xlsx"))
+
+    @staticmethod
+    def _generate_pdf(viz_obj: BaseViz) -> FlaskResponse:
+        payload = viz_obj.get_df_payload()
+        df = payload.get("df")
+        records = df.to_dict("records") if df is not None else []
+        pdf_data = build_pdf_from_chart_data(records)
+        return Response(
+            pdf_data,
+            headers=generate_download_headers("pdf"),
+            mimetype="application/pdf",
+        )
 
     @event_logger.log_this
     @api
@@ -316,6 +332,7 @@ class Superset(BaseSupersetView):
         # Verify user has permission to export data files
         if response_type in (
             ChartDataResultFormat.CSV,
+            ChartDataResultFormat.PDF,
             ChartDataResultFormat.XLSX,
         ):
             if is_feature_enabled("GRANULAR_EXPORT_CONTROLS"):

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -26,8 +26,10 @@ from pytest_mock import MockerFixture
 from superset.app import SupersetApp
 from superset.commands.exceptions import UpdateFailedError
 from superset.commands.report.execute import BaseReportState
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.dashboards.permalink.types import DashboardPermalinkState
 from superset.reports.models import (
+    ReportDataFormat,
     ReportRecipients,
     ReportRecipientType,
     ReportSchedule,
@@ -582,3 +584,66 @@ def test_update_recipient_to_slack_v2_missing_channels(mocker: MockerFixture):
     )
     with pytest.raises(UpdateFailedError):
         mock_cmmd.update_report_schedule_slack_v2()
+
+
+def test_get_url_with_pdf_result_format_uses_chart_data_endpoint(
+    mocker: MockerFixture,
+) -> None:
+    mock_report_schedule: ReportSchedule = mocker.Mock(spec=ReportSchedule)
+    mock_report_schedule.chart = True
+    mock_report_schedule.chart_id = 456
+    mock_report_schedule.force_screenshot = False
+
+    expected_url = "https://superset.local/api/v1/chart/456/data/"
+    get_url_path_mock = mocker.patch(
+        "superset.commands.report.execute.get_url_path",
+        return_value=expected_url,
+    )
+
+    class_instance = BaseReportState(
+        mock_report_schedule, "January 1, 2021", "execution_id_example"
+    )
+
+    result = class_instance._get_url(result_format=ChartDataResultFormat.PDF)
+
+    assert result == expected_url
+    get_url_path_mock.assert_called_once_with(
+        "ChartDataRestApi.get_data",
+        pk=456,
+        format=ChartDataResultFormat.PDF.value,
+        type=ChartDataResultType.FULL.value,
+        force="false",
+    )
+
+
+def test_get_notification_content_uses_chart_data_pdf_for_pdf_new(
+    mocker: MockerFixture,
+) -> None:
+    mock_report_schedule: ReportSchedule = mocker.Mock(spec=ReportSchedule)
+    mock_report_schedule.type = ReportScheduleType.REPORT
+    mock_report_schedule.name = "Weekly Report"
+    mock_report_schedule.description = "Test Description"
+    mock_report_schedule.report_format = ReportDataFormat.PDF_NEW
+    mock_report_schedule.chart = mocker.Mock()
+    mock_report_schedule.chart.slice_name = "Sales Chart"
+    mock_report_schedule.chart_id = 1
+    mock_report_schedule.dashboard = None
+    mock_report_schedule.owners = []
+    mock_report_schedule.recipients = []
+    mock_report_schedule.email_subject = None
+
+    class_instance = BaseReportState(
+        mock_report_schedule, "January 1, 2021", "execution_id_example"
+    )
+    mocker.patch.object(class_instance, "_get_url", return_value="https://example.com")
+    chart_pdf_mock = mocker.patch.object(
+        class_instance, "_get_chart_data_pdf", return_value=b"pdf-bytes"
+    )
+    screenshot_pdf_mock = mocker.patch.object(class_instance, "_get_pdf")
+
+    content = class_instance._get_notification_content()
+
+    assert content.pdf == b"pdf-bytes"
+    assert content.name == "Weekly Report: Sales Chart"
+    chart_pdf_mock.assert_called_once()
+    screenshot_pdf_mock.assert_not_called()

--- a/tests/unit_tests/utils/pdf_test.py
+++ b/tests/unit_tests/utils/pdf_test.py
@@ -14,34 +14,28 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset.utils.backports import StrEnum
+
+import pytest
+
+from superset.utils.pdf import build_pdf_from_chart_data
+
+pytest.importorskip("PIL")
 
 
-class ChartDataResultFormat(StrEnum):
-    """
-    Chart data response format
-    """
+def test_build_pdf_from_chart_data_with_rows() -> None:
+    pdf_bytes = build_pdf_from_chart_data(
+        [
+            {"country": "TR", "value": 10},
+            {"country": "US", "value": 25},
+        ]
+    )
 
-    CSV = "csv"
-    JSON = "json"
-    PDF = "pdf"
-    XLSX = "xlsx"
-
-    @classmethod
-    def table_like(cls) -> set["ChartDataResultFormat"]:
-        return {cls.CSV} | {cls.XLSX}
+    assert pdf_bytes.startswith(b"%PDF")
+    assert len(pdf_bytes) > 100
 
 
-class ChartDataResultType(StrEnum):
-    """
-    Chart data response type
-    """
+def test_build_pdf_from_chart_data_with_empty_rows() -> None:
+    pdf_bytes = build_pdf_from_chart_data([])
 
-    COLUMNS = "columns"
-    FULL = "full"
-    QUERY = "query"
-    RESULTS = "results"
-    SAMPLES = "samples"
-    TIMEGRAINS = "timegrains"
-    POST_PROCESSED = "post_processed"
-    DRILL_DETAIL = "drill_detail"
+    assert pdf_bytes.startswith(b"%PDF")
+    assert len(pdf_bytes) > 100

--- a/tests/unit_tests/utils/pdf_test.py
+++ b/tests/unit_tests/utils/pdf_test.py
@@ -42,7 +42,9 @@ def test_build_pdf_from_chart_data_with_empty_rows() -> None:
     assert len(pdf_bytes) > 100
 
 
-def _capture_page_width(monkeypatch: pytest.MonkeyPatch, rows: list[dict[str, str]]) -> int:
+def _capture_page_width(
+    monkeypatch: pytest.MonkeyPatch, rows: list[dict[str, str]]
+) -> int:
     captured_widths: list[int] = []
     original_image_new = pdf_utils.Image.new
 
@@ -76,16 +78,31 @@ def test_build_pdf_from_chart_data_adjusts_page_width_to_content(
 def test_apply_column_labels_to_rows_uses_dataset_labels() -> None:
     rows = apply_column_labels_to_rows(
         [{"country": "TR", "sales": 10}],
-        {"country": "Ülke", "sales": "Satış"},
+        {"country": "\u00dclke", "sales": "Sat\u0131\u015f"},
     )
 
-    assert rows == [{"Ülke": "TR", "Satış": 10}]
+    assert rows == [{"\u00dclke": "TR", "Sat\u0131\u015f": 10}]
 
 
 def test_apply_column_labels_to_rows_avoids_header_collisions() -> None:
     rows = apply_column_labels_to_rows(
         [{"src_a": 1, "src_b": 2}],
-        {"src_a": "Aynı", "src_b": "Aynı"},
+        {"src_a": "Ayn\u0131", "src_b": "Ayn\u0131"},
     )
 
-    assert rows == [{"Aynı": 1, "Aynı (src_b)": 2}]
+    assert rows == [{"Ayn\u0131": 1, "Ayn\u0131 (src_b)": 2}]
+
+
+def test_build_pdf_from_chart_data_handles_turkish_characters() -> None:
+    pdf_bytes = build_pdf_from_chart_data(
+        [
+            {
+                "\u00dclke": "T\u00fcrkiye",
+                "\u015eehir": "\u0130zmir",
+                "A\u00e7\u0131klama": "\u00c7al\u0131\u015f\u0131yor",
+            }
+        ]
+    )
+
+    assert pdf_bytes.startswith(b"%PDF")
+    assert len(pdf_bytes) > 100

--- a/tests/unit_tests/utils/pdf_test.py
+++ b/tests/unit_tests/utils/pdf_test.py
@@ -17,7 +17,8 @@
 
 import pytest
 
-from superset.utils.pdf import build_pdf_from_chart_data
+from superset.utils import pdf as pdf_utils
+from superset.utils.pdf import apply_column_labels_to_rows, build_pdf_from_chart_data
 
 pytest.importorskip("PIL")
 
@@ -39,3 +40,52 @@ def test_build_pdf_from_chart_data_with_empty_rows() -> None:
 
     assert pdf_bytes.startswith(b"%PDF")
     assert len(pdf_bytes) > 100
+
+
+def _capture_page_width(monkeypatch: pytest.MonkeyPatch, rows: list[dict[str, str]]) -> int:
+    captured_widths: list[int] = []
+    original_image_new = pdf_utils.Image.new
+
+    def image_new_spy(mode: str, size: tuple[int, int], color: str) -> object:
+        captured_widths.append(size[0])
+        return original_image_new(mode, size, color)
+
+    monkeypatch.setattr(pdf_utils.Image, "new", image_new_spy)
+    build_pdf_from_chart_data(rows)
+    # Ignore tiny probe canvases and return the real document width.
+    return max(width for width in captured_widths if width > 10)
+
+
+def test_build_pdf_from_chart_data_adjusts_page_width_to_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    narrow_width = _capture_page_width(monkeypatch, [{"country": "TR"}])
+    wide_width = _capture_page_width(
+        monkeypatch,
+        [
+            {
+                "description": "network-device-" * 20,
+                "details": "cisco-ios-release-" * 20,
+            }
+        ],
+    )
+
+    assert narrow_width < wide_width
+
+
+def test_apply_column_labels_to_rows_uses_dataset_labels() -> None:
+    rows = apply_column_labels_to_rows(
+        [{"country": "TR", "sales": 10}],
+        {"country": "Ülke", "sales": "Satış"},
+    )
+
+    assert rows == [{"Ülke": "TR", "Satış": 10}]
+
+
+def test_apply_column_labels_to_rows_avoids_header_collisions() -> None:
+    rows = apply_column_labels_to_rows(
+        [{"src_a": 1, "src_b": 2}],
+        {"src_a": "Aynı", "src_b": "Aynı"},
+    )
+
+    assert rows == [{"Aynı": 1, "Aynı (src_b)": 2}]


### PR DESCRIPTION
## **User description**
… field for email delivery

feat: add PDF export support for Superset charts and new PDF field for email sending

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Add PDF export for charts and a new chart-data PDF report option

### What Changed
- Users can export charts as PDF from chart menus and the Explore export options; "Export to PDF" appears alongside CSV/XLSX and triggers a PDF download of chart data.
- Scheduled reports can attach PDFs: existing screenshot-based PDFs remain, and a new "PDF NEW" report format attaches a PDF generated from chart data for chart reports.
- Server now produces PDF files from chart data and from screenshots so exported PDFs and report attachments are returned with a PDF Content-Type and proper download headers.
- Explore endpoints and export utilities accept pdf as an export type; export logs record PDF download actions and frontend menus/tests updated to cover PDF exports.
- Alert/report UI hides the screenshot-width input when the new chart-data "PDF NEW" format is selected; unit tests added/updated for PDF behaviors.

### Impact
`✅ Export charts as PDF`
`✅ Attach chart-data PDF to scheduled reports`
`✅ Clearer PDF export options in chart menus`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
