### PR TITLE
fix(mcp): add TEMPORAL_RANGE filter for temporal x-axis in generate_chart

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -26,6 +26,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict
 
+from superset.constants import NO_TIME_RANGE
 from superset.mcp_service.chart.schemas import (
     ChartCapabilities,
     ChartSemantics,
@@ -40,6 +41,7 @@ from superset.mcp_service.chart.schemas import (
 )
 from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.utils import json
+from superset.utils.core import FilterOperator
 
 logger = logging.getLogger(__name__)
 
@@ -535,6 +537,7 @@ def configure_temporal_handling(
     Stores any warnings in ``form_data["_mcp_warnings"]``.
     """
     if x_is_temporal:
+        form_data["granularity_sqla"] = form_data.get("x_axis")
         if time_grain:
             form_data["time_grain_sqla"] = time_grain
     else:
@@ -549,6 +552,33 @@ def configure_temporal_handling(
                 f"column is not a temporal type. time_grain only applies to "
                 f"DATE/DATETIME/TIMESTAMP columns."
             )
+
+
+def _ensure_temporal_adhoc_filter(form_data: Dict[str, Any], column: str) -> None:
+    """Ensure a TEMPORAL_RANGE adhoc filter exists for the given column.
+
+    Mirrors the Explore UI behavior: when a temporal column is set as
+    the x-axis, a TEMPORAL_RANGE filter must be present so dashboard
+    time-range filters can bind to it.  Without this filter, Explore
+    shows a warning dialog asking the user to add it manually.
+    """
+    existing = form_data.get("adhoc_filters", [])
+    if any(
+        f.get("operator") == FilterOperator.TEMPORAL_RANGE.value
+        and f.get("subject") == column
+        for f in existing
+    ):
+        return
+    existing.append(
+        {
+            "clause": "WHERE",
+            "expressionType": "SIMPLE",
+            "subject": column,
+            "operator": FilterOperator.TEMPORAL_RANGE.value,
+            "comparator": NO_TIME_RANGE,
+        }
+    )
+    form_data["adhoc_filters"] = existing
 
 
 def map_xy_config(
@@ -607,6 +637,9 @@ def map_xy_config(
             form_data["groupby"] = groupby_columns
 
     _add_adhoc_filters(form_data, config.filters)
+
+    if x_is_temporal:
+        _ensure_temporal_adhoc_filter(form_data, config.x.name)
 
     form_data["row_limit"] = config.row_limit
 

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -22,8 +22,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from superset.constants import NO_TIME_RANGE
 from superset.mcp_service.chart.chart_utils import (
     _add_adhoc_filters,
+    _ensure_temporal_adhoc_filter,
     adhoc_filters_to_query_filters,
     configure_temporal_handling,
     create_metric_object,
@@ -44,7 +46,7 @@ from superset.mcp_service.chart.schemas import (
     TableChartConfig,
     XYChartConfig,
 )
-from superset.utils.core import GenericDataType
+from superset.utils.core import FilterOperator, GenericDataType
 
 
 class TestCreateMetricObject:
@@ -665,10 +667,13 @@ class TestMapXYConfig:
         result = map_xy_config(config)
 
         assert "adhoc_filters" in result
-        assert len(result["adhoc_filters"]) == 1
+        # User filter + auto-added TEMPORAL_RANGE filter for temporal x-axis
+        assert len(result["adhoc_filters"]) == 2
         assert result["adhoc_filters"][0]["subject"] == "region"
         assert result["adhoc_filters"][0]["operator"] == "=="
         assert result["adhoc_filters"][0]["comparator"] == "US"
+        assert result["adhoc_filters"][1]["operator"] == "TEMPORAL_RANGE"
+        assert result["adhoc_filters"][1]["subject"] == "date"
 
     @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
     def test_map_xy_config_row_limit(self, mock_is_temporal) -> None:
@@ -1284,16 +1289,18 @@ class TestConfigureTemporalHandling:
     """Test configure_temporal_handling function"""
 
     def test_temporal_column_with_time_grain(self) -> None:
-        """Test temporal column sets time_grain_sqla"""
-        form_data: dict[str, Any] = {}
+        """Test temporal column sets time_grain_sqla and granularity_sqla"""
+        form_data: dict[str, Any] = {"x_axis": "order_date"}
         configure_temporal_handling(form_data, x_is_temporal=True, time_grain="P1M")
         assert form_data["time_grain_sqla"] == "P1M"
+        assert form_data["granularity_sqla"] == "order_date"
 
     def test_temporal_column_without_time_grain(self) -> None:
-        """Test temporal column without time_grain doesn't set time_grain_sqla"""
-        form_data: dict[str, Any] = {}
+        """Test temporal column sets granularity_sqla but not time_grain_sqla"""
+        form_data: dict[str, Any] = {"x_axis": "order_date"}
         configure_temporal_handling(form_data, x_is_temporal=True, time_grain=None)
         assert "time_grain_sqla" not in form_data
+        assert form_data["granularity_sqla"] == "order_date"
 
     def test_non_temporal_column_sets_categorical_config(self) -> None:
         """Test non-temporal column sets categorical configuration"""
@@ -1355,7 +1362,16 @@ class TestMapXYConfigWithNonTemporalColumn:
 
         assert result["x_axis"] == "created_at"
         assert result["time_grain_sqla"] == "P1W"
+        assert result["granularity_sqla"] == "created_at"
         assert "x_axis_sort_series_type" not in result
+        # Temporal x-axis should have a TEMPORAL_RANGE adhoc filter
+        temporal_filters = [
+            f
+            for f in result.get("adhoc_filters", [])
+            if f.get("operator") == "TEMPORAL_RANGE"
+        ]
+        assert len(temporal_filters) == 1
+        assert temporal_filters[0]["subject"] == "created_at"
 
     @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
     def test_non_temporal_ignores_time_grain_param(self, mock_is_temporal) -> None:
@@ -1375,6 +1391,112 @@ class TestMapXYConfigWithNonTemporalColumn:
         # time_grain_sqla should be None, not P1M
         assert result["time_grain_sqla"] is None
         assert result["x_axis_sort_series_type"] == "name"
+
+
+class TestEnsureTemporalAdhocFilter:
+    """Test _ensure_temporal_adhoc_filter helper and its integration in map_xy_config"""
+
+    def test_adds_filter_to_empty_form_data(self) -> None:
+        """Test adds TEMPORAL_RANGE filter when no adhoc_filters exist"""
+        form_data: dict[str, Any] = {}
+        _ensure_temporal_adhoc_filter(form_data, "order_date")
+
+        assert len(form_data["adhoc_filters"]) == 1
+        f = form_data["adhoc_filters"][0]
+        assert f["operator"] == FilterOperator.TEMPORAL_RANGE.value
+        assert f["subject"] == "order_date"
+        assert f["comparator"] == NO_TIME_RANGE
+        assert f["expressionType"] == "SIMPLE"
+        assert f["clause"] == "WHERE"
+
+    def test_appends_to_existing_filters(self) -> None:
+        """Test appends temporal filter after existing user filters"""
+        form_data: dict[str, Any] = {
+            "adhoc_filters": [
+                {"subject": "region", "operator": "==", "comparator": "US"}
+            ]
+        }
+        _ensure_temporal_adhoc_filter(form_data, "order_date")
+
+        assert len(form_data["adhoc_filters"]) == 2
+        assert form_data["adhoc_filters"][0]["subject"] == "region"
+        assert (
+            form_data["adhoc_filters"][1]["operator"]
+            == FilterOperator.TEMPORAL_RANGE.value
+        )
+
+    def test_does_not_duplicate_existing_temporal_filter(self) -> None:
+        """Test skips adding if a TEMPORAL_RANGE filter already exists for the column"""
+        form_data: dict[str, Any] = {
+            "adhoc_filters": [
+                {
+                    "subject": "order_date",
+                    "operator": FilterOperator.TEMPORAL_RANGE.value,
+                    "comparator": "Last 7 days",
+                }
+            ]
+        }
+        _ensure_temporal_adhoc_filter(form_data, "order_date")
+
+        # Should still be just 1 filter (no duplicate)
+        assert len(form_data["adhoc_filters"]) == 1
+
+    def test_adds_filter_for_different_column(self) -> None:
+        """Test adds filter when existing temporal filter is on a different column"""
+        form_data: dict[str, Any] = {
+            "adhoc_filters": [
+                {
+                    "subject": "created_at",
+                    "operator": FilterOperator.TEMPORAL_RANGE.value,
+                    "comparator": NO_TIME_RANGE,
+                }
+            ]
+        }
+        _ensure_temporal_adhoc_filter(form_data, "order_date")
+
+        assert len(form_data["adhoc_filters"]) == 2
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_temporal_x_axis_adds_filter_in_map_xy(self, mock_is_temporal) -> None:
+        """Test map_xy_config adds TEMPORAL_RANGE filter for temporal x-axis"""
+        mock_is_temporal.return_value = True
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="order_date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="bar",
+        )
+
+        result = map_xy_config(config, dataset_id=123)
+
+        temporal_filters = [
+            f
+            for f in result.get("adhoc_filters", [])
+            if f.get("operator") == FilterOperator.TEMPORAL_RANGE.value
+        ]
+        assert len(temporal_filters) == 1
+        assert temporal_filters[0]["subject"] == "order_date"
+        assert temporal_filters[0]["comparator"] == NO_TIME_RANGE
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_non_temporal_x_axis_no_temporal_filter(self, mock_is_temporal) -> None:
+        """Test non-temporal x-axis skips TEMPORAL_RANGE filter"""
+        mock_is_temporal.return_value = False
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="year"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            kind="bar",
+        )
+
+        result = map_xy_config(config, dataset_id=123)
+
+        temporal_filters = [
+            f
+            for f in result.get("adhoc_filters", [])
+            if f.get("operator") == FilterOperator.TEMPORAL_RANGE.value
+        ]
+        assert len(temporal_filters) == 0
 
 
 class TestFilterConfigValidation:

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -879,8 +879,12 @@ class TestGenerateExploreLinkColumnNormalization:
             assert form_data["x_axis"] == "OrderDate"
             # filter subject normalized to match x-axis
             adhoc_filters = form_data.get("adhoc_filters", [])
-            assert len(adhoc_filters) == 1
+            # User filter + auto-added TEMPORAL_RANGE for temporal x-axis
+            assert len(adhoc_filters) == 2
             assert adhoc_filters[0]["subject"] == "OrderDate"
+            assert adhoc_filters[0]["operator"] == ">"
+            assert adhoc_filters[1]["operator"] == "TEMPORAL_RANGE"
+            assert adhoc_filters[1]["subject"] == "OrderDate"
 
     @patch(
         "superset.mcp_service.chart.validation.dataset_validator.DatasetValidator._get_dataset_context"


### PR DESCRIPTION
## **User description**
## Summary

When `generate_chart` creates an XY chart with a temporal x-axis column (e.g., `order_date`) that differs from the dataset's primary datetime column, opening the chart in Explore triggers a warning: "The X-axis is not on the filters list."

This happens because the MCP tool was not adding a `TEMPORAL_RANGE` adhoc filter for the x-axis column, which the Explore frontend expects for dashboard time-range filter binding.

### Changes

- **`chart_utils.py`**: Set `granularity_sqla` to the x-axis column in `configure_temporal_handling()` when temporal, ensuring Superset uses the correct column for time filtering instead of defaulting to the dataset's primary datetime column
- **`chart_utils.py`**: Add `_ensure_temporal_adhoc_filter()` helper that appends a `TEMPORAL_RANGE` adhoc filter (using existing `FilterOperator` and `NO_TIME_RANGE` constants) when one doesn't already exist for the column — mirrors the Explore UI's own behavior when a user confirms the dialog
- **`chart_utils.py`**: Call the helper in `map_xy_config()` after user filters are applied, only for temporal x-axis columns
- **`test_chart_utils.py`**: Update existing tests and add 6 new tests for the helper and its integration

### Test plan

- [x] All 116 unit tests pass (`pytest tests/unit_tests/mcp_service/chart/test_chart_utils.py`)
- [x] Pre-commit passes on changed files
- [ ] Create a bar chart via MCP with temporal x-axis different from primary datetime → open in Explore → no warning
- [ ] Create a bar chart via MCP with non-temporal x-axis (e.g., BIGINT year) → still works without DATE_TRUNC errors


___

## **CodeAnt-AI Description**
Fix temporal x-axis charts so Explore opens without a filter warning

### What Changed
- Temporal x-axis charts now include the matching time-range filter, so opening them in Explore no longer triggers the “x-axis is not on the filters list” warning
- The x-axis column is now used for time filtering on temporal charts, while non-temporal x-axis columns still keep categorical behavior and ignore time-grain settings
- Existing user filters are preserved, and the new time-range filter is only added once for the x-axis column

### Impact
`✅ Fewer Explore warning dialogs`
`✅ Cleaner temporal chart setup`
`✅ No duplicate time-range filters`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

![Uploading Screenshot 2026-03-31 at 12.01.39 PM.png…]()
