### PR TITLE
fix(bigquery): use backslash escaping for apostrophes in filter values

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 import logging
 import re
 import urllib
+from collections.abc import Callable
 from datetime import datetime
 from re import Pattern
-from collections.abc import Callable
 from typing import Any, TYPE_CHECKING, TypedDict
 
 import pandas as pd
@@ -136,9 +136,7 @@ class BigQueryStringType(types.TypeDecorator):
     impl = types.String
     cache_ok = True
 
-    def literal_processor(
-        self, dialect: DefaultDialect
-    ) -> Callable[[Any], str]:
+    def literal_processor(self, dialect: DefaultDialect) -> Callable[[Any], str]:
         def process(value: Any) -> str:
             raw = str(value)
             escaped = raw.replace("\\", "\\\\").replace("'", "\\'")
@@ -161,7 +159,7 @@ def _monkeypatch_bigquery_dialect() -> None:
     try:
         from sqlalchemy_bigquery import BigQueryDialect
 
-        BigQueryDialect.colspecs[types.String] = BigQueryStringType  # type: ignore
+        BigQueryDialect.colspecs[types.String] = BigQueryStringType
     except ImportError:
         pass
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -22,6 +22,7 @@ import re
 import urllib
 from datetime import datetime
 from re import Pattern
+from collections.abc import Callable
 from typing import Any, TYPE_CHECKING, TypedDict
 
 import pandas as pd
@@ -32,6 +33,7 @@ from marshmallow import fields, Schema
 from marshmallow.exceptions import ValidationError
 from sqlalchemy import column, func, types
 from sqlalchemy.engine.base import Engine
+from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
@@ -118,6 +120,53 @@ class BigQueryParametersSchema(Schema):
 class BigQueryParametersType(TypedDict):
     credentials_info: dict[str, Any]
     query: dict[str, Any]
+
+
+class BigQueryStringType(types.TypeDecorator):
+    """Custom string type for BigQuery that uses backslash escaping for apostrophes.
+
+    BigQuery does not support double-apostrophe escaping ('O''Hara'). Instead,
+    it requires backslash escaping ('O\\'Hara'). SQLAlchemy's default literal
+    processor uses double-apostrophe escaping, which causes syntax errors when
+    filter values contain apostrophes.
+
+    See: https://github.com/apache/superset/issues/35857
+    """
+
+    impl = types.String
+    cache_ok = True
+
+    def literal_processor(
+        self, dialect: DefaultDialect
+    ) -> Callable[[Any], str]:
+        def process(value: Any) -> str:
+            raw = str(value)
+            escaped = raw.replace("\\", "\\\\").replace("'", "\\'")
+            return f"'{escaped}'"
+
+        return process
+
+
+def _monkeypatch_bigquery_dialect() -> None:
+    """Monkeypatch the BigQuery dialect to escape apostrophes with backslash.
+
+    The sqlalchemy-bigquery dialect incorrectly escapes single quotes by
+    doubling them ('O''Hara') instead of using backslash escaping ('O\\'Hara').
+    This causes BigQuery to throw a syntax error when filter values contain
+    apostrophes.
+
+    This follows the same pattern used for the Databricks dialect fix in
+    superset/db_engine_specs/databricks.py.
+    """
+    try:
+        from sqlalchemy_bigquery import BigQueryDialect
+
+        BigQueryDialect.colspecs[types.String] = BigQueryStringType  # type: ignore
+    except ImportError:
+        pass
+
+
+_monkeypatch_bigquery_dialect()
 
 
 class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-methods

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -523,7 +523,9 @@ def test_where_in_bigquery_apostrophe() -> None:
         assert "''" not in result, (
             f"BigQuery should use backslash escaping, got double-apostrophe: {result}"
         )
-        assert "\\'" in result or "Armando" in result
+        assert "\\'" in result, (
+            f"BigQuery should escape apostrophes with backslash: {result}"
+        )
     except ImportError:
         pytest.skip("sqlalchemy-bigquery not installed")
 

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -507,6 +507,27 @@ def test_where_in() -> None:
     assert where_in(["O'Malley's"]) == "('O''Malley''s')"
 
 
+def test_where_in_bigquery_apostrophe() -> None:
+    """
+    Test that BigQuery dialect uses backslash escaping for apostrophes
+    instead of double-apostrophe escaping, which causes syntax errors.
+
+    See: https://github.com/apache/superset/issues/35857
+    """
+    try:
+        from sqlalchemy_bigquery import BigQueryDialect
+
+        where_in = WhereInMacro(BigQueryDialect())
+        result = where_in(["Armando's"])
+        # BigQuery requires backslash escaping, not double-apostrophe
+        assert "''" not in result, (
+            f"BigQuery should use backslash escaping, got double-apostrophe: {result}"
+        )
+        assert "\\'" in result or "Armando" in result
+    except ImportError:
+        pytest.skip("sqlalchemy-bigquery not installed")
+
+
 def test_where_in_empty_list() -> None:
     """
     Test the ``where_in`` Jinja2 filter when it receives an

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -515,16 +515,29 @@ def test_where_in_bigquery_apostrophe() -> None:
     See: https://github.com/apache/superset/issues/35857
     """
     try:
+        # Import the Superset BigQuery engine spec so its dialect monkeypatch is applied
         from sqlalchemy_bigquery import BigQueryDialect
+
+        from superset.db_engine_specs import (
+            bigquery as _bigquery_engine_spec,  # noqa: F401
+        )
 
         where_in = WhereInMacro(BigQueryDialect())
         result = where_in(["Armando's"])
+        assert result is not None
         # BigQuery requires backslash escaping, not double-apostrophe
         assert "''" not in result, (
             f"BigQuery should use backslash escaping, got double-apostrophe: {result}"
         )
         assert "\\'" in result, (
             f"BigQuery should escape apostrophes with backslash: {result}"
+        )
+
+        # Verify literal backslashes are also escaped (not just apostrophes)
+        backslash_result = where_in(["C:\\path"])
+        assert backslash_result is not None
+        assert "\\\\" in backslash_result, (
+            f"BigQuery should escape backslashes: {backslash_result}"
         )
     except ImportError:
         pytest.skip("sqlalchemy-bigquery not installed")


### PR DESCRIPTION
## **User description**
## SUMMARY

Fixes BigQuery syntax errors when filter values contain apostrophes (e.g., "Armando's").

BigQuery does not support double-apostrophe escaping (`'Armando''s'`), which is the default behavior of SQLAlchemy's literal processor. This causes a `400 Syntax error: concatenated string literals must be separated by whitespace or comments` error.

### BEFORE
```sql
-- Generated SQL (broken)
WHERE `restaurant_name` IN ('Armando''s')
-- BigQuery error: Syntax error: concatenated string literals must be separated by whitespace
```

### AFTER
```sql
-- Generated SQL (correct)
WHERE `restaurant_name` IN ('Armando\'s')
-- BigQuery executes successfully
```

## CHANGES

**`superset/db_engine_specs/bigquery.py`:**
- Add `BigQueryStringType` — a `TypeDecorator` that overrides `literal_processor` to use backslash escaping instead of double-apostrophe escaping
- Add `_monkeypatch_bigquery_dialect()` — patches `BigQueryDialect.colspecs` to use the custom string type
- Follows the same proven pattern as the Databricks dialect fix (`DatabricksStringType` + `monkeypatch_dialect()`)

**`tests/unit_tests/jinja_context_test.py`:**
- Add `test_where_in_bigquery_apostrophe` — verifies BigQuery dialect uses backslash escaping for filter values containing apostrophes

## TESTING INSTRUCTIONS

1. Connect a BigQuery data source
2. Create a filter on a text column
3. Select a value containing an apostrophe (e.g., "Armando's", "O'Brien")
4. Verify the chart/dashboard loads without a 400 syntax error

## ADDITIONAL INFORMATION
- Fixes #35857
- Pattern precedent: Databricks fix in `superset/db_engine_specs/databricks.py` lines 57-107


___

## **CodeAnt-AI Description**
**Fix BigQuery filters with apostrophes**

### What Changed
- BigQuery filter values now keep apostrophes in a format BigQuery accepts, so names like `Armando's` no longer trigger a query syntax error
- Added coverage to confirm BigQuery does not fall back to the broken double-apostrophe escaping for quoted filter values

### Impact
`✅ Fewer BigQuery filter errors`
`✅ More reliable dashboards with apostrophe-containing values`
`✅ Clearer filter behavior for quoted names`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
