### PR TITLE
fix(mcp): use correct permission class for save_sql_query tool

### DIFF
--- a/superset/mcp_service/sql_lab/tool/save_sql_query.py
+++ b/superset/mcp_service/sql_lab/tool/save_sql_query.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 @tool(
     tags=["mutate"],
-    class_permission_name="SQLLab",
+    class_permission_name="SavedQuery",
     method_permission_name="write",
     annotations=ToolAnnotations(
         title="Save SQL query",


### PR DESCRIPTION
## **User description**
### SUMMARY

The `save_sql_query` MCP tool was using `class_permission_name="SQLLab"` with `method_permission_name="write"`, which checks for `can_write` on `SQLLab`. However, this permission pair doesn't exist in Superset's RBAC system — the registered SQLLab permissions are `can_read`, `can_get_results`, `can_execute_sql_query`, etc. (no `can_write`).

This caused a `MCPPermissionDeniedError` for **all users**, including admins, when trying to save a SQL query via the MCP tool.

The fix changes the permission class to `SavedQuery`, which:
- Matches the REST API at `superset/queries/saved_queries/api.py` (`class_permission_name = "SavedQuery"`)
- Is a registered permission in the security manager (`("can_write", "SavedQuery")`)
- Correctly reflects what the tool does — it creates a `SavedQuery`, not a SQLLab operation

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** `MCPPermissionDeniedError: Permission denied: can_write on SQLLab` for all users
**After:** Permission check uses `can_write` on `SavedQuery`, which admins (and users with SQL Lab access) have

### TESTING INSTRUCTIONS

1. Use the `save_sql_query` MCP tool with an admin account
2. Verify it no longer returns a permission denied error
3. Verify the saved query appears in SQL Lab's Saved Queries list

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix permission denied when saving SQL queries via the MCP tool

### What Changed
- The save SQL query tool now checks write permission on SavedQuery instead of SQLLab, preventing permission-denied errors for admins and authorized users
- Permission behavior now matches the REST API, so saved queries created via the tool appear in SQL Lab's Saved Queries list
- Users with the appropriate SavedQuery write permission can save queries; previously the tool blocked all users with a mismatched permission check

### Impact
`✅ No permission denied when saving queries`
`✅ Saved queries created via the tool appear in SQL Lab`
`✅ Permission checks consistent with REST API`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
