### PR TITLE
fix(explore): prevent verbose_name from overriding column_name in filter resolution

### DIFF
--- a/superset/mcp_service/screenshot/webdriver_pool.py
+++ b/superset/mcp_service/screenshot/webdriver_pool.py
@@ -18,7 +18,7 @@
 """
 WebDriver connection pooling for improved screenshot performance
 """
-
+import platform
 import logging
 import signal
 import threading
@@ -115,70 +115,36 @@ class WebDriverPool:
                 "max_pool_size": self.max_pool_size,
             }
 
-    def _create_driver(
-        self, window_size: WindowSize, user_id: int | None = None
-    ) -> PooledWebDriver:
-        """Create a new WebDriver instance with timeout protection"""
-        driver = None
-        old_handler = None
-
+    def _create_driver(self) -> PooledWebDriver:
+        """Create a new webdriver instance with timeout protection"""
         try:
             # SECURITY FIX: Set up timeout protection for driver creation
-            old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
-            signal.alarm(self.creation_timeout_seconds)
+            old_handler = None
+            if platform.system() != "Windows":
+                old_handler = signal.signal(signal.SIGALRM, self._timeout_handler)
+                signal.alarm(self.creation_timeout_seconds)
 
             driver_type = current_app.config.get("WEBDRIVER_TYPE", "firefox")
-            selenium_driver = WebDriverSelenium(driver_type, window_size)
-
-            # Create the actual WebDriver with timeout protection
-            driver = selenium_driver.create()
+            driver = WebDriverSelenium(driver_type, window_size)
             driver.set_window_size(*window_size)
 
             # Clear the alarm - creation successful
-            signal.alarm(0)
+            if platform.system() != "Windows":
+                signal.alarm(0)
 
             pooled_driver = PooledWebDriver(
                 driver=driver,
-                created_at=time.time(),
-                last_used=time.time(),
-                window_size=window_size,
-                user_id=user_id,
-                is_healthy=True,
-                usage_count=0,
-            )
-
-            self._stats["created"] += 1
-            logger.debug(
-                "Created new WebDriver instance for window size %s", window_size
+                in_use=False,
+                last_used=datetime.now()
             )
             return pooled_driver
 
-        except WebDriverCreationError:
-            logger.error(
-                "WebDriver creation timed out after %s seconds",
-                self.creation_timeout_seconds,
-            )
-            if driver:
-                try:
-                    driver.quit()
-                except Exception:
-                    logger.debug("Failed to cleanup driver during timeout")
-            raise Exception("WebDriver creation timed out") from None
-
-        except Exception as e:
-            logger.error("Failed to create WebDriver: %s", e)
-            if driver:
-                try:
-                    driver.quit()
-                except Exception:
-                    logger.debug("Failed to cleanup driver during error")
-            raise
-
         finally:
             # Restore original signal handler and clear alarm
-            signal.alarm(0)
-            if old_handler is not None:
-                signal.signal(signal.SIGALRM, old_handler)
+            if platform.system() != "Windows":
+                signal.alarm(0)
+                if old_handler is not None:
+                    signal.signal(signal.SIGALRM, old_handler)
 
     def _is_driver_valid(self, pooled_driver: PooledWebDriver) -> bool:
         """Check if a pooled driver is still valid for use"""

--- a/superset/mcp_service/screenshot/webdriver_pool.py
+++ b/superset/mcp_service/screenshot/webdriver_pool.py
@@ -18,7 +18,7 @@
 """
 WebDriver connection pooling for improved screenshot performance
 """
-import platform
+
 import logging
 import signal
 import threading
@@ -115,36 +115,70 @@ class WebDriverPool:
                 "max_pool_size": self.max_pool_size,
             }
 
-    def _create_driver(self) -> PooledWebDriver:
-        """Create a new webdriver instance with timeout protection"""
+    def _create_driver(
+        self, window_size: WindowSize, user_id: int | None = None
+    ) -> PooledWebDriver:
+        """Create a new WebDriver instance with timeout protection"""
+        driver = None
+        old_handler = None
+
         try:
             # SECURITY FIX: Set up timeout protection for driver creation
-            old_handler = None
-            if platform.system() != "Windows":
-                old_handler = signal.signal(signal.SIGALRM, self._timeout_handler)
-                signal.alarm(self.creation_timeout_seconds)
+            old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
+            signal.alarm(self.creation_timeout_seconds)
 
             driver_type = current_app.config.get("WEBDRIVER_TYPE", "firefox")
-            driver = WebDriverSelenium(driver_type, window_size)
+            selenium_driver = WebDriverSelenium(driver_type, window_size)
+
+            # Create the actual WebDriver with timeout protection
+            driver = selenium_driver.create()
             driver.set_window_size(*window_size)
 
             # Clear the alarm - creation successful
-            if platform.system() != "Windows":
-                signal.alarm(0)
+            signal.alarm(0)
 
             pooled_driver = PooledWebDriver(
                 driver=driver,
-                in_use=False,
-                last_used=datetime.now()
+                created_at=time.time(),
+                last_used=time.time(),
+                window_size=window_size,
+                user_id=user_id,
+                is_healthy=True,
+                usage_count=0,
+            )
+
+            self._stats["created"] += 1
+            logger.debug(
+                "Created new WebDriver instance for window size %s", window_size
             )
             return pooled_driver
 
+        except WebDriverCreationError:
+            logger.error(
+                "WebDriver creation timed out after %s seconds",
+                self.creation_timeout_seconds,
+            )
+            if driver:
+                try:
+                    driver.quit()
+                except Exception:
+                    logger.debug("Failed to cleanup driver during timeout")
+            raise Exception("WebDriver creation timed out") from None
+
+        except Exception as e:
+            logger.error("Failed to create WebDriver: %s", e)
+            if driver:
+                try:
+                    driver.quit()
+                except Exception:
+                    logger.debug("Failed to cleanup driver during error")
+            raise
+
         finally:
             # Restore original signal handler and clear alarm
-            if platform.system() != "Windows":
-                signal.alarm(0)
-                if old_handler is not None:
-                    signal.signal(signal.SIGALRM, old_handler)
+            signal.alarm(0)
+            if old_handler is not None:
+                signal.signal(signal.SIGALRM, old_handler)
 
     def _is_driver_valid(self, pooled_driver: PooledWebDriver) -> bool:
         """Check if a pooled driver is still valid for use"""

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3531,9 +3531,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         column_names_lower = {col.column_name.lower() for col in self.columns}
 
         metric_names = {
-            m.metric_name
-            for m in self.metrics
-            if getattr(m, "metric_name", None)
+            m.metric_name for m in self.metrics if getattr(m, "metric_name", None)
         }
 
         metric_names_lower = {
@@ -3552,7 +3550,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
             if (
                 vname in columns_by_name
-                or vname in column_names              
+                or vname in column_names
                 or vname_lower in column_names_lower
                 or vname in metric_names
                 or vname_lower in metric_names_lower

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3526,6 +3526,41 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             m.metric_name: m for m in self.metrics
         }
 
+        # Build normalized sets for conflict detection
+        column_names = {col.column_name for col in self.columns}
+        column_names_lower = {col.column_name.lower() for col in self.columns}
+
+        metric_names = {
+            m.metric_name
+            for m in self.metrics
+            if getattr(m, "metric_name", None)
+        }
+
+        metric_names_lower = {
+            m.metric_name.lower()
+            for m in self.metrics
+            if getattr(m, "metric_name", None)
+        }
+
+        # Add verbose_name safely as alias
+        for column in self.columns:
+            if not column.verbose_name:
+                continue
+
+            vname = column.verbose_name
+            vname_lower = vname.lower()
+
+            if (
+                vname in columns_by_name
+                or vname in column_names              
+                or vname_lower in column_names_lower
+                or vname in metric_names
+                or vname_lower in metric_names_lower
+            ):
+                continue
+
+            columns_by_name[vname] = column
+
         if not granularity and is_timeseries:
             raise QueryObjectValidationError(
                 _(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -4545,6 +4545,41 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             m.metric_name: m for m in self.metrics
         }
 
+        # Build normalized sets for conflict detection
+        column_names = {col.column_name for col in self.columns}
+        column_names_lower = {col.column_name.lower() for col in self.columns}
+
+        metric_names = {
+            m.metric_name
+            for m in self.metrics
+            if getattr(m, "metric_name", None)
+        }
+
+        metric_names_lower = {
+            m.metric_name.lower()
+            for m in self.metrics
+            if getattr(m, "metric_name", None)
+        }
+
+        # Add verbose_name safely as alias
+        for column in self.columns:
+            if not column.verbose_name:
+                continue
+
+            vname = column.verbose_name
+            vname_lower = vname.lower()
+
+            if (
+                vname in columns_by_name
+                or vname in column_names              
+                or vname_lower in column_names_lower
+                or vname in metric_names
+                or vname_lower in metric_names_lower
+            ):
+                continue
+
+            columns_by_name[vname] = column
+
         if not granularity and is_timeseries:
             raise QueryObjectValidationError(
                 _(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -4550,9 +4550,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         column_names_lower = {col.column_name.lower() for col in self.columns}
 
         metric_names = {
-            m.metric_name
-            for m in self.metrics
-            if getattr(m, "metric_name", None)
+            m.metric_name for m in self.metrics if getattr(m, "metric_name", None)
         }
 
         metric_names_lower = {
@@ -4571,7 +4569,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
             if (
                 vname in columns_by_name
-                or vname in column_names              
+                or vname in column_names
                 or vname_lower in column_names_lower
                 or vname in metric_names
                 or vname_lower in metric_names_lower

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -746,21 +746,25 @@ class SigalrmTimeout:
 
     def __enter__(self) -> None:
         try:
-            if threading.current_thread() == threading.main_thread():
+            if (
+                threading.current_thread() == threading.main_thread()
+                and platform.system() != "Windows"
+            ):
                 signal.signal(signal.SIGALRM, self.handle_timeout)
                 signal.alarm(self.seconds)
-        except ValueError as ex:
+        except (ValueError, AttributeError) as ex:
             logger.warning("timeout can't be used in the current context")
-            logger.exception(ex)
+            logger.debug(ex)
 
     def __exit__(  # pylint: disable=redefined-outer-name,redefined-builtin
         self, type: Any, value: Any, traceback: TracebackType
     ) -> None:
         try:
-            signal.alarm(0)
-        except ValueError as ex:
+            if platform.system() != "Windows":
+                signal.alarm(0)
+        except (ValueError, AttributeError) as ex:
             logger.warning("timeout can't be used in the current context")
-            logger.exception(ex)
+            logger.debug(ex)
 
 
 class TimerTimeout:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -796,21 +796,25 @@ class SigalrmTimeout:
 
     def __enter__(self) -> None:
         try:
-            if threading.current_thread() == threading.main_thread():
+            if (
+                threading.current_thread() == threading.main_thread()
+                and platform.system() != "Windows"
+            ):
                 signal.signal(signal.SIGALRM, self.handle_timeout)
                 signal.alarm(self.seconds)
-        except ValueError as ex:
+        except (ValueError, AttributeError) as ex:
             logger.warning("timeout can't be used in the current context")
-            logger.exception(ex)
+            logger.debug(ex)
 
     def __exit__(  # pylint: disable=redefined-outer-name,redefined-builtin
         self, type: Any, value: Any, traceback: TracebackType
     ) -> None:
         try:
-            signal.alarm(0)
-        except ValueError as ex:
+            if platform.system() != "Windows":
+                signal.alarm(0)
+        except (ValueError, AttributeError) as ex:
             logger.warning("timeout can't be used in the current context")
-            logger.exception(ex)
+            logger.debug(ex)
 
 
 class TimerTimeout:

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -32,6 +32,7 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.elements import Cast, ColumnElement
 from sqlalchemy.sql.visitors import iterate
 
+from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.superset_typing import AdhocColumn, AdhocMetric, OrderBy
 from superset.utils.core import FilterOperator, GenericDataType
 from tests.unit_tests.conftest import with_feature_flags
@@ -3875,3 +3876,53 @@ def test_metric_not_overridden_by_verbose_name(database: Database) -> None:
     assert "total_revenue" in metrics_by_name
     assert "total_revenue" not in columns_by_name
     assert columns_by_name["sales"] == column
+
+
+def test_verbose_name_does_not_override_existing_column():
+    col1 = TableColumn(column_name="sales", verbose_name="profit")
+    col2 = TableColumn(column_name="profit")
+
+    dataset = SqlaTable()
+    dataset.columns = [col1, col2]
+    dataset.metrics = []
+
+    columns = dataset.columns_by_name
+
+    assert columns["profit"] == col2  # real column wins
+
+
+def test_verbose_name_does_not_override_metric():
+    column = TableColumn(column_name="sales", verbose_name="total_revenue")
+    metric = SqlMetric(metric_name="total_revenue", expression="SUM(sales)")
+
+    dataset = SqlaTable()
+    dataset.columns = [column]
+    dataset.metrics = [metric]
+
+    columns = dataset.columns_by_name
+
+    assert "total_revenue" not in columns
+
+def test_verbose_name_added_when_no_conflict():
+    column = TableColumn(column_name="sales", verbose_name="revenue_label")
+
+    dataset = SqlaTable()
+    dataset.columns = [column]
+    dataset.metrics = []
+
+    columns = dataset.columns_by_name
+
+    assert "revenue_label" in columns
+    assert columns["revenue_label"] == column
+
+def test_column_name_always_present():
+    column = TableColumn(column_name="sales", verbose_name="sales_label")
+
+    dataset = SqlaTable()
+    dataset.columns = [column]
+    dataset.metrics = []
+
+    columns = dataset.columns_by_name
+
+    assert "sales" in columns
+    assert columns["sales"] == column

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -25,7 +25,6 @@ from typing import Any, cast, TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from pytest_mock import MockerFixture
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
@@ -36,7 +35,6 @@ from sqlalchemy.sql.visitors import iterate
 from superset.superset_typing import AdhocColumn, AdhocMetric, OrderBy
 from superset.utils.core import FilterOperator, GenericDataType
 from tests.unit_tests.conftest import with_feature_flags
-
 
 if TYPE_CHECKING:
     from superset.jinja_context import BaseTemplateProcessor

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3814,11 +3814,7 @@ def test_columns_by_name_verbose_overrides_column_name(database: Database) -> No
     col1 = TableColumn(column_name="revenue", verbose_name="sales")
     col2 = TableColumn(column_name="sales", verbose_name=None)
 
-    table = SqlaTable(
-        database=database,
-        table_name="test_table",
-        columns=[col1, col2]
-    )
+    table = SqlaTable(database=database, table_name="test_table", columns=[col1, col2])
 
     columns_by_name = table.columns_by_name
 
@@ -3826,11 +3822,12 @@ def test_columns_by_name_verbose_overrides_column_name(database: Database) -> No
     assert columns_by_name["sales"] == col2
     assert columns_by_name["revenue"] == col1
 
+
 def test_columns_by_name_excludes_metric_conflicts(database: Database) -> None:
     """
     Test that verbose_name does NOT conflict with metric names (exact case).
     """
-    from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
+    from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 
     # Column: revenue (verbose_name="profit")
     # Metric: profit
@@ -3838,10 +3835,7 @@ def test_columns_by_name_excludes_metric_conflicts(database: Database) -> None:
     metric = SqlMetric(metric_name="profit")
 
     table = SqlaTable(
-        database=database,
-        table_name="test_table",
-        columns=[col],
-        metrics=[metric]
+        database=database, table_name="test_table", columns=[col], metrics=[metric]
     )
 
     columns_by_name = table.columns_by_name
@@ -3855,17 +3849,14 @@ def test_metric_not_overridden_by_verbose_name(database: Database) -> None:
     """
     Test that verbose_name doesn't override metric names in columns_by_name.
     """
-    from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
+    from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 
     column = TableColumn(column_name="sales", verbose_name="total_revenue")
     metric = SqlMetric(metric_name="total_revenue", expression="SUM(sales)")
 
     # Use SqlaTable directly instead of MockDataset
     table = SqlaTable(
-        database=database,
-        table_name="test_table",
-        columns=[column],
-        metrics=[metric]
+        database=database, table_name="test_table", columns=[column], metrics=[metric]
     )
 
     # The columns_by_name property will use the logic from your PR
@@ -3903,6 +3894,7 @@ def test_verbose_name_does_not_override_metric():
 
     assert "total_revenue" not in columns
 
+
 def test_verbose_name_added_when_no_conflict():
     column = TableColumn(column_name="sales", verbose_name="revenue_label")
 
@@ -3914,6 +3906,7 @@ def test_verbose_name_added_when_no_conflict():
 
     assert "revenue_label" in columns
     assert columns["revenue_label"] == column
+
 
 def test_column_name_always_present():
     column = TableColumn(column_name="sales", verbose_name="sales_label")

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -25,6 +25,7 @@ from typing import Any, cast, TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from pytest_mock import MockerFixture
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
@@ -35,6 +36,7 @@ from sqlalchemy.sql.visitors import iterate
 from superset.superset_typing import AdhocColumn, AdhocMetric, OrderBy
 from superset.utils.core import FilterOperator, GenericDataType
 from tests.unit_tests.conftest import with_feature_flags
+
 
 if TYPE_CHECKING:
     from superset.jinja_context import BaseTemplateProcessor
@@ -3800,3 +3802,78 @@ def test_like_filter_on_string_column_does_not_cast(database: Database) -> None:
     assert not any(isinstance(node, Cast) for node in iterate(whereclause)), (
         f"Unexpected Cast node in the filter expression: {whereclause}"
     )
+
+
+def test_columns_by_name_verbose_overrides_column_name(database: Database) -> None:
+    """
+    Test that verbose_name does NOT override existing column_name mapping.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+
+    # Column1: revenue (verbose_name="sales")
+    # Column2: sales (no verbose_name)
+    col1 = TableColumn(column_name="revenue", verbose_name="sales")
+    col2 = TableColumn(column_name="sales", verbose_name=None)
+
+    table = SqlaTable(
+        database=database,
+        table_name="test_table",
+        columns=[col1, col2]
+    )
+
+    columns_by_name = table.columns_by_name
+
+    # column_name "sales" should WIN over verbose_name "sales"
+    assert columns_by_name["sales"] == col2
+    assert columns_by_name["revenue"] == col1
+
+def test_columns_by_name_excludes_metric_conflicts(database: Database) -> None:
+    """
+    Test that verbose_name does NOT conflict with metric names (exact case).
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
+
+    # Column: revenue (verbose_name="profit")
+    # Metric: profit
+    col = TableColumn(column_name="revenue", verbose_name="profit")
+    metric = SqlMetric(metric_name="profit")
+
+    table = SqlaTable(
+        database=database,
+        table_name="test_table",
+        columns=[col],
+        metrics=[metric]
+    )
+
+    columns_by_name = table.columns_by_name
+
+    # "profit" should NOT map to column (metric conflict)
+    assert "profit" not in columns_by_name
+    assert columns_by_name["revenue"] == col
+
+
+def test_metric_not_overridden_by_verbose_name(database: Database) -> None:
+    """
+    Test that verbose_name doesn't override metric names in columns_by_name.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
+
+    column = TableColumn(column_name="sales", verbose_name="total_revenue")
+    metric = SqlMetric(metric_name="total_revenue", expression="SUM(sales)")
+
+    # Use SqlaTable directly instead of MockDataset
+    table = SqlaTable(
+        database=database,
+        table_name="test_table",
+        columns=[column],
+        metrics=[metric]
+    )
+
+    # The columns_by_name property will use the logic from your PR
+    columns_by_name = table.columns_by_name
+    metrics_by_name = {metric.metric_name: metric}
+
+    # KEY ASSERTIONS:
+    assert "total_revenue" in metrics_by_name
+    assert "total_revenue" not in columns_by_name
+    assert columns_by_name["sales"] == column

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -27,6 +27,7 @@ from typing import Any, cast, TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from pytest_mock import MockerFixture
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
@@ -37,6 +38,7 @@ from sqlalchemy.sql.visitors import iterate
 from superset.superset_typing import AdhocColumn, AdhocMetric, OrderBy
 from superset.utils.core import FilterOperator, GenericDataType
 from tests.unit_tests.conftest import with_feature_flags
+
 
 if TYPE_CHECKING:
     from superset.jinja_context import BaseTemplateProcessor
@@ -5759,3 +5761,78 @@ def test_filter_adhoc_column(database: Database) -> None:
     # The adhoc column resolved by label is parenthesized in the WHERE clause,
     # consistent with inline adhoc columns, to guard operator precedence.
     assert "lower((real_name)) LIKE lower('Zona%')" in sql
+
+
+def test_columns_by_name_verbose_overrides_column_name(database: Database) -> None:
+    """
+    Test that verbose_name does NOT override existing column_name mapping.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+
+    # Column1: revenue (verbose_name="sales")
+    # Column2: sales (no verbose_name)
+    col1 = TableColumn(column_name="revenue", verbose_name="sales")
+    col2 = TableColumn(column_name="sales", verbose_name=None)
+
+    table = SqlaTable(
+        database=database,
+        table_name="test_table",
+        columns=[col1, col2]
+    )
+
+    columns_by_name = table.columns_by_name
+
+    # column_name "sales" should WIN over verbose_name "sales"
+    assert columns_by_name["sales"] == col2
+    assert columns_by_name["revenue"] == col1
+
+def test_columns_by_name_excludes_metric_conflicts(database: Database) -> None:
+    """
+    Test that verbose_name does NOT conflict with metric names (exact case).
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
+
+    # Column: revenue (verbose_name="profit")
+    # Metric: profit
+    col = TableColumn(column_name="revenue", verbose_name="profit")
+    metric = SqlMetric(metric_name="profit")
+
+    table = SqlaTable(
+        database=database,
+        table_name="test_table",
+        columns=[col],
+        metrics=[metric]
+    )
+
+    columns_by_name = table.columns_by_name
+
+    # "profit" should NOT map to column (metric conflict)
+    assert "profit" not in columns_by_name
+    assert columns_by_name["revenue"] == col
+
+
+def test_metric_not_overridden_by_verbose_name(database: Database) -> None:
+    """
+    Test that verbose_name doesn't override metric names in columns_by_name.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
+
+    column = TableColumn(column_name="sales", verbose_name="total_revenue")
+    metric = SqlMetric(metric_name="total_revenue", expression="SUM(sales)")
+
+    # Use SqlaTable directly instead of MockDataset
+    table = SqlaTable(
+        database=database,
+        table_name="test_table",
+        columns=[column],
+        metrics=[metric]
+    )
+
+    # The columns_by_name property will use the logic from your PR
+    columns_by_name = table.columns_by_name
+    metrics_by_name = {metric.metric_name: metric}
+
+    # KEY ASSERTIONS:
+    assert "total_revenue" in metrics_by_name
+    assert "total_revenue" not in columns_by_name
+    assert columns_by_name["sales"] == column

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -34,6 +34,7 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.elements import Cast, ColumnElement
 from sqlalchemy.sql.visitors import iterate
 
+from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.superset_typing import AdhocColumn, AdhocMetric, OrderBy
 from superset.utils.core import FilterOperator, GenericDataType
 from tests.unit_tests.conftest import with_feature_flags
@@ -5834,3 +5835,53 @@ def test_metric_not_overridden_by_verbose_name(database: Database) -> None:
     assert "total_revenue" in metrics_by_name
     assert "total_revenue" not in columns_by_name
     assert columns_by_name["sales"] == column
+
+
+def test_verbose_name_does_not_override_existing_column():
+    col1 = TableColumn(column_name="sales", verbose_name="profit")
+    col2 = TableColumn(column_name="profit")
+
+    dataset = SqlaTable()
+    dataset.columns = [col1, col2]
+    dataset.metrics = []
+
+    columns = dataset.columns_by_name
+
+    assert columns["profit"] == col2  # real column wins
+
+
+def test_verbose_name_does_not_override_metric():
+    column = TableColumn(column_name="sales", verbose_name="total_revenue")
+    metric = SqlMetric(metric_name="total_revenue", expression="SUM(sales)")
+
+    dataset = SqlaTable()
+    dataset.columns = [column]
+    dataset.metrics = [metric]
+
+    columns = dataset.columns_by_name
+
+    assert "total_revenue" not in columns
+
+def test_verbose_name_added_when_no_conflict():
+    column = TableColumn(column_name="sales", verbose_name="revenue_label")
+
+    dataset = SqlaTable()
+    dataset.columns = [column]
+    dataset.metrics = []
+
+    columns = dataset.columns_by_name
+
+    assert "revenue_label" in columns
+    assert columns["revenue_label"] == column
+
+def test_column_name_always_present():
+    column = TableColumn(column_name="sales", verbose_name="sales_label")
+
+    dataset = SqlaTable()
+    dataset.columns = [column]
+    dataset.metrics = []
+
+    columns = dataset.columns_by_name
+
+    assert "sales" in columns
+    assert columns["sales"] == column

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -27,7 +27,6 @@ from typing import Any, cast, TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from pytest_mock import MockerFixture
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
@@ -38,7 +37,6 @@ from sqlalchemy.sql.visitors import iterate
 from superset.superset_typing import AdhocColumn, AdhocMetric, OrderBy
 from superset.utils.core import FilterOperator, GenericDataType
 from tests.unit_tests.conftest import with_feature_flags
-
 
 if TYPE_CHECKING:
     from superset.jinja_context import BaseTemplateProcessor

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -5773,11 +5773,7 @@ def test_columns_by_name_verbose_overrides_column_name(database: Database) -> No
     col1 = TableColumn(column_name="revenue", verbose_name="sales")
     col2 = TableColumn(column_name="sales", verbose_name=None)
 
-    table = SqlaTable(
-        database=database,
-        table_name="test_table",
-        columns=[col1, col2]
-    )
+    table = SqlaTable(database=database, table_name="test_table", columns=[col1, col2])
 
     columns_by_name = table.columns_by_name
 
@@ -5785,11 +5781,12 @@ def test_columns_by_name_verbose_overrides_column_name(database: Database) -> No
     assert columns_by_name["sales"] == col2
     assert columns_by_name["revenue"] == col1
 
+
 def test_columns_by_name_excludes_metric_conflicts(database: Database) -> None:
     """
     Test that verbose_name does NOT conflict with metric names (exact case).
     """
-    from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
+    from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 
     # Column: revenue (verbose_name="profit")
     # Metric: profit
@@ -5797,10 +5794,7 @@ def test_columns_by_name_excludes_metric_conflicts(database: Database) -> None:
     metric = SqlMetric(metric_name="profit")
 
     table = SqlaTable(
-        database=database,
-        table_name="test_table",
-        columns=[col],
-        metrics=[metric]
+        database=database, table_name="test_table", columns=[col], metrics=[metric]
     )
 
     columns_by_name = table.columns_by_name
@@ -5814,17 +5808,14 @@ def test_metric_not_overridden_by_verbose_name(database: Database) -> None:
     """
     Test that verbose_name doesn't override metric names in columns_by_name.
     """
-    from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
+    from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 
     column = TableColumn(column_name="sales", verbose_name="total_revenue")
     metric = SqlMetric(metric_name="total_revenue", expression="SUM(sales)")
 
     # Use SqlaTable directly instead of MockDataset
     table = SqlaTable(
-        database=database,
-        table_name="test_table",
-        columns=[column],
-        metrics=[metric]
+        database=database, table_name="test_table", columns=[column], metrics=[metric]
     )
 
     # The columns_by_name property will use the logic from your PR
@@ -5862,6 +5853,7 @@ def test_verbose_name_does_not_override_metric():
 
     assert "total_revenue" not in columns
 
+
 def test_verbose_name_added_when_no_conflict():
     column = TableColumn(column_name="sales", verbose_name="revenue_label")
 
@@ -5873,6 +5865,7 @@ def test_verbose_name_added_when_no_conflict():
 
     assert "revenue_label" in columns
     assert columns["revenue_label"] == column
+
 
 def test_column_name_always_present():
     column = TableColumn(column_name="sales", verbose_name="sales_label")


### PR DESCRIPTION
## **User description**
## What problem does this solve?

Filtering can break when a column has a `verbose_name` that conflicts with an existing column name.

In the current implementation, both `column_name` and `verbose_name` are added to the `columns_by_name` mapping. If a `verbose_name` matches an existing key, it can override the actual column mapping. This leads to incorrect column resolution during query building, causing filters to fail or behave unexpectedly.

## What does this PR do?

- Ensures `column_name` remains the primary and authoritative key in `columns_by_name`
- Adds `verbose_name` as a secondary alias only when it does not conflict with existing keys
- Prevents overriding of actual column mappings, keeping query generation consistent

## Why is this change needed?

`column_name` is the true identifier used in SQL queries, while `verbose_name` is intended for display purposes. Allowing `verbose_name` to override `column_name` breaks this distinction and can result in invalid or missing filters.

This change ensures predictable and correct filter behavior even when `verbose_name` is present.

## Testing

- Verified filtering works correctly using both `column_name` and non-conflicting `verbose_name`
- Confirmed no regressions in existing query behavior

## Related

Related to #38339

This addresses part of the issue where filter resolution fails due to mismatches between displayed labels and actual column identifiers. Additional handling may still be required for adhoc column labels.


___

## **CodeAnt-AI Description**
Prevent verbose_name from overriding column and metric names in filter resolution

### What Changed
- Display names (verbose_name) are only added as filter aliases when they do not conflict with any existing column name or metric name (checked case-insensitively); the real column_name and metric names keep priority
- Filters that previously matched the wrong field because a verbose_name collided with a column or metric now resolve to the correct column or metric
- Signal-based timeout setup is skipped on Windows to avoid inappropriate signal usage; driver-creation timeout handling and timeout context manager logging are made less noisy
- Unit tests added to verify that verbose_name does not override column_name or metric names and to cover the conflict cases

### Impact
`✅ Fewer broken filters due to display-name collisions`
`✅ Clearer filter-to-column/metric resolution`
`✅ Fewer Windows timeout/signal errors during driver creation and timeout handling`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
