### PR TITLE
fix(mcp): normalize call_tool proxy arguments to prevent encoding TypeError

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -25,7 +25,7 @@ For multi-pod deployments, configure MCP_EVENT_STORE_CONFIG with Redis URL.
 import logging
 import os
 from collections.abc import Sequence
-from typing import Any
+from typing import Annotated, Any
 
 import uvicorn
 
@@ -41,6 +41,7 @@ from superset.mcp_service.middleware import (
     LoggingMiddleware,
 )
 from superset.mcp_service.storage import _create_redis_store
+from superset.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +214,37 @@ def _fix_call_tool_arguments(tool: Any) -> Any:
     return tool
 
 
+def _normalize_call_tool_arguments(
+    arguments: dict[str, Any] | None,
+    tool_schema: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """JSON-serialize dict/list values when the tool schema accepts both
+    string and object variants (anyOf or oneOf with a string type).
+
+    When the BM25/regex ``call_tool`` proxy forwards arguments to the
+    actual tool, dict/list values must be serialized if the tool's schema
+    declares ``anyOf``/``oneOf`` with a string variant
+    (e.g. ``request: str | RequestModel``).
+
+    Without this, the MCP transport calls ``bytes(dict, 'utf-8')``
+    which raises ``TypeError: encoding without a string argument``.
+    """
+    if not arguments or not isinstance(tool_schema, dict):
+        return arguments
+
+    properties = tool_schema.get("properties", {})
+    result = dict(arguments)
+    for key, value in result.items():
+        if not isinstance(value, (dict, list)) or key not in properties:
+            continue
+        prop_schema = properties[key]
+        variants = prop_schema.get("oneOf") or prop_schema.get("anyOf") or []
+        has_string = any(v.get("type") == "string" for v in variants)
+        if has_string:
+            result[key] = json.dumps(value)
+    return result
+
+
 def _apply_tool_search_transform(mcp_instance: Any, config: dict[str, Any]) -> None:
     """Apply tool search transform to reduce initial context size.
 
@@ -221,12 +253,16 @@ def _apply_tool_search_transform(mcp_instance: Any, config: dict[str, Any]) -> N
     discover other tools on-demand via natural language search.
 
     Uses subclassing (not monkey-patching) to override ``_make_call_tool``
-    and fix the ``arguments`` schema for MCP bridge compatibility.
+    and fix the ``arguments`` schema for MCP bridge compatibility, and
+    normalize forwarded arguments to prevent encoding errors.
 
     NOTE: ``_make_call_tool`` is a private API in FastMCP 3.x
     (fastmcp>=3.1.0,<4.0). If FastMCP changes or removes this method
     in a future major version, these subclasses will need to be updated.
     """
+    from fastmcp.server.context import Context
+    from fastmcp.tools.tool import Tool, ToolResult
+
     strategy = config.get("strategy", "bm25")
     kwargs: dict[str, Any] = {
         "max_results": config.get("max_results", 5),
@@ -236,24 +272,61 @@ def _apply_tool_search_transform(mcp_instance: Any, config: dict[str, Any]) -> N
         "search_result_serializer": _serialize_tools_without_output_schema,
     }
 
+    def _make_normalizing_call_tool(transform: Any) -> Tool:
+        """Create a call_tool proxy that normalizes arguments before forwarding.
+
+        This fixes two issues:
+        1. anyOf schema incompatibility with MCP bridges (schema fix).
+        2. ``encoding without a string argument`` TypeError when dict/list
+           values are forwarded for parameters declared as
+           ``str | SomeModel`` (argument normalization).
+        """
+
+        async def call_tool(
+            name: Annotated[str, "The name of the tool to call"],
+            arguments: Annotated[
+                dict[str, Any] | None, "Arguments to pass to the tool"
+            ] = None,
+            ctx: Context = None,
+        ) -> ToolResult:
+            """Call a tool by name with the given arguments.
+
+            Use this to execute tools discovered via search_tools.
+            """
+            if name in {transform._call_tool_name, transform._search_tool_name}:
+                raise ValueError(
+                    f"'{name}' is a synthetic search tool and cannot be "
+                    f"called via the call_tool proxy"
+                )
+            if arguments:
+                target_tool = await ctx.fastmcp.get_tool(name)
+                if target_tool is not None:
+                    arguments = _normalize_call_tool_arguments(
+                        arguments, target_tool.parameters
+                    )
+            return await ctx.fastmcp.call_tool(name, arguments)
+
+        tool = Tool.from_function(fn=call_tool, name=transform._call_tool_name)
+        return _fix_call_tool_arguments(tool)
+
     if strategy == "regex":
         from fastmcp.server.transforms.search import RegexSearchTransform
 
         class _FixedRegexSearchTransform(RegexSearchTransform):
-            """Regex search with fixed call_tool arguments schema."""
+            """Regex search with fixed call_tool schema and arg normalization."""
 
-            def _make_call_tool(self) -> Any:
-                return _fix_call_tool_arguments(super()._make_call_tool())
+            def _make_call_tool(self) -> Tool:
+                return _make_normalizing_call_tool(self)
 
         transform = _FixedRegexSearchTransform(**kwargs)
     else:
         from fastmcp.server.transforms.search import BM25SearchTransform
 
         class _FixedBM25SearchTransform(BM25SearchTransform):
-            """BM25 search with fixed call_tool arguments schema."""
+            """BM25 search with fixed call_tool schema and arg normalization."""
 
-            def _make_call_tool(self) -> Any:
-                return _fix_call_tool_arguments(super()._make_call_tool())
+            def _make_call_tool(self) -> Tool:
+                return _make_normalizing_call_tool(self)
 
         transform = _FixedBM25SearchTransform(**kwargs)
 

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -26,8 +26,10 @@ from superset.mcp_service.mcp_config import MCP_TOOL_SEARCH_CONFIG
 from superset.mcp_service.server import (
     _apply_tool_search_transform,
     _fix_call_tool_arguments,
+    _normalize_call_tool_arguments,
     _serialize_tools_without_output_schema,
 )
+from superset.utils import json
 
 
 def test_tool_search_config_defaults():
@@ -171,3 +173,130 @@ def test_serialize_tools_handles_no_output_schema():
     assert len(result) == 1
     assert result[0]["name"] == "simple_tool"
     assert "outputSchema" not in result[0]
+
+
+# -- _normalize_call_tool_arguments tests --
+
+
+def test_normalize_serializes_dict_with_anyof_string():
+    """Dict value is JSON-serialized when schema has anyOf with string type."""
+    arguments = {"request": {"dataset_id": 1, "config": {"key": "val"}}}
+    schema = {
+        "properties": {
+            "request": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"$ref": "#/$defs/SomeModel"},
+                ]
+            }
+        }
+    }
+
+    result = _normalize_call_tool_arguments(arguments, schema)
+
+    assert isinstance(result["request"], str)
+    assert json.loads(result["request"]) == {
+        "dataset_id": 1,
+        "config": {"key": "val"},
+    }
+
+
+def test_normalize_serializes_dict_with_oneof_string():
+    """Dict value is JSON-serialized when schema has oneOf with string type."""
+    arguments = {"request": {"name": "test"}}
+    schema = {
+        "properties": {
+            "request": {
+                "oneOf": [
+                    {"type": "string"},
+                    {"type": "object"},
+                ]
+            }
+        }
+    }
+
+    result = _normalize_call_tool_arguments(arguments, schema)
+
+    assert isinstance(result["request"], str)
+
+
+def test_normalize_leaves_dict_without_string_variant():
+    """Dict value is left as-is when schema has no string variant."""
+    arguments = {"config": {"key": "val"}}
+    schema = {
+        "properties": {
+            "config": {
+                "anyOf": [
+                    {"type": "object"},
+                    {"type": "null"},
+                ]
+            }
+        }
+    }
+
+    result = _normalize_call_tool_arguments(arguments, schema)
+
+    assert isinstance(result["config"], dict)
+    assert result["config"] == {"key": "val"}
+
+
+def test_normalize_leaves_non_dict_unchanged():
+    """Non-dict/list values pass through unchanged."""
+    arguments = {"name": "test", "count": 42, "flag": True}
+    schema = {
+        "properties": {
+            "name": {"type": "string"},
+            "count": {"type": "integer"},
+            "flag": {"type": "boolean"},
+        }
+    }
+
+    result = _normalize_call_tool_arguments(arguments, schema)
+
+    assert result == {"name": "test", "count": 42, "flag": True}
+
+
+def test_normalize_returns_none_for_none_arguments():
+    """None arguments returns None."""
+    result = _normalize_call_tool_arguments(None, {"properties": {}})
+
+    assert result is None
+
+
+def test_normalize_returns_arguments_for_non_dict_schema():
+    """Non-dict schema returns arguments unchanged."""
+    arguments = {"request": {"key": "val"}}
+
+    result = _normalize_call_tool_arguments(arguments, None)
+
+    assert result is arguments
+
+
+def test_normalize_serializes_list_with_anyof_string():
+    """List value is JSON-serialized when schema has anyOf with string type."""
+    arguments = {"items": [1, 2, 3]}
+    schema = {
+        "properties": {
+            "items": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "integer"}},
+                ]
+            }
+        }
+    }
+
+    result = _normalize_call_tool_arguments(arguments, schema)
+
+    assert isinstance(result["items"], str)
+    assert json.loads(result["items"]) == [1, 2, 3]
+
+
+def test_normalize_ignores_keys_not_in_schema():
+    """Dict values for keys not in schema properties are left unchanged."""
+    arguments = {"unknown_key": {"nested": True}}
+    schema = {"properties": {"other_key": {"type": "string"}}}
+
+    result = _normalize_call_tool_arguments(arguments, schema)
+
+    assert isinstance(result["unknown_key"], dict)


### PR DESCRIPTION
## **User description**
### SUMMARY

When the BM25/regex search transform's `call_tool` proxy forwards arguments to the actual tool, dict/list values for parameters declared as `str | SomeModel` (anyOf/oneOf with a string variant) cause `TypeError: encoding without a string argument` because the MCP transport calls `bytes(dict, 'utf-8')`.

This adds `_normalize_call_tool_arguments()` which JSON-serializes dict/list values when the target tool's schema accepts both string and object types. The custom `_make_call_tool` override now looks up the target tool's schema before forwarding, preventing the encoding error.

### BEFORE/AFTER SCREENSHOTS OR COVERAGE AREA

**Before**: When an LLM sends `call_tool(name="save_sql_query", arguments={"request": {"database_id": 1, ...}})` through the BM25 search transform, the dict value for `request` is forwarded as-is. Since the underlying tool declares `request: str | SaveSQLQueryRequest`, the MCP transport attempts `bytes(dict, 'utf-8')` and fails.

**After**: The `call_tool` proxy looks up the target tool's schema, detects that `request` has `anyOf: [{type: string}, {$ref: ...}]`, and JSON-serializes the dict to a string before forwarding. The tool's `@parse_request` decorator then deserializes it back.

### TESTING INSTRUCTIONS

- 16 unit tests in `tests/unit_tests/mcp_service/test_tool_search_transform.py`
- 8 new tests for `_normalize_call_tool_arguments`:
  - Dict with anyOf string → serialized
  - Dict with oneOf string → serialized
  - Dict without string variant → left as dict
  - Non-dict values → unchanged
  - None arguments → None
  - Non-dict schema → unchanged
  - List with anyOf string → serialized
  - Unknown keys → unchanged

### ADDITIONAL INFORMATION

- Requires FastMCP >= 3.1.0 (`_make_call_tool` is a private API)
- Related to the BM25 tool search transform that reduces initial context by ~70%


___

## **CodeAnt-AI Description**
**Prevent call_tool failures when proxying tools that accept either text or structured input**

### What Changed
- The tool search proxy now converts dictionary and list arguments into text when the target tool also accepts a text form, so calls no longer fail with an encoding error.
- Search-based tool calls still block the synthetic search tools themselves from being invoked through the proxy.
- Added coverage for dict, list, empty, unknown, and non-matching schema cases.

### Impact
`✅ Fewer tool call failures`
`✅ Clearer tool execution through search`
`✅ More reliable calls to tools with mixed text and structured inputs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
