### PR TITLE
fix(sqllab): long cell content overflooding

### DIFF
--- a/superset-frontend/src/components/FilterableTable/utils.tsx
+++ b/superset-frontend/src/components/FilterableTable/utils.tsx
@@ -50,6 +50,7 @@ export const renderResultCell = ({
         modalTitle={t('Cell content')}
         jsonObject={jsonObject}
         jsonValue={cellData}
+        wrapContent={false}
       />
     );
   }

--- a/superset-frontend/src/components/JsonModal/index.tsx
+++ b/superset-frontend/src/components/JsonModal/index.tsx
@@ -42,6 +42,7 @@ export const JsonModal: FC<JsonModalProps> = ({
   modalTitle,
   jsonObject,
   jsonValue,
+  wrapContent = true,
 }) => {
   const jsonTreeTheme = useJsonTreeTheme();
 
@@ -66,7 +67,7 @@ export const JsonModal: FC<JsonModalProps> = ({
         </Button>
       }
       modalTitle={modalTitle}
-      triggerNode={<PreWrap>{content}</PreWrap>}
+      triggerNode={wrapContent ? <PreWrap>{content}</PreWrap> : content}
     />
   );
 };

--- a/superset-frontend/src/components/JsonModal/types.ts
+++ b/superset-frontend/src/components/JsonModal/types.ts
@@ -23,4 +23,5 @@ export interface JsonModalProps {
   modalTitle: string;
   jsonObject: Record<string, unknown> | unknown[];
   jsonValue: CellDataType;
+  wrapContent?: boolean;
 }


### PR DESCRIPTION
## **User description**
### SUMMARY
Fixes #38854

Due to the pre-wrap added in #37036, an issue occurred where the SQL Lab result table cell content supporting the JSON viewer was overlapping with the content of the next line. This has been fixed by making pre-wrap configurable as a props option, so that pre-wrap is excluded for the result table.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="609" height="464" alt="Screenshot 2026-03-25 at 12 00 46 PM" src="https://github.com/user-attachments/assets/19b57108-9e19-48c0-90a6-92630b37b2bf" />

After:

<img width="599" height="196" alt="Screenshot 2026-03-25 at 12 06 17 PM" src="https://github.com/user-attachments/assets/0f283553-e4f3-4d79-a9d3-e2b8c53ecd46" />

### TESTING INSTRUCTIONS

locally tested

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Prevent JSON cell content from overflowing in SQL Lab results**

### What Changed
- JSON values in the SQL Lab result table no longer wrap into the next line or overlap nearby content
- The JSON preview still opens normally, but the table cell now shows the content without the extra wrapping that caused the display issue

### Impact
`✅ Clearer SQL Lab result tables`
`✅ Fewer overlapping cell contents`
`✅ Easier reading of long JSON values`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
