### PR TITLE
fix: Simplify extension folder name

### DIFF
--- a/docs/developer_docs/extensions/development.md
+++ b/docs/developer_docs/extensions/development.md
@@ -49,7 +49,7 @@ superset-extensions update: Updates derived and generated files in the extension
 When creating a new extension with `superset-extensions init`, the CLI generates a standardized folder structure:
 
 ```
-my-org.dataset-references/
+dataset-references/
 ├── extension.json
 ├── frontend/
 │   ├── src/
@@ -80,7 +80,7 @@ my-org.dataset-references/
 ```
 
 **Note**: With publisher `my-org` and name `dataset-references`, the technical names are:
-- Directory name: `my-org.dataset-references` (kebab-case)
+- Directory name: `dataset-references` (kebab-case)
 - Backend Python namespace: `my_org.dataset_references`
 - Backend distribution package: `my_org-dataset_references`
 - Frontend package name: `@my-org/dataset-references` (scoped)

--- a/docs/developer_docs/extensions/quick-start.md
+++ b/docs/developer_docs/extensions/quick-start.md
@@ -75,7 +75,7 @@ This approach ensures that extensions from different organizations cannot confli
 This creates a complete project structure:
 
 ```
-my-org.hello-world/
+hello-world/
 ├── extension.json           # Extension metadata and configuration
 ├── backend/                 # Backend Python code
 │   ├── src/

--- a/superset-extensions-cli/src/superset_extensions_cli/cli.py
+++ b/superset-extensions-cli/src/superset_extensions_cli/cli.py
@@ -824,7 +824,7 @@ def init(
         else click.confirm("Include backend?", default=True)
     )
 
-    target_dir = Path.cwd() / names["id"]
+    target_dir = Path.cwd() / names["name"]
     if target_dir.exists():
         click.secho(f"❌ Directory {target_dir} already exists.", fg="red")
         sys.exit(1)

--- a/superset-extensions-cli/tests/test_cli_init.py
+++ b/superset-extensions-cli/tests/test_cli_init.py
@@ -48,12 +48,12 @@ def test_init_creates_extension_with_both_frontend_and_backend(
     )
 
     # Verify directory structure
-    extension_path = isolated_filesystem / "test-org.test-extension"
+    extension_path = isolated_filesystem / "test-extension"
     assert_directory_exists(extension_path, "main extension directory")
 
     expected_structure = create_test_extension_structure(
         isolated_filesystem,
-        "test-org.test-extension",
+        "test-extension",
         include_frontend=True,
         include_backend=True,
     )
@@ -74,7 +74,7 @@ def test_init_creates_extension_with_frontend_only(
 
     assert result.exit_code == 0, f"Command failed with output: {result.output}"
 
-    extension_path = isolated_filesystem / "test-org.test-extension"
+    extension_path = isolated_filesystem / "test-extension"
     assert_directory_exists(extension_path)
 
     # Should have frontend directory and package.json
@@ -97,7 +97,7 @@ def test_init_creates_extension_with_backend_only(
 
     assert result.exit_code == 0, f"Command failed with output: {result.output}"
 
-    extension_path = isolated_filesystem / "test-org.test-extension"
+    extension_path = isolated_filesystem / "test-extension"
     assert_directory_exists(extension_path)
 
     # Should have backend directory and pyproject.toml
@@ -120,7 +120,7 @@ def test_init_creates_extension_with_neither_frontend_nor_backend(
 
     assert result.exit_code == 0, f"Command failed with output: {result.output}"
 
-    extension_path = isolated_filesystem / "test-org.test-extension"
+    extension_path = isolated_filesystem / "test-extension"
     assert_directory_exists(extension_path)
 
     # Should only have extension.json
@@ -138,8 +138,8 @@ def test_init_accepts_valid_display_name(cli_runner, isolated_filesystem):
     result = cli_runner.invoke(app, ["init"], input=cli_input)
 
     assert result.exit_code == 0, f"Should accept display name: {result.output}"
-    assert Path("test-org.my-awesome-extension").exists(), (
-        "Directory for generated composite ID should be created"
+    assert Path("my-awesome-extension").exists(), (
+        "Directory with extension name should be created"
     )
 
 
@@ -152,23 +152,23 @@ def test_init_accepts_mixed_alphanumeric_name(cli_runner, isolated_filesystem):
     assert result.exit_code == 0, (
         f"Mixed alphanumeric display name should be valid: {result.output}"
     )
-    assert Path("test-org.tool-123").exists(), (
-        "Directory for 'test-org.tool-123' should be created"
+    assert Path("tool-123").exists(), (
+        "Directory for 'tool-123' should be created"
     )
 
 
 @pytest.mark.cli
 @pytest.mark.parametrize(
-    "display_name,expected_id",
+    "display_name,expected_dir",
     [
-        ("Test Extension", "test-org.test-extension"),
-        ("My Tool v2", "test-org.my-tool-v2"),
-        ("Dashboard Helper", "test-org.dashboard-helper"),
-        ("Chart Builder Pro", "test-org.chart-builder-pro"),
+        ("Test Extension", "test-extension"),
+        ("My Tool v2", "my-tool-v2"),
+        ("Dashboard Helper", "dashboard-helper"),
+        ("Chart Builder Pro", "chart-builder-pro"),
     ],
 )
-def test_init_with_various_display_names(cli_runner, display_name, expected_id):
-    """Test that init accepts various display names and generates proper IDs."""
+def test_init_with_various_display_names(cli_runner, display_name, expected_dir):
+    """Test that init accepts various display names and creates directory named after extension."""
     with cli_runner.isolated_filesystem():
         cli_input = f"{display_name}\n\ntest-org\n0.1.0\nApache-2.0\ny\ny\n"
         result = cli_runner.invoke(app, ["init"], input=cli_input)
@@ -176,8 +176,8 @@ def test_init_with_various_display_names(cli_runner, display_name, expected_id):
         assert result.exit_code == 0, (
             f"Valid display name '{display_name}' was rejected: {result.output}"
         )
-        assert Path(expected_id).exists(), (
-            f"Directory for '{expected_id}' was not created"
+        assert Path(expected_dir).exists(), (
+            f"Directory '{expected_dir}' was not created"
         )
 
 
@@ -187,7 +187,7 @@ def test_init_fails_when_directory_already_exists(
 ):
     """Test that init fails gracefully when target directory already exists."""
     # Create the directory first
-    existing_dir = isolated_filesystem / "test-org.test-extension"
+    existing_dir = isolated_filesystem / "test-extension"
     existing_dir.mkdir()
 
     result = cli_runner.invoke(app, ["init"], input=cli_input_both)
@@ -204,7 +204,7 @@ def test_extension_json_content_is_correct(
     result = cli_runner.invoke(app, ["init"], input=cli_input_both)
     assert result.exit_code == 0
 
-    extension_path = isolated_filesystem / "test-org.test-extension"
+    extension_path = isolated_filesystem / "test-extension"
     extension_json_path = extension_path / "extension.json"
 
     # Verify the JSON structure and values
@@ -238,7 +238,7 @@ def test_frontend_package_json_content_is_correct(
     result = cli_runner.invoke(app, ["init"], input=cli_input_both)
     assert result.exit_code == 0
 
-    extension_path = isolated_filesystem / "test-org.test-extension"
+    extension_path = isolated_filesystem / "test-extension"
     package_json_path = extension_path / "frontend" / "package.json"
 
     # Verify the package.json structure and values
@@ -267,7 +267,7 @@ def test_backend_pyproject_toml_is_created(
     result = cli_runner.invoke(app, ["init"], input=cli_input_both)
     assert result.exit_code == 0
 
-    extension_path = isolated_filesystem / "test-org.test-extension"
+    extension_path = isolated_filesystem / "test-extension"
     pyproject_path = extension_path / "backend" / "pyproject.toml"
 
     assert_file_exists(pyproject_path, "backend pyproject.toml")
@@ -305,7 +305,7 @@ def test_gitignore_content_is_correct(cli_runner, isolated_filesystem, cli_input
     result = cli_runner.invoke(app, ["init"], input=cli_input_both)
     assert result.exit_code == 0
 
-    extension_path = isolated_filesystem / "test-org.test-extension"
+    extension_path = isolated_filesystem / "test-extension"
     gitignore_path = extension_path / ".gitignore"
 
     assert_file_exists(gitignore_path, ".gitignore")
@@ -330,7 +330,7 @@ def test_init_with_custom_version_and_license(cli_runner, isolated_filesystem):
 
     assert result.exit_code == 0
 
-    extension_path = isolated_filesystem / "test-org.my-extension"
+    extension_path = isolated_filesystem / "my-extension"
     extension_json_path = extension_path / "extension.json"
 
     assert_json_content(
@@ -357,10 +357,10 @@ def test_full_init_workflow_integration(cli_runner, isolated_filesystem):
     assert result.exit_code == 0
 
     # Verify complete directory structure
-    extension_path = isolated_filesystem / "awesome-org.awesome-charts"
+    extension_path = isolated_filesystem / "awesome-charts"
     expected_structure = create_test_extension_structure(
         isolated_filesystem,
-        "awesome-org.awesome-charts",
+        "awesome-charts",
         include_frontend=True,
         include_backend=True,
     )
@@ -412,7 +412,7 @@ def test_init_non_interactive_with_all_options(cli_runner, isolated_filesystem):
     assert result.exit_code == 0, f"Command failed with output: {result.output}"
     assert "🎉 Extension My Extension (ID: my-org.my-ext) initialized" in result.output
 
-    extension_path = isolated_filesystem / "my-org.my-ext"
+    extension_path = isolated_filesystem / "my-ext"
     assert_directory_exists(extension_path)
     assert_directory_exists(extension_path / "frontend")
     assert_directory_exists(extension_path / "backend")
@@ -449,7 +449,7 @@ def test_init_frontend_only_with_cli_options(cli_runner, isolated_filesystem):
 
     assert result.exit_code == 0, f"Command failed with output: {result.output}"
 
-    extension_path = isolated_filesystem / "frontend-org.frontend-ext"
+    extension_path = isolated_filesystem / "frontend-ext"
     assert_directory_exists(extension_path / "frontend")
     assert not (extension_path / "backend").exists()
 
@@ -478,7 +478,7 @@ def test_init_backend_only_with_cli_options(cli_runner, isolated_filesystem):
 
     assert result.exit_code == 0, f"Command failed with output: {result.output}"
 
-    extension_path = isolated_filesystem / "backend-org.backend-ext"
+    extension_path = isolated_filesystem / "backend-ext"
     assert not (extension_path / "frontend").exists()
     assert_directory_exists(extension_path / "backend")
 
@@ -505,7 +505,7 @@ def test_init_prompts_for_missing_options(cli_runner, isolated_filesystem):
 
     assert result.exit_code == 0, f"Command failed with output: {result.output}"
 
-    extension_path = isolated_filesystem / "default-org.default-ext"
+    extension_path = isolated_filesystem / "default-ext"
     extension_json = load_json_file(extension_path / "extension.json")
     assert extension_json["version"] == "0.1.0"
     assert extension_json["license"] == "Apache-2.0"

--- a/superset-extensions-cli/tests/test_cli_init.py
+++ b/superset-extensions-cli/tests/test_cli_init.py
@@ -152,9 +152,7 @@ def test_init_accepts_mixed_alphanumeric_name(cli_runner, isolated_filesystem):
     assert result.exit_code == 0, (
         f"Mixed alphanumeric display name should be valid: {result.output}"
     )
-    assert Path("tool-123").exists(), (
-        "Directory for 'tool-123' should be created"
-    )
+    assert Path("tool-123").exists(), "Directory for 'tool-123' should be created"
 
 
 @pytest.mark.cli


### PR DESCRIPTION
### SUMMARY
The `superset-extensions init` command was creating the extension folder using the `id` (e.g., `acme.example`) instead of the provided `name`. This caused confusion for users, as they expected the folder name to match the extension name specified during initialization.

There's no need to include the publisher in the extension folder name to handle naming conflicts—`extension.json` contains all the necessary information. However, users are still free to add the publisher name to the folder (e.g., `acme-example`) if they prefer.

The folder name is purely a local development convention — it has no bearing on how the  extension is identified, loaded, or resolved in a marketplace. The source of truth is always `extension.json` (and the derived `dist/manifest.json`), which contains the full composite ID (`publisher.name`). That's what  Superset reads when installing or loading an extension, and what the marketplace would use to identify, version, and deduplicate extensions.                                                                         

The publisher prefix in the folder name was solving a problem that doesn't actually exist at the filesystem level. Naming conflicts between two different publishers' extensions named dashboard-widgets only matter to the platform, and the platform resolves them via the manifest — not the directory structure on a developer's machine.

The analogy holds with other ecosystems too: npm scoped packages have `@publisher/name` as their registry identity, but `node_modules/name` (or sometimes `node_modules/@publisher/name`) as their local path. The local path format doesn't need to encode all the identity information.

The only scenario where it could be useful is if a developer is simultaneously maintaining `acme/dashboard-widgets` and `corp/dashboard-widgets` in the same parent directory — but that's uncommon enough that it's better left to the developer's discretion (e.g., naming the folder `acme-dashboard-widgets` or creating a `3rd-party` folder) rather than forcing it on everyone.

### TESTING INSTRUCTIONS
1. Run `superset-extensions init`
2. Use `example` as the extension name
3. Use `acme` as the publisher
4. Check that the extension folder name is `example` and not `acme.example`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API



