### PR TITLE
fix: Row limit support for chart mcp tools

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -30,6 +30,7 @@ from superset.mcp_service.chart.schemas import (
     ChartCapabilities,
     ChartSemantics,
     ColumnRef,
+    FilterConfig,
     MixedTimeseriesChartConfig,
     PieChartConfig,
     PivotTableChartConfig,
@@ -326,7 +327,9 @@ def map_config_to_form_data(
         raise ValueError(f"Unsupported config type: {type(config)}")
 
 
-def _add_adhoc_filters(form_data: Dict[str, Any], filters: list[Any] | None) -> None:
+def _add_adhoc_filters(
+    form_data: Dict[str, Any], filters: list[FilterConfig] | None
+) -> None:
     """Add adhoc filters to form_data if any are specified."""
     if filters:
         form_data["adhoc_filters"] = [
@@ -378,7 +381,6 @@ def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
                 "query_mode": "raw",
                 "include_time": False,
                 "order_desc": True,
-                "row_limit": 1000,  # Reasonable limit for raw data
             }
         )
 
@@ -785,7 +787,7 @@ def _humanize_column(col: ColumnRef) -> str:
 
 
 def _summarize_filters(
-    filters: list[Any] | None,
+    filters: list[FilterConfig] | None,
 ) -> str | None:
     """Extract a short context string from filter configs."""
     if not filters:

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -326,6 +326,22 @@ def map_config_to_form_data(
         raise ValueError(f"Unsupported config type: {type(config)}")
 
 
+def _add_adhoc_filters(form_data: Dict[str, Any], filters: list[Any] | None) -> None:
+    """Add adhoc filters to form_data if any are specified."""
+    if filters:
+        form_data["adhoc_filters"] = [
+            {
+                "clause": "WHERE",
+                "expressionType": "SIMPLE",
+                "subject": filter_config.column,
+                "operator": map_filter_operator(filter_config.op),
+                "comparator": filter_config.value,
+            }
+            for filter_config in filters
+            if filter_config is not None
+        ]
+
+
 def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
     """Map table chart config to form_data with defensive validation."""
     # Early validation to prevent empty charts
@@ -388,21 +404,12 @@ def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
             }
         )
 
-    if config.filters:
-        form_data["adhoc_filters"] = [
-            {
-                "clause": "WHERE",
-                "expressionType": "SIMPLE",
-                "subject": filter_config.column,
-                "operator": map_filter_operator(filter_config.op),
-                "comparator": filter_config.value,
-            }
-            for filter_config in config.filters
-            if filter_config is not None
-        ]
+    _add_adhoc_filters(form_data, config.filters)
 
     if config.sort_by:
         form_data["order_by_cols"] = config.sort_by
+
+    form_data["row_limit"] = config.row_limit
 
     return form_data
 
@@ -574,19 +581,9 @@ def map_xy_config(
     if groupby_columns:
         form_data["groupby"] = groupby_columns
 
-    # Add filters if specified
-    if config.filters:
-        form_data["adhoc_filters"] = [
-            {
-                "clause": "WHERE",
-                "expressionType": "SIMPLE",
-                "subject": filter_config.column,
-                "operator": map_filter_operator(filter_config.op),
-                "comparator": filter_config.value,
-            }
-            for filter_config in config.filters
-            if filter_config is not None
-        ]
+    _add_adhoc_filters(form_data, config.filters)
+
+    form_data["row_limit"] = config.row_limit
 
     # Add stacking configuration
     if getattr(config, "stacked", False):
@@ -623,18 +620,7 @@ def map_pie_config(config: PieChartConfig) -> Dict[str, Any]:
         "date_format": "smart_date",
     }
 
-    if config.filters:
-        form_data["adhoc_filters"] = [
-            {
-                "clause": "WHERE",
-                "expressionType": "SIMPLE",
-                "subject": filter_config.column,
-                "operator": map_filter_operator(filter_config.op),
-                "comparator": filter_config.value,
-            }
-            for filter_config in config.filters
-            if filter_config is not None
-        ]
+    _add_adhoc_filters(form_data, config.filters)
 
     return form_data
 
@@ -667,18 +653,7 @@ def map_pivot_table_config(config: PivotTableChartConfig) -> Dict[str, Any]:
         "row_limit": config.row_limit,
     }
 
-    if config.filters:
-        form_data["adhoc_filters"] = [
-            {
-                "clause": "WHERE",
-                "expressionType": "SIMPLE",
-                "subject": filter_config.column,
-                "operator": map_filter_operator(filter_config.op),
-                "comparator": filter_config.value,
-            }
-            for filter_config in config.filters
-            if filter_config is not None
-        ]
+    _add_adhoc_filters(form_data, config.filters)
 
     return form_data
 
@@ -772,21 +747,11 @@ def map_mixed_timeseries_config(
     if config.group_by_secondary and config.group_by_secondary.name != config.x.name:
         form_data["groupby_b"] = [config.group_by_secondary.name]
 
+    form_data["row_limit"] = config.row_limit
+
     _add_mixed_axis_config(form_data, config)
 
-    # Filters
-    if config.filters:
-        form_data["adhoc_filters"] = [
-            {
-                "clause": "WHERE",
-                "expressionType": "SIMPLE",
-                "subject": filter_config.column,
-                "operator": map_filter_operator(filter_config.op),
-                "comparator": filter_config.value,
-            }
-            for filter_config in config.filters
-            if filter_config is not None
-        ]
+    _add_adhoc_filters(form_data, config.filters)
 
     return form_data
 

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -588,6 +588,7 @@ class MixedTimeseriesChartConfig(BaseModel):
     y_axis: AxisConfig | None = None
     y_axis_secondary: AxisConfig | None = None
     filters: List[FilterConfig] | None = None
+    row_limit: int = Field(10000, description="Max rows", ge=1, le=50000)
 
 
 class TableChartConfig(BaseModel):
@@ -604,6 +605,7 @@ class TableChartConfig(BaseModel):
     )
     filters: List[FilterConfig] | None = None
     sort_by: List[str] | None = None
+    row_limit: int = Field(10000, description="Max rows", ge=1, le=50000)
 
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "TableChartConfig":
@@ -656,6 +658,7 @@ class XYChartConfig(BaseModel):
     y_axis: AxisConfig | None = None
     legend: LegendConfig | None = None
     filters: List[FilterConfig] | None = None
+    row_limit: int = Field(10000, description="Max rows", ge=1, le=50000)
 
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "XYChartConfig":

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -588,7 +588,7 @@ class MixedTimeseriesChartConfig(BaseModel):
     y_axis: AxisConfig | None = None
     y_axis_secondary: AxisConfig | None = None
     filters: List[FilterConfig] | None = None
-    row_limit: int = Field(10000, description="Max rows", ge=1, le=50000)
+    row_limit: int = Field(10000, description="Max data points", ge=1, le=50000)
 
 
 class TableChartConfig(BaseModel):
@@ -605,7 +605,7 @@ class TableChartConfig(BaseModel):
     )
     filters: List[FilterConfig] | None = None
     sort_by: List[str] | None = None
-    row_limit: int = Field(10000, description="Max rows", ge=1, le=50000)
+    row_limit: int = Field(1000, description="Max rows returned", ge=1, le=50000)
 
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "TableChartConfig":
@@ -658,7 +658,7 @@ class XYChartConfig(BaseModel):
     y_axis: AxisConfig | None = None
     legend: LegendConfig | None = None
     filters: List[FilterConfig] | None = None
-    row_limit: int = Field(10000, description="Max rows", ge=1, le=50000)
+    row_limit: int = Field(10000, description="Max data points", ge=1, le=50000)
 
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "XYChartConfig":

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -339,12 +339,12 @@ class TestRowLimit:
             )
 
     def test_table_chart_default_row_limit(self) -> None:
-        """Test that TableChartConfig has default row_limit of 10000."""
+        """Test that TableChartConfig has default row_limit of 1000."""
         config = TableChartConfig(
             chart_type="table",
             columns=[ColumnRef(name="product")],
         )
-        assert config.row_limit == 10000
+        assert config.row_limit == 1000
 
     def test_table_chart_custom_row_limit(self) -> None:
         """Test that TableChartConfig accepts custom row_limit."""
@@ -354,6 +354,21 @@ class TestRowLimit:
             row_limit=500,
         )
         assert config.row_limit == 500
+
+    def test_table_chart_row_limit_validation(self) -> None:
+        """Test that TableChartConfig rejects invalid row_limit."""
+        with pytest.raises(ValidationError):
+            TableChartConfig(
+                chart_type="table",
+                columns=[ColumnRef(name="product")],
+                row_limit=0,
+            )
+        with pytest.raises(ValidationError):
+            TableChartConfig(
+                chart_type="table",
+                columns=[ColumnRef(name="product")],
+                row_limit=100000,
+            )
 
 
 class TestTableChartConfigExtraFields:

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -299,6 +299,63 @@ class TestXYChartConfig:
         assert config.orientation == "horizontal"
 
 
+class TestRowLimit:
+    """Test row_limit field on chart configs."""
+
+    def test_xy_chart_default_row_limit(self) -> None:
+        """Test that XYChartConfig has default row_limit of 10000."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+        )
+        assert config.row_limit == 10000
+
+    def test_xy_chart_custom_row_limit(self) -> None:
+        """Test that XYChartConfig accepts custom row_limit."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            row_limit=100,
+        )
+        assert config.row_limit == 100
+
+    def test_xy_chart_row_limit_validation(self) -> None:
+        """Test that XYChartConfig rejects invalid row_limit."""
+        with pytest.raises(ValidationError):
+            XYChartConfig(
+                chart_type="xy",
+                x=ColumnRef(name="date"),
+                y=[ColumnRef(name="revenue", aggregate="SUM")],
+                row_limit=0,
+            )
+        with pytest.raises(ValidationError):
+            XYChartConfig(
+                chart_type="xy",
+                x=ColumnRef(name="date"),
+                y=[ColumnRef(name="revenue", aggregate="SUM")],
+                row_limit=100000,
+            )
+
+    def test_table_chart_default_row_limit(self) -> None:
+        """Test that TableChartConfig has default row_limit of 10000."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="product")],
+        )
+        assert config.row_limit == 10000
+
+    def test_table_chart_custom_row_limit(self) -> None:
+        """Test that TableChartConfig accepts custom row_limit."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="product")],
+            row_limit=500,
+        )
+        assert config.row_limit == 500
+
+
 class TestTableChartConfigExtraFields:
     """Test TableChartConfig rejects unknown fields."""
 

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -313,6 +313,29 @@ class TestMapTableConfig:
 
         assert result["viz_type"] == "table"
 
+    def test_map_table_config_row_limit(self) -> None:
+        """Test that row_limit is mapped to form_data."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="product")],
+            row_limit=500,
+        )
+
+        result = map_table_config(config)
+
+        assert result["row_limit"] == 500
+
+    def test_map_table_config_default_row_limit(self) -> None:
+        """Test that default row_limit is mapped to form_data."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="product", aggregate="SUM")],
+        )
+
+        result = map_table_config(config)
+
+        assert result["row_limit"] == 10000
+
 
 class TestMapXYConfig:
     """Test map_xy_config function"""
@@ -537,6 +560,37 @@ class TestMapXYConfig:
         assert result["orientation"] == "horizontal"
         assert result["stack"] == "Stack"
         assert result["groupby"] == ["level"]
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_map_xy_config_row_limit(self, mock_is_temporal) -> None:
+        """Test that row_limit is mapped to form_data."""
+        mock_is_temporal.return_value = True
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+            row_limit=250,
+        )
+
+        result = map_xy_config(config)
+
+        assert result["row_limit"] == 250
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_map_xy_config_default_row_limit(self, mock_is_temporal) -> None:
+        """Test that default row_limit is mapped to form_data."""
+        mock_is_temporal.return_value = True
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="bar",
+        )
+
+        result = map_xy_config(config)
+
+        assert result["row_limit"] == 10000
 
 
 class TestMapConfigToFormData:

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from superset.mcp_service.chart.chart_utils import (
+    _add_adhoc_filters,
     configure_temporal_handling,
     create_metric_object,
     generate_chart_name,
@@ -334,7 +335,44 @@ class TestMapTableConfig:
 
         result = map_table_config(config)
 
-        assert result["row_limit"] == 10000
+        assert result["row_limit"] == 1000
+
+
+class TestAddAdhocFilters:
+    """Test _add_adhoc_filters helper function"""
+
+    def test_adds_filters_to_form_data(self) -> None:
+        """Test that filters are correctly added to form_data."""
+        form_data: dict[str, Any] = {}
+        filters = [
+            FilterConfig(column="region", op="=", value="US"),
+            FilterConfig(column="year", op=">", value=2020),
+        ]
+
+        _add_adhoc_filters(form_data, filters)
+
+        assert "adhoc_filters" in form_data
+        assert len(form_data["adhoc_filters"]) == 2
+        assert form_data["adhoc_filters"][0]["subject"] == "region"
+        assert form_data["adhoc_filters"][0]["operator"] == "=="
+        assert form_data["adhoc_filters"][1]["subject"] == "year"
+        assert form_data["adhoc_filters"][1]["operator"] == ">"
+
+    def test_no_filters_does_nothing(self) -> None:
+        """Test that None filters leave form_data unchanged."""
+        form_data: dict[str, Any] = {"viz_type": "table"}
+
+        _add_adhoc_filters(form_data, None)
+
+        assert "adhoc_filters" not in form_data
+
+    def test_empty_list_does_nothing(self) -> None:
+        """Test that empty filter list leaves form_data unchanged."""
+        form_data: dict[str, Any] = {"viz_type": "table"}
+
+        _add_adhoc_filters(form_data, [])
+
+        assert "adhoc_filters" not in form_data
 
 
 class TestMapXYConfig:
@@ -560,6 +598,26 @@ class TestMapXYConfig:
         assert result["orientation"] == "horizontal"
         assert result["stack"] == "Stack"
         assert result["groupby"] == ["level"]
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_map_xy_config_with_filters(self, mock_is_temporal) -> None:
+        """Test that filters are mapped to adhoc_filters in XY form_data."""
+        mock_is_temporal.return_value = True
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+            filters=[FilterConfig(column="region", op="=", value="US")],
+        )
+
+        result = map_xy_config(config)
+
+        assert "adhoc_filters" in result
+        assert len(result["adhoc_filters"]) == 1
+        assert result["adhoc_filters"][0]["subject"] == "region"
+        assert result["adhoc_filters"][0]["operator"] == "=="
+        assert result["adhoc_filters"][0]["comparator"] == "US"
 
     @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
     def test_map_xy_config_row_limit(self, mock_is_temporal) -> None:

--- a/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
+++ b/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
@@ -512,6 +512,25 @@ class TestMixedTimeseriesChartConfigSchema:
                 unknown_field="bad",
             )
 
+    def test_mixed_timeseries_default_row_limit(self) -> None:
+        config = MixedTimeseriesChartConfig(
+            chart_type="mixed_timeseries",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            y_secondary=[ColumnRef(name="orders", aggregate="COUNT")],
+        )
+        assert config.row_limit == 10000
+
+    def test_mixed_timeseries_custom_row_limit(self) -> None:
+        config = MixedTimeseriesChartConfig(
+            chart_type="mixed_timeseries",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            y_secondary=[ColumnRef(name="orders", aggregate="COUNT")],
+            row_limit=500,
+        )
+        assert config.row_limit == 500
+
 
 # ============================================================
 # Mixed Timeseries Form Data Mapping Tests
@@ -635,6 +654,35 @@ class TestMapMixedTimeseriesConfig:
         assert result["yAxisTitleSecondary"] == "Orders"
         assert result["y_axis_format_secondary"] == ",d"
         assert result["logAxisSecondary"] is True
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_mixed_form_data_row_limit(self, mock_is_temporal) -> None:
+        mock_is_temporal.return_value = True
+
+        config = MixedTimeseriesChartConfig(
+            chart_type="mixed_timeseries",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            y_secondary=[ColumnRef(name="orders", aggregate="COUNT")],
+            row_limit=300,
+        )
+        result = map_mixed_timeseries_config(config, dataset_id=1)
+
+        assert result["row_limit"] == 300
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_mixed_form_data_default_row_limit(self, mock_is_temporal) -> None:
+        mock_is_temporal.return_value = True
+
+        config = MixedTimeseriesChartConfig(
+            chart_type="mixed_timeseries",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            y_secondary=[ColumnRef(name="orders", aggregate="COUNT")],
+        )
+        result = map_mixed_timeseries_config(config, dataset_id=1)
+
+        assert result["row_limit"] == 10000
 
     @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
     def test_mixed_form_data_with_filters(self, mock_is_temporal) -> None:


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Add row limit support for chart creation tools

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Add row limit support and ensure filters are included when generating chart form data

### What Changed
- Chart config schemas (XY, Table, Mixed Timeseries, Pie, Pivot) now include a validated row_limit with default 10000 and bounds (1–50000).
- The row_limit value is carried into generated Superset form_data for table, XY, pie, pivot, and mixed timeseries charts.
- Ad-hoc filters from chart configs are consistently mapped into form_data so configured filters are applied to generated charts.
- Unit tests added to verify default and custom row_limit behavior, row_limit mapping to form_data, and filter mapping.

### Impact
`✅ Consistent row limits across MCP-generated charts`
`✅ Rejected invalid row_limit inputs during config validation`
`✅ Filters from chart configs are applied to generated charts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
