### PR TITLE
fix(time-format): handle string input in TimeFormatter to fix pivot table NaN dates

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/time-format/TimeFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/TimeFormatter.ts
@@ -28,7 +28,7 @@ export const PREVIEW_TIME = new Date(Date.UTC(2017, 1, 14, 11, 22, 33));
 // Use type augmentation to indicate that
 // an instance of TimeFormatter is also a function
 interface TimeFormatter {
-  (value: Date | number | null | undefined): string;
+  (value: Date | number | string | null | undefined): string;
 }
 
 class TimeFormatter extends ExtensibleFunction {
@@ -49,7 +49,9 @@ class TimeFormatter extends ExtensibleFunction {
     formatFunc: TimeFormatFunction;
     useLocalTime?: boolean;
   }) {
-    super((value: Date | number | null | undefined) => this.format(value));
+    super((value: Date | number | string | null | undefined) =>
+      this.format(value),
+    );
 
     const {
       id = isRequired('config.id'),
@@ -66,7 +68,7 @@ class TimeFormatter extends ExtensibleFunction {
     this.useLocalTime = useLocalTime;
   }
 
-  format(value: Date | number | null | undefined) {
+  format(value: Date | number | string | null | undefined) {
     return stringifyTimeInput(value, time => this.formatFunc(time));
   }
 

--- a/superset-frontend/packages/superset-ui-core/src/time-format/utils/stringifyTimeInput.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/utils/stringifyTimeInput.ts
@@ -18,11 +18,16 @@
  */
 
 export default function stringifyTimeInput(
-  value: Date | number | undefined | null,
+  value: Date | number | string | undefined | null,
   fn: (time: Date) => string,
 ) {
   if (value === null || value === undefined) {
     return `${value}`;
+  }
+
+  if (typeof value === 'string') {
+    const num = Number(value);
+    return fn(new Date(Number.isFinite(num) ? num : value));
   }
 
   return fn(value instanceof Date ? value : new Date(value));

--- a/superset-frontend/packages/superset-ui-core/src/time-format/utils/stringifyTimeInput.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/utils/stringifyTimeInput.ts
@@ -26,8 +26,9 @@ export default function stringifyTimeInput(
   }
 
   if (typeof value === 'string') {
-    const num = Number(value);
-    return fn(new Date(Number.isFinite(num) ? num : value));
+    const trimmed = value.trim();
+    const isIntegerString = /^-?\d+$/.test(trimmed);
+    return fn(new Date(isIntegerString ? Number(trimmed) : value));
   }
 
   return fn(value instanceof Date ? value : new Date(value));

--- a/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatter.test.ts
@@ -67,6 +67,11 @@ describe('TimeFormatter', () => {
     test('handles number, treating it as a timestamp', () => {
       expect(formatter.format(PREVIEW_TIME.getTime())).toEqual('2017');
     });
+    test('handles numeric string, treating it as a timestamp', () => {
+      // PivotData.processRecord coerces values with String(), turning numeric
+      // timestamps into strings. 1704067200000 = 2024-01-01T00:00:00.000Z
+      expect(formatter.format('1704067200000')).toEqual('2024');
+    });
     test('otherwise returns formatted value', () => {
       expect(formatter.format(PREVIEW_TIME)).toEqual('2017');
     });

--- a/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatter.test.ts
@@ -69,8 +69,9 @@ describe('TimeFormatter', () => {
     });
     test('handles numeric string, treating it as a timestamp', () => {
       // PivotData.processRecord coerces values with String(), turning numeric
-      // timestamps into strings. 1704067200000 = 2024-01-01T00:00:00.000Z
-      expect(formatter.format('1704067200000')).toEqual('2024');
+      // timestamps into strings.
+      const timestamp = PREVIEW_TIME.getTime().toString();
+      expect(formatter.format(timestamp)).toEqual('2017');
     });
     test('otherwise returns formatted value', () => {
       expect(formatter.format(PREVIEW_TIME)).toEqual('2017');

--- a/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatter.test.ts
@@ -73,6 +73,9 @@ describe('TimeFormatter', () => {
       const timestamp = PREVIEW_TIME.getTime().toString();
       expect(formatter.format(timestamp)).toEqual('2017');
     });
+    test('handles ISO-8601 string without misinterpreting it as a number', () => {
+      expect(formatter.format('2017-02-14T11:22:33.000Z')).toEqual('2017');
+    });
     test('otherwise returns formatted value', () => {
       expect(formatter.format(PREVIEW_TIME)).toEqual('2017');
     });


### PR DESCRIPTION
## **User description**
### SUMMARY

#37625  converted `PivotData` from JavaScript to TypeScript and typed `colKey`/`rowKey` as `string[][]`. To satisfy this type constraint, `processRecord` was updated to wrap all record values with `String()` before storing them as keys.

This introduced a regression: temporal columns containing **numeric timestamps** (e.g. `1704067200000`) are now stringified to `"1704067200000"`. When `TableRenderers` passes this string to `TimeFormatter`, the underlying `stringifyTimeInput` calls `new Date("1704067200000")`, which returns `Invalid Date` in all browsers — numeric strings are not a valid `Date` constructor input. D3 time formatters then output `"NaN"` for each date component, causing pivot table column/row headers to display `NaN`.

**Root cause chain:**
processRecord: String(1704067200000) → "1704067200000"
→ TableRenderers: dateFormatterscol
→ stringifyTimeInput: new Date("1704067200000") = Invalid Date
→ D3 formatter: "NaN"

**Fix:**

Extend `stringifyTimeInput` to handle `string` inputs, completing the TypeScript migration that `fc5506e466` started at the data layer but did not propagate to the formatting layer:

- **Numeric-only strings** (e.g. `"1704067200000"`) are converted back to `number`
  via `Number()` before `Date` construction, restoring pre-`fc5506e466` behavior.
- **All other strings** (e.g. ISO date strings `"2024-01-01T00:00:00Z"`) are passed
  directly to `new Date()`, which handles them correctly in all browsers.

Also update `TimeFormatter`'s type signature (callable interface, constructor, and `format()` method) to include `string`, making the type system consistent with the actual inputs the formatter receives at runtime.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

| Before | After |
|--------|-------|
| Pivot table date headers show `NaN` for temporal columns with numeric timestamps | Dates display correctly |

### TESTING INSTRUCTIONS

1. Create a chart using the **Pivot Table** visualization
2. Add a temporal column (e.g. `__timestamp`) as a **Row** or **Column**
3. Use a data source that returns dates as numeric timestamps
4. Observe that date headers previously showed `NaN` and now display formatted dates correctly

Unit test added to `TimeFormatter.test.ts`:
handles numeric string, treating it as a timestamp



### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Fix pivot table date headers when timestamps arrive as strings**

### What Changed
- Numeric timestamp strings are now treated as real timestamps, so date headers no longer turn into `NaN`
- Regular date strings still format correctly
- Time formatting now accepts string values throughout, matching the values used by pivot table dates

### Impact
`✅ No more NaN date headers in pivot tables`
`✅ Correct display for numeric timestamp strings`
`✅ Fewer broken date labels from formatted string inputs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
