### PR TITLE
fix(mcp): convert adhoc filters to QueryObject format before query compilation

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -345,6 +345,27 @@ def _add_adhoc_filters(
         ]
 
 
+def adhoc_filters_to_query_filters(
+    adhoc_filters: list[Dict[str, Any]],
+) -> list[Dict[str, Any]]:
+    """Convert adhoc filter format to QueryObject filter format.
+
+    Adhoc filters use ``{subject, operator, comparator}`` keys while
+    ``QueryContextFactory`` expects ``{col, op, val}`` (QueryObjectFilterClause).
+    """
+    result: list[Dict[str, Any]] = []
+    for f in adhoc_filters:
+        if f.get("expressionType") == "SIMPLE":
+            result.append(
+                {
+                    "col": f.get("subject"),
+                    "op": f.get("operator"),
+                    "val": f.get("comparator"),
+                }
+            )
+    return result
+
+
 def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
     """Map table chart config to form_data with defensive validation."""
     # Early validation to prevent empty charts

--- a/superset/mcp_service/chart/preview_utils.py
+++ b/superset/mcp_service/chart/preview_utils.py
@@ -81,11 +81,17 @@ def generate_preview_from_form_data(
 
         # Create query context from form data using factory
         from superset.common.query_context_factory import QueryContextFactory
+        from superset.mcp_service.chart.chart_utils import (
+            adhoc_filters_to_query_filters,
+        )
 
         # Build columns list: include x_axis and groupby for XY charts,
         # fall back to form_data "columns" for table charts
         columns = _build_query_columns(form_data)
 
+        query_filters = adhoc_filters_to_query_filters(
+            form_data.get("adhoc_filters", [])
+        )
         factory = QueryContextFactory()
         query_context_obj = factory.create(
             datasource={"id": dataset_id, "type": "table"},
@@ -95,7 +101,7 @@ def generate_preview_from_form_data(
                     "metrics": form_data.get("metrics", []),
                     "orderby": form_data.get("orderby", []),
                     "row_limit": form_data.get("row_limit", 100),
-                    "filters": form_data.get("adhoc_filters", []),
+                    "filters": query_filters,
                     "time_range": form_data.get("time_range", "No filter"),
                 }
             ],

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -81,10 +81,14 @@ def _compile_chart(
         ChartDataQueryFailedError,
     )
     from superset.common.query_context_factory import QueryContextFactory
+    from superset.mcp_service.chart.chart_utils import adhoc_filters_to_query_filters
     from superset.mcp_service.chart.preview_utils import _build_query_columns
 
     try:
         columns = _build_query_columns(form_data)
+        query_filters = adhoc_filters_to_query_filters(
+            form_data.get("adhoc_filters", [])
+        )
         factory = QueryContextFactory()
         query_context = factory.create(
             datasource={"id": dataset_id, "type": "table"},
@@ -94,7 +98,7 @@ def _compile_chart(
                     "metrics": form_data.get("metrics", []),
                     "orderby": form_data.get("orderby", []),
                     "row_limit": 2,
-                    "filters": form_data.get("adhoc_filters", []),
+                    "filters": query_filters,
                     "time_range": form_data.get("time_range", "No filter"),
                 }
             ],

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -24,6 +24,7 @@ import pytest
 
 from superset.mcp_service.chart.chart_utils import (
     _add_adhoc_filters,
+    adhoc_filters_to_query_filters,
     configure_temporal_handling,
     create_metric_object,
     generate_chart_name,
@@ -1447,3 +1448,56 @@ class TestValidateChartDataset:
         mock_find.side_effect = SQLAlchemyError("db gone")
         url = generate_explore_link(5, {"viz_type": "table"})
         assert "datasource_id=5" in url
+
+
+class TestAdhocFiltersToQueryFilters:
+    """Tests for adhoc_filters_to_query_filters conversion."""
+
+    def test_converts_simple_filters(self) -> None:
+        adhoc = [
+            {
+                "clause": "WHERE",
+                "expressionType": "SIMPLE",
+                "subject": "genre",
+                "operator": "==",
+                "comparator": "Action",
+            }
+        ]
+        result = adhoc_filters_to_query_filters(adhoc)
+        assert result == [{"col": "genre", "op": "==", "val": "Action"}]
+
+    def test_converts_multiple_filters(self) -> None:
+        adhoc = [
+            {
+                "clause": "WHERE",
+                "expressionType": "SIMPLE",
+                "subject": "genre",
+                "operator": "==",
+                "comparator": "Action",
+            },
+            {
+                "clause": "WHERE",
+                "expressionType": "SIMPLE",
+                "subject": "year",
+                "operator": ">=",
+                "comparator": "2010",
+            },
+        ]
+        result = adhoc_filters_to_query_filters(adhoc)
+        assert len(result) == 2
+        assert result[0] == {"col": "genre", "op": "==", "val": "Action"}
+        assert result[1] == {"col": "year", "op": ">=", "val": "2010"}
+
+    def test_empty_list(self) -> None:
+        assert adhoc_filters_to_query_filters([]) == []
+
+    def test_skips_non_simple_expression_types(self) -> None:
+        adhoc = [
+            {
+                "clause": "WHERE",
+                "expressionType": "SQL",
+                "sqlExpression": "col > 5",
+            }
+        ]
+        result = adhoc_filters_to_query_filters(adhoc)
+        assert result == []


### PR DESCRIPTION
## **User description**
### SUMMARY

MCP chart tools (`generate_chart`, `update_chart_preview`) pass adhoc filters directly from `form_data` to `QueryContextFactory` as the `filters` parameter. However, adhoc filters use `{subject, operator, comparator}` keys while `QueryContextFactory` expects `{col, op, val}` (QueryObjectFilterClause format). This causes a `KeyError: 'op'` when charts include filters.

The fix adds an `adhoc_filters_to_query_filters()` helper in `chart_utils.py` that converts between the two formats, and uses it in both `generate_chart.py` and `preview_utils.py` before passing filters to the factory.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - backend fix only

### TESTING INSTRUCTIONS

1. Run `pytest tests/unit_tests/mcp_service/chart/test_chart_utils.py::TestAdhocFiltersToQueryFilters -v` to verify the new tests pass
2. Run `pytest tests/unit_tests/mcp_service/chart/ -q` to verify no regressions (359 tests)
3. Use the MCP `generate_chart` tool with a chart config that includes filters — it should no longer fail with `KeyError: 'op'`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Convert adhoc filters to QueryObject format before query compilation

### What Changed
- Adhoc filters from form data are translated from {subject, operator, comparator} to {col, op, val} before building query contexts so chart queries no longer fail with a missing 'op' key.
- The conversion is applied when generating charts and when building previews, so both tools accept filters supplied as adhoc filter objects.
- Added unit tests for the conversion: handles simple filters, multiple filters, empty lists, and skips non-SIMPLE expression types.

### Impact
`✅ Fewer chart compile errors with adhoc filters`
`✅ Fewer preview failures when charts include filters`
`✅ Correct filter application for generated charts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
