### PR TITLE
fix(mcp): fix detached Slice instance error in chart/dashboard serialization

### DIFF
--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -707,7 +707,21 @@ async def generate_chart(  # noqa: C901
         # Build chart info using serialize_chart_object for saved charts
         chart_info = None
         if request.save_chart and chart:
+            from sqlalchemy.orm import subqueryload
+
+            from superset import db
             from superset.mcp_service.chart.schemas import serialize_chart_object
+            from superset.models.slice import Slice
+
+            chart = (
+                db.session.query(Slice)
+                .options(
+                    subqueryload(Slice.owners),
+                    subqueryload(Slice.tags),
+                )
+                .filter(Slice.id == chart.id)
+                .one_or_none()
+            ) or chart
 
             chart_info = serialize_chart_object(chart)
             if chart_info:

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -709,21 +709,24 @@ async def generate_chart(  # noqa: C901
         if request.save_chart and chart:
             from sqlalchemy.orm import joinedload
 
-            from superset import db
+            from superset.daos.chart import ChartDAO
             from superset.mcp_service.chart.schemas import serialize_chart_object
             from superset.models.slice import Slice
 
-            # Use joinedload (single JOIN query) instead of subqueryload
-            # (3 separate queries) since we're fetching a single chart.
+            # Re-fetch with eager-loaded relationships to avoid detached
+            # instance errors when serialize_chart_object accesses .tags
+            # and .owners.  Use joinedload (single JOIN query) since we
+            # are fetching a single chart.
             chart = (
-                db.session.query(Slice)
-                .options(
-                    joinedload(Slice.owners),
-                    joinedload(Slice.tags),
+                ChartDAO.find_by_id(
+                    chart.id,
+                    query_options=[
+                        joinedload(Slice.owners),
+                        joinedload(Slice.tags),
+                    ],
                 )
-                .filter(Slice.id == chart.id)
-                .one_or_none()
-            ) or chart
+                or chart
+            )
 
             chart_info = serialize_chart_object(chart)
             if chart_info:

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -707,17 +707,19 @@ async def generate_chart(  # noqa: C901
         # Build chart info using serialize_chart_object for saved charts
         chart_info = None
         if request.save_chart and chart:
-            from sqlalchemy.orm import subqueryload
+            from sqlalchemy.orm import joinedload
 
             from superset import db
             from superset.mcp_service.chart.schemas import serialize_chart_object
             from superset.models.slice import Slice
 
+            # Use joinedload (single JOIN query) instead of subqueryload
+            # (3 separate queries) since we're fetching a single chart.
             chart = (
                 db.session.query(Slice)
                 .options(
-                    subqueryload(Slice.owners),
-                    subqueryload(Slice.tags),
+                    joinedload(Slice.owners),
+                    joinedload(Slice.tags),
                 )
                 .filter(Slice.id == chart.id)
                 .one_or_none()

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -406,6 +406,27 @@ def add_chart_to_existing_dashboard(
             command = UpdateDashboardCommand(request.dashboard_id, update_data)
             updated_dashboard = command.run()
 
+        # Re-fetch the dashboard with eager-loaded relationships to avoid
+        # "Instance is not bound to a Session" errors when serializing
+        # chart .tags and .owners.
+        from sqlalchemy.orm import subqueryload
+
+        from superset import db
+        from superset.models.dashboard import Dashboard
+        from superset.models.slice import Slice
+
+        updated_dashboard = (
+            db.session.query(Dashboard)
+            .options(
+                subqueryload(Dashboard.slices).subqueryload(Slice.owners),
+                subqueryload(Dashboard.slices).subqueryload(Slice.tags),
+                subqueryload(Dashboard.owners),
+                subqueryload(Dashboard.tags),
+            )
+            .filter(Dashboard.id == updated_dashboard.id)
+            .one_or_none()
+        ) or updated_dashboard
+
         # Convert to response format
         from superset.mcp_service.dashboard.schemas import (
             serialize_tag_object,

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -411,21 +411,22 @@ def add_chart_to_existing_dashboard(
         # chart .tags and .owners.
         from sqlalchemy.orm import subqueryload
 
-        from superset import db
+        from superset.daos.dashboard import DashboardDAO
         from superset.models.dashboard import Dashboard
         from superset.models.slice import Slice
 
         updated_dashboard = (
-            db.session.query(Dashboard)
-            .options(
-                subqueryload(Dashboard.slices).subqueryload(Slice.owners),
-                subqueryload(Dashboard.slices).subqueryload(Slice.tags),
-                subqueryload(Dashboard.owners),
-                subqueryload(Dashboard.tags),
+            DashboardDAO.find_by_id(
+                updated_dashboard.id,
+                query_options=[
+                    subqueryload(Dashboard.slices).subqueryload(Slice.owners),
+                    subqueryload(Dashboard.slices).subqueryload(Slice.tags),
+                    subqueryload(Dashboard.owners),
+                    subqueryload(Dashboard.tags),
+                ],
             )
-            .filter(Dashboard.id == updated_dashboard.id)
-            .one_or_none()
-        ) or updated_dashboard
+            or updated_dashboard
+        )
 
         # Convert to response format
         from superset.mcp_service.dashboard.schemas import (

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -207,14 +207,8 @@ def generate_dashboard(
         from superset.models.slice import Slice
 
         with event_logger.log_context(action="mcp.generate_dashboard.chart_validation"):
-            from sqlalchemy.orm import subqueryload
-
             chart_objects = (
                 db.session.query(Slice)
-                .options(
-                    subqueryload(Slice.owners),
-                    subqueryload(Slice.tags),
-                )
                 .filter(Slice.id.in_(request.chart_ids))
                 .order_by(Slice.id)
                 .all()

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -285,19 +285,21 @@ def generate_dashboard(
         # chart .tags and .owners.
         from sqlalchemy.orm import subqueryload
 
+        from superset.daos.dashboard import DashboardDAO
         from superset.models.dashboard import Dashboard
 
         dashboard = (
-            db.session.query(Dashboard)
-            .options(
-                subqueryload(Dashboard.slices).subqueryload(Slice.owners),
-                subqueryload(Dashboard.slices).subqueryload(Slice.tags),
-                subqueryload(Dashboard.owners),
-                subqueryload(Dashboard.tags),
+            DashboardDAO.find_by_id(
+                dashboard.id,
+                query_options=[
+                    subqueryload(Dashboard.slices).subqueryload(Slice.owners),
+                    subqueryload(Dashboard.slices).subqueryload(Slice.tags),
+                    subqueryload(Dashboard.owners),
+                    subqueryload(Dashboard.tags),
+                ],
             )
-            .filter(Dashboard.id == dashboard.id)
-            .one_or_none()
-        ) or dashboard
+            or dashboard
+        )
 
         # Convert to our response format
         from superset.mcp_service.dashboard.schemas import (

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -207,8 +207,14 @@ def generate_dashboard(
         from superset.models.slice import Slice
 
         with event_logger.log_context(action="mcp.generate_dashboard.chart_validation"):
+            from sqlalchemy.orm import subqueryload
+
             chart_objects = (
                 db.session.query(Slice)
+                .options(
+                    subqueryload(Slice.owners),
+                    subqueryload(Slice.tags),
+                )
                 .filter(Slice.id.in_(request.chart_ids))
                 .order_by(Slice.id)
                 .all()
@@ -273,6 +279,25 @@ def generate_dashboard(
             # Create the dashboard using Superset's command pattern
             command = CreateDashboardCommand(dashboard_data)
             dashboard = command.run()
+
+        # Re-fetch the dashboard with eager-loaded relationships to avoid
+        # "Instance is not bound to a Session" errors when serializing
+        # chart .tags and .owners.
+        from sqlalchemy.orm import subqueryload
+
+        from superset.models.dashboard import Dashboard
+
+        dashboard = (
+            db.session.query(Dashboard)
+            .options(
+                subqueryload(Dashboard.slices).subqueryload(Slice.owners),
+                subqueryload(Dashboard.slices).subqueryload(Slice.tags),
+                subqueryload(Dashboard.owners),
+                subqueryload(Dashboard.tags),
+            )
+            .filter(Dashboard.id == dashboard.id)
+            .one_or_none()
+        ) or dashboard
 
         # Convert to our response format
         from superset.mcp_service.dashboard.schemas import (

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -410,64 +410,38 @@ class TestChartSerializationEagerLoading:
         with pytest.raises(DetachedInstanceError):
             serialize_chart_object(chart)
 
-    @patch("superset.mcp_service.chart.tool.generate_chart.db")
-    def test_generate_chart_refetches_with_joinedload(self, mock_db):
-        """The serialization path re-fetches the chart with eager loading.
-
-        Uses joinedload (single JOIN query) rather than subqueryload
-        (3 queries) since only one chart is fetched.
-        """
-        original_chart = _make_mock_chart()
+    @patch("superset.daos.chart.ChartDAO.find_by_id")
+    def test_generate_chart_refetches_via_dao(self, mock_find_by_id):
+        """The serialization path re-fetches the chart via ChartDAO.find_by_id
+        with joinedload query_options for owners and tags."""
         refetched_chart = _make_mock_chart()
         refetched_chart.tags = [Mock(id=1, name="tag1", type="custom")]
         refetched_chart.tags[0].description = ""
 
-        # Set up mock query chain
-        mock_query = MagicMock()
-        mock_db.session.query.return_value = mock_query
-        mock_query.options.return_value = mock_query
-        mock_query.filter.return_value = mock_query
-        mock_query.one_or_none.return_value = refetched_chart
+        mock_find_by_id.return_value = refetched_chart
 
-        # Simulate the re-fetch logic from generate_chart.py
-        from sqlalchemy.orm import joinedload
-
-        from superset.models.slice import Slice
+        from superset.daos.chart import ChartDAO
 
         chart = (
-            mock_db.session.query(Slice)
-            .options(
-                joinedload(Slice.owners),
-                joinedload(Slice.tags),
-            )
-            .filter(Slice.id == original_chart.id)
-            .one_or_none()
-        ) or original_chart
+            ChartDAO.find_by_id(42, query_options=["dummy_option"])
+            or _make_mock_chart()
+        )
 
-        # Verify the re-fetch returned the new chart
         assert chart is refetched_chart
-        mock_db.session.query.assert_called_once_with(Slice)
-        mock_query.options.assert_called_once()
-        mock_query.filter.assert_called_once()
+        mock_find_by_id.assert_called_once_with(42, query_options=["dummy_option"])
 
-    @patch("superset.mcp_service.chart.tool.generate_chart.db")
-    def test_generate_chart_falls_back_to_original_on_refetch_failure(self, mock_db):
-        """Falls back to original chart if re-fetch returns None."""
+    @patch("superset.daos.chart.ChartDAO.find_by_id")
+    def test_generate_chart_falls_back_to_original_on_refetch_failure(
+        self, mock_find_by_id
+    ):
+        """Falls back to original chart if ChartDAO.find_by_id returns None."""
         original_chart = _make_mock_chart()
+        mock_find_by_id.return_value = None
 
-        mock_query = MagicMock()
-        mock_db.session.query.return_value = mock_query
-        mock_query.options.return_value = mock_query
-        mock_query.filter.return_value = mock_query
-        mock_query.one_or_none.return_value = None
-
-        from superset.models.slice import Slice
+        from superset.daos.chart import ChartDAO
 
         chart = (
-            mock_db.session.query(Slice)
-            .options()
-            .filter(Slice.id == original_chart.id)
-            .one_or_none()
-        ) or original_chart
+            ChartDAO.find_by_id(original_chart.id, query_options=[]) or original_chart
+        )
 
         assert chart is original_chart

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -411,8 +411,12 @@ class TestChartSerializationEagerLoading:
             serialize_chart_object(chart)
 
     @patch("superset.mcp_service.chart.tool.generate_chart.db")
-    def test_generate_chart_refetches_with_subqueryload(self, mock_db):
-        """The serialization path re-fetches the chart with eager loading."""
+    def test_generate_chart_refetches_with_joinedload(self, mock_db):
+        """The serialization path re-fetches the chart with eager loading.
+
+        Uses joinedload (single JOIN query) rather than subqueryload
+        (3 queries) since only one chart is fetched.
+        """
         original_chart = _make_mock_chart()
         refetched_chart = _make_mock_chart()
         refetched_chart.tags = [Mock(id=1, name="tag1", type="custom")]
@@ -426,15 +430,15 @@ class TestChartSerializationEagerLoading:
         mock_query.one_or_none.return_value = refetched_chart
 
         # Simulate the re-fetch logic from generate_chart.py
-        from sqlalchemy.orm import subqueryload
+        from sqlalchemy.orm import joinedload
 
         from superset.models.slice import Slice
 
         chart = (
             mock_db.session.query(Slice)
             .options(
-                subqueryload(Slice.owners),
-                subqueryload(Slice.tags),
+                joinedload(Slice.owners),
+                joinedload(Slice.tags),
             )
             .filter(Slice.id == original_chart.id)
             .one_or_none()

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -19,9 +19,10 @@
 Unit tests for MCP generate_chart tool
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from sqlalchemy.orm.exc import DetachedInstanceError
 
 from superset.mcp_service.chart.schemas import (
     AxisConfig,
@@ -351,3 +352,118 @@ class TestCompileChart:
 
         assert result.success is False
         assert "invalid metric" in (result.error or "")
+
+
+def _make_mock_chart(chart_id: int = 42) -> Mock:
+    """Create a mock chart with all attributes needed by serialize_chart_object."""
+    chart = Mock()
+    chart.id = chart_id
+    chart.slice_name = "Test Chart"
+    chart.viz_type = "echarts_timeseries_bar"
+    chart.datasource_name = "test_table"
+    chart.datasource_type = "table"
+    chart.description = None
+    chart.cache_timeout = None
+    chart.changed_by = None
+    chart.changed_by_name = "admin"
+    chart.changed_on = None
+    chart.changed_on_humanized = "1 day ago"
+    chart.created_by = None
+    chart.created_by_name = "admin"
+    chart.created_on = None
+    chart.created_on_humanized = "2 days ago"
+    chart.uuid = "test-uuid-42"
+    chart.tags = []
+    chart.owners = []
+    return chart
+
+
+class TestChartSerializationEagerLoading:
+    """Tests for eager loading fix in generate_chart serialization path."""
+
+    def test_serialize_chart_object_succeeds_with_loaded_relationships(self):
+        """serialize_chart_object works when tags/owners are already loaded."""
+        from superset.mcp_service.chart.schemas import serialize_chart_object
+
+        chart = _make_mock_chart()
+        result = serialize_chart_object(chart)
+
+        assert result is not None
+        assert result.id == 42
+        assert result.slice_name == "Test Chart"
+        assert result.tags == []
+        assert result.owners == []
+
+    def test_serialize_chart_object_fails_on_detached_instance(self):
+        """serialize_chart_object raises when accessing lazy attrs on detached
+        instance — this is the bug scenario that the eager-loading fix prevents."""
+        from superset.mcp_service.chart.schemas import serialize_chart_object
+
+        chart = _make_mock_chart()
+        # Simulate detached instance: accessing .tags raises DetachedInstanceError
+        type(chart).tags = property(
+            lambda self: (_ for _ in ()).throw(
+                DetachedInstanceError("Instance <Slice> is not bound to a Session")
+            )
+        )
+
+        with pytest.raises(DetachedInstanceError):
+            serialize_chart_object(chart)
+
+    @patch("superset.mcp_service.chart.tool.generate_chart.db")
+    def test_generate_chart_refetches_with_subqueryload(self, mock_db):
+        """The serialization path re-fetches the chart with eager loading."""
+        original_chart = _make_mock_chart()
+        refetched_chart = _make_mock_chart()
+        refetched_chart.tags = [Mock(id=1, name="tag1", type="custom")]
+        refetched_chart.tags[0].description = ""
+
+        # Set up mock query chain
+        mock_query = MagicMock()
+        mock_db.session.query.return_value = mock_query
+        mock_query.options.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.one_or_none.return_value = refetched_chart
+
+        # Simulate the re-fetch logic from generate_chart.py
+        from sqlalchemy.orm import subqueryload
+
+        from superset.models.slice import Slice
+
+        chart = (
+            mock_db.session.query(Slice)
+            .options(
+                subqueryload(Slice.owners),
+                subqueryload(Slice.tags),
+            )
+            .filter(Slice.id == original_chart.id)
+            .one_or_none()
+        ) or original_chart
+
+        # Verify the re-fetch returned the new chart
+        assert chart is refetched_chart
+        mock_db.session.query.assert_called_once_with(Slice)
+        mock_query.options.assert_called_once()
+        mock_query.filter.assert_called_once()
+
+    @patch("superset.mcp_service.chart.tool.generate_chart.db")
+    def test_generate_chart_falls_back_to_original_on_refetch_failure(self, mock_db):
+        """Falls back to original chart if re-fetch returns None."""
+        original_chart = _make_mock_chart()
+
+        mock_query = MagicMock()
+        mock_db.session.query.return_value = mock_query
+        mock_query.options.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.one_or_none.return_value = None
+
+        from superset.models.slice import Slice
+
+        chart = (
+            mock_db.session.query(Slice)
+            .options()
+            .filter(Slice.id == original_chart.id)
+            .one_or_none()
+        ) or original_chart
+
+        assert chart is original_chart

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -1070,123 +1070,56 @@ class TestGenerateTitleFromCharts:
 class TestDashboardSerializationEagerLoading:
     """Tests for eager loading fix in dashboard serialization paths."""
 
-    @patch(
-        "superset.mcp_service.dashboard.tool.generate_dashboard.db",
-    )
-    def test_generate_dashboard_refetches_with_subqueryload(self, mock_db):
-        """generate_dashboard re-fetches dashboard with eager-loaded slice
-        relationships before serialization."""
-        from unittest.mock import MagicMock
-
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+    def test_generate_dashboard_refetches_via_dao(self, mock_find_by_id):
+        """generate_dashboard re-fetches dashboard via DashboardDAO.find_by_id
+        with eager-loaded slice relationships before serialization."""
         refetched_dashboard = _mock_dashboard()
         refetched_chart = _mock_chart(id=1, slice_name="Refetched Chart")
         refetched_dashboard.slices = [refetched_chart]
 
-        mock_query = MagicMock()
-        mock_db.session.query.return_value = mock_query
-        mock_query.options.return_value = mock_query
-        mock_query.filter.return_value = mock_query
-        mock_query.one_or_none.return_value = refetched_dashboard
+        mock_find_by_id.return_value = refetched_dashboard
 
-        from superset.models.dashboard import Dashboard
+        from superset.daos.dashboard import DashboardDAO
 
         result = (
-            mock_db.session.query(Dashboard)
-            .options()
-            .filter(Dashboard.id == 1)
-            .one_or_none()
-        ) or _mock_dashboard()
-
-        assert result is refetched_dashboard
-        mock_db.session.query.assert_called_once_with(Dashboard)
-
-    @patch(
-        "superset.mcp_service.dashboard.tool.generate_dashboard.db",
-    )
-    def test_generate_dashboard_chart_query_uses_subqueryload(self, mock_db):
-        """generate_dashboard chart query includes subqueryload for owners/tags."""
-        from unittest.mock import MagicMock
-
-        from sqlalchemy.orm import subqueryload
-
-        from superset.models.slice import Slice
-
-        chart = _mock_chart()
-        mock_query = MagicMock()
-        mock_db.session.query.return_value = mock_query
-        mock_query.options.return_value = mock_query
-        mock_query.filter.return_value = mock_query
-        mock_query.order_by.return_value = mock_query
-        mock_query.all.return_value = [chart]
-
-        # Simulate the eager-loaded chart query from generate_dashboard
-        result = (
-            mock_db.session.query(Slice)
-            .options(
-                subqueryload(Slice.owners),
-                subqueryload(Slice.tags),
-            )
-            .filter(Slice.id.in_([1]))
-            .order_by(Slice.id)
-            .all()
+            DashboardDAO.find_by_id(1, query_options=["dummy"]) or _mock_dashboard()
         )
 
-        assert result == [chart]
-        mock_db.session.query.assert_called_once_with(Slice)
-        mock_query.options.assert_called_once()
+        assert result is refetched_dashboard
+        mock_find_by_id.assert_called_once_with(1, query_options=["dummy"])
 
-    @patch(
-        "superset.mcp_service.dashboard.tool.add_chart_to_existing_dashboard.db",
-    )
-    def test_add_chart_refetches_dashboard_with_subqueryload(self, mock_db):
-        """add_chart_to_existing_dashboard re-fetches dashboard with
-        eager-loaded slice relationships."""
-        from unittest.mock import MagicMock
-
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+    def test_add_chart_refetches_dashboard_via_dao(self, mock_find_by_id):
+        """add_chart_to_existing_dashboard re-fetches dashboard via
+        DashboardDAO.find_by_id with eager-loaded slice relationships."""
         original_dashboard = _mock_dashboard()
         refetched_dashboard = _mock_dashboard()
         refetched_dashboard.slices = [_mock_chart()]
 
-        mock_query = MagicMock()
-        mock_db.session.query.return_value = mock_query
-        mock_query.options.return_value = mock_query
-        mock_query.filter.return_value = mock_query
-        mock_query.one_or_none.return_value = refetched_dashboard
+        mock_find_by_id.return_value = refetched_dashboard
 
-        from superset.models.dashboard import Dashboard
+        from superset.daos.dashboard import DashboardDAO
 
         result = (
-            mock_db.session.query(Dashboard)
-            .options()
-            .filter(Dashboard.id == original_dashboard.id)
-            .one_or_none()
-        ) or original_dashboard
+            DashboardDAO.find_by_id(original_dashboard.id, query_options=["dummy"])
+            or original_dashboard
+        )
 
         assert result is refetched_dashboard
 
-    @patch(
-        "superset.mcp_service.dashboard.tool.add_chart_to_existing_dashboard.db",
-    )
-    def test_add_chart_falls_back_on_refetch_failure(self, mock_db):
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+    def test_add_chart_falls_back_on_refetch_failure(self, mock_find_by_id):
         """add_chart_to_existing_dashboard falls back to original dashboard
-        if re-fetch returns None."""
-        from unittest.mock import MagicMock
-
+        if DashboardDAO.find_by_id returns None."""
         original_dashboard = _mock_dashboard()
+        mock_find_by_id.return_value = None
 
-        mock_query = MagicMock()
-        mock_db.session.query.return_value = mock_query
-        mock_query.options.return_value = mock_query
-        mock_query.filter.return_value = mock_query
-        mock_query.one_or_none.return_value = None
-
-        from superset.models.dashboard import Dashboard
+        from superset.daos.dashboard import DashboardDAO
 
         result = (
-            mock_db.session.query(Dashboard)
-            .options()
-            .filter(Dashboard.id == original_dashboard.id)
-            .one_or_none()
-        ) or original_dashboard
+            DashboardDAO.find_by_id(original_dashboard.id, query_options=["dummy"])
+            or original_dashboard
+        )
 
         assert result is original_dashboard

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -1065,3 +1065,128 @@ class TestGenerateTitleFromCharts:
         title = _generate_title_from_charts(charts)
         assert len(title) <= 150
         assert title.endswith("\u2026")
+
+
+class TestDashboardSerializationEagerLoading:
+    """Tests for eager loading fix in dashboard serialization paths."""
+
+    @patch(
+        "superset.mcp_service.dashboard.tool.generate_dashboard.db",
+    )
+    def test_generate_dashboard_refetches_with_subqueryload(self, mock_db):
+        """generate_dashboard re-fetches dashboard with eager-loaded slice
+        relationships before serialization."""
+        from unittest.mock import MagicMock
+
+        refetched_dashboard = _mock_dashboard()
+        refetched_chart = _mock_chart(id=1, slice_name="Refetched Chart")
+        refetched_dashboard.slices = [refetched_chart]
+
+        mock_query = MagicMock()
+        mock_db.session.query.return_value = mock_query
+        mock_query.options.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.one_or_none.return_value = refetched_dashboard
+
+        from superset.models.dashboard import Dashboard
+
+        result = (
+            mock_db.session.query(Dashboard)
+            .options()
+            .filter(Dashboard.id == 1)
+            .one_or_none()
+        ) or _mock_dashboard()
+
+        assert result is refetched_dashboard
+        mock_db.session.query.assert_called_once_with(Dashboard)
+
+    @patch(
+        "superset.mcp_service.dashboard.tool.generate_dashboard.db",
+    )
+    def test_generate_dashboard_chart_query_uses_subqueryload(self, mock_db):
+        """generate_dashboard chart query includes subqueryload for owners/tags."""
+        from unittest.mock import MagicMock
+
+        from sqlalchemy.orm import subqueryload
+
+        from superset.models.slice import Slice
+
+        chart = _mock_chart()
+        mock_query = MagicMock()
+        mock_db.session.query.return_value = mock_query
+        mock_query.options.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.all.return_value = [chart]
+
+        # Simulate the eager-loaded chart query from generate_dashboard
+        result = (
+            mock_db.session.query(Slice)
+            .options(
+                subqueryload(Slice.owners),
+                subqueryload(Slice.tags),
+            )
+            .filter(Slice.id.in_([1]))
+            .order_by(Slice.id)
+            .all()
+        )
+
+        assert result == [chart]
+        mock_db.session.query.assert_called_once_with(Slice)
+        mock_query.options.assert_called_once()
+
+    @patch(
+        "superset.mcp_service.dashboard.tool.add_chart_to_existing_dashboard.db",
+    )
+    def test_add_chart_refetches_dashboard_with_subqueryload(self, mock_db):
+        """add_chart_to_existing_dashboard re-fetches dashboard with
+        eager-loaded slice relationships."""
+        from unittest.mock import MagicMock
+
+        original_dashboard = _mock_dashboard()
+        refetched_dashboard = _mock_dashboard()
+        refetched_dashboard.slices = [_mock_chart()]
+
+        mock_query = MagicMock()
+        mock_db.session.query.return_value = mock_query
+        mock_query.options.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.one_or_none.return_value = refetched_dashboard
+
+        from superset.models.dashboard import Dashboard
+
+        result = (
+            mock_db.session.query(Dashboard)
+            .options()
+            .filter(Dashboard.id == original_dashboard.id)
+            .one_or_none()
+        ) or original_dashboard
+
+        assert result is refetched_dashboard
+
+    @patch(
+        "superset.mcp_service.dashboard.tool.add_chart_to_existing_dashboard.db",
+    )
+    def test_add_chart_falls_back_on_refetch_failure(self, mock_db):
+        """add_chart_to_existing_dashboard falls back to original dashboard
+        if re-fetch returns None."""
+        from unittest.mock import MagicMock
+
+        original_dashboard = _mock_dashboard()
+
+        mock_query = MagicMock()
+        mock_db.session.query.return_value = mock_query
+        mock_query.options.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.one_or_none.return_value = None
+
+        from superset.models.dashboard import Dashboard
+
+        result = (
+            mock_db.session.query(Dashboard)
+            .options()
+            .filter(Dashboard.id == original_dashboard.id)
+            .one_or_none()
+        ) or original_dashboard
+
+        assert result is original_dashboard

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -107,10 +107,11 @@ class TestGenerateDashboard:
     """Tests for generate_dashboard MCP tool."""
 
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
     async def test_generate_dashboard_basic(
-        self, mock_db_session, mock_create_command, mcp_server
+        self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
         """Test basic dashboard generation with valid charts."""
         mock_query = Mock()
@@ -125,6 +126,7 @@ class TestGenerateDashboard:
 
         mock_dashboard = _mock_dashboard(id=10, title="Analytics Dashboard")
         mock_create_command.return_value.run.return_value = mock_dashboard
+        mock_find_by_id.return_value = mock_dashboard
 
         request = {
             "chart_ids": [1, 2],
@@ -170,10 +172,11 @@ class TestGenerateDashboard:
             assert result.structured_content["dashboard_url"] is None
 
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
     async def test_generate_dashboard_single_chart(
-        self, mock_db_session, mock_create_command, mcp_server
+        self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
         """Test dashboard generation with a single chart."""
         mock_query = Mock()
@@ -185,6 +188,7 @@ class TestGenerateDashboard:
 
         mock_dashboard = _mock_dashboard(id=20, title="Single Chart Dashboard")
         mock_create_command.return_value.run.return_value = mock_dashboard
+        mock_find_by_id.return_value = mock_dashboard
 
         request = {
             "chart_ids": [5],
@@ -200,10 +204,11 @@ class TestGenerateDashboard:
             assert result.structured_content["dashboard"]["published"] is True
 
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
     async def test_generate_dashboard_many_charts(
-        self, mock_db_session, mock_create_command, mcp_server
+        self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
         """Test dashboard generation with many charts (grid layout)."""
         chart_ids = list(range(1, 7))
@@ -218,6 +223,7 @@ class TestGenerateDashboard:
 
         mock_dashboard = _mock_dashboard(id=30, title="Multi Chart Dashboard")
         mock_create_command.return_value.run.return_value = mock_dashboard
+        mock_find_by_id.return_value = mock_dashboard
 
         request = {"chart_ids": chart_ids, "dashboard_title": "Multi Chart Dashboard"}
 
@@ -295,10 +301,11 @@ class TestGenerateDashboard:
             assert result.structured_content["dashboard"] is None
 
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
     async def test_generate_dashboard_minimal_request(
-        self, mock_db_session, mock_create_command, mcp_server
+        self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
         """Test dashboard generation with minimal required parameters."""
         mock_query = Mock()
@@ -310,6 +317,7 @@ class TestGenerateDashboard:
 
         mock_dashboard = _mock_dashboard(id=40, title="Minimal Dashboard")
         mock_create_command.return_value.run.return_value = mock_dashboard
+        mock_find_by_id.return_value = mock_dashboard
 
         request = {
             "chart_ids": [3],
@@ -332,10 +340,11 @@ class TestGenerateDashboard:
             )
 
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
     async def test_generate_dashboard_auto_title_from_charts(
-        self, mock_db_session, mock_create_command, mcp_server
+        self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
         """Test that omitting dashboard_title generates a title from chart names."""
         mock_query = Mock()
@@ -350,6 +359,7 @@ class TestGenerateDashboard:
 
         mock_dashboard = _mock_dashboard(id=50, title="Sales Revenue & Customer Count")
         mock_create_command.return_value.run.return_value = mock_dashboard
+        mock_find_by_id.return_value = mock_dashboard
 
         # No dashboard_title provided
         request = {"chart_ids": [1, 2]}
@@ -363,10 +373,11 @@ class TestGenerateDashboard:
             assert call_args["dashboard_title"] == "Sales Revenue & Customer Count"
 
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
     async def test_generate_dashboard_empty_string_title_preserved(
-        self, mock_db_session, mock_create_command, mcp_server
+        self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
         """Test that an explicit empty-string title is NOT replaced by auto-gen."""
         mock_query = Mock()
@@ -380,6 +391,7 @@ class TestGenerateDashboard:
 
         mock_dashboard = _mock_dashboard(id=60, title="")
         mock_create_command.return_value.run.return_value = mock_dashboard
+        mock_find_by_id.return_value = mock_dashboard
 
         # Explicit empty string title
         request = {"chart_ids": [1], "dashboard_title": ""}
@@ -439,17 +451,19 @@ class TestAddChartToExistingDashboard:
                 "DASHBOARD_VERSION_KEY": "v2",
             }
         )
-        mock_find_dashboard.return_value = mock_dashboard
-
-        mock_chart = _mock_chart(id=30, slice_name="New Chart")
-        mock_db_session.get.return_value = mock_chart
-
         updated_dashboard = _mock_dashboard(id=1, title="Existing Dashboard")
         updated_dashboard.slices = [
             _mock_chart(id=10),
             _mock_chart(id=20),
             _mock_chart(id=30),
         ]
+        # First call: initial validation returns original dashboard
+        # Second call: re-fetch after update returns updated dashboard
+        mock_find_dashboard.side_effect = [mock_dashboard, updated_dashboard]
+
+        mock_chart = _mock_chart(id=30, slice_name="New Chart")
+        mock_db_session.get.return_value = mock_chart
+
         mock_update_command.return_value.run.return_value = updated_dashboard
 
         request = {"dashboard_id": 1, "chart_id": 30}


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes "Instance `<Slice>` is not bound to a Session" error in MCP tools (`generate_chart`, `generate_dashboard`, `add_chart_to_existing_dashboard`) by re-fetching ORM objects with eager-loaded relationships before serialization.

**Root cause:** The `Slice` model's `owners` and `tags` relationships use default lazy loading. After `CreateChartCommand.run()` / `CreateDashboardCommand.run()` commits the transaction, SQLAlchemy expires the instances. When `serialize_chart_object()` later accesses these lazy-loaded attributes, the refresh fails because the instance is no longer bound to an active session.

**Fix:** Re-fetch objects with `subqueryload(Slice.owners)` and `subqueryload(Slice.tags)` before serialization — the same pattern already used in `get_chart_info` and `get_dashboard_info`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend-only fix, no UI changes.

### TESTING INSTRUCTIONS
1. Use the `generate_chart` MCP tool with `save_chart=True`
2. Use the `generate_dashboard` MCP tool with valid chart IDs
3. Use the `add_chart_to_existing_dashboard` MCP tool
4. Verify all three return chart/dashboard info with `owners` and `tags` populated instead of raising a detached instance error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix "Instance is not bound to a Session" in MCP chart/dashboard serialization

### What Changed
- MCP tools that create or update charts/dashboards now reload saved chart and dashboard records with their owners and tags preloaded before building the response
- Generate_chart, generate_dashboard, and add_chart_to_existing_dashboard return chart/dashboard info with owners and tags populated instead of raising detached-instance errors
- Responses preserve the expected URLs and preview behavior while avoiding serialization failures after the DB session expires

### Impact
`✅ Fewer MCP tool failures when saving charts or dashboards`
`✅ Chart and dashboard responses include owners and tags reliably`
`✅ Clearer error-free outputs from generate_chart, generate_dashboard, add_chart_to_existing_dashboard`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
