### PR TITLE
fix(models): correct TabState.latest_query_id column type to match FK target

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -540,7 +540,7 @@ class TabState(AuditMixinNullable, ExtraJSONMixin, Model):
 
     # latest query that was run
     latest_query_id = Column(
-        Integer, ForeignKey("query.client_id", ondelete="SET NULL")
+        String(11), ForeignKey("query.client_id", ondelete="SET NULL")
     )
     latest_query = relationship("Query")
 


### PR DESCRIPTION
## **User description**
### SUMMARY

`TabState.latest_query_id` is defined as `Integer` in the ORM model, but it references `Query.client_id` which is `String(11)`. The original migration from 2019 correctly created the column as `VARCHAR(11)`, so existing databases work fine — but the ORM definition has been wrong since the model was first added.

This mismatch is harmless when tables are created via Alembic migrations (which use the correct type). However, any code path that calls `Model.metadata.create_all()` — such as FAB's `SecurityManager.create_db()` — will attempt to create the table using the ORM definition and fail with:

```
psycopg2.errors.DatatypeMismatch: foreign key constraint "tab_state_latest_query_id_fkey" cannot be implemented
DETAIL: Key columns "latest_query_id" and "client_id" are of incompatible types: integer and character varying.
```

This was exposed by the FAB 5.1.0 → 5.2.0 upgrade in #37973. FAB 5.2.0 added the new `ab_api_key` table to the existence check in `_create_db()`, which means `create_all()` now runs on fresh databases where it previously didn't — hitting the type mismatch.

The fix aligns the ORM model with the actual database schema. No migration is needed since every existing database already has the correct `VARCHAR(11)` type from the original migration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend model fix only.

### TESTING INSTRUCTIONS
1. Verify `String` is already imported in `superset/models/sql_lab.py` (line 43)
2. Confirm the original migration uses `sa.String(11)` for this column: `superset/migrations/versions/2019-11-13_11-05_db4b49eb0782_add_tables_for_sql_lab_state.py` line 50
3. Confirm `Query.client_id` is `String(11)` at line 116 of `superset/models/sql_lab.py`
4. Any test that creates tables via `Model.metadata.create_all()` on a fresh PostgreSQL database will now succeed

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Fix database creation for saved SQL tabs on fresh installs**

### What Changed
- Saved SQL tab records now store the latest query ID using the same text format as the query record it points to.
- This prevents database setup from failing when creating tables on a new PostgreSQL database.
- Existing databases are unaffected because they already use the correct column format.

### Impact
`✅ Fewer fresh-install database failures`
`✅ Successful setup for SQL Lab on new databases`
`✅ Clearer upgrade path for FAB-based installs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
