### PR TITLE
fix(mcp): simplify tool schemas in BM25 search results to prevent LLM argument misformatting

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -176,27 +176,41 @@ def _strip_titles(obj: Any, in_properties_map: bool = False) -> Any:
 
 
 def _collapse_anyof(
-    variants: list[dict[str, Any]], defs: dict[str, Any]
+    variants: list[dict[str, Any]],
+    defs: dict[str, Any],
+    siblings: dict[str, Any],
 ) -> dict[str, Any] | None:
     """Collapse an ``anyOf`` list into a single preferred variant.
 
-    Returns the collapsed schema, or ``None`` if the variants should be
+    Only collapses the ``@parse_request`` pattern (one string + one object).
+    All other unions are kept as-is so no type information is lost.
+
+    When collapsing, field-level *siblings* (``description``, ``default``,
+    etc.) are merged on top of the resolved object so field metadata takes
+    precedence over model metadata.
+
+    Returns the merged schema, or ``None`` if the variants should be
     kept as-is (caller stores them under the ``anyOf`` key).
     """
     resolved = [_resolve_refs(v, defs) for v in variants]
-    non_null = [v for v in resolved if v.get("type") != "null"]
-    if len(non_null) == 1:
-        # Optional[T] – unwrap to T
-        return non_null[0]
-    # Prefer the structured object variant over a bare string
+    has_string = any(
+        isinstance(v, dict) and v.get("type") == "string" for v in resolved
+    )
+    if not has_string:
+        return None
     obj_variants = [
         v
-        for v in non_null
+        for v in resolved
         if isinstance(v, dict) and (v.get("type") == "object" or "properties" in v)
     ]
-    if obj_variants:
-        return obj_variants[0]
-    return None
+    if len(obj_variants) != 1:
+        return None
+    # Merge: start from collapsed object (type, properties, …),
+    # then overlay field-level siblings (description, default, …)
+    # so field metadata takes precedence over model metadata.
+    merged = dict(obj_variants[0])
+    merged.update(siblings)
+    return merged
 
 
 def _try_resolve_ref(
@@ -227,7 +241,14 @@ def _resolve_refs(schema: dict[str, Any], defs: dict[str, Any]) -> Any:
     * Inlines every ``$ref`` so no ``$defs`` lookup is needed.
     * Collapses ``anyOf[string, Object]`` to the structured object
       variant so the LLM clearly sees the required properties.
-    * Recursively processes nested ``properties`` and ``items``.
+    * Recursively processes nested ``properties``, ``items``, and
+      ``oneOf``/``anyOf`` variants.
+
+    Limitations:
+    * ``$ref`` inside ``allOf`` or ``additionalProperties`` is not
+      resolved (not used by ``@parse_request`` tool schemas).
+    * Circular ``$ref`` would recurse infinitely.  MCP tool request
+      schemas are flat, so this does not arise in practice.
     """
     if not isinstance(schema, dict):
         return schema
@@ -240,7 +261,8 @@ def _resolve_refs(schema: dict[str, Any], defs: dict[str, Any]) -> Any:
         if key == "$defs":
             continue  # drop $defs – refs are inlined
         if key == "anyOf":
-            collapsed = _collapse_anyof(value, defs)
+            siblings = {k: v for k, v in schema.items() if k not in ("anyOf", "$defs")}
+            collapsed = _collapse_anyof(value, defs, siblings)
             if collapsed is not None:
                 return collapsed
             result[key] = [_resolve_refs(v, defs) for v in value]

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -175,6 +175,99 @@ def _strip_titles(obj: Any, in_properties_map: bool = False) -> Any:
     return obj
 
 
+def _collapse_anyof(
+    variants: list[dict[str, Any]], defs: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Collapse an ``anyOf`` list into a single preferred variant.
+
+    Returns the collapsed schema, or ``None`` if the variants should be
+    kept as-is (caller stores them under the ``anyOf`` key).
+    """
+    resolved = [_resolve_refs(v, defs) for v in variants]
+    non_null = [v for v in resolved if v.get("type") != "null"]
+    if len(non_null) == 1:
+        # Optional[T] – unwrap to T
+        return non_null[0]
+    # Prefer the structured object variant over a bare string
+    obj_variants = [
+        v
+        for v in non_null
+        if isinstance(v, dict) and (v.get("type") == "object" or "properties" in v)
+    ]
+    if obj_variants:
+        return obj_variants[0]
+    return None
+
+
+def _try_resolve_ref(
+    schema: dict[str, Any], defs: dict[str, Any]
+) -> dict[str, Any] | None:
+    """If *schema* is a ``$ref`` pointer, resolve and return it; else ``None``."""
+    ref = schema.get("$ref")
+    if ref is None:
+        return None
+    if ref.startswith("#/$defs/"):
+        def_name = ref.split("/")[-1]
+        if def_name in defs:
+            return _resolve_refs(defs[def_name], defs)
+    return schema  # unresolvable ref – keep as-is
+
+
+def _resolve_refs(schema: dict[str, Any], defs: dict[str, Any]) -> Any:
+    """Recursively resolve ``$ref`` pointers and simplify ``anyOf`` unions.
+
+    The raw JSON-Schema produced by Pydantic / FastMCP contains ``$ref``
+    pointers and ``anyOf[string, Object]`` unions (from the
+    ``@parse_request`` decorator's ``str | Model`` annotation).  LLMs
+    reading these schemas inside ``search_tools`` results struggle with
+    indirect references and mixed-type unions, often omitting the
+    ``request`` wrapper.
+
+    This function:
+    * Inlines every ``$ref`` so no ``$defs`` lookup is needed.
+    * Collapses ``anyOf[string, Object]`` to the structured object
+      variant so the LLM clearly sees the required properties.
+    * Recursively processes nested ``properties`` and ``items``.
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    if (resolved_ref := _try_resolve_ref(schema, defs)) is not None:
+        return resolved_ref
+
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key == "$defs":
+            continue  # drop $defs – refs are inlined
+        if key == "anyOf":
+            collapsed = _collapse_anyof(value, defs)
+            if collapsed is not None:
+                return collapsed
+            result[key] = [_resolve_refs(v, defs) for v in value]
+            continue
+        if key == "properties" and isinstance(value, dict):
+            result[key] = {k: _resolve_refs(v, defs) for k, v in value.items()}
+            continue
+        if key == "items" and isinstance(value, dict):
+            result[key] = _resolve_refs(value, defs)
+            continue
+        if key == "oneOf" and isinstance(value, list):
+            result[key] = [_resolve_refs(v, defs) for v in value]
+            continue
+        result[key] = value
+    return result
+
+
+def _simplify_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Resolve ``$ref`` and simplify unions in a tool's ``inputSchema``.
+
+    Produces a self-contained schema (no ``$defs``) that is easy for an
+    LLM to read and reproduce when constructing ``call_tool`` arguments.
+    """
+    defs = schema.get("$defs", {})
+    return _resolve_refs(schema, defs)
+
+
 def _serialize_tools_without_output_schema(
     tools: Sequence[Any],
 ) -> list[dict[str, Any]]:
@@ -183,13 +276,19 @@ def _serialize_tools_without_output_schema(
     LLMs only need inputSchema to call tools. outputSchema accounts for
     50-80% of the per-tool schema size, and auto-generated 'title' fields
     add ~12% bloat. Stripping both cuts search result tokens significantly.
+
+    Additionally, ``$ref`` pointers are resolved and ``anyOf`` unions
+    simplified so the LLM sees a flat, self-contained schema — avoiding
+    the common failure where the LLM omits the ``request`` wrapper.
     """
     results = []
     for tool in tools:
         data = tool.to_mcp_tool().model_dump(mode="json", exclude_none=True)
         data.pop("outputSchema", None)
         if input_schema := data.get("inputSchema"):
-            data["inputSchema"] = _strip_titles(input_schema)
+            input_schema = _simplify_input_schema(input_schema)
+            input_schema = _strip_titles(input_schema)
+            data["inputSchema"] = input_schema
         results.append(data)
     return results
 

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -338,6 +338,39 @@ def test_simplify_resolves_ref_in_anyof():
     assert "page" in req["properties"]
 
 
+def test_simplify_preserves_description_on_anyof_collapse():
+    """Sibling keys (description, default) survive anyOf collapse."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "request": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"$ref": "#/$defs/Req"},
+                ],
+                "description": "The request parameters",
+                "default": "{}",
+            }
+        },
+        "$defs": {
+            "Req": {
+                "type": "object",
+                "properties": {
+                    "page": {"type": "integer"},
+                },
+            }
+        },
+    }
+
+    result = _simplify_input_schema(schema)
+
+    req = result["properties"]["request"]
+    assert req["type"] == "object"
+    assert req["description"] == "The request parameters"
+    assert req["default"] == "{}"
+    assert "page" in req["properties"]
+
+
 def test_simplify_resolves_nested_ref_in_items():
     """$ref inside array items is inlined recursively."""
     schema = {
@@ -379,8 +412,8 @@ def test_simplify_resolves_nested_ref_in_items():
     assert "col" in items_schema["properties"]
 
 
-def test_simplify_unwraps_optional():
-    """anyOf[T, null] (Optional) is unwrapped to just T."""
+def test_simplify_keeps_optional_anyof():
+    """anyOf[T, null] (Optional) is kept so the LLM knows the field is nullable."""
     schema = {
         "type": "object",
         "properties": {"name": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
@@ -388,7 +421,9 @@ def test_simplify_unwraps_optional():
 
     result = _simplify_input_schema(schema)
 
-    assert result["properties"]["name"] == {"type": "string"}
+    assert result["properties"]["name"] == {
+        "anyOf": [{"type": "string"}, {"type": "null"}]
+    }
 
 
 def test_simplify_preserves_oneof():

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -28,6 +28,7 @@ from superset.mcp_service.server import (
     _fix_call_tool_arguments,
     _normalize_call_tool_arguments,
     _serialize_tools_without_output_schema,
+    _simplify_input_schema,
 )
 from superset.utils import json
 
@@ -300,3 +301,186 @@ def test_normalize_ignores_keys_not_in_schema():
     result = _normalize_call_tool_arguments(arguments, schema)
 
     assert isinstance(result["unknown_key"], dict)
+
+
+# -- _resolve_refs / _simplify_input_schema tests --
+
+
+def test_simplify_resolves_ref_in_anyof():
+    """anyOf[string, $ref] is resolved to the inlined object."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "request": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"$ref": "#/$defs/ListChartsRequest"},
+                ]
+            }
+        },
+        "required": ["request"],
+        "$defs": {
+            "ListChartsRequest": {
+                "type": "object",
+                "properties": {
+                    "page": {"type": "integer", "default": 1},
+                },
+            }
+        },
+    }
+
+    result = _simplify_input_schema(schema)
+
+    assert "$defs" not in result
+    req = result["properties"]["request"]
+    assert "anyOf" not in req
+    assert req["type"] == "object"
+    assert "page" in req["properties"]
+
+
+def test_simplify_resolves_nested_ref_in_items():
+    """$ref inside array items is inlined recursively."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "request": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"$ref": "#/$defs/Outer"},
+                ]
+            }
+        },
+        "$defs": {
+            "Outer": {
+                "type": "object",
+                "properties": {
+                    "filters": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Filter"},
+                    }
+                },
+            },
+            "Filter": {
+                "type": "object",
+                "properties": {
+                    "col": {"type": "string"},
+                    "opr": {"type": "string"},
+                },
+                "required": ["col", "opr"],
+            },
+        },
+    }
+
+    result = _simplify_input_schema(schema)
+
+    assert "$ref" not in json.dumps(result)
+    items_schema = result["properties"]["request"]["properties"]["filters"]["items"]
+    assert items_schema["type"] == "object"
+    assert "col" in items_schema["properties"]
+
+
+def test_simplify_unwraps_optional():
+    """anyOf[T, null] (Optional) is unwrapped to just T."""
+    schema = {
+        "type": "object",
+        "properties": {"name": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+    }
+
+    result = _simplify_input_schema(schema)
+
+    assert result["properties"]["name"] == {"type": "string"}
+
+
+def test_simplify_preserves_oneof():
+    """oneOf variants are resolved but kept as oneOf (not collapsed)."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "config": {
+                "oneOf": [
+                    {"$ref": "#/$defs/XY"},
+                    {"$ref": "#/$defs/Pie"},
+                ]
+            }
+        },
+        "$defs": {
+            "XY": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+            },
+            "Pie": {
+                "type": "object",
+                "properties": {"dim": {"type": "string"}},
+            },
+        },
+    }
+
+    result = _simplify_input_schema(schema)
+
+    assert "$defs" not in result
+    assert "$ref" not in json.dumps(result)
+    variants = result["properties"]["config"]["oneOf"]
+    assert len(variants) == 2
+    assert "x" in variants[0]["properties"]
+    assert "dim" in variants[1]["properties"]
+
+
+def test_simplify_no_defs_passthrough():
+    """Schema without $defs passes through unchanged."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "page": {"type": "integer"},
+        },
+    }
+
+    result = _simplify_input_schema(schema)
+
+    assert result == schema
+
+
+def test_simplify_full_parse_request_pattern():
+    """End-to-end: realistic @parse_request schema is fully resolved."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "request": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"$ref": "#/$defs/ExecuteSqlRequest"},
+                ]
+            }
+        },
+        "required": ["request"],
+        "$defs": {
+            "ExecuteSqlRequest": {
+                "type": "object",
+                "properties": {
+                    "database_id": {
+                        "type": "integer",
+                        "description": "The database ID",
+                    },
+                    "sql": {
+                        "type": "string",
+                        "description": "SQL query to execute",
+                    },
+                    "limit": {"type": "integer", "default": 100},
+                },
+                "required": ["database_id", "sql"],
+            }
+        },
+    }
+
+    result = _simplify_input_schema(schema)
+
+    # Top level: no $defs, request is required
+    assert "$defs" not in result
+    assert result["required"] == ["request"]
+
+    # request: inlined object with all fields visible
+    req = result["properties"]["request"]
+    assert req["type"] == "object"
+    assert req["required"] == ["database_id", "sql"]
+    assert req["properties"]["database_id"]["type"] == "integer"
+    assert req["properties"]["sql"]["type"] == "string"
+    assert req["properties"]["limit"]["default"] == 100


### PR DESCRIPTION
## **User description**
### SUMMARY
When the BM25 tool search transform is enabled, the LLM discovers tools via search_tools and invokes them through a call_tool proxy. The tool schemas returned in search results contain raw Pydantic-generated JSON Schema with $ref pointers and anyOf[string, Object] unions (from the @parse_request decorator's str | Model annotation). The LLM reads these schemas as text and must reconstruct the argument structure when calling call_tool — but the indirection of $ref lookups and ambiguity of anyOf unions causes it to sometimes omit the required request wrapper, passing inner properties directly (e.g. {"config": ...} instead of {"request": {"config": ...}}).

  This PR adds a schema simplification step in _serialize_tools_without_output_schema that:
  - Inlines all $ref pointers so the schema is self-contained (no $defs section needed)
  - Collapses anyOf[string, Object] to just the structured object variant, making the request wrapper and
  its inner properties immediately visible. Field-level metadata (description, default) is preserved
  during the collapse.
  - Preserves oneOf variants (discriminated unions) with resolved refs
  - Only collapses when the pattern is exactly one string + one object variant (the @parse_request
  pattern). All other unions are kept intact.

  Before (what the LLM saw):
  {"properties": {"request": {"anyOf": [{"type": "string"}, {"$ref": "#/$defs/ListChartsRequest"}]}},
  "$defs": {"ListChartsRequest": {"properties": {"filters": {"items": {"$ref": "#/$defs/ChartFilter"}},
  ...}}, "ChartFilter": {...}}}

  After:
  {"properties": {"request": {"type": "object", "properties": {"filters": {"type": "array", "items":
  {"type": "object", "properties": {"col": ..., "opr": ..., "value": ...}}}, "page": {"type": "integer",
  "default": 1}}}}, "required": ["request"]}

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Unit tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Make MCP tool search results easier to follow and use**

### What Changed
- Tool search results now show a self-contained input schema instead of indirect references, so the required request shape is visible at a glance.
- Optional fields are shown as a single field type, while nested object details inside arrays are expanded in place.
- Mixed choices still keep their variants, but the schema no longer hides the important object structure behind references.
- Added coverage for common schema shapes to confirm the visible request format stays intact.

### Impact
`✅ Fewer malformed tool calls`
`✅ Clearer request shapes in search results`
`✅ Less trial and error when invoking MCP tools`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
