### PR TITLE
chore(mcp): clarify saved metrics vs columns in MCP instructions

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -88,11 +88,29 @@ Available Prompts:
 - quickstart: Interactive guide for getting started with the MCP service
 - create_chart_guided: Step-by-step chart creation wizard
 
+IMPORTANT - Using Saved Metrics vs Columns:
+When get_dataset_info returns a dataset, it includes both 'columns' and 'metrics'.
+- 'columns' are raw database columns (e.g., order_date, product_name, revenue)
+- 'metrics' are pre-defined saved metrics with SQL expressions
+  (e.g., count, total_revenue)
+
+When building chart configurations
+(generate_chart, generate_explore_link, update_chart):
+- For raw columns: use {{"name": "col_name", "aggregate": "SUM"}}
+- For saved metrics: use {{"name": "metric", "saved_metric": true}}
+  Do NOT add an aggregate when using saved_metric=true
+  (it's already defined in the metric).
+  Do NOT use a saved metric name as if it were a column — it will fail.
+
+Example: If get_dataset_info returns metrics=[{{"metric_name": "count", ...}}], use:
+  {{"name": "count", "saved_metric": true}}  ← CORRECT
+  {{"name": "count", "aggregate": "COUNT"}}  ← WRONG (count is not a column)
+
 Recommended Workflows:
 
 To create a chart:
 1. list_datasets -> find a dataset
-2. get_dataset_info(id) -> examine columns and metrics
+2. get_dataset_info(id) -> examine columns AND metrics (note which names are metrics!)
 3. generate_explore_link(dataset_id, config) -> preview interactively
 4. generate_chart(dataset_id, config, save_chart=True) -> save permanently
 

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -84,7 +84,11 @@ class TableColumnInfo(BaseModel):
 
 
 class SqlMetricInfo(BaseModel):
-    metric_name: str = Field(..., description="Metric name")
+    metric_name: str = Field(
+        ...,
+        description="Saved metric name. In chart configs, reference as "
+        '{"name": "<metric_name>", "saved_metric": true}.',
+    )
     verbose_name: str | None = Field(None, description="Verbose name")
     expression: str | None = Field(None, description="SQL expression")
     description: str | None = Field(None, description="Metric description")
@@ -133,7 +137,9 @@ class DatasetInfo(BaseModel):
         default_factory=list, description="Columns in the dataset"
     )
     metrics: List[SqlMetricInfo] = Field(
-        default_factory=list, description="Metrics in the dataset"
+        default_factory=list,
+        description="Saved metrics (pre-defined aggregations). "
+        "NOT columns — use saved_metric=true in chart configs.",
     )
     is_favorite: bool | None = Field(
         None, description="Whether this dataset is favorited by the current user"

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -62,6 +62,11 @@ async def get_dataset_info(
     - DO NOT use schema.table_name format (e.g., "public.customers")
     - To find a dataset ID, use the list_datasets tool first
 
+    IMPORTANT - Saved Metrics vs Columns:
+    The response includes both 'columns' (raw database columns) and 'metrics'
+    (pre-defined saved metrics). When building chart configs, use saved_metric=true
+    for metrics — do not treat them as columns. See instructions for details.
+
     Example usage:
     ```json
     {


### PR DESCRIPTION
## **User description**
### SUMMARY

Improves MCP service documentation to help LLM clients distinguish between dataset columns and saved metrics when building chart configurations. LLM agents were incorrectly using saved metric names as if they were columns, causing chart generation failures.

Changes across 3 files:
- **`app.py`**: Added a dedicated "Saved Metrics vs Columns" section to `DEFAULT_INSTRUCTIONS` with examples of correct/incorrect usage
- **`dataset/schemas.py`**: Updated field descriptions for `SqlMetricInfo.metric_name` and `DatasetInfo.metrics` to clarify usage with `saved_metric=true`
- **`dataset/tool/get_dataset_info.py`**: Added a note in the tool docstring pointing out the distinction

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — documentation-only change

### TESTING INSTRUCTIONS
- Review the updated instructions in `app.py` for clarity
- Verify the Pydantic schema descriptions in `schemas.py` are accurate
- Confirm the `get_dataset_info` docstring note is consistent with the main instructions

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Clarify how to use saved metrics in MCP chart configs**

### What Changed
- Added a clear note that dataset results include both raw columns and saved metrics, and that they must be used differently when building charts
- Explained that saved metrics should be sent as saved metrics, not as regular columns with an aggregate
- Updated dataset details and tool guidance so the metric names are easier to recognize and use correctly

### Impact
`✅ Fewer chart setup failures`
`✅ Clearer dataset info for LLM clients`
`✅ Less confusion between columns and saved metrics`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
