### PR TITLE
fix(mixed-timeseries): apply same axis formatting options as timeseries charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -578,8 +578,30 @@ export default function transformProps(
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat)
+      ? getXAxisFormatter(xAxisTimeFormat, timeGrainSqla)
       : String;
+
+  const showMaxLabel = xAxisType === AxisType.Time && xAxisLabelRotation === 0;
+  const deduplicatedFormatter = showMaxLabel
+    ? (() => {
+        let lastLabel: string | undefined;
+        const wrapper = (value: number | string) => {
+          const label =
+            typeof xAxisFormatter === 'function'
+              ? (xAxisFormatter as Function)(value)
+              : String(value);
+          if (label === lastLabel) {
+            return '';
+          }
+          lastLabel = label;
+          return label;
+        };
+        if (typeof xAxisFormatter === 'function' && 'id' in xAxisFormatter) {
+          (wrapper as any).id = (xAxisFormatter as any).id;
+        }
+        return wrapper;
+      })()
+    : xAxisFormatter;
 
   const addYAxisTitleOffset =
     !!(yAxisTitle || yAxisTitleSecondary) &&
@@ -658,9 +680,14 @@ export default function transformProps(
       nameGap: convertInteger(xAxisTitleMargin),
       nameLocation: 'middle',
       axisLabel: {
-        formatter: xAxisFormatter,
+        hideOverlap: !(xAxisType === AxisType.Time && xAxisLabelRotation !== 0),
+        formatter: deduplicatedFormatter,
         rotate: xAxisLabelRotation,
         interval: xAxisLabelInterval,
+        ...(showMaxLabel && {
+          showMaxLabel: true,
+          alignMaxLabel: 'right',
+        }),
       },
       minorTick: { show: minorTicks },
       minInterval:


### PR DESCRIPTION
### SUMMARY
Mixed timeseries charts were missing several axis formatting behaviors that regular timeseries charts already had:
- `timeGrainSqla` was not passed to `getXAxisFormatter`, so time-grain-aware formatting was missing
- Label deduplication for time axes with no rotation was not applied
- `hideOverlap` and max label alignment (`showMaxLabel`, `alignMaxLabel`) were not configured

This fix brings mixed timeseries charts in line with regular timeseries chart axis formatting.

Fixes https://github.com/apache/superset/issues/38778

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="614" height="409" alt="Screenshot 2026-03-31 at 12 02 10" src="https://github.com/user-attachments/assets/c4b55d76-095d-4d91-8f57-c377595fc496" />
<img width="617" height="412" alt="Screenshot 2026-03-31 at 12 02 00" src="https://github.com/user-attachments/assets/2dcc5b5b-ad58-4e6e-9f2c-2c575cb67b0d" />

### TESTING INSTRUCTIONS
1. Create a mixed timeseries chart with a temporal X axis
2. Verify that time grain formatting (e.g., monthly labels) renders correctly
3. Verify that duplicate labels are suppressed when `showMaxLabel` is active
4. Compare axis label behavior against a regular timeseries chart — should be consistent

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API