### PR TITLE
fix(mcp): Chart schema followups - DRY extraction, template fix, alias and test gaps

### DIFF
--- a/superset/mcp_service/chart/resources/chart_configs.py
+++ b/superset/mcp_service/chart/resources/chart_configs.py
@@ -80,7 +80,7 @@ def get_chart_configs_resource() -> str:
                 "y": [
                     {"name": "revenue", "aggregate": "SUM", "label": "Revenue"},
                 ],
-                "group_by": {"name": "region", "label": "Region"},
+                "group_by": [{"name": "region", "label": "Region"}],
                 "stacked": True,
                 "legend": {"show": True, "position": "right"},
             },
@@ -123,7 +123,7 @@ def get_chart_configs_resource() -> str:
                         "label": "Avg Conversion Rate",
                     }
                 ],
-                "group_by": {"name": "campaign_type", "label": "Campaign"},
+                "group_by": [{"name": "campaign_type", "label": "Campaign"}],
                 "x_axis": {"format": "$,.0f"},
                 "y_axis": {"format": ".2%"},
             },
@@ -159,7 +159,7 @@ def get_chart_configs_resource() -> str:
                 "kind": "area",
                 "x": {"name": "order_date", "label": "Date"},
                 "y": [{"name": "signups", "aggregate": "SUM", "label": "Signups"}],
-                "group_by": {"name": "channel", "label": "Channel"},
+                "group_by": [{"name": "channel", "label": "Channel"}],
                 "stacked": True,
                 "time_grain": "P1W",
             },

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -382,6 +382,19 @@ class ChartList(BaseModel):
 
 
 # Common pieces
+
+
+def _normalize_group_by_input(v: Any) -> Any:
+    """Accept a single ColumnRef/dict/str and normalize to list of dicts."""
+    if isinstance(v, str):
+        return [{"name": v}]
+    if isinstance(v, (dict, ColumnRef)):
+        return [v]
+    if isinstance(v, list):
+        return [{"name": item} if isinstance(item, str) else item for item in v]
+    return v
+
+
 class ColumnRef(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -624,7 +637,9 @@ class MixedTimeseriesChartConfig(BaseModel):
     group_by_secondary: List[ColumnRef] | None = Field(
         None,
         description="Secondary series group by",
-        validation_alias=AliasChoices("group_by_secondary", "groupby_b"),
+        validation_alias=AliasChoices(
+            "group_by_secondary", "groupby_b", "groupby_secondary"
+        ),
     )
     # Display options
     show_legend: bool = True
@@ -641,14 +656,7 @@ class MixedTimeseriesChartConfig(BaseModel):
     @field_validator("group_by", "group_by_secondary", mode="before")
     @classmethod
     def wrap_single_group_by(cls, v: Any) -> Any:
-        """Accept a single ColumnRef/dict/str and normalize to list of dicts."""
-        if isinstance(v, str):
-            return [{"name": v}]
-        if isinstance(v, (dict, ColumnRef)):
-            return [v]
-        if isinstance(v, list):
-            return [{"name": item} if isinstance(item, str) else item for item in v]
-        return v
+        return _normalize_group_by_input(v)
 
 
 class TableChartConfig(BaseModel):
@@ -743,14 +751,7 @@ class XYChartConfig(BaseModel):
     @field_validator("group_by", mode="before")
     @classmethod
     def wrap_single_group_by(cls, v: Any) -> Any:
-        """Accept a single ColumnRef/dict/str and normalize to list of dicts."""
-        if isinstance(v, str):
-            return [{"name": v}]
-        if isinstance(v, (dict, ColumnRef)):
-            return [v]
-        if isinstance(v, list):
-            return [{"name": item} if isinstance(item, str) else item for item in v]
-        return v
+        return _normalize_group_by_input(v)
 
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "XYChartConfig":

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -286,6 +286,19 @@ class TestXYChartConfig:
         assert config.group_by is not None
         assert len(config.group_by) == 2
 
+    def test_group_by_bare_string(self) -> None:
+        """Test that group_by accepts a bare string (auto-wrapped)."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="territory"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            kind="bar",
+            group_by="region",
+        )
+        assert config.group_by is not None
+        assert len(config.group_by) == 1
+        assert config.group_by[0].name == "region"
+
     def test_orientation_horizontal_accepted(self) -> None:
         """Test that orientation='horizontal' is accepted for bar charts."""
         config = XYChartConfig(


### PR DESCRIPTION
## **User description**
### SUMMARY

Followup fixes from code review of #38740:

- **DRY extraction**: Extracted duplicated `wrap_single_group_by` validator body into shared `_normalize_group_by_input()` helper used by both `XYChartConfig` and `MixedTimeseriesChartConfig`
- **Template fix**: Updated `chart_configs.py` resource templates to use the new list format for `group_by` (`[{...}]` instead of `{...}`), so LLMs consuming the resource produce correct payloads
- **Missing alias**: Added `groupby_secondary` alias to `MixedTimeseriesChartConfig.group_by_secondary` (already had `groupby_b`, was missing the underscore variant)
- **Test gap**: Added test for bare string `group_by="region"` input path through `wrap_single_group_by`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend schema changes only.

### TESTING INSTRUCTIONS
- `pytest tests/unit_tests/mcp_service/chart/test_chart_schemas.py tests/unit_tests/mcp_service/chart/test_new_chart_types.py tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix chart configs: normalize group_by inputs, update templates, add secondary alias, and test

### What Changed
- Example chart templates now use a list for group_by (e.g., [{"name":"region"}]) so generated payloads match the schema
- Schema accepts a bare string, single dict/column ref, or list for group_by and always normalizes it into a list of column refs
- Added the missing alias that recognizes the underscore variant for the secondary group_by field so both "groupby_b" and "groupby_secondary" are accepted
- Added a unit test that verifies providing group_by as a bare string is correctly wrapped into a one-item list

### Impact
`✅ Correct example chart payloads`
`✅ Fewer chart schema validation errors for group_by inputs`
`✅ Clearer secondary group_by alias support`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
