### PR TITLE
fix(tests): resolve flakey SouthPane extension test caused by nwsapi

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.tsx
@@ -172,8 +172,6 @@ test('should remove tab', async () => {
   const totalTabs = mockState.sqlLab.tables.length + 2;
   expect(tabs).toHaveLength(totalTabs);
 
-  console.log(tabs[2].parentElement?.innerHTML); // debug
-
   const removeButton = tabs[2].parentElement?.querySelector(
     'button[aria-label="remove"]',
   );
@@ -226,9 +224,7 @@ test('renders slot-wide toolbar actions via PanelToolbar', () => {
     initialState: mockState,
   });
 
-  expect(
-    screen.getByRole('button', { name: 'Panels Action' }),
-  ).toBeInTheDocument();
+  expect(screen.getByLabelText('Panels Action')).toBeInTheDocument();
 });
 
 test('renders per-view toolbar actions for contributed tab', () => {
@@ -251,8 +247,5 @@ test('renders per-view toolbar actions for contributed tab', () => {
   });
 
   // Content is rendered via forceRender: true even when tab is not active.
-  // Use { hidden: true } to find button in non-active tab pane.
-  expect(
-    screen.getByRole('button', { name: 'Per-View Action', hidden: true }),
-  ).toBeInTheDocument();
+  expect(screen.getByLabelText('Per-View Action')).toBeInTheDocument();
 });


### PR DESCRIPTION
## **User description**
### SUMMARY

The SouthPane extension contract test "renders slot-wide toolbar actions via PanelToolbar" fails intermittently in CI.

**Root cause:** `screen.getByRole('button', { name: ... })` triggers `dom-accessibility-api` to compute accessible names by traversing the DOM. When it encounters antd Tabs' overflow "more" button, it evaluates a CSS selector containing `:focus-visible` — a pseudo-class that jsdom's nwsapi engine cannot parse — causing a `SyntaxError`.

**Fix:** Replace `getByRole('button', { name })` with `getByLabelText(name)` in the two affected assertions. `getByLabelText` queries the `aria-label` attribute directly without triggering CSS selector evaluation via nwsapi. The PanelToolbar component renders buttons with `aria-label={command.title}`, so the assertions remain semantically equivalent.

Also removes a leftover debug `console.log` and a stale comment referencing the old `{ hidden: true }` query option.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only change.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest --no-coverage src/SqlLab/components/SouthPane/SouthPane.test.tsx
```

All 7 tests should pass, including:
- "renders slot-wide toolbar actions via PanelToolbar"
- "renders per-view toolbar actions for contributed tab"

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Stabilize SouthPane extension test coverage**

### What Changed
- Replaced flaky button lookups in SouthPane toolbar tests with direct label-based checks so they no longer fail in CI
- Removed a leftover debug print from the tab removal test
- Kept the same toolbar coverage for both panel-wide and per-view actions

### Impact
`✅ Fewer flaky test failures`
`✅ More reliable CI runs`
`✅ Clearer SouthPane test output`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
