### PR TITLE
fix(mcp): detect unknown chart config fields and suggest correct ones

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -159,8 +159,8 @@ CRITICAL RULES - NEVER VIOLATE:
   open_sql_lab_with_context, etc.) and use the URL it returns.
 - To modify an existing chart's filters, metrics, or dimensions, use update_chart.
   Do NOT use execute_sql for chart modifications.
-- Parameter name reminders: open_sql_lab_with_context uses "sql" (not "query"),
-  execute_sql uses "sql" (not "query").
+- Parameter name reminders: ALWAYS use the EXACT parameter names from the tool schema.
+  Do NOT use Superset's internal form_data names.
 
 IMPORTANT - Tool-Only Interaction:
 - Do NOT generate code artifacts, HTML pages, JavaScript snippets, or any code intended

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -21,6 +21,7 @@ Pydantic schemas for chart-related responses
 
 from __future__ import annotations
 
+import difflib
 from datetime import datetime, timezone
 from typing import Annotated, Any, Dict, List, Literal, Protocol
 
@@ -395,6 +396,44 @@ def _normalize_group_by_input(v: Any) -> Any:
     return v
 
 
+def _get_known_fields(model_class: type[BaseModel]) -> set[str]:
+    """Collect all valid field names including validation aliases."""
+    known: set[str] = set()
+    for field_name, field_info in model_class.model_fields.items():
+        known.add(field_name)
+        alias = field_info.validation_alias
+        if isinstance(alias, AliasChoices):
+            for choice in alias.choices:
+                if isinstance(choice, str):
+                    known.add(choice)
+    return known
+
+
+def _check_unknown_fields(data: Any, model_class: type[BaseModel]) -> Any:
+    """Raise ValueError for unrecognized fields with 'did you mean?' suggestions.
+
+    Catches fields that would be silently dropped by extra='ignore' and provides
+    actionable error messages to help LLMs self-correct parameter names.
+    """
+    if not isinstance(data, dict):
+        return data
+    known = _get_known_fields(model_class)
+    unknown = set(data.keys()) - known
+    if not unknown:
+        return data
+
+    messages = []
+    for field in sorted(unknown):
+        matches = difflib.get_close_matches(field, sorted(known), n=1, cutoff=0.6)
+        if matches:
+            messages.append(f"Unknown field '{field}' — did you mean '{matches[0]}'?")
+        else:
+            messages.append(
+                f"Unknown field '{field}'. Valid fields: {', '.join(sorted(known))}"
+            )
+    raise ValueError(" | ".join(messages))
+
+
 class ColumnRef(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -558,6 +597,11 @@ class PieChartConfig(BaseModel):
         30, description="Donut inner radius % (1-100)", ge=1, le=100
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def check_unknown_fields(cls, data: Any) -> Any:
+        return _check_unknown_fields(data, cls)
+
 
 class PivotTableChartConfig(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
@@ -602,6 +646,11 @@ class PivotTableChartConfig(BaseModel):
     row_limit: int = Field(10000, description="Max cells", ge=1, le=50000)
     value_format: str = Field("SMART_NUMBER", max_length=50)
 
+    @model_validator(mode="before")
+    @classmethod
+    def check_unknown_fields(cls, data: Any) -> Any:
+        return _check_unknown_fields(data, cls)
+
 
 class MixedTimeseriesChartConfig(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
@@ -612,7 +661,11 @@ class MixedTimeseriesChartConfig(BaseModel):
         description="Shared temporal X-axis column",
         validation_alias=AliasChoices("x", "x_axis"),
     )
-    time_grain: TimeGrain | None = Field(None, description="PT1H, P1D, P1W, P1M, P1Y")
+    time_grain: TimeGrain | None = Field(
+        None,
+        description="PT1H, P1D, P1W, P1M, P1Y",
+        validation_alias=AliasChoices("time_grain", "time_grain_sqla"),
+    )
     # Primary series (Query A)
     y: List[ColumnRef] = Field(
         ...,
@@ -653,6 +706,11 @@ class MixedTimeseriesChartConfig(BaseModel):
     )
     row_limit: int = Field(10000, description="Max data points", ge=1, le=50000)
 
+    @model_validator(mode="before")
+    @classmethod
+    def check_unknown_fields(cls, data: Any) -> Any:
+        return _check_unknown_fields(data, cls)
+
     @field_validator("group_by", "group_by_secondary", mode="before")
     @classmethod
     def wrap_single_group_by(cls, v: Any) -> Any:
@@ -660,7 +718,7 @@ class MixedTimeseriesChartConfig(BaseModel):
 
 
 class HandlebarsChartConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     chart_type: Literal["handlebars"] = Field(
         ...,
@@ -703,6 +761,7 @@ class HandlebarsChartConfig(BaseModel):
             "Columns to group by in aggregate mode (query_mode='aggregate'). "
             "These become the dimensions for aggregation."
         ),
+        validation_alias=AliasChoices("groupby", "group_by"),
     )
     metrics: list[ColumnRef] | None = Field(
         None,
@@ -724,6 +783,11 @@ class HandlebarsChartConfig(BaseModel):
         description="Optional CSS styles to apply to the rendered template",
         max_length=10000,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_unknown_fields(cls, data: Any) -> Any:
+        return _check_unknown_fields(data, cls)
 
     @model_validator(mode="after")
     def validate_query_fields(self) -> "HandlebarsChartConfig":
@@ -779,8 +843,16 @@ class TableChartConfig(BaseModel):
         description="Structured filters (column/op/value). "
         "Do NOT use adhoc_filters or raw SQL expressions.",
     )
-    sort_by: List[str] | None = None
+    sort_by: List[str] | None = Field(
+        None,
+        validation_alias=AliasChoices("sort_by", "order_by_cols", "order_by"),
+    )
     row_limit: int = Field(1000, description="Max rows returned", ge=1, le=50000)
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_unknown_fields(cls, data: Any) -> Any:
+        return _check_unknown_fields(data, cls)
 
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "TableChartConfig":
@@ -827,12 +899,17 @@ class XYChartConfig(BaseModel):
     )
     kind: Literal["line", "bar", "area", "scatter"] = "line"
     time_grain: TimeGrain | None = Field(
-        None, description="PT1S, PT1M, PT1H, P1D, P1W, P1M, P3M, P1Y"
+        None,
+        description="PT1S, PT1M, PT1H, P1D, P1W, P1M, P3M, P1Y",
+        validation_alias=AliasChoices("time_grain", "time_grain_sqla"),
     )
     orientation: Literal["vertical", "horizontal"] | None = Field(
         None, description="Bar orientation (only for kind='bar')"
     )
-    stacked: bool = False
+    stacked: bool = Field(
+        False,
+        validation_alias=AliasChoices("stacked", "stack"),
+    )
     group_by: List[ColumnRef] | None = Field(
         None,
         description="Series breakdown columns",
@@ -849,6 +926,11 @@ class XYChartConfig(BaseModel):
         "Do NOT use adhoc_filters or raw SQL expressions.",
     )
     row_limit: int = Field(10000, description="Max data points", ge=1, le=50000)
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_unknown_fields(cls, data: Any) -> Any:
+        return _check_unknown_fields(data, cls)
 
     @field_validator("group_by", mode="before")
     @classmethod

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -412,15 +412,15 @@ def _get_known_fields(model_class: type[BaseModel]) -> set[str]:
     for field_name, field_info in model_class.model_fields.items():
         known.add(field_name)
         alias = field_info.validation_alias
-        if isinstance(alias, (str, AliasPath)):
-            key = _top_level_key(alias)
-            if key:
-                known.add(key)
-        elif isinstance(alias, AliasChoices):
+        if isinstance(alias, AliasChoices):
             for choice in alias.choices:
                 key = _top_level_key(choice)
                 if key:
                     known.add(key)
+        elif alias is not None:
+            key = _top_level_key(alias)
+            if key:
+                known.add(key)
     return known
 
 

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -27,6 +27,7 @@ from typing import Annotated, Any, Dict, List, Literal, Protocol
 
 from pydantic import (
     AliasChoices,
+    AliasPath,
     BaseModel,
     ConfigDict,
     Field,
@@ -396,18 +397,30 @@ def _normalize_group_by_input(v: Any) -> Any:
     return v
 
 
+def _top_level_key(alias: str | AliasPath) -> str | None:
+    """Extract the top-level dict key from a str or AliasPath."""
+    if isinstance(alias, str):
+        return alias
+    if isinstance(alias, AliasPath) and alias.path and isinstance(alias.path[0], str):
+        return alias.path[0]
+    return None
+
+
 def _get_known_fields(model_class: type[BaseModel]) -> set[str]:
     """Collect all valid field names including validation aliases."""
     known: set[str] = set()
     for field_name, field_info in model_class.model_fields.items():
         known.add(field_name)
         alias = field_info.validation_alias
-        if isinstance(alias, str):
-            known.add(alias)
+        if isinstance(alias, (str, AliasPath)):
+            key = _top_level_key(alias)
+            if key:
+                known.add(key)
         elif isinstance(alias, AliasChoices):
             for choice in alias.choices:
-                if isinstance(choice, str):
-                    known.add(choice)
+                key = _top_level_key(choice)
+                if key:
+                    known.add(key)
     return known
 
 
@@ -434,6 +447,15 @@ def _check_unknown_fields(data: Any, model_class: type[BaseModel]) -> Any:
                 f"Unknown field '{field}'. Valid fields: {', '.join(sorted(known))}"
             )
     raise ValueError(" | ".join(messages))
+
+
+class UnknownFieldCheckMixin(BaseModel):
+    """Mixin that rejects unknown fields with 'did you mean?' suggestions."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_unknown_fields(cls, data: Any) -> Any:
+        return _check_unknown_fields(data, cls)
 
 
 class ColumnRef(BaseModel):
@@ -560,7 +582,7 @@ class FilterConfig(BaseModel):
 
 
 # Actual chart types
-class PieChartConfig(BaseModel):
+class PieChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     chart_type: Literal["pie"] = "pie"
@@ -599,13 +621,8 @@ class PieChartConfig(BaseModel):
         30, description="Donut inner radius % (1-100)", ge=1, le=100
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_unknown_fields(cls, data: Any) -> Any:
-        return _check_unknown_fields(data, cls)
 
-
-class PivotTableChartConfig(BaseModel):
+class PivotTableChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     chart_type: Literal["pivot_table"] = "pivot_table"
@@ -648,13 +665,8 @@ class PivotTableChartConfig(BaseModel):
     row_limit: int = Field(10000, description="Max cells", ge=1, le=50000)
     value_format: str = Field("SMART_NUMBER", max_length=50)
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_unknown_fields(cls, data: Any) -> Any:
-        return _check_unknown_fields(data, cls)
 
-
-class MixedTimeseriesChartConfig(BaseModel):
+class MixedTimeseriesChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     chart_type: Literal["mixed_timeseries"] = "mixed_timeseries"
@@ -708,18 +720,13 @@ class MixedTimeseriesChartConfig(BaseModel):
     )
     row_limit: int = Field(10000, description="Max data points", ge=1, le=50000)
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_unknown_fields(cls, data: Any) -> Any:
-        return _check_unknown_fields(data, cls)
-
     @field_validator("group_by", "group_by_secondary", mode="before")
     @classmethod
     def wrap_single_group_by(cls, v: Any) -> Any:
         return _normalize_group_by_input(v)
 
 
-class HandlebarsChartConfig(BaseModel):
+class HandlebarsChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore")
 
     chart_type: Literal["handlebars"] = Field(
@@ -786,11 +793,6 @@ class HandlebarsChartConfig(BaseModel):
         max_length=10000,
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_unknown_fields(cls, data: Any) -> Any:
-        return _check_unknown_fields(data, cls)
-
     @model_validator(mode="after")
     def validate_query_fields(self) -> "HandlebarsChartConfig":
         """Validate that the right fields are provided for the query mode."""
@@ -827,7 +829,7 @@ class HandlebarsChartConfig(BaseModel):
         return self
 
 
-class TableChartConfig(BaseModel):
+class TableChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     chart_type: Literal["table"] = "table"
@@ -850,11 +852,6 @@ class TableChartConfig(BaseModel):
         validation_alias=AliasChoices("sort_by", "order_by_cols", "order_by"),
     )
     row_limit: int = Field(1000, description="Max rows returned", ge=1, le=50000)
-
-    @model_validator(mode="before")
-    @classmethod
-    def check_unknown_fields(cls, data: Any) -> Any:
-        return _check_unknown_fields(data, cls)
 
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "TableChartConfig":
@@ -884,7 +881,7 @@ class TableChartConfig(BaseModel):
         return self
 
 
-class XYChartConfig(BaseModel):
+class XYChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     chart_type: Literal["xy"] = "xy"
@@ -928,11 +925,6 @@ class XYChartConfig(BaseModel):
         "Do NOT use adhoc_filters or raw SQL expressions.",
     )
     row_limit: int = Field(10000, description="Max data points", ge=1, le=50000)
-
-    @model_validator(mode="before")
-    @classmethod
-    def check_unknown_fields(cls, data: Any) -> Any:
-        return _check_unknown_fields(data, cls)
 
     @field_validator("group_by", mode="before")
     @classmethod

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -402,7 +402,9 @@ def _get_known_fields(model_class: type[BaseModel]) -> set[str]:
     for field_name, field_info in model_class.model_fields.items():
         known.add(field_name)
         alias = field_info.validation_alias
-        if isinstance(alias, AliasChoices):
+        if isinstance(alias, str):
+            known.add(alias)
+        elif isinstance(alias, AliasChoices):
             for choice in alias.choices:
                 if isinstance(choice, str):
                     known.add(choice)

--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -33,6 +33,7 @@ class ExecuteSqlRequest(BaseModel):
     sql: str = Field(
         ...,
         description="SQL query to execute (supports Jinja2 {{ var }} template syntax)",
+        validation_alias=AliasChoices("sql", "query"),
     )
     schema_name: str | None = Field(
         None, description="Schema to use for query execution", alias="schema"

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -235,17 +235,16 @@ class TestXYChartConfig:
         )
         assert config.kind == "area"
 
-    def test_unknown_fields_ignored(self) -> None:
-        """Test that unknown fields are silently ignored (extra='ignore')."""
-        config = XYChartConfig(
-            chart_type="xy",
-            x=ColumnRef(name="territory"),
-            y=[ColumnRef(name="sales", aggregate="SUM")],
-            kind="bar",
-            unknown_field="bad",
-        )
-        assert config.kind == "bar"
-        assert not hasattr(config, "unknown_field")
+    def test_unknown_fields_raise_error(self) -> None:
+        """Test that unknown fields raise ValueError with suggestions."""
+        with pytest.raises(ValidationError, match="Unknown field"):
+            XYChartConfig(
+                chart_type="xy",
+                x=ColumnRef(name="territory"),
+                y=[ColumnRef(name="sales", aggregate="SUM")],
+                kind="bar",
+                unknown_field="bad",
+            )
 
     def test_series_alias_accepted(self) -> None:
         """Test that 'series' is accepted as alias for 'group_by'."""
@@ -430,12 +429,145 @@ class TestRowLimit:
 class TestTableChartConfigExtraFields:
     """Test TableChartConfig rejects unknown fields."""
 
-    def test_unknown_fields_ignored(self) -> None:
-        """Test that unknown fields are silently ignored (extra='ignore')."""
-        config = TableChartConfig(
-            chart_type="table",
-            columns=[ColumnRef(name="product")],
-            foo="bar",
+    def test_unknown_fields_raise_error(self) -> None:
+        """Test that unknown fields raise ValueError with valid field list."""
+        with pytest.raises(ValidationError, match="Unknown field 'foo'"):
+            TableChartConfig(
+                chart_type="table",
+                columns=[ColumnRef(name="product")],
+                foo="bar",
+            )
+
+
+class TestAliasChoices:
+    """Test that common Superset form_data aliases are accepted."""
+
+    def test_xy_stack_alias_for_stacked(self) -> None:
+        """Test that 'stack' is accepted as alias for 'stacked'."""
+        config = XYChartConfig.model_validate(
+            {
+                "chart_type": "xy",
+                "x": {"name": "category"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "stack": True,
+            }
         )
-        assert len(config.columns) == 1
-        assert not hasattr(config, "foo")
+        assert config.stacked is True
+
+    def test_xy_stacked_still_works(self) -> None:
+        """Test that 'stacked' still works as primary field name."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="category"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            stacked=True,
+        )
+        assert config.stacked is True
+
+    def test_xy_time_grain_sqla_alias(self) -> None:
+        """Test that 'time_grain_sqla' is accepted as alias for 'time_grain'."""
+        config = XYChartConfig.model_validate(
+            {
+                "chart_type": "xy",
+                "x": {"name": "order_date"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "time_grain_sqla": "P1D",
+            }
+        )
+        assert config.time_grain is not None
+
+    def test_table_order_by_alias_for_sort_by(self) -> None:
+        """Test that 'order_by' is accepted as alias for 'sort_by'."""
+        config = TableChartConfig.model_validate(
+            {
+                "chart_type": "table",
+                "columns": [{"name": "product"}],
+                "order_by": ["product"],
+            }
+        )
+        assert config.sort_by == ["product"]
+
+    def test_mixed_timeseries_time_grain_sqla_alias(self) -> None:
+        """Test that 'time_grain_sqla' works for MixedTimeseriesChartConfig."""
+        from superset.mcp_service.chart.schemas import MixedTimeseriesChartConfig
+
+        config = MixedTimeseriesChartConfig.model_validate(
+            {
+                "chart_type": "mixed_timeseries",
+                "x": {"name": "order_date"},
+                "y": [{"name": "sales", "aggregate": "SUM"}],
+                "y_secondary": [{"name": "profit", "aggregate": "SUM"}],
+                "time_grain_sqla": "P1M",
+            }
+        )
+        assert config.time_grain is not None
+
+
+class TestUnknownFieldDetection:
+    """Test that unknown fields produce helpful error messages."""
+
+    def test_near_miss_suggests_correct_field(self) -> None:
+        """Test that a near-miss field name produces 'did you mean?' suggestion."""
+        with pytest.raises(ValidationError, match="did you mean"):
+            XYChartConfig.model_validate(
+                {
+                    "chart_type": "xy",
+                    "x": {"name": "category"},
+                    "y": [{"name": "sales", "aggregate": "SUM"}],
+                    "stacks": True,
+                }
+            )
+
+    def test_completely_unknown_field_lists_valid_fields(self) -> None:
+        """Test that a completely unknown field lists valid fields."""
+        with pytest.raises(ValidationError, match="Valid fields:"):
+            XYChartConfig.model_validate(
+                {
+                    "chart_type": "xy",
+                    "x": {"name": "category"},
+                    "y": [{"name": "sales", "aggregate": "SUM"}],
+                    "zzz_nonexistent": True,
+                }
+            )
+
+    def test_pie_chart_unknown_field(self) -> None:
+        """Test unknown field detection on PieChartConfig."""
+        from superset.mcp_service.chart.schemas import PieChartConfig
+
+        with pytest.raises(ValidationError, match="Unknown field"):
+            PieChartConfig.model_validate(
+                {
+                    "chart_type": "pie",
+                    "dimension": {"name": "category"},
+                    "metric": {"name": "sales", "aggregate": "SUM"},
+                    "bad_field": True,
+                }
+            )
+
+    def test_table_chart_unknown_field(self) -> None:
+        """Test unknown field detection on TableChartConfig."""
+        with pytest.raises(ValidationError, match="Unknown field"):
+            TableChartConfig.model_validate(
+                {
+                    "chart_type": "table",
+                    "columns": [{"name": "product"}],
+                    "invalid_param": "test",
+                }
+            )
+
+    def test_known_aliases_not_flagged_as_unknown(self) -> None:
+        """Test that known aliases pass validation without errors."""
+        config = XYChartConfig.model_validate(
+            {
+                "chart_type": "xy",
+                "x_axis": {"name": "category"},
+                "metrics": [{"name": "sales", "aggregate": "SUM"}],
+                "groupby": [{"name": "region"}],
+                "stack": True,
+                "limit": 500,
+                "time_grain_sqla": "P1D",
+            }
+        )
+        assert config.stacked is True
+        assert config.row_limit == 500
+        assert config.group_by is not None

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -564,10 +564,9 @@ class TestUnknownFieldDetection:
                 "metrics": [{"name": "sales", "aggregate": "SUM"}],
                 "groupby": [{"name": "region"}],
                 "stack": True,
-                "limit": 500,
                 "time_grain_sqla": "P1D",
             }
         )
         assert config.stacked is True
-        assert config.row_limit == 500
+        assert config.row_limit == 10000
         assert config.group_by is not None

--- a/tests/unit_tests/mcp_service/chart/test_handlebars_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_handlebars_chart.py
@@ -119,7 +119,7 @@ class TestHandlebarsChartConfig:
             )
 
     def test_extra_fields_forbidden(self) -> None:
-        with pytest.raises(ValueError, match="Extra inputs"):
+        with pytest.raises(ValueError, match="Unknown field 'unknown_field'"):
             HandlebarsChartConfig(
                 chart_type="handlebars",
                 handlebars_template="<p>test</p>",

--- a/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
+++ b/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
@@ -103,15 +103,14 @@ class TestPieChartConfigSchema:
         assert config.filters is not None
         assert len(config.filters) == 1
 
-    def test_pie_config_ignores_extra_fields(self) -> None:
-        config = PieChartConfig(
-            chart_type="pie",
-            dimension=ColumnRef(name="product"),
-            metric=ColumnRef(name="revenue", aggregate="SUM"),
-            unknown_field="bad",
-        )
-        assert config.dimension.name == "product"
-        assert not hasattr(config, "unknown_field")
+    def test_pie_config_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError, match="Unknown field"):
+            PieChartConfig(
+                chart_type="pie",
+                dimension=ColumnRef(name="product"),
+                metric=ColumnRef(name="revenue", aggregate="SUM"),
+                unknown_field="bad",
+            )
 
     def test_pie_config_missing_dimension(self) -> None:
         with pytest.raises(ValidationError):
@@ -324,15 +323,14 @@ class TestPivotTableChartConfigSchema:
                 metrics=[ColumnRef(name="revenue", aggregate="SUM")],
             )
 
-    def test_pivot_table_ignores_extra_fields(self) -> None:
-        config = PivotTableChartConfig(
-            chart_type="pivot_table",
-            rows=[ColumnRef(name="product")],
-            metrics=[ColumnRef(name="revenue", aggregate="SUM")],
-            unknown_field="bad",
-        )
-        assert config.rows[0].name == "product"
-        assert not hasattr(config, "unknown_field")
+    def test_pivot_table_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError, match="Unknown field"):
+            PivotTableChartConfig(
+                chart_type="pivot_table",
+                rows=[ColumnRef(name="product")],
+                metrics=[ColumnRef(name="revenue", aggregate="SUM")],
+                unknown_field="bad",
+            )
 
     def test_pivot_table_valid_aggregate_functions(self) -> None:
         for agg in ["Sum", "Average", "Median", "Count", "Minimum", "Maximum"]:
@@ -504,16 +502,15 @@ class TestMixedTimeseriesChartConfigSchema:
                 y_secondary=[ColumnRef(name="orders", aggregate="COUNT")],
             )
 
-    def test_mixed_timeseries_ignores_extra_fields(self) -> None:
-        config = MixedTimeseriesChartConfig(
-            chart_type="mixed_timeseries",
-            x=ColumnRef(name="date"),
-            y=[ColumnRef(name="revenue", aggregate="SUM")],
-            y_secondary=[ColumnRef(name="orders", aggregate="COUNT")],
-            unknown_field="bad",
-        )
-        assert config.x.name == "date"
-        assert not hasattr(config, "unknown_field")
+    def test_mixed_timeseries_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError, match="Unknown field"):
+            MixedTimeseriesChartConfig(
+                chart_type="mixed_timeseries",
+                x=ColumnRef(name="date"),
+                y=[ColumnRef(name="revenue", aggregate="SUM")],
+                y_secondary=[ColumnRef(name="orders", aggregate="COUNT")],
+                unknown_field="bad",
+            )
 
     def test_mixed_timeseries_default_row_limit(self) -> None:
         config = MixedTimeseriesChartConfig(


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

 ### Summary
  - Add unknown-field detection to all chart config Pydantic models — fields that
    would be silently dropped by `extra="ignore"` now raise actionable errors with
    "did you mean?" suggestions (via `difflib.get_close_matches`)
  - Update system prompt to generalize parameter name guidance



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
- Send a `generate_chart` request with a misspelled config field (e.g.
    `"stackd": true`) and verify the error message includes a "did you mean
    'stacked'?" suggestion
- Send a request using an internal Superset name (e.g. `time_grain_sqla`)
    and verify it is accepted via the alias
- Verify existing valid requests continue to work unchanged
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Catch misspelled chart settings and accept common chart parameter names**

### What Changed
- Chart requests now fail with a clear “did you mean” message when they include an unknown setting instead of silently dropping it
- Several chart inputs now accept common alternate names, including chart time grain, stacked/stack, group by, and table sort settings
- Handlebars charts now ignore extra inputs instead of rejecting them, while still checking required fields
- Tool guidance now tells the assistant to use the exact parameter names from the tool schema

### Impact
`✅ Fewer broken chart requests`
`✅ Clearer chart setup errors`
`✅ Fewer failed retries from wrong parameter names`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
