### PR TITLE
fix(firebolt): Firebolt SQL entered with EXCLUDE is rewritten to EXCEPT

### DIFF
--- a/superset/sql/dialects/firebolt.py
+++ b/superset/sql/dialects/firebolt.py
@@ -58,6 +58,8 @@ class Firebolt(Dialect):
         Custom generator for Firebolt.
         """
 
+        STAR_EXCEPT = "EXCLUDE"
+
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.VARBINARY: "BYTEA",

--- a/tests/unit_tests/sql/test_firebolt_dialect.py
+++ b/tests/unit_tests/sql/test_firebolt_dialect.py
@@ -28,6 +28,7 @@ def test_firebolt_exclude_syntax() -> None:
     generated = script.format()
     assert "EXCLUDE" in generated
     assert "EXCEPT" not in generated
+    assert "source_file_timestamp" in generated
 
 
 def test_firebolt_exclude_multiple_columns() -> None:
@@ -38,6 +39,9 @@ def test_firebolt_exclude_multiple_columns() -> None:
     generated = script.format()
     assert "EXCLUDE" in generated
     assert "EXCEPT" not in generated
+    assert "col1" in generated
+    assert "col2" in generated
+    assert "col3" in generated
 
 
 def test_firebolt_sql_parsing() -> None:

--- a/tests/unit_tests/sql/test_firebolt_dialect.py
+++ b/tests/unit_tests/sql/test_firebolt_dialect.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Firebolt dialect support in sqlglot."""
+
+from superset.sql.parse import SQLScript
+
+
+def test_firebolt_exclude_syntax() -> None:
+    """Test that Firebolt EXCLUDE syntax is preserved (not transformed to EXCEPT)."""
+    sql = "SELECT g.* EXCLUDE (source_file_timestamp) FROM public.games g"
+    script = SQLScript(sql, "firebolt")
+
+    generated = script.format()
+    assert "EXCLUDE" in generated
+    assert "EXCEPT" not in generated
+
+
+def test_firebolt_exclude_multiple_columns() -> None:
+    """Test EXCLUDE with multiple columns."""
+    sql = "SELECT * EXCLUDE (col1, col2, col3) FROM my_table"
+    script = SQLScript(sql, "firebolt")
+
+    generated = script.format()
+    assert "EXCLUDE" in generated
+    assert "EXCEPT" not in generated
+
+
+def test_firebolt_sql_parsing() -> None:
+    """Test that Firebolt SQL can be parsed without errors."""
+    sql = "SELECT * FROM my_table LIMIT 10"
+    script = SQLScript(sql, "firebolt")
+    assert len(script.statements) == 1
+    assert not script.has_mutation()
+
+
+def test_firebolt_not_in_parenthesized() -> None:
+    """Test that NOT IN is properly parenthesized in Firebolt."""
+    sql = "SELECT * FROM my_table WHERE id NOT IN (1, 2, 3)"
+    script = SQLScript(sql, "firebolt")
+
+    generated = script.format()
+    assert "NOT" in generated
+    assert "IN" in generated


### PR DESCRIPTION
## **User description**
### SUMMARY
When using Firebolt in Superset, queries with SELECT * EXCLUDE (column) syntax would fail because SQLGlot was incorrectly transforming the EXCLUDE keyword to EXCEPT before sending the query to Firebolt, which only supports EXCLUDE.

**Root Cause:** The Superset Firebolt SQLGlot dialect was using the default `STAR_EXCEPT = "EXCEPT"` from the base Generator class, but Firebolt actually uses `EXCLUDE` syntax (like DuckDB and Snowflake).

**Fix:** Added `STAR_EXCEPT = "EXCLUDE"` to the Firebolt Generator class in `superset/sql/dialects/firebolt.py`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

https://github.com/user-attachments/assets/6daed08d-bd41-4a23-9ec1-d5cdb77017b7

#### AFTER

https://github.com/user-attachments/assets/cab19292-e90f-4f79-aa18-925201a94518

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Preserve Firebolt's EXCLUDE syntax in generated SQL and add tests

### What Changed
- Generated SQL now uses EXCLUDE (not EXCEPT) for SELECT * EXCLUDE, so queries with EXCLUDE are sent to Firebolt unchanged
- Multiple-column EXCLUDE clauses are preserved in formatted output
- Firebolt SQL parsing and formatting for simple SELECT and NOT IN queries is verified to parse and produce expected output

### Impact
`✅ Firebolt queries with SELECT * EXCLUDE succeed instead of erroring`
`✅ Fewer query translation errors for Firebolt users`
`✅ Test coverage for Firebolt EXCLUDE formatting`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
