### PR TITLE
feat(mcp): support saved metrics from datasets in chart generation

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -381,7 +381,7 @@ def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
     aggregated_metrics = []
 
     for col in config.columns:
-        if col.saved_metric or col.aggregate:
+        if col.is_metric:
             # Saved metric or column with aggregation - treat as metric
             aggregated_metrics.append(create_metric_object(col))
         else:
@@ -884,9 +884,9 @@ def _truncate(name: str, max_length: int = 60) -> str:
 
 def _table_chart_what(config: TableChartConfig, dataset_name: str | None) -> str:
     """Build the descriptive fragment for a table chart."""
-    has_agg = any(col.aggregate or col.saved_metric for col in config.columns)
+    has_agg = any(col.is_metric for col in config.columns)
     if has_agg:
-        metrics = [col for col in config.columns if col.aggregate or col.saved_metric]
+        metrics = [col for col in config.columns if col.is_metric]
         what = ", ".join(_humanize_column(m) for m in metrics[:2])
         return f"{what} Summary"
     if dataset_name:
@@ -1083,11 +1083,7 @@ def analyze_chart_capabilities(chart: Any | None, config: Any) -> ChartCapabilit
     # Classify data types
     data_types = []
     if hasattr(config, "x") and config.x:
-        data_types.append(
-            "categorical"
-            if not config.x.aggregate and not config.x.saved_metric
-            else "metric"
-        )
+        data_types.append("categorical" if not config.x.is_metric else "metric")
     if hasattr(config, "y") and config.y:
         data_types.extend(["metric"] * len(config.y))
     if "time" in viz_type or "timeseries" in viz_type:

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -884,9 +884,9 @@ def _truncate(name: str, max_length: int = 60) -> str:
 
 def _table_chart_what(config: TableChartConfig, dataset_name: str | None) -> str:
     """Build the descriptive fragment for a table chart."""
-    has_agg = any(col.aggregate for col in config.columns)
+    has_agg = any(col.aggregate or col.saved_metric for col in config.columns)
     if has_agg:
-        metrics = [col for col in config.columns if col.aggregate]
+        metrics = [col for col in config.columns if col.aggregate or col.saved_metric]
         what = ", ".join(_humanize_column(m) for m in metrics[:2])
         return f"{what} Summary"
     if dataset_name:

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -381,8 +381,8 @@ def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
     aggregated_metrics = []
 
     for col in config.columns:
-        if col.aggregate:
-            # Column has aggregation - treat as metric
+        if col.saved_metric or col.aggregate:
+            # Saved metric or column with aggregation - treat as metric
             aggregated_metrics.append(create_metric_object(col))
         else:
             # No aggregation - treat as raw column
@@ -441,8 +441,16 @@ def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
     return form_data
 
 
-def create_metric_object(col: ColumnRef) -> Dict[str, Any]:
-    """Create a metric object for a column with enhanced validation."""
+def create_metric_object(col: ColumnRef) -> Dict[str, Any] | str:
+    """Create a metric object for a column with enhanced validation.
+
+    For saved metrics, returns the metric name as a plain string which
+    Superset's query engine resolves via its metrics_by_name lookup.
+    For ad-hoc metrics, returns a SIMPLE expression dict.
+    """
+    if col.saved_metric:
+        return col.name
+
     # Ensure aggregate is valid - default to SUM if not specified or invalid
     valid_aggregates = {
         "SUM",
@@ -840,6 +848,8 @@ def _humanize_column(col: ColumnRef) -> str:
     if col.label:
         return col.label
     name = col.name.replace("_", " ").title()
+    if col.saved_metric:
+        return name
     if col.aggregate:
         return f"{col.aggregate.capitalize()}({name})"
     return name

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -1083,7 +1083,11 @@ def analyze_chart_capabilities(chart: Any | None, config: Any) -> ChartCapabilit
     # Classify data types
     data_types = []
     if hasattr(config, "x") and config.x:
-        data_types.append("categorical" if not config.x.aggregate else "metric")
+        data_types.append(
+            "categorical"
+            if not config.x.aggregate and not config.x.saved_metric
+            else "metric"
+        )
     if hasattr(config, "y") and config.y:
         data_types.extend(["metric"] * len(config.y))
     if "time" in viz_type or "timeseries" in viz_type:

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -492,6 +492,11 @@ class ColumnRef(BaseModel):
         "When set, 'aggregate' is ignored.",
     )
 
+    @property
+    def is_metric(self) -> bool:
+        """Whether this ref acts as a metric (has aggregate or is a saved metric)."""
+        return bool(self.aggregate) or self.saved_metric
+
     @model_validator(mode="after")
     def clear_aggregate_for_saved_metric(self) -> "ColumnRef":
         """Clear aggregate when saved_metric is True since it's ignored."""
@@ -834,9 +839,7 @@ class HandlebarsChartConfig(UnknownFieldCheckMixin):
                     "Handlebars chart in 'aggregate' query mode requires 'metrics' "
                     "field. Specify at least one metric with an aggregate function."
                 )
-            missing_agg = [
-                m.name for m in self.metrics if not m.aggregate and not m.saved_metric
-            ]
+            missing_agg = [m.name for m in self.metrics if not m.is_metric]
             if missing_agg:
                 raise ValueError(
                     f"Handlebars chart in 'aggregate' query mode requires an "

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -831,7 +831,9 @@ class HandlebarsChartConfig(UnknownFieldCheckMixin):
                     "Handlebars chart in 'aggregate' query mode requires 'metrics' "
                     "field. Specify at least one metric with an aggregate function."
                 )
-            missing_agg = [m.name for m in self.metrics if not m.aggregate]
+            missing_agg = [
+                m.name for m in self.metrics if not m.aggregate and not m.saved_metric
+            ]
             if missing_agg:
                 raise ValueError(
                     f"Handlebars chart in 'aggregate' query mode requires an "

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -605,7 +605,9 @@ class PieChartConfig(UnknownFieldCheckMixin):
         validation_alias=AliasChoices("dimension", "groupby"),
     )
     metric: ColumnRef = Field(
-        ..., description="Value metric (needs aggregate e.g. SUM, COUNT)"
+        ...,
+        description="Value metric (use aggregate e.g. SUM, COUNT for ad-hoc, "
+        "or set saved_metric=True for a saved dataset metric)",
     )
     donut: bool = False
     show_labels: bool = True
@@ -651,7 +653,8 @@ class PivotTableChartConfig(UnknownFieldCheckMixin):
     metrics: List[ColumnRef] = Field(
         ...,
         min_length=1,
-        description="Metrics (need aggregate e.g. SUM, COUNT, AVG)",
+        description="Metrics (use aggregate e.g. SUM, COUNT, AVG for ad-hoc, "
+        "or set saved_metric=True for saved dataset metrics)",
     )
     aggregate_function: Literal[
         "Sum",

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -485,6 +485,19 @@ class ColumnRef(BaseModel):
         ]
         | None
     ) = Field(None, description="SQL aggregate function")
+    saved_metric: bool = Field(
+        False,
+        description="If true, 'name' refers to a saved metric from the dataset "
+        "(use get_dataset_info to see available metrics). "
+        "When set, 'aggregate' is ignored.",
+    )
+
+    @model_validator(mode="after")
+    def clear_aggregate_for_saved_metric(self) -> "ColumnRef":
+        """Clear aggregate when saved_metric is True since it's ignored."""
+        if self.saved_metric and self.aggregate is not None:
+            self.aggregate = None
+        return self
 
     @field_validator("name")
     @classmethod
@@ -861,7 +874,9 @@ class TableChartConfig(UnknownFieldCheckMixin):
 
         for i, col in enumerate(self.columns):
             # Generate the label that will be used (same logic as create_metric_object)
-            if col.aggregate:
+            if col.saved_metric:
+                label = col.label or col.name
+            elif col.aggregate:
                 label = col.label or f"{col.aggregate}({col.name})"
             else:
                 label = col.label or col.name
@@ -943,7 +958,9 @@ class XYChartConfig(UnknownFieldCheckMixin):
 
         # Check Y-axis labels
         for i, col in enumerate(self.y):
-            if col.aggregate:
+            if col.saved_metric:
+                label = col.label or col.name
+            elif col.aggregate:
                 label = col.label or f"{col.aggregate}({col.name})"
             else:
                 label = col.label or col.name

--- a/superset/mcp_service/chart/validation/dataset_validator.py
+++ b/superset/mcp_service/chart/validation/dataset_validator.py
@@ -82,32 +82,19 @@ class DatasetValidator:
         # Collect all column references
         column_refs = DatasetValidator._extract_column_references(config)
 
-        # Validate each column exists
-        invalid_columns = []
-        for col_ref in column_refs:
-            if not DatasetValidator._column_exists(col_ref.name, dataset_context):
-                invalid_columns.append(col_ref)
-
-        if invalid_columns:
-            # Generate suggestions for invalid columns
-            suggestions_map = {}
-            for col_ref in invalid_columns:
-                suggestions = DatasetValidator._get_column_suggestions(
-                    col_ref.name, dataset_context
-                )
-                suggestions_map[col_ref.name] = suggestions
-
-            # Build error with suggestions
-            return False, DatasetValidator._build_column_error(
-                invalid_columns, suggestions_map, dataset_context
-            )
-
-        # Validate saved metrics exist in dataset metrics (not just columns)
+        # Validate saved metrics exist in dataset metrics specifically
         invalid_saved = DatasetValidator._validate_saved_metrics(
             column_refs, dataset_context
         )
         if invalid_saved:
             return False, invalid_saved
+
+        # Validate columns exist (skip saved metrics — already validated above)
+        column_error = DatasetValidator._validate_columns_exist(
+            column_refs, dataset_context
+        )
+        if column_error:
+            return False, column_error
 
         # Validate aggregation compatibility
         if isinstance(config, (TableChartConfig, XYChartConfig)):
@@ -118,6 +105,32 @@ class DatasetValidator:
                 return False, aggregation_errors[0]
 
         return True, None
+
+    @staticmethod
+    def _validate_columns_exist(
+        column_refs: List[ColumnRef], dataset_context: DatasetContext
+    ) -> ChartGenerationError | None:
+        """Validate that non-saved-metric column refs exist in the dataset."""
+        invalid_columns = []
+        for col_ref in column_refs:
+            if col_ref.saved_metric:
+                continue
+            if not DatasetValidator._column_exists(col_ref.name, dataset_context):
+                invalid_columns.append(col_ref)
+
+        if not invalid_columns:
+            return None
+
+        suggestions_map = {}
+        for col_ref in invalid_columns:
+            suggestions = DatasetValidator._get_column_suggestions(
+                col_ref.name, dataset_context
+            )
+            suggestions_map[col_ref.name] = suggestions
+
+        return DatasetValidator._build_column_error(
+            invalid_columns, suggestions_map, dataset_context
+        )
 
     @staticmethod
     def _get_dataset_context(dataset_id: int | str) -> DatasetContext | None:

--- a/superset/mcp_service/chart/validation/dataset_validator.py
+++ b/superset/mcp_service/chart/validation/dataset_validator.py
@@ -426,6 +426,8 @@ class DatasetValidator:
         errors = []
 
         for col_ref in column_refs:
+            if col_ref.saved_metric:
+                continue  # Saved metrics have built-in aggregation
             if not col_ref.aggregate:
                 continue
 

--- a/superset/mcp_service/chart/validation/dataset_validator.py
+++ b/superset/mcp_service/chart/validation/dataset_validator.py
@@ -102,6 +102,13 @@ class DatasetValidator:
                 invalid_columns, suggestions_map, dataset_context
             )
 
+        # Validate saved metrics exist in dataset metrics (not just columns)
+        invalid_saved = DatasetValidator._validate_saved_metrics(
+            column_refs, dataset_context
+        )
+        if invalid_saved:
+            return False, invalid_saved
+
         # Validate aggregation compatibility
         if isinstance(config, (TableChartConfig, XYChartConfig)):
             aggregation_errors = DatasetValidator._validate_aggregations(
@@ -417,6 +424,49 @@ class DatasetValidator:
                 ],
                 error_code="MULTIPLE_INVALID_COLUMNS",
             )
+
+    @staticmethod
+    def _validate_saved_metrics(
+        column_refs: List[ColumnRef], dataset_context: DatasetContext
+    ) -> ChartGenerationError | None:
+        """Validate that saved_metric refs exist in dataset metrics.
+
+        A ColumnRef with saved_metric=True must match an entry in
+        available_metrics, not just available_columns.  Without this check
+        a regular column name marked as saved_metric would pass
+        _column_exists (which checks both lists) but fail at query time.
+        """
+        metric_names = {m["name"].lower() for m in dataset_context.available_metrics}
+        invalid = [
+            col_ref.name
+            for col_ref in column_refs
+            if col_ref.saved_metric and col_ref.name.lower() not in metric_names
+        ]
+        if not invalid:
+            return None
+
+        from superset.mcp_service.utils.error_builder import ChartErrorBuilder
+
+        available = [m["name"] for m in dataset_context.available_metrics]
+        return ChartErrorBuilder.build_error(
+            error_type="invalid_saved_metric",
+            template_key="column_not_found",
+            template_vars={
+                "column": ", ".join(invalid),
+                "suggestions": (
+                    f"Available saved metrics: {', '.join(available[:10])}"
+                    if available
+                    else "This dataset has no saved metrics"
+                ),
+            },
+            custom_suggestions=[
+                f"'{name}' is not a saved metric in this dataset. "
+                "Remove saved_metric=True to use it as a column with an aggregate, "
+                "or use get_dataset_info to see available saved metrics."
+                for name in invalid
+            ],
+            error_code="INVALID_SAVED_METRIC",
+        )
 
     @staticmethod
     def _validate_aggregations(

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -570,3 +570,58 @@ class TestUnknownFieldDetection:
         assert config.stacked is True
         assert config.row_limit == 10000
         assert config.group_by is not None
+
+
+class TestColumnRefSavedMetric:
+    """Test ColumnRef saved_metric support."""
+
+    def test_saved_metric_defaults_to_false(self) -> None:
+        col = ColumnRef(name="revenue", aggregate="SUM")
+        assert col.saved_metric is False
+
+    def test_saved_metric_flag_accepted(self) -> None:
+        col = ColumnRef(name="total_revenue", saved_metric=True)
+        assert col.saved_metric is True
+        assert col.name == "total_revenue"
+
+    def test_saved_metric_clears_aggregate(self) -> None:
+        col = ColumnRef(name="total_revenue", saved_metric=True, aggregate="SUM")
+        assert col.saved_metric is True
+        assert col.aggregate is None
+
+    def test_saved_metric_preserves_label(self) -> None:
+        col = ColumnRef(name="total_revenue", saved_metric=True, label="Revenue")
+        assert col.label == "Revenue"
+
+    def test_saved_metric_in_table_config_unique_labels(self) -> None:
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[
+                ColumnRef(name="product_line"),
+                ColumnRef(name="total_revenue", saved_metric=True),
+            ],
+        )
+        assert len(config.columns) == 2
+
+    def test_saved_metric_in_xy_config_unique_labels(self) -> None:
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="order_date"),
+            y=[ColumnRef(name="total_revenue", saved_metric=True)],
+        )
+        assert len(config.y) == 1
+
+    def test_saved_metric_duplicate_label_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
+            XYChartConfig(
+                chart_type="xy",
+                x=ColumnRef(name="order_date"),
+                y=[
+                    ColumnRef(name="total_revenue", saved_metric=True),
+                    ColumnRef(
+                        name="other_metric",
+                        saved_metric=True,
+                        label="total_revenue",
+                    ),
+                ],
+            )

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -701,6 +701,44 @@ class TestMapXYConfig:
 
         assert result["row_limit"] == 10000
 
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_map_xy_config_saved_metric(self, mock_is_temporal: Any) -> None:
+        """Test XY config with saved metric emits string in metrics list"""
+        mock_is_temporal.return_value = True
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="order_date"),
+            y=[ColumnRef(name="total_revenue", saved_metric=True)],
+            kind="line",
+        )
+
+        result = map_xy_config(config, dataset_id=1)
+
+        assert result["metrics"] == ["total_revenue"]
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_map_xy_config_mixed_saved_and_adhoc_metrics(
+        self, mock_is_temporal: Any
+    ) -> None:
+        """Test XY config with both saved and ad-hoc metrics"""
+        mock_is_temporal.return_value = True
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="order_date"),
+            y=[
+                ColumnRef(name="total_revenue", saved_metric=True),
+                ColumnRef(name="quantity", aggregate="SUM"),
+            ],
+            kind="line",
+        )
+
+        result = map_xy_config(config, dataset_id=1)
+
+        assert len(result["metrics"]) == 2
+        assert result["metrics"][0] == "total_revenue"
+        assert isinstance(result["metrics"][1], dict)
+        assert result["metrics"][1]["aggregate"] == "SUM"
+
 
 class TestMapConfigToFormData:
     """Test map_config_to_form_data function"""

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -55,6 +55,7 @@ class TestCreateMetricObject:
         col = ColumnRef(name="revenue", aggregate="SUM", label="Total Revenue")
         result = create_metric_object(col)
 
+        assert isinstance(result, dict)
         assert result["aggregate"] == "SUM"
         assert result["column"]["column_name"] == "revenue"
         assert result["label"] == "Total Revenue"
@@ -66,10 +67,27 @@ class TestCreateMetricObject:
         col = ColumnRef(name="orders")
         result = create_metric_object(col)
 
+        assert isinstance(result, dict)
         assert result["aggregate"] == "SUM"
         assert result["column"]["column_name"] == "orders"
         assert result["label"] == "SUM(orders)"
         assert result["optionName"] == "metric_orders"
+
+    def test_create_metric_object_saved_metric_returns_string(self) -> None:
+        """Test that saved metrics return a plain string metric name"""
+        col = ColumnRef(name="total_revenue", saved_metric=True)
+        result = create_metric_object(col)
+
+        assert result == "total_revenue"
+        assert isinstance(result, str)
+
+    def test_create_metric_object_saved_metric_ignores_aggregate(self) -> None:
+        """Test that saved metrics ignore aggregate even if somehow set"""
+        col = ColumnRef(name="total_revenue", saved_metric=True, aggregate="SUM")
+        result = create_metric_object(col)
+
+        # saved_metric validator clears aggregate, result is plain string
+        assert result == "total_revenue"
 
 
 class TestMapFilterOperator:
@@ -337,6 +355,38 @@ class TestMapTableConfig:
         result = map_table_config(config)
 
         assert result["row_limit"] == 1000
+
+    def test_map_table_config_saved_metric_as_metric(self) -> None:
+        """Test that saved metrics are routed to metrics, not raw columns."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[
+                ColumnRef(name="product_line"),
+                ColumnRef(name="total_revenue", saved_metric=True),
+            ],
+        )
+
+        result = map_table_config(config)
+
+        assert result["query_mode"] == "aggregate"
+        assert result["metrics"] == ["total_revenue"]
+        assert "product_line" in result["groupby"]
+
+    def test_map_table_config_saved_metric_only(self) -> None:
+        """Test table with only saved metrics (no raw columns)."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[
+                ColumnRef(name="total_revenue", saved_metric=True),
+                ColumnRef(name="avg_order_value", saved_metric=True),
+            ],
+        )
+
+        result = map_table_config(config)
+
+        assert result["query_mode"] == "aggregate"
+        assert result["metrics"] == ["total_revenue", "avg_order_value"]
+        assert "all_columns" not in result
 
 
 class TestAddAdhocFilters:

--- a/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
@@ -679,3 +679,50 @@ class TestNormalizeXAxisFilterConsistency:
         assert normalized.group_by is not None
         assert normalized.filters is not None
         assert normalized.group_by[0].name == normalized.filters[0].column == "AIRLINE"
+
+
+class TestValidateSavedMetrics:
+    """Test that saved_metric refs are validated against dataset metrics."""
+
+    def test_valid_saved_metric_passes(
+        self, mock_dataset_context: DatasetContext
+    ) -> None:
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="OrderDate"),
+            y=[ColumnRef(name="TotalRevenue", saved_metric=True)],
+        )
+        is_valid, error = DatasetValidator.validate_against_dataset(
+            config, dataset_id=18, dataset_context=mock_dataset_context
+        )
+        assert is_valid
+        assert error is None
+
+    def test_column_name_as_saved_metric_fails(
+        self, mock_dataset_context: DatasetContext
+    ) -> None:
+        """A regular column marked as saved_metric should be rejected."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="OrderDate"),
+            y=[ColumnRef(name="Sales", saved_metric=True)],
+        )
+        is_valid, error = DatasetValidator.validate_against_dataset(
+            config, dataset_id=18, dataset_context=mock_dataset_context
+        )
+        assert not is_valid
+        assert error is not None
+
+    def test_nonexistent_saved_metric_fails(
+        self, mock_dataset_context: DatasetContext
+    ) -> None:
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="OrderDate"),
+            y=[ColumnRef(name="nonexistent_metric", saved_metric=True)],
+        )
+        is_valid, error = DatasetValidator.validate_against_dataset(
+            config, dataset_id=18, dataset_context=mock_dataset_context
+        )
+        assert not is_valid
+        assert error is not None

--- a/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
@@ -712,10 +712,12 @@ class TestValidateSavedMetrics:
         )
         assert not is_valid
         assert error is not None
+        assert error.error_code == "INVALID_SAVED_METRIC"
 
     def test_nonexistent_saved_metric_fails(
         self, mock_dataset_context: DatasetContext
     ) -> None:
+        """A nonexistent saved metric should produce a specific error."""
         config = XYChartConfig(
             chart_type="xy",
             x=ColumnRef(name="OrderDate"),
@@ -726,3 +728,4 @@ class TestValidateSavedMetrics:
         )
         assert not is_valid
         assert error is not None
+        assert error.error_code == "INVALID_SAVED_METRIC"


### PR DESCRIPTION
## **User description**
### SUMMARY

The MCP `generate_chart` tool only supported ad-hoc metrics (column name + aggregate function). When an LLM used `get_dataset_info` and saw saved metrics like "total_revenue" (expression: `SUM(amount) / COUNT(*)`), it could not reference them in chart generation — it had to reconstruct them as ad-hoc expressions, which breaks for complex SQL expressions.

This PR adds a `saved_metric: bool` flag to `ColumnRef`. When `true`, the `name` field references a saved metric from the dataset, and the form_data output uses a plain string (which Superset's query engine already resolves via `metrics_by_name` lookup).

**Changes:**
- `schemas.py`: Added `saved_metric` field to `ColumnRef` with a model validator that clears `aggregate` when set. Updated label computation in `TableChartConfig` and `XYChartConfig` validators.
- `chart_utils.py`: `create_metric_object` returns a plain string for saved metrics. `map_table_config` routes saved metrics to the metrics list. `_humanize_column` handles saved metric labels.
- `dataset_validator.py`: Skips aggregation validation for saved metrics (they have built-in aggregation).

Fully backward-compatible — `saved_metric` defaults to `False`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change to MCP tool schemas.

### TESTING INSTRUCTIONS

1. Use `get_dataset_info` to find a dataset with saved metrics
2. Use `generate_chart` with a saved metric reference:
   ```json
   {
     "dataset_id": 1,
     "config": {
       "chart_type": "xy",
       "x": {"name": "order_date"},
       "y": [{"name": "total_revenue", "saved_metric": true}]
     }
   }
   ```
3. Verify the chart renders correctly using the saved metric
4. Run tests: `pytest tests/unit_tests/mcp_service/chart/test_chart_schemas.py tests/unit_tests/mcp_service/chart/test_chart_utils.py -x`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Allow charts to use saved dataset metrics**

### What Changed
- Charts can now use saved metrics from a dataset directly, instead of rebuilding them as ad-hoc formulas
- Saved metrics are treated as metrics in table charts, including tables with only saved metrics
- Chart labels now stay clear and unique when saved metrics are mixed with regular columns
- Saved metrics no longer require an aggregate value, and any aggregate passed with them is ignored

### Impact
`✅ Saved dataset metrics work in charts`
`✅ Fewer chart setup failures for complex metrics`
`✅ Clearer metric labels in table and chart views`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
