### PR TITLE
fix(dataset): add email field to owners_data for Chart Explore path

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -299,6 +299,7 @@ class BaseDatasource(
                 "last_name": o.last_name,
                 "username": o.username,
                 "id": o.id,
+                "email": o.email,
             }
             for o in self.owners
         ]

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -946,3 +946,40 @@ def test_data_for_slices_handles_missing_datasource(mocker: MockerFixture) -> No
     assert "columns" in result
     assert "metrics" in result
     assert "verbose_map" in result
+
+
+def test_owners_data_includes_email(mocker: MockerFixture) -> None:
+    """
+    Test that the owners_data property includes the email field.
+
+    PR #37906 added email display to owner selectors in the frontend, but the
+    owners_data property used by the Chart Explore path was not updated, causing
+    owners to not display when editing a dataset from Chart Explore.
+    """
+    database = mocker.MagicMock()
+
+    table = SqlaTable(
+        table_name="test_table",
+        database=database,
+        columns=[],
+        metrics=[],
+    )
+
+    mock_owner = mocker.MagicMock()
+    mock_owner.first_name = "John"
+    mock_owner.last_name = "Doe"
+    mock_owner.username = "johndoe"
+    mock_owner.id = 1
+    mock_owner.email = "john@example.com"
+
+    table.owners = [mock_owner]
+
+    owners_data = table.owners_data
+    assert len(owners_data) == 1
+    assert owners_data[0] == {
+        "first_name": "John",
+        "last_name": "Doe",
+        "username": "johndoe",
+        "id": 1,
+        "email": "john@example.com",
+    }

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -949,13 +949,7 @@ def test_data_for_slices_handles_missing_datasource(mocker: MockerFixture) -> No
 
 
 def test_owners_data_includes_email(mocker: MockerFixture) -> None:
-    """
-    Test that the owners_data property includes the email field.
-
-    PR #37906 added email display to owner selectors in the frontend, but the
-    owners_data property used by the Chart Explore path was not updated, causing
-    owners to not display when editing a dataset from Chart Explore.
-    """
+    """Test that the owners_data property includes the email field."""
     database = mocker.MagicMock()
 
     table = SqlaTable(


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes #38834

The `owners_data` property in `BaseDatasource` (`superset/connectors/sqla/models.py`) was missing the `email` field that the frontend's `OwnerSelectLabel` component expects after PR #37906 added email display to owner selectors. This caused owners to not display on the Dataset Settings page when opened from Chart Explore, while the Dataset List page (which uses the updated API) showed owners correctly.

**Root cause:** PR #37906 updated the Dataset List API to include `email` in owner data and updated the frontend `OwnerSelectLabel` component to render it, but did not update the `owners_data` property used by the Chart Explore path. Without the `email` field, the frontend's `OwnerSelectLabel` could not match the expected data shape, causing owners to not render.

**Fix:** Add `"email": o.email` to the `owners_data` property dictionary, aligning it with the data shape the frontend expects.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Owners are not displayed on Dataset Settings page when opened from Chart Explore.
**After:** Owners display correctly with name and email, consistent with the Dataset List page behavior.

### TESTING INSTRUCTIONS

1. Open any chart in Chart Explore view
2. Click "Edit Dataset" to open the Dataset Editor
3. Go to the "Settings" tab
4. Verify that owners are displayed correctly in the Owners selector
5. Verify that email addresses appear below owner names
6. Also verify that the Dataset List page still works correctly (edit dataset from list view)

### ADDITIONAL INFORMATION
- [x] Has associated issue: #38834
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Show owner email in dataset settings opened from Chart Explore

### What Changed
- Dataset owners now include their email address when the Settings page is opened from Chart Explore, so owner names can render correctly there
- The returned owner details now match the dataset list view, keeping the owner display consistent across both paths
- Added a test to confirm owner email is included in the data sent to the UI

### Impact
`✅ Owners appear again in Chart Explore dataset settings`
`✅ Consistent owner display across dataset pages`
`✅ Fewer missing-owner issues in the editor`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
