### PR TITLE
feat: prevent Postgres connection to Redshift

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -81,11 +81,6 @@ COLUMN_DOES_NOT_EXIST_REGEX = re.compile(
 
 SYNTAX_ERROR_REGEX = re.compile('syntax error at or near "(?P<syntax_error>.*?)"')
 
-REDSHIFT_HOST_SUFFIXES = {
-    ".redshift.amazonaws.com",
-    ".redshift-serverless.amazonaws.com",
-}
-
 
 def _check_not_redshift(dbapi_connection: Any, connection_record: Any) -> None:
     """
@@ -611,30 +606,6 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
             uri = uri.set(database=catalog)
 
         return uri, connect_args
-
-    @classmethod
-    def validate_database_uri(cls, sqlalchemy_uri: URL) -> None:
-        """
-        Reject `postgresql://` URIs that point at Amazon Redshift.
-
-        When a user connects to Redshift via the PostgreSQL dialect, basic
-        queries work but Superset picks the wrong sqlglot dialect for SQL
-        transpilation, which leads to errors.
-
-        This is a fast, hostname-only check that catches standard AWS
-        endpoints.  Custom domains and private endpoints are caught
-        separately by the `SELECT version()` check that runs during
-        `test_connection` (see `_check_not_redshift`).
-        """
-        host = sqlalchemy_uri.host or ""
-        if any(host.endswith(suffix) for suffix in REDSHIFT_HOST_SUFFIXES):
-            raise ValueError(
-                "It looks like you're connecting to Amazon Redshift using the "
-                "PostgreSQL driver. Please use the Redshift driver instead "
-                "(redshift+psycopg2://) to ensure proper SQL dialect support."
-            )
-
-        super().validate_database_uri(sqlalchemy_uri)
 
     @staticmethod
     def mutate_db_for_connection_test(database: Database) -> None:

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -81,6 +81,48 @@ COLUMN_DOES_NOT_EXIST_REGEX = re.compile(
 
 SYNTAX_ERROR_REGEX = re.compile('syntax error at or near "(?P<syntax_error>.*?)"')
 
+REDSHIFT_HOST_SUFFIXES = {
+    ".redshift.amazonaws.com",
+    ".redshift-serverless.amazonaws.com",
+}
+
+
+def _check_not_redshift(dbapi_connection: Any, connection_record: Any) -> None:
+    """
+    Event that checks if database is Amazon Redshift.
+
+    SQLAlchemy pool `connect` event that checks whether the database is actually
+    Amazon Redshift by running `SELECT version()`. Redshift returns a version string
+    containing `Redshift`, e.g.::
+
+        PostgreSQL 8.0.2 on ... Redshift 1.0.77467
+
+    If detected, a `ValueError` is raised so that the user is prompted to
+    switch to the `redshift+psycopg2://` driver, which ensures the correct
+    sqlglot dialect is used for SQL transpilation.
+    """
+    try:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("SELECT version()")
+            version = cursor.fetchone()[0]
+        finally:
+            cursor.close()
+
+        if "redshift" in str(version).lower():
+            raise ValueError(
+                "It looks like you're connecting to Amazon Redshift using the "
+                "PostgreSQL driver. Please use the Redshift driver instead "
+                "(redshift+psycopg2://) to ensure proper SQL dialect support."
+            )
+    except ValueError:
+        raise
+    except Exception:
+        logger.debug(
+            "Failed to check database version for Redshift detection",
+            exc_info=True,
+        )
+
 
 def parse_options(connect_args: dict[str, Any]) -> dict[str, str]:
     """
@@ -570,6 +612,39 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
 
         return uri, connect_args
 
+    @classmethod
+    def validate_database_uri(cls, sqlalchemy_uri: URL) -> None:
+        """
+        Reject `postgresql://` URIs that point at Amazon Redshift.
+
+        When a user connects to Redshift via the PostgreSQL dialect, basic
+        queries work but Superset picks the wrong sqlglot dialect for SQL
+        transpilation, which leads to errors.
+
+        This is a fast, hostname-only check that catches standard AWS
+        endpoints.  Custom domains and private endpoints are caught
+        separately by the `SELECT version()` check that runs during
+        `test_connection` (see `_check_not_redshift`).
+        """
+        host = sqlalchemy_uri.host or ""
+        if any(host.endswith(suffix) for suffix in REDSHIFT_HOST_SUFFIXES):
+            raise ValueError(
+                "It looks like you're connecting to Amazon Redshift using the "
+                "PostgreSQL driver. Please use the Redshift driver instead "
+                "(redshift+psycopg2://) to ensure proper SQL dialect support."
+            )
+
+        super().validate_database_uri(sqlalchemy_uri)
+
+    @staticmethod
+    def mutate_db_for_connection_test(database: Database) -> None:
+        """
+        Flag the database so that the Redshift `SELECT version()` check
+        runs during `test_connection`.  The actual check is injected as a
+        pool `connect` event inside `update_params_from_encrypted_extra`.
+        """
+        database._check_redshift_version = True
+
     @staticmethod
     def update_params_from_encrypted_extra(
         database: Database,
@@ -581,6 +656,13 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
         Handles AWS IAM authentication if configured, then merges any
         remaining encrypted_extra keys into params (standard behavior).
         """
+        # During test_connection, inject a pool event to detect Redshift by
+        # checking SELECT version().  This catches cases where the hostname
+        # doesn't reveal Redshift (custom domains, private endpoints, etc.).
+        if getattr(database, "_check_redshift_version", False):
+            pool_events = params.setdefault("pool_events", [])
+            pool_events.append((_check_not_redshift, "connect"))
+
         if not database.encrypted_extra:
             return
 

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -659,7 +659,7 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
         # During test_connection, inject a pool event to detect Redshift by
         # checking SELECT version().  This catches cases where the hostname
         # doesn't reveal Redshift (custom domains, private endpoints, etc.).
-        if getattr(database, "_check_redshift_version", False):
+        if getattr(database, "_check_redshift_version", False) is True:
             pool_events = params.setdefault("pool_events", [])
             pool_events.append((_check_not_redshift, "connect"))
 

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -17,6 +17,7 @@
 
 from datetime import datetime
 from typing import Any, Optional
+from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
@@ -25,7 +26,10 @@ from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, ENUM, JSON
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.engine.url import make_url
 
-from superset.db_engine_specs.postgres import PostgresEngineSpec as spec  # noqa: N813
+from superset.db_engine_specs.postgres import (
+    _check_not_redshift,
+    PostgresEngineSpec as spec,  # noqa: N813
+)
 from superset.exceptions import SupersetSecurityException
 from superset.sql.parse import Table
 from superset.utils.core import GenericDataType
@@ -280,3 +284,128 @@ SELECT * \nFROM my_schema.my_table
  LIMIT :param_1
     """.strip()
     )
+
+
+class TestRedshiftDetection:
+    """
+    Tests for detecting Redshift connections via the PostgreSQL dialect.
+    """
+
+    def test_validate_database_uri_redshift_host(self) -> None:
+        """
+        Standard Redshift endpoint is rejected.
+        """
+        uri = make_url(
+            "postgresql://user:pass@my-cluster.abc123.us-east-1"
+            ".redshift.amazonaws.com:5439/dev"
+        )
+        with pytest.raises(ValueError, match="Redshift"):
+            spec.validate_database_uri(uri)
+
+    def test_validate_database_uri_redshift_serverless_host(self) -> None:
+        """
+        Redshift Serverless endpoint is rejected.
+        """
+        uri = make_url(
+            "postgresql://user:pass@my-wg.abc123.us-west-2"
+            ".redshift-serverless.amazonaws.com:5439/dev"
+        )
+        with pytest.raises(ValueError, match="Redshift"):
+            spec.validate_database_uri(uri)
+
+    def test_validate_database_uri_regular_postgres(self) -> None:
+        """
+        Regular PostgreSQL host is allowed.
+        """
+        uri = make_url("postgresql://user:pass@pg.example.com:5432/mydb")
+        spec.validate_database_uri(uri)  # should not raise
+
+    def test_validate_database_uri_rds_postgres(self) -> None:
+        """
+        RDS PostgreSQL host is allowed.
+        """
+        uri = make_url(
+            "postgresql://user:pass@my-instance.abc123.us-east-1"
+            ".rds.amazonaws.com:5432/mydb"
+        )
+        spec.validate_database_uri(uri)  # should not raise
+
+    def test_validate_database_uri_localhost(self) -> None:
+        """
+        Localhost is allowed.
+        """
+        uri = make_url("postgresql://user:pass@localhost:5432/mydb")
+        spec.validate_database_uri(uri)  # should not raise
+
+    def test_check_not_redshift_detects_redshift(self) -> None:
+        """
+        Pool connect event raises for a Redshift version string.
+        """
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (
+            "PostgreSQL 8.0.2 on i686-pc-linux-gnu, compiled by GCC gcc (GCC) "
+            "3.4.2 20041017 (Red Hat 3.4.2-6.fc3), Redshift 1.0.77467",
+        )
+        dbapi_conn = MagicMock()
+        dbapi_conn.cursor.return_value = cursor
+
+        with pytest.raises(ValueError, match="Redshift"):
+            _check_not_redshift(dbapi_conn, None)
+
+    def test_check_not_redshift_allows_postgres(self) -> None:
+        """
+        Pool connect event allows a regular PostgreSQL version string.
+        """
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (
+            "PostgreSQL 15.2 on x86_64-pc-linux-gnu, compiled by gcc",
+        )
+        dbapi_conn = MagicMock()
+        dbapi_conn.cursor.return_value = cursor
+
+        _check_not_redshift(dbapi_conn, None)  # should not raise
+
+    def test_check_not_redshift_fails_open(self) -> None:
+        """
+        If SELECT version() errors, the connection is still allowed.
+        """
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("permission denied")
+        dbapi_conn = MagicMock()
+        dbapi_conn.cursor.return_value = cursor
+
+        _check_not_redshift(dbapi_conn, None)  # should not raise
+
+    def test_mutate_db_sets_flag(self) -> None:
+        """
+        mutate_db_for_connection_test sets the check flag.
+        """
+        database = MagicMock()
+        spec.mutate_db_for_connection_test(database)
+        assert database._check_redshift_version is True
+
+    def test_pool_event_injected_when_flag_set(self, mocker: MockerFixture) -> None:
+        """
+        Pool event is added during test_connection.
+        """
+        database = mocker.MagicMock(
+            encrypted_extra=None,
+            _check_redshift_version=True,
+        )
+        params: dict[str, Any] = {}
+        spec.update_params_from_encrypted_extra(database, params)
+
+        assert "pool_events" in params
+        fns = [fn for fn, _ in params["pool_events"]]
+        assert _check_not_redshift in fns
+
+    def test_pool_event_not_injected_without_flag(self, mocker: MockerFixture) -> None:
+        """
+        Pool event is NOT added during normal operation.
+        """
+        database = mocker.MagicMock(encrypted_extra=None)
+        database._check_redshift_version = False
+        params: dict[str, Any] = {}
+        spec.update_params_from_encrypted_extra(database, params)
+
+        assert "pool_events" not in params

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -291,52 +291,6 @@ class TestRedshiftDetection:
     Tests for detecting Redshift connections via the PostgreSQL dialect.
     """
 
-    def test_validate_database_uri_redshift_host(self) -> None:
-        """
-        Standard Redshift endpoint is rejected.
-        """
-        uri = make_url(
-            "postgresql://user:pass@my-cluster.abc123.us-east-1"
-            ".redshift.amazonaws.com:5439/dev"
-        )
-        with pytest.raises(ValueError, match="Redshift"):
-            spec.validate_database_uri(uri)
-
-    def test_validate_database_uri_redshift_serverless_host(self) -> None:
-        """
-        Redshift Serverless endpoint is rejected.
-        """
-        uri = make_url(
-            "postgresql://user:pass@my-wg.abc123.us-west-2"
-            ".redshift-serverless.amazonaws.com:5439/dev"
-        )
-        with pytest.raises(ValueError, match="Redshift"):
-            spec.validate_database_uri(uri)
-
-    def test_validate_database_uri_regular_postgres(self) -> None:
-        """
-        Regular PostgreSQL host is allowed.
-        """
-        uri = make_url("postgresql://user:pass@pg.example.com:5432/mydb")
-        spec.validate_database_uri(uri)  # should not raise
-
-    def test_validate_database_uri_rds_postgres(self) -> None:
-        """
-        RDS PostgreSQL host is allowed.
-        """
-        uri = make_url(
-            "postgresql://user:pass@my-instance.abc123.us-east-1"
-            ".rds.amazonaws.com:5432/mydb"
-        )
-        spec.validate_database_uri(uri)  # should not raise
-
-    def test_validate_database_uri_localhost(self) -> None:
-        """
-        Localhost is allowed.
-        """
-        uri = make_url("postgresql://user:pass@localhost:5432/mydb")
-        spec.validate_database_uri(uri)  # should not raise
-
     def test_check_not_redshift_detects_redshift(self) -> None:
         """
         Pool connect event raises for a Redshift version string.


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

While it's technically possible to connect to Amazon Redshift using `postgresql://`, it makes Superset use the Postgres  `sqlglot` dialect instead of the Redshift one, resulting in incorrectly formatted queries when we need to apply RLS or manipulate the query somehow.

This PR introduces 2 checks to prevent users from connecting to Amazon Redshift with the Postgres SQLAlchemy dialect/DB engine spec:

1. A cheap one, checking the hostname.
2. A more expensive one, looking for the string "redshift" in the result from `VERSION()`.

The checks run only during the "test connection" phase, when adding or editing a DB.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="1052" height="1758" alt="Screenshot 2026-03-17 at 11 15 08 AM" src="https://github.com/user-attachments/assets/cc4f243b-15b3-4d5f-9f34-f76e17440d7c" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Prevent connecting to Amazon Redshift using the PostgreSQL driver during DB connection tests

### What Changed
- When running a database "test connection", Superset now runs SELECT version() to detect Amazon Redshift and rejects connections that report Redshift, prompting users to use the redshift+psycopg2:// driver
- The Redshift check runs only during the connection test flow (a flag is set for that operation) and is not performed during normal runtime connections
- Added unit tests covering Redshift detection, allowed PostgreSQL connections, error-tolerant behavior when version() fails, and injection of the connection check into test-time parameters

### Impact
`✅ Clearer Redshift connection errors during DB setup`
`✅ Fewer incorrectly transpiled queries caused by using the wrong driver`
`✅ Shorter debug time when configuring Redshift databases`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
