### PR TITLE
fix(mcp): fix generate_chart crashing with "Working outside of request context"

### DIFF
--- a/superset/mcp_service/commands/create_form_data.py
+++ b/superset/mcp_service/commands/create_form_data.py
@@ -19,15 +19,59 @@
 MCP-specific form data command that extends the base CreateFormDataCommand
 """
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from superset.commands.explore.form_data.create import CreateFormDataCommand
-from superset.utils.core import get_user_id
+from superset.commands.explore.form_data.state import TemporaryExploreState
+from superset.commands.explore.form_data.utils import check_access
+from superset.commands.temporary_cache.exceptions import TemporaryCacheCreateFailedError
+from superset.extensions import cache_manager
+from superset.key_value.utils import random_key
+from superset.temporary_cache.utils import cache_key
+from superset.utils.core import DatasourceType, get_user_id
 
 
 class MCPCreateFormDataCommand(CreateFormDataCommand):
     """
-    MCP-specific CreateFormDataCommand that uses user_id instead of session._id
+    MCP-specific CreateFormDataCommand that avoids Flask request context.
+
+    The base class calls flask.session.get("_id") inside run(), which requires
+    an active HTTP request context. MCP tools execute outside of any HTTP
+    request, so calling the base run() raises "Working outside of request
+    context". This override replaces the session ID with get_user_id(), which
+    is available via Flask g and does not require a request context.
     """
 
-    def _get_session_id(self) -> str:
-        """Override to use user_id instead of Flask session for MCP context."""
-        return str(get_user_id())
+    def run(self) -> str:
+        self.validate()
+        try:
+            datasource_id = self._cmd_params.datasource_id
+            datasource_type = self._cmd_params.datasource_type
+            chart_id = self._cmd_params.chart_id
+            tab_id = self._cmd_params.tab_id
+            form_data = self._cmd_params.form_data
+            check_access(datasource_id, chart_id, datasource_type)
+            # Use user_id in place of flask.session.get("_id"). The session ID
+            # is only used as part of a cache key for contextual form data
+            # deduplication; substituting the user ID preserves that behaviour
+            # without requiring an HTTP request context.
+            session_id = str(get_user_id())
+            contextual_key = cache_key(
+                session_id, tab_id, datasource_id, chart_id, datasource_type
+            )
+            key = cache_manager.explore_form_data_cache.get(contextual_key)
+            if not key or not tab_id:
+                key = random_key()
+            if form_data:
+                state: TemporaryExploreState = {
+                    "owner": get_user_id(),
+                    "datasource_id": datasource_id,
+                    "datasource_type": DatasourceType(datasource_type),
+                    "chart_id": chart_id,
+                    "form_data": form_data,
+                }
+                cache_manager.explore_form_data_cache.set(key, state)
+                cache_manager.explore_form_data_cache.set(contextual_key, key)
+            return key
+        except SQLAlchemyError as ex:
+            raise TemporaryCacheCreateFailedError() from ex


### PR DESCRIPTION
## **User description**
## Problem

`generate_chart` and `generate_explore_link` crash with:

```
RuntimeError: Working outside of request context.
```

This happens because `MCPCreateFormDataCommand` inherits `CreateFormDataCommand.run()`, which calls `flask.session.get("_id")` directly. Flask's `session` proxy requires an active HTTP request context, but MCP tools run in an **app context only** — there is no HTTP request.

## Root cause

`MCPCreateFormDataCommand` already had a `_get_session_id()` override intended to fix this, but it was **never called**. The base class `run()` accesses `flask.session` directly rather than going through `self._get_session_id()`, making the override a no-op.

## Fix

Override `run()` in `MCPCreateFormDataCommand` and replace `session.get("_id")` with `get_user_id()`. The session ID is only used as part of a Redis cache key for contextual form-data deduplication — substituting the user ID preserves that behaviour without requiring a request context.

## Test plan

- [ ] Call `generate_chart` via MCP — confirm it no longer raises `Working outside of request context`
- [ ] Call `generate_explore_link` via MCP — confirm explore URL is returned successfully
- [ ] Existing unit tests pass


___

## **CodeAnt-AI Description**
**Keep MCP chart and explore link generation working without a request context**

### What Changed
- MCP chart and explore link generation no longer crash when there is no browser request
- The command now uses the current user instead of session data to build and reuse cached form data
- If saving temporary form data fails, the command now returns a clear cache-creation failure instead of a lower-level database error

### Impact
`✅ Fewer MCP request-context crashes`
`✅ Reliable chart and explore link generation`
`✅ Clearer temporary cache failure errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
