### PR TITLE
fix(mcp): validate dataset exists in generate_explore_link before generating URL

### DIFF
--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -97,7 +97,38 @@ async def generate_explore_link(
     )
 
     try:
-        await ctx.report_progress(1, 3, "Converting configuration to form data")
+        await ctx.report_progress(1, 4, "Validating dataset exists")
+        with event_logger.log_context(action="mcp.generate_explore_link.dataset_check"):
+            from superset.daos.dataset import DatasetDAO
+
+            dataset = None
+            if isinstance(request.dataset_id, int) or (
+                isinstance(request.dataset_id, str) and request.dataset_id.isdigit()
+            ):
+                dataset_id_int = (
+                    int(request.dataset_id)
+                    if isinstance(request.dataset_id, str)
+                    else request.dataset_id
+                )
+                dataset = DatasetDAO.find_by_id(dataset_id_int)
+            else:
+                dataset = DatasetDAO.find_by_id(request.dataset_id, id_column="uuid")
+
+            if not dataset:
+                await ctx.error(
+                    "Dataset not found: dataset_id=%s" % (request.dataset_id,)
+                )
+                return {
+                    "url": "",
+                    "form_data": {},
+                    "form_data_key": None,
+                    "error": (
+                        f"Dataset not found: {request.dataset_id}. "
+                        "Use list_datasets to find valid dataset IDs."
+                    ),
+                }
+
+        await ctx.report_progress(2, 4, "Converting configuration to form data")
         with event_logger.log_context(action="mcp.generate_explore_link.form_data"):
             # Normalize column names to match canonical dataset column names
             # This fixes case sensitivity issues (e.g., 'order_date' vs 'OrderDate')
@@ -131,7 +162,7 @@ async def generate_explore_link(
             )
         )
 
-        await ctx.report_progress(2, 3, "Generating explore URL")
+        await ctx.report_progress(3, 4, "Generating explore URL")
         with event_logger.log_context(
             action="mcp.generate_explore_link.url_generation"
         ):
@@ -149,7 +180,7 @@ async def generate_explore_link(
             if form_data_key_list:
                 form_data_key = form_data_key_list[0]
 
-        await ctx.report_progress(3, 3, "URL generation complete")
+        await ctx.report_progress(4, 4, "URL generation complete")
         await ctx.info(
             "Explore link generated successfully: url_length=%s, dataset_id=%s, "
             "form_data_key=%s"

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -41,7 +41,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mcp_server():
     return mcp
 
@@ -103,7 +103,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_table_explore_link_minimal(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -132,7 +132,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_table_explore_link_with_features(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -171,7 +171,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_line_chart_explore_link(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -210,7 +210,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_bar_chart_explore_link(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -244,7 +244,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_area_chart_explore_link(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -281,7 +281,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_scatter_chart_explore_link(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -316,7 +316,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_cache_failure_fallback(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -347,7 +347,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_database_lock_fallback(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -383,7 +383,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_with_many_columns(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -420,7 +420,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_with_many_filters(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -463,7 +463,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_explore_link_url_format_consistency(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -518,7 +518,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_dataset_id_types(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -549,7 +549,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_complex_configuration(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -594,7 +594,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_fallback_url_different_datasets(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -623,7 +623,7 @@ class TestGenerateExploreLink:
                 assert result.data["url"] == expected_url
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_tool_exception_handling(
         self, mock_find_dataset, mcp_server
     ):
@@ -667,7 +667,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_returns_form_data_key(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -693,7 +693,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_returns_form_data(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -723,7 +723,7 @@ class TestGenerateExploreLink:
             assert result.data["form_data"].get("datasource") == "1__table"
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_nonexistent_dataset(
         self, mock_find_dataset, mcp_server
     ):
@@ -747,7 +747,7 @@ class TestGenerateExploreLink:
             assert "list_datasets" in result.data["error"]
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_generate_explore_link_nonexistent_uuid_dataset(
         self, mock_find_dataset, mcp_server
     ):
@@ -787,7 +787,7 @@ class TestGenerateExploreLinkColumnNormalization:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_xy_chart_x_axis_normalized_in_form_data(
         self,
         mock_create_form_data,
@@ -834,7 +834,7 @@ class TestGenerateExploreLinkColumnNormalization:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_filter_column_normalized_in_form_data(
         self,
         mock_create_form_data,
@@ -889,7 +889,7 @@ class TestGenerateExploreLinkColumnNormalization:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_normalization_fallback_when_dataset_not_found(
         self,
         mock_create_form_data,

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -41,7 +41,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
+@pytest.fixture()
 def mcp_server():
     return mcp
 
@@ -103,7 +103,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_table_explore_link_minimal(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -132,7 +132,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_table_explore_link_with_features(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -171,7 +171,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_line_chart_explore_link(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -210,7 +210,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_bar_chart_explore_link(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -244,7 +244,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_area_chart_explore_link(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -281,7 +281,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_scatter_chart_explore_link(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -312,15 +312,19 @@ class TestGenerateExploreLink:
             )
             mock_create_form_data.assert_called_once()
 
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_explore_link_cache_failure_fallback(
-        self, mock_create_form_data, mcp_server
+        self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
         """Test fallback when form_data cache creation fails."""
-        mock_create_form_data.side_effect = Exception("Cache storage failed")
+        mock_find_dataset.return_value = _mock_dataset(id=1)
+        from superset.commands.exceptions import CommandException
+
+        mock_create_form_data.side_effect = CommandException("Cache storage failed")
 
         config = TableChartConfig(
             chart_type="table", columns=[ColumnRef(name="test_col")]
@@ -339,16 +343,18 @@ class TestGenerateExploreLink:
                 == "http://localhost:9001/explore/?datasource_type=table&datasource_id=1"
             )
 
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_explore_link_database_lock_fallback(
-        self, mock_create_form_data, mcp_server
+        self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
         """Test fallback when database is locked."""
         from sqlalchemy.exc import OperationalError
 
+        mock_find_dataset.return_value = _mock_dataset(id=5)
         mock_create_form_data.side_effect = OperationalError(
             "database is locked", None, None
         )
@@ -377,7 +383,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_explore_link_with_many_columns(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -414,7 +420,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_explore_link_with_many_filters(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -457,7 +463,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_explore_link_url_format_consistency(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -512,7 +518,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_explore_link_dataset_id_types(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -543,7 +549,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_explore_link_complex_configuration(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -584,15 +590,19 @@ class TestGenerateExploreLink:
             )
             mock_create_form_data.assert_called_once()
 
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_fallback_url_different_datasets(
-        self, mock_create_form_data, mcp_server
+        self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
         """Test fallback URLs are correct for different dataset IDs."""
-        mock_create_form_data.side_effect = Exception(
+        mock_find_dataset.return_value = _mock_dataset(id=1)
+        from superset.commands.exceptions import CommandException
+
+        mock_create_form_data.side_effect = CommandException(
             "Always fail for fallback testing"
         )
 
@@ -612,9 +622,13 @@ class TestGenerateExploreLink:
                 assert result.data["error"] is None
                 assert result.data["url"] == expected_url
 
-    @pytest.mark.asyncio
-    async def test_generate_explore_link_tool_exception_handling(self, mcp_server):
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
+    @pytest.mark.asyncio()
+    async def test_generate_explore_link_tool_exception_handling(
+        self, mock_find_dataset, mcp_server
+    ):
         """Test that tool-level exceptions are properly handled and return error."""
+        mock_find_dataset.return_value = _mock_dataset(id=1)
         import sys
 
         # Get the actual module object from sys.modules (not via __init__.py which
@@ -653,7 +667,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_explore_link_returns_form_data_key(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -679,7 +693,7 @@ class TestGenerateExploreLink:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_generate_explore_link_returns_form_data(
         self, mock_create_form_data, mock_find_dataset, mcp_server
     ):
@@ -708,6 +722,55 @@ class TestGenerateExploreLink:
             # Verify datasource field format: "{dataset_id}__table"
             assert result.data["form_data"].get("datasource") == "1__table"
 
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
+    @pytest.mark.asyncio()
+    async def test_generate_explore_link_nonexistent_dataset(
+        self, mock_find_dataset, mcp_server
+    ):
+        """Test nonexistent dataset_id returns error instead of broken URL."""
+        mock_find_dataset.return_value = None
+
+        config = TableChartConfig(
+            chart_type="table", columns=[ColumnRef(name="test_col")]
+        )
+        request = GenerateExploreLinkRequest(dataset_id="99999", config=config)
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "generate_explore_link", {"request": request.model_dump()}
+            )
+
+            assert result.data["url"] == ""
+            assert result.data["form_data"] == {}
+            assert result.data["form_data_key"] is None
+            assert "Dataset not found: 99999" in result.data["error"]
+            assert "list_datasets" in result.data["error"]
+
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
+    @pytest.mark.asyncio()
+    async def test_generate_explore_link_nonexistent_uuid_dataset(
+        self, mock_find_dataset, mcp_server
+    ):
+        """Test that nonexistent UUID dataset_id returns structured error."""
+        mock_find_dataset.return_value = None
+
+        config = TableChartConfig(
+            chart_type="table", columns=[ColumnRef(name="test_col")]
+        )
+        request = GenerateExploreLinkRequest(
+            dataset_id="00000000-0000-0000-0000-000000000000", config=config
+        )
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "generate_explore_link", {"request": request.model_dump()}
+            )
+
+            assert result.data["url"] == ""
+            assert result.data["form_data"] == {}
+            assert result.data["form_data_key"] is None
+            assert "Dataset not found" in result.data["error"]
+
 
 class TestGenerateExploreLinkColumnNormalization:
     """Tests that generate_explore_link normalizes column names.
@@ -724,7 +787,7 @@ class TestGenerateExploreLinkColumnNormalization:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_xy_chart_x_axis_normalized_in_form_data(
         self,
         mock_create_form_data,
@@ -771,7 +834,7 @@ class TestGenerateExploreLinkColumnNormalization:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_filter_column_normalized_in_form_data(
         self,
         mock_create_form_data,
@@ -826,7 +889,7 @@ class TestGenerateExploreLinkColumnNormalization:
     @patch(
         "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
     )
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_normalization_fallback_when_dataset_not_found(
         self,
         mock_create_form_data,


### PR DESCRIPTION
## **User description**
### SUMMARY
`generate_explore_link` silently returned a broken URL (leading to a 404 in the browser) when given a nonexistent `dataset_id`. This adds an early `DatasetDAO.find_by_id` validation check and returns a structured error response with an actionable message when the dataset is not found.

### BEFORE/AFTER SCREENSHOTS OR COVERAGE BLURB
**Before:** Tool returns `{"url": "http://superset/explore/?datasource_type=table&datasource_id=99999", "error": null}` — a broken URL with no indication of the problem.

**After:** Tool returns `{"url": "", "error": "Dataset not found: 99999. Use list_datasets to find valid dataset IDs."}` — a clear error with guidance.

### TESTING INSTRUCTIONS
1. Call `generate_explore_link` with a nonexistent `dataset_id` (e.g., `99999`)
2. Verify you get a structured error response instead of a broken URL
3. Call with a valid `dataset_id` and verify normal behavior is unchanged

### ADDITIONAL INFORMATION
- Added 2 new unit tests (numeric ID and UUID cases)
- Updated 3 existing fallback tests that were accidentally passing due to unmocked `DatasetDAO` — they now properly mock the dataset and use `CommandException` (matching the actual catch block in `chart_utils.py`)


___

## **CodeAnt-AI Description**
**Show a clear error when an explore link is requested for a missing dataset**

### What Changed
- Explore link generation now checks that the dataset exists before building the URL
- If the dataset is missing, it returns an empty URL and a direct error message instead of a broken link
- Dataset IDs given as numbers, numeric text, or UUIDs are handled correctly
- Added coverage for missing-dataset cases and kept existing successful link flows working

### Impact
`✅ Fewer broken explore links`
`✅ Clearer missing-dataset errors`
`✅ Safer link generation for invalid dataset IDs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
