### PR TITLE
fix: pin 1 unpinned action(s),extract 21 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -51,27 +51,31 @@ jobs:
       - name: supersetbot bump-python -p "${{ github.event.inputs.package }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PACKAGE: ${{ github.event.inputs.package }}
+          INPUT_GROUP: ${{ github.event.inputs.group }}
+          INPUT_EXTRA_FLAGS: ${{ github.event.inputs.extra-flags }}
+          INPUT_LIMIT: ${{ github.event.inputs.limit }}
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
 
           PACKAGE_OPT=""
-          if [ -n "${{ github.event.inputs.package }}" ]; then
-            PACKAGE_OPT="-p ${{ github.event.inputs.package }}"
+          if [ -n "${INPUT_PACKAGE}" ]; then
+            PACKAGE_OPT="-p ${INPUT_PACKAGE}"
           fi
 
           GROUP_OPT=""
-          if [ -n "${{ github.event.inputs.group }}" ]; then
-            GROUP_OPT="-g ${{ github.event.inputs.group }}"
+          if [ -n "${INPUT_GROUP}" ]; then
+            GROUP_OPT="-g ${INPUT_GROUP}"
           fi
 
-          EXTRA_FLAGS="${{ github.event.inputs.extra-flags }}"
+          EXTRA_FLAGS="${INPUT_EXTRA_FLAGS}"
 
           supersetbot bump-python \
             --verbose \
             --use-current-repo \
             --include-subpackages \
-            --limit ${{ github.event.inputs.limit }} \
+            --limit ${INPUT_LIMIT} \
             $PACKAGE_OPT \
             $GROUP_OPT \
             $EXTRA_FLAGS

--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -16,10 +16,12 @@ jobs:
         id: check
         shell: bash
         run: |
-          if [ -n "${{ (secrets.NPM_TOKEN != '') || '' }}" ]; then
+          if [ -n "${NPM_TOKEN}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi
 
+        env:
+          NPM_TOKEN: ${{ (secrets.NPM_TOKEN != '') || '' }}
   build:
     needs: config
     if: needs.config.outputs.has-secrets

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -20,10 +20,12 @@ jobs:
         id: check
         shell: bash
         run: |
-          if [ -n "${{ (secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}" ]; then
+          if [ -n "${AWS_ACCESS_KEY_ID}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi
 
+        env:
+          AWS_ACCESS_KEY_ID: ${{ (secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}
   ephemeral-env-cleanup:
     needs: config
     if: needs.config.outputs.has-secrets
@@ -56,7 +58,7 @@ jobs:
       - name: Login to Amazon ECR
         if: steps.describe-services.outputs.active == 'true'
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2
 
       - name: Delete ECR image tag
         if: steps.describe-services.outputs.active == 'true'

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -47,7 +47,7 @@ jobs:
         id: eval-label
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            LABEL_NAME="${{ github.event.inputs.label_name }}"
+            LABEL_NAME="${INPUT_LABEL_NAME}"
           else
             LABEL_NAME="${{ github.event.label.name }}"
           fi
@@ -60,6 +60,8 @@ jobs:
             echo "result=noop" >> $GITHUB_OUTPUT
           fi
 
+        env:
+          INPUT_LABEL_NAME: ${{ github.event.inputs.label_name }}
       - name: Get event SHA
         id: get-sha
         if: steps.eval-label.outputs.result == 'up'
@@ -276,7 +278,9 @@ jobs:
       - name: Describe ECS service
         id: describe-services
         run: |
-          echo "active=$(aws ecs describe-services --cluster superset-ci --services pr-${{ github.event.inputs.issue_number || github.event.pull_request.number }}-service | jq '.services[] | select(.status == "ACTIVE") | any')" >> $GITHUB_OUTPUT
+          echo "active=$(aws ecs describe-services --cluster superset-ci --services pr-${INPUT_ISSUE_NUMBER}-service | jq '.services[] | select(.status == "ACTIVE") | any')" >> $GITHUB_OUTPUT
+        env:
+          INPUT_ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.pull_request.number }}
       - name: Create ECS service
         id: create-service
         if: steps.describe-services.outputs.active != 'true'
@@ -307,7 +311,9 @@ jobs:
       - name: List tasks
         id: list-tasks
         run: |
-          echo "task=$(aws ecs list-tasks --cluster superset-ci --service-name pr-${{ github.event.inputs.issue_number || github.event.pull_request.number }}-service | jq '.taskArns | first')" >> $GITHUB_OUTPUT
+          echo "task=$(aws ecs list-tasks --cluster superset-ci --service-name pr-${INPUT_ISSUE_NUMBER}-service | jq '.taskArns | first')" >> $GITHUB_OUTPUT
+        env:
+          INPUT_ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.pull_request.number }}
       - name: Get network interface
         id: get-eni
         run: |

--- a/.github/workflows/generate-FOSSA-report.yml
+++ b/.github/workflows/generate-FOSSA-report.yml
@@ -16,10 +16,12 @@ jobs:
         id: check
         shell: bash
         run: |
-          if [ -n "${{ (secrets.FOSSA_API_KEY != '' ) || '' }}" ]; then
+          if [ -n "${FOSSA_API_KEY}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi
 
+        env:
+          FOSSA_API_KEY: ${{ (secrets.FOSSA_API_KEY != '' ) || '' }}
   license_check:
     needs: config
     if: needs.config.outputs.has-secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,12 @@ jobs:
         id: check
         shell: bash
         run: |
-          if [ -n "${{ (secrets.NPM_TOKEN != '' && secrets.GH_PERSONAL_ACCESS_TOKEN != '') || '' }}" ]; then
+          if [ -n "${NPM_TOKEN}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi
 
+        env:
+          NPM_TOKEN: ${{ (secrets.NPM_TOKEN != '' && secrets.GH_PERSONAL_ACCESS_TOKEN != '') || '' }}
   build:
     needs: config
     if: needs.config.outputs.has-secrets

--- a/.github/workflows/showtime-trigger.yml
+++ b/.github/workflows/showtime-trigger.yml
@@ -102,10 +102,12 @@ jobs:
       - name: Install Superset Showtime
         if: steps.auth.outputs.authorized == 'true'
         run: |
-          echo "::notice::Maintainer ${{ github.actor }} triggered deploy for PR ${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
+          echo "::notice::Maintainer ${{ github.actor }} triggered deploy for PR ${PULL_REQUEST_NUMBER}"
           pip install --upgrade superset-showtime
           showtime version
 
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       - name: Check what actions are needed
         if: steps.auth.outputs.authorized == 'true'
         id: check
@@ -113,12 +115,14 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          INPUT_SHA: ${{ github.event.inputs.sha }}
         run: |
           # Bulletproof PR number extraction
           if [[ -n "${{ github.event.pull_request.number }}" ]]; then
             PR_NUM="${{ github.event.pull_request.number }}"
-          elif [[ -n "${{ github.event.inputs.pr_number }}" ]]; then
-            PR_NUM="${{ github.event.inputs.pr_number }}"
+          elif [[ -n "${INPUT_PR_NUMBER}" ]]; then
+            PR_NUM="${INPUT_PR_NUMBER}"
           else
             echo "❌ No PR number found in event or inputs"
             exit 1
@@ -127,8 +131,8 @@ jobs:
           echo "Using PR number: $PR_NUM"
 
           # Run sync check-only with optional SHA override
-          if [[ -n "${{ github.event.inputs.sha }}" ]]; then
-            OUTPUT=$(python -m showtime sync $PR_NUM --check-only --sha "${{ github.event.inputs.sha }}")
+          if [[ -n "${INPUT_SHA}" ]]; then
+            OUTPUT=$(python -m showtime sync $PR_NUM --check-only --sha "${INPUT_SHA}")
           else
             OUTPUT=$(python -m showtime sync $PR_NUM --check-only)
           fi

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -27,10 +27,12 @@ jobs:
         id: check
         shell: bash
         run: |
-          if [ -n "${{ (secrets.SUPERSET_SITE_BUILD != '' && secrets.SUPERSET_SITE_BUILD != '') || '' }}" ]; then
+          if [ -n "${SUPERSET_SITE_BUILD}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi
 
+        env:
+          SUPERSET_SITE_BUILD: ${{ (secrets.SUPERSET_SITE_BUILD != '' && secrets.SUPERSET_SITE_BUILD != '') || '' }}
   build-deploy:
     needs: config
     if: needs.config.outputs.has-secrets

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -31,10 +31,12 @@ jobs:
         id: check
         shell: bash
         run: |
-          if [ -n "${{ (secrets.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '') || '' }}" ]; then
+          if [ -n "${DOCKERHUB_USER}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi
 
+        env:
+          DOCKERHUB_USER: ${{ (secrets.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '') || '' }}
   docker-release:
     needs: config
     if: needs.config.outputs.has-secrets
@@ -72,17 +74,20 @@ jobs:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE: ${{ github.event.inputs.release }}
+          INPUT_FORCE_LATEST: ${{ github.event.inputs.force-latest }}
+          INPUT_GIT_REF: ${{ github.event.inputs.git-ref }}
         run: |
           RELEASE="${{ github.event.release.tag_name }}"
           FORCE_LATEST=""
           EVENT="${{github.event_name}}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # in the case of a manually-triggered run, read release from input
-            RELEASE="${{ github.event.inputs.release }}"
-            if [ "${{ github.event.inputs.force-latest }}" = "true" ]; then
+            RELEASE="${INPUT_RELEASE}"
+            if [ "${INPUT_FORCE_LATEST}" = "true" ]; then
               FORCE_LATEST="--force-latest"
             fi
-            git checkout "${{ github.event.inputs.git-ref }}"
+            git checkout "${INPUT_GIT_REF}"
             EVENT="release"
           fi
 
@@ -122,6 +127,7 @@ jobs:
       - name: Label the PRs with the right release-related labels
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE: ${{ github.event.inputs.release }}
         run: |
           export GITHUB_ACTOR=""
           git fetch --all --tags
@@ -129,6 +135,6 @@ jobs:
           RELEASE="${{ github.event.release.tag_name }}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # in the case of a manually-triggered run, read release from input
-            RELEASE="${{ github.event.inputs.release }}"
+            RELEASE="${INPUT_RELEASE}"
           fi
           supersetbot release-label $RELEASE

--- a/.github/workflows/tech-debt.yml
+++ b/.github/workflows/tech-debt.yml
@@ -19,10 +19,12 @@ jobs:
         id: check
         shell: bash
         run: |
-          if [ -n "${{ (secrets.GSHEET_KEY != '' ) || '' }}" ]; then
+          if [ -n "${GSHEET_KEY}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi
 
+        env:
+          GSHEET_KEY: ${{ (secrets.GSHEET_KEY != '' ) || '' }}
   process-and-upload:
     needs: config
     if: needs.config.outputs.has-secrets


### PR DESCRIPTION
## **User description**
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/bump-python-package.yml` | Extracted 4 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/embedded-sdk-release.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/ephemeral-env-pr-close.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/ephemeral-env-pr-close.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/ephemeral-env.yml` | Extracted 3 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/generate-FOSSA-report.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/release.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/showtime-trigger.yml` | Extracted 3 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/superset-docs-deploy.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/tag-release.yml` | Extracted 5 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/tech-debt.yml` | Extracted 1 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-016 | critical | `.github/workflows/check_db_migration_confict.yml` | Unicode Steganography in Workflow File |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-003 | high | `.github/workflows/pre-commit.yml` | Filename Injection via Git Diff or File Listing |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-012 | high | `.github/workflows/superset-docs-deploy.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/superset-docs-deploy.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/supersetbot.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/supersetbot.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/supersetbot.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/supersetbot.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-005 | medium | `.github/workflows/claude.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/claude.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/ephemeral-env-pr-close.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-007 | medium | `.github/workflows/ephemeral-env-pr-close.yml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-005 | medium | `.github/workflows/ephemeral-env.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/ephemeral-env.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/labeler.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/showtime-trigger.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/supersetbot.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/welcome-new-users.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.


___

## **CodeAnt-AI Description**
**Harden workflow triggers and secret checks**

### What Changed
- Workflow inputs and secrets are now read through saved values instead of being used directly in shell commands, reducing the risk of unsafe CI runs.
- Release, docs, tech-debt, FOSSA, embedded SDK, ephemeral environment, and showtime workflows now gate their jobs using clearer secret checks.
- The ephemeral environment cleanup flow now uses a pinned third-party action version.

### Impact
`✅ Safer CI runs`
`✅ Fewer workflow failures from malformed inputs`
`✅ More reliable release and cleanup jobs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
