### PR TITLE
fix(auth): guest token takes priority over active session for embedded dashboards

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -23,7 +23,7 @@ import time
 from collections import defaultdict
 from typing import Any, Callable, cast, NamedTuple, Optional, TYPE_CHECKING
 
-from flask import current_app, Flask, g, Request
+from flask import current_app, Flask, g, Request, request
 from flask_appbuilder import Model
 from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.security.sqla.apis import RoleApi, UserApi
@@ -478,14 +478,30 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     def create_login_manager(self, app: Flask) -> LoginManager:
         lm = super().create_login_manager(app)
         lm.request_loader(self.request_loader)
+
+        @app.before_request
+        def load_guest_user_from_token() -> None:
+            # pylint: disable=import-outside-toplevel
+            from superset.extensions import feature_flag_manager
+
+            if feature_flag_manager.is_feature_enabled("EMBEDDED_SUPERSET"):
+                guest_user = self.get_guest_user_from_request(request)
+                if guest_user is not None:
+                    # Preempt Flask-Login's session-based user loading.
+                    # Flask-Login's _get_user() skips _load_user() (which would
+                    # prefer the session over the request_loader) if g._login_user
+                    # is already set, so setting it here ensures the guest token
+                    # takes priority over any active session.
+                    g._login_user = guest_user
+
         return lm
 
-    def request_loader(self, request: Request) -> Optional[User]:
+    def request_loader(self, req: Request) -> Optional[User]:
         # pylint: disable=import-outside-toplevel
         from superset.extensions import feature_flag_manager
 
         if feature_flag_manager.is_feature_enabled("EMBEDDED_SUPERSET"):
-            return self.get_guest_user_from_request(request)
+            return self.get_guest_user_from_request(req)
         return None
 
     def get_catalog_perm(

--- a/tests/integration_tests/security/guest_token_security_tests.py
+++ b/tests/integration_tests/security/guest_token_security_tests.py
@@ -19,7 +19,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from flask import g
+from flask import g, session
 
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable
@@ -98,6 +98,35 @@ class TestGuestUserSecurity(SupersetTestCase):
 
         roles = security_manager.get_user_roles()
         assert guest.roles == roles
+
+    def test_guest_token_takes_priority_over_session(self):
+        """Guest token should take priority over an active session cookie.
+
+        When a user has both a Superset session cookie (their real account) and
+        a guest token in the request headers, the guest token identity should be
+        used. Without this, users with active sessions would always be identified
+        as their real account, ignoring the guest token entirely.
+        """
+        token = security_manager.create_guest_access_token(
+            {"username": "test_guest"},
+            [{"some": "resource"}],
+            [{"dataset": 1, "clause": "access = 1"}],
+        )
+        admin = security_manager.find_user("admin")
+
+        with self.app.test_request_context(
+            headers={self.app.config["GUEST_TOKEN_HEADER_NAME"]: token}
+        ):
+            # Simulate an active session with a regular user
+            session["_user_id"] = admin.get_id()
+
+            # Run before_request hooks to simulate the request lifecycle
+            for func in self.app.before_request_funcs.get(None, []):
+                func()
+
+            # Despite the active session, the guest token should take priority
+            assert hasattr(g, "_login_user")
+            assert g._login_user.username == "test_guest"
 
 
 @patch.dict(


### PR DESCRIPTION
## **User description**
### SUMMARY
When a user has an active Superset session (e.g. they are logged in as themselves in another tab) and visits an embedded dashboard that uses a guest token, their session identity was silently taking precedence over the guest token identity. This caused 403 errors for users whose real account does not have access to the embedded dashboard's underlying datasets.

**Root cause:** Flask-Login's `_load_user()` checks the session first. If a `_user_id` is found in the session, it loads that user and sets `g._login_user`, then stops — the `request_loader` (where guest token auth lives) is never reached. Flask-Login's `_get_user()` only calls `_load_user()` if `g._login_user` is not already set, so preemptively setting it before the session is consulted is the correct fix.

**Fix:** Register a `before_request` hook in `create_login_manager` that checks for a guest token on every request. If a valid token is found, it sets `g._login_user` to the guest user before Flask-Login runs. Since `_get_user()` short-circuits when `g._login_user` is already set, the session is never consulted for requests that carry a guest token.

```python
# Flask-Login's _get_user() in utils.py
def _get_user():
    if has_request_context():
        if "_login_user" not in g:   # short-circuits if already set
            current_app.login_manager._load_user()
        return g._login_user
```

The existing `request_loader` (`request_loader` method) is kept as-is; it still handles the case where there is no active session at all.

### TESTING INSTRUCTIONS

1. Log in to Superset with a regular user account.
2. In the same browser session, open an embedded dashboard that uses a guest token for a different user identity.
3. **Before fix:** API calls for the embedded dashboard are made as your real logged-in user. If your account lacks access to the dashboard's datasets, you get a 403.
4. **After fix:** API calls are made as the guest user from the token regardless of the active session.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Guest tokens now take priority over an active Superset session for embedded dashboards**

### What Changed
- Embedded dashboards use the guest token identity even when the browser already has an active Superset login
- Users no longer get blocked by their own account permissions when viewing an embedded dashboard meant for a guest user
- Added coverage for the case where a session cookie and guest token are both present

### Impact
`✅ Fewer embedded dashboard access errors`
`✅ Fewer 403s for logged-in users viewing shared dashboards`
`✅ Clearer embedded dashboard access behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
