### PR TITLE
fix(pivot-table): safely cast numeric strings to numbers for date formatting

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -269,6 +269,11 @@ function sortHierarchicalObject(
   return result;
 }
 
+function convertToNumberIfNumeric(value: string): string | number {
+  const n = Number(value);
+  return value.trim() !== '' && !Number.isNaN(n) ? n : value;
+}
+
 function convertToArray(
   obj: Map<string, unknown>,
   rowEnabled: boolean | undefined,
@@ -868,7 +873,7 @@ export class TableRenderer extends Component<
           );
         };
         const headerCellFormattedValue =
-          dateFormatters?.[attrName]?.(colKey[attrIdx]) ?? colKey[attrIdx];
+          dateFormatters?.[attrName]?.(convertToNumberIfNumeric(colKey[attrIdx])) ?? colKey[attrIdx];
         const { backgroundColor, color } = getCellColor(
           [attrName],
           headerCellFormattedValue,
@@ -1111,7 +1116,7 @@ export class TableRenderer extends Component<
           : null;
 
         const headerCellFormattedValue =
-          dateFormatters?.[rowAttrs[i]]?.(r) ?? r;
+          dateFormatters?.[rowAttrs[i]]?.(convertToNumberIfNumeric(r)) ?? r;
 
         const { backgroundColor, color } = getCellColor(
           [rowAttrs[i]],

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -1061,7 +1061,11 @@ function makeColPivotSettings(
     visibleColKeys: [[value]],
     colAttrSpans: [[1]],
     rowTotals: false,
-    colSubtotalDisplay: { enabled: false, displayOnTop: false, hideOnExpand: false },
+    colSubtotalDisplay: {
+      enabled: false,
+      displayOnTop: false,
+      hideOnExpand: false,
+    },
     maxColVisible: 1,
     pivotData: {},
     namesMapping: {},
@@ -1069,7 +1073,9 @@ function makeColPivotSettings(
   } as unknown as Parameters<TableRenderer['renderColHeaderRow']>[2];
 }
 
-function makeRowPivotSettings(): Parameters<TableRenderer['renderTableRow']>[2] {
+function makeRowPivotSettings(): Parameters<
+  TableRenderer['renderTableRow']
+>[2] {
   const aggregator = {
     value: jest.fn().mockReturnValue(1),
     format: jest.fn().mockReturnValue('1'),
@@ -1082,7 +1088,11 @@ function makeRowPivotSettings(): Parameters<TableRenderer['renderTableRow']>[2] 
     visibleColKeys: [[]],
     pivotData: { getAggregator: jest.fn().mockReturnValue(aggregator) },
     rowTotals: false,
-    rowSubtotalDisplay: { enabled: false, displayOnTop: false, hideOnExpand: false },
+    rowSubtotalDisplay: {
+      enabled: false,
+      displayOnTop: false,
+      hideOnExpand: false,
+    },
     arrowExpanded: null,
     arrowCollapsed: null,
     cellCallbacks: {},
@@ -1108,7 +1118,11 @@ test.each([
         dateFormatters: { event_time: formatter },
       },
     });
-    tableRenderer.renderColHeaderRow('event_time', 0, makeColPivotSettings(input));
+    tableRenderer.renderColHeaderRow(
+      'event_time',
+      0,
+      makeColPivotSettings(input),
+    );
     expect(formatter).toHaveBeenCalledWith(expected);
   },
 );

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -1050,3 +1050,85 @@ test('renderTableRow uses active header surface for adaptive contrast', () => {
     ),
   });
 });
+
+function makeColPivotSettings(
+  value: string,
+): Parameters<TableRenderer['renderColHeaderRow']>[2] {
+  return {
+    rowAttrs: [],
+    colAttrs: ['event_time'],
+    colKeys: [[value]],
+    visibleColKeys: [[value]],
+    colAttrSpans: [[1]],
+    rowTotals: false,
+    colSubtotalDisplay: { enabled: false, displayOnTop: false, hideOnExpand: false },
+    maxColVisible: 1,
+    pivotData: {},
+    namesMapping: {},
+    allowRenderHtml: false,
+  } as unknown as Parameters<TableRenderer['renderColHeaderRow']>[2];
+}
+
+function makeRowPivotSettings(): Parameters<TableRenderer['renderTableRow']>[2] {
+  const aggregator = {
+    value: jest.fn().mockReturnValue(1),
+    format: jest.fn().mockReturnValue('1'),
+    isSubtotal: false,
+  };
+  return {
+    rowAttrs: ['event_time'],
+    colAttrs: [],
+    rowAttrSpans: [[1]],
+    visibleColKeys: [[]],
+    pivotData: { getAggregator: jest.fn().mockReturnValue(aggregator) },
+    rowTotals: false,
+    rowSubtotalDisplay: { enabled: false, displayOnTop: false, hideOnExpand: false },
+    arrowExpanded: null,
+    arrowCollapsed: null,
+    cellCallbacks: {},
+    rowTotalCallbacks: {},
+    namesMapping: {},
+    allowRenderHtml: false,
+  } as unknown as Parameters<TableRenderer['renderTableRow']>[2];
+}
+
+test.each([
+  ['numeric timestamp string', '1700000000000', 1700000000000],
+  ['non-numeric date string', 'Dec. 16 2020', 'Dec. 16 2020'],
+  ['ISO timestamp string', '2024-01-15T00:00:00Z', '2024-01-15T00:00:00Z'],
+])(
+  'col header date formatter receives correct value for %s',
+  (_, input, expected) => {
+    const formatter = jest.fn().mockReturnValue('formatted');
+    tableRenderer = new TableRenderer({
+      ...mockProps,
+      cols: ['event_time'],
+      tableOptions: {
+        ...mockProps.tableOptions,
+        dateFormatters: { event_time: formatter },
+      },
+    });
+    tableRenderer.renderColHeaderRow('event_time', 0, makeColPivotSettings(input));
+    expect(formatter).toHaveBeenCalledWith(expected);
+  },
+);
+
+test.each([
+  ['numeric timestamp string', '1700000000000', 1700000000000],
+  ['non-numeric date string', 'Dec. 16 2020', 'Dec. 16 2020'],
+])(
+  'row header date formatter receives correct value for %s',
+  (_, input, expected) => {
+    const formatter = jest.fn().mockReturnValue('formatted');
+    tableRenderer = new TableRenderer({
+      ...mockProps,
+      rows: ['event_time'],
+      tableOptions: {
+        ...mockProps.tableOptions,
+        dateFormatters: { event_time: formatter },
+      },
+    });
+    tableRenderer.renderTableRow([input], 0, makeRowPivotSettings());
+    expect(formatter).toHaveBeenCalledWith(expected);
+  },
+);


### PR DESCRIPTION
## **User description**
### SUMMARY

Pivot Table was showing `0NaN` in column and row headers when using Date/Timestamp data because `dateFormatters` expect a `number` but were receiving a `string`.

The original fix by @marcioibm in #38191 used a bare `Number()` cast, which returns `NaN` for non-numeric date strings like `'Dec. 16 2020'` or `'2024-01-15T00:00:00Z'`. This PR improves the fix by introducing a `convertToNumberIfNumeric` helper that only converts to a number when the string is genuinely numeric, and falls back to the original string otherwise.

Credit to @marcioibm for the original fix and tests in #38191.

Fixes https://github.com/apache/superset/issues/38596

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See #38191 for before/after screenshots.

### TESTING INSTRUCTIONS

1. Load default dev environment
2. Create a Pivot Table chart with a timestamp/date column or row
3. Verify dates display correctly and no `0NaN` appears
4. Run unit tests: `npm run test -- plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Stop pivot table date headers from showing broken values for date strings**

### What Changed
- Pivot table row and column headers now only turn numeric-looking strings into numbers before date formatting
- Text date values and ISO date strings stay unchanged, so they no longer produce broken header output
- Added coverage for both row and column headers with numeric timestamps, plain date text, and ISO timestamps

### Impact
`✅ Clearer pivot table date headers`
`✅ Fewer broken timestamp displays`
`✅ Safer date formatting for mixed data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
