### PR TITLE
fix(mcp): improve chart save behavior and error messaging in generate_chart

### DIFF
--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -319,19 +319,54 @@ async def generate_chart(  # noqa: C901
                 )
 
                 execution_time = int((time.time() - start_time) * 1000)
-                error = ChartGenerationError(
-                    error_type="dataset_not_found",
-                    message=f"Dataset not found: {request.dataset_id}",
-                    details=(
-                        f"No dataset found with identifier '{request.dataset_id}'. "
-                        f"This could be an invalid ID/UUID or a permissions issue."
-                    ),
-                    suggestions=[
+
+                # Detect when user passed a dataset name instead of ID/UUID
+                _is_numeric = isinstance(request.dataset_id, int) or (
+                    isinstance(request.dataset_id, str) and request.dataset_id.isdigit()
+                )
+                _looks_like_uuid = (
+                    isinstance(request.dataset_id, str)
+                    and len(request.dataset_id) == 36
+                    and request.dataset_id.count("-") == 4
+                )
+                _looks_like_name = (
+                    isinstance(request.dataset_id, str)
+                    and not _is_numeric
+                    and not _looks_like_uuid
+                )
+
+                if _looks_like_name:
+                    details = (
+                        f"No dataset found with identifier "
+                        f"'{request.dataset_id}'. It looks like you passed "
+                        f"a dataset name instead of a numeric ID or UUID. "
+                        f"Use the list_datasets tool to find the correct "
+                        f"numeric dataset ID."
+                    )
+                    suggestions = [
+                        "Use list_datasets to find the numeric ID for this dataset",
+                        "Pass the numeric dataset ID (e.g., 123) or UUID, "
+                        "not the dataset name",
+                        "Check that you have access to this dataset",
+                    ]
+                else:
+                    details = (
+                        f"No dataset found with identifier "
+                        f"'{request.dataset_id}'. This could be an invalid "
+                        f"ID/UUID or a permissions issue."
+                    )
+                    suggestions = [
                         "Verify the dataset ID or UUID is correct",
                         "Check that you have access to this dataset",
                         "Use the list_datasets tool to find available datasets",
                         "If using UUID, ensure it's the correct format",
-                    ],
+                    ]
+
+                error = ChartGenerationError(
+                    error_type="dataset_not_found",
+                    message=f"Dataset not found: {request.dataset_id}",
+                    details=details,
+                    suggestions=suggestions,
                     error_code="DATASET_NOT_FOUND",
                 )
                 return GenerateChartResponse.model_validate(
@@ -412,53 +447,23 @@ async def generate_chart(  # noqa: C901
                 ):
                     compile_result = _compile_chart(form_data, dataset.id)
                 if not compile_result.success:
-                    # Query failed — delete the broken chart and return an error
+                    # Query failed — keep the saved chart but warn the user
                     logger.warning(
                         "Compile check failed for chart %s: %s",
                         chart.id,
                         compile_result.error,
                     )
-                    await ctx.error(
-                        "Chart compile check failed: error=%s" % (compile_result.error,)
+                    await ctx.warning(
+                        "Chart saved but compile check failed: error=%s"
+                        % (compile_result.error,)
                     )
-                    from superset.daos.chart import ChartDAO
-
-                    ChartDAO.delete([chart])
-                    from superset.mcp_service.common.error_schemas import (
-                        ChartGenerationError,
+                    compile_warning = (
+                        "Chart was saved but the query failed to execute: %s. "
+                        "The chart may need configuration adjustments before "
+                        "it renders correctly."
+                        % (compile_result.error or "unknown error")
                     )
-
-                    execution_time = int((time.time() - start_time) * 1000)
-                    error = ChartGenerationError(
-                        error_type="compile_error",
-                        message=(
-                            "Chart query failed to execute. The chart was not saved."
-                        ),
-                        details=str(compile_result.error) or "",
-                        suggestions=[
-                            "Check that all columns exist in the dataset",
-                            "Verify aggregate functions are compatible "
-                            "with column types",
-                            "Ensure filters reference valid columns",
-                            "Try simplifying the chart configuration",
-                        ],
-                        error_code="CHART_COMPILE_FAILED",
-                    )
-                    return GenerateChartResponse.model_validate(
-                        {
-                            "chart": None,
-                            "error": error.model_dump(),
-                            "form_data": form_data,
-                            "performance": {
-                                "query_duration_ms": execution_time,
-                                "cache_status": "error",
-                                "optimization_suggestions": [],
-                            },
-                            "success": False,
-                            "schema_version": "2.0",
-                            "api_version": "v1",
-                        }
-                    )
+                    response_warnings.append(compile_warning)
                 response_warnings.extend(compile_result.warnings)
 
             except CommandException as e:
@@ -560,13 +565,18 @@ async def generate_chart(  # noqa: C901
                     )
 
                     execution_time = int((time.time() - start_time) * 1000)
+                    compile_error_detail = str(compile_result.error) or ""
                     error = ChartGenerationError(
                         error_type="compile_error",
                         message=(
-                            "Chart query failed to execute. "
-                            "The chart configuration is invalid."
+                            "Chart query failed to execute: %s"
+                            % (
+                                compile_error_detail[:200]
+                                if compile_error_detail
+                                else "unknown error"
+                            )
                         ),
-                        details=str(compile_result.error) or "",
+                        details=compile_error_detail,
                         suggestions=[
                             "Check that all columns exist in the dataset",
                             "Verify aggregate functions are compatible "


### PR DESCRIPTION
## **User description**
### SUMMARY

Two related bug fixes in the MCP `generate_chart` tool:

**1. Chart deletion on compile failure was too aggressive when `save_chart=True`**

When a user explicitly requests `save_chart=True`, the chart was being deleted if the post-creation compile check (test query) failed. This is incorrect -- the user asked to save the chart, so we should keep it and return a warning instead. The chart can still be viewed and fixed in the Explore view.

- **Before**: Compile failure + `save_chart=True` = chart deleted, error returned, user loses work
- **After**: Compile failure + `save_chart=True` = chart kept, warning added to `warnings` list, chart URL and ID returned normally. Preview-only mode (`save_chart=False`) still returns compile errors as before since there is no saved chart to keep.

**2. Poor error messaging for dataset lookup and compile failures**

When chart creation fails due to dataset issues, the error propagated to the chatbot frontend was too generic ("network error"). Two improvements:

- When a non-numeric/non-UUID string is passed as `dataset_id` (user passed a dataset name instead of ID), the error message explicitly tells the user to use `list_datasets` to find the numeric ID
- Compile check failures in preview mode include the actual database error message in the `message` field (truncated to 200 chars) so the chatbot can display actionable information

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - backend-only changes

### TESTING INSTRUCTIONS
1. Run MCP chart unit tests: `pytest tests/unit_tests/mcp_service/chart/ -x -q` (333 tests pass)
2. Test `generate_chart` with `save_chart=True` and a dataset that has a broken column -- chart should be saved with a warning instead of deleted
3. Test `generate_chart` with `dataset_id="my_dataset_name"` -- error should suggest using `list_datasets`
4. Test `generate_chart` in preview mode with invalid columns -- error message should include the actual DB error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Keep saved charts when compile check fails and show clearer dataset/compile errors**

### What Changed
- When a user requests save_chart=True, charts are now kept if the compile (test query) fails; the response includes a warning instead of deleting the chart.
- If dataset lookup fails and the provided dataset_id looks like a name (not a numeric ID or UUID), the error message tells the user to use list_datasets to find the numeric ID.
- Compile failures in preview mode now include the actual database error (truncated to 200 characters) in the error message so frontends can display actionable information.

### Impact
`✅ Fewer lost charts when save_chart=True`
`✅ Clearer dataset ID guidance for users who passed a name`
`✅ Clearer compile error messages for previewed charts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
