### PR TITLE
fix(mcp): handle Superset-native field names in XYChartConfig

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -660,6 +660,32 @@ class XYChartConfig(BaseModel):
     filters: List[FilterConfig] | None = None
     row_limit: int = Field(10000, description="Max data points", ge=1, le=50000)
 
+    @model_validator(mode="before")
+    @classmethod
+    def handle_legacy_field_names(cls, data: Any) -> Any:
+        """Map Superset-native field names to MCP schema field names.
+
+        LLMs sometimes use native Superset field names instead of MCP field names.
+        This validator remaps known aliases before extra="forbid" validation runs.
+        """
+        if not isinstance(data, dict):
+            return data
+        # groupby: list[str] -> group_by: ColumnRef (take first item only)
+        # Always pop groupby to avoid extra="forbid" rejection; only map it if
+        # group_by is not already set (explicit group_by takes precedence).
+        if "groupby" in data:
+            groupby_val = data.pop("groupby")
+            if "group_by" not in data:
+                if isinstance(groupby_val, list) and groupby_val:
+                    data["group_by"] = {"name": str(groupby_val[0])}
+                elif isinstance(groupby_val, str):
+                    data["group_by"] = {"name": groupby_val}
+        # adhoc_filters: incompatible format with MCP FilterConfig - strip silently
+        data.pop("adhoc_filters", None)
+        # order_desc: no equivalent in MCP schema - strip silently
+        data.pop("order_desc", None)
+        return data
+
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "XYChartConfig":
         """Ensure all column labels are unique across x, y, and group_by."""

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -382,3 +382,98 @@ class TestTableChartConfigExtraFields:
                 columns=[ColumnRef(name="product")],
                 foo="bar",
             )
+
+
+class TestXYChartConfigLegacyFields:
+    """Test XYChartConfig handles Superset-native field names."""
+
+    def test_groupby_list_converts_to_group_by(self) -> None:
+        config = XYChartConfig(
+            **{
+                "chart_type": "xy",
+                "x": {"name": "date"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "groupby": ["product_line"],
+            }
+        )
+        assert config.group_by is not None
+        assert config.group_by.name == "product_line"
+
+    def test_adhoc_filters_stripped_silently(self) -> None:
+        config = XYChartConfig(
+            **{
+                "chart_type": "xy",
+                "x": {"name": "date"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "adhoc_filters": [
+                    {
+                        "clause": "WHERE",
+                        "expressionType": "SQL",
+                        "sqlExpression": "x > 0",
+                    }
+                ],
+            }
+        )
+        assert config.filters is None
+
+    def test_order_desc_stripped_silently(self) -> None:
+        config = XYChartConfig(
+            **{
+                "chart_type": "xy",
+                "x": {"name": "date"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "order_desc": True,
+            }
+        )
+        assert config.x.name == "date"
+
+    def test_all_legacy_fields_together(self) -> None:
+        """LLM scenario: groupby, adhoc_filters, and order_desc sent together."""
+        config = XYChartConfig(
+            **{
+                "chart_type": "xy",
+                "x": {"name": "customer_name"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "kind": "bar",
+                "groupby": ["product_line"],
+                "adhoc_filters": [
+                    {
+                        "clause": "WHERE",
+                        "expressionType": "SQL",
+                        "sqlExpression": "x > 0",
+                    }
+                ],
+                "row_limit": 100,
+                "order_desc": True,
+            }
+        )
+        assert config.group_by is not None
+        assert config.group_by.name == "product_line"
+        assert config.filters is None
+
+    def test_group_by_still_works_directly(self) -> None:
+        """group_by field continues to work (no regression)."""
+        config = XYChartConfig(
+            **{
+                "chart_type": "xy",
+                "x": {"name": "date"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "group_by": {"name": "region"},
+            }
+        )
+        assert config.group_by is not None
+        assert config.group_by.name == "region"
+
+    def test_groupby_does_not_override_group_by(self) -> None:
+        """If both present, group_by wins (explicit takes precedence)."""
+        config = XYChartConfig(
+            **{
+                "chart_type": "xy",
+                "x": {"name": "date"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "group_by": {"name": "region"},
+                "groupby": ["product_line"],
+            }
+        )
+        assert config.group_by is not None
+        assert config.group_by.name == "region"


### PR DESCRIPTION
## **User description**
### SUMMARY

When an LLM calls `generate_chart` or `generate_explore_link`, it sometimes sends Superset-native field names (`groupby`, `adhoc_filters`, `order_desc`) instead of the MCP schema field names (`group_by`, `filters`). Previously `XYChartConfig` rejected the entire request with a `ValidationError` (extra fields not permitted), causing the LLM to fall back to a minimal config with no grouping or filters.

This adds a `model_validator(mode="before")` to `XYChartConfig` that intercepts the raw input dict before the `extra="forbid"` check runs:
- `groupby` (list of column names) → maps first item to `group_by` as a `ColumnRef`
- `adhoc_filters` → stripped silently (format is incompatible with `FilterConfig`)
- `order_desc` → stripped silently (no equivalent in the MCP schema)

If both `groupby` and `group_by` are provided, the explicit `group_by` takes precedence.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend validation fix.

### TESTING INSTRUCTIONS

Unit tests cover all scenarios in `TestXYChartConfigLegacyFields`:
- `groupby` list converts to `group_by`
- `adhoc_filters` stripped silently
- `order_desc` stripped silently
- All three legacy fields together (the original failing scenario)
- `group_by` still works directly (no regression)
- `groupby` does not override explicit `group_by`

```bash
pytest tests/unit_tests/mcp_service/chart/test_chart_schemas.py::TestXYChartConfigLegacyFields -v
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Handle Superset-native field names in XY chart config so LLM-generated requests are accepted

### What Changed
- XYChartConfig now accepts Superset-native names sent by LLMs: "groupby" (list or string) is converted to "group_by" using the first item; "adhoc_filters" and "order_desc" are silently ignored instead of causing validation errors
- If both "group_by" and "groupby" are provided, the explicit "group_by" value is preserved
- Unit tests added to verify conversion of "groupby", stripping of "adhoc_filters" and "order_desc", combined legacy-field scenarios, and no regression for direct "group_by"

### Impact
`✅ Fewer chart fallbacks when LLMs send Superset field names`
`✅ Fewer validation errors for incoming chart requests`
`✅ Consistent grouping when both legacy and explicit fields are provided`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
