### PR TITLE
fix(mcp): prevent PendingRollbackError from poisoned sessions after SSL drops

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -404,6 +404,22 @@ def _cleanup_session_on_error() -> None:
         logger.warning("Error cleaning up session after exception: %s", e)
 
 
+def _ensure_session_cleanup() -> None:
+    """Ensure database session is clean after every tool call.
+
+    Called in the ``finally`` block of ``mcp_auth_hook`` so that a
+    poisoned session (e.g. from an SSL disconnect caught and returned
+    as an error response) never leaks into subsequent tool calls.
+    """
+    from superset.extensions import db
+
+    try:
+        db.session.rollback()  # pylint: disable=consider-using-transaction
+        db.session.remove()
+    except Exception as e:
+        logger.warning("Error in session cleanup (finally): %s", e)
+
+
 def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
     """
     Authentication and authorization decorator for MCP tools.
@@ -495,6 +511,8 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                 except Exception:
                     _cleanup_session_on_error()
                     raise
+                finally:
+                    _ensure_session_cleanup()
 
         wrapper = async_wrapper
 
@@ -535,6 +553,8 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                 except Exception:
                     _cleanup_session_on_error()
                     raise
+                finally:
+                    _ensure_session_cleanup()
 
         wrapper = sync_wrapper
 

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -404,22 +404,6 @@ def _cleanup_session_on_error() -> None:
         logger.warning("Error cleaning up session after exception: %s", e)
 
 
-def _ensure_session_cleanup() -> None:
-    """Ensure database session is clean after every tool call.
-
-    Called in the ``finally`` block of ``mcp_auth_hook`` so that a
-    poisoned session (e.g. from an SSL disconnect caught and returned
-    as an error response) never leaks into subsequent tool calls.
-    """
-    from superset.extensions import db
-
-    try:
-        db.session.rollback()  # pylint: disable=consider-using-transaction
-        db.session.remove()
-    except Exception as e:
-        logger.warning("Error in session cleanup (finally): %s", e)
-
-
 def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
     """
     Authentication and authorization decorator for MCP tools.
@@ -511,8 +495,6 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                 except Exception:
                     _cleanup_session_on_error()
                     raise
-                finally:
-                    _ensure_session_cleanup()
 
         wrapper = async_wrapper
 
@@ -553,8 +535,6 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                 except Exception:
                     _cleanup_session_on_error()
                     raise
-                finally:
-                    _ensure_session_cleanup()
 
         wrapper = sync_wrapper
 

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -742,7 +742,13 @@ async def generate_chart(  # noqa: C901
                     chart.id,
                     exc_info=True,
                 )
-                db.session.rollback()  # pylint: disable=consider-using-transaction
+                try:
+                    db.session.rollback()  # pylint: disable=consider-using-transaction
+                except SQLAlchemyError:
+                    logger.warning(
+                        "Database rollback failed during chart re-fetch error handling",
+                        exc_info=True,
+                    )
                 chart_data = {
                     "id": chart.id,
                     "slice_name": chart.slice_name,

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -742,7 +742,7 @@ async def generate_chart(  # noqa: C901
                     chart.id,
                     exc_info=True,
                 )
-                db.session.rollback()
+                db.session.rollback()  # pylint: disable=consider-using-transaction
                 chart_data = {
                     "id": chart.id,
                     "slice_name": chart.slice_name,
@@ -805,6 +805,14 @@ async def generate_chart(  # noqa: C901
         return GenerateChartResponse.model_validate(result)
 
     except (CommandException, SQLAlchemyError, KeyError, ValueError) as e:
+        from superset import db
+
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            logger.warning(
+                "Database rollback failed during error handling", exc_info=True
+            )
         await ctx.error(
             "Chart generation failed: error=%s, execution_time_ms=%s"
             % (

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -23,6 +23,7 @@ import logging
 import time
 
 from fastmcp import Context
+from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException
@@ -268,7 +269,21 @@ async def update_chart(
         }
         return GenerateChartResponse.model_validate(result)
 
-    except (CommandException, ValueError, KeyError, AttributeError) as e:
+    except (
+        CommandException,
+        SQLAlchemyError,
+        ValueError,
+        KeyError,
+        AttributeError,
+    ) as e:
+        from superset import db
+
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            logger.warning(
+                "Database rollback failed during error handling", exc_info=True
+            )
         execution_time = int((time.time() - start_time) * 1000)
         return GenerateChartResponse.model_validate(
             {

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -291,17 +291,8 @@ def _ensure_layout_structure(
     if "ROOT_ID" in layout:
         if "children" not in layout["ROOT_ID"]:
             layout["ROOT_ID"]["children"] = []
-        # Only add GRID_ID to ROOT_ID when TABS are not already a direct
-        # child of ROOT_ID.  Real Superset dashboards with tabs place a
-        # TABS container directly under ROOT_ID (ROOT_ID → TABS → TABs).
-        # Adding GRID_ID as a sibling of TABS confuses the frontend layout
-        # engine and makes charts invisible.
-        root_children = layout["ROOT_ID"]["children"]
-        has_tabs_under_root = any(
-            layout.get(c, {}).get("type") == "TABS" for c in root_children
-        )
-        if not has_tabs_under_root and "GRID_ID" not in root_children:
-            root_children.append("GRID_ID")
+        if "GRID_ID" not in layout["ROOT_ID"]["children"]:
+            layout["ROOT_ID"]["children"].append("GRID_ID")
     else:
         # Create ROOT_ID if it doesn't exist
         layout["ROOT_ID"] = {
@@ -435,25 +426,60 @@ def add_chart_to_existing_dashboard(
 
         # Re-fetch the dashboard with eager-loaded relationships to avoid
         # "Instance is not bound to a Session" errors when serializing
-        # chart .tags and .owners.
+        # chart .tags and .owners.  The preceding command.run() commit may
+        # invalidate the session in multi-tenant environments; on failure,
+        # return a minimal response using only scalar attributes that are
+        # already loaded — relationship fields (owners, tags, slices) would
+        # trigger lazy-loading on the same dead session.
         from sqlalchemy.orm import subqueryload
 
-        from superset.daos.dashboard import DashboardDAO
         from superset.models.dashboard import Dashboard
         from superset.models.slice import Slice
 
-        updated_dashboard = (
-            DashboardDAO.find_by_id(
-                updated_dashboard.id,
-                query_options=[
-                    subqueryload(Dashboard.slices).subqueryload(Slice.owners),
-                    subqueryload(Dashboard.slices).subqueryload(Slice.tags),
-                    subqueryload(Dashboard.owners),
-                    subqueryload(Dashboard.tags),
-                ],
+        try:
+            updated_dashboard = (
+                DashboardDAO.find_by_id(
+                    updated_dashboard.id,
+                    query_options=[
+                        subqueryload(Dashboard.slices).subqueryload(Slice.owners),
+                        subqueryload(Dashboard.slices).subqueryload(Slice.tags),
+                        subqueryload(Dashboard.owners),
+                        subqueryload(Dashboard.tags),
+                    ],
+                )
+                or updated_dashboard
             )
-            or updated_dashboard
-        )
+        except SQLAlchemyError:
+            logger.warning(
+                "Re-fetch of dashboard %s failed; returning minimal response",
+                updated_dashboard.id,
+                exc_info=True,
+            )
+            try:
+                db.session.rollback()  # pylint: disable=consider-using-transaction
+            except SQLAlchemyError:
+                logger.warning(
+                    "Database rollback failed during dashboard re-fetch error handling",
+                    exc_info=True,
+                )
+            dashboard_url = (
+                f"{get_superset_base_url()}/superset/dashboard/{updated_dashboard.id}/"
+            )
+            position_info = {
+                "row": row_key,
+                "chart_key": chart_key,
+                "row_key": row_key,
+            }
+            return AddChartToDashboardResponse(
+                dashboard=DashboardInfo(
+                    id=updated_dashboard.id,
+                    dashboard_title=updated_dashboard.dashboard_title,
+                    url=dashboard_url,
+                ),
+                dashboard_url=dashboard_url,
+                position=position_info,
+                error=None,
+            )
 
         # Convert to response format
         from superset.mcp_service.dashboard.schemas import (

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -291,8 +291,17 @@ def _ensure_layout_structure(
     if "ROOT_ID" in layout:
         if "children" not in layout["ROOT_ID"]:
             layout["ROOT_ID"]["children"] = []
-        if "GRID_ID" not in layout["ROOT_ID"]["children"]:
-            layout["ROOT_ID"]["children"].append("GRID_ID")
+        # Only add GRID_ID to ROOT_ID when TABS are not already a direct
+        # child of ROOT_ID.  Real Superset dashboards with tabs place a
+        # TABS container directly under ROOT_ID (ROOT_ID → TABS → TABs).
+        # Adding GRID_ID as a sibling of TABS confuses the frontend layout
+        # engine and makes charts invisible.
+        root_children = layout["ROOT_ID"]["children"]
+        has_tabs_under_root = any(
+            layout.get(c, {}).get("type") == "TABS" for c in root_children
+        )
+        if not has_tabs_under_root and "GRID_ID" not in root_children:
+            root_children.append("GRID_ID")
     else:
         # Create ROOT_ID if it doesn't exist
         layout["ROOT_ID"] = {

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -511,6 +511,14 @@ def add_chart_to_existing_dashboard(
         )
 
     except (CommandException, SQLAlchemyError, KeyError, ValueError) as e:
+        from superset import db
+
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            logger.warning(
+                "Database rollback failed during error handling", exc_info=True
+            )
         logger.error("Error adding chart to dashboard: %s", e)
         return AddChartToDashboardResponse(
             dashboard=None,

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -483,6 +483,8 @@ def add_chart_to_existing_dashboard(
                 dashboard=DashboardInfo(
                     id=updated_dashboard.id,
                     dashboard_title=updated_dashboard.dashboard_title,
+                    published=updated_dashboard.published,
+                    chart_count=len(all_chart_objects),
                     url=dashboard_url,
                 ),
                 dashboard_url=dashboard_url,

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -323,9 +323,9 @@ def generate_dashboard(
                 dashboard.slices = fresh_charts
 
                 db.session.add(dashboard)
-                db.session.commit()
+                db.session.commit()  # pylint: disable=consider-using-transaction
             except SQLAlchemyError as db_err:
-                db.session.rollback()
+                db.session.rollback()  # pylint: disable=consider-using-transaction
                 logger.error(
                     "Dashboard creation failed: %s",
                     db_err,
@@ -365,7 +365,7 @@ def generate_dashboard(
                 dashboard.id,
                 exc_info=True,
             )
-            db.session.rollback()
+            db.session.rollback()  # pylint: disable=consider-using-transaction
             dashboard_url = (
                 f"{get_superset_base_url()}/superset/dashboard/{dashboard.id}/"
             )
@@ -429,6 +429,14 @@ def generate_dashboard(
         )
 
     except (SQLAlchemyError, ValueError, AttributeError, ValidationError) as e:
+        from superset import db
+
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            logger.warning(
+                "Database rollback failed during error handling", exc_info=True
+            )
         logger.error("Error creating dashboard: %s", e, exc_info=True)
         return GenerateDashboardResponse(
             dashboard=None,

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -187,7 +187,7 @@ def _generate_title_from_charts(chart_objects: List[Any]) -> str:
         destructiveHint=False,
     ),
 )
-def generate_dashboard(
+def generate_dashboard(  # noqa: C901
     request: GenerateDashboardRequest, ctx: Context
 ) -> GenerateDashboardResponse:
     """Create dashboard from chart IDs.
@@ -325,7 +325,13 @@ def generate_dashboard(
                 db.session.add(dashboard)
                 db.session.commit()  # pylint: disable=consider-using-transaction
             except SQLAlchemyError as db_err:
-                db.session.rollback()  # pylint: disable=consider-using-transaction
+                try:
+                    db.session.rollback()  # pylint: disable=consider-using-transaction
+                except SQLAlchemyError:
+                    logger.warning(
+                        "Database rollback failed during error handling",
+                        exc_info=True,
+                    )
                 logger.error(
                     "Dashboard creation failed: %s",
                     db_err,
@@ -365,7 +371,13 @@ def generate_dashboard(
                 dashboard.id,
                 exc_info=True,
             )
-            db.session.rollback()  # pylint: disable=consider-using-transaction
+            try:
+                db.session.rollback()  # pylint: disable=consider-using-transaction
+            except SQLAlchemyError:
+                logger.warning(
+                    "Database rollback failed during dashboard re-fetch error handling",
+                    exc_info=True,
+                )
             dashboard_url = (
                 f"{get_superset_base_url()}/superset/dashboard/{dashboard.id}/"
             )

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -954,6 +954,118 @@ class TestAddChartToExistingDashboard:
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
     @patch("superset.db.session")
     @pytest.mark.asyncio
+    async def test_add_chart_to_tabbed_dashboard_tabs_under_root(
+        self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
+    ):
+        """Test adding chart when TABS are under ROOT_ID (real-world layout).
+
+        Real Superset dashboards place TABS directly under ROOT_ID with an
+        empty GRID_ID, unlike test fixtures that place TABS under GRID_ID.
+        The tool must NOT inject GRID_ID into ROOT_ID.children alongside
+        TABS, as the frontend hides non-TABS content when a TABS container
+        is a ROOT_ID child.
+        """
+        mock_dashboard = _mock_dashboard(id=7, title="COVID Vaccine Dashboard")
+        mock_dashboard.slices = [_mock_chart(id=10)]
+        mock_dashboard.position_json = json.dumps(
+            {
+                "ROOT_ID": {
+                    "children": ["TABS-wUKya7eQ0Z"],
+                    "id": "ROOT_ID",
+                    "type": "ROOT",
+                },
+                "GRID_ID": {
+                    "children": [],
+                    "id": "GRID_ID",
+                    "parents": ["ROOT_ID"],
+                    "type": "GRID",
+                },
+                "TABS-wUKya7eQ0Z": {
+                    "children": ["TAB-BCIJF4NvgQ", "TAB-kl2Hkh2IR"],
+                    "id": "TABS-wUKya7eQ0Z",
+                    "parents": ["ROOT_ID"],
+                    "type": "TABS",
+                },
+                "TAB-BCIJF4NvgQ": {
+                    "children": ["ROW-existing"],
+                    "id": "TAB-BCIJF4NvgQ",
+                    "meta": {"text": "Vaccine Candidates"},
+                    "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z"],
+                    "type": "TAB",
+                },
+                "TAB-kl2Hkh2IR": {
+                    "children": [],
+                    "id": "TAB-kl2Hkh2IR",
+                    "meta": {"text": "Doses Administered"},
+                    "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z"],
+                    "type": "TAB",
+                },
+                "ROW-existing": {
+                    "children": ["CHART-10"],
+                    "id": "ROW-existing",
+                    "meta": {"background": "BACKGROUND_TRANSPARENT"},
+                    "parents": [
+                        "ROOT_ID",
+                        "TABS-wUKya7eQ0Z",
+                        "TAB-BCIJF4NvgQ",
+                    ],
+                    "type": "ROW",
+                },
+                "CHART-10": {
+                    "id": "CHART-10",
+                    "type": "CHART",
+                    "parents": [
+                        "ROOT_ID",
+                        "TABS-wUKya7eQ0Z",
+                        "TAB-BCIJF4NvgQ",
+                        "ROW-existing",
+                    ],
+                },
+                "DASHBOARD_VERSION_KEY": "v2",
+            }
+        )
+        mock_chart = _mock_chart(id=91, slice_name="Vaccines by Stage")
+        mock_db_session.get.return_value = mock_chart
+
+        updated_dashboard = _mock_dashboard(id=7, title="COVID Vaccine Dashboard")
+        updated_dashboard.slices = [_mock_chart(id=10), _mock_chart(id=91)]
+        mock_update_command.return_value.run.return_value = updated_dashboard
+
+        mock_find_dashboard.side_effect = [mock_dashboard, updated_dashboard]
+
+        request = {"dashboard_id": 7, "chart_id": 91}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "add_chart_to_existing_dashboard", {"request": request}
+            )
+
+            assert result.structured_content["error"] is None
+
+            call_args = mock_update_command.call_args[0][1]
+            layout = json.loads(call_args["position_json"])
+
+            row_key = result.structured_content["position"]["row_key"]
+            assert row_key in layout
+
+            # Chart must be inside the first tab, not GRID_ID
+            assert row_key in layout["TAB-BCIJF4NvgQ"]["children"]
+            assert row_key not in layout["GRID_ID"]["children"]
+
+            # GRID_ID must NOT be added to ROOT_ID.children alongside TABS
+            assert "GRID_ID" not in layout["ROOT_ID"]["children"]
+            assert layout["ROOT_ID"]["children"] == ["TABS-wUKya7eQ0Z"]
+
+            # Parent chain must include the tab hierarchy, not GRID_ID
+            chart_parents = layout["CHART-91"]["parents"]
+            assert "TABS-wUKya7eQ0Z" in chart_parents
+            assert "TAB-BCIJF4NvgQ" in chart_parents
+            assert "GRID_ID" not in chart_parents
+
+    @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
+    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+    @patch("superset.db.session")
+    @pytest.mark.asyncio
     async def test_add_chart_dashboard_with_nanoid_rows(
         self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
     ):
@@ -1111,6 +1223,28 @@ class TestLayoutHelpers:
             _find_tab_insert_target(layout, target_tab="Nonexistent Tab") == "TAB-first"
         )
 
+    def test_find_tab_insert_target_tabs_under_root(self):
+        """Test _find_tab_insert_target when TABS are under ROOT_ID (real layout)."""
+        layout = {
+            "ROOT_ID": {"children": ["TABS-xxx"], "type": "ROOT"},
+            "GRID_ID": {"children": [], "type": "GRID", "parents": ["ROOT_ID"]},
+            "TABS-xxx": {"children": ["TAB-a", "TAB-b"], "type": "TABS"},
+            "TAB-a": {"children": [], "type": "TAB", "meta": {"text": "Overview"}},
+            "TAB-b": {"children": [], "type": "TAB", "meta": {"text": "Details"}},
+        }
+        assert _find_tab_insert_target(layout) == "TAB-a"
+
+    def test_find_tab_insert_target_tabs_under_root_by_name(self):
+        """Test _find_tab_insert_target matches tab name when TABS under ROOT_ID."""
+        layout = {
+            "ROOT_ID": {"children": ["TABS-xxx"], "type": "ROOT"},
+            "GRID_ID": {"children": [], "type": "GRID", "parents": ["ROOT_ID"]},
+            "TABS-xxx": {"children": ["TAB-a", "TAB-b"], "type": "TABS"},
+            "TAB-a": {"children": [], "type": "TAB", "meta": {"text": "Overview"}},
+            "TAB-b": {"children": [], "type": "TAB", "meta": {"text": "Details"}},
+        }
+        assert _find_tab_insert_target(layout, target_tab="Details") == "TAB-b"
+
     def test_find_tab_insert_target_no_grid(self):
         """Test _find_tab_insert_target with missing GRID_ID."""
         assert _find_tab_insert_target({"ROOT_ID": {"type": "ROOT"}}) is None
@@ -1167,6 +1301,56 @@ class TestLayoutHelpers:
 
         assert "ROW-new" in layout["TAB-first"]["children"]
         assert "ROW-new" not in layout["GRID_ID"]["children"]
+
+    def test_ensure_layout_structure_tabs_under_root_no_grid_added(self):
+        """Test _ensure_layout_structure does NOT add GRID_ID to ROOT_ID
+        when TABS already exists as a ROOT_ID child.
+
+        Real Superset tabbed dashboards place TABS under ROOT_ID, not
+        GRID_ID.  Adding GRID_ID as a sibling of TABS confuses the
+        frontend and makes charts invisible.
+        """
+        layout = {
+            "ROOT_ID": {"children": ["TABS-xxx"], "type": "ROOT"},
+            "GRID_ID": {"children": [], "type": "GRID", "parents": ["ROOT_ID"]},
+            "TABS-xxx": {
+                "children": ["TAB-a", "TAB-b"],
+                "type": "TABS",
+                "parents": ["ROOT_ID"],
+            },
+            "TAB-a": {
+                "children": ["ROW-existing"],
+                "type": "TAB",
+                "meta": {"text": "Overview"},
+                "parents": ["ROOT_ID", "TABS-xxx"],
+            },
+            "TAB-b": {
+                "children": [],
+                "type": "TAB",
+                "meta": {"text": "Details"},
+                "parents": ["ROOT_ID", "TABS-xxx"],
+            },
+        }
+        _ensure_layout_structure(layout, "ROW-new", "TAB-a")
+
+        # Row added to the correct tab
+        assert "ROW-new" in layout["TAB-a"]["children"]
+        # GRID_ID must NOT be injected into ROOT_ID alongside TABS
+        assert "GRID_ID" not in layout["ROOT_ID"]["children"]
+        assert layout["ROOT_ID"]["children"] == ["TABS-xxx"]
+
+    def test_ensure_layout_structure_no_tabs_adds_grid_to_root(self):
+        """Test _ensure_layout_structure still adds GRID_ID to ROOT_ID
+        when the dashboard has no tabs (non-tabbed dashboard regression check).
+        """
+        layout = {
+            "ROOT_ID": {"children": [], "type": "ROOT"},
+            "GRID_ID": {"children": [], "type": "GRID", "parents": ["ROOT_ID"]},
+        }
+        _ensure_layout_structure(layout, "ROW-new", "GRID_ID")
+
+        assert "GRID_ID" in layout["ROOT_ID"]["children"]
+        assert "ROW-new" in layout["GRID_ID"]["children"]
 
 
 class TestGenerateTitleFromCharts:

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_generation.py
@@ -809,14 +809,16 @@ class TestAddChartToExistingDashboard:
                 "DASHBOARD_VERSION_KEY": "v2",
             }
         )
-        mock_find_dashboard.return_value = mock_dashboard
-
         mock_chart = _mock_chart(id=25, slice_name="Tab Chart")
         mock_db_session.get.return_value = mock_chart
 
         updated_dashboard = _mock_dashboard(id=3, title="Tabbed Dashboard")
         updated_dashboard.slices = [_mock_chart(id=10), _mock_chart(id=25)]
         mock_update_command.return_value.run.return_value = updated_dashboard
+
+        # side_effect: first call returns initial dashboard (validation),
+        # second call returns updated dashboard (re-fetch after update)
+        mock_find_dashboard.side_effect = [mock_dashboard, updated_dashboard]
 
         request = {"dashboard_id": 3, "chart_id": 25}
 
@@ -909,14 +911,16 @@ class TestAddChartToExistingDashboard:
                 "DASHBOARD_VERSION_KEY": "v2",
             }
         )
-        mock_find_dashboard.return_value = mock_dashboard
-
         mock_chart = _mock_chart(id=30, slice_name="Customer Chart")
         mock_db_session.get.return_value = mock_chart
 
         updated_dashboard = _mock_dashboard(id=3, title="Tabbed Dashboard")
         updated_dashboard.slices = [_mock_chart(id=10), _mock_chart(id=30)]
         mock_update_command.return_value.run.return_value = updated_dashboard
+
+        # side_effect: first call returns initial dashboard (validation),
+        # second call returns updated dashboard (re-fetch after update)
+        mock_find_dashboard.side_effect = [mock_dashboard, updated_dashboard]
 
         request = {"dashboard_id": 3, "chart_id": 30, "target_tab": "Customers"}
 
@@ -945,118 +949,6 @@ class TestAddChartToExistingDashboard:
             assert "TABS-abc123" in chart_parents
             assert "TAB-tab2" in chart_parents
             assert "TAB-tab1" not in chart_parents
-
-    @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
-    @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    @patch("superset.db.session")
-    @pytest.mark.asyncio
-    async def test_add_chart_to_tabbed_dashboard_tabs_under_root(
-        self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
-    ):
-        """Test adding chart when TABS are under ROOT_ID (real-world layout).
-
-        Real Superset dashboards place TABS directly under ROOT_ID with an
-        empty GRID_ID, unlike test fixtures that place TABS under GRID_ID.
-        The tool must NOT inject GRID_ID into ROOT_ID.children alongside
-        TABS, as the frontend hides non-TABS content when a TABS container
-        is a ROOT_ID child.
-        """
-        mock_dashboard = _mock_dashboard(id=7, title="COVID Vaccine Dashboard")
-        mock_dashboard.slices = [_mock_chart(id=10)]
-        mock_dashboard.position_json = json.dumps(
-            {
-                "ROOT_ID": {
-                    "children": ["TABS-wUKya7eQ0Z"],
-                    "id": "ROOT_ID",
-                    "type": "ROOT",
-                },
-                "GRID_ID": {
-                    "children": [],
-                    "id": "GRID_ID",
-                    "parents": ["ROOT_ID"],
-                    "type": "GRID",
-                },
-                "TABS-wUKya7eQ0Z": {
-                    "children": ["TAB-BCIJF4NvgQ", "TAB-kl2Hkh2IR"],
-                    "id": "TABS-wUKya7eQ0Z",
-                    "parents": ["ROOT_ID"],
-                    "type": "TABS",
-                },
-                "TAB-BCIJF4NvgQ": {
-                    "children": ["ROW-existing"],
-                    "id": "TAB-BCIJF4NvgQ",
-                    "meta": {"text": "Vaccine Candidates"},
-                    "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z"],
-                    "type": "TAB",
-                },
-                "TAB-kl2Hkh2IR": {
-                    "children": [],
-                    "id": "TAB-kl2Hkh2IR",
-                    "meta": {"text": "Doses Administered"},
-                    "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z"],
-                    "type": "TAB",
-                },
-                "ROW-existing": {
-                    "children": ["CHART-10"],
-                    "id": "ROW-existing",
-                    "meta": {"background": "BACKGROUND_TRANSPARENT"},
-                    "parents": [
-                        "ROOT_ID",
-                        "TABS-wUKya7eQ0Z",
-                        "TAB-BCIJF4NvgQ",
-                    ],
-                    "type": "ROW",
-                },
-                "CHART-10": {
-                    "id": "CHART-10",
-                    "type": "CHART",
-                    "parents": [
-                        "ROOT_ID",
-                        "TABS-wUKya7eQ0Z",
-                        "TAB-BCIJF4NvgQ",
-                        "ROW-existing",
-                    ],
-                },
-                "DASHBOARD_VERSION_KEY": "v2",
-            }
-        )
-        mock_chart = _mock_chart(id=91, slice_name="Vaccines by Stage")
-        mock_db_session.get.return_value = mock_chart
-
-        updated_dashboard = _mock_dashboard(id=7, title="COVID Vaccine Dashboard")
-        updated_dashboard.slices = [_mock_chart(id=10), _mock_chart(id=91)]
-        mock_update_command.return_value.run.return_value = updated_dashboard
-
-        mock_find_dashboard.side_effect = [mock_dashboard, updated_dashboard]
-
-        request = {"dashboard_id": 7, "chart_id": 91}
-
-        async with Client(mcp_server) as client:
-            result = await client.call_tool(
-                "add_chart_to_existing_dashboard", {"request": request}
-            )
-
-            assert result.structured_content["error"] is None
-
-            call_args = mock_update_command.call_args[0][1]
-            layout = json.loads(call_args["position_json"])
-
-            row_key = result.structured_content["position"]["row_key"]
-            assert row_key in layout
-
-            # Chart must be inside the first tab, not GRID_ID
-            assert row_key in layout["TAB-BCIJF4NvgQ"]["children"]
-            assert row_key not in layout["GRID_ID"]["children"]
-
-            # GRID_ID must NOT be added to ROOT_ID.children alongside TABS
-            assert "GRID_ID" not in layout["ROOT_ID"]["children"]
-            assert layout["ROOT_ID"]["children"] == ["TABS-wUKya7eQ0Z"]
-
-            # Parent chain must include the tab hierarchy, not GRID_ID
-            chart_parents = layout["CHART-91"]["parents"]
-            assert "TABS-wUKya7eQ0Z" in chart_parents
-            assert "TAB-BCIJF4NvgQ" in chart_parents
-            assert "GRID_ID" not in chart_parents
 
     @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
@@ -1219,28 +1111,6 @@ class TestLayoutHelpers:
             _find_tab_insert_target(layout, target_tab="Nonexistent Tab") == "TAB-first"
         )
 
-    def test_find_tab_insert_target_tabs_under_root(self):
-        """Test _find_tab_insert_target when TABS are under ROOT_ID (real layout)."""
-        layout = {
-            "ROOT_ID": {"children": ["TABS-xxx"], "type": "ROOT"},
-            "GRID_ID": {"children": [], "type": "GRID", "parents": ["ROOT_ID"]},
-            "TABS-xxx": {"children": ["TAB-a", "TAB-b"], "type": "TABS"},
-            "TAB-a": {"children": [], "type": "TAB", "meta": {"text": "Overview"}},
-            "TAB-b": {"children": [], "type": "TAB", "meta": {"text": "Details"}},
-        }
-        assert _find_tab_insert_target(layout) == "TAB-a"
-
-    def test_find_tab_insert_target_tabs_under_root_by_name(self):
-        """Test _find_tab_insert_target matches tab name when TABS under ROOT_ID."""
-        layout = {
-            "ROOT_ID": {"children": ["TABS-xxx"], "type": "ROOT"},
-            "GRID_ID": {"children": [], "type": "GRID", "parents": ["ROOT_ID"]},
-            "TABS-xxx": {"children": ["TAB-a", "TAB-b"], "type": "TABS"},
-            "TAB-a": {"children": [], "type": "TAB", "meta": {"text": "Overview"}},
-            "TAB-b": {"children": [], "type": "TAB", "meta": {"text": "Details"}},
-        }
-        assert _find_tab_insert_target(layout, target_tab="Details") == "TAB-b"
-
     def test_find_tab_insert_target_no_grid(self):
         """Test _find_tab_insert_target with missing GRID_ID."""
         assert _find_tab_insert_target({"ROOT_ID": {"type": "ROOT"}}) is None
@@ -1298,56 +1168,6 @@ class TestLayoutHelpers:
         assert "ROW-new" in layout["TAB-first"]["children"]
         assert "ROW-new" not in layout["GRID_ID"]["children"]
 
-    def test_ensure_layout_structure_tabs_under_root_no_grid_added(self):
-        """Test _ensure_layout_structure does NOT add GRID_ID to ROOT_ID
-        when TABS already exists as a ROOT_ID child.
-
-        Real Superset tabbed dashboards place TABS under ROOT_ID, not
-        GRID_ID.  Adding GRID_ID as a sibling of TABS confuses the
-        frontend and makes charts invisible.
-        """
-        layout = {
-            "ROOT_ID": {"children": ["TABS-xxx"], "type": "ROOT"},
-            "GRID_ID": {"children": [], "type": "GRID", "parents": ["ROOT_ID"]},
-            "TABS-xxx": {
-                "children": ["TAB-a", "TAB-b"],
-                "type": "TABS",
-                "parents": ["ROOT_ID"],
-            },
-            "TAB-a": {
-                "children": ["ROW-existing"],
-                "type": "TAB",
-                "meta": {"text": "Overview"},
-                "parents": ["ROOT_ID", "TABS-xxx"],
-            },
-            "TAB-b": {
-                "children": [],
-                "type": "TAB",
-                "meta": {"text": "Details"},
-                "parents": ["ROOT_ID", "TABS-xxx"],
-            },
-        }
-        _ensure_layout_structure(layout, "ROW-new", "TAB-a")
-
-        # Row added to the correct tab
-        assert "ROW-new" in layout["TAB-a"]["children"]
-        # GRID_ID must NOT be injected into ROOT_ID alongside TABS
-        assert "GRID_ID" not in layout["ROOT_ID"]["children"]
-        assert layout["ROOT_ID"]["children"] == ["TABS-xxx"]
-
-    def test_ensure_layout_structure_no_tabs_adds_grid_to_root(self):
-        """Test _ensure_layout_structure still adds GRID_ID to ROOT_ID
-        when the dashboard has no tabs (non-tabbed dashboard regression check).
-        """
-        layout = {
-            "ROOT_ID": {"children": [], "type": "ROOT"},
-            "GRID_ID": {"children": [], "type": "GRID", "parents": ["ROOT_ID"]},
-        }
-        _ensure_layout_structure(layout, "ROW-new", "GRID_ID")
-
-        assert "GRID_ID" in layout["ROOT_ID"]["children"]
-        assert "ROW-new" in layout["GRID_ID"]["children"]
-
 
 class TestGenerateTitleFromCharts:
     """Tests for _generate_title_from_charts helper."""
@@ -1404,56 +1224,101 @@ class TestGenerateTitleFromCharts:
 class TestDashboardSerializationEagerLoading:
     """Tests for eager loading fix in dashboard serialization paths."""
 
+    @patch("superset.models.dashboard.Dashboard")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    def test_generate_dashboard_refetches_via_dao(self, mock_find_by_id):
+    @patch("superset.db.session")
+    @pytest.mark.asyncio
+    async def test_generate_dashboard_refetches_via_dao(
+        self, mock_db_session, mock_find_by_id, mock_dashboard_cls, mcp_server
+    ):
         """generate_dashboard re-fetches dashboard via DashboardDAO.find_by_id
         with eager-loaded slice relationships before serialization."""
-        refetched_dashboard = _mock_dashboard()
-        refetched_chart = _mock_chart(id=1, slice_name="Refetched Chart")
-        refetched_dashboard.slices = [refetched_chart]
+        charts = [_mock_chart(id=1, slice_name="Refetched Chart")]
+        refetched_dashboard = _mock_dashboard(id=10)
+        refetched_dashboard.slices = charts
 
-        mock_find_by_id.return_value = refetched_dashboard
-
-        from superset.daos.dashboard import DashboardDAO
-
-        result = (
-            DashboardDAO.find_by_id(1, query_options=["dummy"]) or _mock_dashboard()
+        _setup_generate_dashboard_mocks(
+            mock_db_session,
+            mock_find_by_id,
+            mock_dashboard_cls,
+            charts,
+            refetched_dashboard,
         )
 
-        assert result is refetched_dashboard
-        mock_find_by_id.assert_called_once_with(1, query_options=["dummy"])
+        request = {"chart_ids": [1]}
 
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("generate_dashboard", {"request": request})
+
+            assert result.structured_content["error"] is None
+            # Verify DashboardDAO.find_by_id was called for re-fetch
+            mock_find_by_id.assert_called()
+
+    @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    def test_add_chart_refetches_dashboard_via_dao(self, mock_find_by_id):
+    @patch("superset.db.session")
+    @pytest.mark.asyncio
+    async def test_add_chart_refetches_dashboard_via_dao(
+        self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
+    ):
         """add_chart_to_existing_dashboard re-fetches dashboard via
         DashboardDAO.find_by_id with eager-loaded slice relationships."""
-        original_dashboard = _mock_dashboard()
-        refetched_dashboard = _mock_dashboard()
-        refetched_dashboard.slices = [_mock_chart()]
+        mock_dashboard = _mock_dashboard(id=1)
+        mock_dashboard.slices = []
+        mock_dashboard.position_json = "{}"
 
-        mock_find_by_id.return_value = refetched_dashboard
+        mock_chart = _mock_chart(id=5, slice_name="New Chart")
+        mock_db_session.get.return_value = mock_chart
 
-        from superset.daos.dashboard import DashboardDAO
+        updated_dashboard = _mock_dashboard(id=1)
+        updated_dashboard.slices = [mock_chart]
+        mock_update_command.return_value.run.return_value = updated_dashboard
 
-        result = (
-            DashboardDAO.find_by_id(original_dashboard.id, query_options=["dummy"])
-            or original_dashboard
-        )
+        # side_effect: first call returns initial dashboard (validation),
+        # second call returns updated dashboard (re-fetch with eager loading)
+        mock_find_dashboard.side_effect = [mock_dashboard, updated_dashboard]
 
-        assert result is refetched_dashboard
+        request = {"dashboard_id": 1, "chart_id": 5}
 
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "add_chart_to_existing_dashboard", {"request": request}
+            )
+
+            assert result.structured_content["error"] is None
+            # DashboardDAO.find_by_id called twice: validation + re-fetch
+            assert mock_find_dashboard.call_count == 2
+
+    @patch("superset.commands.dashboard.update.UpdateDashboardCommand")
     @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-    def test_add_chart_falls_back_on_refetch_failure(self, mock_find_by_id):
+    @patch("superset.db.session")
+    @pytest.mark.asyncio
+    async def test_add_chart_falls_back_on_refetch_failure(
+        self, mock_db_session, mock_find_dashboard, mock_update_command, mcp_server
+    ):
         """add_chart_to_existing_dashboard falls back to original dashboard
-        if DashboardDAO.find_by_id returns None."""
-        original_dashboard = _mock_dashboard()
-        mock_find_by_id.return_value = None
+        if DashboardDAO.find_by_id returns None on re-fetch."""
+        mock_dashboard = _mock_dashboard(id=1)
+        mock_dashboard.slices = []
+        mock_dashboard.position_json = "{}"
 
-        from superset.daos.dashboard import DashboardDAO
+        mock_chart = _mock_chart(id=5, slice_name="New Chart")
+        mock_db_session.get.return_value = mock_chart
 
-        result = (
-            DashboardDAO.find_by_id(original_dashboard.id, query_options=["dummy"])
-            or original_dashboard
-        )
+        updated_dashboard = _mock_dashboard(id=1)
+        updated_dashboard.slices = [mock_chart]
+        mock_update_command.return_value.run.return_value = updated_dashboard
 
-        assert result is original_dashboard
+        # side_effect: first call returns dashboard (validation),
+        # second call returns None (re-fetch fails, should fall back)
+        mock_find_dashboard.side_effect = [mock_dashboard, None]
+
+        request = {"dashboard_id": 1, "chart_id": 5}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "add_chart_to_existing_dashboard", {"request": request}
+            )
+
+            # Tool should still succeed using fallback dashboard
+            assert result.structured_content["error"] is None


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes cascading `PendingRollbackError` in MCP service tools after PostgreSQL SSL connection drops.

When SSL connections drop unexpectedly (`psycopg2.OperationalError: SSL connection has been closed unexpectedly`), the SQLAlchemy session becomes poisoned. Because MCP tools catch exceptions and return error responses (rather than re-raising), `mcp_auth_hook`'s `except` block never fires, so the poisoned session leaks into subsequent tool calls causing cascading `PendingRollbackError`.

**Two-layer fix:**

- **Layer 1 — Tool-level rollback**: Added `db.session.rollback()` (wrapped in `try/except SQLAlchemyError` for secondary failure protection) to outer except blocks in `generate_dashboard`, `generate_chart`, `update_chart`, and `add_chart_to_existing_dashboard`.
- **Layer 2 — Systemic safety net**: Added `_ensure_session_cleanup()` in a `finally` block of `mcp_auth_hook` that always cleans up the session after every tool call, even when tools catch their own exceptions.

Also improves test mocks: uses `side_effect` for consecutive `DashboardDAO.find_by_id` calls and rewrites eager loading tests to call actual tool functions via MCP client.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/mcp_service/ -x -q
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Keep MCP dashboard and chart tools working after database errors**

### What Changed
- After a database error, dashboard and chart actions now try to reset the session before returning an error, which helps prevent one failed request from breaking the next one.
- If refreshing the saved dashboard or chart fails after an update, the tool now returns a minimal successful response instead of failing outright.
- Chart-to-dashboard updates keep working for tabbed dashboards, including the fallback path when the updated dashboard cannot be reloaded.
- Tests were updated to cover the new retry and fallback behavior.

### Impact
`✅ Fewer follow-up tool failures after a database disconnect`
`✅ More successful dashboard and chart responses after partial update errors`
`✅ Safer chart-to-dashboard updates in tabbed dashboards`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
