### PR TITLE
fix(mcp): convert ValidationError to ToolError in flattened wrapper

### DIFF
--- a/superset/mcp_service/utils/schema_utils.py
+++ b/superset/mcp_service/utils/schema_utils.py
@@ -561,10 +561,27 @@ def _create_flattened_wrapper(
 
         @wraps(func)
         async def async_wrapper(**kwargs: Any) -> Any:
+            from fastmcp.exceptions import ToolError
             from fastmcp.server.dependencies import get_context
 
             ctx = get_context()
-            model = request_class.model_validate(kwargs)
+            try:
+                model = request_class.model_validate(kwargs)
+            except ValidationError as e:
+                details = []
+                for err in e.errors():
+                    field = " -> ".join(str(loc) for loc in err["loc"])
+                    details.append(f"{field}: {err['msg']}")
+                required_fields = [
+                    f.alias or name
+                    for name, f in request_class.model_fields.items()
+                    if f.is_required()
+                ]
+                raise ToolError(
+                    f"Invalid request parameters: {'; '.join(details)}. "
+                    f"Required fields for {request_class.__name__}: "
+                    f"{', '.join(required_fields)}"
+                ) from None
             return await func(model, ctx)
 
         wrapper = async_wrapper
@@ -572,10 +589,27 @@ def _create_flattened_wrapper(
 
         @wraps(func)
         def sync_wrapper(**kwargs: Any) -> Any:
+            from fastmcp.exceptions import ToolError
             from fastmcp.server.dependencies import get_context
 
             ctx = get_context()
-            model = request_class.model_validate(kwargs)
+            try:
+                model = request_class.model_validate(kwargs)
+            except ValidationError as e:
+                details = []
+                for err in e.errors():
+                    field = " -> ".join(str(loc) for loc in err["loc"])
+                    details.append(f"{field}: {err['msg']}")
+                required_fields = [
+                    f.alias or name
+                    for name, f in request_class.model_fields.items()
+                    if f.is_required()
+                ]
+                raise ToolError(
+                    f"Invalid request parameters: {'; '.join(details)}. "
+                    f"Required fields for {request_class.__name__}: "
+                    f"{', '.join(required_fields)}"
+                ) from None
             return func(model, ctx)
 
         wrapper = sync_wrapper

--- a/tests/unit_tests/mcp_service/utils/test_schema_utils.py
+++ b/tests/unit_tests/mcp_service/utils/test_schema_utils.py
@@ -24,7 +24,7 @@ import inspect
 from typing import Annotated, List
 
 import pytest
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from superset.mcp_service.utils.schema_utils import (
     JSONParseError,
@@ -758,9 +758,15 @@ class TestParseRequestFlattenedDecorator:
         for param in sig.parameters.values():
             assert param.kind == inspect.Parameter.KEYWORD_ONLY
 
-    def test_flattened_validation_error(self):
-        """Pydantic validation errors should propagate when constructing model."""
+    def test_flattened_validation_error_raises_tool_error(self):
+        """Pydantic validation errors should be converted to ToolError.
+
+        Raw ValidationError propagation causes LangGraph serialization failures
+        (TypeError: encoding without a string argument).
+        """
         from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
 
         @parse_request(self.SimpleRequest)
         def my_tool(request, ctx=None):
@@ -768,8 +774,63 @@ class TestParseRequestFlattenedDecorator:
 
         mock_ctx = MagicMock()
         with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
-            with pytest.raises(ValidationError):
+            with pytest.raises(ToolError):
                 my_tool(name="test", count="not_a_number")
+
+    async def test_flattened_validation_error_raises_tool_error_async(self):
+        """Async flattened wrapper should also convert ValidationError to ToolError."""
+        from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        @parse_request(self.SimpleRequest)
+        async def my_tool(request, ctx=None):
+            return "ok"
+
+        mock_ctx = MagicMock()
+        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+            with pytest.raises(ToolError):
+                await my_tool(name="test", count="not_a_number")
+
+    def test_flattened_missing_required_field_raises_tool_error(self):
+        """Missing required fields should raise ToolError with helpful message."""
+        from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        class RequiredFieldRequest(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+            name: str = Field(..., description="Required name")
+            count: int = Field(..., description="Required count")
+
+        @parse_request(RequiredFieldRequest)
+        def my_tool(request, ctx=None):
+            return "ok"
+
+        mock_ctx = MagicMock()
+        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+            with pytest.raises(ToolError, match="Invalid request parameters"):
+                my_tool(name="test")  # missing count
+
+    async def test_flattened_missing_required_field_raises_tool_error_async(self):
+        """Async: missing required fields should raise ToolError."""
+        from unittest.mock import MagicMock, patch
+
+        from fastmcp.exceptions import ToolError
+
+        class RequiredFieldRequest(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+            name: str = Field(..., description="Required name")
+            count: int = Field(..., description="Required count")
+
+        @parse_request(RequiredFieldRequest)
+        async def my_tool(request, ctx=None):
+            return "ok"
+
+        mock_ctx = MagicMock()
+        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+            with pytest.raises(ToolError, match="Invalid request parameters"):
+                await my_tool(name="test")  # missing count
 
     def test_flattened_annotations_have_descriptions(self):
         """Annotations should include Field descriptions for FastMCP schema."""


### PR DESCRIPTION
## **User description**
### TLDR

When `MCP_PARSE_REQUEST_ENABLED` is `False` (flattened mode), `_create_flattened_wrapper` did not catch `ValidationError` from `model_validate(kwargs)`. A raw `ValidationError` propagating from an MCP tool call causes downstream serialization failures (`TypeError: encoding without a string argument`).

### What changed

In `_create_flattened_wrapper` (both async and sync paths), wrap `model_validate(kwargs)` in `try/except ValidationError` and raise `ToolError` with a descriptive message listing the invalid/missing fields. This matches the existing behavior of `_create_string_parsing_wrapper`.

### Tests

- Updated the existing test that documented the old buggy behavior (expected `ValidationError` to propagate raw) to now expect `ToolError`
- Added a test for the missing-required-field case specifically

### Checklist

- [x] Unit tests added/updated
- [x] `ruff format` applied
- [x] Pre-commit hooks pass


___

## **CodeAnt-AI Description**
Convert Pydantic validation failures to ToolError for flattened MCP tool calls

### What Changed
- When MCP tools are invoked in flattened mode (individual fields as params), Pydantic validation failures are caught and converted into a ToolError that lists invalid fields and required fields instead of letting a raw ValidationError propagate
- Both sync and async flattened wrappers now raise ToolError for invalid types or missing required fields; unit tests updated and added to cover these cases

### Impact
`✅ Clearer invalid request errors`
`✅ Fewer downstream serialization failures in MCP tool calls`
`✅ Consistent error type for flattened tool invocations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
