### PR TITLE
fix(chart): prevent chart list from failing when a datasource lacks explore_url

### DIFF
--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -164,10 +164,13 @@ class Slice(  # pylint: disable=too-many-public-methods
 
     @renders("datasource_url")
     def datasource_url(self) -> str | None:
+        # Use getattr to guard against datasource types that don't have explore_url
+        # (e.g. Query objects), which would otherwise raise AttributeError and cause
+        # the entire chart list response to fail.
         if self.table:
-            return self.table.explore_url
+            return getattr(self.table, "explore_url", None)
         datasource = self.datasource
-        return datasource.explore_url if datasource else None
+        return getattr(datasource, "explore_url", None) if datasource else None
 
     def datasource_name_text(self) -> str | None:
         if self.table:

--- a/tests/unit_tests/models/slice_test.py
+++ b/tests/unit_tests/models/slice_test.py
@@ -85,3 +85,41 @@ class TestSlice:
         """Test id_or_uuid_filter returns correct BinaryExpression."""
         result = id_or_uuid_filter(input_value)
         assert result is not None
+
+    def test_datasource_url_returns_none_when_datasource_lacks_explore_url(self):
+        """datasource_url() must not raise when the datasource has no explore_url.
+
+        Charts whose datasource resolves to a Query (or any other type without
+        explore_url) used to raise AttributeError, which caused the entire chart
+        list API response to fail instead of just skipping that one chart.
+        """
+        slc = Slice()
+        slc.id = 1
+
+        # Simulate a datasource object that does NOT have explore_url (e.g. Query)
+        mock_datasource = MagicMock(spec=[])  # spec=[] means no attributes at all
+        slc.table = mock_datasource
+
+        result = slc.datasource_url()
+        assert result is None
+
+    def test_datasource_url_returns_explore_url_when_present(self):
+        """datasource_url() returns the datasource explore_url when it exists."""
+        slc = Slice()
+        slc.id = 1
+
+        mock_table = MagicMock()
+        mock_table.explore_url = "/explore/?datasource_type=table&datasource_id=1"
+        slc.table = mock_table
+
+        result = slc.datasource_url()
+        assert result == "/explore/?datasource_type=table&datasource_id=1"
+
+    def test_datasource_url_returns_none_when_no_datasource(self):
+        """datasource_url() returns None when there is no datasource."""
+        slc = Slice()
+        slc.id = 1
+        slc.table = None
+
+        result = slc.datasource_url()
+        assert result is None


### PR DESCRIPTION
## **User description**
### SUMMARY

When a chart is created from a SQL query, the chart's datasource can end up resolving to a `Query` object at runtime. `Query` objects do not have an `explore_url` attribute (only `SqlaTable` does). The `Slice.datasource_url()` method was accessing `.explore_url` directly, which raised an `AttributeError`. Because Marshmallow propagates serialization exceptions, this caused the **entire** chart list API response to fail — not just the one affected chart.

**Root cause:** `Slice.datasource_url()` used direct attribute access (`datasource.explore_url`) instead of safe access, so any datasource type that doesn't implement `explore_url` would blow up the whole list.

**Fix:** Replace direct attribute access with `getattr(..., None)` in both branches of `datasource_url()`. This ensures the method returns `None` gracefully for any datasource type that doesn't have `explore_url`, while still returning the correct URL for normal `SqlaTable`-backed charts.

```python
# Before
return self.table.explore_url
return datasource.explore_url if datasource else None

# After
return getattr(self.table, "explore_url", None)
return getattr(datasource, "explore_url", None) if datasource else None
```

Three unit tests are added to cover the new behaviour:
1. `datasource_url()` returns `None` (does not raise) when the datasource has no `explore_url`
2. `datasource_url()` returns the correct URL when the datasource has `explore_url`
3. `datasource_url()` returns `None` when there is no datasource at all

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only fix. Before the fix, loading the chart list (e.g. the "Add chart" panel on a dashboard) would display:

> Sorry there was an error fetching saved charts: 'Query' object has no attribute 'explore_url'

After the fix the list loads normally; charts with a non-`SqlaTable` datasource simply have `datasource_url: null`.

### TESTING INSTRUCTIONS

1. Create a chart whose underlying datasource is a SQL Lab query (i.e. the chart ends up with `datasource_type='query'` in the `slices` table, or the datasource object has no `explore_url`).
2. Navigate to a dashboard → open the "Add chart" panel (or the `/chart/list` page).
3. **Before fix:** the whole list fails with the `'Query' object has no attribute 'explore_url'` toast.
4. **After fix:** the list renders; the affected chart shows `datasource_url` as `null` but does not break other charts.

Unit tests:
```bash
pytest tests/unit_tests/models/slice_test.py -v
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Prevent chart list from failing when a chart's datasource has no explore_url

### What Changed
- datasource_url() now safely returns None instead of raising when a chart's datasource (or table) lacks an explore_url attribute
- The chart list API and UI components that fetch saved charts no longer fail when a datasource resolves to a type without explore_url
- Added unit tests verifying: None is returned for datasources without explore_url, the URL is returned when present, and None is returned when no datasource exists

### Impact
`✅ Fewer chart list API failures`
`✅ No crash when a chart's datasource is a query object`
`✅ More reliable loading of the Add Chart / saved charts list`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
