### PR TITLE
fix(DropdownContainer): add fresh to avoid stale data

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -352,6 +352,7 @@ export const DropdownContainer = forwardRef(
               onOpenChange={visible => setPopoverVisible(visible)}
               placement="bottom"
               forceRender={forceRender}
+              destroyTooltipOnHide
             >
               <Tooltip title={dropdownTriggerTooltip}>
                 <Button

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -352,7 +352,7 @@ export const DropdownContainer = forwardRef(
               onOpenChange={visible => setPopoverVisible(visible)}
               placement="bottom"
               forceRender={forceRender}
-              destroyTooltipOnHide
+              fresh
             >
               <Tooltip title={dropdownTriggerTooltip}>
                 <Button

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownContainer/DropdownContainer.tsx
@@ -352,7 +352,7 @@ export const DropdownContainer = forwardRef(
               onOpenChange={visible => setPopoverVisible(visible)}
               placement="bottom"
               forceRender={forceRender}
-              fresh
+              fresh // This prop prevents caching and stale data for filter scoping.
             >
               <Tooltip title={dropdownTriggerTooltip}>
                 <Button


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This pr fixes a bug where:
The Popover caches its portal DOM after being rendered. When switching tabs, filters briefly evaluate as out-of-scope during the intermediate render (main tab activates before nested tabs). The Popover captures that stale state and filters seem out of scope.

> [!NOTE]
> Since we can't mock the Popover and jsdom doesn't reproduce the browser caching behavior, there's no meaningful unit test we can write for this one-prop fix.
  
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

  1. Create a dashboard with 2 main tabs, each with 2 nested tabs
  2. Add a few charts spread across the nested tabs
  3. Add 3-4 filters scoped to specific tabs (not "All charts")
  4. Set filter bar to horizontal orientation
  5. Make the browser window narrow enough that some filters overflow into "More filters"
  6. Switch between the main tabs a few times
  7. Open the "More filters" dropdown. 
  8. Check if filters show in "Filters out of scope" when they shouldn't

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Prevent "More filters" dropdown from showing stale out-of-scope filters after tab switches

### What Changed
- The dropdown's popover now mounts fresh each time it opens, so it no longer captures transient stale filter scope during tab switches
- Opening "More filters" after switching tabs reliably shows the correct in-scope/out-of-scope state for filters

### Impact
`✅ Fewer stale filters shown in dropdown`
`✅ Clearer filter visibility when switching tabs`
`✅ Less confusion during dashboard navigation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
