### PR TITLE
fix(drill-detail): restrict page size options to match defaultPageSize

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -314,6 +314,7 @@ export default function DrillDetailPane({
           columns={mappedColumns}
           size={TableSize.Small}
           defaultPageSize={PAGE_SIZE}
+          pageSizeOptions={[`${PAGE_SIZE}`]}
           recordCount={resultsPage?.total}
           usePagination
           loading={isLoading}


### PR DESCRIPTION
## **User description**
## Summary

Fixes #36267

The DrillDetailPane Table component uses `defaultPageSize={PAGE_SIZE}` (where `PAGE_SIZE = 50`) but does not pass `pageSizeOptions`, causing the Table to display the default options (`[5, 15, 25, 50, 100]`). Since the server-side pagination always fetches exactly 50 rows per page, these other page size options are misleading and break the pagination display.

## Fix

Pass `pageSizeOptions={[\`${PAGE_SIZE}\`]}` to the Table component so the page size selector only shows 50 — matching the actual server-side page size.

## Testing

- The only change is adding a single prop to `<Table>`. The existing `DrillDetailPane.test.tsx` test suite does not test page size options, and the fix is a pure prop passthrough.


___

## **CodeAnt-AI Description**
**Drill detail table only offers the actual page size used by the data**

### What Changed
- The drill detail table now shows only the 50-row page size option
- Users can no longer pick page sizes that do not match the data returned by the server

### Impact
`✅ Fewer misleading pagination choices`
`✅ Consistent drill detail page counts`
`✅ Less confusion when browsing results`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
