### PR TITLE
feat(themes): add JSON formatting to theme modal editor

### DIFF
--- a/superset-frontend/src/features/themes/ThemeModal.test.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.test.tsx
@@ -712,6 +712,138 @@ test('applies theme locally when clicking Apply button', async () => {
   expect(mockThemeContext.setTemporaryTheme).toHaveBeenCalled();
 });
 
+test('shows Format button when modal is in edit mode', () => {
+  render(
+    <ThemeModal
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+      onThemeAdd={jest.fn()}
+      onHide={jest.fn()}
+      show
+      canDevelop={false}
+    />,
+    { useRedux: true, useRouter: true },
+  );
+
+  expect(screen.getByRole('button', { name: /format/i })).toBeInTheDocument();
+});
+
+test('does not show Format button for read-only system themes', async () => {
+  render(
+    <ThemeModal
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+      onThemeAdd={jest.fn()}
+      onHide={jest.fn()}
+      show
+      canDevelop={false}
+      theme={mockSystemTheme}
+    />,
+    { useRedux: true, useRouter: true },
+  );
+
+  await screen.findByText('System Theme - Read Only');
+
+  expect(
+    screen.queryByRole('button', { name: /format/i }),
+  ).not.toBeInTheDocument();
+});
+
+test('disables Format button when JSON is invalid', async () => {
+  render(
+    <ThemeModal
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+      onThemeAdd={jest.fn()}
+      onHide={jest.fn()}
+      show
+      canDevelop={false}
+    />,
+    { useRedux: true, useRouter: true },
+  );
+
+  const jsonEditor = screen.getByTestId('json-editor');
+  userEvent.clear(jsonEditor);
+  userEvent.type(jsonEditor, '{invalid json');
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /format/i })).toBeDisabled();
+  });
+});
+
+test('enables Format button when JSON is valid', async () => {
+  render(
+    <ThemeModal
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+      onThemeAdd={jest.fn()}
+      onHide={jest.fn()}
+      show
+      canDevelop={false}
+    />,
+    { useRedux: true, useRouter: true },
+  );
+
+  await addValidJsonData();
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /format/i })).toBeEnabled();
+  });
+});
+
+test('Format button pretty-prints minified JSON', async () => {
+  render(
+    <ThemeModal
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+      onThemeAdd={jest.fn()}
+      onHide={jest.fn()}
+      show
+      canDevelop={false}
+    />,
+    { useRedux: true, useRouter: true },
+  );
+
+  const minifiedJson = '{"token":{"colorPrimary":"#1890ff"}}';
+  const jsonEditor = screen.getByTestId('json-editor');
+  userEvent.clear(jsonEditor);
+  userEvent.type(jsonEditor, minifiedJson);
+
+  const formatButton = screen.getByRole('button', { name: /format/i });
+  userEvent.click(formatButton);
+
+  const expectedFormatted = JSON.stringify(
+    { token: { colorPrimary: '#1890ff' } },
+    null,
+    2,
+  );
+  await waitFor(() => {
+    expect(jsonEditor).toHaveValue(expectedFormatted);
+  });
+});
+
+test('Format button is disabled when JSON editor is empty', async () => {
+  render(
+    <ThemeModal
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+      onThemeAdd={jest.fn()}
+      onHide={jest.fn()}
+      show
+      canDevelop={false}
+    />,
+    { useRedux: true, useRouter: true },
+  );
+
+  // The editor initializes with `{}` — clear it to reach the empty state
+  const jsonEditor = screen.getByTestId('json-editor');
+  userEvent.clear(jsonEditor);
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /format/i })).toBeDisabled();
+  });
+});
+
 test('disables Apply button when JSON configuration is invalid', async () => {
   fetchMock.clearHistory().removeRoutes();
   fetchMock.get('glob:*/api/v1/theme/*', {

--- a/superset-frontend/src/features/themes/ThemeModal.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.tsx
@@ -325,6 +325,15 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
     [currentTheme],
   );
 
+  const onFormat = useCallback(() => {
+    if (currentTheme?.json_data) {
+      const formatted = formatJsonData(currentTheme.json_data);
+      if (formatted !== currentTheme.json_data) {
+        onJsonDataChange(formatted || '');
+      }
+    }
+  }, [currentTheme?.json_data, onJsonDataChange]);
+
   const validate = () => {
     if (isReadOnly || !currentTheme) {
       setDisableSave(true);
@@ -535,27 +544,46 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
                 annotations={toEditorAnnotations(validation.annotations)}
               />
             </StyledEditorWrapper>
-            {canDevelopThemes && (
-              <div className="apply-button-container">
-                <Tooltip
-                  title={t('Set local theme for testing (preview only)')}
-                  placement="top"
-                >
-                  <Button
-                    icon={<Icons.ThunderboltOutlined />}
-                    onClick={onApply}
-                    disabled={
-                      !currentTheme?.json_data ||
-                      !isValidJson(currentTheme.json_data) ||
-                      validation.hasErrors
-                    }
-                    buttonStyle="secondary"
+            <div className="apply-button-container">
+              <Space>
+                {!isReadOnly && (
+                  <Tooltip
+                    title={t('Format JSON configuration')}
+                    placement="top"
                   >
-                    {t('Apply')}
-                  </Button>
-                </Tooltip>
-              </div>
-            )}
+                    <Button
+                      icon={<Icons.FormatPainterOutlined />}
+                      onClick={onFormat}
+                      disabled={
+                        !currentTheme?.json_data ||
+                        !isValidJson(currentTheme.json_data)
+                      }
+                    >
+                      {t('Format')}
+                    </Button>
+                  </Tooltip>
+                )}
+                {canDevelopThemes && (
+                  <Tooltip
+                    title={t('Set local theme for testing (preview only)')}
+                    placement="top"
+                  >
+                    <Button
+                      icon={<Icons.ThunderboltOutlined />}
+                      onClick={onApply}
+                      disabled={
+                        !currentTheme?.json_data ||
+                        !isValidJson(currentTheme.json_data) ||
+                        validation.hasErrors
+                      }
+                      buttonStyle="secondary"
+                    >
+                      {t('Apply')}
+                    </Button>
+                  </Tooltip>
+                )}
+              </Space>
+            </div>
           </Form.Item>
         </Form>
       </StyledFormWrapper>

--- a/superset-frontend/src/features/themes/ThemeModal.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.tsx
@@ -71,6 +71,15 @@ const toEditorAnnotations = (
     message: ann.text,
   }));
 
+const formatJsonData = (jsonData?: string): string | undefined => {
+  if (!jsonData) return jsonData;
+  try {
+    return JSON.stringify(JSON.parse(jsonData), null, 2);
+  } catch {
+    return jsonData;
+  }
+};
+
 interface ThemeModalProps {
   addDangerToast: (msg: string) => void;
   addSuccessToast?: (msg: string) => void;
@@ -357,8 +366,12 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
 
   useEffect(() => {
     if (resource) {
-      setCurrentTheme(resource);
-      setInitialTheme(resource);
+      const formatted = {
+        ...resource,
+        json_data: formatJsonData(resource.json_data),
+      };
+      setCurrentTheme(formatted);
+      setInitialTheme(formatted);
     }
   }, [resource]);
 

--- a/superset-frontend/src/features/themes/ThemeModal.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.tsx
@@ -552,7 +552,8 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
                     placement="top"
                   >
                     <Button
-                      icon={<Icons.FormatPainterOutlined />}
+                      icon={<Icons.AlignLeftOutlined />}
+                      buttonStyle="secondary"
                       onClick={onFormat}
                       disabled={
                         !currentTheme?.json_data ||


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When editing theme configurations, the JSON was displayed as a single unformatted line, making it difficult to read and modify. This PR adds a small formatting utility that pretty-prints theme JSON with 2-space indentation. Existing themes are now automatically formatted when loaded into the modal, and a new "Format" button next to the "Apply" button allows users to re-format the JSON at any time while editing. The button is disabled when the JSON is invalid and hidden in read-only mode for system themes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
- Before
<img width="1113" height="923" alt="Screenshot 2026-03-19 103923" src="https://github.com/user-attachments/assets/ca821f51-7279-49e0-b198-ad91164ef82c" />

- After
<img width="1335" height="907" alt="Screenshot 2026-03-20 094056" src="https://github.com/user-attachments/assets/cefd1558-d433-495d-9469-6823d8d2e0c3" />


https://github.com/user-attachments/assets/a07cc46f-cf65-4ca1-892f-8561f0a07a33


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open an existing theme in edit mode — JSON should be formatted on load
- Click the Format button — JSON should be re-indented
- Paste minified JSON, click Format — should pretty-print
- Enter invalid JSON — Format button should be disabled
- View a system theme (read-only) — Format button should be hidden

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Add JSON formatting and a Format button to the theme editor modal**

### What Changed
- Theme JSON is automatically pretty-printed (2-space indentation) when a theme is loaded into the modal
- A "Format" button appears in edit mode beside the Apply control and reformats the editor contents; the button is hidden for read-only system themes
- The Format button is disabled when the editor is empty or contains invalid JSON; clicking it turns minified JSON into readable, indented JSON
- Existing validation and Apply preview behavior remain, with the Format action only affecting editor content

### Impact
`✅ Clearer theme JSON when opening and editing themes`
`✅ Fewer invalid theme edits saved due to visible formatting/validation`
`✅ Shorter time to edit and inspect theme JSON`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
