### PR TITLE
fix(sqllab): invalid treeview folder expansion

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableExploreTree/TableExploreTree.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/TableExploreTree.test.tsx
@@ -264,3 +264,85 @@ test('renders contributed toolbar action in leftSidebar slot', async () => {
     screen.getByRole('button', { name: 'Left Sidebar Action' }),
   ).toBeInTheDocument();
 });
+
+test('shows columns immediately on first toggle when searchTerm is active', async () => {
+  // Regression: treeData change after async fetch was resetting react-arborist's
+  // internal open state, so children only appeared after toggling twice.
+  // The useEffect([treeData]) fix ensures manually-opened nodes stay open.
+  renderComponent();
+
+  await waitFor(() => {
+    expect(screen.getByText('public')).toBeInTheDocument();
+  });
+
+  // Expand schema to load tables
+  await userEvent.click(screen.getByText('public'));
+  await waitFor(() => {
+    expect(screen.getByText('users')).toBeInTheDocument();
+  });
+
+  // Activate search while schema is already expanded
+  const searchInput = screen.getByPlaceholderText(
+    'Enter a part of the object name',
+  );
+  await userEvent.type(searchInput, 'pub');
+
+  // Tables remain visible under the search-matched schema
+  expect(screen.getByText('users')).toBeInTheDocument();
+
+  // Toggle the table with searchTerm active — columns must appear on the FIRST click
+  await userEvent.click(screen.getByText('users'));
+
+  await waitFor(() => {
+    expect(screen.getByText('id')).toBeInTheDocument();
+  });
+  expect(screen.getByText('name')).toBeInTheDocument();
+  expect(screen.getByText('created_at')).toBeInTheDocument();
+});
+
+test('closes a schema while searchTerm is active and keeps it closed', async () => {
+  // Regression: manuallyOpenedNodes must record the schema as closed when the
+  // user collapses it with a searchTerm active. If it remains true, the treeData
+  // effect would immediately re-open the schema on the next data change.
+  //
+  // Note: searchTerm 'users' is intentional. A term that matches the schema name
+  // (e.g. 'pub') would cause highlightText to split 'public' across two DOM nodes,
+  // making screen.getByText('public') unreliable. 'users' matches a table name so
+  // the schema label is left as a plain text node and remains queryable.
+  renderComponent();
+
+  await waitFor(() => {
+    expect(screen.getByText('public')).toBeInTheDocument();
+  });
+
+  // Expand schema to load tables
+  await userEvent.click(screen.getByText('public'));
+  await waitFor(() => {
+    expect(screen.getByText('users')).toBeInTheDocument();
+  });
+
+  // Activate search with a term that matches a table name; 'public' schema is
+  // visible as an ancestor and its text is not highlighted (safe to query by text)
+  const searchInput = screen.getByPlaceholderText(
+    'Enter a part of the object name',
+  );
+  await userEvent.type(searchInput, 'users');
+  expect(screen.getByText('public')).toBeInTheDocument();
+
+  // Load columns to trigger a treeData change that could accidentally reopen the schema
+  await userEvent.click(screen.getByText('users'));
+  await waitFor(() => {
+    expect(screen.getByText('id')).toBeInTheDocument();
+  });
+
+  // Close the schema while searchTerm is active
+  await userEvent.click(screen.getByText('public'));
+
+  // Tables and columns must disappear and stay gone — the treeData effect must not
+  // reopen the schema because manuallyOpenedNodes was updated to false on close
+  await waitFor(() => {
+    expect(screen.queryByText('id')).not.toBeInTheDocument();
+  });
+  // The schema node itself remains visible as a matching ancestor (just collapsed)
+  expect(screen.getByText('public')).toBeInTheDocument();
+});

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
@@ -352,8 +352,8 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
                   // click as a close action, so fall back to manuallyOpenedNodes instead.
                   const wasOpen = searchTerm
                     ? (treeRef.current?.get(id)?.isOpen ??
-                        manuallyOpenedNodes[id] ??
-                        false)
+                      manuallyOpenedNodes[id] ??
+                      false)
                     : (manuallyOpenedNodes[id] ?? false);
                   const isNowOpen = !wasOpen;
 

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
@@ -18,6 +18,7 @@
  */
 import {
   useCallback,
+  useEffect,
   useState,
   useRef,
   type ChangeEvent,
@@ -164,6 +165,21 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
   const [manuallyOpenedNodes, setManuallyOpenedNodes] = useState<
     Record<string, boolean>
   >({});
+
+  // Keep a ref so the treeData effect below always reads the latest value
+  // without needing it as a dependency (we only want to re-open on data change).
+  const manuallyOpenedNodesRef = useRef(manuallyOpenedNodes);
+  manuallyOpenedNodesRef.current = manuallyOpenedNodes;
+
+  // When treeData changes (e.g., children arrive after an async fetch),
+  // react-arborist may reset the open state of nodes that just received children.
+  // Explicitly re-open every node the user has manually opened so children
+  // become visible immediately without requiring a second toggle.
+  useEffect(() => {
+    Object.entries(manuallyOpenedNodesRef.current)
+      .filter(([, isOpen]) => isOpen)
+      .forEach(([id]) => treeRef.current?.open(id));
+  }, [treeData]);
 
   // Custom search match function for react-arborist
   const searchMatch = useCallback(
@@ -320,18 +336,37 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
                     return;
                   }
 
+                  // Determine the previous open state to compute the new state.
+                  //
+                  // When searchTerm is active, react-arborist auto-expands nodes whose
+                  // descendants match the query. Those nodes have isOpen=true in the tree
+                  // but are absent from manuallyOpenedNodes, so the original check
+                  // (`manuallyOpenedNodes[id] ?? false`) misidentifies them as closed and
+                  // inverts the toggle direction. Reading from treeRef (which holds the
+                  // actual pre-toggle state because onToggle fires before the state change)
+                  // fixes this.
+                  //
+                  // When searchTerm is empty, searchMatch returns true for every node and
+                  // react-arborist marks all schemas as open (isOpen=true) even before any
+                  // user interaction. Using treeRef in that case would treat every first
+                  // click as a close action, so fall back to manuallyOpenedNodes instead.
+                  const wasOpen = searchTerm
+                    ? (treeRef.current?.get(id)?.isOpen ??
+                        manuallyOpenedNodes[id] ??
+                        false)
+                    : (manuallyOpenedNodes[id] ?? false);
+                  const isNowOpen = !wasOpen;
+
+                  // Trigger data fetch when opening
+                  if (isNowOpen) {
+                    handleToggle(id, true);
+                  }
+
                   // Track manually opened/closed state
-                  setManuallyOpenedNodes(prev => {
-                    const wasOpen = prev[id] ?? false;
-                    const isNowOpen = !wasOpen;
-
-                    // Trigger data fetch when opening
-                    if (isNowOpen) {
-                      handleToggle(id, true);
-                    }
-
-                    return { ...prev, [id]: isNowOpen };
-                  });
+                  setManuallyOpenedNodes(prev => ({
+                    ...prev,
+                    [id]: isNowOpen,
+                  }));
                 }}
               >
                 {renderNode}


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes #38896

Fixes bugs in TableExploreTree where children fetched via an async API call would not appear after the first toggle, or a closed schema would unexpectedly reopen, when a searchTerm was active.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/e6642c18-da1d-44d3-b47f-a411a52f8d50

After:

https://github.com/user-attachments/assets/81404b02-b755-4753-bb62-29c71f6c4287


### TESTING INSTRUCTIONS

1. In SQL Lab, choose a schema (Trino / superset).
2. Then search within the schema using the search box. 
3. The matching table entries are expanded, but show the "+" icon to expand them. 
4. Clicking the "+" collapses the entry, and then shows the "-" icon (also backward).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Fix SQL Lab tree folders expanding and collapsing correctly during search**

### What Changed
- Search results in the SQL Lab tree now open children on the first click, instead of requiring a second click after data loads.
- Collapsing a schema while searching now keeps it closed, instead of reopening it when new tree data arrives.
- Added coverage for both search-related expand and collapse cases.

### Impact
`✅ Fewer missed clicks in SQL Lab`
`✅ Faster table browsing during search`
`✅ Fewer unexpected folder reopenings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
