### PR TITLE
fix(mcp): prevent encoding errors and fix tool bugs on MCP client transports

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -277,6 +277,20 @@ def _setup_user_context() -> User | None:
             logger.debug("No Flask app context available for user setup")
             return None
         raise
+    except ValueError as e:
+        # JWT user resolution failed (e.g. SAML subject not in DB).
+        # If middleware already set g.user (request context exists),
+        # use that instead of failing closed.
+        from flask import has_request_context
+
+        if has_request_context() and hasattr(g, "user") and g.user:
+            logger.warning(
+                "JWT user resolution failed (%s), using middleware-provided g.user=%s",
+                e,
+                g.user.username,
+            )
+            return g.user
+        raise
 
     # Validate user has necessary relationships loaded
     # (Force access to ensure they're loaded if lazy)

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -289,8 +289,11 @@ def _setup_user_context() -> User | None:
                 e,
                 g.user.username,
             )
-            return g.user
-        raise
+            # Assign to local so relationship validation below runs
+            # (same as the normal path) to prevent detached instance errors.
+            user = g.user
+        else:
+            raise
 
     # Validate user has necessary relationships loaded
     # (Force access to ensure they're loaded if lazy)

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -442,12 +442,8 @@ def add_chart_to_existing_dashboard(
             published=updated_dashboard.published,
             created_on=updated_dashboard.created_on,
             changed_on=updated_dashboard.changed_on,
-            created_by=updated_dashboard.created_by.username
-            if updated_dashboard.created_by
-            else None,
-            changed_by=updated_dashboard.changed_by.username
-            if updated_dashboard.changed_by
-            else None,
+            created_by=updated_dashboard.changed_by_name or None,
+            changed_by=updated_dashboard.changed_by_name or None,
             uuid=str(updated_dashboard.uuid) if updated_dashboard.uuid else None,
             url=f"{get_superset_base_url()}/superset/dashboard/{updated_dashboard.id}/",
             chart_count=len(updated_dashboard.slices),

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -442,7 +442,7 @@ def add_chart_to_existing_dashboard(
             published=updated_dashboard.published,
             created_on=updated_dashboard.created_on,
             changed_on=updated_dashboard.changed_on,
-            created_by=updated_dashboard.changed_by_name or None,
+            created_by=updated_dashboard.created_by_name or None,
             changed_by=updated_dashboard.changed_by_name or None,
             uuid=str(updated_dashboard.uuid) if updated_dashboard.uuid else None,
             url=f"{get_superset_base_url()}/superset/dashboard/{updated_dashboard.id}/",

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -322,7 +322,7 @@ def generate_dashboard(
             published=dashboard.published,
             created_on=dashboard.created_on,
             changed_on=dashboard.changed_on,
-            created_by=dashboard.changed_by_name or None,
+            created_by=dashboard.created_by_name or None,
             changed_by=dashboard.changed_by_name or None,
             uuid=str(dashboard.uuid) if dashboard.uuid else None,
             url=f"{get_superset_base_url()}/superset/dashboard/{dashboard.id}/",

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -237,10 +237,8 @@ def generate_dashboard(
 
         # Prepare dashboard data and create dashboard
         with event_logger.log_context(action="mcp.generate_dashboard.db_write"):
-            dashboard_data = {
+            dashboard_data: Dict[str, Any] = {
                 "dashboard_title": dashboard_title,
-                "slug": None,  # Let Superset auto-generate slug
-                "css": "",
                 "json_metadata": json.dumps(
                     {
                         "filter_scopes": {},
@@ -271,8 +269,23 @@ def generate_dashboard(
                 dashboard_data["description"] = request.description
 
             # Create the dashboard using Superset's command pattern
-            command = CreateDashboardCommand(dashboard_data)
-            dashboard = command.run()
+            try:
+                command = CreateDashboardCommand(dashboard_data)
+                dashboard = command.run()
+            except Exception as cmd_err:
+                # Surface the root cause from @transaction's error wrapping
+                root_cause = cmd_err.__cause__ or cmd_err
+                logger.error(
+                    "CreateDashboardCommand failed: %s (cause: %s)",
+                    cmd_err,
+                    root_cause,
+                    exc_info=True,
+                )
+                return GenerateDashboardResponse(
+                    dashboard=None,
+                    dashboard_url=None,
+                    error=f"Failed to create dashboard: {root_cause}",
+                )
 
         # Re-fetch the dashboard with eager-loaded relationships to avoid
         # "Instance is not bound to a Session" errors when serializing
@@ -309,8 +322,8 @@ def generate_dashboard(
             published=dashboard.published,
             created_on=dashboard.created_on,
             changed_on=dashboard.changed_on,
-            created_by=dashboard.created_by.username if dashboard.created_by else None,
-            changed_by=dashboard.changed_by.username if dashboard.changed_by else None,
+            created_by=dashboard.changed_by_name or None,
+            changed_by=dashboard.changed_by_name or None,
             uuid=str(dashboard.uuid) if dashboard.uuid else None,
             url=f"{get_superset_base_url()}/superset/dashboard/{dashboard.id}/",
             chart_count=len(request.chart_ids),

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -20,8 +20,10 @@ import time
 from collections import defaultdict
 from typing import Any, Awaitable, Callable, Dict, Protocol
 
+import mcp.types as mt
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
 from flask import has_app_context
 from pydantic import ValidationError
 from sqlalchemy.exc import OperationalError, TimeoutError
@@ -257,6 +259,29 @@ class PrivateToolMiddleware(Middleware):
         if "private" in getattr(tool, "tags", set()):
             raise ToolError(f"Access denied to private tool: {context.message.name}")
         return await call_next(context)
+
+
+class StructuredContentStripperMiddleware(Middleware):
+    """Strip ``structured_content`` from tool results to prevent encoding errors.
+
+    FastMCP 3.x auto-generates ``structuredContent`` in tool call responses
+    when the tool has a typed return annotation or output schema.  Some MCP
+    client transports (e.g. Claude.ai's MCP bridge) mishandle this dict,
+    causing ``TypeError: encoding without a string argument``.
+
+    This middleware intercepts every ``tools/call`` result and clears
+    ``structured_content`` so only the text ``content`` list is returned.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: Callable[[MiddlewareContext], Awaitable[ToolResult]],
+    ) -> ToolResult:
+        result = await call_next(context)
+        if isinstance(result, ToolResult) and result.structured_content is not None:
+            result = ToolResult(content=result.content, meta=result.meta)
+        return result
 
 
 class GlobalErrorHandlerMiddleware(Middleware):

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from typing import Any, Awaitable, Callable, Dict, Protocol, Sequence
 
 import mcp.types as mt
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import FastMCPError, NotFoundError, ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.server.middleware.middleware import CallNext
 from fastmcp.tools.tool import Tool, ToolResult
@@ -299,7 +299,18 @@ class StructuredContentStripperMiddleware(Middleware):
         context: MiddlewareContext[mt.CallToolRequestParams],
         call_next: Callable[[MiddlewareContext], Awaitable[ToolResult]],
     ) -> ToolResult:
-        result = await call_next(context)
+        try:
+            result = await call_next(context)
+        except (FastMCPError, NotFoundError, ValidationError) as e:
+            # When exceptions propagate past the middleware chain to the
+            # MCP SDK layer, they become CallToolResult(isError=True).
+            # Some transports (Claude.ai's MCP bridge) cannot encode these
+            # error responses, producing "encoding without a string argument".
+            # Convert to a plain text ToolResult so the error message reaches
+            # the client through the normal response path.
+            return ToolResult(
+                content=[mt.TextContent(type="text", text=f"Error: {e}")],
+            )
         if isinstance(result, ToolResult) and result.structured_content is not None:
             result = ToolResult(content=result.content, meta=result.meta)
         return result

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -18,12 +18,13 @@
 import logging
 import time
 from collections import defaultdict
-from typing import Any, Awaitable, Callable, Dict, Protocol
+from typing import Any, Awaitable, Callable, Dict, Protocol, Sequence
 
 import mcp.types as mt
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
-from fastmcp.tools.tool import ToolResult
+from fastmcp.server.middleware.middleware import CallNext
+from fastmcp.tools.tool import Tool, ToolResult
 from flask import has_app_context
 from pydantic import ValidationError
 from sqlalchemy.exc import OperationalError, TimeoutError
@@ -262,16 +263,36 @@ class PrivateToolMiddleware(Middleware):
 
 
 class StructuredContentStripperMiddleware(Middleware):
-    """Strip ``structured_content`` from tool results to prevent encoding errors.
+    """Strip ``outputSchema`` and ``structured_content`` to prevent encoding errors.
 
-    FastMCP 3.x auto-generates ``structuredContent`` in tool call responses
-    when the tool has a typed return annotation or output schema.  Some MCP
-    client transports (e.g. Claude.ai's MCP bridge) mishandle this dict,
-    causing ``TypeError: encoding without a string argument``.
+    FastMCP 3.x auto-generates ``outputSchema`` in tool definitions
+    (``tools/list``) and ``structuredContent`` in tool call responses
+    (``tools/call``) when the tool has a typed return annotation.
 
-    This middleware intercepts every ``tools/call`` result and clears
-    ``structured_content`` so only the text ``content`` list is returned.
+    Some MCP client transports (e.g. Claude.ai's MCP bridge) cannot handle
+    ``structuredContent`` dicts, causing ``TypeError: encoding without a
+    string argument``.  Additionally, if ``outputSchema`` is advertised but
+    ``structuredContent`` is stripped from the response, clients may raise
+    ``Output validation error: outputSchema defined but no structured output
+    returned``.
+
+    This middleware handles both sides:
+    - ``on_list_tools``: removes ``output_schema`` from every tool definition
+    - ``on_call_tool``: removes ``structured_content`` from every tool result
     """
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        tools = await call_next(context)
+        return [
+            t.model_copy(update={"output_schema": None})
+            if t.output_schema is not None
+            else t
+            for t in tools
+        ]
 
     async def on_call_tool(
         self,

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from typing import Any, Awaitable, Callable, Dict, Protocol, Sequence
 
 import mcp.types as mt
-from fastmcp.exceptions import FastMCPError, NotFoundError, ToolError
+from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.server.middleware.middleware import CallNext
 from fastmcp.tools.tool import Tool, ToolResult
@@ -301,13 +301,15 @@ class StructuredContentStripperMiddleware(Middleware):
     ) -> ToolResult:
         try:
             result = await call_next(context)
-        except (FastMCPError, NotFoundError, ValidationError) as e:
+        except Exception as e:
             # When exceptions propagate past the middleware chain to the
             # MCP SDK layer, they become CallToolResult(isError=True).
             # Some transports (Claude.ai's MCP bridge) cannot encode these
             # error responses, producing "encoding without a string argument".
-            # Convert to a plain text ToolResult so the error message reaches
-            # the client through the normal response path.
+            # Catch ALL exceptions (not just specific types) because any
+            # unhandled exception — including ToolError from
+            # GlobalErrorHandlerMiddleware, ValueError, TypeError, etc. —
+            # will cause encoding failures on the wire.
             return ToolResult(
                 content=[mt.TextContent(type="text", text=f"Error: {e}")],
             )

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -39,6 +39,7 @@ from superset.mcp_service.middleware import (
     create_response_size_guard_middleware,
     GlobalErrorHandlerMiddleware,
     LoggingMiddleware,
+    StructuredContentStripperMiddleware,
 )
 from superset.mcp_service.storage import _create_redis_store
 from superset.utils import json
@@ -435,6 +436,10 @@ def run_server(
 
         # Add logging middleware (logs all tool calls with duration tracking)
         middleware_list.append(LoggingMiddleware())
+
+        # Strip outputSchema from tool definitions and structuredContent from
+        # tool responses to prevent encoding errors on Claude.ai's MCP bridge.
+        middleware_list.append(StructuredContentStripperMiddleware())
 
         # Add global error handler (outermost – catches all exceptions)
         middleware_list.append(GlobalErrorHandlerMiddleware())

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -437,12 +437,14 @@ def run_server(
         # Add logging middleware (logs all tool calls with duration tracking)
         middleware_list.append(LoggingMiddleware())
 
+        # Add global error handler (catches all exceptions, raises ToolError)
+        middleware_list.append(GlobalErrorHandlerMiddleware())
+
         # Strip outputSchema from tool definitions and structuredContent from
         # tool responses to prevent encoding errors on Claude.ai's MCP bridge.
+        # MUST be outermost so it catches ToolError from GlobalErrorHandler
+        # and converts to plain text before the MCP SDK tries to encode it.
         middleware_list.append(StructuredContentStripperMiddleware())
-
-        # Add global error handler (outermost – catches all exceptions)
-        middleware_list.append(GlobalErrorHandlerMiddleware())
 
         mcp_instance = init_fastmcp_server(
             auth=auth_provider,

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -28,6 +28,7 @@ import logging
 from decimal import Decimal
 from typing import Any
 
+import pandas as pd
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 from superset_core.queries.types import (
@@ -176,6 +177,46 @@ def _sanitize_row_values(rows: list[dict[str, Any]]) -> None:
                 row[key] = str(value)
 
 
+def _data_to_statement_data(data: Any) -> StatementData:
+    """Convert statement data (DataFrame, list, dict, bytes) to StatementData.
+
+    When results come from cache, data may be a dict/list/bytes instead of
+    a pandas DataFrame. This function handles all cases defensively.
+    """
+    from superset.utils import json as json_utils
+
+    if isinstance(data, list):
+        rows_data = data
+    elif isinstance(data, dict):
+        rows_data = data.get("data", [data])
+        if not isinstance(rows_data, list):
+            rows_data = [rows_data]
+    elif isinstance(data, pd.DataFrame):
+        rows_data = data.to_dict(orient="records")
+        _sanitize_row_values(rows_data)
+        return StatementData(
+            rows=rows_data,
+            columns=[
+                ColumnInfo(name=col, type=str(data[col].dtype)) for col in data.columns
+            ],
+        )
+    elif isinstance(data, bytes):
+        try:
+            decoded = json_utils.loads(data)
+            rows_data = decoded if isinstance(decoded, list) else [decoded]
+        except (ValueError, UnicodeDecodeError):
+            rows_data = []
+    else:
+        rows_data = [{"value": str(data)}]
+
+    _sanitize_row_values(rows_data)
+    col_names = list(rows_data[0].keys()) if rows_data else []
+    return StatementData(
+        rows=rows_data,
+        columns=[ColumnInfo(name=col, type="object") for col in col_names],
+    )
+
+
 def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
     """Convert QueryResult to ExecuteSqlResponse."""
     if result.status != QueryStatus.SUCCESS:
@@ -193,15 +234,7 @@ def _convert_to_response(result: QueryResult) -> ExecuteSqlResponse:
     for stmt in result.statements:
         stmt_data: StatementData | None = None
         if stmt.data is not None:
-            df = stmt.data
-            rows_data = df.to_dict(orient="records")
-            _sanitize_row_values(rows_data)
-            stmt_data = StatementData(
-                rows=rows_data,
-                columns=[
-                    ColumnInfo(name=col, type=str(df[col].dtype)) for col in df.columns
-                ],
-            )
+            stmt_data = _data_to_statement_data(stmt.data)
             data_bearing_count += 1
 
         statements.append(

--- a/superset/mcp_service/sql_lab/tool/save_sql_query.py
+++ b/superset/mcp_service/sql_lab/tool/save_sql_query.py
@@ -126,10 +126,10 @@ async def save_sql_query(
             id=saved_query.id,
             label=saved_query.label,
             sql=saved_query.sql,
-            database_id=request.database_id,
-            schema_name=request.schema_name,
+            database_id=saved_query.db_id,
+            schema_name=saved_query.schema or None,
             catalog=getattr(saved_query, "catalog", None),
-            description=request.description,
+            description=saved_query.description or None,
             url=saved_query_url,
         )
 

--- a/superset/mcp_service/utils/schema_utils.py
+++ b/superset/mcp_service/utils/schema_utils.py
@@ -467,7 +467,18 @@ def _create_string_parsing_wrapper(
     """
     import types
 
+    # Detect empty request models (no required fields) so
+    # FastMCP doesn't reject calls without arguments
+    # (e.g. get_instance_info via call_tool proxy).
+    _model_has_no_required_fields = not any(
+        f.is_required() for f in request_class.model_fields.values()
+    )
+
     def _maybe_parse(request: Any) -> Any:
+        # Auto-instantiate empty request models when no arguments provided
+        if (request is None or request == "{}") and _model_has_no_required_fields:
+            return request_class()
+
         if _is_parse_request_enabled():
             try:
                 return parse_json_or_model(request, request_class, "request")
@@ -539,7 +550,12 @@ def _create_string_parsing_wrapper(
     new_wrapper.__doc__ = func.__doc__
 
     request_annotation = str | request_class
-    _apply_signature_for_fastmcp(new_wrapper, func, request_annotation)
+    _apply_signature_for_fastmcp(
+        new_wrapper,
+        func,
+        request_annotation,
+        request_default="{}" if _model_has_no_required_fields else None,
+    )
 
     return new_wrapper
 
@@ -678,6 +694,7 @@ def _apply_signature_for_fastmcp(
     wrapper: Any,
     original_func: Callable[..., Any],
     request_annotation: Any,
+    request_default: Any = None,
 ) -> None:
     """Apply annotations and signature to wrapper, stripping ctx for FastMCP.
 
@@ -705,7 +722,10 @@ def _apply_signature_for_fastmcp(
         if _is_context_param(param, name, FMContext):
             continue
         if name == "request":
-            new_params.append(param.replace(annotation=request_annotation))
+            replacement = {"annotation": request_annotation}
+            if request_default is not None:
+                replacement["default"] = request_default
+            new_params.append(param.replace(**replacement))
         else:
             new_params.append(param)
     wrapper.__signature__ = orig_sig.replace(parameters=new_params)

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -839,13 +839,22 @@ class SQLExecutor:
             or app.config.get("CACHE_DEFAULT_TIMEOUT", 300)
         )
 
-        # Serialize statement results for caching
+        # Serialize statement results for caching.
+        # Convert DataFrames to list-of-dicts so the cache backend
+        # does not need to pickle pandas objects (which can fail to
+        # deserialize correctly with some backends or pandas versions).
+        import pandas as pd
+
         cached_data = {
             "statements": [
                 {
                     "original_sql": stmt.original_sql,
                     "executed_sql": stmt.executed_sql,
-                    "data": stmt.data,
+                    "data": (
+                        stmt.data.to_dict(orient="records")
+                        if isinstance(stmt.data, pd.DataFrame)
+                        else stmt.data
+                    ),
                     "row_count": stmt.row_count,
                     "execution_time_ms": stmt.execution_time_ms,
                 }

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -42,7 +42,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
+@pytest.fixture()
 def mcp_server():
     return mcp
 
@@ -96,6 +96,7 @@ def _mock_dashboard(id: int = 1, title: str = "Test Dashboard") -> Mock:
     dashboard.created_by.username = "test_user"
     dashboard.changed_by = Mock()
     dashboard.changed_by.username = "test_user"
+    dashboard.changed_by_name = "test_user"
     dashboard.uuid = f"dashboard-uuid-{id}"
     dashboard.slices = []
     dashboard.owners = []
@@ -109,7 +110,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_basic(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -151,7 +152,7 @@ class TestGenerateDashboard:
             )
 
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_missing_charts(self, mock_db_session, mcp_server):
         """Test error handling when some charts don't exist."""
         mock_query = Mock()
@@ -174,7 +175,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_single_chart(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -206,7 +207,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_many_charts(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -278,7 +279,7 @@ class TestGenerateDashboard:
 
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_creation_failure(
         self, mock_db_session, mock_create_command, mcp_server
     ):
@@ -303,7 +304,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_minimal_request(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -342,7 +343,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_auto_title_from_charts(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -375,7 +376,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_empty_string_title_preserved(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -411,7 +412,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_dashboard_basic(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -497,7 +498,7 @@ class TestAddChartToExistingDashboard:
             assert layout[column_key]["type"] == "COLUMN"
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_dashboard_not_found(self, mock_find_dashboard, mcp_server):
         """Test error when dashboard doesn't exist."""
         mock_find_dashboard.return_value = None
@@ -514,7 +515,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_chart_not_found(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -532,7 +533,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_already_in_dashboard(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -556,7 +557,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_empty_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -612,7 +613,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_tabbed_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -712,7 +713,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_specific_tab_by_name(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -813,7 +814,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -42,7 +42,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mcp_server():
     return mcp
 
@@ -111,7 +111,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_basic(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -153,7 +153,7 @@ class TestGenerateDashboard:
             )
 
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_missing_charts(self, mock_db_session, mcp_server):
         """Test error handling when some charts don't exist."""
         mock_query = Mock()
@@ -176,7 +176,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_single_chart(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -208,7 +208,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_many_charts(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -280,7 +280,7 @@ class TestGenerateDashboard:
 
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_creation_failure(
         self, mock_db_session, mock_create_command, mcp_server
     ):
@@ -305,7 +305,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_minimal_request(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -344,7 +344,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_auto_title_from_charts(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -377,7 +377,7 @@ class TestGenerateDashboard:
     @patch("superset.commands.dashboard.create.CreateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_empty_string_title_preserved(
         self, mock_db_session, mock_find_by_id, mock_create_command, mcp_server
     ):
@@ -413,7 +413,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_dashboard_basic(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -499,7 +499,7 @@ class TestAddChartToExistingDashboard:
             assert layout[column_key]["type"] == "COLUMN"
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_not_found(self, mock_find_dashboard, mcp_server):
         """Test error when dashboard doesn't exist."""
         mock_find_dashboard.return_value = None
@@ -516,7 +516,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_chart_not_found(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -534,7 +534,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_already_in_dashboard(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -558,7 +558,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_empty_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -614,7 +614,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_tabbed_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -714,7 +714,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_specific_tab_by_name(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -815,7 +815,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -96,6 +96,7 @@ def _mock_dashboard(id: int = 1, title: str = "Test Dashboard") -> Mock:
     dashboard.created_by.username = "test_user"
     dashboard.changed_by = Mock()
     dashboard.changed_by.username = "test_user"
+    dashboard.created_by_name = "test_user"
     dashboard.changed_by_name = "test_user"
     dashboard.uuid = f"dashboard-uuid-{id}"
     dashboard.slices = []

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_save_sql_query.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_save_sql_query.py
@@ -233,7 +233,7 @@ class TestSaveSqlQueryToolLogic:
     directly (without unwrapping).
     """
 
-    @pytest.mark.anyio
+    @pytest.mark.anyio()
     async def test_save_query_creates_saved_query(self) -> None:
         """Verify the tool calls SavedQueryDAO.create with correct attrs."""
         mod, saved = _get_tool_module()
@@ -248,6 +248,9 @@ class TestSaveSqlQueryToolLogic:
             mock_sq.id = 42
             mock_sq.label = "Revenue Query"
             mock_sq.sql = "SELECT SUM(revenue) FROM sales"
+            mock_sq.db_id = 1
+            mock_sq.schema = ""
+            mock_sq.description = ""
             mock_sq.catalog = None
 
             request = SaveSqlQueryRequest(
@@ -306,7 +309,7 @@ class TestSaveSqlQueryToolLogic:
         finally:
             _restore_modules(saved)
 
-    @pytest.mark.anyio
+    @pytest.mark.anyio()
     async def test_save_query_database_not_found(self) -> None:
         mod, saved = _get_tool_module()
         try:
@@ -348,7 +351,7 @@ class TestSaveSqlQueryToolLogic:
         finally:
             _restore_modules(saved)
 
-    @pytest.mark.anyio
+    @pytest.mark.anyio()
     async def test_save_query_access_denied(self) -> None:
         mod, saved = _get_tool_module()
         try:
@@ -398,7 +401,7 @@ class TestSaveSqlQueryToolLogic:
         finally:
             _restore_modules(saved)
 
-    @pytest.mark.anyio
+    @pytest.mark.anyio()
     async def test_save_query_with_schema_and_description(self) -> None:
         mod, saved = _get_tool_module()
         try:
@@ -412,6 +415,9 @@ class TestSaveSqlQueryToolLogic:
             mock_sq.id = 10
             mock_sq.label = "Test"
             mock_sq.sql = "SELECT 1"
+            mock_sq.db_id = 1
+            mock_sq.schema = "public"
+            mock_sq.description = ""
             mock_sq.catalog = None
 
             request = SaveSqlQueryRequest(

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_save_sql_query.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_save_sql_query.py
@@ -233,7 +233,7 @@ class TestSaveSqlQueryToolLogic:
     directly (without unwrapping).
     """
 
-    @pytest.mark.anyio()
+    @pytest.mark.anyio
     async def test_save_query_creates_saved_query(self) -> None:
         """Verify the tool calls SavedQueryDAO.create with correct attrs."""
         mod, saved = _get_tool_module()
@@ -309,7 +309,7 @@ class TestSaveSqlQueryToolLogic:
         finally:
             _restore_modules(saved)
 
-    @pytest.mark.anyio()
+    @pytest.mark.anyio
     async def test_save_query_database_not_found(self) -> None:
         mod, saved = _get_tool_module()
         try:
@@ -351,7 +351,7 @@ class TestSaveSqlQueryToolLogic:
         finally:
             _restore_modules(saved)
 
-    @pytest.mark.anyio()
+    @pytest.mark.anyio
     async def test_save_query_access_denied(self) -> None:
         mod, saved = _get_tool_module()
         try:
@@ -401,7 +401,7 @@ class TestSaveSqlQueryToolLogic:
         finally:
             _restore_modules(saved)
 
-    @pytest.mark.anyio()
+    @pytest.mark.anyio
     async def test_save_query_with_schema_and_description(self) -> None:
         mod, saved = _get_tool_module()
         try:


### PR DESCRIPTION
## **User description**
## Summary

Fixes the `encoding without a string argument` error on MCP tools when accessed through certain MCP client transports (e.g. Claude.ai's MCP bridge), plus 4 additional bugs found during staging tool testing.

### Bug 1: Auth user resolution failure
`ValueError` in `_setup_user_context()` when the JWT subject format doesn't match any username in the DB. Adds `ValueError` catch with `g.user` fallback.

### Bug 2: FastMCP 3.x structuredContent/outputSchema
FastMCP 3.x auto-generates `outputSchema` in tool definitions and `structuredContent` in tool responses. Some MCP transports cannot encode these fields.

Adds `StructuredContentStripperMiddleware`:
- `on_list_tools`: strips `output_schema` from tool definitions
- `on_call_tool`: strips `structured_content` from tool results
- `on_call_tool`: catches `FastMCPError`/`NotFoundError`/`ValidationError` and converts to plain text responses

### Bug 3: execute_sql cache deserialization crash
`_store_in_cache()` stored raw pandas DataFrames in cache. When deserialized by some cache backends, they come back as `bytes` or `dict` instead of DataFrame.

Fix: Convert DataFrames to `list[dict]` before caching, and add explicit type checks in response conversion.

### Bug 4: save_sql_query returns null for schema_name
Response echoed request values instead of reading from the saved DB object, causing `schema_name` to return `null`.

Fix: Read from `saved_query` ORM object instead of request.

### Bug 5: Dashboard tools show raw SAML subject for changed_by
`generate_dashboard` and `add_chart_to_existing_dashboard` used `.username` (raw subject) instead of `.changed_by_name` (display name).

### Bug 6: generate_dashboard swallows root cause errors
`CreateDashboardCommand` uses `@transaction` which obscures the actual failure. Added inner try/except to surface `__cause__`.

### Bug 7: get_instance_info fails via call_tool proxy
`@parse_request` required a `request` parameter even for empty models. Auto-detect empty models and provide default value.

## Test plan
- [x] All 18+ tools return valid responses through MCP bridge transport
- [x] Error cases return readable text instead of encoding errors
- [x] execute_sql handles cached results that deserialize as list/dict/bytes
- [x] save_sql_query returns correct schema_name
- [x] Dashboard tools show display name
- [x] get_instance_info works via call_tool proxy


___

## **CodeAnt-AI Description**
**Fix MCP tool responses and dashboard metadata issues**

### What Changed
- MCP auth now falls back to the user already set by middleware when JWT user lookup fails, so tools keep working instead of failing with encoding errors.
- Saved SQL queries now return the database, schema, and description from the saved record, and dashboard tools now show the display name of who created or changed a dashboard.
- Dashboard creation now returns a clear error message when creation fails.
- SQL query results are cached in a format that can be read back reliably, and cached or returned SQL rows are converted safely even when they are not plain tables.
- MCP tools now hide structured output fields that some clients cannot handle, preventing Claude.ai bridge errors and allowing tools with no required input to be called without extra arguments.

### Impact
`✅ Fewer MCP tool failures`
`✅ Clearer saved query details`
`✅ Correct dashboard author and editor names`
`✅ Fewer Claude.ai MCP bridge errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
