### PR TITLE
fix(mcp): enforce MAX_PAGE_SIZE limit on list tools to prevent oversized responses

### DIFF
--- a/superset/mcp_service/__main__.py
+++ b/superset/mcp_service/__main__.py
@@ -44,6 +44,36 @@ if os.environ.get("FASTMCP_TRANSPORT", "stdio") == "stdio":
 from superset.mcp_service.app import init_fastmcp_server, mcp
 
 
+def _add_default_middlewares() -> None:
+    """Add the standard middleware stack to the MCP instance.
+
+    This ensures all entry points (stdio, streamable-http, etc.) get
+    the same protection middlewares that the Flask CLI and server.py add.
+    Order is innermost → outermost (last-added wraps everything).
+    """
+    from superset.mcp_service.middleware import (
+        create_response_size_guard_middleware,
+        GlobalErrorHandlerMiddleware,
+        LoggingMiddleware,
+        StructuredContentStripperMiddleware,
+    )
+
+    # Response size guard (innermost among these)
+    if size_guard := create_response_size_guard_middleware():
+        mcp.add_middleware(size_guard)
+        limit = size_guard.token_limit
+        sys.stderr.write(f"[MCP] Response size guard enabled (token_limit={limit})\n")
+
+    # Logging
+    mcp.add_middleware(LoggingMiddleware())
+
+    # Global error handler
+    mcp.add_middleware(GlobalErrorHandlerMiddleware())
+
+    # Structured content stripper (must be outermost)
+    mcp.add_middleware(StructuredContentStripperMiddleware())
+
+
 def main() -> None:
     """
     Run the MCP service in stdio mode with proper output suppression.
@@ -97,6 +127,7 @@ def main() -> None:
             # Initialize the FastMCP server
             # Disable auth config for stdio mode to avoid Flask app output
             init_fastmcp_server()
+            _add_default_middlewares()
 
         # Log captured output to stderr for debugging (optional)
         captured = captured_output.getvalue()
@@ -118,6 +149,7 @@ def main() -> None:
     else:
         # For other transports, use normal initialization
         init_fastmcp_server()
+        _add_default_middlewares()
 
         # Run with specified transport
         if transport == "streamable-http":

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -46,6 +46,7 @@ from superset.mcp_service.common.cache_schemas import (
     QueryCacheControl,
 )
 from superset.mcp_service.common.error_schemas import ChartGenerationError
+from superset.mcp_service.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from superset.mcp_service.system.schemas import (
     PaginationInfo,
     serialize_user_object,
@@ -1094,7 +1095,13 @@ class ListChartsRequest(MetadataCacheControl):
         Field(default=1, description="Page number for pagination (1-based)"),
     ]
     page_size: Annotated[
-        PositiveInt, Field(default=10, description="Number of items per page")
+        int,
+        Field(
+            default=DEFAULT_PAGE_SIZE,
+            gt=0,
+            le=MAX_PAGE_SIZE,
+            description=f"Number of items per page (max {MAX_PAGE_SIZE})",
+        ),
     ]
 
     @model_validator(mode="after")

--- a/superset/mcp_service/constants.py
+++ b/superset/mcp_service/constants.py
@@ -16,6 +16,10 @@
 # under the License.
 """Constants for the MCP service."""
 
+# Pagination defaults
+DEFAULT_PAGE_SIZE = 10  # Default number of items per page
+MAX_PAGE_SIZE = 100  # Maximum allowed page_size to prevent oversized responses
+
 # Response size guard defaults
 DEFAULT_TOKEN_LIMIT = 25_000  # ~25k tokens prevents overwhelming LLM context windows
 DEFAULT_WARN_THRESHOLD_PCT = 80  # Log warnings above 80% of limit

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -84,6 +84,7 @@ if TYPE_CHECKING:
 from superset.daos.base import ColumnOperator, ColumnOperatorEnum
 from superset.mcp_service.chart.schemas import ChartInfo, serialize_chart_object
 from superset.mcp_service.common.cache_schemas import MetadataCacheControl
+from superset.mcp_service.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from superset.mcp_service.system.schemas import (
     PaginationInfo,
     RoleInfo,
@@ -244,7 +245,13 @@ class ListDashboardsRequest(MetadataCacheControl):
         Field(default=1, description="Page number for pagination (1-based)"),
     ]
     page_size: Annotated[
-        PositiveInt, Field(default=10, description="Number of items per page")
+        int,
+        Field(
+            default=DEFAULT_PAGE_SIZE,
+            gt=0,
+            le=MAX_PAGE_SIZE,
+            description=f"Number of items per page (max {MAX_PAGE_SIZE})",
+        ),
     ]
 
     @model_validator(mode="after")

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -35,6 +35,7 @@ from pydantic import (
 
 from superset.daos.base import ColumnOperator, ColumnOperatorEnum
 from superset.mcp_service.common.cache_schemas import MetadataCacheControl
+from superset.mcp_service.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from superset.mcp_service.system.schemas import (
     PaginationInfo,
     serialize_user_object,
@@ -247,7 +248,13 @@ class ListDatasetsRequest(MetadataCacheControl):
         Field(default=1, description="Page number for pagination (1-based)"),
     ]
     page_size: Annotated[
-        PositiveInt, Field(default=10, description="Number of items per page")
+        int,
+        Field(
+            default=DEFAULT_PAGE_SIZE,
+            gt=0,
+            le=MAX_PAGE_SIZE,
+            description=f"Number of items per page (max {MAX_PAGE_SIZE})",
+        ),
     ]
 
     @model_validator(mode="after")

--- a/superset/mcp_service/mcp_core.py
+++ b/superset/mcp_service/mcp_core.py
@@ -142,6 +142,11 @@ class ModelListCore(BaseCore, Generic[L]):
         page: int = 0,
         page_size: int = 10,
     ) -> L:
+        from superset.mcp_service.constants import MAX_PAGE_SIZE
+
+        # Clamp page_size to MAX_PAGE_SIZE as defense-in-depth
+        page_size = min(page_size, MAX_PAGE_SIZE)
+
         # Parse filters using generic utility (accepts JSON string or object)
         from superset.mcp_service.utils.schema_utils import (
             parse_json_or_list,

--- a/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
@@ -31,12 +31,12 @@ from superset.mcp_service.chart.schemas import (
 from superset.mcp_service.constants import MAX_PAGE_SIZE
 
 
-@pytest.fixture()
+@pytest.fixture
 def mcp_server():
     return mcp
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_chart():
     """Create a mock chart object."""
     chart = Mock()

--- a/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
@@ -28,14 +28,15 @@ from superset.mcp_service.chart.schemas import (
     ChartFilter,
     ListChartsRequest,
 )
+from superset.mcp_service.constants import MAX_PAGE_SIZE
 
 
-@pytest.fixture
+@pytest.fixture()
 def mcp_server():
     return mcp
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_chart():
     """Create a mock chart object."""
     chart = Mock()
@@ -132,6 +133,19 @@ class TestListChartsRequestSchema:
 
         with pytest.raises(ValueError, match="Input should be greater than 0"):
             ListChartsRequest(page_size=0)
+
+    def test_page_size_exceeds_max(self):
+        """Test that page_size over MAX_PAGE_SIZE raises validation error."""
+        with pytest.raises(
+            ValueError,
+            match=f"Input should be less than or equal to {MAX_PAGE_SIZE}",
+        ):
+            ListChartsRequest(page_size=MAX_PAGE_SIZE + 1)
+
+    def test_page_size_at_max(self):
+        """Test that page_size at MAX_PAGE_SIZE is accepted."""
+        request = ListChartsRequest(page_size=MAX_PAGE_SIZE)
+        assert request.page_size == MAX_PAGE_SIZE
 
     def test_filter_validation(self):
         """Test that filter validation works correctly."""


### PR DESCRIPTION
## **User description**
## Summary

- Add `MAX_PAGE_SIZE=100` and `DEFAULT_PAGE_SIZE=10` constants
- Add `le=MAX_PAGE_SIZE` constraint to `page_size` field in all three list request schemas (charts, dashboards, datasets) so Pydantic rejects values over 100
- Add defense-in-depth clamp in `ModelListCore.run_tool()` 
- Add missing middleware stack (response size guard, logging, error handler) to `__main__.py` entry point which had none
- Add tests for page_size boundary validation

### BEFORE/AFTER SCREENSHOTS OR ANIMATIONS

**Before:** LLMs could request `page_size=10000` and get back massive responses (e.g., 177k chars / ~50k tokens for 1000 charts), overwhelming client context windows and causing 5-10 minute delays.

**After:** `page_size` is capped at 100 via Pydantic schema validation. Values over 100 return a clear validation error:
```
Input should be less than or equal to 100
```

### TESTING INSTRUCTIONS

```python
# Should fail with validation error
list_charts(request={"page_size": 200})

# Should succeed
list_charts(request={"page_size": 100})
list_charts(request={"page_size": 10})
```

### ADDITIONAL INFORMATION

- `execute_sql` already has proper bounds (`le=10000`) — this brings list tools in line
- The `__main__.py` entry point (`python -m superset.mcp_service`) previously had zero middleware protection


___

## **CodeAnt-AI Description**
Limit list results and ensure MCP protections are active in every startup mode

### What Changed
- List charts, dashboards, and datasets now reject page sizes above 100, so requests can no longer return oversized result sets
- Requests at the limit still work, and invalid page sizes now fail with a clear validation error
- The MCP service now loads the standard safety, logging, and error-handling protections when started from the command line or other transport modes

### Impact
`✅ Smaller list responses`
`✅ Fewer slow or stalled requests`
`✅ Safer MCP startup across entry points`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
