### PR TITLE
feat(filters): Adding empty state for filter modal

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
@@ -75,6 +75,7 @@ export const BaseModalWrapper = styled(StyledModal)<BaseModalWrapperProps>`
 export const BaseModalBody = styled.div<BaseModalBodyProps>`
   display: flex;
   height: 100%;
+  min-height: 500px;
   flex-direction: row;
   flex: 1;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 
-import { act, render, screen, userEvent } from 'spec/helpers/testing-library';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+} from 'spec/helpers/testing-library';
 import { stateWithoutNativeFilters } from 'spec/fixtures/mockStore';
 import { testWithId } from 'src/utils/testUtils';
 import { Preset, makeApi } from '@superset-ui/core';
@@ -387,6 +393,15 @@ test('FilterBar apply button is disabled after creating a filter', async () => {
   userEvent.click(screen.getByTestId(getTestId('collapsable')));
   userEvent.click(screen.getByLabelText('setting'));
   userEvent.click(screen.getByText('Add or edit filters and controls'));
+
+  // First add a filter via the dropdown (modal now shows empty state by default)
+  const dropdownButton = screen.getByTestId('new-item-dropdown-button');
+  fireEvent.mouseEnter(dropdownButton);
+  const addFilterMenuItem = await screen.findByRole('menuitem', {
+    name: /add filter/i,
+  });
+  fireEvent.click(addFilterMenuItem);
+
   userEvent.click(screen.getByText('Value'));
   userEvent.click(screen.getByText('Time range'));
   userEvent.type(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
@@ -84,7 +84,7 @@ const FilterBarSettings = () => {
 
   const { openFilterConfigModal, FilterConfigModalComponent } =
     useFilterConfigModal({
-      createNewOnOpen: filterValues.length === 0,
+      createNewOnOpen: false,
       dashboardId,
     });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalContent/ConfigModalContent.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalContent/ConfigModalContent.tsx
@@ -25,7 +25,8 @@ import {
 } from '@superset-ui/core';
 import type { FormInstance } from '@superset-ui/core/components';
 import { styled } from '@apache-superset/core/theme';
-import { Flex } from '@superset-ui/core/components';
+import { EmptyState, Flex } from '@superset-ui/core/components';
+import { t } from '@apache-superset/core/translation';
 import FilterContentRenderer from './FilterContentRenderer';
 import CustomizationContentRenderer from './CustomizationContentRenderer';
 import { FiltersConfigFormHandle } from '../FiltersConfigForm/FiltersConfigForm';
@@ -104,6 +105,28 @@ function ConfigModalContent({
   const isCustomizationActive =
     isChartCustomizationId(currentItemId) &&
     chartCustomizationIds.includes(currentItemId);
+
+  const hasNoItems =
+    filterState.orderedIds.length === 0 &&
+    customizationState.orderedIds.length === 0;
+  const showEmptyState = hasNoItems || !currentItemId;
+
+  if (showEmptyState) {
+    return (
+      <StyledContentFlex vertical>
+        <Flex flex={1}>
+          <EmptyState
+            size="small"
+            title=""
+            image="empty.svg"
+            description={t(
+              'Manage filters and customizations to set scoping, descriptions, and limitations. Create new elements for better dashboard insights.',
+            )}
+          />
+        </Flex>
+      </StyledContentFlex>
+    );
+  }
 
   return (
     <StyledContentFlex vertical>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -45,10 +45,6 @@ const StyledSidebarFlex = styled(Flex)`
 const StyledHeaderFlex = styled(Flex)`
   padding: ${({ theme }) => theme.sizeUnit * 3}px;
 
-  & > * {
-    width: 100%;
-  }
-
   & button {
     width: 100%;
   }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -20,7 +20,7 @@ import { FC, ReactNode, useCallback, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { NativeFilterType, ChartCustomizationType } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
-import { Collapse, Flex } from '@superset-ui/core/components';
+import { Collapse, EmptyState, Flex } from '@superset-ui/core/components';
 import type { DragEndEvent } from '@dnd-kit/core';
 import {
   DndContext,
@@ -44,6 +44,14 @@ const StyledSidebarFlex = styled(Flex)`
 
 const StyledHeaderFlex = styled(Flex)`
   padding: ${({ theme }) => theme.sizeUnit * 3}px;
+
+  & > * {
+    width: 100%;
+  }
+
+  & button {
+    width: 100%;
+  }
 `;
 
 const BaseStyledCollapse = styled(Collapse)<{ isDragging: boolean }>`
@@ -254,6 +262,9 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
     </div>
   );
 
+  const hasNoItems =
+    filterOrderedIds.length === 0 && customizationOrderedIds.length === 0;
+
   return (
     <DndContext
       sensors={sensors}
@@ -269,54 +280,65 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
             onAddCustomization={onAddCustomization}
           />
         </StyledHeaderFlex>
-        <StyledCollapse
-          key={formValuesVersion}
-          activeKey={activeCollapseKeys}
-          onChange={keys => onCollapseChange(keys as string[])}
-          ghost
-          isDragging={isDragging}
-        >
-          <StyledCollapse.Panel key="filters" header={filtersHeader}>
-            <ItemSectionContent
-              currentItemId={currentItemId}
-              items={filterOrderedIds}
-              removedItems={filterRemovedItems}
-              erroredItems={filterErroredItems}
-              getItemTitle={getTitle}
-              onChange={onChange}
-              onRearrange={onRearrange}
-              onRemove={onRemove}
-              restoreItem={restoreItem}
-              dataTestId="filter-title-container"
-              deleteAltText={t('Remove filter')}
-              dragType={FILTER_TYPE}
-              isCurrentSection={isFilterId(currentItemId)}
-              onCrossListDrop={handleFilterCrossListDrop}
+        {hasNoItems ? (
+          <Flex>
+            <EmptyState
+              size="small"
+              title=""
+              image="empty.svg"
+              description={t('No filters or customizations created yet')}
             />
-          </StyledCollapse.Panel>
-
-          <StyledCollapse.Panel
-            key="chartCustomizations"
-            header={customizationsHeader}
+          </Flex>
+        ) : (
+          <StyledCollapse
+            key={formValuesVersion}
+            activeKey={activeCollapseKeys}
+            onChange={keys => onCollapseChange(keys as string[])}
+            ghost
+            isDragging={isDragging}
           >
-            <ItemSectionContent
-              currentItemId={currentItemId}
-              items={customizationOrderedIds}
-              removedItems={customizationRemovedItems}
-              erroredItems={customizationErroredItems}
-              getItemTitle={getTitle}
-              onChange={onChange}
-              onRearrange={onRearrange}
-              onRemove={onRemove}
-              restoreItem={restoreItem}
-              dataTestId="customization-title-container"
-              deleteAltText={t('Remove customization')}
-              dragType={CUSTOMIZATION_TYPE}
-              isCurrentSection={isChartCustomizationId(currentItemId)}
-              onCrossListDrop={handleCustomizationCrossListDrop}
-            />
-          </StyledCollapse.Panel>
-        </StyledCollapse>
+            <StyledCollapse.Panel key="filters" header={filtersHeader}>
+              <ItemSectionContent
+                currentItemId={currentItemId}
+                items={filterOrderedIds}
+                removedItems={filterRemovedItems}
+                erroredItems={filterErroredItems}
+                getItemTitle={getTitle}
+                onChange={onChange}
+                onRearrange={onRearrange}
+                onRemove={onRemove}
+                restoreItem={restoreItem}
+                dataTestId="filter-title-container"
+                deleteAltText={t('Remove filter')}
+                dragType={FILTER_TYPE}
+                isCurrentSection={isFilterId(currentItemId)}
+                onCrossListDrop={handleFilterCrossListDrop}
+              />
+            </StyledCollapse.Panel>
+
+            <StyledCollapse.Panel
+              key="chartCustomizations"
+              header={customizationsHeader}
+            >
+              <ItemSectionContent
+                currentItemId={currentItemId}
+                items={customizationOrderedIds}
+                removedItems={customizationRemovedItems}
+                erroredItems={customizationErroredItems}
+                getItemTitle={getTitle}
+                onChange={onChange}
+                onRearrange={onRearrange}
+                onRemove={onRemove}
+                restoreItem={restoreItem}
+                dataTestId="customization-title-container"
+                deleteAltText={t('Remove customization')}
+                dragType={CUSTOMIZATION_TYPE}
+                isCurrentSection={isChartCustomizationId(currentItemId)}
+                onCrossListDrop={handleCustomizationCrossListDrop}
+              />
+            </StyledCollapse.Panel>
+          </StyledCollapse>
+        )}
       </StyledSidebarFlex>
     </DndContext>
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -768,3 +768,58 @@ test('renders a filter with a chart containing BigInt values', async () => {
 
   expect(screen.getByText(FILTER_TYPE_REGEX)).toBeInTheDocument();
 });
+
+test('displays empty state when modal opens with no filters and createNewOnOpen is false', () => {
+  defaultRender(defaultState(), { ...props, createNewOnOpen: false });
+
+  // Check left panel empty state
+  expect(
+    screen.getByText('No filters or customizations created yet'),
+  ).toBeInTheDocument();
+
+  // Check right panel empty state
+  expect(
+    screen.getByText(
+      /Manage filters and customizations to set scoping, descriptions, and limitations/,
+    ),
+  ).toBeInTheDocument();
+
+  // Verify no filter form is rendered (no "Untitled" filter created)
+  expect(screen.queryByText(FILTER_TYPE_REGEX)).not.toBeInTheDocument();
+});
+
+test('does not auto-create a filter when createNewOnOpen is false', () => {
+  defaultRender(defaultState(), { ...props, createNewOnOpen: false });
+
+  // The filter configuration form should not be visible
+  expect(screen.queryByText(FILTER_NAME_REGEX)).not.toBeInTheDocument();
+  expect(screen.queryByText(DATASET_REGEX)).not.toBeInTheDocument();
+});
+
+test('empty state disappears when a filter is added via dropdown', async () => {
+  defaultRender(defaultState(), {
+    ...props,
+    createNewOnOpen: false,
+  });
+
+  // Verify empty state is shown initially
+  expect(
+    screen.getByText('No filters or customizations created yet'),
+  ).toBeInTheDocument();
+
+  // Add a filter via the dropdown
+  const dropdownButton = screen.getByTestId('new-item-dropdown-button');
+  fireEvent.mouseEnter(dropdownButton);
+  const addFilterMenuItem = await screen.findByRole('menuitem', {
+    name: /add filter/i,
+  });
+  fireEvent.click(addFilterMenuItem);
+
+  // Verify empty state is gone and filter form is shown
+  await waitFor(() => {
+    expect(
+      screen.queryByText('No filters or customizations created yet'),
+    ).not.toBeInTheDocument();
+  });
+  expect(screen.getByText(FILTER_TYPE_REGEX)).toBeInTheDocument();
+});


### PR DESCRIPTION
## **User description**
### SUMMARY

This PR aims to add empty state UI to the filter configuration modal and prevent auto-creation of filters when opening the modal with no existing filters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="887" height="624" alt="image" src="https://github.com/user-attachments/assets/dbf4be32-a6cd-4950-90ee-a97c26ad5e14" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Show an empty state in the filter setup modal instead of creating a filter automatically**

### What Changed
- When the filter setup modal opens with no items, it now shows an empty state in both the sidebar and main panel instead of creating a blank filter
- Filters and display controls are only added when the user chooses them from the dropdown
- The modal keeps enough height to display the empty state and controls cleanly
- After a user adds a filter, the empty state disappears and the filter editor appears

### Impact
`✅ No unexpected draft filters`
`✅ Clearer empty filter setup`
`✅ Fewer accidental filter creations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
