### PR TITLE
fix(plugin-chart-table): allow numerical sorting on Time-series Table metrics

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -20,7 +20,7 @@
 process.env.TZ = 'America/New_York';
 module.exports = {
   testRegex:
-    '\\/superset-frontend\\/(spec|src|plugins|packages|tools)\\/.*(_spec|\\.test)\\.[jt]sx?$',
+    '([\\\\/]?superset-frontend[\\\\/])?(spec|src|plugins|packages|tools)[\\\\/].*(_spec|\\.test)\\.[jt]sx?$',
   moduleNameMapper: {
     '\\.(css|less|geojson)$': '<rootDir>/spec/__mocks__/mockExportObject.js',
     '\\.(gif|ttf|eot|png|jpg)$': '<rootDir>/spec/__mocks__/mockExportString.js',

--- a/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.regression.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.regression.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { sortNumberWithMixedTypes } from './sortUtils';
+
+describe('sortNumberWithMixedTypes Regression Tests', () => {
+  const columnId = '2020-01-01.metric'; // Complex ID with dots
+
+  const createMockRow = (value: any, useOriginal = false, colType?: string) => {
+    const props = {
+      valueField: 'metric',
+      column: {
+        key: columnId,
+        colType,
+      },
+      reversedEntries: [{ metric: value }],
+    };
+
+    if (useOriginal) {
+      return {
+        original: {
+          [columnId]: { props },
+        },
+        values: {}, // Accessing this via dot notation would fail in react-table
+      };
+    }
+
+    return {
+      values: {
+        [columnId]: { props },
+      },
+    };
+  };
+
+  test('should resolve cell from row.original when row.values lookup fails (dot notation)', () => {
+    const rowA = createMockRow(10, true, 'time');
+    const rowB = createMockRow(20, true, 'time');
+
+    const result = sortNumberWithMixedTypes(rowA, rowB, columnId);
+    expect(result).toBeLessThan(0);
+  });
+
+  test('should fallback to localeCompare for purely string values', () => {
+    const rowA = createMockRow('Apple', true);
+    const rowB = createMockRow('Banana', true);
+
+    const result = sortNumberWithMixedTypes(rowA, rowB, columnId);
+    expect(result).toBeLessThan(0); // 'Apple' < 'Banana'
+  });
+
+  test('should correctly sort strings with mixed numbers', () => {
+    const rowA = createMockRow('10', true);
+    const rowB = createMockRow('2', true);
+
+    const result = sortNumberWithMixedTypes(rowA, rowB, columnId);
+    expect(result).toBeGreaterThan(0); // 10 > 2 numerically even without colType: 'time'
+  });
+
+  test('should handle null and undefined values consistently', () => {
+    const rowNull = createMockRow(null, true);
+    const rowUndefined = createMockRow(undefined, true);
+    const rowValue = createMockRow(10, true);
+
+    expect(sortNumberWithMixedTypes(rowNull, rowValue, columnId)).toBeLessThan(
+      0,
+    );
+    expect(
+      sortNumberWithMixedTypes(rowValue, rowNull, columnId),
+    ).toBeGreaterThan(0);
+    expect(sortNumberWithMixedTypes(rowNull, rowUndefined, columnId)).toBe(0);
+  });
+
+  test('should handle zero correctly', () => {
+    const rowZero = createMockRow(0, true, 'time');
+    const rowPos = createMockRow(1, true, 'time');
+    const rowNeg = createMockRow(-1, true, 'time');
+
+    expect(sortNumberWithMixedTypes(rowZero, rowPos, columnId)).toBeLessThan(0);
+    expect(sortNumberWithMixedTypes(rowZero, rowNeg, columnId)).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.ts
@@ -36,7 +36,12 @@ function compareValues(
   const isAValid = numA !== null && numA !== undefined && !Number.isNaN(numA);
   const isBValid = numB !== null && numB !== undefined && !Number.isNaN(numB);
 
-  if (!isAValid && !isBValid) return 0;
+  if (!isAValid && !isBValid) {
+    if (typeof a === 'string' && typeof b === 'string') {
+      return a < b ? -1 : a > b ? 1 : 0;
+    }
+    return 0;
+  }
   if (!isAValid) return nanTreatment === 'asSmallest' ? -1 : 1;
   if (!isBValid) return nanTreatment === 'asSmallest' ? 1 : -1;
 
@@ -49,7 +54,6 @@ function compareValues(
  * @param rowA - First row to compare
  * @param rowB - Second row to compare
  * @param columnId - Column identifier for sorting
- * @param descending - Whether to sort in descending order
  * @returns Numeric comparison result for react-table
  * react-table handles the asc/desc direction flip internally after calling
  * this function, so we only return the raw comparison result.
@@ -59,8 +63,8 @@ export function sortNumberWithMixedTypes(
   rowB: any,
   columnId: string,
 ) {
-  const cellA = rowA.values?.[columnId];
-  const cellB = rowB.values?.[columnId];
+  const cellA = rowA.original?.[columnId] ?? rowA.values?.[columnId];
+  const cellB = rowB.original?.[columnId] ?? rowB.values?.[columnId];
 
   // Both ValueCell and Sparkline cells pass React elements here.
   // ValueCell uses { valueField, column, reversedEntries }
@@ -105,3 +109,5 @@ export function sortNumberWithMixedTypes(
 
   return compareValues(valueA, valueB, 'asSmallest');
 }
+
+


### PR DESCRIPTION
## **User description**
### SUMMARY
The **Time-series Table** visualization was previously locked to sorting only by the first column (dimensions). Clicking on metric headers (time-series values) displayed a sort indicator but did not actually re-order the rows. 

This was caused by a failure in `react-table` value resolution when using complex/nested accessor keys (e.g., date-prefixed metric keys). The custom [sortNumberWithMixedTypes](cci:1://file:///c:/Users/Nirek%20Jaiswal/superset/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.ts:50:0-110:1) utility was returning `0` (equality) because it couldn't resolve the cell data from the standard `row.values` lookup.

**Changes introduced in this PR:**
1.  **Metric Resolution Fix:** Updated [sortNumberWithMixedTypes](cci:1://file:///c:/Users/Nirek%20Jaiswal/superset/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.ts:50:0-110:1) to resolve cell values from `row.original` as a fallback. This reliably sidesteps nested dot-notation parsing issues in React Table.
2.  **String Fallback:** Enhanced the [compareValues](cci:1://file:///c:/Users/Nirek%20Jaiswal/superset/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.ts:20:0-48:1) helper to include an alphabetical fallback for dimension columns and mixed string-number data, preventing them from being treated as equivalent `NaN` values.
3.  **Cross-Platform CI Support:** Fixed a regex in [jest.config.js](cci:7://file:///c:/Users/Nirek%20Jaiswal/superset/superset-frontend/jest.config.js:0:0-0:0) that used leading slashes incompatible with Windows-style paths, allowing unit tests to run correctly on all OS environments.


### TESTING INSTRUCTIONS
1. Open a "Time-series Table" chart in Explore or a Dashboard.
2. Click any metric column header (e.g., a date-prefixed metric).
3. Verify that the table correctly re-orders rows numerically.
4. Toggle the sort order (ASC/DESC) and verify consistency.
5. **Automated Verification:** All 14 tests (original + regression suite) passed. Run:
   `npm run test -- src/visualizations/TimeTable/utils/sortUtils/`

### ADDITIONAL INFORMATION
- [x] Changes UI
- [x] Includes unit tests

Signed-off-by: Nirek Jaiswal <nirekjaiswal110106@gmail.com>


___

## **CodeAnt-AI Description**
**Allow Time-series Table metric columns to sort correctly**

### What Changed
- Metric columns in Time-series Table now sort using the actual cell value even when the column name contains dots or other complex text.
- Text values are no longer treated as ties when sorting; alphabetical order now works for string-only columns and mixed string-number values.
- Unit tests now cover complex column names, string sorting, null values, and zero values.
- Test discovery now works on Windows-style paths, so the frontend test suite runs in more environments.

### Impact
`✅ Correct metric sorting in Time-series Table`
`✅ Clearer ordering for text and mixed-value columns`
`✅ Fewer test failures on Windows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
