### PR TITLE
fix(embedded-sdk): wire `hideTab` to actually hide the dashboard tab

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -523,7 +523,7 @@ const DashboardBuilder = () => {
     ({ dropIndicatorProps }: { dropIndicatorProps: JsonObject }) => (
       <div>
         {dropIndicatorProps && <div {...dropIndicatorProps} />}
-        {!isReport && topLevelTabs && !uiConfig.hideNav && (
+        {!isReport && topLevelTabs && !uiConfig.hideTab && !uiConfig.hideNav && (
           <WithPopoverMenu
             shouldFocus={shouldFocusTabs}
             menuItems={[
@@ -555,6 +555,7 @@ const DashboardBuilder = () => {
       handleDeleteTopLevelTabs,
       isReport,
       topLevelTabs,
+      uiConfig.hideTab,
       uiConfig.hideNav,
     ],
   );


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The `hideTab` option in the Superset Embedded SDK's `dashboardUiConfig` was silently ignored — passing `hideTab: true` had no effect on the dashboard tab bar.

**Root cause:** `DashboardBuilder.tsx` was rendering the top-level tab bar conditioned on `!uiConfig.hideNav` (bit 4) rather than `!uiConfig.hideTab` (bit 2). The `hideTab` flag was correctly parsed from the URL bitmask by `UiConfigContext` but never read anywhere in the component tree.

**Fix:** Add `!uiConfig.hideTab` to the render condition in `DashboardBuilder.tsx` alongside the existing `!uiConfig.hideNav` check. This is fully backward-compatible — `hideNav` continues to suppress the tab bar as before, and `hideTab` now works as documented.

### TESTING INSTRUCTIONS
1. Set up a dashboard with top-level tabs (multiple tabs at the root level).
2. Embed the dashboard using the SDK with `dashboardUiConfig: { hideTab: true }`.
3. **Before:** Tab bar renders regardless of the flag.
4. **After:** Tab bar is hidden; only the content of the active tab is shown.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Make `hideTab` hide the dashboard tab bar**

### What Changed
- Embeds that set `hideTab: true` now hide the dashboard tab bar
- Existing `hideNav` behavior stays the same, so either setting can suppress the tabs

### Impact
`✅ Hidden tabs in embedded dashboards`
`✅ Fewer confusing controls in embed views`
`✅ Clearer tabless dashboard layouts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
