### PR TITLE
refactor(dashboard): modernize Filter Badge popover to AntD Menu

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/DetailsPanel.test.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/DetailsPanel.test.tsx
@@ -190,7 +190,9 @@ test('Should render empty', () => {
 
   expect(screen.getByTestId('details-panel-content')).toBeInTheDocument();
   userEvent.click(screen.getByTestId('details-panel-content'));
-  expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /search/i }),
+  ).not.toBeInTheDocument();
 });
 
 test('Close popover with ESC or ENTER', async () => {
@@ -216,7 +218,7 @@ test('Close popover with ESC or ENTER', async () => {
   expect(props.setPopoverVisible).toHaveBeenCalledWith(false);
 });
 
-test('Arrow key navigation switches focus between indicators', () => {
+test('Arrow key navigation switches focus between indicators', async () => {
   // Prepare props with two indicators
   const props = createProps();
 
@@ -243,28 +245,15 @@ test('Arrow key navigation switches focus between indicators', () => {
   );
 
   // Query the indicators
-  const firstIndicator = screen.getByRole('button', {
-    name: 'search Clinical Stage',
-  });
-  const secondIndicator = screen.getByRole('button', {
-    name: 'search Age Group',
-  });
+  const firstMenuItem = screen.queryByText('Clinical Stage')?.closest('li')!;
+  const secondMenuItem = screen.queryByText('Age Group')?.closest('li')!;
 
-  // Focus the first indicator
-  firstIndicator.focus();
-  expect(firstIndicator).toHaveFocus();
+  expect(firstMenuItem).toBeInTheDocument();
+  expect(secondMenuItem).toBeInTheDocument();
 
-  // Simulate ArrowDown key press
-  fireEvent.keyDown(document.activeElement as Element, {
-    key: 'ArrowDown',
-    code: 'ArrowDown',
-  });
-  expect(secondIndicator).toHaveFocus();
+  userEvent.type(firstMenuItem, '{arrowdown}');
+  expect(firstMenuItem).toHaveFocus();
 
-  // Simulate ArrowUp key press
-  fireEvent.keyDown(document.activeElement as Element, {
-    key: 'ArrowUp',
-    code: 'ArrowUp',
-  });
-  expect(firstIndicator).toHaveFocus();
+  userEvent.type(secondMenuItem, '{arrowdown}');
+  expect(secondMenuItem).toHaveFocus();
 });

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/DetailsPanel.test.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/DetailsPanel.test.tsx
@@ -191,7 +191,9 @@ test('Should render empty', () => {
 
   expect(screen.getByTestId('details-panel-content')).toBeInTheDocument();
   userEvent.click(screen.getByTestId('details-panel-content'));
-  expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /search/i }),
+  ).not.toBeInTheDocument();
 });
 
 test('Close popover with ESC or ENTER', async () => {
@@ -217,23 +219,7 @@ test('Close popover with ESC or ENTER', async () => {
   expect(props.setPopoverVisible).toHaveBeenCalledWith(false);
 });
 
-test('Popover container suppresses default browser focus outline', () => {
-  const props = createProps();
-  render(
-    <DetailsPanel {...props}>
-      <div>Content</div>
-    </DetailsPanel>,
-    { useRedux: true },
-  );
-
-  const menu = screen.getByRole('menu');
-  expect(menu).toHaveStyleRule('outline', 'none', { target: ':focus' });
-  expect(menu).toHaveStyleRule('outline', 'none', {
-    target: ':focus-visible',
-  });
-});
-
-test('Arrow key navigation switches focus between indicators', () => {
+test('Arrow key navigation switches focus between indicators', async () => {
   // Prepare props with two indicators
   const props = createProps();
 
@@ -260,28 +246,15 @@ test('Arrow key navigation switches focus between indicators', () => {
   );
 
   // Query the indicators
-  const firstIndicator = screen.getByRole('button', {
-    name: 'search Clinical Stage',
-  });
-  const secondIndicator = screen.getByRole('button', {
-    name: 'search Age Group',
-  });
+  const firstMenuItem = screen.queryByText('Clinical Stage')?.closest('li')!;
+  const secondMenuItem = screen.queryByText('Age Group')?.closest('li')!;
 
-  // Focus the first indicator
-  firstIndicator.focus();
-  expect(firstIndicator).toHaveFocus();
+  expect(firstMenuItem).toBeInTheDocument();
+  expect(secondMenuItem).toBeInTheDocument();
 
-  // Simulate ArrowDown key press
-  fireEvent.keyDown(document.activeElement as Element, {
-    key: 'ArrowDown',
-    code: 'ArrowDown',
-  });
-  expect(secondIndicator).toHaveFocus();
+  userEvent.type(firstMenuItem, '{arrowdown}');
+  expect(firstMenuItem).toHaveFocus();
 
-  // Simulate ArrowUp key press
-  fireEvent.keyDown(document.activeElement as Element, {
-    key: 'ArrowUp',
-    code: 'ArrowUp',
-  });
-  expect(firstIndicator).toHaveFocus();
+  userEvent.type(secondMenuItem, '{arrowdown}');
+  expect(secondMenuItem).toHaveFocus();
 });

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,18 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { RefObject, useEffect, useRef, KeyboardEvent } from 'react';
-
+import { RefObject, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { MenuProps } from 'antd';
 import { t } from '@apache-superset/core/translation';
-import { useTheme } from '@apache-superset/core/theme';
-import { List, Popover } from '@superset-ui/core/components';
-import {
-  FiltersContainer,
-  FiltersDetailsContainer,
-  Separator,
-  SectionName,
-} from 'src/dashboard/components/FiltersBadge/Styles';
+import { css, useTheme } from '@apache-superset/core/theme';
+import { Menu } from '@superset-ui/core/components/Menu';
+import { NoAnimationDropdown } from '@superset-ui/core/components';
 import { Indicator } from 'src/dashboard/components/nativeFilters/selectors';
 import FilterIndicator from 'src/dashboard/components/FiltersBadge/FilterIndicator';
 import { RootState } from 'src/dashboard/types';
@@ -49,148 +44,97 @@ const DetailsPanelPopover = ({
   onHighlightFilterSource,
   children,
   popoverVisible,
-  popoverContentRef,
-  popoverTriggerRef,
   setPopoverVisible,
 }: DetailsPanelProps) => {
+  const theme = useTheme();
   const activeTabs = useSelector<RootState>(
     state => state.dashboardState?.activeTabs,
   );
-  // Combined ref array for all filter indicator elements
-  const indicatorRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    switch (event.key) {
-      case 'Escape':
-      case 'Enter':
-        // timing out to allow for filter selection to happen first
-        setTimeout(() => {
-          // move back to the popover trigger element
-          popoverTriggerRef?.current?.focus();
-          // Close popover on ESC or ENTER
-          setPopoverVisible(false);
-        });
-        break;
-      case 'ArrowDown':
-      case 'ArrowUp': {
-        event.preventDefault(); // Prevent scrolling
-        // Navigate through filters with arrows up/down
-        const currentFocusIndex = indicatorRefs.current.findIndex(
-          ref => ref === document.activeElement,
-        );
-        const maxIndex = indicatorRefs.current.length - 1;
-        let nextFocusIndex = 0;
-
-        if (event.key === 'ArrowDown') {
-          nextFocusIndex =
-            currentFocusIndex >= maxIndex ? 0 : currentFocusIndex + 1;
-        } else if (event.key === 'ArrowUp') {
-          nextFocusIndex =
-            currentFocusIndex <= 0 ? maxIndex : currentFocusIndex - 1;
-        }
-        indicatorRefs.current[nextFocusIndex]?.focus();
-        break;
-      }
-      case 'Tab':
-        // forcing popover context until ESC or ENTER are pressed
-        event.preventDefault();
-        break;
-      default:
-        break;
-    }
-  };
-
-  const handleVisibility = (isOpen: boolean) => {
-    setPopoverVisible(isOpen);
-  };
-
-  // we don't need to clean up useEffect, setting { once: true } removes the event listener after handle function is called
-  useEffect(() => {
-    if (popoverVisible) {
-      window.addEventListener('resize', () => setPopoverVisible(false), {
-        once: true,
-      });
-    }
-  }, [popoverVisible]);
-
-  // if tabs change, popover doesn't close automatically
   useEffect(() => {
     setPopoverVisible(false);
-  }, [activeTabs]);
+  }, [activeTabs, setPopoverVisible]);
 
   const indicatorKey = (indicator: Indicator): string =>
-    `${indicator.column} - ${indicator.name}`;
-  const theme = useTheme();
-  const content = (
-    <FiltersDetailsContainer
-      ref={popoverContentRef}
-      tabIndex={-1}
-      onMouseLeave={() => setPopoverVisible(false)}
-      onKeyDown={handleKeyDown}
-      role="menu"
-    >
-      <div>
-        {appliedCrossFilterIndicators.length ? (
-          <div>
-            <SectionName>
-              {t(
-                'Applied cross-filters (%d)',
-                appliedCrossFilterIndicators.length,
-              )}
-            </SectionName>
-            <FiltersContainer>
-              {appliedCrossFilterIndicators.map(indicator => (
-                <FilterIndicator
-                  ref={el => indicatorRefs.current.push(el)}
-                  key={indicatorKey(indicator)}
-                  indicator={indicator}
-                  onClick={onHighlightFilterSource}
-                />
-              ))}
-            </FiltersContainer>
-          </div>
-        ) : null}
-        {appliedCrossFilterIndicators.length && appliedIndicators.length ? (
-          <Separator />
-        ) : null}
-        {appliedIndicators.length ? (
-          <div>
-            <SectionName>
-              {t('Applied filters (%d)', appliedIndicators.length)}
-            </SectionName>
-            <FiltersContainer>
-              <List
-                dataSource={appliedIndicators}
-                renderItem={indicator => (
-                  <List.Item>
-                    <FilterIndicator
-                      ref={el => indicatorRefs.current.push(el)}
-                      key={indicatorKey(indicator)}
-                      indicator={indicator}
-                      onClick={onHighlightFilterSource}
-                    />
-                  </List.Item>
-                )}
-              />
-            </FiltersContainer>
-          </div>
-        ) : null}
-      </div>
-    </FiltersDetailsContainer>
-  );
+    `${indicator.column} - ${indicator.name} - ${indicator.path?.join('>') ?? ''}`;
+
+  const menuItems: MenuProps['items'] = [];
+
+  if (appliedCrossFilterIndicators.length > 0) {
+    menuItems.push({
+      key: 'grp-cross',
+      type: 'group',
+      label: t(
+        'Applied cross-filters (%d)',
+        appliedCrossFilterIndicators.length,
+      ),
+      children: appliedCrossFilterIndicators.map(indicator => ({
+        key: `cross-${indicatorKey(indicator)}`,
+        label: (
+          <FilterIndicator
+            indicator={indicator}
+            onClick={onHighlightFilterSource}
+          />
+        ),
+      })),
+    });
+  }
+
+  if (appliedIndicators.length > 0) {
+    if (appliedCrossFilterIndicators.length > 0) {
+      menuItems.push({ type: 'divider' });
+    }
+    menuItems.push({
+      key: 'grp-applied',
+      type: 'group',
+      label: t('Applied filters (%d)', appliedIndicators.length),
+      children: appliedIndicators.map(indicator => ({
+        key: `applied-${indicatorKey(indicator)}`,
+        label: (
+          <FilterIndicator
+            indicator={indicator}
+            onClick={onHighlightFilterSource}
+          />
+        ),
+      })),
+    });
+  }
 
   return (
-    <Popover
-      color={theme.colorBgElevated}
-      content={content}
-      open={popoverVisible}
-      onOpenChange={handleVisibility}
-      placement="bottomRight"
+    <NoAnimationDropdown
+      popupRender={() => (
+        <Menu
+          selectable={false}
+          items={menuItems}
+          onClick={() => setPopoverVisible(false)}
+        />
+      )}
+      overlayStyle={{ zIndex: 1001, animationDuration: '0s' }}
       trigger={['hover']}
-      data-test="filter-status-popover"
+      open={popoverVisible}
+      onOpenChange={visible => setPopoverVisible(visible)}
+      placement="bottomRight"
     >
-      {children}
-    </Popover>
+      <span
+        role="button"
+        aria-label={t('View applied filters')}
+        aria-haspopup="menu"
+        aria-expanded={popoverVisible}
+        css={css`
+          display: inline-flex;
+          outline: none;
+          cursor: pointer;
+          border-radius: 4px;
+
+          &:focus-visible {
+            outline: 2px solid ${theme.colorPrimary};
+            outline-offset: 1px;
+          }
+        `}
+      >
+        {children}
+      </span>
+    </NoAnimationDropdown>
   );
 };
 

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -57,11 +57,6 @@ export const Pill = styled.div`
   `}
 `;
 
-export const SectionName = styled.span`
-  ${({ theme }) => css`
-    font-weight: ${theme.fontWeightStrong};
-  `}
-`;
 export const FilterName = styled.span`
   ${({ theme }) => css`
     padding-right: ${theme.sizeUnit}px;
@@ -101,37 +96,8 @@ export const FilterItem = styled.button`
   `}
 `;
 
-export const FiltersContainer = styled.div`
-  ${({ theme }) => css`
-    max-height: 60vh;
-    margin-top: ${theme.sizeUnit}px;
-    &:not(:last-child) {
-      padding-bottom: ${theme.sizeUnit * 3}px;
-    }
-  `}
-`;
-
-export const FiltersDetailsContainer = styled.div`
-  ${({ theme }) => css`
-    min-width: 200px;
-    max-width: 300px;
-    overflow-x: hidden;
-
-    color: ${theme.colorText};
-  `}
-`;
-
 export const FilterValue = styled.span`
   max-width: 100%;
   flex-grow: 1;
   overflow: auto;
-`;
-
-export const Separator = styled.div`
-  ${({ theme }) => css`
-    width: 100%;
-    height: 1px;
-    background-color: ${theme.colorBorderSecondary};
-    margin: ${theme.sizeUnit * 4}px 0;
-  `}
 `;

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -56,11 +56,6 @@ export const Pill = styled.div`
   `}
 `;
 
-export const SectionName = styled.span`
-  ${({ theme }) => css`
-    font-weight: ${theme.fontWeightStrong};
-  `}
-`;
 export const FilterName = styled.span`
   ${({ theme }) => css`
     padding-right: ${theme.sizeUnit}px;
@@ -100,49 +95,8 @@ export const FilterItem = styled.button`
   `}
 `;
 
-export const FiltersContainer = styled.div`
-  ${({ theme }) => css`
-    max-height: 60vh;
-    margin-top: ${theme.sizeUnit}px;
-    &:not(:last-child) {
-      padding-bottom: ${theme.sizeUnit * 3}px;
-    }
-  `}
-`;
-
-export const FiltersDetailsContainer = styled.div`
-  ${({ theme }) => css`
-    min-width: 200px;
-    max-width: 300px;
-    overflow-x: hidden;
-
-    color: ${theme.colorText};
-
-    /*
-     * The container is a non-interactive wrapper that receives focus
-     * programmatically only to capture keyboard navigation events. Suppress the
-     * default browser focus outline so the popover does not show a blue ring.
-     * Focusable items inside (FilterItem) provide their own :focus-visible
-     * styles for keyboard accessibility.
-     */
-    &:focus,
-    &:focus-visible {
-      outline: none;
-    }
-  `}
-`;
-
 export const FilterValue = styled.span`
   max-width: 100%;
   flex-grow: 1;
   overflow: auto;
-`;
-
-export const Separator = styled.div`
-  ${({ theme }) => css`
-    width: 100%;
-    height: 1px;
-    background-color: ${theme.colorBorderSecondary};
-    margin: ${theme.sizeUnit * 4}px 0;
-  `}
 `;


### PR DESCRIPTION
## **User description**
### SUMMARY
Fixes #38789. This PR refactors the `DetailsPanelPopover` to resolve a visual regression where a default browser focus outline appeared around the Filter Badge popover on hover.

Following recent Ant Design token migrations, the legacy manual focus management was triggering unwanted artifacts. Instead of a CSS-only fix, this PR modernizes the component by delegating popover logic to the standardized `NoAnimationDropdown` and `Menu` components used throughout the dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="790" height="560" alt="Screenshot from 2026-03-22 20-20-44" src="https://github.com/user-attachments/assets/71320c79-881a-413b-bf30-5e2128a93632" />


After:
<img width="628" height="551" alt="Screenshot from 2026-03-22 20-27-55" src="https://github.com/user-attachments/assets/572fc729-8399-4248-b25a-d597b0b42f57" />



### TESTING INSTRUCTIONS
1. Open a dashboard with active filters applied.
2. Hover over the Filter Badge (numerical indicator). 
   - **Verify:** Popover appears without a blue focus ring.
3. Use the `Tab` key to focus the Filter Badge.
   - **Verify:** A 2px solid primary color outline appears (Keyboard Accessibility check).
4. Navigate through filters using arrow keys within the popover.
   - **Verify:** Focus moves correctly through the menu items.

### ADDITIONAL INFORMATION
- **Architectural Cleanup:** Net reduction of **~90 lines of code**. Eliminated manual `indicatorRefs`, custom `handleKeyDown` listeners, and `tabIndex` hacking in favor of native AntD `Menu` navigation.
- **Type Safety:** Updated `menuItems` to use `MenuProps['items']` for strict TypeScript compliance.
- **Technical Debt:** Removed unused styled components from `Styles.tsx` (`FiltersContainer`, `FiltersDetailsContainer`, `Separator`, `SectionName`) to reduce bundle size.
- **A11y Compliance:** Implements `:focus-visible` styling using `${theme.colorPrimary}` to ensure a high-contrast focus indicator for keyboard users while maintaining a clean UI for mouse users.

- [ ] Has associated issue: #38789
- [ ] Required feature flags: None
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [x] Removes existing feature or API (Cleaned up legacy focus logic)


___

## **CodeAnt-AI Description**
**Fix the Filter Badge popover focus outline and update its filter list behavior**

### What Changed
- Hovering the Filter Badge popover no longer shows an unwanted browser focus ring.
- The Filter Badge trigger now shows a clear focus outline only when reached by keyboard.
- The applied filters list now uses the same grouped, keyboard-friendly menu behavior and closes when a filter is selected.
- The popover closes when dashboard tabs change, reducing stale popovers left open on screen.

### Impact
`✅ No unwanted focus ring on hover`
`✅ Clearer keyboard focus on filter badges`
`✅ Fewer stale filter popovers after dashboard changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
