### PR TITLE
fix(mcp): prevent stale g.user from causing user impersonation across tool calls

### DIFF
--- a/superset/mcp_service/SECURITY.md
+++ b/superset/mcp_service/SECURITY.md
@@ -35,9 +35,12 @@ MCP_DEV_USERNAME = "admin"
 ```
 
 **How it works**:
-1. The `@mcp_auth_hook` decorator calls `get_user_from_request()`
-2. `get_user_from_request()` reads `MCP_DEV_USERNAME` from config
-3. User is queried from database and set as `g.user`
+1. The `@mcp_auth_hook` decorator clears any stale `g.user` and calls `get_user_from_request()`
+2. `get_user_from_request()` resolves the user in priority order:
+   - **JWT auth context** (per-request ContextVar from MCP SDK) — safest, prevents stale user impersonation
+   - **`MCP_DEV_USERNAME`** from config — for development/single-user deployments
+   - **`g.user` fallback** — for external middleware (e.g., Preset's WorkspaceContextMiddleware)
+3. User is queried from database (with roles/groups eagerly loaded) and set as `g.user`
 4. All subsequent Superset operations use this user's permissions
 
 **Development Use Only**:

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -419,6 +419,15 @@ def _setup_user_context() -> User | None:
     Returns:
         User object with roles and groups loaded, or None if no Flask context
     """
+    # Clear stale g.user to prevent user impersonation across
+    # tool calls when no per-request middleware refreshes it.
+    # Only clear in app-context-only mode; preserve g.user when
+    # a request context is active (external middleware set it).
+    from flask import has_request_context
+
+    if not has_request_context():
+        g.pop("user", None)
+
     try:
         user = get_user_from_request()
     except RuntimeError as e:
@@ -527,14 +536,6 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
         @functools.wraps(tool_func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             with _get_app_context_manager():
-                # Clear stale g.user to prevent user impersonation across
-                # tool calls when no per-request middleware refreshes it.
-                # Only clear in app-context-only mode; preserve g.user when
-                # a request context is active (external middleware set it).
-                from flask import has_request_context
-
-                if not has_request_context():
-                    g.pop("user", None)
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation
@@ -575,14 +576,6 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
         @functools.wraps(tool_func)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             with _get_app_context_manager():
-                # Clear stale g.user to prevent user impersonation across
-                # tool calls when no per-request middleware refreshes it.
-                # Only clear in app-context-only mode; preserve g.user when
-                # a request context is active (external middleware set it).
-                from flask import has_request_context
-
-                if not has_request_context():
-                    g.pop("user", None)
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -246,6 +246,69 @@ def _resolve_user_from_jwt_context(app: Any) -> User | None:
     return user
 
 
+def _resolve_user_from_api_key(app: Any) -> User | None:
+    """
+    Resolve the current user from an API key in the Authorization header.
+
+    Uses FAB SecurityManager's API key validation. Only attempts when
+    FAB_API_KEY_ENABLED is True and a request context is active.
+
+    Returns:
+        User object with relationships loaded, or None if no API key present
+        or API key auth is not enabled/available.
+
+    Raises:
+        PermissionError: If an API key is present but invalid/expired,
+            or if validation is not available in this FAB version.
+    """
+    if not app.config.get("FAB_API_KEY_ENABLED", False) or not has_request_context():
+        return None
+
+    sm = app.appbuilder.sm
+    # _extract_api_key_from_request is FAB's internal method for reading
+    # the Bearer token from the Authorization header and matching prefixes.
+    # Not all FAB versions include this method, so guard with hasattr.
+    if not hasattr(sm, "_extract_api_key_from_request"):
+        logger.debug(
+            "FAB SecurityManager does not have _extract_api_key_from_request; "
+            "API key authentication is not available in this FAB version"
+        )
+        return None
+
+    api_key_string = sm._extract_api_key_from_request()
+    if api_key_string is None:
+        return None
+
+    if not hasattr(sm, "validate_api_key"):
+        logger.warning(
+            "FAB SecurityManager does not have validate_api_key; "
+            "cannot validate API key"
+        )
+        raise PermissionError(
+            "API key validation is not available in this FAB version."
+        )
+
+    user = sm.validate_api_key(api_key_string)
+    if not user:
+        raise PermissionError(
+            "Invalid or expired API key. "
+            "Create a new key at /api/v1/security/api_keys/."
+        )
+
+    # Reload user with all relationships eagerly loaded to avoid
+    # detached-instance errors during later permission checks.
+    user_with_rels = load_user_with_relationships(username=user.username)
+    if user_with_rels is None:
+        logger.warning(
+            "Failed to reload API key user %s with relationships; "
+            "using original user object which may have lazy-loaded "
+            "relationships",
+            user.username,
+        )
+        return user
+    return user_with_rels
+
+
 def get_user_from_request() -> User:
     """
     Get the current user for the MCP tool request.
@@ -274,53 +337,8 @@ def get_user_from_request() -> User:
         return jwt_user
 
     # Priority 2: API key authentication via FAB SecurityManager
-    # Only attempt when in a request context (not for MCP internal operations
-    # like tool discovery that run with only an application context)
-    # Use the Flask config key FAB_API_KEY_ENABLED (not the feature flag),
-    # because the config key controls whether FAB registers the API key
-    # endpoints and validation logic. The feature flag with the same name
-    # in DEFAULT_FEATURE_FLAGS only controls the frontend UI visibility.
-    if current_app.config.get("FAB_API_KEY_ENABLED", False) and has_request_context():
-        sm = current_app.appbuilder.sm
-        # _extract_api_key_from_request is FAB's internal method for reading
-        # the Bearer token from the Authorization header and matching prefixes.
-        # Not all FAB versions include this method, so guard with hasattr.
-        if not hasattr(sm, "_extract_api_key_from_request"):
-            logger.debug(
-                "FAB SecurityManager does not have _extract_api_key_from_request; "
-                "API key authentication is not available in this FAB version"
-            )
-        else:
-            api_key_string = sm._extract_api_key_from_request()
-            if api_key_string is not None:
-                if not hasattr(sm, "validate_api_key"):
-                    logger.warning(
-                        "FAB SecurityManager does not have validate_api_key; "
-                        "cannot validate API key"
-                    )
-                    raise PermissionError(
-                        "API key validation is not available in this FAB version."
-                    )
-                user = sm.validate_api_key(api_key_string)
-                if user:
-                    # Reload user with all relationships eagerly loaded to avoid
-                    # detached-instance errors during later permission checks.
-                    user_with_rels = load_user_with_relationships(
-                        username=user.username,
-                    )
-                    if user_with_rels is None:
-                        logger.warning(
-                            "Failed to reload API key user %s with relationships; "
-                            "using original user object which may have lazy-loaded "
-                            "relationships",
-                            user.username,
-                        )
-                        return user
-                    return user_with_rels
-                raise PermissionError(
-                    "Invalid or expired API key. "
-                    "Create a new key at /api/v1/security/api_keys/."
-                )
+    if (api_key_user := _resolve_user_from_api_key(current_app)) is not None:
+        return api_key_user
 
     # Priority 3: Configured dev username for development/single-user deployments
     if username := current_app.config.get("MCP_DEV_USERNAME"):

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -189,14 +189,73 @@ def load_user_with_relationships(
     return query.first()
 
 
+def _resolve_user_from_jwt_context(app: Any) -> User | None:
+    """
+    Resolve the current user from the MCP SDK's per-request JWT context.
+
+    Uses FastMCP's ``get_access_token()`` which returns the JWT AccessToken
+    for the current async task via a ContextVar — safe across concurrent
+    requests, unlike ``g.user`` which can be stale.
+
+    The username is extracted from token claims using a configurable resolver
+    (``MCP_USER_RESOLVER`` config) or the default ``default_user_resolver()``.
+
+    Returns:
+        User object with relationships loaded, or None if no JWT context
+        (i.e. no token present — caller should fall through to next source).
+
+    Raises:
+        ValueError: If JWT resolves a username that doesn't exist in the DB
+            (fail closed — do NOT fall through to weaker auth sources).
+    """
+    try:
+        from fastmcp.server.dependencies import get_access_token
+    except ImportError:
+        logger.debug("fastmcp.server.dependencies not available, skipping JWT context")
+        return None
+
+    access_token = get_access_token()
+    if access_token is None:
+        return None
+
+    # Use configurable resolver or default
+    from superset.mcp_service.mcp_config import default_user_resolver
+
+    resolver = app.config.get("MCP_USER_RESOLVER", default_user_resolver)
+    username = resolver(app, access_token)
+
+    if not username:
+        logger.warning(
+            "JWT context present but no username could be extracted from claims"
+        )
+        return None
+
+    user = load_user_with_relationships(username)
+    if not user:
+        # Fail closed: JWT says this user should exist but they don't.
+        # Do NOT fall through to MCP_DEV_USERNAME or stale g.user.
+        raise ValueError(
+            f"JWT authenticated user '{username}' not found in Superset database. "
+            f"Ensure the user exists before granting MCP access."
+        )
+
+    return user
+
+
 def get_user_from_request() -> User:
     """
     Get the current user for the MCP tool request.
 
     Priority order:
-    1. g.user if already set (by Preset workspace middleware or FastMCP auth)
+    1. JWT auth context (per-request ContextVar from MCP SDK) — safest
     2. API key from Authorization header (via FAB SecurityManager)
     3. MCP_DEV_USERNAME from configuration (for development/testing)
+    4. g.user fallback (for external middleware like Preset's
+       WorkspaceContextMiddleware that sets g.user fresh per request)
+
+    This ordering prevents stale ``g.user`` from a previous tool call
+    from being used in open-source deployments where no middleware
+    refreshes ``g.user`` per request.
 
     Returns:
         User object with roles and groups eagerly loaded
@@ -206,11 +265,11 @@ def get_user_from_request() -> User:
     """
     from flask import current_app
 
-    # First check if user is already set by Preset workspace middleware
-    if hasattr(g, "user") and g.user:
-        return g.user
+    # Priority 1: JWT context (per-request safe via ContextVar)
+    if (jwt_user := _resolve_user_from_jwt_context(current_app)) is not None:
+        return jwt_user
 
-    # Try API key authentication via FAB SecurityManager
+    # Priority 2: API key authentication via FAB SecurityManager
     # Only attempt when in a request context (not for MCP internal operations
     # like tool discovery that run with only an application context)
     # Use the Flask config key FAB_API_KEY_ENABLED (not the feature flag),
@@ -259,42 +318,43 @@ def get_user_from_request() -> User:
                     "Create a new key at /api/v1/security/api_keys/."
                 )
 
-    # Fall back to configured username for development/single-user deployments
-    username = current_app.config.get("MCP_DEV_USERNAME")
+    # Priority 3: Configured dev username for development/single-user deployments
+    if username := current_app.config.get("MCP_DEV_USERNAME"):
+        user = load_user_with_relationships(username)
+        if not user:
+            raise ValueError(
+                f"User '{username}' not found. "
+                f"Please create admin user with: superset fab create-admin"
+            )
+        return user
 
-    if not username:
-        auth_enabled = current_app.config.get("MCP_AUTH_ENABLED", False)
-        jwt_configured = bool(
-            current_app.config.get("MCP_JWKS_URI")
-            or current_app.config.get("MCP_JWT_PUBLIC_KEY")
-            or current_app.config.get("MCP_JWT_SECRET")
-        )
-        details = []
-        details.append(
-            f"g.user was not set by JWT middleware "
-            f"(MCP_AUTH_ENABLED={auth_enabled}, "
-            f"JWT keys configured={jwt_configured})"
-        )
-        details.append("MCP_DEV_USERNAME is not configured")
-        configured_prefixes = current_app.config.get("FAB_API_KEY_PREFIXES", ["sst_"])
-        prefix_example = configured_prefixes[0] if configured_prefixes else "sst_"
-        raise ValueError(
-            "No authenticated user found. Tried:\n"
-            + "\n".join(f"  - {d}" for d in details)
-            + f"\n\nEither pass a valid API key (Bearer {prefix_example}...), "
-            "JWT token, or configure MCP_DEV_USERNAME for development."
-        )
+    # Priority 4: g.user fallback (set by external middleware, e.g. Preset)
+    if hasattr(g, "user") and g.user:
+        return g.user
 
-    # Use helper function to load user with all required relationships
-    user = load_user_with_relationships(username)
-
-    if not user:
-        raise ValueError(
-            f"User '{username}' not found. "
-            f"Please create admin user with: superset fab create-admin"
-        )
-
-    return user
+    # No auth source available — raise with diagnostic details
+    auth_enabled = current_app.config.get("MCP_AUTH_ENABLED", False)
+    jwt_configured = bool(
+        current_app.config.get("MCP_JWKS_URI")
+        or current_app.config.get("MCP_JWT_PUBLIC_KEY")
+        or current_app.config.get("MCP_JWT_SECRET")
+    )
+    details = [
+        f"No JWT access token in MCP request context "
+        f"(MCP_AUTH_ENABLED={auth_enabled}, "
+        f"JWT keys configured={jwt_configured})",
+        "No API key in Authorization header",
+        "MCP_DEV_USERNAME is not configured",
+        "g.user was not set by external middleware",
+    ]
+    configured_prefixes = current_app.config.get("FAB_API_KEY_PREFIXES", ["sst_"])
+    prefix_example = configured_prefixes[0] if configured_prefixes else "sst_"
+    raise ValueError(
+        "No authenticated user found. Tried:\n"
+        + "\n".join(f"  - {d}" for d in details)
+        + f"\n\nEither pass a valid API key (Bearer {prefix_example}...), "
+        "JWT token, or configure MCP_DEV_USERNAME for development."
+    )
 
 
 def has_dataset_access(dataset: "SqlaTable") -> bool:
@@ -463,6 +523,9 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
         @functools.wraps(tool_func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             with _get_app_context_manager():
+                # Clear stale g.user to prevent user impersonation across
+                # tool calls when no per-request middleware refreshes it.
+                g.pop("user", None)
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation
@@ -503,6 +566,9 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
         @functools.wraps(tool_func)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             with _get_app_context_manager():
+                # Clear stale g.user to prevent user impersonation across
+                # tool calls when no per-request middleware refreshes it.
+                g.pop("user", None)
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -225,12 +225,16 @@ def _resolve_user_from_jwt_context(app: Any) -> User | None:
     username = resolver(app, access_token)
 
     if not username:
-        logger.warning(
+        # Fail closed: JWT is present but identity cannot be determined.
+        # Do NOT fall through to weaker auth sources.
+        raise ValueError(
             "JWT context present but no username could be extracted from claims"
         )
-        return None
 
+    # Try username lookup first, then email fallback for OIDC email claims
     user = load_user_with_relationships(username)
+    if not user and "@" in username:
+        user = load_user_with_relationships(email=username)
     if not user:
         # Fail closed: JWT says this user should exist but they don't.
         # Do NOT fall through to MCP_DEV_USERNAME or stale g.user.
@@ -525,7 +529,12 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
             with _get_app_context_manager():
                 # Clear stale g.user to prevent user impersonation across
                 # tool calls when no per-request middleware refreshes it.
-                g.pop("user", None)
+                # Only clear in app-context-only mode; preserve g.user when
+                # a request context is active (external middleware set it).
+                from flask import has_request_context
+
+                if not has_request_context():
+                    g.pop("user", None)
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation
@@ -568,7 +577,12 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
             with _get_app_context_manager():
                 # Clear stale g.user to prevent user impersonation across
                 # tool calls when no per-request middleware refreshes it.
-                g.pop("user", None)
+                # Only clear in app-context-only mode; preserve g.user when
+                # a request context is active (external middleware set it).
+                from flask import has_request_context
+
+                if not has_request_context():
+                    g.pop("user", None)
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -327,11 +327,13 @@ def default_user_resolver(app: Any, access_token: Any) -> str | None:
     # FastMCP AccessToken stores JWT claims in a dict
     claims = getattr(access_token, "claims", None)
     if isinstance(claims, dict) and claims:
+        # Prefer human-readable username claims over opaque `sub`
+        # (OIDC `sub` is often a stable opaque ID, not a Superset username)
         username = (
-            claims.get("sub")
-            or claims.get("preferred_username")
-            or claims.get("email")
+            claims.get("preferred_username")
             or claims.get("username")
+            or claims.get("email")
+            or claims.get("sub")
         )
         if username:
             return username

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -318,11 +318,28 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
         return None
 
 
-def default_user_resolver(app: Any, access_token: Any) -> Optional[str]:
-    """Extract username from JWT token claims."""
-    if hasattr(access_token, "subject"):
+def default_user_resolver(app: Any, access_token: Any) -> str | None:
+    """Extract username from JWT token claims.
+
+    Checks the ``claims`` dict first (FastMCP's AccessToken format),
+    then falls back to legacy attribute access for backward compatibility.
+    """
+    # FastMCP AccessToken stores JWT claims in a dict
+    claims = getattr(access_token, "claims", None)
+    if isinstance(claims, dict) and claims:
+        username = (
+            claims.get("sub")
+            or claims.get("preferred_username")
+            or claims.get("email")
+            or claims.get("username")
+        )
+        if username:
+            return username
+
+    # Legacy attribute access for backward compatibility
+    if hasattr(access_token, "subject") and access_token.subject:
         return access_token.subject
-    if hasattr(access_token, "client_id"):
+    if hasattr(access_token, "client_id") and access_token.client_id:
         return access_token.client_id
     if hasattr(access_token, "payload") and isinstance(access_token.payload, dict):
         return (

--- a/tests/unit_tests/mcp_service/test_auth_api_key.py
+++ b/tests/unit_tests/mcp_service/test_auth_api_key.py
@@ -25,14 +25,14 @@ from flask import g
 from superset.mcp_service.auth import get_user_from_request
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_user():
     user = MagicMock()
     user.username = "api_key_user"
     return user
 
 
-@pytest.fixture()
+@pytest.fixture
 def _enable_api_keys(app):
     """Enable FAB API key auth and clear MCP_DEV_USERNAME so the API key
     path is exercised instead of falling through to the dev-user fallback."""
@@ -44,7 +44,7 @@ def _enable_api_keys(app):
         app.config["MCP_DEV_USERNAME"] = old_dev
 
 
-@pytest.fixture()
+@pytest.fixture
 def _disable_api_keys(app):
     app.config["FAB_API_KEY_ENABLED"] = False
     old_dev = app.config.pop("MCP_DEV_USERNAME", None)

--- a/tests/unit_tests/mcp_service/test_auth_api_key.py
+++ b/tests/unit_tests/mcp_service/test_auth_api_key.py
@@ -25,14 +25,14 @@ from flask import g
 from superset.mcp_service.auth import get_user_from_request
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_user():
     user = MagicMock()
     user.username = "api_key_user"
     return user
 
 
-@pytest.fixture
+@pytest.fixture()
 def _enable_api_keys(app):
     """Enable FAB API key auth and clear MCP_DEV_USERNAME so the API key
     path is exercised instead of falling through to the dev-user fallback."""
@@ -44,7 +44,7 @@ def _enable_api_keys(app):
         app.config["MCP_DEV_USERNAME"] = old_dev
 
 
-@pytest.fixture
+@pytest.fixture()
 def _disable_api_keys(app):
     app.config["FAB_API_KEY_ENABLED"] = False
     old_dev = app.config.pop("MCP_DEV_USERNAME", None)
@@ -143,24 +143,19 @@ def test_no_request_context_skips_api_key_auth(app) -> None:
     mock_sm._extract_api_key_from_request.assert_not_called()
 
 
-# -- g.user already set -> API key auth skipped (JWT precedence) --
+# -- g.user fallback when no higher-priority auth succeeds --
 
 
-@pytest.mark.usefixtures("_enable_api_keys")
-def test_existing_g_user_takes_precedence(app, mock_user) -> None:
-    """If g.user is already set (e.g., by JWT middleware), API key auth
-    should not be attempted."""
-    mock_sm = MagicMock()
-
-    with app.test_request_context(headers={"Authorization": "Bearer sst_abc123"}):
+@pytest.mark.usefixtures("_disable_api_keys")
+def test_g_user_fallback_when_no_jwt_or_api_key(app, mock_user) -> None:
+    """When no JWT or API key auth succeeds and MCP_DEV_USERNAME is not set,
+    g.user (set by external middleware) is used as fallback."""
+    with app.test_request_context():
         g.user = mock_user
-        app.appbuilder = MagicMock()
-        app.appbuilder.sm = mock_sm
 
         result = get_user_from_request()
 
     assert result.username == "api_key_user"
-    mock_sm._extract_api_key_from_request.assert_not_called()
 
 
 # -- FAB version without _extract_api_key_from_request --

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -1,0 +1,330 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for MCP user resolution priority and stale g.user prevention."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import g
+
+from superset.mcp_service.auth import (
+    _resolve_user_from_jwt_context,
+    get_user_from_request,
+    mcp_auth_hook,
+)
+from superset.mcp_service.mcp_config import default_user_resolver
+
+
+def _make_mock_user(username: str = "testuser") -> MagicMock:
+    """Create a mock User with required attributes."""
+    user = MagicMock()
+    user.username = username
+    user.roles = []
+    user.groups = []
+    return user
+
+
+def _make_access_token(
+    claims: dict[str, str] | None = None, **kwargs: str
+) -> MagicMock:
+    """Create a mock AccessToken matching FastMCP's format."""
+    token = MagicMock()
+    token.claims = claims or {}
+    token.client_id = kwargs.get("client_id", "")
+    token.scopes = kwargs.get("scopes", [])
+    # Remove auto-created attributes so getattr fallbacks work correctly
+    for attr in ("subject", "payload"):
+        if attr not in kwargs:
+            delattr(token, attr)
+    for attr in kwargs:
+        setattr(token, attr, kwargs[attr])
+    return token
+
+
+# -- _resolve_user_from_jwt_context --
+
+
+def test_jwt_context_resolves_correct_user(app) -> None:
+    """JWT context with valid claims resolves the correct DB user."""
+    mock_user = _make_mock_user("alice")
+    token = _make_access_token(claims={"sub": "alice"})
+
+    with app.app_context():
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=token),
+            patch(
+                "superset.mcp_service.auth.load_user_with_relationships",
+                return_value=mock_user,
+            ),
+        ):
+            result = _resolve_user_from_jwt_context(app)
+
+    assert result is not None
+    assert result.username == "alice"
+
+
+def test_jwt_context_returns_none_when_no_token(app) -> None:
+    """No JWT token present returns None (fall through to next source)."""
+    with app.app_context():
+        with patch("fastmcp.server.dependencies.get_access_token", return_value=None):
+            result = _resolve_user_from_jwt_context(app)
+
+    assert result is None
+
+
+def test_jwt_context_raises_for_unknown_user(app) -> None:
+    """JWT resolves a username not in DB — raises ValueError (fail closed)."""
+    token = _make_access_token(claims={"sub": "nonexistent"})
+
+    with app.app_context():
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=token),
+            patch(
+                "superset.mcp_service.auth.load_user_with_relationships",
+                return_value=None,
+            ),
+        ):
+            with pytest.raises(ValueError, match="not found in Superset database"):
+                _resolve_user_from_jwt_context(app)
+
+
+def test_jwt_context_returns_none_when_no_username_in_claims(app) -> None:
+    """JWT present but claims have no extractable username — returns None."""
+    token = _make_access_token(claims={"iss": "some-issuer"})
+
+    with app.app_context():
+        with patch("fastmcp.server.dependencies.get_access_token", return_value=token):
+            result = _resolve_user_from_jwt_context(app)
+
+    assert result is None
+
+
+def test_jwt_context_uses_custom_resolver(app) -> None:
+    """Custom MCP_USER_RESOLVER config is used when set."""
+    mock_user = _make_mock_user("custom_user")
+    token = _make_access_token(claims={"custom_field": "custom_user"})
+    custom_resolver = MagicMock(return_value="custom_user")
+
+    with app.app_context():
+        app.config["MCP_USER_RESOLVER"] = custom_resolver
+        try:
+            with (
+                patch(
+                    "fastmcp.server.dependencies.get_access_token", return_value=token
+                ),
+                patch(
+                    "superset.mcp_service.auth.load_user_with_relationships",
+                    return_value=mock_user,
+                ),
+            ):
+                result = _resolve_user_from_jwt_context(app)
+        finally:
+            app.config.pop("MCP_USER_RESOLVER", None)
+
+    assert result is not None
+    assert result.username == "custom_user"
+    custom_resolver.assert_called_once_with(app, token)
+
+
+# -- get_user_from_request priority order --
+
+
+def test_jwt_takes_priority_over_stale_g_user(app) -> None:
+    """Core regression test: JWT user wins over stale g.user."""
+    stale_user = _make_mock_user("stale_bob")
+    jwt_user = _make_mock_user("jwt_alice")
+    token = _make_access_token(claims={"sub": "jwt_alice"})
+
+    with app.app_context():
+        g.user = stale_user
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=token),
+            patch(
+                "superset.mcp_service.auth.load_user_with_relationships",
+                return_value=jwt_user,
+            ),
+        ):
+            result = get_user_from_request()
+
+    assert result.username == "jwt_alice"
+
+
+def test_dev_username_fallback_when_no_jwt(app) -> None:
+    """MCP_DEV_USERNAME used when no JWT context available."""
+    mock_user = _make_mock_user("dev_admin")
+
+    with app.app_context():
+        app.config["MCP_DEV_USERNAME"] = "dev_admin"
+        try:
+            with (
+                patch(
+                    "fastmcp.server.dependencies.get_access_token", return_value=None
+                ),
+                patch(
+                    "superset.mcp_service.auth.load_user_with_relationships",
+                    return_value=mock_user,
+                ),
+            ):
+                result = get_user_from_request()
+        finally:
+            app.config.pop("MCP_DEV_USERNAME", None)
+
+    assert result.username == "dev_admin"
+
+
+def test_g_user_fallback_when_no_jwt_and_no_dev_username(app) -> None:
+    """g.user used as last-resort fallback (Preset middleware compatibility)."""
+    preset_user = _make_mock_user("preset_user")
+
+    with app.app_context():
+        app.config.pop("MCP_DEV_USERNAME", None)
+        g.user = preset_user
+        with patch("fastmcp.server.dependencies.get_access_token", return_value=None):
+            result = get_user_from_request()
+
+    assert result.username == "preset_user"
+
+
+def test_raises_when_no_auth_source(app) -> None:
+    """ValueError raised when no auth source is available."""
+    with app.app_context():
+        app.config.pop("MCP_DEV_USERNAME", None)
+        g.pop("user", None)
+        with patch("fastmcp.server.dependencies.get_access_token", return_value=None):
+            with pytest.raises(ValueError, match="No authenticated user found"):
+                get_user_from_request()
+
+
+def test_dev_username_not_found_raises(app) -> None:
+    """MCP_DEV_USERNAME configured but user not in DB raises ValueError."""
+    with app.app_context():
+        app.config["MCP_DEV_USERNAME"] = "ghost"
+        try:
+            with (
+                patch(
+                    "fastmcp.server.dependencies.get_access_token", return_value=None
+                ),
+                patch(
+                    "superset.mcp_service.auth.load_user_with_relationships",
+                    return_value=None,
+                ),
+            ):
+                with pytest.raises(ValueError, match="not found"):
+                    get_user_from_request()
+        finally:
+            app.config.pop("MCP_DEV_USERNAME", None)
+
+
+# -- g.user clearing in mcp_auth_hook --
+
+
+def test_mcp_auth_hook_clears_stale_g_user(app) -> None:
+    """mcp_auth_hook clears g.user before setting up user context."""
+    stale_user = _make_mock_user("stale")
+    fresh_user = _make_mock_user("fresh")
+
+    def dummy_tool():
+        """Dummy tool."""
+        return g.user.username
+
+    wrapped = mcp_auth_hook(dummy_tool)
+
+    with app.app_context():
+        g.user = stale_user
+        with patch(
+            "superset.mcp_service.auth.get_user_from_request",
+            return_value=fresh_user,
+        ):
+            result = wrapped()
+
+    assert result == "fresh"
+
+
+def test_mcp_auth_hook_clears_stale_g_user_async(app) -> None:
+    """mcp_auth_hook clears g.user before setting up user context (async)."""
+    import asyncio
+
+    stale_user = _make_mock_user("stale")
+    fresh_user = _make_mock_user("fresh")
+
+    async def dummy_tool():
+        """Dummy tool."""
+        return g.user.username
+
+    wrapped = mcp_auth_hook(dummy_tool)
+
+    with app.app_context():
+        g.user = stale_user
+        with patch(
+            "superset.mcp_service.auth.get_user_from_request",
+            return_value=fresh_user,
+        ):
+            result = asyncio.get_event_loop().run_until_complete(wrapped())
+
+    assert result == "fresh"
+
+
+# -- default_user_resolver --
+
+
+def test_default_resolver_extracts_sub_from_claims() -> None:
+    """Extracts 'sub' claim from AccessToken.claims dict."""
+    token = _make_access_token(claims={"sub": "alice"})
+    assert default_user_resolver(None, token) == "alice"
+
+
+def test_default_resolver_extracts_preferred_username() -> None:
+    """Extracts 'preferred_username' claim (common OIDC claim)."""
+    token = _make_access_token(claims={"preferred_username": "alice"})
+    assert default_user_resolver(None, token) == "alice"
+
+
+def test_default_resolver_extracts_email_from_claims() -> None:
+    """Falls back to 'email' claim when 'sub' is absent."""
+    token = _make_access_token(claims={"email": "alice@example.com"})
+    assert default_user_resolver(None, token) == "alice@example.com"
+
+
+def test_default_resolver_extracts_username_from_claims() -> None:
+    """Falls back to 'username' claim."""
+    token = _make_access_token(claims={"username": "alice"})
+    assert default_user_resolver(None, token) == "alice"
+
+
+def test_default_resolver_falls_back_to_subject_attr() -> None:
+    """Falls back to legacy .subject attribute when claims empty."""
+    token = _make_access_token(claims={}, subject="legacy_user")
+    assert default_user_resolver(None, token) == "legacy_user"
+
+
+def test_default_resolver_falls_back_to_client_id() -> None:
+    """Falls back to .client_id when claims empty and no subject."""
+    token = _make_access_token(claims={}, client_id="service-account")
+    assert default_user_resolver(None, token) == "service-account"
+
+
+def test_default_resolver_returns_none_for_empty_token() -> None:
+    """Returns None when no claims or attributes have a username."""
+    token = _make_access_token(claims={}, client_id="")
+    assert default_user_resolver(None, token) is None
+
+
+def test_default_resolver_sub_takes_priority_over_email() -> None:
+    """'sub' takes priority over 'email' in claims dict."""
+    token = _make_access_token(claims={"sub": "alice", "email": "alice@example.com"})
+    assert default_user_resolver(None, token) == "alice"

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -257,7 +257,11 @@ def test_dev_username_not_found_raises(app) -> None:
 
 
 def test_mcp_auth_hook_clears_stale_g_user(app) -> None:
-    """mcp_auth_hook clears g.user before setting up user context."""
+    """mcp_auth_hook clears g.user before setting up user context.
+
+    Uses a side_effect that asserts g.user was cleared before user
+    resolution runs, so the test fails if g.pop("user") is removed.
+    """
     stale_user = _make_mock_user("stale")
     fresh_user = _make_mock_user("fresh")
 
@@ -267,11 +271,19 @@ def test_mcp_auth_hook_clears_stale_g_user(app) -> None:
 
     wrapped = mcp_auth_hook(dummy_tool)
 
+    def _assert_cleared_then_return():
+        """Verify stale g.user was cleared before returning fresh user."""
+        assert not hasattr(g, "user") or g.user is None, (
+            "g.user should have been cleared before get_user_from_request() "
+            f"but found g.user={getattr(g, 'user', '<missing>')}"
+        )
+        return fresh_user
+
     with app.app_context():
         g.user = stale_user
         with patch(
             "superset.mcp_service.auth.get_user_from_request",
-            return_value=fresh_user,
+            side_effect=lambda: _assert_cleared_then_return(),
         ):
             result = wrapped()
 
@@ -279,7 +291,11 @@ def test_mcp_auth_hook_clears_stale_g_user(app) -> None:
 
 
 def test_mcp_auth_hook_clears_stale_g_user_async(app) -> None:
-    """mcp_auth_hook clears g.user before setting up user context (async)."""
+    """mcp_auth_hook clears g.user before setting up user context (async).
+
+    Uses a side_effect that asserts g.user was cleared before user
+    resolution runs, so the test fails if g.pop("user") is removed.
+    """
     import asyncio
 
     stale_user = _make_mock_user("stale")
@@ -291,11 +307,19 @@ def test_mcp_auth_hook_clears_stale_g_user_async(app) -> None:
 
     wrapped = mcp_auth_hook(dummy_tool)
 
+    def _assert_cleared_then_return():
+        """Verify stale g.user was cleared before returning fresh user."""
+        assert not hasattr(g, "user") or g.user is None, (
+            "g.user should have been cleared before get_user_from_request() "
+            f"but found g.user={getattr(g, 'user', '<missing>')}"
+        )
+        return fresh_user
+
     with app.app_context():
         g.user = stale_user
         with patch(
             "superset.mcp_service.auth.get_user_from_request",
-            return_value=fresh_user,
+            side_effect=lambda: _assert_cleared_then_return(),
         ):
             result = asyncio.run(wrapped())
 
@@ -303,7 +327,12 @@ def test_mcp_auth_hook_clears_stale_g_user_async(app) -> None:
 
 
 def test_mcp_auth_hook_preserves_g_user_in_request_context(app) -> None:
-    """g.user is NOT cleared when a request context is active (middleware compat)."""
+    """g.user is NOT cleared when a request context is active (middleware compat).
+
+    Uses a side_effect that asserts g.user is still the middleware-set
+    user when get_user_from_request() is called, proving the hook did
+    NOT clear it.
+    """
     middleware_user = _make_mock_user("middleware_user")
 
     def dummy_tool():
@@ -312,11 +341,22 @@ def test_mcp_auth_hook_preserves_g_user_in_request_context(app) -> None:
 
     wrapped = mcp_auth_hook(dummy_tool)
 
+    def _assert_preserved_then_return():
+        """Verify g.user was preserved (not cleared) before returning."""
+        assert hasattr(g, "user"), (
+            "g.user should be preserved in request context but was removed"
+        )
+        assert g.user is middleware_user, (
+            "g.user should be preserved in request context but was changed; "
+            f"g.user={g.user}"
+        )
+        return middleware_user
+
     with app.test_request_context():
         g.user = middleware_user
         with patch(
             "superset.mcp_service.auth.get_user_from_request",
-            return_value=middleware_user,
+            side_effect=lambda: _assert_preserved_then_return(),
         ):
             result = wrapped()
 

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -281,9 +281,15 @@ def test_mcp_auth_hook_clears_stale_g_user(app) -> None:
 
     with app.app_context():
         g.user = stale_user
-        with patch(
-            "superset.mcp_service.auth.get_user_from_request",
-            side_effect=lambda: _assert_cleared_then_return(),
+        # Explicitly mock has_request_context to False because the test
+        # framework's autouse app_context fixture may implicitly provide
+        # a request context in some CI environments.
+        with (
+            patch("superset.mcp_service.auth.has_request_context", return_value=False),
+            patch(
+                "superset.mcp_service.auth.get_user_from_request",
+                side_effect=lambda: _assert_cleared_then_return(),
+            ),
         ):
             result = wrapped()
 
@@ -317,9 +323,12 @@ def test_mcp_auth_hook_clears_stale_g_user_async(app) -> None:
 
     with app.app_context():
         g.user = stale_user
-        with patch(
-            "superset.mcp_service.auth.get_user_from_request",
-            side_effect=lambda: _assert_cleared_then_return(),
+        with (
+            patch("superset.mcp_service.auth.has_request_context", return_value=False),
+            patch(
+                "superset.mcp_service.auth.get_user_from_request",
+                side_effect=lambda: _assert_cleared_then_return(),
+            ),
         ):
             result = asyncio.run(wrapped())
 

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -285,7 +285,7 @@ def test_mcp_auth_hook_clears_stale_g_user(app) -> None:
         # framework's autouse app_context fixture may implicitly provide
         # a request context in some CI environments.
         with (
-            patch("superset.mcp_service.auth.has_request_context", return_value=False),
+            patch("flask.has_request_context", return_value=False),
             patch(
                 "superset.mcp_service.auth.get_user_from_request",
                 side_effect=lambda: _assert_cleared_then_return(),
@@ -324,7 +324,7 @@ def test_mcp_auth_hook_clears_stale_g_user_async(app) -> None:
     with app.app_context():
         g.user = stale_user
         with (
-            patch("superset.mcp_service.auth.has_request_context", return_value=False),
+            patch("flask.has_request_context", return_value=False),
             patch(
                 "superset.mcp_service.auth.get_user_from_request",
                 side_effect=lambda: _assert_cleared_then_return(),

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -103,15 +103,14 @@ def test_jwt_context_raises_for_unknown_user(app) -> None:
                 _resolve_user_from_jwt_context(app)
 
 
-def test_jwt_context_returns_none_when_no_username_in_claims(app) -> None:
-    """JWT present but claims have no extractable username — returns None."""
+def test_jwt_context_raises_when_no_username_in_claims(app) -> None:
+    """JWT present but claims have no extractable username — fails closed."""
     token = _make_access_token(claims={"iss": "some-issuer"})
 
     with app.app_context():
         with patch("fastmcp.server.dependencies.get_access_token", return_value=token):
-            result = _resolve_user_from_jwt_context(app)
-
-    assert result is None
+            with pytest.raises(ValueError, match="no username could be extracted"):
+                _resolve_user_from_jwt_context(app)
 
 
 def test_jwt_context_uses_custom_resolver(app) -> None:
@@ -139,6 +138,30 @@ def test_jwt_context_uses_custom_resolver(app) -> None:
     assert result is not None
     assert result.username == "custom_user"
     custom_resolver.assert_called_once_with(app, token)
+
+
+def test_jwt_context_email_fallback_lookup(app) -> None:
+    """When resolver returns an email, tries email lookup after username miss."""
+    mock_user = _make_mock_user("alice")
+    token = _make_access_token(claims={"email": "alice@example.com"})
+
+    def _load_side_effect(username=None, email=None):
+        if email == "alice@example.com":
+            return mock_user
+        return None
+
+    with app.app_context():
+        with (
+            patch("fastmcp.server.dependencies.get_access_token", return_value=token),
+            patch(
+                "superset.mcp_service.auth.load_user_with_relationships",
+                side_effect=_load_side_effect,
+            ),
+        ):
+            result = _resolve_user_from_jwt_context(app)
+
+    assert result is not None
+    assert result.username == "alice"
 
 
 # -- get_user_from_request priority order --
@@ -274,16 +297,37 @@ def test_mcp_auth_hook_clears_stale_g_user_async(app) -> None:
             "superset.mcp_service.auth.get_user_from_request",
             return_value=fresh_user,
         ):
-            result = asyncio.get_event_loop().run_until_complete(wrapped())
+            result = asyncio.run(wrapped())
 
     assert result == "fresh"
+
+
+def test_mcp_auth_hook_preserves_g_user_in_request_context(app) -> None:
+    """g.user is NOT cleared when a request context is active (middleware compat)."""
+    middleware_user = _make_mock_user("middleware_user")
+
+    def dummy_tool():
+        """Dummy tool."""
+        return g.user.username
+
+    wrapped = mcp_auth_hook(dummy_tool)
+
+    with app.test_request_context():
+        g.user = middleware_user
+        with patch(
+            "superset.mcp_service.auth.get_user_from_request",
+            return_value=middleware_user,
+        ):
+            result = wrapped()
+
+    assert result == "middleware_user"
 
 
 # -- default_user_resolver --
 
 
 def test_default_resolver_extracts_sub_from_claims() -> None:
-    """Extracts 'sub' claim from AccessToken.claims dict."""
+    """Extracts 'sub' claim as last-resort from AccessToken.claims dict."""
     token = _make_access_token(claims={"sub": "alice"})
     assert default_user_resolver(None, token) == "alice"
 
@@ -324,7 +368,13 @@ def test_default_resolver_returns_none_for_empty_token() -> None:
     assert default_user_resolver(None, token) is None
 
 
-def test_default_resolver_sub_takes_priority_over_email() -> None:
-    """'sub' takes priority over 'email' in claims dict."""
-    token = _make_access_token(claims={"sub": "alice", "email": "alice@example.com"})
+def test_default_resolver_preferred_username_takes_priority() -> None:
+    """'preferred_username' takes priority over 'sub' and 'email' in claims."""
+    token = _make_access_token(
+        claims={
+            "sub": "opaque-id-123",
+            "preferred_username": "alice",
+            "email": "alice@example.com",
+        }
+    )
     assert default_user_resolver(None, token) == "alice"


### PR DESCRIPTION
## **User description**
### SUMMARY

In certain Superset deployments, `get_user_from_request()` in `mcp_service/auth.py` blindly returns `g.user` if already set — without verifying it belongs to the current request. Since `mcp_auth_hook` pushes Flask **app context** only (not request context), `g.user` can persist between tool calls, leading to **privilege escalation** where one user's MCP actions execute under another user's identity.

**Root cause:** `mcp_auth_hook` uses `nullcontext()` if already in an app context, so `g` persists. `_setup_user_context()` sets `g.user = user`, and the next tool call finds the stale `g.user` and returns it immediately.

**Fix — changed auth priority order in `get_user_from_request()`:**

| Priority | Source | Safety |
|---|---|---|
| 1 | JWT auth context (per-request ContextVar from MCP SDK via `get_access_token()`) | Per-async-task safe |
| 2 | `MCP_DEV_USERNAME` config | Static dev user |
| 3 | `g.user` fallback | For external middleware that sets g.user fresh per request |
| 4 | Raise `ValueError` | No auth source |

**Additional hardening:**
- Clear `g.user` at the start of each `mcp_auth_hook` wrapper (belt-and-suspenders)
- If JWT resolves a username not found in DB → **fail closed** (raise error, don't fall through to weaker auth)
- Updated `default_user_resolver()` to check `AccessToken.claims` dict first (FastMCP format) and added `preferred_username` OIDC claim support

**Safe for all environments:**

| Environment | Before | After |
|---|---|---|
| With per-request middleware | g.user (fresh, works) | No JWT → no DEV_USERNAME → g.user (still fresh) |
| With JWT auth | g.user from PREVIOUS request (BUG) | JWT claims → fresh user per request (FIXED) |
| Dev mode | g.user if set, else MCP_DEV_USERNAME | No JWT → MCP_DEV_USERNAME (same) |

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend auth logic change, no UI.

### TESTING INSTRUCTIONS

1. Run new tests: `pytest tests/unit_tests/mcp_service/test_auth_user_resolution.py -x -q` (20 tests)
2. Run existing auth tests: `pytest tests/unit_tests/mcp_service/test_auth_rbac.py -x -q` (15 tests)
3. Run full MCP test suite: `pytest tests/unit_tests/mcp_service/ -x -q` (871 tests)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

## MCP Tool Testing Results

Tested against running Superset MCP service (localhost:5008) on 2026-03-24:

| Tool | Request | Result |
|------|---------|--------|
| `health_check` | `{}` | `{"status":"healthy","service":"Preset MCP Service","version":"amin/ch101753/bump-fastmcp-3.1.0"}` |
| `get_instance_info` | `{}` | 13 dashboards, 91 charts, 20 datasets, current_user=Amin (Admin) |
| `list_dashboards` | `{"page":1,"page_size":3}` | Returned 3/13 dashboards (World Bank's Data, Slack Dashboard, FCC New Coder Survey 2018) |
| `list_charts` | `{"page":1,"page_size":3}` | Returned 3/91 charts (Work Location Preference, Weekly Threads, Weekly Messages) |
| `list_datasets` | `{"page":1,"page_size":3}` | Returned 3/20 datasets (COVID Vaccines, FCC 2018 Survey, Flights) |
| `get_chart_info` | `{"identifier":4}` | Returned pie chart "Work Location Preference" with metadata |
| `execute_sql` | `{"database_id":2,"sql":"SELECT 1 as test_col, 'hello' as test_str"}` | Returned 1 row: `{"test_col":1,"test_str":"hello"}` in 0.13s |
| `generate_explore_link` | `{"dataset_id":19,"config":{"chart_type":"xy","kind":"bar",...}}` | Generated explore URL with form_data_key |

All tools executed successfully with proper auth context (Admin user).


___

## **CodeAnt-AI Description**
Prevent stale MCP user data from being reused across tool calls

### What Changed
- MCP requests now resolve the active user from the current JWT first, so one user’s identity is not carried over to the next tool call
- If JWT-based identity cannot be matched to a Superset user, the request now stops instead of falling back to a weaker identity source
- User lookup now accepts common login fields such as preferred username and email, and still supports older token formats
- Stale `g.user` is cleared before tool setup in app-only flows, while request-scoped middleware identities are preserved
- Added coverage for JWT priority, fallback behavior, stale user cleanup, and request-context preservation
- Updated the MCP security notes to match the new auth order

### Impact
`✅ Fewer cross-user impersonation errors`
`✅ Safer MCP tool calls`
`✅ Clearer authentication behavior for Preset and JWT deployments`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
