### PR TITLE
fix(dashboard): live CSS preview in PropertiesModal

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -53,6 +53,7 @@ import {
   setColorScheme,
   setDashboardMetadata,
 } from 'src/dashboard/actions/dashboardState';
+import { dashboardInfoChanged } from 'src/dashboard/actions/dashboardInfo';
 import { areObjectsEqual } from 'src/reduxUtils';
 import { StandardModal, useModalValidation } from 'src/components/Modal';
 import { validateRefreshFrequency } from '../RefreshFrequency';
@@ -143,6 +144,8 @@ const PropertiesModal = ({
   >([]);
   const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
   const originalDashboardMetadata = useRef<Record<string, any>>({});
+  const originalCss = useRef<string | null>(null);
+  const cssDebounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleErrorResponse = async (response: Response) => {
     const { error, statusText, message } = await getClientErrorObject(response);
@@ -195,6 +198,9 @@ const PropertiesModal = ({
       setOwners(owners);
       setRoles(roles);
       setCustomCss(css || '');
+      if (originalCss.current === null) {
+        originalCss.current = css || '';
+      }
       setCurrentColorScheme(metadata?.color_scheme);
       setSelectedThemeId(theme?.id || null);
 
@@ -269,7 +275,16 @@ const PropertiesModal = ({
     setRoles(parsedRoles);
   };
 
-  const handleOnCancel = () => onHide();
+  const handleOnCancel = () => {
+    if (cssDebounceTimer.current) {
+      clearTimeout(cssDebounceTimer.current);
+    }
+    dispatch(dashboardInfoChanged({ css: originalCss.current ?? '' }));
+    dispatch(
+      setColorScheme(originalDashboardMetadata.current.color_scheme ?? ''),
+    );
+    onHide();
+  };
 
   const onColorSchemeChange = (
     colorScheme = '',
@@ -428,6 +443,14 @@ const PropertiesModal = ({
       }, handleErrorResponse);
     }
   };
+
+  // Must be defined before the data-loading effect so it runs first when show
+  // becomes true, ensuring handleDashboardData sees null and captures original CSS
+  useEffect(() => {
+    if (show) {
+      originalCss.current = null;
+    }
+  }, [show]);
 
   useEffect(() => {
     if (show) {
@@ -596,6 +619,21 @@ const PropertiesModal = ({
 
   const isDataReady = !isLoading && dashboardInfo;
 
+  // Debounced live CSS preview so changes are reflected on the dashboard
+  // without clicking Apply. Called only on user edits, not on data load.
+  const handleCustomCssChange = useCallback(
+    (css: string) => {
+      setCustomCss(css);
+      if (cssDebounceTimer.current) {
+        clearTimeout(cssDebounceTimer.current);
+      }
+      cssDebounceTimer.current = setTimeout(() => {
+        dispatch(dashboardInfoChanged({ css }));
+      }, 500);
+    },
+    [dispatch],
+  );
+
   // Validate basic section when title changes or data loads
   useEffect(() => {
     if (isDataReady) {
@@ -722,7 +760,7 @@ const PropertiesModal = ({
                   showChartTimestamps={showChartTimestamps}
                   onThemeChange={handleThemeChange}
                   onColorSchemeChange={onColorSchemeChange}
-                  onCustomCssChange={setCustomCss}
+                  onCustomCssChange={handleCustomCssChange}
                   onShowChartTimestampsChange={setShowChartTimestamps}
                   addDangerToast={addDangerToast}
                 />

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -279,10 +279,14 @@ const PropertiesModal = ({
     if (cssDebounceTimer.current) {
       clearTimeout(cssDebounceTimer.current);
     }
-    dispatch(dashboardInfoChanged({ css: originalCss.current ?? '' }));
-    dispatch(
-      setColorScheme(originalDashboardMetadata.current.color_scheme ?? ''),
-    );
+    if (originalCss.current !== null) {
+      dispatch(dashboardInfoChanged({ css: originalCss.current }));
+    }
+    const originalColorScheme = originalDashboardMetadata.current
+      .color_scheme as string | undefined;
+    if (typeof originalColorScheme === 'string') {
+      dispatch(setColorScheme(originalColorScheme));
+    }
     onHide();
   };
 

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -278,6 +278,7 @@ const PropertiesModal = ({
   const handleOnCancel = () => {
     if (cssDebounceTimer.current) {
       clearTimeout(cssDebounceTimer.current);
+      cssDebounceTimer.current = null;
     }
     if (originalCss.current !== null) {
       dispatch(dashboardInfoChanged({ css: originalCss.current }));
@@ -628,12 +629,23 @@ const PropertiesModal = ({
       setCustomCss(css);
       if (cssDebounceTimer.current) {
         clearTimeout(cssDebounceTimer.current);
+        cssDebounceTimer.current = null;
       }
       cssDebounceTimer.current = setTimeout(() => {
         dispatch(dashboardInfoChanged({ css }));
       }, 500);
     },
     [dispatch],
+  );
+
+  useEffect(
+    () => () => {
+      if (cssDebounceTimer.current) {
+        clearTimeout(cssDebounceTimer.current);
+        cssDebounceTimer.current = null;
+      }
+    },
+    [],
   );
 
   // Validate basic section when title changes or data loads

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -281,11 +281,9 @@ const PropertiesModal = ({
     }
     if (originalCss.current !== null) {
       dispatch(dashboardInfoChanged({ css: originalCss.current }));
-    }
-    const originalColorScheme = originalDashboardMetadata.current
-      .color_scheme as string | undefined;
-    if (typeof originalColorScheme === 'string') {
-      dispatch(setColorScheme(originalColorScheme));
+      dispatch(
+        setColorScheme(originalDashboardMetadata.current.color_scheme ?? ''),
+      );
     }
     onHide();
   };


### PR DESCRIPTION
## **User description**
### SUMMARY

Adds live CSS preview in the PropertiesModal: as the user types in the CSS editor, changes are reflected on the dashboard in real time (debounced 500ms). When the user cancels, the original CSS is restored.

Fixes https://github.com/apache/superset/issues/38849

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** CSS changes only applied after clicking Save/Apply

**After:** CSS changes reflected on the dashboard as the user types; reverted on Cancel

### TESTING INSTRUCTIONS

1. Open a dashboard in edit mode
2. Open Dashboard Properties → Styling section
3. Type custom CSS (e.g. `body { background: red; }`) — verify it applies live on the dashboard
4. Click **Cancel** — verify the original CSS is restored
5. Repeat: type CSS, click **Save** — verify CSS persists

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Restore the original dashboard styling when canceling Properties modal edits**

### What Changed
- Cancel now restores the dashboard’s original CSS and color scheme instead of keeping previewed changes
- Live CSS preview still updates the dashboard while typing, without waiting for Apply
- Cancel also ignores unfinished preview updates, so slow-loading modals do not wipe dashboard styling

### Impact
`✅ Correct dashboard styling after cancel`
`✅ Fewer accidental theme changes`
`✅ Safer live CSS editing`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
