### PR TITLE
fix(bigquery): backslash-escape apostrophes in filter values

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -88,18 +88,22 @@ def _process_string_literal(value: str) -> str:
     """
     Escape a string value for use as a BigQuery SQL literal.
 
-    BigQuery uses standard SQL quoting: single quotes delimit string literals,
-    and embedded single quotes are escaped by doubling them.  The upstream
-    sqlalchemy-bigquery dialect relies on Python's ``repr()`` to quote values,
-    which switches to double-quote delimiters when the string contains an
-    apostrophe (e.g. ``repr("O'Brien")`` -> ``"O'Brien"``).  In BigQuery SQL,
-    double-quoted tokens are *identifiers*, not string literals, so the query
-    fails with a syntax error.
+    BigQuery requires backslash escaping for single quotes inside string
+    literals (``'O\\'Brien'``).  Doubled single quotes (``'O''Brien'``) are
+    **not** valid — BigQuery parses them as two concatenated string literals
+    without whitespace, causing a syntax error:
+    ``concatenated string literals must be separated by whitespace``.
 
-    This helper always produces a single-quoted literal with properly doubled
-    internal quotes.
+    The upstream ``sqlalchemy-bigquery`` dialect relies on Python's ``repr()``
+    to quote values, which switches to double-quote delimiters when the string
+    contains an apostrophe (e.g. ``repr("O'Brien")`` → ``"O'Brien"``).
+    In BigQuery SQL, double-quoted tokens are *identifiers*, not string
+    literals, so the query also fails.
+
+    This helper always produces a single-quoted literal with backslash-escaped
+    internal quotes, following BigQuery's lexical rules.
     """
-    escaped = value.replace("'", "''").replace("%", "%%")
+    escaped = value.replace("\\", "\\\\").replace("'", "\\'")
     return f"'{escaped}'"
 
 
@@ -110,7 +114,10 @@ def _monkeypatch_bigquery_string_literal() -> None:
 
     Without this patch, a filter value like ``O'Brien`` is compiled as the
     double-quoted identifier ``"O'Brien"`` instead of the single-quoted literal
-    ``'O''Brien'``, causing BigQuery to return a syntax error.
+    ``'O\\'Brien'``, causing BigQuery to return a syntax error.
+
+    This follows the same pattern used for the Databricks dialect fix in
+    ``superset/db_engine_specs/databricks.py``.
     """
     try:
         from sqlalchemy_bigquery import BigQueryDialect

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -84,6 +84,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger()
 
 
+# BigQuery string escape sequences keyed off documented escapes in
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals.
+# Backslash MUST be first so subsequent escapes don't double-escape their own
+# backslash.  ``\?``, ``\"`` and ``\``` are valid BigQuery escapes but
+# intentionally omitted because those characters do not require escaping
+# inside a single-quoted literal.  ``\0`` is NOT a valid BigQuery escape
+# (octal escapes require exactly three digits); the null byte instead falls
+# through to the ``\xhh`` fallback below.
+_BIGQUERY_STRING_ESCAPES = {
+    "\\": "\\\\",
+    "'": "\\'",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+    "\b": "\\b",
+    "\f": "\\f",
+    "\v": "\\v",
+    "\a": "\\a",
+}
+
+
 def _process_string_literal(value: str) -> str:
     """
     Escape a string value for use as a BigQuery SQL literal.
@@ -94,17 +115,30 @@ def _process_string_literal(value: str) -> str:
     without whitespace, causing a syntax error:
     ``concatenated string literals must be separated by whitespace``.
 
-    The upstream ``sqlalchemy-bigquery`` dialect relies on Python's ``repr()``
-    to quote values, which switches to double-quote delimiters when the string
-    contains an apostrophe (e.g. ``repr("O'Brien")`` → ``"O'Brien"``).
-    In BigQuery SQL, double-quoted tokens are *identifiers*, not string
-    literals, so the query also fails.
+    BigQuery also forbids literal newlines, carriage returns, and other
+    control characters inside a quoted string; those must be written using
+    escape sequences (``\\n``, ``\\r``, ``\\t`` …).  Control characters
+    without a named escape are emitted as a ``\\xhh`` hex escape; printable
+    Unicode passes through unchanged because BigQuery accepts UTF-8 inside
+    string literals.
 
-    This helper always produces a single-quoted literal with backslash-escaped
-    internal quotes, following BigQuery's lexical rules.
+    The upstream ``sqlalchemy-bigquery`` dialect relies on Python's ``repr()``
+    to quote values, which switches to double-quote delimiters when the
+    string contains an apostrophe (e.g. ``repr("O'Brien")`` → ``"O'Brien"``).
+    Double-quoted tokens inside compiled SQL would be parsed as identifiers,
+    so the query also fails.  This helper always produces a single-quoted
+    literal.
     """
-    escaped = value.replace("\\", "\\\\").replace("'", "\\'")
-    return f"'{escaped}'"
+    parts = []
+    for ch in value:
+        escape = _BIGQUERY_STRING_ESCAPES.get(ch)
+        if escape is not None:
+            parts.append(escape)
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            parts.append(f"\\x{ord(ch):02x}")
+        else:
+            parts.append(ch)
+    return f"'{''.join(parts)}'"
 
 
 def _monkeypatch_bigquery_string_literal() -> None:

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -23,7 +23,7 @@ import sys
 import urllib
 from datetime import datetime
 from re import Pattern
-from typing import Any, TYPE_CHECKING, TypedDict
+from typing import Any, Callable, TYPE_CHECKING, TypedDict
 
 import pandas as pd
 from apispec import APISpec
@@ -82,6 +82,58 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger()
+
+
+def _process_string_literal(value: str) -> str:
+    """
+    Escape a string value for use as a BigQuery SQL literal.
+
+    BigQuery uses standard SQL quoting: single quotes delimit string literals,
+    and embedded single quotes are escaped by doubling them.  The upstream
+    sqlalchemy-bigquery dialect relies on Python's ``repr()`` to quote values,
+    which switches to double-quote delimiters when the string contains an
+    apostrophe (e.g. ``repr("O'Brien")`` -> ``"O'Brien"``).  In BigQuery SQL,
+    double-quoted tokens are *identifiers*, not string literals, so the query
+    fails with a syntax error.
+
+    This helper always produces a single-quoted literal with properly doubled
+    internal quotes.
+    """
+    escaped = value.replace("'", "''").replace("%", "%%")
+    return f"'{escaped}'"
+
+
+def _monkeypatch_bigquery_string_literal() -> None:
+    """
+    Patch the sqlalchemy-bigquery dialect so that string literals containing
+    apostrophes are rendered correctly when ``literal_binds=True``.
+
+    Without this patch, a filter value like ``O'Brien`` is compiled as the
+    double-quoted identifier ``"O'Brien"`` instead of the single-quoted literal
+    ``'O''Brien'``, causing BigQuery to return a syntax error.
+    """
+    try:
+        from sqlalchemy_bigquery import BigQueryDialect
+
+        class BigQuerySafeString(types.TypeDecorator):  # type: ignore
+            impl = types.String
+            cache_ok = True
+
+            def literal_processor(
+                self, dialect: Any
+            ) -> Callable[[str], str]:
+                if dialect.name == "bigquery":
+                    return _process_string_literal
+                return super().literal_processor(dialect)  # type: ignore
+
+        BigQueryDialect.colspecs[types.String] = BigQuerySafeString  # type: ignore
+
+    except ImportError:
+        pass
+
+
+_monkeypatch_bigquery_string_literal()
+
 
 CONNECTION_DATABASE_PERMISSIONS_REGEX = re.compile(
     "Access Denied: Project (?P<project_name>.+?): User does not have "

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -119,9 +119,7 @@ def _monkeypatch_bigquery_string_literal() -> None:
             impl = types.String
             cache_ok = True
 
-            def literal_processor(
-                self, dialect: Any
-            ) -> Callable[[str], str]:
+            def literal_processor(self, dialect: Any) -> Callable[[str], str]:
                 if dialect.name == "bigquery":
                     return _process_string_literal
                 return super().literal_processor(dialect)  # type: ignore

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -115,16 +115,16 @@ def _monkeypatch_bigquery_string_literal() -> None:
     try:
         from sqlalchemy_bigquery import BigQueryDialect
 
-        class BigQuerySafeString(types.TypeDecorator):  # type: ignore
+        class BigQuerySafeString(types.TypeDecorator):
             impl = types.String
             cache_ok = True
 
             def literal_processor(self, dialect: Any) -> Callable[[str], str]:
                 if dialect.name == "bigquery":
                     return _process_string_literal
-                return super().literal_processor(dialect)  # type: ignore
+                return super().literal_processor(dialect)
 
-        BigQueryDialect.colspecs[types.String] = BigQuerySafeString  # type: ignore
+        BigQueryDialect.colspecs[types.String] = BigQuerySafeString
 
     except ImportError:
         pass

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -875,3 +875,50 @@ def test_monkeypatch_is_applied() -> None:
     assert sa_sqltypes.String in colspecs
     safe_cls = colspecs[sa_sqltypes.String]
     assert safe_cls.__name__ == "BigQuerySafeString"
+
+
+def test_literal_processor_returns_process_string_literal_for_bigquery() -> None:
+    """
+    Test that BigQuerySafeString.literal_processor returns the
+    _process_string_literal function when given a BigQuery dialect,
+    and that calling it produces correctly escaped output.
+    """
+    from superset.db_engine_specs.bigquery import (
+        _monkeypatch_bigquery_string_literal,
+        _process_string_literal,
+    )
+
+    _monkeypatch_bigquery_string_literal()
+
+    safe_cls = BigQueryDialect.colspecs[sqltypes.String]
+    instance = safe_cls()
+
+    dialect = BigQueryDialect()
+    processor = instance.literal_processor(dialect)
+
+    assert processor is _process_string_literal
+    assert processor("O'Brien") == "'O''Brien'"
+    assert processor("plain") == "'plain'"
+
+
+def test_monkeypatch_handles_missing_bigquery_package() -> None:
+    """
+    Test that _monkeypatch_bigquery_string_literal gracefully handles
+    the case where sqlalchemy_bigquery is not installed.
+    """
+    import builtins
+
+    from superset.db_engine_specs.bigquery import (
+        _monkeypatch_bigquery_string_literal,
+    )
+
+    original_import = builtins.__import__
+
+    def mock_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "sqlalchemy_bigquery":
+            raise ImportError("mocked missing package")
+        return original_import(name, *args, **kwargs)
+
+    with mock.patch("builtins.__import__", side_effect=mock_import):
+        # Should not raise — the except ImportError branch handles it
+        _monkeypatch_bigquery_string_literal()

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -743,3 +743,79 @@ def test_fetch_data_converts_bigquery_row_objects(mocker: MockerFixture) -> None
 
     assert result == [(1, "a"), (2, "b")]
     assert flask_g.bq_memory_limited is False
+
+
+def test_string_literal_with_apostrophe() -> None:
+    """
+    Test that string literals containing apostrophes are properly escaped
+    for BigQuery.
+
+    BigQuery uses standard SQL quoting where single quotes delimit string
+    literals and embedded single quotes are escaped by doubling them.
+    The upstream sqlalchemy-bigquery dialect uses ``repr()`` which switches
+    to double-quote delimiters when the value contains an apostrophe.
+    Double-quoted tokens are identifiers in BigQuery, causing syntax errors.
+    """
+    from sqlalchemy import column as sa_column
+
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F811
+
+    # Ensure the monkey-patch was applied
+    assert BigQueryEngineSpec  # trigger module load / patch
+
+    dialect = BigQueryDialect()
+
+    stmt = select(sa_column("name")).where(sa_column("name") == "Fernando's")
+    compiled_sql = str(
+        stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    )
+
+    # The compiled SQL must use single-quoted literal with doubled apostrophes.
+    # It must NOT contain backslash-escaped or double-quoted forms.
+    assert "= 'Fernando''s'" in compiled_sql
+    assert '\\"' not in compiled_sql
+    assert "\\'" not in compiled_sql
+
+
+def test_string_literal_without_apostrophe() -> None:
+    """
+    Test that normal string literals (without apostrophes) still compile
+    correctly after the monkey-patch.
+    """
+    from sqlalchemy import column as sa_column
+
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F811
+
+    assert BigQueryEngineSpec
+
+    dialect = BigQueryDialect()
+
+    stmt = select(sa_column("name")).where(sa_column("name") == "Fernando")
+    compiled_sql = str(
+        stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    )
+
+    assert "= 'Fernando'" in compiled_sql
+
+
+def test_string_literal_in_filter_with_apostrophe() -> None:
+    """
+    Test that IN filters with apostrophes in values compile correctly.
+    """
+    from sqlalchemy import column as sa_column
+
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F811
+
+    assert BigQueryEngineSpec
+
+    dialect = BigQueryDialect()
+
+    stmt = select(sa_column("name")).where(
+        sa_column("name").in_(["Fernando's", "O'Brien"])
+    )
+    compiled_sql = str(
+        stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    )
+
+    assert "'Fernando''s'" in compiled_sql
+    assert "'O''Brien'" in compiled_sql

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -819,3 +819,59 @@ def test_string_literal_in_filter_with_apostrophe() -> None:
 
     assert "'Fernando''s'" in compiled_sql
     assert "'O''Brien'" in compiled_sql
+
+
+def test_process_string_literal_directly() -> None:
+    """
+    Test _process_string_literal covers apostrophe doubling and percent
+    escaping for format-string safety.
+    """
+    from superset.db_engine_specs.bigquery import _process_string_literal
+
+    assert _process_string_literal("hello") == "'hello'"
+    assert _process_string_literal("O'Brien") == "'O''Brien'"
+    assert _process_string_literal("100%") == "'100%%'"
+    assert _process_string_literal("it's 100%") == "'it''s 100%%'"
+
+
+def test_literal_processor_non_bigquery_dialect() -> None:
+    """
+    Test that BigQuerySafeString.literal_processor falls back to the parent
+    implementation when used with a non-BigQuery dialect.
+    """
+    from sqlalchemy import create_engine
+
+    from superset.db_engine_specs.bigquery import (
+        _monkeypatch_bigquery_string_literal,  # noqa: F811
+    )
+
+    _monkeypatch_bigquery_string_literal()
+
+    safe_cls = BigQueryDialect.colspecs[sqltypes.String]
+    instance = safe_cls()
+
+    # Use a non-BigQuery dialect (sqlite)
+    sqlite_dialect = create_engine("sqlite://").dialect
+    processor = instance.literal_processor(sqlite_dialect)
+
+    # The fallback processor should still produce a valid quoted string
+    assert processor is not None
+
+
+def test_monkeypatch_is_applied() -> None:
+    """
+    Test that _monkeypatch_bigquery_string_literal installs the custom
+    type decorator into BigQueryDialect.colspecs.
+    """
+    from sqlalchemy.sql import sqltypes as sa_sqltypes
+
+    from superset.db_engine_specs.bigquery import (
+        BigQueryEngineSpec,  # noqa: F811
+    )
+
+    assert BigQueryEngineSpec
+
+    colspecs = BigQueryDialect.colspecs
+    assert sa_sqltypes.String in colspecs
+    safe_cls = colspecs[sa_sqltypes.String]
+    assert safe_cls.__name__ == "BigQuerySafeString"

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -914,7 +914,7 @@ def test_monkeypatch_handles_missing_bigquery_package() -> None:
 
     original_import = builtins.__import__
 
-    def mock_import(name: str, *args: object, **kwargs: object) -> object:
+    def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
         if name == "sqlalchemy_bigquery":
             raise ImportError("mocked missing package")
         return original_import(name, *args, **kwargs)

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -829,19 +829,92 @@ def test_string_literal_in_filter_with_apostrophe() -> None:
 
 def test_process_string_literal_directly() -> None:
     """
-    Test _process_string_literal covers backslash escaping for apostrophes
-    and proper handling of existing backslashes.
+    Test _process_string_literal covers backslash escaping for apostrophes,
+    control-character escaping (newline/CR/tab/etc.), the ``\\xhh`` fallback
+    for control chars without a named escape, and pass-through for printable
+    Unicode and other characters BigQuery accepts unescaped.
     """
     from superset.db_engine_specs.bigquery import _process_string_literal
 
+    # Plain values
     assert _process_string_literal("hello") == "'hello'"
+    assert _process_string_literal("") == "''"
+
+    # Apostrophes (the original fix)
     assert _process_string_literal("O'Brien") == "'O\\'Brien'"
     assert _process_string_literal("it's a test") == "'it\\'s a test'"
+
     # Backslashes must be escaped before apostrophes
     assert _process_string_literal("C:\\path") == "'C:\\\\path'"
     assert _process_string_literal("it's C:\\path") == "'it\\'s C:\\\\path'"
-    # Percent signs are NOT escaped (BigQuery doesn't require it)
+
+    # Literal backslash followed by 'n' (two characters, not a newline)
+    # must produce the two-char sequence '\\n' (escaped backslash + n) so
+    # BigQuery does not misread it as a newline escape.
+    assert _process_string_literal("\\n") == "'\\\\n'"
+
+    # Control characters must be escaped using named escapes — BigQuery
+    # rejects literal control characters inside quoted strings.
+    assert _process_string_literal("foo\nbar") == "'foo\\nbar'"
+    assert _process_string_literal("foo\rbar") == "'foo\\rbar'"
+    assert _process_string_literal("foo\tbar") == "'foo\\tbar'"
+    assert _process_string_literal("a\bb\fc\vd\ae") == "'a\\bb\\fc\\vd\\ae'"
+
+    # Control characters without a named escape fall through to ``\\xhh``.
+    assert _process_string_literal("null\0byte") == "'null\\x00byte'"
+    assert _process_string_literal("a\x01b") == "'a\\x01b'"
+    assert _process_string_literal("a\x1bb") == "'a\\x1bb'"
+    assert _process_string_literal("a\x7fb") == "'a\\x7fb'"
+
+    # Double quotes do NOT need escaping in single-quoted BigQuery literals.
+    assert _process_string_literal('say "hello"') == "'say \"hello\"'"
+
+    # Printable Unicode and percent signs pass through unchanged.
+    assert _process_string_literal("café") == "'café'"
+    assert _process_string_literal("日本") == "'日本'"
     assert _process_string_literal("100%") == "'100%'"
+
+    # Combined: apostrophe + newline + backslash + unicode.
+    assert _process_string_literal("it's\nC:\\café") == "'it\\'s\\nC:\\\\café'"
+
+
+def test_process_string_literal_no_literal_control_chars() -> None:
+    """
+    Regression test for the issue raised in PR #38835 review: BigQuery
+    rejects literal control characters inside quoted string literals, so the
+    output must never contain them as literal characters.
+    """
+    from superset.db_engine_specs.bigquery import _process_string_literal
+
+    for char in ["\n", "\r", "\t", "\b", "\f", "\v", "\a", "\0", "\x01", "\x7f"]:
+        result = _process_string_literal(f"prefix{char}suffix")
+        assert char not in result, (
+            f"Literal {char!r} leaked into output {result!r}; "
+            "BigQuery would reject this literal."
+        )
+
+
+def test_string_literal_with_newline_in_filter() -> None:
+    """
+    End-to-end regression test for @rusackas's review feedback on PR #38835:
+    a filter value containing a newline must compile to valid BigQuery SQL
+    using the ``\\n`` escape sequence, not a literal newline.
+    """
+    from sqlalchemy import column as sa_column
+
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F811
+
+    assert BigQueryEngineSpec is not None
+
+    dialect = BigQueryDialect()
+    stmt = select(sa_column("note")).where(sa_column("note") == "line1\nline2")
+    compiled_sql = str(
+        stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    )
+
+    # Must use the escape sequence form, not a literal newline.
+    assert "'line1\\nline2'" in compiled_sql
+    assert "\n" not in compiled_sql.split("note")[-1]
 
 
 def test_literal_processor_non_bigquery_dialect() -> None:

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -748,10 +748,11 @@ def test_fetch_data_converts_bigquery_row_objects(mocker: MockerFixture) -> None
 def test_string_literal_with_apostrophe() -> None:
     """
     Test that string literals containing apostrophes are properly escaped
-    for BigQuery.
+    for BigQuery using backslash escaping.
 
-    BigQuery uses standard SQL quoting where single quotes delimit string
-    literals and embedded single quotes are escaped by doubling them.
+    BigQuery requires backslash escaping for single quotes ('O\\'Brien').
+    Doubled single quotes ('O''Brien') are NOT valid — BigQuery parses them
+    as two concatenated string literals, causing a syntax error.
     The upstream sqlalchemy-bigquery dialect uses ``repr()`` which switches
     to double-quote delimiters when the value contains an apostrophe.
     Double-quoted tokens are identifiers in BigQuery, causing syntax errors.
@@ -770,11 +771,13 @@ def test_string_literal_with_apostrophe() -> None:
         stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
     )
 
-    # The compiled SQL must use single-quoted literal with doubled apostrophes.
-    # It must NOT contain backslash-escaped or double-quoted forms.
-    assert "= 'Fernando''s'" in compiled_sql
+    # The compiled SQL must use single-quoted literal with backslash-escaped
+    # apostrophes.  Doubled single quotes are NOT valid in BigQuery.
+    assert "= 'Fernando\\'s'" in compiled_sql
+    # Must NOT contain doubled-quote escaping (BigQuery rejects this)
+    assert "''" not in compiled_sql
+    # Must NOT contain double-quoted identifiers
     assert '\\"' not in compiled_sql
-    assert "\\'" not in compiled_sql
 
 
 def test_string_literal_without_apostrophe() -> None:
@@ -800,7 +803,8 @@ def test_string_literal_without_apostrophe() -> None:
 
 def test_string_literal_in_filter_with_apostrophe() -> None:
     """
-    Test that IN filters with apostrophes in values compile correctly.
+    Test that IN filters with apostrophes in values compile correctly
+    using backslash escaping.
     """
     from sqlalchemy import column as sa_column
 
@@ -817,21 +821,27 @@ def test_string_literal_in_filter_with_apostrophe() -> None:
         stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
     )
 
-    assert "'Fernando''s'" in compiled_sql
-    assert "'O''Brien'" in compiled_sql
+    assert "'Fernando\\'s'" in compiled_sql
+    assert "'O\\'Brien'" in compiled_sql
+    # Must NOT contain doubled-quote escaping
+    assert "''" not in compiled_sql
 
 
 def test_process_string_literal_directly() -> None:
     """
-    Test _process_string_literal covers apostrophe doubling and percent
-    escaping for format-string safety.
+    Test _process_string_literal covers backslash escaping for apostrophes
+    and proper handling of existing backslashes.
     """
     from superset.db_engine_specs.bigquery import _process_string_literal
 
     assert _process_string_literal("hello") == "'hello'"
-    assert _process_string_literal("O'Brien") == "'O''Brien'"
-    assert _process_string_literal("100%") == "'100%%'"
-    assert _process_string_literal("it's 100%") == "'it''s 100%%'"
+    assert _process_string_literal("O'Brien") == "'O\\'Brien'"
+    assert _process_string_literal("it's a test") == "'it\\'s a test'"
+    # Backslashes must be escaped before apostrophes
+    assert _process_string_literal("C:\\path") == "'C:\\\\path'"
+    assert _process_string_literal("it's C:\\path") == "'it\\'s C:\\\\path'"
+    # Percent signs are NOT escaped (BigQuery doesn't require it)
+    assert _process_string_literal("100%") == "'100%'"
 
 
 def test_literal_processor_non_bigquery_dialect() -> None:
@@ -897,7 +907,7 @@ def test_literal_processor_returns_process_string_literal_for_bigquery() -> None
     processor = instance.literal_processor(dialect)
 
     assert processor is _process_string_literal
-    assert processor("O'Brien") == "'O''Brien'"
+    assert processor("O'Brien") == "'O\\'Brien'"
     assert processor("plain") == "'plain'"
 
 

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -760,8 +760,8 @@ def test_string_literal_with_apostrophe() -> None:
 
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F811
 
-    # Ensure the monkey-patch was applied
-    assert BigQueryEngineSpec  # trigger module load / patch
+    # Trigger module load to ensure the monkey-patch is applied
+    assert BigQueryEngineSpec is not None
 
     dialect = BigQueryDialect()
 
@@ -786,7 +786,7 @@ def test_string_literal_without_apostrophe() -> None:
 
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F811
 
-    assert BigQueryEngineSpec
+    assert BigQueryEngineSpec is not None
 
     dialect = BigQueryDialect()
 
@@ -806,7 +806,7 @@ def test_string_literal_in_filter_with_apostrophe() -> None:
 
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F811
 
-    assert BigQueryEngineSpec
+    assert BigQueryEngineSpec is not None
 
     dialect = BigQueryDialect()
 
@@ -869,7 +869,7 @@ def test_monkeypatch_is_applied() -> None:
         BigQueryEngineSpec,  # noqa: F811
     )
 
-    assert BigQueryEngineSpec
+    assert BigQueryEngineSpec is not None
 
     colspecs = BigQueryDialect.colspecs
     assert sa_sqltypes.String in colspecs


### PR DESCRIPTION
> **Note (updated during review):** the final implementation uses BigQuery **backslash** escaping (`'O\'Brien'`), not the doubled-quote (`'O''Brien'`) approach the SUMMARY below originally described. Doubled single quotes are *not* valid in BigQuery. The summary is left intact for history; see the thread for the evolution.

---

## **User description**
### SUMMARY

Fixes #35857

BigQuery errors when dashboard filters on text columns contain apostrophes (e.g. `O'Brien`, `Fernando's`).

**Root cause:** The `sqlalchemy-bigquery` dialect's `process_string_literal` function uses Python's `repr()` to render string literals when `literal_binds=True` is used during query compilation. When the string contains an apostrophe, `repr()` wraps the value in double quotes (e.g. `repr("O'Brien")` -> `"O'Brien"`). In BigQuery SQL, double-quoted tokens are **identifiers** (like column or table names), not string literals, so the query fails with a syntax error.

**Fix:** Monkey-patch the BigQuery dialect's `colspecs` to use a custom `TypeDecorator` whose `literal_processor` always produces single-quoted literals with properly doubled internal quotes (`'O''Brien'`), which is the standard SQL escaping convention that BigQuery expects. This approach follows the same pattern used for the Databricks engine spec (`superset/db_engine_specs/databricks.py`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Filter with `Fernando's` generates SQL `WHERE name = "Fernando's"` (double-quoted identifier, causes BigQuery syntax error)

**After:** Filter with `Fernando's` generates SQL `WHERE name = 'Fernando''s'` (properly escaped single-quoted literal)

### TESTING INSTRUCTIONS

1. Set up a BigQuery connection in Superset
2. Create a dataset with a text column containing values with apostrophes (e.g. names like `O'Brien`, `Fernando's`)
3. Create a chart using this dataset
4. Add a filter on the text column selecting a value with an apostrophe
5. Verify the chart renders without errors
6. Also verify filters without apostrophes continue to work normally

Unit tests are included:
- `test_string_literal_with_apostrophe` - verifies apostrophe escaping
- `test_string_literal_without_apostrophe` - verifies normal strings unaffected
- `test_string_literal_in_filter_with_apostrophe` - verifies IN clause escaping

### ADDITIONAL INFORMATION
- [x] Has associated issue: #35857
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Escape BigQuery filter values that contain apostrophes**

### What Changed
- Filters using names like `O'Brien` now run in BigQuery instead of failing with a syntax error
- String values are written with standard single-quote escaping, including values inside multi-select filters
- Normal text filters without apostrophes still work the same way

### Impact
`✅ Fewer BigQuery filter errors`
`✅ Clearer text filtering in dashboards`
`✅ Reliable filters for names with apostrophes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

