### PR TITLE
fix(reports): validate nativeFilters on report create/update and deactivate on dashboard filter deletion

### DIFF
--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -60,6 +60,7 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
         self.validate()
         assert self._model is not None
         self.process_tab_diff()
+        self.process_native_filter_diff()
 
         # Update tags
         if (tags := self._properties.pop("tags", None)) is not None:
@@ -121,7 +122,43 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
         if exceptions:
             raise DashboardInvalidError(exceptions=exceptions)
 
-    def process_tab_diff(self) -> None:  # noqa: C901
+    @staticmethod
+    def _send_deactivated_report_email(
+        report: ReportSchedule, description: str
+    ) -> None:
+        html_content = textwrap.dedent(
+            f"""
+                <html>
+                <head>
+                    <style type="text/css">
+                    table, th, td {{
+                        border-collapse: collapse;
+                        border-color: rgb(200, 212, 227);
+                        color: rgb(42, 63, 95);
+                        padding: 4px 8px;
+                    }}
+                    .image{{
+                        margin-bottom: 18px;
+                    }}
+                    </style>
+                </head>
+                <body>
+                    <div>{description}</div>
+                    <br>
+                </body>
+                </html>
+                """
+        )
+        for report_owner in report.owners:
+            if email := report_owner.email:
+                send_email_smtp(
+                    to=email,
+                    subject=f"[Report: {report.name}] Deactivated",
+                    html_content=html_content,
+                    config=current_app.config,
+                )
+
+    def process_tab_diff(self) -> None:
         def find_deleted_tabs() -> list[str]:
             position_json = self._properties.get("position_json", "")
             current_tabs = self._model.tabs  # type: ignore
@@ -147,49 +184,58 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
                 Please update your report settings to remove or change the tab used.
                 """  # noqa: E501
             )
-
-            html_content = textwrap.dedent(
-                f"""
-                    <html>
-                    <head>
-                        <style type="text/css">
-                        table, th, td {{
-                            border-collapse: collapse;
-                            border-color: rgb(200, 212, 227);
-                            color: rgb(42, 63, 95);
-                            padding: 4px 8px;
-                        }}
-                        .image{{
-                            margin-bottom: 18px;
-                        }}
-                        </style>
-                    </head>
-                    <body>
-                        <div>{description}</div>
-                        <br>
-                    </body>
-                    </html>
-                    """
-            )
-            for report_owner in report.owners:
-                if email := report_owner.email:
-                    send_email_smtp(
-                        to=email,
-                        subject=f"[Report: {report.name}] Deactivated",
-                        html_content=html_content,
-                        config=current_app.config,
-                    )
+            self._send_deactivated_report_email(report, description)
 
         def deactivate_reports(reports_list: list[ReportSchedule]) -> None:
             for report in reports_list:
-                # deactivate
                 ReportScheduleDAO.update(report, {"active": False})
-                # send email to report owner
                 send_deactivated_email_warning(report)
 
         deleted_tabs = find_deleted_tabs()
         reports = find_reports_containing_tabs(deleted_tabs)
         deactivate_reports(reports)
+
+    def process_native_filter_diff(self) -> None:
+        def find_deleted_native_filter_ids() -> list[str]:
+            new_json_metadata = self._properties.get("json_metadata", "")
+            if not new_json_metadata:
+                return []
+            current_metadata = json.loads(self._model.json_metadata or "{}")  # type: ignore
+            new_metadata = json.loads(new_json_metadata)
+            current_filter_ids = {
+                f["id"]
+                for f in current_metadata.get("native_filter_configuration", [])
+                if "id" in f
+            }
+            new_filter_ids = {
+                f["id"]
+                for f in new_metadata.get("native_filter_configuration", [])
+                if "id" in f
+            }
+            return list(current_filter_ids - new_filter_ids)
+
+        def find_reports_containing_native_filters(
+            filter_ids: list[str],
+        ) -> list[ReportSchedule]:
+            seen: set[int] = set()
+            reports: list[ReportSchedule] = []
+            for filter_id in filter_ids:
+                for report in ReportScheduleDAO.find_by_native_filter_id(filter_id):
+                    if report.id not in seen:
+                        seen.add(report.id)
+                        reports.append(report)
+            return reports
+
+        description = textwrap.dedent(
+            """
+            The dashboard filter used in this report has been deleted and your report has not been sent.
+            Please update your report settings to remove or change the filter used.
+            """  # noqa: E501
+        )
+        deleted_filter_ids = find_deleted_native_filter_ids()
+        for report in find_reports_containing_native_filters(deleted_filter_ids):
+            ReportScheduleDAO.update(report, {"active": False})
+            self._send_deactivated_report_email(report, description)
 
 
 class UpdateDashboardNativeFiltersCommand(UpdateDashboardCommand):

--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -204,12 +204,12 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
             new_metadata = json.loads(new_json_metadata)
             current_filter_ids = {
                 f["id"]
-                for f in current_metadata.get("native_filter_configuration", [])
+                for f in (current_metadata.get("native_filter_configuration") or [])
                 if "id" in f
             }
             new_filter_ids = {
                 f["id"]
-                for f in new_metadata.get("native_filter_configuration", [])
+                for f in (new_metadata.get("native_filter_configuration") or [])
                 if "id" in f
             }
             return list(current_filter_ids - new_filter_ids)
@@ -221,6 +221,8 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
             reports: list[ReportSchedule] = []
             for filter_id in filter_ids:
                 for report in ReportScheduleDAO.find_by_native_filter_id(filter_id):
+                    if report.dashboard_id != self._model.id:  # type: ignore
+                        continue
                     if report.id not in seen:
                         seen.add(report.id)
                         reports.append(report)

--- a/superset/commands/report/base.py
+++ b/superset/commands/report/base.py
@@ -87,11 +87,25 @@ class BaseReportScheduleCommand(BaseCommand):
         extra: Optional[ReportScheduleExtra] = self._properties.get("extra")
         dashboard = self._properties.get("dashboard")
 
+        # On PUT requests, dashboard may not be in the payload — fall back to the model
+        if dashboard is None:
+            model = getattr(self, "_model", None)
+            dashboard = getattr(model, "dashboard", None)
+
         if extra is None or dashboard is None:
             return
 
         dashboard_state = extra.get("dashboard")
         if not dashboard_state:
+            return
+
+        if not isinstance(dashboard_state, dict):
+            exceptions.append(
+                ValidationError(
+                    _("extra.dashboard must be an object"),
+                    "extra",
+                )
+            )
             return
 
         position_data = json.loads(dashboard.position_json or "{}")
@@ -110,7 +124,7 @@ class BaseReportScheduleCommand(BaseCommand):
         if invalid_tab_ids:
             exceptions.append(
                 ValidationError(
-                    _("Invalid tab ids: %s(tab_ids)", tab_ids=str(invalid_tab_ids)),
+                    _("Invalid tab ids: %(tab_ids)s", tab_ids=str(invalid_tab_ids)),
                     "extra",
                 )
             )
@@ -176,26 +190,37 @@ class BaseReportScheduleCommand(BaseCommand):
                 continue
 
             filter_id = native_filter["nativeFilterId"]
-            if filter_id is not None:
-                if valid_filter_ids is None:
-                    json_metadata = json.loads(dashboard.json_metadata or "{}")
-                    valid_filter_ids = {
-                        f["id"]
-                        for f in json_metadata.get("native_filter_configuration", [])
-                        if "id" in f
-                    }
-                if filter_id not in valid_filter_ids:
-                    exceptions.append(
-                        ValidationError(
-                            _(
-                                "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' "
-                                "does not exist on the dashboard",
-                                idx=idx,
-                                filter_id=filter_id,
-                            ),
-                            "extra",
-                        )
+            if not isinstance(filter_id, str) or not filter_id:
+                exceptions.append(
+                    ValidationError(
+                        _(
+                            "nativeFilters[%(idx)s].nativeFilterId"
+                            " must be a non-empty string",
+                            idx=idx,
+                        ),
+                        "extra",
                     )
+                )
+                continue
+            if valid_filter_ids is None:
+                json_metadata = json.loads(dashboard.json_metadata or "{}")
+                valid_filter_ids = {
+                    f["id"]
+                    for f in json_metadata.get("native_filter_configuration", [])
+                    if "id" in f
+                }
+            if filter_id not in valid_filter_ids:
+                exceptions.append(
+                    ValidationError(
+                        _(
+                            "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' "
+                            "does not exist on the dashboard",
+                            idx=idx,
+                            filter_id=filter_id,
+                        ),
+                        "extra",
+                    )
+                )
 
     def validate_report_frequency(
         self,

--- a/superset/commands/report/base.py
+++ b/superset/commands/report/base.py
@@ -15,10 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from croniter import croniter
 from flask import current_app as app
+from flask_babel import gettext as _
 from marshmallow import ValidationError
 
 from superset.commands.base import BaseCommand
@@ -34,6 +35,8 @@ from superset.commands.report.exceptions import (
 from superset.daos.chart import ChartDAO
 from superset.daos.dashboard import DashboardDAO
 from superset.reports.models import ReportCreationMethod, ReportScheduleType
+from superset.reports.types import ReportScheduleExtra
+from superset.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +83,120 @@ class BaseReportScheduleCommand(BaseCommand):
         elif not update:
             exceptions.append(ReportScheduleEitherChartOrDashboardError())
 
+    def _validate_report_extra(self, exceptions: list[ValidationError]) -> None:
+        extra: Optional[ReportScheduleExtra] = self._properties.get("extra")
+        dashboard = self._properties.get("dashboard")
+
+        if extra is None or dashboard is None:
+            return
+
+        dashboard_state = extra.get("dashboard")
+        if not dashboard_state:
+            return
+
+        position_data = json.loads(dashboard.position_json or "{}")
+        active_tabs = dashboard_state.get("activeTabs") or []
+        invalid_tab_ids = set(active_tabs) - set(position_data.keys())
+
+        if anchor := dashboard_state.get("anchor"):
+            try:
+                anchor_list: list[str] = json.loads(anchor)
+                if _invalid_tab_ids := set(anchor_list) - set(position_data.keys()):
+                    invalid_tab_ids.update(_invalid_tab_ids)
+            except json.JSONDecodeError:
+                if anchor not in position_data:
+                    invalid_tab_ids.add(anchor)
+
+        if invalid_tab_ids:
+            exceptions.append(
+                ValidationError(
+                    _("Invalid tab ids: %s(tab_ids)", tab_ids=str(invalid_tab_ids)),
+                    "extra",
+                )
+            )
+
+        self._validate_native_filters(dashboard, dashboard_state, exceptions)
+
+    def _validate_native_filters(
+        self,
+        dashboard: Any,
+        dashboard_state: Any,
+        exceptions: list[ValidationError],
+    ) -> None:
+        native_filters = dashboard_state.get("nativeFilters")
+        if not native_filters:
+            return
+
+        if not isinstance(native_filters, list):
+            exceptions.append(
+                ValidationError(
+                    _("nativeFilters must be a list"),
+                    "extra",
+                )
+            )
+            return
+
+        required_keys = {"nativeFilterId", "filterType", "columnName", "filterValues"}
+        valid_filter_ids: set[str] | None = None
+
+        for idx, native_filter in enumerate(native_filters):
+            if not isinstance(native_filter, dict):
+                exceptions.append(
+                    ValidationError(
+                        _("nativeFilters[%(idx)s] must be an object", idx=idx),
+                        "extra",
+                    )
+                )
+                continue
+
+            missing_keys = required_keys - set(native_filter.keys())
+            if missing_keys:
+                exceptions.append(
+                    ValidationError(
+                        _(
+                            "nativeFilters[%(idx)s] missing required keys: %(keys)s",
+                            idx=idx,
+                            keys=", ".join(sorted(missing_keys)),
+                        ),
+                        "extra",
+                    )
+                )
+                continue
+
+            if not isinstance(native_filter["filterValues"], list):
+                exceptions.append(
+                    ValidationError(
+                        _(
+                            "nativeFilters[%(idx)s].filterValues must be a list",
+                            idx=idx,
+                        ),
+                        "extra",
+                    )
+                )
+                continue
+
+            filter_id = native_filter["nativeFilterId"]
+            if filter_id is not None:
+                if valid_filter_ids is None:
+                    json_metadata = json.loads(dashboard.json_metadata or "{}")
+                    valid_filter_ids = {
+                        f["id"]
+                        for f in json_metadata.get("native_filter_configuration", [])
+                        if "id" in f
+                    }
+                if filter_id not in valid_filter_ids:
+                    exceptions.append(
+                        ValidationError(
+                            _(
+                                "nativeFilters[%(idx)s].nativeFilterId '%(filter_id)s' "
+                                "does not exist on the dashboard",
+                                idx=idx,
+                                filter_id=filter_id,
+                            ),
+                            "extra",
+                        )
+                    )
+
     def validate_report_frequency(
         self,
         cron_schedule: str,
@@ -116,7 +233,7 @@ class BaseReportScheduleCommand(BaseCommand):
         schedule = croniter(cron_schedule)
         current_exec = next(schedule)
 
-        for _ in range(iterations):
+        for _i in range(iterations):
             next_exec = next(schedule)
             diff, current_exec = next_exec - current_exec, next_exec
             if int(diff) < minimum_interval:

--- a/superset/commands/report/create.py
+++ b/superset/commands/report/create.py
@@ -19,7 +19,6 @@ from functools import partial
 from typing import Any, Optional
 
 from flask import g
-from flask_babel import gettext as _
 from marshmallow import ValidationError
 
 from superset.commands.base import CreateMixin
@@ -41,7 +40,6 @@ from superset.reports.models import (
     ReportSchedule,
     ReportScheduleType,
 )
-from superset.reports.types import ReportScheduleExtra
 from superset.utils import json
 from superset.utils.decorators import on_error, transaction
 
@@ -164,35 +162,3 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
             exceptions.append(ex)
         if exceptions:
             raise ReportScheduleInvalidError(exceptions=exceptions)
-
-    def _validate_report_extra(self, exceptions: list[ValidationError]) -> None:
-        extra: Optional[ReportScheduleExtra] = self._properties.get("extra")
-        dashboard = self._properties.get("dashboard")
-
-        if extra is None or dashboard is None:
-            return
-
-        dashboard_state = extra.get("dashboard")
-        if not dashboard_state:
-            return
-
-        position_data = json.loads(dashboard.position_json or "{}")
-        active_tabs = dashboard_state.get("activeTabs") or []
-        invalid_tab_ids = set(active_tabs) - set(position_data.keys())
-
-        if anchor := dashboard_state.get("anchor"):
-            try:
-                anchor_list: list[str] = json.loads(anchor)
-                if _invalid_tab_ids := set(anchor_list) - set(position_data.keys()):
-                    invalid_tab_ids.update(_invalid_tab_ids)
-            except json.JSONDecodeError:
-                if anchor not in position_data:
-                    invalid_tab_ids.add(anchor)
-
-        if invalid_tab_ids:
-            exceptions.append(
-                ValidationError(
-                    _("Invalid tab ids: %s(tab_ids)", tab_ids=str(invalid_tab_ids)),
-                    "extra",
-                )
-            )

--- a/superset/commands/report/update.py
+++ b/superset/commands/report/update.py
@@ -131,6 +131,7 @@ class UpdateReportScheduleCommand(UpdateMixin, BaseReportScheduleCommand):
 
         # Validate chart or dashboard relations
         self.validate_chart_dashboard(exceptions, update=True)
+        self._validate_report_extra(exceptions)
 
         if "validator_config_json" in self._properties:
             self._properties["validator_config_json"] = json.dumps(

--- a/superset/daos/report.py
+++ b/superset/daos/report.py
@@ -105,7 +105,9 @@ class ReportScheduleDAO(BaseDAO[ReportSchedule]):
         """
         return (
             db.session.query(ReportSchedule)
-            .filter(ReportSchedule.extra_json.like(f"%{native_filter_id}%"))
+            .filter(
+                ReportSchedule.extra_json.contains(native_filter_id, autoescape=True)
+            )
             .all()
         )
 

--- a/superset/daos/report.py
+++ b/superset/daos/report.py
@@ -99,6 +99,17 @@ class ReportScheduleDAO(BaseDAO[ReportSchedule]):
         )
 
     @staticmethod
+    def find_by_native_filter_id(native_filter_id: str) -> list[ReportSchedule]:
+        """
+        searches extra_json for a filter ID string
+        """
+        return (
+            db.session.query(ReportSchedule)
+            .filter(ReportSchedule.extra_json.like(f"%{native_filter_id}%"))
+            .all()
+        )
+
+    @staticmethod
     def validate_unique_creation_method(
         dashboard_id: int | None = None, chart_id: int | None = None
     ) -> bool:

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -2345,3 +2345,371 @@ class TestReportSchedulesApi(SupersetTestCase):
         )
 
         assert json.loads(report_schedule.extra_json) == extra_json
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    def test_create_report_schedule_with_garbage_native_filters(self):
+        """
+        ReportSchedule API: POST with nativeFilters containing garbage data returns 422
+        """
+        dashboard = db.session.query(Dashboard).first()
+        self.login(ADMIN_USERNAME)
+        report_schedule_data = {
+            "type": ReportScheduleType.REPORT,
+            "name": "garbage_native_filters_test",
+            "description": "description",
+            "creation_method": ReportCreationMethod.ALERTS_REPORTS,
+            "crontab": "0 9 * * *",
+            "working_timeout": 3600,
+            "dashboard": dashboard.id,
+            "extra": {"dashboard": {"nativeFilters": [{"garbage": True}]}},
+        }
+        uri = "api/v1/report/"
+        rv = self.post_assert_metric(uri, report_schedule_data, "post")
+        assert rv.status_code == 422
+        data = json.loads(rv.data.decode("utf-8"))
+        assert "message" in data
+        assert "extra" in data["message"]
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    def test_create_report_schedule_with_missing_native_filter_keys(self):
+        """
+        ReportSchedule API: POST with nativeFilters missing required keys returns 422
+        """
+        dashboard = db.session.query(Dashboard).first()
+        self.login(ADMIN_USERNAME)
+        report_schedule_data = {
+            "type": ReportScheduleType.REPORT,
+            "name": "missing_keys_native_filters_test",
+            "description": "description",
+            "creation_method": ReportCreationMethod.ALERTS_REPORTS,
+            "crontab": "0 9 * * *",
+            "working_timeout": 3600,
+            "dashboard": dashboard.id,
+            "extra": {
+                "dashboard": {
+                    "nativeFilters": [{"nativeFilterId": "NATIVE_FILTER-abc"}]
+                }
+            },
+        }
+        uri = "api/v1/report/"
+        rv = self.post_assert_metric(uri, report_schedule_data, "post")
+        assert rv.status_code == 422
+        data = json.loads(rv.data.decode("utf-8"))
+        assert "message" in data
+        assert "extra" in data["message"]
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    def test_create_report_schedule_with_nonexistent_native_filter_id(self):
+        """
+        ReportSchedule API: POST with nativeFilterId not on dashboard returns 422
+        """
+        dashboard = db.session.query(Dashboard).first()
+        self.login(ADMIN_USERNAME)
+        report_schedule_data = {
+            "type": ReportScheduleType.REPORT,
+            "name": "nonexistent_filter_id_test",
+            "description": "description",
+            "creation_method": ReportCreationMethod.ALERTS_REPORTS,
+            "crontab": "0 9 * * *",
+            "working_timeout": 3600,
+            "dashboard": dashboard.id,
+            "extra": {
+                "dashboard": {
+                    "nativeFilters": [
+                        {
+                            "nativeFilterId": "NATIVE_FILTER-does-not-exist",
+                            "filterType": "filter_select",
+                            "columnName": "col",
+                            "filterValues": ["a"],
+                        }
+                    ]
+                }
+            },
+        }
+        uri = "api/v1/report/"
+        rv = self.post_assert_metric(uri, report_schedule_data, "post")
+        assert rv.status_code == 422
+        data = json.loads(rv.data.decode("utf-8"))
+        assert "message" in data
+        assert "extra" in data["message"]
+
+    def test_create_report_schedule_with_valid_native_filter_empty_values(self):
+        """
+        ReportSchedule API: POST with valid nativeFilterId and empty filterValues
+        returns 201
+        """
+        # Create a dashboard with a native filter in json_metadata
+        filter_id = "NATIVE_FILTER-valid123"
+        dashboard = Dashboard()
+        dashboard.dashboard_title = "dash_with_native_filter"
+        dashboard.slug = "dash_with_native_filter"
+        dashboard.json_metadata = json.dumps(
+            {"native_filter_configuration": [{"id": filter_id, "name": "Test Filter"}]}
+        )
+        db.session.add(dashboard)
+        db.session.commit()
+
+        self.login(ADMIN_USERNAME)
+        report_schedule_data = {
+            "type": ReportScheduleType.REPORT,
+            "name": "valid_native_filter_empty_values",
+            "description": "description",
+            "creation_method": ReportCreationMethod.ALERTS_REPORTS,
+            "crontab": "0 9 * * *",
+            "working_timeout": 3600,
+            "dashboard": dashboard.id,
+            "extra": {
+                "dashboard": {
+                    "nativeFilters": [
+                        {
+                            "nativeFilterId": filter_id,
+                            "filterType": "filter_select",
+                            "columnName": "col",
+                            "filterValues": [],
+                        }
+                    ]
+                }
+            },
+        }
+        uri = "api/v1/report/"
+        rv = self.post_assert_metric(uri, report_schedule_data, "post")
+        assert rv.status_code == 201
+
+        created_id = json.loads(rv.data.decode("utf-8")).get("id")
+        created_model = db.session.query(ReportSchedule).get(created_id)
+        db.session.delete(created_model)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    def test_update_report_schedule_with_garbage_native_filters(self):
+        """
+        ReportSchedule API: PUT with nativeFilters containing garbage data returns 422
+        """
+        report_schedule = (
+            db.session.query(ReportSchedule)
+            .filter(ReportSchedule.name == "name2")
+            .one_or_none()
+        )
+        dashboard = db.session.query(Dashboard).first()
+        self.login(ADMIN_USERNAME)
+        report_schedule_data = {
+            "type": ReportScheduleType.REPORT,
+            "name": "name2",
+            "crontab": "0 10 * * *",
+            "dashboard": dashboard.id,
+            "extra": {"dashboard": {"nativeFilters": [{"garbage": True}]}},
+        }
+        uri = f"api/v1/report/{report_schedule.id}"
+        rv = self.put_assert_metric(uri, report_schedule_data, "put")
+        assert rv.status_code == 422
+        data = json.loads(rv.data.decode("utf-8"))
+        assert "message" in data
+        assert "extra" in data["message"]
+
+    @pytest.mark.usefixtures("create_report_schedules")
+    def test_update_report_schedule_with_stale_native_filter_id(self):
+        """
+        ReportSchedule API: PUT with nativeFilterId no longer on dashboard returns 422
+        """
+        report_schedule = (
+            db.session.query(ReportSchedule)
+            .filter(ReportSchedule.name == "name2")
+            .one_or_none()
+        )
+        # Dashboard with no native filters configured
+        dashboard = db.session.query(Dashboard).first()
+        self.login(ADMIN_USERNAME)
+        report_schedule_data = {
+            "type": ReportScheduleType.REPORT,
+            "name": "name2",
+            "crontab": "0 10 * * *",
+            "dashboard": dashboard.id,
+            "extra": {
+                "dashboard": {
+                    "nativeFilters": [
+                        {
+                            "nativeFilterId": "NATIVE_FILTER-stale",
+                            "filterType": "filter_select",
+                            "columnName": "col",
+                            "filterValues": ["val"],
+                        }
+                    ]
+                }
+            },
+        }
+        uri = f"api/v1/report/{report_schedule.id}"
+        rv = self.put_assert_metric(uri, report_schedule_data, "put")
+        assert rv.status_code == 422
+        data = json.loads(rv.data.decode("utf-8"))
+        assert "message" in data
+        assert "extra" in data["message"]
+
+    @patch("superset.commands.dashboard.update.send_email_smtp")
+    def test_dashboard_update_deletes_native_filter_deactivates_reports(
+        self, mock_send_email: Any
+    ):
+        """
+        Dashboard API: removing a native filter deactivates referencing reports
+        and emails each owner
+        """
+        filter_id = "NATIVE_FILTER-todelete"
+
+        # Create dashboard with that filter
+        dashboard = Dashboard()
+        dashboard.dashboard_title = "dash_filter_delete"
+        dashboard.slug = "dash_filter_delete"
+        dashboard.json_metadata = json.dumps(
+            {"native_filter_configuration": [{"id": filter_id, "name": "To Delete"}]}
+        )
+        db.session.add(dashboard)
+        db.session.flush()
+
+        admin = self.get_user("admin")
+
+        # Create report referencing that filter
+        report = insert_report_schedule(
+            type=ReportScheduleType.REPORT,
+            name="report_with_filter",
+            crontab="0 9 * * *",
+            owners=[admin],
+            dashboard=dashboard,
+            extra={
+                "dashboard": {
+                    "nativeFilters": [
+                        {
+                            "nativeFilterId": filter_id,
+                            "filterType": "filter_select",
+                            "columnName": "col",
+                            "filterValues": [],
+                        }
+                    ]
+                }
+            },
+        )
+
+        db.session.commit()
+
+        self.login(ADMIN_USERNAME)
+        # Update dashboard removing the native filter
+        uri = f"api/v1/dashboard/{dashboard.id}"
+        rv = self.put_assert_metric(
+            uri,
+            {"json_metadata": json.dumps({"native_filter_configuration": []})},
+            "put",
+        )
+        assert rv.status_code == 200
+
+        db.session.refresh(report)
+        assert report.active is False
+        assert mock_send_email.called
+
+        db.session.delete(report)
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @patch("superset.commands.dashboard.update.send_email_smtp")
+    def test_dashboard_update_unrelated_filter_removal_no_side_effects(
+        self, mock_send_email: Any
+    ):
+        """
+        Dashboard API: removing a filter not referenced by any report has no
+        side effects
+        """
+        filter_id = "NATIVE_FILTER-unreferenced"
+
+        dashboard = Dashboard()
+        dashboard.dashboard_title = "dash_no_reports"
+        dashboard.slug = "dash_no_reports"
+        dashboard.json_metadata = json.dumps(
+            {"native_filter_configuration": [{"id": filter_id, "name": "Unused"}]}
+        )
+        db.session.add(dashboard)
+        db.session.commit()
+
+        self.login(ADMIN_USERNAME)
+        uri = f"api/v1/dashboard/{dashboard.id}"
+        rv = self.put_assert_metric(
+            uri,
+            {"json_metadata": json.dumps({"native_filter_configuration": []})},
+            "put",
+        )
+        assert rv.status_code == 200
+        assert not mock_send_email.called
+
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    @patch("superset.commands.dashboard.update.send_email_smtp")
+    def test_dashboard_update_deleted_filter_multiple_reports_notifies_all_owners(
+        self, mock_send_email: Any
+    ):
+        """
+        Dashboard API: removing a filter referenced by multiple reports deactivates
+        all of them and emails each owner once per report
+        """
+        filter_id = "NATIVE_FILTER-shared"
+
+        dashboard = Dashboard()
+        dashboard.dashboard_title = "dash_shared_filter"
+        dashboard.slug = "dash_shared_filter"
+        dashboard.json_metadata = json.dumps(
+            {"native_filter_configuration": [{"id": filter_id, "name": "Shared"}]}
+        )
+        db.session.add(dashboard)
+        db.session.flush()
+
+        admin = self.get_user("admin")
+
+        native_filter_extra = {
+            "dashboard": {
+                "nativeFilters": [
+                    {
+                        "nativeFilterId": filter_id,
+                        "filterType": "filter_select",
+                        "columnName": "col",
+                        "filterValues": [],
+                    }
+                ]
+            }
+        }
+
+        report_a = insert_report_schedule(
+            type=ReportScheduleType.REPORT,
+            name="report_shared_filter_a",
+            crontab="0 9 * * *",
+            owners=[admin],
+            dashboard=dashboard,
+            extra=native_filter_extra,
+        )
+        report_b = insert_report_schedule(
+            type=ReportScheduleType.REPORT,
+            name="report_shared_filter_b",
+            crontab="0 10 * * *",
+            owners=[admin],
+            dashboard=dashboard,
+            extra=native_filter_extra,
+        )
+
+        db.session.commit()
+
+        self.login(ADMIN_USERNAME)
+        uri = f"api/v1/dashboard/{dashboard.id}"
+        rv = self.put_assert_metric(
+            uri,
+            {"json_metadata": json.dumps({"native_filter_configuration": []})},
+            "put",
+        )
+        assert rv.status_code == 200
+
+        db.session.refresh(report_a)
+        db.session.refresh(report_b)
+        assert report_a.active is False
+        assert report_b.active is False
+        # One email call per report (admin owns both)
+        assert mock_send_email.call_count == 2
+
+        db.session.delete(report_a)
+        db.session.delete(report_b)
+        db.session.delete(dashboard)
+        db.session.commit()


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Reports scheduled from dashboards can include native filter state (`nativeFilters`) in
their `extra.dashboard` payload. Previously, this field was never validated — any
arbitrary data was accepted at creation/update time and only crashed at execution when
the scheduler tried to read required keys from the filter objects.

Changes:
- Added `_validate_native_filters()` to `BaseReportScheduleCommand` validating that
  each `nativeFilters` item has all required keys (`nativeFilterId`, `filterType`,
  `columnName`, `filterValues`), that `filterValues` is a list, and that
  `nativeFilterId` references a filter that actually exists on the dashboard
- Moved `_validate_report_extra()` to `BaseReportScheduleCommand` so validation runs
  on both create and update (previously only ran on create)
- Added `process_native_filter_diff()` to `UpdateDashboardCommand` — when a native
  filter is removed from a dashboard, any report referencing that filter ID is
  deactivated and each report owner receives an email notification
- Added `ReportScheduleDAO.find_by_native_filter_id()` for filter ID lookups
- Extracted shared `_send_deactivated_report_email()` helper to avoid duplicating the
  HTML email template between tab and filter deactivation flows
  
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a dashboard with no native filters configured
2. POST to `/api/v1/report/` with `extra: {"dashboard": {"nativeFilters": [{"garbage": true}]}}` → expect **422**
3. POST with a valid `nativeFilterId` that doesn't exist on the dashboard → expect **422**
4. POST with a valid `nativeFilterId` that exists on the dashboard and `filterValues: []` → expect **201**
5. Same validations apply on PUT
6. Create a report referencing a valid native filter, then remove that filter from the
   dashboard via PUT `/api/v1/dashboard/:id` → report is deactivated and owner receives
   email
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Validate native dashboard filters on report create/update and deactivate reports when dashboard filters are removed**

### What Changed
- Creating or updating a scheduled report now rejects invalid dashboard nativeFilters with a 422 error (garbage entries, missing required keys, non-list values, or a nativeFilterId not present on the dashboard).
- When a native filter is removed from a dashboard, any scheduled reports that reference that filter are deactivated and each report owner receives an email notification.
- Validation of report.extra.dashboard runs on both create and update; added tests cover invalid inputs and the deactivation/email behavior.

### Impact
`✅ Fewer report creation/update errors slipping to execution`
`✅ Clearer deactivation emails when dashboard filters are removed`
`✅ Fewer failing scheduled reports after dashboard changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
