### PR TITLE
fix(explore): migrate from window.history to React Router history API

### DIFF
--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -211,7 +211,7 @@ export const hydrateExplore =
       sliceFormData,
       queryController: null,
       queriesResponse: null,
-      triggerQuery: false,
+      triggerQuery: !!saveAction,
       lastRendered: 0,
     };
 

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -26,7 +26,8 @@ import {
   VizType,
 } from '@superset-ui/core';
 import { QUERY_MODE_REQUISITES } from 'src/explore/constants';
-import { MemoryRouter, Route } from 'react-router-dom';
+import { Router, Route } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import {
   render,
   screen,
@@ -124,11 +125,13 @@ const renderWithRouter = ({
   overridePathname,
   initialState = reduxState,
   store,
+  history: existingHistory,
 }: {
   search?: string;
   overridePathname?: string;
   initialState?: object;
   store?: Store;
+  history?: ReturnType<typeof createMemoryHistory>;
 } = {}) => {
   const path = overridePathname ?? defaultPath;
   Object.defineProperty(window, 'location', {
@@ -136,14 +139,18 @@ const renderWithRouter = ({
       return { pathname: path, search };
     },
   });
-  return render(
-    <MemoryRouter initialEntries={[`${path}${search}`]}>
+  const history =
+    existingHistory ??
+    createMemoryHistory({ initialEntries: [`${path}${search}`] });
+  const result = render(
+    <Router history={history}>
       <Route path={path}>
         <ExploreViewContainer />
       </Route>
-    </MemoryRouter>,
+    </Router>,
     { useRedux: true, useDnd: true, initialState, store },
   );
+  return { ...result, history };
 };
 
 test('generates a new form_data param when none is available', async () => {
@@ -155,19 +162,18 @@ test('generates a new form_data param when none is available', async () => {
       useLegacyApi: false,
     }),
   );
-  const replaceState = jest.spyOn(window.history, 'replaceState');
-  await waitFor(() => renderWithRouter());
-  expect(replaceState).toHaveBeenCalledWith(
-    expect.anything(),
-    undefined,
+  const history = createMemoryHistory({ initialEntries: [defaultPath] });
+  const replaceSpy = jest.spyOn(history, 'replace');
+  await waitFor(() => renderWithRouter({ history }));
+  expect(replaceSpy).toHaveBeenCalledWith(
     expect.stringMatching('form_data_key'),
-  );
-  expect(replaceState).toHaveBeenCalledWith(
     expect.anything(),
-    undefined,
-    expect.stringMatching('datasource_id'),
   );
-  replaceState.mockRestore();
+  expect(replaceSpy).toHaveBeenCalledWith(
+    expect.stringMatching('datasource_id'),
+    expect.anything(),
+  );
+  replaceSpy.mockRestore();
 });
 
 test('renders chart in standalone mode', () => {
@@ -180,40 +186,37 @@ test('renders chart in standalone mode', () => {
   expect(queryByTestId('standalone-app')).toBeInTheDocument();
 });
 
-test('generates a different form_data param when one is provided and is mounting', async () => {
-  const replaceState = jest.spyOn(window.history, 'replaceState');
-  await waitFor(() => renderWithRouter({ search: SEARCH }));
-  expect(replaceState).not.toHaveBeenLastCalledWith(
-    0,
-    expect.anything(),
-    undefined,
-    expect.stringMatching(KEY),
-  );
-  expect(replaceState).toHaveBeenCalledWith(
-    expect.anything(),
-    undefined,
+test('generates a form_data param with datasource_id when mounting with existing key', async () => {
+  const history = createMemoryHistory({
+    initialEntries: [`${defaultPath}${SEARCH}`],
+  });
+  const replaceSpy = jest.spyOn(history, 'replace');
+  await waitFor(() => renderWithRouter({ search: SEARCH, history }));
+  expect(replaceSpy).toHaveBeenCalledWith(
     expect.stringMatching('datasource_id'),
+    expect.anything(),
   );
-  replaceState.mockRestore();
+  replaceSpy.mockRestore();
 });
 
 test('reuses the same form_data param when updating', async () => {
   getChartControlPanelRegistry().registerValue('table', {
     controlPanelSections: [],
   });
-  const replaceState = jest.spyOn(window.history, 'replaceState');
-  const pushState = jest.spyOn(window.history, 'pushState');
-  await waitFor(() => renderWithRouter({ search: SEARCH }));
-  expect(replaceState.mock.calls.length).toBe(1);
+  const history = createMemoryHistory({
+    initialEntries: [`${defaultPath}${SEARCH}`],
+  });
+  const replaceSpy = jest.spyOn(history, 'replace');
+  await waitFor(() => renderWithRouter({ search: SEARCH, history }));
+  expect(replaceSpy.mock.calls.length).toBe(1);
   userEvent.click(screen.getByText('Update chart'));
-  await waitFor(() => expect(pushState.mock.calls.length).toBe(1));
-  expect(replaceState.mock.calls[0]).toEqual(pushState.mock.calls[0]);
-  replaceState.mockRestore();
-  pushState.mockRestore();
+  await waitFor(() => expect(replaceSpy.mock.calls.length).toBe(2));
+  expect(replaceSpy.mock.calls[0]).toEqual(replaceSpy.mock.calls[1]);
+  replaceSpy.mockRestore();
   getChartControlPanelRegistry().remove('table');
 });
 
-test('doesnt call replaceState when pathname is not /explore', async () => {
+test('doesnt call replace when pathname is not /explore', async () => {
   getChartMetadataRegistry().registerValue(
     'table',
     new ChartMetadata({
@@ -222,24 +225,29 @@ test('doesnt call replaceState when pathname is not /explore', async () => {
       useLegacyApi: false,
     }),
   );
-  const replaceState = jest.spyOn(window.history, 'replaceState');
-  await waitFor(() => renderWithRouter({ overridePathname: '/dashboard' }));
-  expect(replaceState).not.toHaveBeenCalled();
-  replaceState.mockRestore();
+  const history = createMemoryHistory({ initialEntries: ['/dashboard'] });
+  const replaceSpy = jest.spyOn(history, 'replace');
+  await waitFor(() =>
+    renderWithRouter({ overridePathname: '/dashboard', history }),
+  );
+  expect(replaceSpy).not.toHaveBeenCalled();
+  replaceSpy.mockRestore();
 });
 
 test('preserves unknown parameters', async () => {
-  const replaceState = jest.spyOn(window.history, 'replaceState');
   const unknownParam = 'test=123';
+  const history = createMemoryHistory({
+    initialEntries: [`${defaultPath}${SEARCH}&${unknownParam}`],
+  });
+  const replaceSpy = jest.spyOn(history, 'replace');
   await waitFor(() =>
-    renderWithRouter({ search: `${SEARCH}&${unknownParam}` }),
+    renderWithRouter({ search: `${SEARCH}&${unknownParam}`, history }),
   );
-  expect(replaceState).toHaveBeenCalledWith(
-    expect.anything(),
-    undefined,
+  expect(replaceSpy).toHaveBeenCalledWith(
     expect.stringMatching(unknownParam),
+    expect.anything(),
   );
-  replaceState.mockRestore();
+  replaceSpy.mockRestore();
 });
 
 test('retains query mode requirements when query_mode is enabled', async () => {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
@@ -46,6 +46,7 @@ import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
 import { debounce, isEqual, isObjectLike, omit, pick } from 'lodash';
 import { Resizable } from 're-resizable';
+import { useHistory } from 'react-router-dom';
 import { Tooltip } from '@superset-ui/core/components';
 import { usePluginContext } from 'src/components';
 import { Global } from '@emotion/react';
@@ -63,7 +64,6 @@ import {
   LOG_ACTIONS_MOUNT_EXPLORER,
   LOG_ACTIONS_CHANGE_EXPLORE_CONTROLS,
 } from 'src/logger/LogUtils';
-import { ensureAppRoot } from 'src/utils/pathUtils';
 import { getUrlParam } from 'src/utils/urlUtils';
 import cx from 'classnames';
 import * as chartActions from 'src/components/Chart/chartAction';
@@ -170,10 +170,11 @@ const updateHistory = debounce(
     force,
     title,
     tabId,
+    history,
   ) => {
     const payload = { ...formData };
     const chartId = formData.slice_id;
-    const params = new URLSearchParams(window.location.search);
+    const params = new URLSearchParams(history.location.search);
     const additionalParam = Object.fromEntries(params);
 
     if (chartId) {
@@ -192,7 +193,6 @@ const updateHistory = debounce(
 
     try {
       let key: string | null | undefined;
-      let stateModifier: 'replaceState' | 'pushState';
       if (isReplace) {
         key = await postFormData(
           datasourceId,
@@ -201,7 +201,6 @@ const updateHistory = debounce(
           chartId,
           tabId,
         );
-        stateModifier = 'replaceState';
       } else {
         key = getUrlParam(URL_PARAMS.formDataKey);
         if (key) {
@@ -214,10 +213,9 @@ const updateHistory = debounce(
             tabId,
           );
         }
-        stateModifier = 'pushState';
       }
       // avoid race condition in case user changes route before explore updates the url
-      if (window.location.pathname.startsWith(ensureAppRoot('/explore'))) {
+      if (history.location.pathname.startsWith('/explore')) {
         const url = mountExploreUrl(
           standalone ? URL_PARAMS.standalone.name : 'base',
           {
@@ -225,8 +223,9 @@ const updateHistory = debounce(
             ...additionalParam,
           },
           force,
+          false,
         );
-        window.history[stateModifier](payload, title, url);
+        history.replace(url, payload);
       }
     } catch (e) {
       logging.warn('Failed at altering browser history', e);
@@ -387,6 +386,7 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
     getSidebarWidths(LocalStorageKeys.DatasourceWidth),
   );
   const tabId = useTabId();
+  const history = useHistory();
 
   const theme = useTheme();
 
@@ -431,6 +431,7 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
         props.force,
         title,
         tabId,
+        history,
       );
     },
     [
@@ -441,21 +442,9 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
       props.standalone,
       props.force,
       tabId,
+      history,
     ],
   );
-
-  const handlePopstate = useCallback(() => {
-    const formData = window.history.state;
-    if (formData && Object.keys(formData).length) {
-      props.actions.setExploreControls(formData);
-      props.actions.postChartFormData(
-        formData,
-        props.force,
-        props.timeout,
-        props.chart.id,
-      );
-    }
-  }, [props.actions, props.chart.id, props.timeout]);
 
   const onQuery = useCallback(() => {
     props.actions.setForceQuery(false);
@@ -525,17 +514,6 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
       addHistory({ isReplace: true });
     }
   });
-
-  const previousHandlePopstate = usePrevious(handlePopstate);
-  useEffect(() => {
-    if (previousHandlePopstate) {
-      window.removeEventListener('popstate', previousHandlePopstate);
-    }
-    window.addEventListener('popstate', handlePopstate);
-    return () => {
-      window.removeEventListener('popstate', handlePopstate);
-    };
-  }, [handlePopstate, previousHandlePopstate]);
 
   const previousHandleKeyDown = usePrevious(handleKeydown);
   useEffect(() => {

--- a/superset-frontend/src/explore/components/SaveModal.test.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.tsx
@@ -381,7 +381,7 @@ test('removes form_data_key from URL parameters after save', () => {
   // other parameters should remain
   expect(result.get('other_param')).toEqual('value');
   expect(result.get('slice_id')).toEqual('1');
-  expect(result.get('save_action')).toEqual('overwrite');
+  expect(result.has('save_action')).toBe(false);
 });
 
 test('dispatches removeChartState when saving and going to dashboard', async () => {

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -196,10 +196,7 @@ class SaveModal extends Component<SaveModalProps, SaveModalState> {
 
   handleRedirect = (windowLocationSearch: string, chart: any) => {
     const searchParams = new URLSearchParams(windowLocationSearch);
-    searchParams.set('save_action', this.state.action);
-
     searchParams.delete('form_data_key');
-
     searchParams.set('slice_id', chart.id.toString());
     return searchParams;
   };
@@ -343,7 +340,9 @@ class SaveModal extends Component<SaveModalProps, SaveModalState> {
         return;
       }
       const searchParams = this.handleRedirect(window.location.search, value);
-      this.props.history.replace(`/explore/?${searchParams.toString()}`);
+      this.props.history.replace(`/explore/?${searchParams.toString()}`, {
+        saveAction: this.state.action,
+      });
 
       this.setState({ isLoading: false });
       this.onHide();

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
@@ -71,13 +71,23 @@ export const useUnsavedChangesPrompt = ({
   }, [onSave]);
 
   const blockCallback = useCallback(
-    ({
-      pathname,
-      state,
-    }: {
-      pathname: Location['pathname'];
-      state: Location['state'];
-    }) => {
+    (
+      {
+        pathname,
+        search,
+        state,
+      }: {
+        pathname: Location['pathname'];
+        search: Location['search'];
+        state: Location['state'];
+      },
+      action: string,
+    ) => {
+      // REPLACE actions are URL sync (e.g. updating form_data_key), not navigation
+      if (action === 'REPLACE') {
+        return undefined;
+      }
+
       if (manualSaveRef.current) {
         manualSaveRef.current = false;
         return undefined;
@@ -85,7 +95,7 @@ export const useUnsavedChangesPrompt = ({
 
       confirmNavigationRef.current = () => {
         unblockRef.current?.();
-        history.push(pathname, state);
+        history.push({ pathname, search }, state);
       };
 
       setShowModal(true);

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
@@ -21,7 +21,7 @@ import { getClientErrorObject } from '@superset-ui/core';
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useBeforeUnload } from 'src/hooks/useBeforeUnload';
-import type { Location } from 'history';
+import type { Location, Action } from 'history';
 
 type UseUnsavedChangesPromptProps = {
   hasUnsavedChanges: boolean;
@@ -81,7 +81,7 @@ export const useUnsavedChangesPrompt = ({
         search: Location['search'];
         state: Location['state'];
       },
-      action: string,
+      action: Action,
     ) => {
       // REPLACE actions are URL sync (e.g. updating form_data_key), not navigation
       if (action === 'REPLACE') {

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
@@ -95,7 +95,11 @@ export const useUnsavedChangesPrompt = ({
 
       confirmNavigationRef.current = () => {
         unblockRef.current?.();
-        history.push({ pathname, search }, state);
+        if (action === 'POP') {
+          history.go(-1);
+        } else {
+          history.push({ pathname, search }, state);
+        }
       };
 
       setShowModal(true);

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
@@ -125,7 +125,7 @@ test('should close modal when handleConfirmNavigation is called', () => {
   expect(result.current.showModal).toBe(false);
 });
 
-test('should preserve pathname and state when confirming navigation', () => {
+test('should preserve pathname, search, and state when confirming navigation', () => {
   const onSave = jest.fn();
   const history = createMemoryHistory();
   const wrapper = ({ children }: any) => (
@@ -134,6 +134,7 @@ test('should preserve pathname and state when confirming navigation', () => {
 
   const locationState = { fromDashboard: true, dashboardId: 123 };
   const pathname = '/another-page';
+  const search = '?slice_id=42&foo=bar';
 
   const { result } = renderHook(
     () => useUnsavedChangesPrompt({ hasUnsavedChanges: true, onSave }),
@@ -144,7 +145,7 @@ test('should preserve pathname and state when confirming navigation', () => {
 
   // Simulate a blocked navigation (the hook sets up history.block internally)
   act(() => {
-    history.push(pathname, locationState);
+    history.push({ pathname, search }, locationState);
   });
 
   // Modal should now be visible
@@ -158,8 +159,8 @@ test('should preserve pathname and state when confirming navigation', () => {
   // Modal should close
   expect(result.current.showModal).toBe(false);
 
-  // Verify correct call with pathname and state preserved
-  expect(pushSpy).toHaveBeenCalledWith(pathname, locationState);
+  // Verify correct call with pathname, search, and state preserved
+  expect(pushSpy).toHaveBeenCalledWith({ pathname, search }, locationState);
 
   pushSpy.mockRestore();
 });

--- a/superset-frontend/src/pages/Chart/Chart.test.tsx
+++ b/superset-frontend/src/pages/Chart/Chart.test.tsx
@@ -260,7 +260,11 @@ describe('ChartPage', () => {
       const { getByTestId } = render(
         <>
           <Link
-            to={`/?${URL_PARAMS.dashboardPageId.name}=${dashboardPageId}&${URL_PARAMS.saveAction.name}=overwrite`}
+            to={{
+              pathname: '/',
+              search: `?${URL_PARAMS.dashboardPageId.name}=${dashboardPageId}`,
+              state: { saveAction: 'overwrite' },
+            }}
           >
             Change route
           </Link>
@@ -296,6 +300,61 @@ describe('ChartPage', () => {
         JSON.stringify({
           show_cell_bars: updatedExploreFormData.show_cell_bars,
         }).slice(1, -1),
+      );
+    });
+
+    test('re-fetches explore data on back-button navigation (POP)', async () => {
+      const exploreApiRoute = 'glob:*/api/v1/explore/*';
+      const initialFormData = getExploreFormData({
+        viz_type: VizType.Table,
+        show_cell_bars: true,
+      });
+      const updatedFormData = getExploreFormData({
+        viz_type: VizType.Table,
+        show_cell_bars: false,
+      });
+      fetchMock.get(exploreApiRoute, {
+        result: { dataset: { id: 1 }, form_data: initialFormData },
+      });
+      render(
+        <>
+          <Link to="/?slice_id=99">Navigate away</Link>
+          <ChartPage />
+        </>,
+        {
+          useRouter: true,
+          useRedux: true,
+          useDnd: true,
+        },
+      );
+      await waitFor(() =>
+        expect(fetchMock.callHistory.calls(exploreApiRoute).length).toBe(1),
+      );
+      expect(screen.getByTestId('mock-explore-chart-panel')).toHaveTextContent(
+        JSON.stringify({ show_cell_bars: true }).slice(1, -1),
+      );
+
+      // Navigate forward (PUSH) then simulate back-button (POP)
+      fetchMock.clearHistory().removeRoutes();
+      fetchMock.get(exploreApiRoute, {
+        result: { dataset: { id: 1 }, form_data: updatedFormData },
+      });
+      fireEvent.click(screen.getByText('Navigate away'));
+      await waitFor(() =>
+        expect(fetchMock.callHistory.calls(exploreApiRoute).length).toBe(1),
+      );
+
+      fetchMock.clearHistory().removeRoutes();
+      fetchMock.get(exploreApiRoute, {
+        result: { dataset: { id: 1 }, form_data: initialFormData },
+      });
+      // Simulate back button
+      window.history.back();
+      await waitFor(() =>
+        expect(fetchMock.callHistory.calls(exploreApiRoute).length).toBe(1),
+      );
+      expect(screen.getByTestId('mock-explore-chart-panel')).toHaveTextContent(
+        JSON.stringify({ show_cell_bars: true }).slice(1, -1),
       );
     });
   });

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -134,13 +134,13 @@ export default function ExplorePage() {
   const history = useHistory();
 
   const loadExploreData = useCallback(
-    (loc: { search: string; pathname: string }) => {
+    (
+      loc: { search: string; pathname: string },
+      saveAction?: SaveActionType | null,
+    ) => {
       fetchGeneration.current += 1;
       const generation = fetchGeneration.current;
       const exploreUrlParams = getParsedExploreURLParams(loc);
-      const saveAction = new URLSearchParams(loc.search).get(
-        URL_PARAMS.saveAction.name,
-      ) as SaveActionType | null;
       const dashboardContextFormData = getDashboardContextFormData();
 
       const isStale = () => generation !== fetchGeneration.current;
@@ -266,12 +266,20 @@ export default function ExplorePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Re-fetch on real navigation (PUSH/POP), ignore REPLACE (URL sync from updateHistory)
+  // Re-fetch on navigation or post-save.
+  // PUSH/POP: full reload (unmount + re-fetch).
+  // REPLACE with saveAction state: re-fetch without unmount (keeps chart visible).
+  // Other REPLACE: ignored (URL sync from updateHistory).
   useEffect(() => {
     const unlisten = history.listen((loc: Location, action: Action) => {
       if (action === 'PUSH' || action === 'POP') {
         setIsLoaded(false);
         loadExploreData(loc);
+      } else if ((loc.state as Record<string, unknown>)?.saveAction) {
+        loadExploreData(
+          loc,
+          (loc.state as Record<string, unknown>).saveAction as SaveActionType,
+        );
       }
     });
     return unlisten;

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { t } from '@apache-superset/core/translation';
 import {
   getLabelsColorMap,
@@ -128,20 +128,28 @@ const getDashboardContextFormData = () => {
 
 export default function ExplorePage() {
   const [isLoaded, setIsLoaded] = useState(false);
-  const isExploreInitialized = useRef(false);
+  const fetchGeneration = useRef(0);
   const dispatch = useDispatch();
-  const location = useLocation();
+  const history = useHistory();
 
-  useEffect(() => {
-    const exploreUrlParams = getParsedExploreURLParams(location);
-    const saveAction = getUrlParam(
-      URL_PARAMS.saveAction,
-    ) as SaveActionType | null;
-    const dashboardContextFormData = getDashboardContextFormData();
+  const loadExploreData = useCallback(
+    (loc: { search: string; pathname: string }) => {
+      fetchGeneration.current += 1;
+      const generation = fetchGeneration.current;
+      const exploreUrlParams = getParsedExploreURLParams(loc);
+      const saveAction = new URLSearchParams(loc.search).get(
+        URL_PARAMS.saveAction.name,
+      ) as SaveActionType | null;
+      const dashboardContextFormData = getDashboardContextFormData();
 
-    if (!isExploreInitialized.current || !!saveAction) {
+      const isStale = () => generation !== fetchGeneration.current;
+
       fetchExploreData(exploreUrlParams)
         .then(({ result }) => {
+          if (isStale()) {
+            return;
+          }
+
           const formData = dashboardContextFormData
             ? getFormDataWithDashboardContext(
                 result.form_data,
@@ -176,6 +184,10 @@ export default function ExplorePage() {
         })
         .catch(err => Promise.all([getClientErrorObject(err), err]))
         .then(resolved => {
+          if (isStale()) {
+            return;
+          }
+
           const [clientError, err] = resolved || [];
           if (!err) {
             return Promise.resolve();
@@ -209,6 +221,9 @@ export default function ExplorePage() {
             )
               .then(
                 ({ result: { id, url, owners, form_data: _, ...data } }) => {
+                  if (isStale()) {
+                    return;
+                  }
                   const slice = {
                     ...data,
                     datasource: err.extra?.datasource_name,
@@ -225,6 +240,9 @@ export default function ExplorePage() {
                 },
               )
               .catch(() => {
+                if (isStale()) {
+                  return;
+                }
                 dispatch(hydrateExplore(exploreData));
               });
           }
@@ -232,12 +250,31 @@ export default function ExplorePage() {
           return Promise.resolve();
         })
         .finally(() => {
-          setIsLoaded(true);
-          isExploreInitialized.current = true;
+          if (!isStale()) {
+            setIsLoaded(true);
+          }
         });
-    }
+    },
+    [dispatch],
+  );
+
+  // Initial fetch on mount
+  useEffect(() => {
+    loadExploreData(history.location);
     getLabelsColorMap().source = LabelsColorMapSource.Explore;
-  }, [dispatch, location]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Re-fetch on real navigation (PUSH/POP), ignore REPLACE (URL sync from updateHistory)
+  useEffect(() => {
+    const unlisten = history.listen((loc, action) => {
+      if (action === 'PUSH' || action === 'POP') {
+        setIsLoaded(false);
+        loadExploreData(loc);
+      }
+    });
+    return unlisten;
+  }, [history, loadExploreData]);
 
   if (!isLoaded) {
     return <Loading />;

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -19,6 +19,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import type { Location, Action } from 'history';
 import { t } from '@apache-superset/core/translation';
 import {
   getLabelsColorMap,
@@ -267,7 +268,7 @@ export default function ExplorePage() {
 
   // Re-fetch on real navigation (PUSH/POP), ignore REPLACE (URL sync from updateHistory)
   useEffect(() => {
-    const unlisten = history.listen((loc, action) => {
+    const unlisten = history.listen((loc: Location, action: Action) => {
       if (action === 'PUSH' || action === 'POP') {
         setIsLoaded(false);
         loadExploreData(loc);

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -272,14 +272,14 @@ export default function ExplorePage() {
   // Other REPLACE: ignored (URL sync from updateHistory).
   useEffect(() => {
     const unlisten = history.listen((loc: Location, action: Action) => {
+      const saveAction = (loc.state as Record<string, unknown>)?.saveAction as
+        | SaveActionType
+        | undefined;
       if (action === 'PUSH' || action === 'POP') {
         setIsLoaded(false);
-        loadExploreData(loc);
-      } else if ((loc.state as Record<string, unknown>)?.saveAction) {
-        loadExploreData(
-          loc,
-          (loc.state as Record<string, unknown>).saveAction as SaveActionType,
-        );
+        loadExploreData(loc, saveAction);
+      } else if (saveAction) {
+        loadExploreData(loc, saveAction);
       }
     });
     return unlisten;


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Replaced window.history.pushState/replaceState with react-router's history.replace() in ExploreViewContainer's updateHistory function. This allows other components to detect URL changes (e.g. form_data_key updates) via react-router's useLocation/history.listen, which was not possible with the browser API since it bypasses react-router entirely.

  Key changes:
  - updateHistory now always uses history.replace() — it's URL sync, not navigation
  - ExplorePage uses history.listen to re-fetch only on PUSH/POP (real navigation), ignoring REPLACE (URL
  sync)
  - useUnsavedChangesPrompt uses the action parameter from history.block() to skip blocking REPLACE
  actions
  - Fixed query param loss when confirming navigation after unsaved changes prompt (search is now
  preserved alongside pathname)
  - Added fetchGeneration counter to protect against stale fetch race conditions

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
  - Open an existing chart in Explore, modify controls, click "Update chart" — URL updates, no unsaved
  changes modal
  - Navigate from one chart to another via react-router (e.g. history.push('/explore/?slice_id=42')) — new
   chart loads correctly
  - Modify a chart without saving, then navigate away — unsaved changes modal appears
  - In unsaved changes modal, click "Discard" — navigates to the correct URL with all query params
  preserved

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Keep Explore URL updates and saved chart reloads in sync with navigation**

### What Changed
- Explore now updates the URL without triggering a full navigation, so chart controls keep their state and other parts of the app can react to the change correctly.
- Leaving Explore with unsaved changes now preserves the full destination, including query parameters, when confirming navigation.
- Returning to Explore after saving now reloads the chart from the saved state without relying on a `save_action` URL parameter.
- Explore loading ignores outdated responses, reducing cases where an older chart result can overwrite a newer one.

### Impact
`✅ Fewer lost query parameters during navigation`
`✅ Clearer unsaved-changes navigation`
`✅ Fewer stale chart loads after quick edits`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
