### PR TITLE
fix(mcp): add permission checks to generate_dashboard and update_chart tools

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -53,6 +53,7 @@ from flask_appbuilder.security.sqla.models import Group, User
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
+    from superset.mcp_service.chart.chart_utils import DatasetValidationResult
 
 # Type variable for decorated functions
 F = TypeVar("F", bound=Callable[..., Any])
@@ -327,6 +328,24 @@ def has_dataset_access(dataset: "SqlaTable") -> bool:
     except Exception as e:
         logger.warning("Error checking dataset access: %s", e)
         return False  # Deny access on error
+
+
+def check_chart_data_access(chart: Any) -> "DatasetValidationResult":
+    """Validate that the current user can access a chart's underlying dataset.
+
+    This extends the RBAC system: ``mcp_auth_hook`` enforces class-level
+    permissions before tool execution; this function enforces data-level
+    permissions inside tools after retrieving specific objects.
+
+    Args:
+        chart: A Slice ORM object with datasource_id attribute
+
+    Returns:
+        DatasetValidationResult with is_valid, error, etc.
+    """
+    from superset.mcp_service.chart.chart_utils import validate_chart_dataset
+
+    return validate_chart_dataset(chart, check_access=True)
 
 
 def _setup_user_context() -> User | None:

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -135,10 +135,13 @@ async def update_chart(
                 }
             )
 
-        # Validate dataset access before allowing update
-        from superset.mcp_service.chart.chart_utils import validate_chart_dataset
+        # Validate dataset access before allowing update.
+        # check_chart_data_access is the centralized data-level
+        # permission check that complements the class-level RBAC
+        # enforced by mcp_auth_hook.
+        from superset.mcp_service.auth import check_chart_data_access
 
-        validation_result = validate_chart_dataset(chart, check_access=True)
+        validation_result = check_chart_data_access(chart)
         if not validation_result.is_valid:
             error_msg = validation_result.error or "Chart's dataset is not accessible"
             return GenerateChartResponse.model_validate(

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -25,6 +25,7 @@ import time
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
+from superset.commands.exceptions import CommandException
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import (
     analyze_chart_capabilities,
@@ -266,7 +267,7 @@ async def update_chart(
         }
         return GenerateChartResponse.model_validate(result)
 
-    except Exception as e:
+    except (CommandException, ValueError, KeyError, AttributeError) as e:
         execution_time = int((time.time() - start_time) * 1000)
         return GenerateChartResponse.model_validate(
             {

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -134,6 +134,26 @@ async def update_chart(
                 }
             )
 
+        # Validate dataset access before allowing update
+        from superset.mcp_service.chart.chart_utils import validate_chart_dataset
+
+        validation_result = validate_chart_dataset(chart, check_access=True)
+        if not validation_result.is_valid:
+            error_msg = validation_result.error or "Chart's dataset is not accessible"
+            return GenerateChartResponse.model_validate(
+                {
+                    "chart": None,
+                    "error": {
+                        "error_type": "DatasetNotAccessible",
+                        "message": error_msg,
+                        "details": error_msg,
+                    },
+                    "success": False,
+                    "schema_version": "2.0",
+                    "api_version": "v1",
+                }
+            )
+
         # Map the new config to form_data format
         # Get dataset_id from existing chart for column type checking
         dataset_id = chart.datasource_id if chart.datasource_id else None

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -350,13 +350,13 @@ def add_chart_to_existing_dashboard(
                     error=f"Chart with ID {request.chart_id} not found",
                 )
 
-            # Validate dataset access for the chart using the same
-            # pattern as get_chart_info / get_chart_data / get_chart_preview.
-            from superset.mcp_service.chart.chart_utils import (
-                validate_chart_dataset,
-            )
+            # Validate dataset access for the chart.
+            # check_chart_data_access is the centralized data-level
+            # permission check that complements the class-level RBAC
+            # enforced by mcp_auth_hook.
+            from superset.mcp_service.auth import check_chart_data_access
 
-            validation = validate_chart_dataset(new_chart, check_access=True)
+            validation = check_chart_data_access(new_chart)
             if not validation.is_valid:
                 return AddChartToDashboardResponse(
                     dashboard=None,

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -350,6 +350,24 @@ def add_chart_to_existing_dashboard(
                     error=f"Chart with ID {request.chart_id} not found",
                 )
 
+            # Validate dataset access for the chart using the same
+            # pattern as get_chart_info / get_chart_data / get_chart_preview.
+            from superset.mcp_service.chart.chart_utils import (
+                validate_chart_dataset,
+            )
+
+            validation = validate_chart_dataset(new_chart, check_access=True)
+            if not validation.is_valid:
+                return AddChartToDashboardResponse(
+                    dashboard=None,
+                    dashboard_url=None,
+                    position=None,
+                    error=(
+                        f"Chart {request.chart_id} is not accessible: "
+                        f"{validation.error}"
+                    ),
+                )
+
             # Check if chart is already in dashboard
             current_chart_ids = [slice.id for slice in dashboard.slices]
             if request.chart_id in current_chart_ids:

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -227,20 +227,22 @@ def generate_dashboard(
                     error=f"Charts not found: {list(missing_chart_ids)}",
                 )
 
-            # Check if user has access to all charts
-            from superset.extensions import security_manager
+            # Validate dataset access for each chart using the same
+            # pattern as get_chart_info / get_chart_data / get_chart_preview.
+            from superset.mcp_service.chart.chart_utils import (
+                validate_chart_dataset,
+            )
 
-            inaccessible_chart_ids = [
-                chart.id
-                for chart in chart_objects
-                if not security_manager.can_access_chart(chart)
-            ]
-            if inaccessible_chart_ids:
-                return GenerateDashboardResponse(
-                    dashboard=None,
-                    dashboard_url=None,
-                    error=f"Access denied to charts: {inaccessible_chart_ids}",
-                )
+            for chart in chart_objects:
+                validation = validate_chart_dataset(chart, check_access=True)
+                if not validation.is_valid:
+                    return GenerateDashboardResponse(
+                        dashboard=None,
+                        dashboard_url=None,
+                        error=(
+                            f"Chart {chart.id} is not accessible: {validation.error}"
+                        ),
+                    )
 
         # Create dashboard layout with chart objects
         with event_logger.log_context(action="mcp.generate_dashboard.layout"):

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -227,6 +227,21 @@ def generate_dashboard(
                     error=f"Charts not found: {list(missing_chart_ids)}",
                 )
 
+            # Check if user has access to all charts
+            from superset.extensions import security_manager
+
+            inaccessible_chart_ids = [
+                chart.id
+                for chart in chart_objects
+                if not security_manager.can_access_chart(chart)
+            ]
+            if inaccessible_chart_ids:
+                return GenerateDashboardResponse(
+                    dashboard=None,
+                    dashboard_url=None,
+                    error=f"Access denied to charts: {inaccessible_chart_ids}",
+                )
+
         # Create dashboard layout with chart objects
         with event_logger.log_context(action="mcp.generate_dashboard.layout"):
             layout = _create_dashboard_layout(chart_objects)

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -227,14 +227,14 @@ def generate_dashboard(
                     error=f"Charts not found: {list(missing_chart_ids)}",
                 )
 
-            # Validate dataset access for each chart using the same
-            # pattern as get_chart_info / get_chart_data / get_chart_preview.
-            from superset.mcp_service.chart.chart_utils import (
-                validate_chart_dataset,
-            )
+            # Validate dataset access for each chart.
+            # check_chart_data_access is the centralized data-level
+            # permission check that complements the class-level RBAC
+            # enforced by mcp_auth_hook.
+            from superset.mcp_service.auth import check_chart_data_access
 
             for chart in chart_objects:
-                validation = validate_chart_dataset(chart, check_access=True)
+                validation = check_chart_data_access(chart)
                 if not validation.is_valid:
                     return GenerateDashboardResponse(
                         dashboard=None,

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -19,8 +19,13 @@
 Unit tests for update_chart MCP tool
 """
 
-import pytest
+from unittest.mock import Mock, patch
 
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.chart.chart_utils import DatasetValidationResult
 from superset.mcp_service.chart.schemas import (
     AxisConfig,
     ColumnRef,
@@ -35,7 +40,7 @@ from superset.mcp_service.chart.schemas import (
 class TestUpdateChart:
     """Tests for update_chart MCP tool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_request_structure(self):
         """Test that chart update request structures are properly formed."""
         # Table chart update with numeric ID
@@ -75,7 +80,7 @@ class TestUpdateChart:
         assert xy_request.config.y[0].aggregate == "SUM"
         assert xy_request.config.kind == "line"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_with_chart_name(self):
         """Test updating chart with custom chart name."""
         config = TableChartConfig(
@@ -93,7 +98,7 @@ class TestUpdateChart:
         )
         assert request2.chart_name == "Updated Sales Report"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_preview_generation(self):
         """Test preview generation options in update request."""
         config = TableChartConfig(
@@ -122,7 +127,7 @@ class TestUpdateChart:
         )
         assert request3.generate_preview is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_identifier_types(self):
         """Test that identifier can be int or string (UUID)."""
         config = TableChartConfig(
@@ -147,7 +152,7 @@ class TestUpdateChart:
         assert request3.identifier == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         assert isinstance(request3.identifier, str)
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_config_variations(self):
         """Test various chart configuration options in updates."""
         # Test all XY chart types
@@ -188,7 +193,7 @@ class TestUpdateChart:
         request = UpdateChartRequest(identifier=1, config=table_config)
         assert len(request.config.filters) == 6
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_response_structure(self):
         """Test the expected response structure for chart updates."""
         # The response should contain these fields
@@ -223,7 +228,7 @@ class TestUpdateChart:
         assert "success" in expected_response
         assert len(optional_fields) > 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_axis_configurations(self):
         """Test axis configuration updates."""
         config = XYChartConfig(
@@ -249,7 +254,7 @@ class TestUpdateChart:
         assert request.config.y_axis.format == "$,.2f"
         assert request.config.y_axis.scale == "log"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_legend_configurations(self):
         """Test legend configuration updates."""
         positions = ["top", "bottom", "left", "right"]
@@ -274,7 +279,7 @@ class TestUpdateChart:
         request = UpdateChartRequest(identifier=1, config=config)
         assert request.config.legend.show is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_aggregation_functions(self):
         """Test all supported aggregation functions in updates."""
         aggs = ["SUM", "AVG", "COUNT", "MIN", "MAX", "COUNT_DISTINCT"]
@@ -286,7 +291,7 @@ class TestUpdateChart:
             request = UpdateChartRequest(identifier=1, config=config)
             assert request.config.columns[0].aggregate == agg
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_error_responses(self):
         """Test expected error response structures."""
         # Chart not found error
@@ -312,7 +317,7 @@ class TestUpdateChart:
         assert update_error["success"] is False
         assert "failed" in update_error["error"].lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_chart_name_sanitization(self):
         """Test that chart names are properly sanitized."""
         config = TableChartConfig(
@@ -333,7 +338,7 @@ class TestUpdateChart:
             # Chart name should be set (sanitization happens in the validator)
             assert request.chart_name is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_with_filters(self):
         """Test updating chart with various filter configurations."""
         filters = [
@@ -358,7 +363,7 @@ class TestUpdateChart:
         assert request.config.filters[1].op == ">="
         assert request.config.filters[2].value == "2024-01-01"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_chart_cache_control(self):
         """Test cache control parameters in update request."""
         config = TableChartConfig(
@@ -383,3 +388,106 @@ class TestUpdateChart:
         assert request2.use_cache is False
         assert request2.force_refresh is True
         assert request2.cache_timeout == 300
+
+
+@pytest.fixture()
+def mcp_server():
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication for all tests."""
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_user.username = "admin"
+        mock_get_user.return_value = mock_user
+        yield mock_get_user
+
+
+class TestUpdateChartDatasetAccess:
+    """Tests for dataset access validation in update_chart."""
+
+    @patch(
+        "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+        new_callable=Mock,
+    )
+    @patch("superset.daos.chart.ChartDAO.find_by_id", new_callable=Mock)
+    @patch("superset.db.session")
+    @pytest.mark.asyncio()
+    async def test_update_chart_dataset_access_denied(
+        self, mock_db_session, mock_find_by_id, mock_validate, mcp_server
+    ):
+        """Test that update_chart returns error when dataset is inaccessible."""
+        mock_chart = Mock()
+        mock_chart.id = 1
+        mock_chart.datasource_id = 10
+        mock_find_by_id.return_value = mock_chart
+
+        mock_validate.return_value = DatasetValidationResult(
+            is_valid=False,
+            dataset_id=10,
+            dataset_name="restricted_dataset",
+            warnings=[],
+            error="Access denied to dataset 'restricted_dataset' (ID: 10). "
+            "You do not have permission to view this dataset.",
+        )
+
+        request = {
+            "identifier": 1,
+            "config": {
+                "chart_type": "table",
+                "columns": [{"name": "col1"}],
+            },
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("update_chart", {"request": request})
+
+            assert result.structured_content["success"] is False
+            assert result.structured_content["chart"] is None
+            error = result.structured_content["error"]
+            assert error["error_type"] == "DatasetNotAccessible"
+            assert "Access denied" in error["message"]
+
+    @patch(
+        "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+        new_callable=Mock,
+    )
+    @patch("superset.daos.chart.ChartDAO.find_by_id", new_callable=Mock)
+    @patch("superset.db.session")
+    @pytest.mark.asyncio()
+    async def test_update_chart_dataset_not_found(
+        self, mock_db_session, mock_find_by_id, mock_validate, mcp_server
+    ):
+        """Test that update_chart returns error when dataset is deleted."""
+        mock_chart = Mock()
+        mock_chart.id = 1
+        mock_chart.datasource_id = 99
+        mock_find_by_id.return_value = mock_chart
+
+        mock_validate.return_value = DatasetValidationResult(
+            is_valid=False,
+            dataset_id=99,
+            dataset_name=None,
+            warnings=[],
+            error="Dataset (ID: 99) has been deleted or does not exist.",
+        )
+
+        request = {
+            "identifier": 1,
+            "config": {
+                "chart_type": "table",
+                "columns": [{"name": "col1"}],
+            },
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("update_chart", {"request": request})
+
+            assert result.structured_content["success"] is False
+            assert result.structured_content["chart"] is None
+            error = result.structured_content["error"]
+            assert error["error_type"] == "DatasetNotAccessible"
+            assert "deleted" in error["message"]

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -40,7 +40,7 @@ from superset.mcp_service.chart.schemas import (
 class TestUpdateChart:
     """Tests for update_chart MCP tool."""
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_request_structure(self):
         """Test that chart update request structures are properly formed."""
         # Table chart update with numeric ID
@@ -80,7 +80,7 @@ class TestUpdateChart:
         assert xy_request.config.y[0].aggregate == "SUM"
         assert xy_request.config.kind == "line"
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_with_chart_name(self):
         """Test updating chart with custom chart name."""
         config = TableChartConfig(
@@ -98,7 +98,7 @@ class TestUpdateChart:
         )
         assert request2.chart_name == "Updated Sales Report"
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_preview_generation(self):
         """Test preview generation options in update request."""
         config = TableChartConfig(
@@ -127,7 +127,7 @@ class TestUpdateChart:
         )
         assert request3.generate_preview is False
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_identifier_types(self):
         """Test that identifier can be int or string (UUID)."""
         config = TableChartConfig(
@@ -152,7 +152,7 @@ class TestUpdateChart:
         assert request3.identifier == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         assert isinstance(request3.identifier, str)
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_config_variations(self):
         """Test various chart configuration options in updates."""
         # Test all XY chart types
@@ -193,7 +193,7 @@ class TestUpdateChart:
         request = UpdateChartRequest(identifier=1, config=table_config)
         assert len(request.config.filters) == 6
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_response_structure(self):
         """Test the expected response structure for chart updates."""
         # The response should contain these fields
@@ -228,7 +228,7 @@ class TestUpdateChart:
         assert "success" in expected_response
         assert len(optional_fields) > 0
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_axis_configurations(self):
         """Test axis configuration updates."""
         config = XYChartConfig(
@@ -254,7 +254,7 @@ class TestUpdateChart:
         assert request.config.y_axis.format == "$,.2f"
         assert request.config.y_axis.scale == "log"
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_legend_configurations(self):
         """Test legend configuration updates."""
         positions = ["top", "bottom", "left", "right"]
@@ -279,7 +279,7 @@ class TestUpdateChart:
         request = UpdateChartRequest(identifier=1, config=config)
         assert request.config.legend.show is False
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_aggregation_functions(self):
         """Test all supported aggregation functions in updates."""
         aggs = ["SUM", "AVG", "COUNT", "MIN", "MAX", "COUNT_DISTINCT"]
@@ -291,7 +291,7 @@ class TestUpdateChart:
             request = UpdateChartRequest(identifier=1, config=config)
             assert request.config.columns[0].aggregate == agg
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_error_responses(self):
         """Test expected error response structures."""
         # Chart not found error
@@ -317,7 +317,7 @@ class TestUpdateChart:
         assert update_error["success"] is False
         assert "failed" in update_error["error"].lower()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_chart_name_sanitization(self):
         """Test that chart names are properly sanitized."""
         config = TableChartConfig(
@@ -338,7 +338,7 @@ class TestUpdateChart:
             # Chart name should be set (sanitization happens in the validator)
             assert request.chart_name is not None
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_with_filters(self):
         """Test updating chart with various filter configurations."""
         filters = [
@@ -363,7 +363,7 @@ class TestUpdateChart:
         assert request.config.filters[1].op == ">="
         assert request.config.filters[2].value == "2024-01-01"
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_cache_control(self):
         """Test cache control parameters in update request."""
         config = TableChartConfig(
@@ -390,7 +390,7 @@ class TestUpdateChart:
         assert request2.cache_timeout == 300
 
 
-@pytest.fixture()
+@pytest.fixture
 def mcp_server():
     return mcp
 
@@ -415,7 +415,7 @@ class TestUpdateChartDatasetAccess:
     )
     @patch("superset.daos.chart.ChartDAO.find_by_id", new_callable=Mock)
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_dataset_access_denied(
         self, mock_db_session, mock_find_by_id, mock_validate, mcp_server
     ):
@@ -457,7 +457,7 @@ class TestUpdateChartDatasetAccess:
     )
     @patch("superset.daos.chart.ChartDAO.find_by_id", new_callable=Mock)
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_update_chart_dataset_not_found(
         self, mock_db_session, mock_find_by_id, mock_validate, mcp_server
     ):

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -410,7 +410,7 @@ class TestUpdateChartDatasetAccess:
     """Tests for dataset access validation in update_chart."""
 
     @patch(
-        "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+        "superset.mcp_service.auth.check_chart_data_access",
         new_callable=Mock,
     )
     @patch("superset.daos.chart.ChartDAO.find_by_id", new_callable=Mock)
@@ -452,7 +452,7 @@ class TestUpdateChartDatasetAccess:
             assert "Access denied" in error["message"]
 
     @patch(
-        "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+        "superset.mcp_service.auth.check_chart_data_access",
         new_callable=Mock,
     )
     @patch("superset.daos.chart.ChartDAO.find_by_id", new_callable=Mock)

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -42,7 +42,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mcp_server():
     return mcp
 
@@ -155,7 +155,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_basic(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -192,7 +192,7 @@ class TestGenerateDashboard:
             )
 
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_missing_charts(self, mock_db_session, mcp_server):
         """Test error handling when some charts don't exist."""
         mock_query = Mock()
@@ -215,7 +215,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_single_chart(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -242,7 +242,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_many_charts(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -311,7 +311,7 @@ class TestGenerateDashboard:
 
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_creation_failure(
         self, mock_db_session, mock_dashboard_cls, mcp_server
     ):
@@ -351,7 +351,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_minimal_request(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -385,7 +385,7 @@ class TestGenerateDashboard:
         new_callable=Mock,
     )
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_inaccessible_charts(
         self, mock_db_session, mock_can_access, mock_chart_access, mcp_server
     ):
@@ -420,7 +420,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_auto_title_from_charts(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -449,7 +449,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_empty_string_title_preserved(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -479,7 +479,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_dashboard_basic(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -565,7 +565,7 @@ class TestAddChartToExistingDashboard:
             assert layout[column_key]["type"] == "COLUMN"
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_not_found(self, mock_find_dashboard, mcp_server):
         """Test error when dashboard doesn't exist."""
         mock_find_dashboard.return_value = None
@@ -582,7 +582,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_chart_not_found(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -600,7 +600,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_already_in_dashboard(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -624,7 +624,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_empty_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -680,7 +680,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_tabbed_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -780,7 +780,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_specific_tab_by_name(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -881,7 +881,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -43,7 +43,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mcp_server():
     return mcp
 
@@ -162,7 +162,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_basic(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -199,7 +199,7 @@ class TestGenerateDashboard:
             )
 
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_missing_charts(self, mock_db_session, mcp_server):
         """Test error handling when some charts don't exist."""
         mock_query = Mock()
@@ -220,7 +220,7 @@ class TestGenerateDashboard:
             assert result.structured_content["dashboard_url"] is None
 
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_inaccessible_charts(
         self, mock_db_session, mock_chart_access, mcp_server
     ):
@@ -283,7 +283,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_single_chart(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -310,7 +310,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_many_charts(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -379,7 +379,7 @@ class TestGenerateDashboard:
 
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_creation_failure(
         self, mock_db_session, mock_dashboard_cls, mcp_server
     ):
@@ -419,7 +419,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_minimal_request(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -451,7 +451,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_auto_title_from_charts(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -480,7 +480,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_dashboard_empty_string_title_preserved(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -510,7 +510,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_dashboard_basic(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -596,7 +596,7 @@ class TestAddChartToExistingDashboard:
             assert layout[column_key]["type"] == "COLUMN"
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_not_found(self, mock_find_dashboard, mcp_server):
         """Test error when dashboard doesn't exist."""
         mock_find_dashboard.return_value = None
@@ -613,7 +613,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_chart_not_found(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -631,7 +631,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_dataset_not_accessible(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -668,7 +668,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_already_in_dashboard(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -692,7 +692,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_empty_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -748,7 +748,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_tabbed_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -848,7 +848,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_to_specific_tab_by_name(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -949,7 +949,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -26,6 +26,7 @@ import pytest
 from fastmcp import Client
 
 from superset.mcp_service.app import mcp
+from superset.mcp_service.chart.chart_utils import DatasetValidationResult
 from superset.mcp_service.dashboard.constants import generate_id
 from superset.mcp_service.dashboard.tool.add_chart_to_existing_dashboard import (
     _add_chart_to_layout,
@@ -42,7 +43,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
+@pytest.fixture()
 def mcp_server():
     return mcp
 
@@ -60,10 +61,16 @@ def mock_auth():
 
 @pytest.fixture(autouse=True)
 def mock_chart_access():
-    """Mock chart access check so tests don't hit real security manager."""
+    """Mock chart dataset validation so tests don't hit real security manager."""
     with patch(
-        "superset.extensions.security_manager.can_access_chart",
-        return_value=True,
+        "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+        return_value=DatasetValidationResult(
+            is_valid=True,
+            dataset_id=1,
+            dataset_name="test_dataset",
+            warnings=[],
+            error=None,
+        ),
     ):
         yield
 
@@ -155,7 +162,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_basic(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -192,7 +199,7 @@ class TestGenerateDashboard:
             )
 
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_missing_charts(self, mock_db_session, mcp_server):
         """Test error handling when some charts don't exist."""
         mock_query = Mock()
@@ -212,10 +219,71 @@ class TestGenerateDashboard:
             assert result.structured_content["dashboard"] is None
             assert result.structured_content["dashboard_url"] is None
 
+    @patch("superset.db.session")
+    @pytest.mark.asyncio()
+    async def test_generate_dashboard_inaccessible_charts(
+        self, mock_db_session, mock_chart_access, mcp_server
+    ):
+        """Test error when user lacks access to some charts."""
+        charts = [
+            _mock_chart(id=1, slice_name="Accessible"),
+            _mock_chart(id=2, slice_name="Restricted"),
+            _mock_chart(id=3, slice_name="Also Restricted"),
+        ]
+
+        mock_query = Mock()
+        mock_filter = Mock()
+        mock_query.filter.return_value = mock_filter
+        mock_filter.order_by.return_value = mock_filter
+        mock_filter.all.return_value = charts
+        mock_db_session.query.return_value = mock_query
+
+        # Override the autouse fixture: chart 2 has inaccessible dataset
+        def mock_validate(chart, check_access=False):
+            if chart.id == 2:
+                return DatasetValidationResult(
+                    is_valid=False,
+                    dataset_id=10,
+                    dataset_name="restricted_dataset",
+                    warnings=[],
+                    error=(
+                        "Access denied to dataset 'restricted_dataset' "
+                        "(ID: 10). You do not have permission to view "
+                        "this dataset."
+                    ),
+                )
+            return DatasetValidationResult(
+                is_valid=True,
+                dataset_id=chart.id,
+                dataset_name=f"dataset_{chart.id}",
+                warnings=[],
+                error=None,
+            )
+
+        with patch(
+            "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+            side_effect=mock_validate,
+        ):
+            request = {
+                "chart_ids": [1, 2, 3],
+                "dashboard_title": "Test Dashboard",
+            }
+
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "generate_dashboard", {"request": request}
+                )
+
+                assert result.structured_content["error"] is not None
+                assert "not accessible" in result.structured_content["error"]
+                assert "2" in result.structured_content["error"]
+                assert result.structured_content["dashboard"] is None
+                assert result.structured_content["dashboard_url"] is None
+
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_single_chart(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -242,7 +310,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_many_charts(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -311,7 +379,7 @@ class TestGenerateDashboard:
 
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_creation_failure(
         self, mock_db_session, mock_dashboard_cls, mcp_server
     ):
@@ -351,7 +419,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_minimal_request(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -380,47 +448,10 @@ class TestGenerateDashboard:
             created = mock_dashboard_cls.return_value
             assert created.published is True
 
-    @patch(
-        "superset.extensions.security_manager.can_access_chart",
-        new_callable=Mock,
-    )
-    @patch("superset.db.session")
-    @pytest.mark.asyncio
-    async def test_generate_dashboard_inaccessible_charts(
-        self, mock_db_session, mock_can_access, mock_chart_access, mcp_server
-    ):
-        """Test error when user lacks access to some charts."""
-        charts = [
-            _mock_chart(id=1, slice_name="Accessible Chart"),
-            _mock_chart(id=2, slice_name="Secret Chart"),
-            _mock_chart(id=3, slice_name="Hidden Chart"),
-        ]
-        mock_query = Mock()
-        mock_filter = Mock()
-        mock_query.filter.return_value = mock_filter
-        mock_filter.order_by.return_value = mock_filter
-        mock_filter.all.return_value = charts
-        mock_db_session.query.return_value = mock_query
-
-        # Only chart 1 is accessible
-        mock_can_access.side_effect = lambda chart: chart.id == 1
-
-        request = {"chart_ids": [1, 2, 3], "dashboard_title": "Mixed Access Dashboard"}
-
-        async with Client(mcp_server) as client:
-            result = await client.call_tool("generate_dashboard", {"request": request})
-
-            assert result.structured_content["dashboard"] is None
-            assert result.structured_content["dashboard_url"] is None
-            error = result.structured_content["error"]
-            assert "Access denied" in error
-            assert "2" in error
-            assert "3" in error
-
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_auto_title_from_charts(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -449,7 +480,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_empty_string_title_preserved(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -479,7 +510,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_dashboard_basic(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -565,7 +596,7 @@ class TestAddChartToExistingDashboard:
             assert layout[column_key]["type"] == "COLUMN"
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_dashboard_not_found(self, mock_find_dashboard, mcp_server):
         """Test error when dashboard doesn't exist."""
         mock_find_dashboard.return_value = None
@@ -582,7 +613,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_chart_not_found(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -600,7 +631,44 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
+    async def test_add_chart_dataset_not_accessible(
+        self, mock_db_session, mock_find_dashboard, mcp_server
+    ):
+        """Test error when chart's dataset is not accessible."""
+        mock_find_dashboard.return_value = _mock_dashboard()
+        mock_chart = _mock_chart(id=7)
+        mock_db_session.get.return_value = mock_chart
+
+        # Override autouse fixture: chart 7 has inaccessible dataset
+        with patch(
+            "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+            return_value=DatasetValidationResult(
+                is_valid=False,
+                dataset_id=10,
+                dataset_name="restricted_dataset",
+                warnings=[],
+                error=(
+                    "Access denied to dataset 'restricted_dataset' "
+                    "(ID: 10). You do not have permission to view "
+                    "this dataset."
+                ),
+            ),
+        ):
+            request = {"dashboard_id": 1, "chart_id": 7}
+
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "add_chart_to_existing_dashboard", {"request": request}
+                )
+                assert result.structured_content["error"] is not None
+                assert "not accessible" in result.structured_content["error"]
+                assert "7" in result.structured_content["error"]
+                assert result.structured_content["dashboard"] is None
+
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+    @patch("superset.db.session")
+    @pytest.mark.asyncio()
     async def test_add_chart_already_in_dashboard(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -624,7 +692,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_empty_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -680,7 +748,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_tabbed_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -780,7 +848,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_specific_tab_by_name(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -881,7 +949,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -63,7 +63,7 @@ def mock_auth():
 def mock_chart_access():
     """Mock chart dataset validation so tests don't hit real security manager."""
     with patch(
-        "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+        "superset.mcp_service.auth.check_chart_data_access",
         return_value=DatasetValidationResult(
             is_valid=True,
             dataset_id=1,
@@ -261,7 +261,7 @@ class TestGenerateDashboard:
             )
 
         with patch(
-            "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+            "superset.mcp_service.auth.check_chart_data_access",
             side_effect=mock_validate,
         ):
             request = {
@@ -642,7 +642,7 @@ class TestAddChartToExistingDashboard:
 
         # Override autouse fixture: chart 7 has inaccessible dataset
         with patch(
-            "superset.mcp_service.chart.chart_utils.validate_chart_dataset",
+            "superset.mcp_service.auth.check_chart_data_access",
             return_value=DatasetValidationResult(
                 is_valid=False,
                 dataset_id=10,

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -42,7 +42,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
+@pytest.fixture()
 def mcp_server():
     return mcp
 
@@ -56,6 +56,16 @@ def mock_auth():
         mock_user.username = "admin"
         mock_get_user.return_value = mock_user
         yield mock_get_user
+
+
+@pytest.fixture(autouse=True)
+def mock_chart_access():
+    """Mock chart access check so tests don't hit real security manager."""
+    with patch(
+        "superset.extensions.security_manager.can_access_chart",
+        return_value=True,
+    ):
+        yield
 
 
 def _mock_chart(id: int = 1, slice_name: str = "Test Chart") -> Mock:
@@ -145,7 +155,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_basic(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -182,7 +192,7 @@ class TestGenerateDashboard:
             )
 
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_missing_charts(self, mock_db_session, mcp_server):
         """Test error handling when some charts don't exist."""
         mock_query = Mock()
@@ -205,7 +215,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_single_chart(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -232,7 +242,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_many_charts(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -301,7 +311,7 @@ class TestGenerateDashboard:
 
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_creation_failure(
         self, mock_db_session, mock_dashboard_cls, mcp_server
     ):
@@ -341,7 +351,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_minimal_request(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -370,10 +380,47 @@ class TestGenerateDashboard:
             created = mock_dashboard_cls.return_value
             assert created.published is True
 
+    @patch(
+        "superset.extensions.security_manager.can_access_chart",
+        new_callable=Mock,
+    )
+    @patch("superset.db.session")
+    @pytest.mark.asyncio()
+    async def test_generate_dashboard_inaccessible_charts(
+        self, mock_db_session, mock_can_access, mock_chart_access, mcp_server
+    ):
+        """Test error when user lacks access to some charts."""
+        charts = [
+            _mock_chart(id=1, slice_name="Accessible Chart"),
+            _mock_chart(id=2, slice_name="Secret Chart"),
+            _mock_chart(id=3, slice_name="Hidden Chart"),
+        ]
+        mock_query = Mock()
+        mock_filter = Mock()
+        mock_query.filter.return_value = mock_filter
+        mock_filter.order_by.return_value = mock_filter
+        mock_filter.all.return_value = charts
+        mock_db_session.query.return_value = mock_query
+
+        # Only chart 1 is accessible
+        mock_can_access.side_effect = lambda chart: chart.id == 1
+
+        request = {"chart_ids": [1, 2, 3], "dashboard_title": "Mixed Access Dashboard"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("generate_dashboard", {"request": request})
+
+            assert result.structured_content["dashboard"] is None
+            assert result.structured_content["dashboard_url"] is None
+            error = result.structured_content["error"]
+            assert "Access denied" in error
+            assert "2" in error
+            assert "3" in error
+
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_auto_title_from_charts(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -402,7 +449,7 @@ class TestGenerateDashboard:
     @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_dashboard_empty_string_title_preserved(
         self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
     ):
@@ -432,7 +479,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_dashboard_basic(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -518,7 +565,7 @@ class TestAddChartToExistingDashboard:
             assert layout[column_key]["type"] == "COLUMN"
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_dashboard_not_found(self, mock_find_dashboard, mcp_server):
         """Test error when dashboard doesn't exist."""
         mock_find_dashboard.return_value = None
@@ -535,7 +582,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_chart_not_found(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -553,7 +600,7 @@ class TestAddChartToExistingDashboard:
 
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_already_in_dashboard(
         self, mock_db_session, mock_find_dashboard, mcp_server
     ):
@@ -577,7 +624,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_empty_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -633,7 +680,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_tabbed_dashboard(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -733,7 +780,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_to_specific_tab_by_name(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -834,7 +881,7 @@ class TestAddChartToExistingDashboard:
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):


### PR DESCRIPTION
## **User description**
### SUMMARY

Fix two permission gaps in MCP tools:

1. **`generate_dashboard`**: Previously checked chart existence but did NOT verify chart access permissions. Users could create dashboards containing charts they shouldn't have access to. Now calls `security_manager.can_access_chart()` after verifying charts exist, returning an error listing inaccessible chart IDs.

2. **`update_chart`**: Previously did not validate dataset access before applying configuration changes. Users could update charts whose underlying dataset they cannot access. Now calls `validate_chart_dataset(chart, check_access=True)` after finding the chart, returning a structured `DatasetNotAccessible` error before any DB writes.

Both fixes reuse existing utilities (`security_manager.can_access_chart` and `validate_chart_dataset`) that are already used in other MCP tools like `get_chart_info`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - backend-only changes

### TESTING INSTRUCTIONS

1. Run MCP unit tests:
   ```bash
   pytest tests/unit_tests/mcp_service/ -x
   ```
2. Verify new tests pass:
   - `test_generate_dashboard_inaccessible_charts` - asserts error when user lacks chart access
   - `test_update_chart_dataset_access_denied` - asserts error when dataset is inaccessible
   - `test_update_chart_dataset_not_found` - asserts error when dataset is deleted
3. Verify existing tests still pass (no regression):
   - `test_generate_dashboard_basic` and all other dashboard generation tests
   - All existing `TestUpdateChart` tests

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Block dashboard and chart updates when the user cannot access the underlying dataset**

### What Changed
- Creating a dashboard now stops if any selected chart points to a dataset the user cannot view, and shows which chart is blocked.
- Adding a chart to an existing dashboard now rejects charts whose dataset is not accessible.
- Updating a chart now fails before saving changes when its dataset is inaccessible, with a clear dataset-access error instead of a generic failure.
- Added test coverage for inaccessible and deleted datasets during chart updates, dashboard generation, and adding charts to dashboards.

### Impact
`✅ Fewer unauthorized dashboard creations`
`✅ Clearer dataset access errors`
`✅ Safer chart updates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
