### PR TITLE
fix(query): pass datasource table to template processor for schema-aware Jinja rendering

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -344,7 +344,9 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             if clause and self.datasource:
                 try:
                     database = self.datasource.database
-                    processor = get_template_processor(database=database)
+                    processor = get_template_processor(
+                        database=database, table=self.datasource
+                    )
                     try:
                         clause = processor.process_template(clause, force=True)
                     except TemplateError as ex:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1257,7 +1257,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
 
         if parse_boolean_string(request.args.get("include_rendered_sql")):
             try:
-                processor = get_template_processor(database=table.database)
+                processor = get_template_processor(database=table.database, table=table)
                 response["result"] = self.render_dataset_fields(
                     response["result"], processor
                 )

--- a/tests/unit_tests/datasets/api_tests.py
+++ b/tests/unit_tests/datasets/api_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 from sqlalchemy.orm.session import Session
 
@@ -72,3 +73,50 @@ def test_put_invalid_dataset(
             }
         ]
     }
+
+
+def test_get_dataset_include_rendered_sql_passes_table_to_template_processor(
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Dataset API: Test that include_rendered_sql passes the table
+    to get_template_processor.
+
+    Regression test for the bug where get_template_processor was called without
+    the `table` argument, leaving self._schema as None in processors like
+    PrestoTemplateProcessor and causing NPEs when templates reference partition
+    functions without an explicit schema.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.core import Database
+
+    SqlaTable.metadata.create_all(db.session.get_bind())
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="sqlite://",
+    )
+    dataset = SqlaTable(
+        table_name="test_render_sql_table",
+        schema="my_schema",
+        database=database,
+        sql="SELECT 1",
+    )
+    db.session.add(dataset)
+    db.session.flush()
+
+    mock_processor = MagicMock()
+    mock_processor.process_template.return_value = "SELECT 1"
+
+    with patch(
+        "superset.datasets.api.get_template_processor",
+        return_value=mock_processor,
+    ) as mock_get_processor:
+        response = client.get(
+            f"/api/v1/dataset/{dataset.id}?include_rendered_sql=true",
+        )
+
+    assert response.status_code == 200
+    mock_get_processor.assert_called_once_with(database=database, table=dataset)


### PR DESCRIPTION
## **User description**
### SUMMARY

When `_sanitize_filters` evaluates Jinja templates during access validation, and when the datasets API renders SQL/metrics/columns via `include_rendered_sql`, the template processor was created without a `table` argument. This means `self._schema` is `None` in processors like `PrestoTemplateProcessor`, so partition function references like `{{ presto.latest_partition('my_table') }}` — where the table name has no explicit schema prefix — cannot resolve the schema and fail.

Passing `table=self.datasource` / `table=table` gives the processor the schema context it needs to correctly resolve unqualified table references.

**Files changed:**
- `superset/common/query_object.py` — `_sanitize_filters` template processor now receives the datasource table
- `superset/datasets/api.py` — `include_rendered_sql` template processor now receives the dataset table

### TESTING INSTRUCTIONS

1. Configure a Presto/Trino datasource with a dataset whose schema is set on the dataset (not inlined in the table name).
2. Add a saved filter using `{{ presto.latest_partition('my_table') }}` (no schema prefix in the argument).
3. Open a chart using that dataset — previously the template processor had no schema context and could not resolve the table reference.
4. After this fix, the processor picks up the schema from the datasource and resolves the reference correctly.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Prevent dataset SQL previews and filter checks from failing on partition-based templates**

### What Changed
- Dataset SQL previews now use the dataset’s schema when rendering Jinja templates, so partition helpers can resolve unqualified table names.
- Filter validation now uses the datasource schema too, avoiding failures when saved filters contain partition-based template calls.
- Added a regression test to confirm the dataset API passes the table into template rendering.

### Impact
`✅ Fewer dataset preview errors`
`✅ Fewer filter validation failures`
`✅ Clearer support for partition-based templates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
