### PR TITLE
fix(ag-grid): jpeg export of ag-grid tables

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/ThemedAgGridReact.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/ThemedAgGridReact.test.tsx
@@ -158,17 +158,60 @@ test('passes all props through to AgGridReact', () => {
     />,
   );
 
+  // onGridReady and onFirstDataRendered are intercepted by the component to expose
+  // the grid API on the container element; the wrapped function is passed instead.
   expect(AgGridReact).toHaveBeenCalledWith(
     expect.objectContaining({
       rowData: mockRowData,
       columnDefs: mockColumnDefs,
-      onGridReady,
+      onGridReady: expect.any(Function),
       onCellClicked,
       pagination: true,
       paginationPageSize: 10,
     }),
     expect.any(Object),
   );
+});
+
+test('onGridReady wrapper calls user callback and exposes api on container', () => {
+  const onGridReady = jest.fn();
+
+  render(
+    <ThemedAgGridReact
+      rowData={mockRowData}
+      columnDefs={mockColumnDefs}
+      onGridReady={onGridReady}
+    />,
+  );
+
+  // Retrieve the wrapped handler that was passed to AgGridReact
+  const lastCall = (AgGridReact as jest.Mock).mock.calls.at(-1)[0];
+  const wrappedOnGridReady = lastCall.onGridReady as Function;
+
+  const mockApi = { setGridOption: jest.fn() };
+  wrappedOnGridReady({ api: mockApi });
+
+  // The user-provided callback must be forwarded
+  expect(onGridReady).toHaveBeenCalledWith({ api: mockApi });
+});
+
+test('onFirstDataRendered wrapper calls user callback', () => {
+  const onFirstDataRendered = jest.fn();
+
+  render(
+    <ThemedAgGridReact
+      rowData={mockRowData}
+      columnDefs={mockColumnDefs}
+      onFirstDataRendered={onFirstDataRendered}
+    />,
+  );
+
+  const lastCall = (AgGridReact as jest.Mock).mock.calls.at(-1)[0];
+  const wrappedOnFirstDataRendered = lastCall.onFirstDataRendered as Function;
+
+  wrappedOnFirstDataRendered({ firstRow: 0 });
+
+  expect(onFirstDataRendered).toHaveBeenCalledWith({ firstRow: 0 });
 });
 
 test('applies custom theme colors from Superset theme', () => {

--- a/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/index.tsx
@@ -23,6 +23,7 @@ import {
   themeQuartz,
   colorSchemeDark,
   colorSchemeLight,
+  type GridApi,
   type GridReadyEvent,
   type FirstDataRenderedEvent,
 } from 'ag-grid-community';
@@ -30,6 +31,12 @@ import { useTheme, useThemeMode } from '@apache-superset/core/theme';
 
 // Note: With ag-grid v34's new theming API, CSS files are injected automatically
 // Do NOT import 'ag-grid-community/styles/ag-grid.css' or theme CSS files
+
+// Extends HTMLDivElement with ag-grid state attached to the container for downloadAsImage.
+export interface AgGridContainerElement extends HTMLDivElement {
+  _agGridApi?: GridApi;
+  _agGridFirstDataRendered?: boolean;
+}
 
 export interface ThemedAgGridReactProps extends AgGridReactProps {
   /**
@@ -79,7 +86,7 @@ export const ThemedAgGridReact = forwardRef<
 ) {
   const theme = useTheme();
   const isDarkMode = useThemeMode();
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<AgGridContainerElement>(null);
 
   // Get the appropriate ag-grid theme based on dark/light mode
   const agGridTheme = useMemo(() => {
@@ -150,8 +157,8 @@ export const ThemedAgGridReact = forwardRef<
   const handleGridReady = useCallback(
     (event: GridReadyEvent) => {
       if (containerRef.current) {
-        (containerRef.current as any)._agGridFirstDataRendered = false;
-        (containerRef.current as any)._agGridApi = event.api;
+        containerRef.current._agGridFirstDataRendered = false;
+        containerRef.current._agGridApi = event.api;
       }
       onGridReady?.(event);
     },
@@ -162,7 +169,7 @@ export const ThemedAgGridReact = forwardRef<
   const handleFirstDataRendered = useCallback(
     (event: FirstDataRenderedEvent) => {
       if (containerRef.current) {
-        (containerRef.current as any)._agGridFirstDataRendered = true;
+        containerRef.current._agGridFirstDataRendered = true;
       }
       onFirstDataRendered?.(event);
     },

--- a/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/index.tsx
@@ -150,6 +150,7 @@ export const ThemedAgGridReact = forwardRef<
   const handleGridReady = useCallback(
     (event: GridReadyEvent) => {
       if (containerRef.current) {
+        (containerRef.current as any)._agGridFirstDataRendered = false;
         (containerRef.current as any)._agGridApi = event.api;
       }
       onGridReady?.(event);

--- a/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/index.tsx
@@ -16,13 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, forwardRef } from 'react';
+import { useMemo, useRef, useCallback, forwardRef } from 'react';
 import { css } from '@emotion/react';
 import { AgGridReact, type AgGridReactProps } from 'ag-grid-react';
 import {
   themeQuartz,
   colorSchemeDark,
   colorSchemeLight,
+  type GridReadyEvent,
+  type FirstDataRenderedEvent,
 } from 'ag-grid-community';
 import { useTheme, useThemeMode } from '@apache-superset/core/theme';
 
@@ -71,9 +73,13 @@ export interface ThemedAgGridReactProps extends AgGridReactProps {
 export const ThemedAgGridReact = forwardRef<
   AgGridReact,
   ThemedAgGridReactProps
->(function ThemedAgGridReact({ themeOverrides, ...props }, ref) {
+>(function ThemedAgGridReact(
+  { themeOverrides, onGridReady, onFirstDataRendered, ...props },
+  ref,
+) {
   const theme = useTheme();
   const isDarkMode = useThemeMode();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Get the appropriate ag-grid theme based on dark/light mode
   const agGridTheme = useMemo(() => {
@@ -140,8 +146,31 @@ export const ThemedAgGridReact = forwardRef<
     return baseTheme.withParams(finalParams);
   }, [theme, isDarkMode, themeOverrides]);
 
+  // Expose gridApi and first-data-rendered flag on the container for downloadAsImage.
+  const handleGridReady = useCallback(
+    (event: GridReadyEvent) => {
+      if (containerRef.current) {
+        (containerRef.current as any)._agGridApi = event.api;
+      }
+      onGridReady?.(event);
+    },
+    [onGridReady],
+  );
+
+  // Mark the container once rows are painted so downloadAsImage can gate on readiness.
+  const handleFirstDataRendered = useCallback(
+    (event: FirstDataRenderedEvent) => {
+      if (containerRef.current) {
+        (containerRef.current as any)._agGridFirstDataRendered = true;
+      }
+      onFirstDataRendered?.(event);
+    },
+    [onFirstDataRendered],
+  );
+
   return (
     <div
+      ref={containerRef}
       css={css`
         width: 100%;
         height: 100%;
@@ -151,7 +180,13 @@ export const ThemedAgGridReact = forwardRef<
       `}
       data-themed-ag-grid="true"
     >
-      <AgGridReact ref={ref} theme={agGridTheme} {...props} />
+      <AgGridReact
+        ref={ref}
+        theme={agGridTheme}
+        onGridReady={handleGridReady}
+        onFirstDataRendered={handleFirstDataRendered}
+        {...props}
+      />
     </div>
   );
 });

--- a/superset-frontend/packages/superset-ui-core/src/components/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/index.ts
@@ -201,6 +201,7 @@ export * from './Result';
 export {
   ThemedAgGridReact,
   type ThemedAgGridReactProps,
+  type AgGridContainerElement,
   setupAGGridModules,
   defaultModules,
 } from './ThemedAgGridReact';

--- a/superset-frontend/src/utils/downloadAsImage.test.ts
+++ b/superset-frontend/src/utils/downloadAsImage.test.ts
@@ -83,6 +83,10 @@ beforeEach(() => {
   mockToJpeg.mockResolvedValue('data:image/jpeg;base64,test');
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 test('waitForStableScrollHeight resolves after 2 consecutive stable scrollHeight readings', async () => {
   jest.useFakeTimers();
   const el = document.createElement('div');
@@ -93,7 +97,7 @@ test('waitForStableScrollHeight resolves after 2 consecutive stable scrollHeight
 
   const promise = waitForStableScrollHeight(el);
   await jest.runAllTimersAsync();
-  await promise;
+  await expect(promise).resolves.toBeUndefined();
 
   jest.useRealTimers();
 });
@@ -110,14 +114,16 @@ test('waitForStableScrollHeight respects a custom minStablePolls', async () => {
   const promise = waitForStableScrollHeight(el, 5000, 5);
   jest.advanceTimersByTime(300);
   let resolved = false;
-  promise.then(() => { resolved = true; });
+  promise.then(() => {
+    resolved = true;
+  });
   // Flush microtasks so the .then() above has a chance to run if resolved
   await Promise.resolve();
   expect(resolved).toBe(false);
 
   // Now run the remaining polls (2 more stable polls → total 5) and confirm resolution.
   jest.advanceTimersByTime(300);
-  await promise;
+  await expect(promise).resolves.toBeUndefined();
 
   jest.useRealTimers();
 });
@@ -138,7 +144,7 @@ test('waitForStableScrollHeight resets stable count when height changes mid-poll
   height = 200;
   // Run until new height stabilises (2 consecutive 100 ms polls)
   jest.advanceTimersByTime(300);
-  await promise;
+  await expect(promise).resolves.toBeUndefined();
 
   jest.useRealTimers();
 });
@@ -158,7 +164,7 @@ test('waitForStableScrollHeight resolves after maxMs even if height never stabil
 
   const promise = waitForStableScrollHeight(el, 200);
   jest.advanceTimersByTime(400); // past the 200 ms deadline
-  await promise;
+  await expect(promise).resolves.toBeUndefined();
 
   jest.useRealTimers();
 });
@@ -179,7 +185,7 @@ test('waitForStableScrollHeight resolves if scrollHeight throws (element removed
   jest.advanceTimersByTime(100); // poll 1: stable, stableCount = 1
   shouldThrow = true; // simulate DOM removal
   jest.advanceTimersByTime(100); // poll 2: throws → resolves immediately
-  await promise;
+  await expect(promise).resolves.toBeUndefined();
 
   jest.useRealTimers();
 });
@@ -278,7 +284,10 @@ test('resolves ag-cell min-height to row pixel height when content fits within i
   // Build a row with a cell inside the grid
   const row = document.createElement('div');
   row.className = 'ag-row';
-  Object.defineProperty(row, 'offsetHeight', { get: () => 32, configurable: true });
+  Object.defineProperty(row, 'offsetHeight', {
+    get: () => 32,
+    configurable: true,
+  });
   const cell = document.createElement('div');
   cell.className = 'ag-cell';
   row.appendChild(cell);
@@ -312,10 +321,16 @@ test('uses cell scrollHeight when it exceeds row offsetHeight (stale row heights
 
   const row = document.createElement('div');
   row.className = 'ag-row';
-  Object.defineProperty(row, 'offsetHeight', { get: () => 25, configurable: true }); // stale default
+  Object.defineProperty(row, 'offsetHeight', {
+    get: () => 25,
+    configurable: true,
+  }); // stale default
   const cell = document.createElement('div');
   cell.className = 'ag-cell';
-  Object.defineProperty(cell, 'scrollHeight', { get: () => 120, configurable: true }); // actual content
+  Object.defineProperty(cell, 'scrollHeight', {
+    get: () => 120,
+    configurable: true,
+  }); // actual content
   row.appendChild(cell);
   agRootWrapper.appendChild(row);
 
@@ -353,10 +368,12 @@ test('derives image width from getColumnState by summing visible column pixel wi
   (api as any).applyColumnState = jest.fn();
 
   let capturedWidth: number | undefined;
-  mockToJpeg.mockImplementation((_el: HTMLElement, opts: { width?: number }) => {
-    capturedWidth = opts.width;
-    return Promise.resolve('data:image/jpeg;base64,test');
-  });
+  mockToJpeg.mockImplementation(
+    (_el: HTMLElement, opts: { width?: number }) => {
+      capturedWidth = opts.width;
+      return Promise.resolve('data:image/jpeg;base64,test');
+    },
+  );
 
   const handler = downloadAsImageOptimized('div', 'My Chart');
   const exportPromise = handler(syntheticEventFor(container));
@@ -401,6 +418,33 @@ test('restores column pixel widths via applyColumnState with flex stripped after
   jest.useRealTimers();
 });
 
+test('restores original column state with flex in finally after capture', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  const api = attachMockApi(agContainer);
+
+  const savedState = [
+    { colId: 'col1', width: 300, flex: 1, hide: false },
+    { colId: 'col2', width: 400, flex: 1.5, hide: false },
+  ];
+  (api as any).getColumnState = jest.fn(() => savedState);
+  (api as any).applyColumnState = jest.fn();
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  // Last call must restore the original state (with flex) so the live grid is unaffected
+  expect((api as any).applyColumnState.mock.calls.at(-1)[0]).toEqual({
+    state: savedState,
+    applyOrder: false,
+  });
+
+  cleanup();
+  jest.useRealTimers();
+});
+
 test('falls back to agRootWrapper.offsetWidth when getColumnState returns no visible columns', async () => {
   jest.useFakeTimers();
   const { container, agContainer, agRootWrapper, cleanup } =
@@ -419,10 +463,12 @@ test('falls back to agRootWrapper.offsetWidth when getColumnState returns no vis
   });
 
   let capturedWidth: number | undefined;
-  mockToJpeg.mockImplementation((_el: HTMLElement, opts: { width?: number }) => {
-    capturedWidth = opts.width;
-    return Promise.resolve('data:image/jpeg;base64,test');
-  });
+  mockToJpeg.mockImplementation(
+    (_el: HTMLElement, opts: { width?: number }) => {
+      capturedWidth = opts.width;
+      return Promise.resolve('data:image/jpeg;base64,test');
+    },
+  );
 
   const handler = downloadAsImageOptimized('div', 'My Chart');
   const exportPromise = handler(syntheticEventFor(container));
@@ -444,7 +490,10 @@ test('restores ag-cell styles after capture even when toJpeg throws', async () =
 
   const row = document.createElement('div');
   row.className = 'ag-row';
-  Object.defineProperty(row, 'offsetHeight', { get: () => 28, configurable: true });
+  Object.defineProperty(row, 'offsetHeight', {
+    get: () => 28,
+    configurable: true,
+  });
   const cell = document.createElement('div');
   cell.className = 'ag-cell';
   cell.style.minHeight = '100%';
@@ -496,6 +545,58 @@ test('does not throw when resetRowHeights is absent from the api', async () => {
 
   cleanup();
   jest.useRealTimers();
+});
+
+test('falls through to clone path for dashboard export with a single ag-grid chart', async () => {
+  const dashboard = document.createElement('div');
+  dashboard.className = 'dashboard';
+
+  const agContainer = document.createElement('div');
+  agContainer.setAttribute('data-themed-ag-grid', 'true');
+  const agRootWrapper = document.createElement('div');
+  agRootWrapper.className = 'ag-root-wrapper';
+  agContainer.appendChild(agRootWrapper);
+  (agContainer as any)._agGridFirstDataRendered = true;
+  dashboard.appendChild(agContainer);
+  document.body.appendChild(dashboard);
+
+  const handler = downloadAsImageOptimized('.dashboard', 'My Dashboard', true);
+  await handler({ currentTarget: {} } as any);
+
+  expect(mockToJpeg).toHaveBeenCalledWith(
+    expect.any(HTMLElement),
+    expect.objectContaining({ quality: 0.95 }),
+  );
+  expect(mockAddWarningToast).not.toHaveBeenCalled();
+
+  document.body.removeChild(dashboard);
+});
+
+test('falls through to clone path for dashboard export with multiple ag-grid charts', async () => {
+  const dashboard = document.createElement('div');
+  dashboard.className = 'dashboard';
+
+  for (let i = 0; i < 2; i += 1) {
+    const agContainer = document.createElement('div');
+    agContainer.setAttribute('data-themed-ag-grid', 'true');
+    const agRootWrapper = document.createElement('div');
+    agRootWrapper.className = 'ag-root-wrapper';
+    agContainer.appendChild(agRootWrapper);
+    (agContainer as any)._agGridFirstDataRendered = true;
+    dashboard.appendChild(agContainer);
+  }
+  document.body.appendChild(dashboard);
+
+  const handler = downloadAsImageOptimized('.dashboard', 'My Dashboard', true);
+  await handler({ currentTarget: {} } as any);
+
+  expect(mockToJpeg).toHaveBeenCalledWith(
+    expect.any(HTMLElement),
+    expect.objectContaining({ quality: 0.95 }),
+  );
+  expect(mockAddWarningToast).not.toHaveBeenCalled();
+
+  document.body.removeChild(dashboard);
 });
 
 test('captures JPEG for non-ag-grid elements via the clone path', async () => {
@@ -561,7 +662,7 @@ test('ag-grid path falls back to white background when theme is absent', async (
 
   expect(mockToJpeg).toHaveBeenCalledWith(
     expect.any(HTMLElement),
-    expect.objectContaining({ bgcolor: '#ffffff' }),
+    expect.objectContaining({ bgcolor: undefined }),
   );
 
   cleanup();
@@ -577,7 +678,7 @@ test('clone path falls back to white background when theme is absent', async () 
 
   expect(mockToJpeg).toHaveBeenCalledWith(
     expect.any(HTMLElement),
-    expect.objectContaining({ bgcolor: '#ffffff' }),
+    expect.objectContaining({ bgcolor: undefined }),
   );
 
   document.body.removeChild(container);

--- a/superset-frontend/src/utils/downloadAsImage.test.ts
+++ b/superset-frontend/src/utils/downloadAsImage.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import domToImage from 'dom-to-image-more';
+import { addWarningToast } from 'src/components/MessageToasts/actions';
+import downloadAsImageOptimized, {
+  waitForStableScrollHeight,
+} from './downloadAsImage';
+
+jest.mock('dom-to-image-more', () => ({
+  __esModule: true,
+  default: { toJpeg: jest.fn() },
+}));
+
+jest.mock('src/components/MessageToasts/actions', () => ({
+  addWarningToast: jest.fn(),
+}));
+
+jest.mock('@apache-superset/core/translation', () => ({
+  t: (str: string) => str,
+}));
+
+const mockToJpeg = domToImage.toJpeg as jest.Mock;
+const mockAddWarningToast = addWarningToast as jest.Mock;
+
+// document.fonts.ready is not implemented in jsdom; provide a resolved promise
+Object.defineProperty(document, 'fonts', {
+  value: { ready: Promise.resolve() },
+  configurable: true,
+});
+
+// Build a synthetic React event that resolves `currentTarget.closest()` to a given element
+function syntheticEventFor(el: Element) {
+  return { currentTarget: { closest: () => el } } as any;
+}
+
+// Build and attach an ag-grid DOM structure; returns cleanup function
+function buildAgGridElement() {
+  const container = document.createElement('div');
+  const agContainer = document.createElement('div');
+  agContainer.setAttribute('data-themed-ag-grid', 'true');
+  const agRootWrapper = document.createElement('div');
+  agRootWrapper.className = 'ag-root-wrapper';
+  agContainer.appendChild(agRootWrapper);
+  container.appendChild(agContainer);
+  document.body.appendChild(container);
+  return {
+    container,
+    agContainer,
+    agRootWrapper,
+    cleanup: () => document.body.removeChild(container),
+  };
+}
+
+// Attach a mock GridApi and set the first-data-rendered flag on the container
+function attachMockApi(
+  agContainer: HTMLElement,
+  { firstDataRendered = true } = {},
+) {
+  const api = { setGridOption: jest.fn() };
+  (agContainer as any)._agGridApi = api;
+  (agContainer as any)._agGridFirstDataRendered = firstDataRendered;
+  return api;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockToJpeg.mockResolvedValue('data:image/jpeg;base64,test');
+});
+
+test('waitForStableScrollHeight resolves after 2 consecutive stable scrollHeight readings', async () => {
+  jest.useFakeTimers();
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'scrollHeight', {
+    get: () => 100,
+    configurable: true,
+  });
+
+  const promise = waitForStableScrollHeight(el);
+  await jest.runAllTimersAsync();
+  await promise;
+
+  jest.useRealTimers();
+});
+
+test('waitForStableScrollHeight respects a custom minStablePolls', async () => {
+  jest.useFakeTimers();
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'scrollHeight', {
+    get: () => 100,
+    configurable: true,
+  });
+
+  // With minStablePolls=5 the promise must not resolve after just 2 polls.
+  const promise = waitForStableScrollHeight(el, 5000, 5);
+  jest.advanceTimersByTime(300);
+  let resolved = false;
+  promise.then(() => { resolved = true; });
+  // Flush microtasks so the .then() above has a chance to run if resolved
+  await Promise.resolve();
+  expect(resolved).toBe(false);
+
+  // Now run the remaining polls (2 more stable polls → total 5) and confirm resolution.
+  jest.advanceTimersByTime(300);
+  await promise;
+
+  jest.useRealTimers();
+});
+
+test('waitForStableScrollHeight resets stable count when height changes mid-poll', async () => {
+  jest.useFakeTimers();
+  const el = document.createElement('div');
+  let height = 100;
+  Object.defineProperty(el, 'scrollHeight', {
+    get: () => height,
+    configurable: true,
+  });
+
+  const promise = waitForStableScrollHeight(el);
+  // Poll 1: height is 100, stableCount becomes 1
+  jest.advanceTimersByTime(100);
+  // Height changes — stable counter must reset
+  height = 200;
+  // Run until new height stabilises (2 consecutive 100 ms polls)
+  jest.advanceTimersByTime(300);
+  await promise;
+
+  jest.useRealTimers();
+});
+
+test('waitForStableScrollHeight resolves after maxMs even if height never stabilises', async () => {
+  jest.useFakeTimers();
+  const el = document.createElement('div');
+  let height = 0;
+  Object.defineProperty(el, 'scrollHeight', {
+    // Always increments so stableFrames never reaches 4
+    get: () => {
+      height += 1;
+      return height;
+    },
+    configurable: true,
+  });
+
+  const promise = waitForStableScrollHeight(el, 200);
+  jest.advanceTimersByTime(400); // past the 200 ms deadline
+  await promise;
+
+  jest.useRealTimers();
+});
+
+test('waitForStableScrollHeight resolves if scrollHeight throws (element removed from DOM)', async () => {
+  jest.useFakeTimers();
+  const el = document.createElement('div');
+  let shouldThrow = false;
+  Object.defineProperty(el, 'scrollHeight', {
+    get: () => {
+      if (shouldThrow) throw new Error('element detached');
+      return 100;
+    },
+    configurable: true,
+  });
+
+  const promise = waitForStableScrollHeight(el);
+  jest.advanceTimersByTime(100); // poll 1: stable, stableCount = 1
+  shouldThrow = true; // simulate DOM removal
+  jest.advanceTimersByTime(100); // poll 2: throws → resolves immediately
+  await promise;
+
+  jest.useRealTimers();
+});
+
+test('shows warning toast when element is not found', async () => {
+  const handler = downloadAsImageOptimized('div', 'test');
+  // closest() returning null simulates a selector that matches nothing
+  await handler({ currentTarget: { closest: () => null } } as any);
+
+  expect(mockAddWarningToast).toHaveBeenCalledWith(
+    'Image download failed, please refresh and try again.',
+  );
+  expect(mockToJpeg).not.toHaveBeenCalled();
+});
+
+test('shows "still loading" toast when grid has not yet rendered its first rows', async () => {
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  attachMockApi(agContainer, { firstDataRendered: false });
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  await handler(syntheticEventFor(container));
+
+  expect(mockAddWarningToast).toHaveBeenCalledWith(
+    'The chart is still loading. Please wait a moment and try again.',
+  );
+  expect(mockToJpeg).not.toHaveBeenCalled();
+
+  cleanup();
+});
+
+test('switches to print layout, captures JPEG, and restores normal layout', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  const api = attachMockApi(agContainer);
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  expect(api.setGridOption).toHaveBeenCalledWith('domLayout', 'print');
+  expect(mockToJpeg).toHaveBeenCalledWith(
+    expect.any(HTMLElement),
+    expect.objectContaining({ quality: 0.95 }),
+  );
+  expect(api.setGridOption).toHaveBeenCalledWith('domLayout', 'normal');
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('restores normal layout in finally even when image capture throws', async () => {
+  jest.useFakeTimers();
+  mockToJpeg.mockRejectedValue(new Error('capture failed'));
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  const api = attachMockApi(agContainer);
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  expect(api.setGridOption).toHaveBeenCalledWith('domLayout', 'normal');
+  expect(mockAddWarningToast).toHaveBeenCalledWith(
+    'Image download failed, please refresh and try again.',
+  );
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('still captures image when _agGridApi is absent (graceful degradation)', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  // No API — only the first-data-rendered flag
+  (agContainer as any)._agGridFirstDataRendered = true;
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  expect(mockToJpeg).toHaveBeenCalled();
+  expect(mockAddWarningToast).not.toHaveBeenCalled();
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('resolves ag-cell min-height to row pixel height when content fits within it', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, agRootWrapper, cleanup } =
+    buildAgGridElement();
+  attachMockApi(agContainer);
+
+  // Build a row with a cell inside the grid
+  const row = document.createElement('div');
+  row.className = 'ag-row';
+  Object.defineProperty(row, 'offsetHeight', { get: () => 32, configurable: true });
+  const cell = document.createElement('div');
+  cell.className = 'ag-cell';
+  row.appendChild(cell);
+  agRootWrapper.appendChild(row);
+
+  let capturedMinHeight = '';
+  mockToJpeg.mockImplementation(() => {
+    capturedMinHeight = cell.style.minHeight;
+    return Promise.resolve('data:image/jpeg;base64,test');
+  });
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  // Cell min-height was resolved to the row's pixel height during capture
+  expect(capturedMinHeight).toBe('32px');
+  // Cell min-height was restored after capture
+  expect(cell.style.minHeight).toBe('');
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('uses cell scrollHeight when it exceeds row offsetHeight (stale row heights for off-screen rows)', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, agRootWrapper, cleanup } =
+    buildAgGridElement();
+  attachMockApi(agContainer);
+
+  const row = document.createElement('div');
+  row.className = 'ag-row';
+  Object.defineProperty(row, 'offsetHeight', { get: () => 25, configurable: true }); // stale default
+  const cell = document.createElement('div');
+  cell.className = 'ag-cell';
+  Object.defineProperty(cell, 'scrollHeight', { get: () => 120, configurable: true }); // actual content
+  row.appendChild(cell);
+  agRootWrapper.appendChild(row);
+
+  let capturedMinHeight = '';
+  mockToJpeg.mockImplementation(() => {
+    capturedMinHeight = cell.style.minHeight;
+    return Promise.resolve('data:image/jpeg;base64,test');
+  });
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  // Uses the larger content height, not the stale row height
+  expect(capturedMinHeight).toBe('120px');
+  expect(cell.style.minHeight).toBe('');
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('derives image width from getColumnState by summing visible column pixel widths', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  const api = attachMockApi(agContainer);
+
+  // 3 visible columns (200 + 350 + 150 = 700 px) plus one hidden column excluded from sum
+  (api as any).getColumnState = jest.fn(() => [
+    { colId: 'col1', width: 200, hide: false },
+    { colId: 'col2', width: 350, hide: false },
+    { colId: 'col3', width: 150, hide: false },
+    { colId: 'col4', width: 999, hide: true },
+  ]);
+  (api as any).applyColumnState = jest.fn();
+
+  let capturedWidth: number | undefined;
+  mockToJpeg.mockImplementation((_el: HTMLElement, opts: { width?: number }) => {
+    capturedWidth = opts.width;
+    return Promise.resolve('data:image/jpeg;base64,test');
+  });
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  // Width passed to toJpeg is the sum of visible column widths, not agRootWrapper.offsetWidth
+  expect(capturedWidth).toBe(700);
+  expect((api as any).getColumnState).toHaveBeenCalled();
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('restores column pixel widths via applyColumnState with flex stripped after print layout', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  const api = attachMockApi(agContainer);
+
+  const savedState = [
+    { colId: 'col1', width: 300, flex: 1, hide: false },
+    { colId: 'col2', width: 400, flex: 1.5, hide: false },
+  ];
+  (api as any).getColumnState = jest.fn(() => savedState);
+  (api as any).applyColumnState = jest.fn();
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  // flex must be stripped (set to null) so pixel width is used, not flex ratio
+  expect((api as any).applyColumnState).toHaveBeenCalledWith({
+    state: [
+      { colId: 'col1', width: 300, flex: null },
+      { colId: 'col2', width: 400, flex: null },
+    ],
+    applyOrder: false,
+  });
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('falls back to agRootWrapper.offsetWidth when getColumnState returns no visible columns', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, agRootWrapper, cleanup } =
+    buildAgGridElement();
+  const api = attachMockApi(agContainer);
+
+  // All columns hidden → visible sum is 0 → fall back to offsetWidth
+  (api as any).getColumnState = jest.fn(() => [
+    { colId: 'col1', width: 500, hide: true },
+  ]);
+  (api as any).applyColumnState = jest.fn();
+
+  Object.defineProperty(agRootWrapper, 'offsetWidth', {
+    get: () => 600,
+    configurable: true,
+  });
+
+  let capturedWidth: number | undefined;
+  mockToJpeg.mockImplementation((_el: HTMLElement, opts: { width?: number }) => {
+    capturedWidth = opts.width;
+    return Promise.resolve('data:image/jpeg;base64,test');
+  });
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  expect(capturedWidth).toBe(600);
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('restores ag-cell styles after capture even when toJpeg throws', async () => {
+  jest.useFakeTimers();
+  mockToJpeg.mockRejectedValue(new Error('capture failed'));
+  const { container, agContainer, agRootWrapper, cleanup } =
+    buildAgGridElement();
+  attachMockApi(agContainer);
+
+  const row = document.createElement('div');
+  row.className = 'ag-row';
+  Object.defineProperty(row, 'offsetHeight', { get: () => 28, configurable: true });
+  const cell = document.createElement('div');
+  cell.className = 'ag-cell';
+  cell.style.minHeight = '100%';
+  cell.style.overflow = 'visible';
+  row.appendChild(cell);
+  agRootWrapper.appendChild(row);
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  // Styles restored to original values despite capture error
+  expect(cell.style.minHeight).toBe('100%');
+  expect(cell.style.overflow).toBe('visible');
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('calls resetRowHeights after print layout to force ag-grid to re-measure rows with stale cached heights', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  const api = attachMockApi(agContainer);
+  (api as any).resetRowHeights = jest.fn();
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  expect(api.setGridOption).toHaveBeenCalledWith('domLayout', 'print');
+  expect((api as any).resetRowHeights).toHaveBeenCalled();
+  expect(api.setGridOption).toHaveBeenCalledWith('domLayout', 'normal');
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('does not throw when resetRowHeights is absent from the api', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  attachMockApi(agContainer); // api has only setGridOption, no resetRowHeights
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await expect(exportPromise).resolves.toBeUndefined();
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('captures JPEG for non-ag-grid elements via the clone path', async () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const handler = downloadAsImageOptimized('div', 'Bar Chart');
+  await handler(syntheticEventFor(container));
+
+  expect(mockToJpeg).toHaveBeenCalledWith(
+    expect.any(HTMLElement),
+    expect.objectContaining({ quality: 0.95 }),
+  );
+  expect(mockAddWarningToast).not.toHaveBeenCalled();
+
+  document.body.removeChild(container);
+});
+
+test('shows warning toast when clone capture throws', async () => {
+  mockToJpeg.mockRejectedValue(new Error('clone capture failed'));
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const handler = downloadAsImageOptimized('div', 'Bar Chart');
+  await handler(syntheticEventFor(container));
+
+  expect(mockAddWarningToast).toHaveBeenCalledWith(
+    'Image download failed, please refresh and try again.',
+  );
+
+  document.body.removeChild(container);
+});
+
+test('ag-grid path uses theme colorBgContainer as background', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  attachMockApi(agContainer);
+
+  const theme = { colorBgContainer: '#1a1a2e' } as any;
+  const handler = downloadAsImageOptimized('div', 'My Chart', false, theme);
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  expect(mockToJpeg).toHaveBeenCalledWith(
+    expect.any(HTMLElement),
+    expect.objectContaining({ bgcolor: '#1a1a2e' }),
+  );
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('ag-grid path falls back to white background when theme is absent', async () => {
+  jest.useFakeTimers();
+  const { container, agContainer, cleanup } = buildAgGridElement();
+  attachMockApi(agContainer);
+
+  const handler = downloadAsImageOptimized('div', 'My Chart');
+  const exportPromise = handler(syntheticEventFor(container));
+  await jest.runAllTimersAsync();
+  await exportPromise;
+
+  expect(mockToJpeg).toHaveBeenCalledWith(
+    expect.any(HTMLElement),
+    expect.objectContaining({ bgcolor: '#ffffff' }),
+  );
+
+  cleanup();
+  jest.useRealTimers();
+});
+
+test('clone path falls back to white background when theme is absent', async () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const handler = downloadAsImageOptimized('div', 'Bar Chart');
+  await handler(syntheticEventFor(container));
+
+  expect(mockToJpeg).toHaveBeenCalledWith(
+    expect.any(HTMLElement),
+    expect.objectContaining({ bgcolor: '#ffffff' }),
+  );
+
+  document.body.removeChild(container);
+});

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -26,6 +26,18 @@ import { addWarningToast } from 'src/components/MessageToasts/actions';
 
 const IMAGE_DOWNLOAD_QUALITY = 0.95;
 const TRANSPARENT_RGBA = 'transparent';
+const POLL_INTERVAL_MS = 100;
+
+// ag-grid column state subset used for width capture and restoration
+type ColumnState = {
+  colId: string;
+  width?: number;
+  flex?: number | null;
+  hide?: boolean | null;
+};
+
+// Tracks original cell styles to restore after capture
+type CellFixup = { el: HTMLElement; minHeight: string; overflow: string };
 
 /**
  * generate a consistent file stem from a description and date
@@ -80,6 +92,9 @@ const CRITICAL_STYLE_PROPERTIES = new Set([
   'table-layout',
   'vertical-align',
   'text-align',
+  'box-sizing',
+  'min-height',
+  'min-width',
 ]);
 
 const styleCache = new WeakMap<Element, CSSStyleDeclaration>();
@@ -262,6 +277,45 @@ const createEnhancedClone = (
   return { clone, cleanup };
 };
 
+// Polls until scrollHeight is stable for minStablePolls consecutive intervals or maxMs elapses.
+// ag-grid has no "layout settled" event, so polling is the recommended workaround.
+export const waitForStableScrollHeight = (
+  el: HTMLElement,
+  maxMs = 5000,
+  minStablePolls = 2,
+): Promise<void> =>
+  new Promise<void>(resolve => {
+    const deadline = Date.now() + maxMs;
+    let lastHeight = el.scrollHeight;
+    let stableCount = 0;
+
+    const poll = () => {
+      if (Date.now() >= deadline) {
+        resolve();
+        return;
+      }
+      try {
+        const h = el.scrollHeight;
+        if (h === lastHeight) {
+          stableCount += 1;
+          if (stableCount >= minStablePolls) {
+            resolve();
+            return;
+          }
+        } else {
+          stableCount = 0;
+          lastHeight = h;
+        }
+      } catch {
+        resolve(); // element removed from DOM
+        return;
+      }
+      setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    setTimeout(poll, POLL_INTERVAL_MS);
+  });
+
 export default function downloadAsImageOptimized(
   selector: string,
   description: string,
@@ -280,6 +334,126 @@ export default function downloadAsImageOptimized(
       return;
     }
 
+    const filter = (node: Element) =>
+      typeof node.className === 'string'
+        ? !node.className.includes('mapboxgl-control-container') &&
+          !node.className.includes('header-controls')
+        : true;
+
+    // ag-grid: switch to print layout (all rows in DOM), capture the live element
+    const agContainer = elementToPrint.querySelector(
+      '[data-themed-ag-grid]',
+    ) as HTMLElement | null;
+    const agRootWrapper = elementToPrint.querySelector(
+      '.ag-root-wrapper',
+    ) as HTMLElement | null;
+
+    if (agContainer && agRootWrapper) {
+      const api = (agContainer as any)._agGridApi as
+        | { setGridOption: (key: string, value: unknown) => void }
+        | undefined;
+      const isFirstDataRendered =
+        (agContainer as any)._agGridFirstDataRendered === true;
+
+      if (!isFirstDataRendered) {
+        addWarningToast(
+          t('The chart is still loading. Please wait a moment and try again.'),
+        );
+        return;
+      }
+
+      // Capture resolved pixel widths before print layout can re-trigger sizeColumnsToFit.
+      // sizeColumnsToFit() sets flex (not pixel widths), so after print layout expands the
+      // container it recalculates column widths wider. We restore with flex: null to force
+      // pixel widths when calling applyColumnState after the layout switch.
+      const savedColumnState = (api as any)?.getColumnState?.() as
+        | ColumnState[]
+        | undefined;
+      const visibleColumnState =
+        savedColumnState?.filter(col => !col.hide) ?? [];
+      const originalWidth =
+        visibleColumnState.reduce((sum, col) => sum + (col.width ?? 0), 0) ||
+        agRootWrapper.offsetWidth;
+
+      // Chrome SVG foreignObject bug: % min-height resolves against canvas height,
+      // causing cells to expand to full image height and overlap adjacent rows.
+      const cellFixups: CellFixup[] = [];
+
+      try {
+        await document.fonts.ready;
+
+        if (api) {
+          api.setGridOption('domLayout', 'print');
+
+          // Wait for ResizeObserver + any triggered sizeColumnsToFit() to settle,
+          // then restore column widths before measurement.
+          await new Promise<void>(resolve =>
+            requestAnimationFrame(() => requestAnimationFrame(resolve)),
+          );
+
+          if (visibleColumnState.length > 0) {
+            (api as any).applyColumnState?.({
+              state: visibleColumnState.map(col => ({
+                colId: col.colId,
+                width: col.width,
+                flex: null,
+              })),
+              applyOrder: false,
+            });
+          }
+
+          // Rows never scrolled into view have stale cached heights; remeasure all.
+          (api as any).resetRowHeights?.();
+
+          // 5 polls × POLL_INTERVAL_MS = 500 ms; autoHeight rows batch-measure slowly.
+          await waitForStableScrollHeight(agRootWrapper, 5000, 5);
+        }
+
+        agRootWrapper.querySelectorAll('.ag-cell').forEach(cell => {
+          const el = cell as HTMLElement;
+          const rowHeight = (el.parentElement as HTMLElement)?.offsetHeight ?? 0;
+          // scrollHeight catches any cells where resetRowHeights lagged behind.
+          const minH = Math.max(rowHeight, el.scrollHeight);
+          cellFixups.push({
+            el,
+            minHeight: el.style.minHeight,
+            overflow: el.style.overflow,
+          });
+          el.style.minHeight = minH > 0 ? `${minH}px` : '0px';
+          el.style.overflow = 'hidden';
+        });
+
+        const imageHeight = agRootWrapper.scrollHeight;
+
+        const dataUrl = await domToImage.toJpeg(agRootWrapper, {
+          bgcolor: theme?.colorBgContainer ?? '#ffffff',
+          filter,
+          quality: IMAGE_DOWNLOAD_QUALITY,
+          height: imageHeight,
+          width: originalWidth,
+          cacheBust: true,
+        });
+
+        const link = document.createElement('a');
+        link.download = `${generateFileStem(description)}.jpg`;
+        link.href = dataUrl;
+        link.click();
+      } catch (error) {
+        console.error('Creating image failed', error);
+        addWarningToast(
+          t('Image download failed, please refresh and try again.'),
+        );
+      } finally {
+        cellFixups.forEach(({ el, minHeight, overflow }) => {
+          el.style.minHeight = minHeight;
+          el.style.overflow = overflow;
+        });
+        api?.setGridOption('domLayout', 'normal');
+      }
+      return;
+    }
+
+    // All other chart types: use the clone-based approach
     let cleanup: (() => void) | null = null;
 
     try {
@@ -289,14 +463,8 @@ export default function downloadAsImageOptimized(
       );
       cleanup = cleanupFn;
 
-      const filter = (node: Element) =>
-        typeof node.className === 'string'
-          ? !node.className.includes('mapboxgl-control-container') &&
-            !node.className.includes('header-controls')
-          : true;
-
       const dataUrl = await domToImage.toJpeg(clone, {
-        bgcolor: theme?.colorBgContainer,
+        bgcolor: theme?.colorBgContainer ?? '#ffffff',
         filter,
         quality: IMAGE_DOWNLOAD_QUALITY,
         height: clone.scrollHeight,

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -340,13 +340,19 @@ export default function downloadAsImageOptimized(
           !node.className.includes('header-controls')
         : true;
 
-    // ag-grid: switch to print layout (all rows in DOM), capture the live element
-    const agContainer = elementToPrint.querySelector(
-      '[data-themed-ag-grid]',
-    ) as HTMLElement | null;
-    const agRootWrapper = elementToPrint.querySelector(
-      '.ag-root-wrapper',
-    ) as HTMLElement | null;
+    // Only apply ag-grid path for single-chart captures.
+    // Skip entirely for dashboard-level exports (selector targets the .dashboard root).
+    const isDashboardCapture = (
+      elementToPrint as HTMLElement
+    ).classList.contains('dashboard');
+    const agContainers = isDashboardCapture
+      ? []
+      : elementToPrint.querySelectorAll('[data-themed-ag-grid]');
+    const agContainer =
+      agContainers.length === 1 ? (agContainers[0] as HTMLElement) : null;
+    const agRootWrapper = agContainer
+      ? (agContainer.querySelector('.ag-root-wrapper') as HTMLElement | null)
+      : null;
 
     if (agContainer && agRootWrapper) {
       const api = (agContainer as any)._agGridApi as
@@ -388,7 +394,7 @@ export default function downloadAsImageOptimized(
           // Wait for ResizeObserver + any triggered sizeColumnsToFit() to settle,
           // then restore column widths before measurement.
           await new Promise<void>(resolve =>
-            requestAnimationFrame(() => requestAnimationFrame(resolve)),
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
           );
 
           if (visibleColumnState.length > 0) {
@@ -411,7 +417,8 @@ export default function downloadAsImageOptimized(
 
         agRootWrapper.querySelectorAll('.ag-cell').forEach(cell => {
           const el = cell as HTMLElement;
-          const rowHeight = (el.parentElement as HTMLElement)?.offsetHeight ?? 0;
+          const rowHeight =
+            (el.parentElement as HTMLElement)?.offsetHeight ?? 0;
           // scrollHeight catches any cells where resetRowHeights lagged behind.
           const minH = Math.max(rowHeight, el.scrollHeight);
           cellFixups.push({
@@ -426,7 +433,7 @@ export default function downloadAsImageOptimized(
         const imageHeight = agRootWrapper.scrollHeight;
 
         const dataUrl = await domToImage.toJpeg(agRootWrapper, {
-          bgcolor: theme?.colorBgContainer ?? '#ffffff',
+          bgcolor: theme?.colorBgContainer,
           filter,
           quality: IMAGE_DOWNLOAD_QUALITY,
           height: imageHeight,
@@ -448,7 +455,15 @@ export default function downloadAsImageOptimized(
           el.style.minHeight = minHeight;
           el.style.overflow = overflow;
         });
-        api?.setGridOption('domLayout', 'normal');
+        if (api) {
+          api.setGridOption('domLayout', 'normal');
+          if (savedColumnState) {
+            (api as any).applyColumnState?.({
+              state: savedColumnState,
+              applyOrder: false,
+            });
+          }
+        }
       }
       return;
     }
@@ -464,7 +479,7 @@ export default function downloadAsImageOptimized(
       cleanup = cleanupFn;
 
       const dataUrl = await domToImage.toJpeg(clone, {
-        bgcolor: theme?.colorBgContainer ?? '#ffffff',
+        bgcolor: theme?.colorBgContainer,
         filter,
         quality: IMAGE_DOWNLOAD_QUALITY,
         height: clone.scrollHeight,

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -19,22 +19,14 @@
 import { SyntheticEvent } from 'react';
 import domToImage from 'dom-to-image-more';
 import { kebabCase } from 'lodash';
-// eslint-disable-next-line no-restricted-imports
 import { t } from '@apache-superset/core/translation';
 import { SupersetTheme } from '@apache-superset/core/theme';
 import { addWarningToast } from 'src/components/MessageToasts/actions';
+import type { AgGridContainerElement } from '@superset-ui/core/components';
 
 const IMAGE_DOWNLOAD_QUALITY = 0.95;
 const TRANSPARENT_RGBA = 'transparent';
 const POLL_INTERVAL_MS = 100;
-
-// ag-grid column state subset used for width capture and restoration
-type ColumnState = {
-  colId: string;
-  width?: number;
-  flex?: number | null;
-  hide?: boolean | null;
-};
 
 // Tracks original cell styles to restore after capture
 type CellFixup = { el: HTMLElement; minHeight: string; overflow: string };
@@ -349,17 +341,17 @@ export default function downloadAsImageOptimized(
       ? []
       : elementToPrint.querySelectorAll('[data-themed-ag-grid]');
     const agContainer =
-      agContainers.length === 1 ? (agContainers[0] as HTMLElement) : null;
+      agContainers.length === 1
+        ? (agContainers[0] as AgGridContainerElement)
+        : null;
     const agRootWrapper = agContainer
       ? (agContainer.querySelector('.ag-root-wrapper') as HTMLElement | null)
       : null;
 
     if (agContainer && agRootWrapper) {
-      const api = (agContainer as any)._agGridApi as
-        | { setGridOption: (key: string, value: unknown) => void }
-        | undefined;
+      const api = agContainer._agGridApi;
       const isFirstDataRendered =
-        (agContainer as any)._agGridFirstDataRendered === true;
+        agContainer._agGridFirstDataRendered === true;
 
       if (!isFirstDataRendered) {
         addWarningToast(
@@ -372,9 +364,7 @@ export default function downloadAsImageOptimized(
       // sizeColumnsToFit() sets flex (not pixel widths), so after print layout expands the
       // container it recalculates column widths wider. We restore with flex: null to force
       // pixel widths when calling applyColumnState after the layout switch.
-      const savedColumnState = (api as any)?.getColumnState?.() as
-        | ColumnState[]
-        | undefined;
+      const savedColumnState = api?.getColumnState?.();
       const visibleColumnState =
         savedColumnState?.filter(col => !col.hide) ?? [];
       const originalWidth =
@@ -398,7 +388,7 @@ export default function downloadAsImageOptimized(
           );
 
           if (visibleColumnState.length > 0) {
-            (api as any).applyColumnState?.({
+            api.applyColumnState?.({
               state: visibleColumnState.map(col => ({
                 colId: col.colId,
                 width: col.width,
@@ -409,7 +399,7 @@ export default function downloadAsImageOptimized(
           }
 
           // Rows never scrolled into view have stale cached heights; remeasure all.
-          (api as any).resetRowHeights?.();
+          api.resetRowHeights?.();
 
           // 5 polls × POLL_INTERVAL_MS = 500 ms; autoHeight rows batch-measure slowly.
           await waitForStableScrollHeight(agRootWrapper, 5000, 5);
@@ -458,7 +448,7 @@ export default function downloadAsImageOptimized(
         if (api) {
           api.setGridOption('domLayout', 'normal');
           if (savedColumnState) {
-            (api as any).applyColumnState?.({
+            api.applyColumnState?.({
               state: savedColumnState,
               applyOrder: false,
             });


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes an existing issue when downloading an `ag-grid` table as an image (jpeg). Now everytime we want to export as an image an `ag-grid` table, this should should work as expected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before:** (jpeg image generated on export)
<img width="584" height="399" alt="image" src="https://github.com/user-attachments/assets/6059a6d6-33cc-41bd-a87b-674ae6f2ecdd" />

**After:** (jpeg image generated on export)
![test-2026-03-21T04-03-36 822Z](https://github.com/user-attachments/assets/1f649d8c-5d6f-4473-aa75-9054807b562c)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Open an `ag-grid` Table chart (or a dashboard with an `ag-grid` table).
2. Click `Export screenshot (jpeg)` from chart editor. All loaded rows should appear with correct layout and colors.
3. Click `Download as image` from a dashboard. All loaded rows should appear with correct layout and colors.


___

## **CodeAnt-AI Description**
**Fix ag-grid JPEG exports and keep table layout intact**

### What Changed
- ag-grid tables now wait until rows are fully rendered before image export starts, with a clear warning if the chart is still loading.
- During export, the table switches to a print-friendly layout so all rows and columns appear in the JPEG, then returns to its normal layout afterward.
- Row heights and column widths are preserved during capture to avoid cropped, overlapping, or stretched cells.
- Other chart types still use the existing image export path.

### Impact
`✅ Reliable ag-grid image downloads`
`✅ Fewer cropped or overlapping table rows`
`✅ Clearer loading warnings during export`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
