### PR TITLE
fix(sqllab): inactive leftbar selector on empty state

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
@@ -33,6 +33,7 @@ import {
 } from 'src/SqlLab/fixtures';
 import { SupersetClient, isFeatureEnabled } from '@superset-ui/core';
 import { ADD_TOAST } from 'src/components/MessageToasts/actions';
+import { TMP_QUERY_ID } from 'src/SqlLab/hooks/useQueryEditor';
 import { ToastType } from '../../components/MessageToasts/types';
 
 const isFeatureEnabledMock = isFeatureEnabled as unknown as jest.Mock;
@@ -874,6 +875,44 @@ describe('async actions', () => {
                 (defaultQueryEditor as any).queryLimit ||
                 initialState.common.conf.DEFAULT_SQLLAB_LIMIT,
               inLocalStorage: true,
+              loaded: true,
+            },
+          },
+        ];
+        const request = actions.addNewQueryEditor();
+        request(store.dispatch, store.getState, undefined);
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+
+      test('creates a new query editor from the saved state in the empty tab', () => {
+        const unsavedEmptyTabState = {
+          id: TMP_QUERY_ID,
+          dbId: 2,
+          catalog: 'test_catalog',
+          schema: 'test_schema',
+        };
+        const store = mockStore({
+          ...initialState,
+          sqlLab: {
+            ...initialState.sqlLab,
+            tabHistory: [TMP_QUERY_ID],
+            unsavedQueryEditor: unsavedEmptyTabState,
+          },
+        });
+        const expectedActions = [
+          {
+            type: actions.ADD_QUERY_EDITOR,
+            queryEditor: {
+              id: 'abcd',
+              immutableId: 'abcd',
+              sql: expect.stringContaining('SELECT ...'),
+              name: 'Untitled Query 4',
+              dbId: unsavedEmptyTabState.dbId,
+              catalog: unsavedEmptyTabState.catalog,
+              schema: unsavedEmptyTabState.schema,
+              inLocalStorage: true,
+              autorun: false,
+              queryLimit: initialState.common.conf.DEFAULT_SQLLAB_LIMIT,
               loaded: true,
             },
           },

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
@@ -33,7 +33,7 @@ import {
 } from 'src/SqlLab/fixtures';
 import { SupersetClient, isFeatureEnabled } from '@superset-ui/core';
 import { ADD_TOAST } from 'src/components/MessageToasts/actions';
-import { TMP_QUERY_ID } from 'src/SqlLab/hooks/useQueryEditor';
+import { EMPTY_STATE_QE_ID } from 'src/SqlLab/hooks/useQueryEditor';
 import { ToastType } from '../../components/MessageToasts/types';
 
 const isFeatureEnabledMock = isFeatureEnabled as unknown as jest.Mock;
@@ -886,7 +886,7 @@ describe('async actions', () => {
 
       test('creates a new query editor from the saved state in the empty tab', () => {
         const unsavedEmptyTabState = {
-          id: TMP_QUERY_ID,
+          id: EMPTY_STATE_QE_ID,
           dbId: 2,
           catalog: 'test_catalog',
           schema: 'test_schema',
@@ -895,7 +895,7 @@ describe('async actions', () => {
           ...initialState,
           sqlLab: {
             ...initialState.sqlLab,
-            tabHistory: [TMP_QUERY_ID],
+            tabHistory: [EMPTY_STATE_QE_ID],
             unsavedQueryEditor: unsavedEmptyTabState,
           },
         });

--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -47,7 +47,7 @@ import { newQueryTabName } from '../utils/newQueryTabName';
 import getInitialState from '../reducers/getInitialState';
 import { rehydratePersistedState } from '../utils/reduxStateToLocalStorageHelper';
 import { PREVIEW_QUERY_LIMIT } from '../constants';
-import { TMP_QUERY_ID } from '../hooks/useQueryEditor';
+import { EMPTY_STATE_QE_ID } from '../hooks/useQueryEditor';
 
 // Type definitions for SqlLab actions
 export interface Query {
@@ -755,7 +755,7 @@ export function addNewQueryEditor(): SqlLabThunkAction<SqlLabAction> {
     const defaultDbId = common.conf.SQLLAB_DEFAULT_DBID as number | undefined;
     const activeQueryEditor = queryEditors.find(
       (qe: QueryEditor) => qe.id === tabHistory[tabHistory.length - 1],
-    ) ?? { id: TMP_QUERY_ID };
+    ) ?? { id: EMPTY_STATE_QE_ID };
     const dbIds = Object.values(databases).map(
       (database: { id: number }) => database.id,
     );

--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -47,6 +47,7 @@ import { newQueryTabName } from '../utils/newQueryTabName';
 import getInitialState from '../reducers/getInitialState';
 import { rehydratePersistedState } from '../utils/reduxStateToLocalStorageHelper';
 import { PREVIEW_QUERY_LIMIT } from '../constants';
+import { TMP_QUERY_ID } from '../hooks/useQueryEditor';
 
 // Type definitions for SqlLab actions
 export interface Query {
@@ -754,7 +755,7 @@ export function addNewQueryEditor(): SqlLabThunkAction<SqlLabAction> {
     const defaultDbId = common.conf.SQLLAB_DEFAULT_DBID as number | undefined;
     const activeQueryEditor = queryEditors.find(
       (qe: QueryEditor) => qe.id === tabHistory[tabHistory.length - 1],
-    );
+    ) ?? { id: TMP_QUERY_ID };
     const dbIds = Object.values(databases).map(
       (database: { id: number }) => database.id,
     );

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.tsx
@@ -32,6 +32,8 @@ import {
   defaultQueryEditor,
   extraQueryEditor2,
 } from 'src/SqlLab/fixtures';
+import { TMP_QUERY_ID } from 'src/SqlLab/hooks/useQueryEditor';
+import * as useDatabaseSelectorModule from '../SqlEditorTopBar/useDatabaseSelector';
 import type { RootState } from 'src/views/store';
 import type { Store } from 'redux';
 
@@ -234,4 +236,17 @@ test('ignore schema api when current schema is deprecated', async () => {
       ),
     ]),
   );
+});
+
+test('uses TMP_QUERY_ID when queryEditorId is empty', async () => {
+  const useDatabaseSelectorSpy = jest.spyOn(
+    useDatabaseSelectorModule,
+    'default',
+  );
+
+  await renderAndWait({ queryEditorId: '' }, undefined, initialState);
+
+  expect(useDatabaseSelectorSpy).toHaveBeenCalledWith(TMP_QUERY_ID);
+
+  useDatabaseSelectorSpy.mockRestore();
 });

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.tsx
@@ -32,7 +32,7 @@ import {
   defaultQueryEditor,
   extraQueryEditor2,
 } from 'src/SqlLab/fixtures';
-import { TMP_QUERY_ID } from 'src/SqlLab/hooks/useQueryEditor';
+import { EMPTY_STATE_QE_ID } from 'src/SqlLab/hooks/useQueryEditor';
 import * as useDatabaseSelectorModule from '../SqlEditorTopBar/useDatabaseSelector';
 import type { RootState } from 'src/views/store';
 import type { Store } from 'redux';
@@ -238,7 +238,7 @@ test('ignore schema api when current schema is deprecated', async () => {
   );
 });
 
-test('uses TMP_QUERY_ID when queryEditorId is empty', async () => {
+test('uses EMPTY_STATE_QE_ID when queryEditorId is empty', async () => {
   const useDatabaseSelectorSpy = jest.spyOn(
     useDatabaseSelectorModule,
     'default',
@@ -246,7 +246,7 @@ test('uses TMP_QUERY_ID when queryEditorId is empty', async () => {
 
   await renderAndWait({ queryEditorId: '' }, undefined, initialState);
 
-  expect(useDatabaseSelectorSpy).toHaveBeenCalledWith(TMP_QUERY_ID);
+  expect(useDatabaseSelectorSpy).toHaveBeenCalledWith(EMPTY_STATE_QE_ID);
 
   useDatabaseSelectorSpy.mockRestore();
 });

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -32,6 +32,7 @@ import { t } from '@apache-superset/core/translation';
 import { styled, css } from '@apache-superset/core/theme';
 import type { SchemaOption, CatalogOption } from 'src/hooks/apiResources';
 import { DatabaseSelector, type DatabaseObject } from 'src/components';
+import { TMP_QUERY_ID } from 'src/SqlLab/hooks/useQueryEditor';
 
 import useDatabaseSelector from '../SqlEditorTopBar/useDatabaseSelector';
 import TableExploreTree from '../TableExploreTree';
@@ -63,7 +64,8 @@ const StyledDivider = styled.div`
 `;
 
 const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
-  const dbSelectorProps = useDatabaseSelector(queryEditorId);
+  const activeQEId = queryEditorId || TMP_QUERY_ID;
+  const dbSelectorProps = useDatabaseSelector(activeQEId);
   const { db, catalog, schema, onDbChange, onCatalogChange, onSchemaChange } =
     dbSelectorProps;
 
@@ -198,7 +200,7 @@ const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
         />
       </Popover>
       <StyledDivider />
-      <TableExploreTree queryEditorId={queryEditorId} />
+      <TableExploreTree queryEditorId={activeQEId} />
       {shouldShowReset && (
         <Button
           buttonSize="small"

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -32,7 +32,7 @@ import { t } from '@apache-superset/core/translation';
 import { styled, css } from '@apache-superset/core/theme';
 import type { SchemaOption, CatalogOption } from 'src/hooks/apiResources';
 import { DatabaseSelector, type DatabaseObject } from 'src/components';
-import { TMP_QUERY_ID } from 'src/SqlLab/hooks/useQueryEditor';
+import { EMPTY_STATE_QE_ID } from 'src/SqlLab/hooks/useQueryEditor';
 
 import useDatabaseSelector from '../SqlEditorTopBar/useDatabaseSelector';
 import TableExploreTree from '../TableExploreTree';
@@ -64,7 +64,7 @@ const StyledDivider = styled.div`
 `;
 
 const SqlEditorLeftBar = ({ queryEditorId }: SqlEditorLeftBarProps) => {
-  const activeQEId = queryEditorId || TMP_QUERY_ID;
+  const activeQEId = queryEditorId || EMPTY_STATE_QE_ID;
   const dbSelectorProps = useDatabaseSelector(activeQEId);
   const { db, catalog, schema, onDbChange, onCatalogChange, onSchemaChange } =
     dbSelectorProps;

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
@@ -21,6 +21,8 @@ import { useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { SqlLabRootState, QueryEditor } from 'src/SqlLab/types';
 
+export const TMP_QUERY_ID = 'tmp_qe_id';
+
 export default function useQueryEditor<T extends keyof QueryEditor>(
   sqlEditorId: string,
   attributes: ReadonlyArray<T>,
@@ -43,6 +45,7 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
         {
           ...queryEditors[queryEditorsById[sqlEditorId]],
           ...(sqlEditorId === unsavedQueryEditor?.id && unsavedQueryEditor),
+          ...(sqlEditorId === TMP_QUERY_ID && { id: sqlEditorId }),
         },
         ['id'].concat(attributes),
       ) as Pick<QueryEditor, T | 'id'>,

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
@@ -21,7 +21,7 @@ import { useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { SqlLabRootState, QueryEditor } from 'src/SqlLab/types';
 
-export const TMP_QUERY_ID = 'tmp_qe_id';
+export const EMPTY_STATE_QE_ID = 'tmp_qe_id';
 
 export default function useQueryEditor<T extends keyof QueryEditor>(
   sqlEditorId: string,
@@ -45,7 +45,7 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
         {
           ...queryEditors[queryEditorsById[sqlEditorId]],
           ...(sqlEditorId === unsavedQueryEditor?.id && unsavedQueryEditor),
-          ...(sqlEditorId === TMP_QUERY_ID && { id: sqlEditorId }),
+          ...(sqlEditorId === EMPTY_STATE_QE_ID && { id: sqlEditorId }),
         },
         ['id'].concat(attributes),
       ) as Pick<QueryEditor, T | 'id'>,

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.ts
@@ -42,7 +42,10 @@ function alterUnsavedQueryEditorState(
   id: string,
   silent = false,
 ): Partial<SqlLabState> {
-  if (state.tabHistory[state.tabHistory.length - 1] !== id) {
+  if (
+    state.tabHistory.length > 0 &&
+    state.tabHistory[state.tabHistory.length - 1] !== id
+  ) {
     const { queryEditors } = alterInArr(
       state,
       'queryEditors',


### PR DESCRIPTION
## **User description**
### SUMMARY
fixes #38482
When a new blank tab is created in SQL Lab before any saved query editors are loaded, the SqlEditorLeftBar received an empty queryEditorId, causing the database/schema selector and table explorer to be inactive/broken.

  This fix introduces a stable sentinel constant TMP_QUERY_ID that acts as a placeholder identity for the unsaved/blank query editor state. Key changes:

  - useQueryEditor/index.ts: Exports TMP_QUERY_ID = 'tmp_qe_id' and ensures the hook returns a valid id when the selector ID matches this sentinel.
  - SqlEditorLeftBar/index.tsx: Falls back to TMP_QUERY_ID when queryEditorId is empty, so useDatabaseSelector and TableExploreTree always receive a
  valid ID.
  - actions/sqlLab.ts: In addNewQueryEditor(), the active query editor lookup now falls back to { id: TMP_QUERY_ID } instead of undefined, so blank-tab
  state (dbId, catalog, schema) is correctly inherited when opening a new tab.
  - reducers/sqlLab.ts: Guards alterUnsavedQueryEditorState against an empty tabHistory array to avoid a stale index lookup.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/55247a55-43d4-4670-bda2-119bc6e8891a

After:

https://github.com/user-attachments/assets/7f4b71b6-ea2b-4975-b2c8-96bffe2c4d0f



### TESTING INSTRUCTIONS

1. Open SQL Lab with no previously saved query editors.
  2. Click + to open a new blank tab.
  3. Verify the left panel (database selector, schema selector, table explorer) is active and interactive.
  4. Select a database/schema in the blank tab, then open another new tab — verify the new tab inherits the selected context.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Keep SQL Lab controls active in blank tabs and carry over the selected database context**

### What Changed
- Blank SQL Lab tabs now keep the database selector, schema selector, and table browser active instead of becoming unresponsive
- New tabs opened from a blank state now inherit the selected database, catalog, and schema from the current empty tab
- The empty-tab behavior is covered by new tests to prevent regressions

### Impact
`✅ Active database and schema selection in blank tabs`
`✅ Fewer broken left-panel controls`
`✅ Preserved context when opening a new SQL Lab tab`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
