### PR TITLE
fix(mcp): fix dashboard owners Pydantic crash and preserve chart preview filters

### DIFF
--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -52,13 +52,15 @@ def _get_old_adhoc_filters(form_data_key: str) -> list[Dict[str, Any]] | None:
 
     try:
         cmd_params = CommandParameters(key=form_data_key)
-        cached_json = GetFormDataCommand(cmd_params).run()
-        if cached_json:
-            cached_form_data = utils_json.loads(cached_json)
-            adhoc_filters = cached_form_data.get("adhoc_filters")
-            if adhoc_filters:
-                return adhoc_filters
-    except (KeyError, ValueError, CommandException):
+        cached_data = GetFormDataCommand(cmd_params).run()
+        if cached_data:
+            if isinstance(cached_data, str):
+                cached_data = utils_json.loads(cached_data)
+            if isinstance(cached_data, dict):
+                adhoc_filters = cached_data.get("adhoc_filters")
+                if adhoc_filters:
+                    return adhoc_filters
+    except (KeyError, ValueError, TypeError, CommandException):
         logger.debug("Could not retrieve old form_data for filter preservation")
     return None
 

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -39,8 +39,28 @@ from superset.mcp_service.chart.schemas import (
     PerformanceMetadata,
     UpdateChartPreviewRequest,
 )
+from superset.utils import json as utils_json
 
 logger = logging.getLogger(__name__)
+
+
+def _get_old_adhoc_filters(form_data_key: str) -> list[Dict[str, Any]] | None:
+    """Retrieve adhoc_filters from the previously cached form_data."""
+    from superset.commands.exceptions import CommandException
+    from superset.commands.explore.form_data.get import GetFormDataCommand
+    from superset.commands.explore.form_data.parameters import CommandParameters
+
+    try:
+        cmd_params = CommandParameters(key=form_data_key)
+        cached_json = GetFormDataCommand(cmd_params).run()
+        if cached_json:
+            cached_form_data = utils_json.loads(cached_json)
+            adhoc_filters = cached_form_data.get("adhoc_filters")
+            if adhoc_filters:
+                return adhoc_filters
+    except (KeyError, ValueError, CommandException):
+        logger.debug("Could not retrieve old form_data for filter preservation")
+    return None
 
 
 @tool(
@@ -80,6 +100,16 @@ def update_chart_preview(
                 request.config, dataset_id=request.dataset_id
             )
             new_form_data.pop("_mcp_warnings", None)
+
+            # Preserve adhoc filters from the previous cached form_data
+            # when the new config doesn't explicitly specify filters
+            if (
+                getattr(request.config, "filters", None) is None
+                and request.form_data_key
+            ):
+                old_adhoc_filters = _get_old_adhoc_filters(request.form_data_key)
+                if old_adhoc_filters:
+                    new_form_data["adhoc_filters"] = old_adhoc_filters
 
             # Generate new explore link with updated form_data
             explore_url = generate_explore_link(request.dataset_id, new_form_data)

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -566,8 +566,9 @@ def serialize_dashboard_object(dashboard: Any) -> DashboardInfo:
         else None,
         chart_count=len(getattr(dashboard, "slices", [])),
         owners=[
-            UserInfo.model_validate(owner, from_attributes=True)
+            info
             for owner in getattr(dashboard, "owners", [])
+            if (info := serialize_user_object(owner)) is not None
         ]
         if getattr(dashboard, "owners", None)
         else [],


### PR DESCRIPTION
## **User description**
## Summary

Two MCP service bug fixes:

1. **Dashboard owners serialization crash**: `serialize_dashboard_object()` in `dashboard/schemas.py` used `UserInfo.model_validate(owner, from_attributes=True)` which passes raw SQLAlchemy `Role` ORM objects to the `roles: List[str]` Pydantic field, causing a validation error. Switched to `serialize_user_object()` which safely extracts role name strings — matching the pattern already used in the chart serializer.

2. **`update_chart_preview` drops adhoc filters**: When rebuilding chart config, the tool created entirely fresh `form_data` from the new config without carrying forward `adhoc_filters` from the previous cached `form_data`. Now retrieves the old cached form_data and preserves adhoc filters when the new config doesn't explicitly specify filters.

## Test plan

- [ ] Call `list_dashboards` with `select_columns: ["id", "dashboard_title", "owners"]` — should return owner data without Pydantic crash
- [ ] Create a chart with adhoc filters via `generate_chart`, then call `update_chart_preview` with a column change but no explicit filters — adhoc filters should be preserved in the new preview


___

## **CodeAnt-AI Description**
Fix dashboard owner details and keep chart filters when updating a preview

### What Changed
- Dashboard owner information now loads without crashing, so dashboards with owners can be viewed and listed normally
- Updating a chart preview now keeps existing ad hoc filters when the new setup does not include any filters
- Preview updates still use the latest chart settings, while preserving filters from the previous version when needed

### Impact
`✅ Fewer dashboard owner crashes`
`✅ Preserved chart filters in preview updates`
`✅ More reliable dashboard and chart browsing`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
