### PR TITLE
fix(mcp): use has_app_context() instead of private appbuilder._session check

### DIFF
--- a/superset/mcp_service/flask_singleton.py
+++ b/superset/mcp_service/flask_singleton.py
@@ -33,35 +33,20 @@ logger = logging.getLogger(__name__)
 logger.info("Creating Flask app instance for MCP service")
 
 try:
-    from superset.extensions import appbuilder
-
-    # Check if appbuilder is already initialized (main Superset app is running).
-    # If so, reuse that app to avoid corrupting the shared appbuilder singleton.
-    # Calling create_app() again would re-initialize appbuilder and break views.
-    #
-    # NOTE: appbuilder.app now returns a LocalProxy to current_app (Flask-AppBuilder
-    # deprecation), so we can't use `appbuilder.app is not None` as that always
-    # returns True (compares LocalProxy object, not the resolved value).
-    # Instead, check if init_app was called by looking at _session.
-    appbuilder_initialized = appbuilder._session is not None
-
-    if appbuilder_initialized and has_app_context():
-        # We're in an app context (e.g., during main Superset startup),
-        # so we can get the actual Flask app instance from current_app
+    # Flask CLI's FlaskGroup automatically calls create_app() and pushes a Flask
+    # app context before subcommands run (e.g., `superset mcp run`). Checking
+    # has_app_context() directly is the most reliable way to detect this — it
+    # avoids reading private FAB attributes like appbuilder._session, which is
+    # an implementation detail that may not exist in all FAB versions.
+    if has_app_context():
+        # We're already in an app context (e.g., FlaskGroup pushed one via CLI,
+        # or we're embedded in the main Superset server).
+        # Reuse that app to avoid calling create_app() a second time, which would
+        # re-initialize appbuilder with a different Flask instance and corrupt
+        # shared state (views, security manager, etc.).
         logger.info("Reusing existing Flask app from app context for MCP service")
         # Use _get_current_object() to get the actual Flask app, not the LocalProxy
         app = current_app._get_current_object()
-    elif appbuilder_initialized:
-        # appbuilder is initialized but we have no app context. Calling
-        # create_app() here would invoke appbuilder.init_app() a second
-        # time with a *different* Flask app, overwriting shared internal
-        # state (views, security manager, etc.).  Fail loudly instead of
-        # silently corrupting the singleton.
-        raise RuntimeError(
-            "appbuilder is already initialized but no Flask app context is "
-            "available.  Cannot call create_app() as it would re-initialize "
-            "appbuilder with a different Flask app instance."
-        )
     else:
         # Standalone MCP server — Superset models are deeply coupled to
         # appbuilder, security_manager, event_logger, encrypted_field_factory,


### PR DESCRIPTION
## **User description**
## Summary

- Replaces `appbuilder._session is not None` with `has_app_context()` to detect whether a Flask app is already running when `flask_singleton.py` is imported
- Removes the now-unreachable `elif appbuilder_initialized` branch that raised a `RuntimeError`
- Eliminates the `from superset.extensions import appbuilder` import, which was only needed for the `_session` check

## Motivation

`appbuilder._session` is a private Flask-AppBuilder implementation detail. Reading it is fragile:
- It may not exist in all FAB versions, causing `AttributeError`
- It causes a spurious second `create_app()` call that corrupts shared appbuilder state (views, security manager, etc.)

When the CLI's `FlaskGroup` invokes `superset mcp run`, it already pushes a Flask app context before the subcommand runs. `has_app_context()` is Flask's canonical, public API for detecting this — no FAB internals needed.

The eliminated `elif` branch (`appbuilder initialized but no app context`) is unreachable in practice: `appbuilder.init_app()` always runs inside an app context, so if appbuilder is initialized an app context must already exist.

## Test plan

- [ ] Run `superset mcp run` and confirm it starts without error
- [ ] Confirm MCP tools are listed at `http://localhost:5008/mcp`
- [ ] Confirm existing unit tests pass


___

## **CodeAnt-AI Description**
**Reuse the existing Flask app when MCP runs inside Superset**

### What Changed
- MCP now detects an active Flask app context directly and reuses that app instead of starting a new one
- This avoids a second app setup that could break shared Superset state such as views and security setup
- The code no longer depends on a private Flask-AppBuilder detail that could fail in some versions
- The unreachable error path for “appbuilder initialized but no app context” was removed

### Impact
`✅ Fewer MCP startup failures`
`✅ Safer Superset server startup`
`✅ Fewer broken admin views and security settings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
