### PR TITLE
fix(AlertsReports): validate anchor_list is a list

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -268,7 +268,11 @@ class BaseReportState:
             native_filter_params = self._report_schedule.get_native_filters_params()
             if anchor := dashboard_state.get("anchor"):
                 try:
-                    anchor_list: list[str] = json.loads(anchor)
+                    anchor_list = json.loads(anchor)
+                    if not isinstance(anchor_list, list):
+                        raise json.JSONDecodeError(
+                            "Anchor value is not a list", anchor, 0
+                        )
                     urls = self._get_tabs_urls(
                         anchor_list,
                         native_filter_params=native_filter_params,

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -259,6 +259,12 @@ def test_log_data_with_missing_values(mocker: MockerFixture) -> None:
             ["url1"],
             ["superset/dashboard/p/url1/"],
         ),
+        # Test JSON scalar string anchor falls back to single tab
+        (
+            json.dumps("mock_tab_anchor_1"),
+            ["url1"],
+            ["superset/dashboard/p/url1/"],
+        ),
     ],
 )
 @patch(


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This pr fixes an edge case where anchor_link is not a list and split into individual characters. We now check for it and raise an error if so.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

  1. Create a dashboard report with the ALERT_REPORT_TABS feature flag enabled
  2. Manually set the report's extra.dashboard.anchor to a JSON-encoded string value (e.g., '"TAB-A"' — note the double quoting)
  3. Trigger the report execution
  4. Before fix: the code iterates over "TAB-A" character by character, generating invalid URLs for "T", "A", "B", "-", "A"
  5. After fix: the code detects the parsed value isn't a list, raises JSONDecodeError, and falls back to the single-tab URL path — same behavior as a plain non-JSON string

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix dashboard report anchor handling to avoid iterating over non-list values

### What Changed
- When a report's dashboard anchor is JSON-encoded but not a list (e.g., a JSON string), the code now detects that and falls back to the single-tab dashboard URL instead of treating the string as a list of characters and generating invalid tab URLs.
- Added a unit test that verifies a JSON scalar anchor (a JSON-encoded string) falls back to the single-tab URL path.

### Impact
`✅ Fewer invalid dashboard tab URLs in alert/report exports`
`✅ Clearer single-tab fallback when anchor value is malformed`
`✅ Fewer broken alert report executions caused by malformed anchor data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
