### PR TITLE
fix(AlteredSliceTag): not display undefined filter value for chart change record

### DIFF
--- a/superset-frontend/src/components/AlteredSliceTag/utils/index.ts
+++ b/superset-frontend/src/components/AlteredSliceTag/utils/index.ts
@@ -52,7 +52,7 @@ export const formatValueHandler = (
           v.comparator && v.comparator.constructor === Array
             ? `[${v.comparator.join(', ')}]`
             : v.comparator;
-        return `${v.subject} ${v.operator} ${filterVal}`;
+        return filterVal ? `${v.subject} ${v.operator} ${filterVal}` : `${v.subject} ${v.operator}`;
       })
       .join(', ');
   }

--- a/superset-frontend/src/components/AlteredSliceTag/utils/utils.test.ts
+++ b/superset-frontend/src/components/AlteredSliceTag/utils/utils.test.ts
@@ -258,6 +258,33 @@ describe('formatValueHandler', () => {
 
     expect(result).toEqual(expected);
   });
+
+  test('formats unary filter', () => {
+    const filters = [
+      {
+        expressionType: 'SIMPLE',
+        operator: 'IS NULL',
+        subject: 'a',
+      },
+      {
+        clause: 'WHERE',
+        comparator: ['hu', 'ho', 'ha'],
+        expressionType: 'SIMPLE',
+        operator: 'NOT IN',
+        subject: 'b',
+      },
+    ];
+    const key = 'adhoc_filters';
+
+    const expected = 'a IS NULL, b NOT IN [hu, ho, ha]';
+    const formattedValue: string | number = formatValueHandler(
+      filters,
+      key,
+      controlsMap,
+    );
+
+    expect(formattedValue).toEqual(expected);
+  });
 });
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(AlteredSliceTag): not display undefined filter value for chart change record

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #38811 

Dosu bot suggested to skip appending `filterVal` only for unary operator. IMO, we should take account of any possible filter that yields empty `filterValue` and skip appending.

Unit test added

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="1148" height="599" alt="image" src="https://github.com/user-attachments/assets/f42a7df8-41be-44ac-bacc-f571361efd77" />


After
<img width="1148" height="599" alt="image" src="https://github.com/user-attachments/assets/96fa45af-0732-42f1-8597-79afeff76a33" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Stop showing undefined filter values in chart change records**

### What Changed
- Chart change records no longer show an undefined filter value when a filter has no comparator value
- Unary filters now display only the operator and subject, instead of ending with an empty value
- Added a test to cover unary and multi-value filter formatting

### Impact
`✅ Clearer chart change history`
`✅ Fewer confusing undefined filter labels`
`✅ More accurate filter summaries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
