### PR TITLE
fix(bubble): Fix Bubble chart axis label rotation

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
@@ -207,13 +207,12 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
   const echartOptions: EChartsCoreOption = {
     series,
     xAxis: {
-      axisLabel: { formatter: xAxisFormatter },
+      axisLabel: { formatter: xAxisFormatter, rotate: xAxisLabelRotation },
       splitLine: {
         lineStyle: {
           type: 'dashed',
         },
       },
-      nameRotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,
       scale: true,
       name: bubbleXAxisTitle,
@@ -226,13 +225,12 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
       ...getMinAndMaxFromBounds(xAxisType, truncateXAxis, xAxisMin, xAxisMax),
     },
     yAxis: {
-      axisLabel: { formatter: yAxisFormatter },
+      axisLabel: { formatter: yAxisFormatter, rotate: yAxisLabelRotation },
       splitLine: {
         lineStyle: {
           type: 'dashed',
         },
       },
-      nameRotate: yAxisLabelRotation,
       scale: truncateYAxis,
       name: bubbleYAxisTitle,
       nameLocation: 'middle',


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes #38916 - Bubble chart axes' labels will now rotate per the form settings.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**

<img width="1510" height="1271" alt="570553058-b3e81ac0-8ab4-418f-9392-97245f3e47e2" src="https://github.com/user-attachments/assets/f9809973-f063-409e-a80c-d66808522f57" />


**After:** (ignore the Time Formatting field there, I was experimenting with dates on the X axis)

<img width="1492" height="1144" alt="570500372-a434d27f-f08b-43d9-a04b-b2a964d37e6b" src="https://github.com/user-attachments/assets/7fb8c043-be2c-40ec-9954-c32561c677b4" />


### TESTING INSTRUCTIONS
- Open the example bubble chart for editing.
- Modify "Rotate x axis label" and "Rotate y axis label" properties.

### ADDITIONAL INFORMATION
Fixes #38916 
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix bubble chart axis label rotation settings

### What Changed
- Bubble chart x-axis labels now rotate as expected when the rotation setting is changed
- Bubble chart y-axis labels now rotate as expected when the rotation setting is changed
- Axis titles are unchanged; this only affects the label angle on the axes

### Impact
`✅ Correctly rotated bubble chart labels`
`✅ Clearer chart labels on crowded axes`
`✅ Fewer layout issues in bubble charts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
