### PR TITLE
fix(sqllab): FilterText does not apply accordingly

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -749,6 +749,7 @@ const ResultSet = ({
               <div
                 css={css`
                   flex: 1 1 auto;
+                  padding-bottom: ${theme.sizeUnit * 3}px;
                 `}
               >
                 <AutoSizer disableWidth>

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -73,6 +73,52 @@ describe('FilterableTable', () => {
     expect(queryByText('b1')).not.toBeInTheDocument();
     expect(queryByText('b3')).not.toBeInTheDocument();
   });
+
+  test('shows all rows when filterText is empty', () => {
+    const props = {
+      ...mockedProps,
+      filterText: '',
+    };
+    const { getByText } = render(<FilterableTable {...props} />);
+    expect(getByText('b1')).toBeInTheDocument();
+    expect(getByText('b2')).toBeInTheDocument();
+    expect(getByText('b3')).toBeInTheDocument();
+  });
+
+  test('updates filtered rows when filterText prop changes', () => {
+    const props = {
+      ...mockedProps,
+      filterText: 'b1',
+    };
+    const { getByText, queryByText, rerender } = render(
+      <FilterableTable {...props} />,
+    );
+    expect(getByText('b1')).toBeInTheDocument();
+    expect(queryByText('b2')).not.toBeInTheDocument();
+    expect(queryByText('b3')).not.toBeInTheDocument();
+
+    rerender(<FilterableTable {...mockedProps} filterText="b2" />);
+    expect(queryByText('b1')).not.toBeInTheDocument();
+    expect(getByText('b2')).toBeInTheDocument();
+    expect(queryByText('b3')).not.toBeInTheDocument();
+  });
+
+  test('shows all rows when filterText is cleared', () => {
+    const props = {
+      ...mockedProps,
+      filterText: 'b1',
+    };
+    const { getByText, queryByText, rerender } = render(
+      <FilterableTable {...props} />,
+    );
+    expect(getByText('b1')).toBeInTheDocument();
+    expect(queryByText('b2')).not.toBeInTheDocument();
+
+    rerender(<FilterableTable {...mockedProps} filterText="" />);
+    expect(getByText('b1')).toBeInTheDocument();
+    expect(getByText('b2')).toBeInTheDocument();
+    expect(getByText('b3')).toBeInTheDocument();
+  });
 });
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, useRef, useCallback, memo } from 'react';
+import { useMemo, useCallback, memo } from 'react';
 import { GridSize } from 'src/components/GridTable/constants';
 import { GridTable } from 'src/components/GridTable';
 import { type ColDef } from 'src/components/GridTable/types';
@@ -109,15 +109,15 @@ export const FilterableTable = ({
     [orderedColumnKeys, allowHTML, getCellContent],
   );
 
-  const keyword = useRef<string | undefined>(filterText);
-  keyword.current = filterText;
-
-  const keywordFilter = useCallback(node => {
-    if (keyword.current && node.data) {
-      return hasMatch(keyword.current, node.data);
-    }
-    return true;
-  }, []);
+  const keywordFilter = useCallback(
+    node => {
+      if (filterText && node.data) {
+        return hasMatch(filterText, node.data);
+      }
+      return true;
+    },
+    [filterText],
+  );
 
   return (
     <div className="filterable-table-container" data-test="table-container">


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes https://github.com/apache/superset/issues/38812

Bug fix: FilterableTable was using useRef to capture filterText inside a useCallback with an empty dependency array [], causing the filter to stale-close over the initial value and never re-apply when the filterText prop changed. Fixed by removing the useRef workaround and properly adding filterText to the useCallback dependency array.

This commit also adds padding-bottom to the SqlLab ResultSet container to prevent the results table from being clipped at the bottom.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/d6e57cda-e944-4807-b529-4dc4e9f20e3f

<img width="1406" height="1170" alt="Screenshot 2026-03-23 at 1 00 58 PM" src="https://github.com/user-attachments/assets/61c5b468-cef8-4604-ada1-db81623d12d6" />

After:

https://github.com/user-attachments/assets/f3bd79c4-97b1-4281-8770-03c5a32a0bd6

<img width="1024" height="762" alt="Screenshot 2026-03-23 at 1 00 12 PM" src="https://github.com/user-attachments/assets/90361346-4856-4720-a834-67e25f74f9fc" />


### TESTING INSTRUCTIONS

Added 3 unit tests to FilterableTable covering:
    - Shows all rows when filterText is empty
    - Updates filtered rows reactively when filterText prop changes
    - Shows all rows when filterText is cleared after filtering

### ADDITIONAL INFORMATION
- [x] Has associated issue: #38812
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Filter results update correctly as the search text changes, and the SQL results table no longer gets clipped at the bottom**

### What Changed
- Changing the filter text now updates the visible rows immediately instead of keeping the old filter
- Clearing the filter shows all rows again
- The SQL results table now has bottom spacing so the last rows are fully visible
- Added tests for empty, changing, and cleared filter states

### Impact
`✅ Live result filtering`
`✅ Fewer stale search results`
`✅ No clipped SQL output`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
