### PR TITLE
fix(extensions-cli): remove publisher prefix from bundle filename

### DIFF
--- a/superset-extensions-cli/src/superset_extensions_cli/cli.py
+++ b/superset-extensions-cli/src/superset_extensions_cli/cli.py
@@ -585,9 +585,9 @@ def bundle(ctx: click.Context, output: Path | None) -> None:
         sys.exit(1)
 
     manifest = json.loads(manifest_path.read_text())
-    id_ = manifest["id"]
+    name = manifest["name"]
     version = manifest["version"]
-    default_filename = f"{id_}-{version}.supx"
+    default_filename = f"{name}-{version}.supx"
 
     if output is None:
         zip_path = Path(default_filename)

--- a/superset-extensions-cli/tests/test_cli_bundle.py
+++ b/superset-extensions-cli/tests/test_cli_bundle.py
@@ -43,10 +43,10 @@ def test_bundle_command_creates_zip_with_default_name(
     result = cli_runner.invoke(app, ["bundle"])
 
     assert result.exit_code == 0
-    assert "✅ Bundle created: test-org.test-extension-1.0.0.supx" in result.output
+    assert "✅ Bundle created: test-extension-1.0.0.supx" in result.output
 
     # Verify zip file was created
-    zip_path = isolated_filesystem / "test-org.test-extension-1.0.0.supx"
+    zip_path = isolated_filesystem / "test-extension-1.0.0.supx"
     assert_file_exists(zip_path)
 
     # Verify zip contents
@@ -100,7 +100,7 @@ def test_bundle_command_with_output_directory(
     assert result.exit_code == 0
 
     # Verify zip file was created in output directory
-    expected_path = output_dir / "test-org.test-extension-1.0.0.supx"
+    expected_path = output_dir / "test-extension-1.0.0.supx"
     assert_file_exists(expected_path)
     assert f"✅ Bundle created: {expected_path}" in result.output
 
@@ -193,7 +193,7 @@ def test_bundle_includes_all_files_recursively(
     assert result.exit_code == 0
 
     # Verify zip file and contents
-    zip_path = isolated_filesystem / "complex-org.complex-extension-2.1.0.supx"
+    zip_path = isolated_filesystem / "complex-extension-2.1.0.supx"
     assert_file_exists(zip_path)
 
     with zipfile.ZipFile(zip_path, "r") as zipf:


### PR DESCRIPTION
## **User description**
### SUMMARY

The `superset-extensions bundle` command was generating the `.supx` bundle filename using the composite ID (`publisher.name`, e.g., `acme.example-1.0.0.supx`) instead of just the extension name (`example-1.0.0.supx`).

This is a continuation of the same rationale introduced in [#38690](https://github.com/apache/superset/pull/38690), which simplified the `init` folder name for the same reason: the publisher prefix in local artifacts is unnecessary because the source of truth for extension identity is always `extension.json` (and the derived `dist/manifest.json`), which contains the full composite ID. The bundle filename is a local development artifact — it has no bearing on how the extension is identified or resolved by Superset or a marketplace.

Forcing the publisher into the bundle filename adds noise without preventing any real conflict, and is inconsistent with how similar ecosystems handle local vs. registry identity.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**
```
✅ Bundle created: acme.example-1.0.0.supx
```

**After:**
```
✅ Bundle created: example-1.0.0.supx
```

### TESTING INSTRUCTIONS

1. Create an extension with `superset-extensions init`, using `example` as the name and `acme` as the publisher.
2. Run `superset-extensions bundle`.
3. Verify the generated file is named `example-1.0.0.supx` (not `acme.example-1.0.0.supx`).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Use the extension name for the default bundle filename**

### What Changed
- Bundles now use the extension name, not the publisher-qualified ID, in the default `.supx` filename
- The bundle output shown in the terminal matches the new filename in the current folder or a chosen output directory
- Existing bundle contents are unchanged

### Impact
`✅ Cleaner bundle filenames`
`✅ Easier local extension packaging`
`✅ Less confusion when sharing build artifacts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
