### PR TITLE
fix(dataset-editor): improve modal layout and fix Settings tab horizontal scroll

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -45,11 +45,19 @@ const DatasourceEditor = AsyncEsmComponent(
   () => import('../components/DatasourceEditor'),
 );
 
+const MODAL_HEIGHT_VH = 90;
+const TOP_MARGIN_VH = (100 - MODAL_HEIGHT_VH) / 2;
+
 const StyledDatasourceModal = styled(Modal)`
+  top: ${TOP_MARGIN_VH}vh;
+  padding-bottom: 0;
+
   && .ant-modal-content {
     max-height: none;
     margin-top: 0;
     margin-bottom: 0;
+    min-height: 500px;
+    min-width: 500px;
   }
 
   && .ant-modal-body {
@@ -367,7 +375,9 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       }
       responsive
       resizable
-      resizableConfig={{ defaultSize: { width: 'auto', height: '900px' } }}
+      resizableConfig={{
+        defaultSize: { width: 'auto', height: `${MODAL_HEIGHT_VH}vh` },
+      }}
       draggable
     >
       <DatasourceEditor

--- a/superset-frontend/src/components/Datasource/FoldersEditor/styles.tsx
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/styles.tsx
@@ -33,7 +33,6 @@ export const FoldersToolbar = styled.div`
     top: -${theme.margin}px; // offsets tabs component bottom margin
     z-index: 10;
     background: ${theme.colorBgContainer};
-    padding-top: ${theme.paddingMD}px;
     display: flex;
     flex-direction: column;
     gap: ${theme.paddingLG}px;

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -370,6 +370,7 @@ const StyledTableTabs = styled(Tabs)`
     flex: 1;
     min-height: 0;
     overflow: auto;
+    padding-top: ${({ theme }) => theme.paddingMD}px;
   }
 
   .ant-tabs-content {
@@ -2525,18 +2526,20 @@ class DatasourceEditor extends PureComponent<
               key: TABS_KEYS.SETTINGS,
               label: t('Settings'),
               children: (
-                <Row gutter={16}>
-                  <Col xs={24} md={12}>
-                    <FormContainer>
-                      {this.renderSettingsFieldset()}
-                    </FormContainer>
-                  </Col>
-                  <Col xs={24} md={12}>
-                    <FormContainer>
-                      {this.renderAdvancedFieldset()}
-                    </FormContainer>
-                  </Col>
-                </Row>
+                <div style={{ overflow: 'hidden' }}>
+                  <Row gutter={16}>
+                    <Col xs={24} md={12}>
+                      <FormContainer>
+                        {this.renderSettingsFieldset()}
+                      </FormContainer>
+                    </Col>
+                    <Col xs={24} md={12}>
+                      <FormContainer>
+                        {this.renderAdvancedFieldset()}
+                      </FormContainer>
+                    </Col>
+                  </Row>
+                </div>
               ),
             },
           ]}

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -2526,7 +2526,7 @@ class DatasourceEditor extends PureComponent<
               key: TABS_KEYS.SETTINGS,
               label: t('Settings'),
               children: (
-                <div style={{ overflow: 'hidden' }}>
+                <div style={{ overflowX: 'hidden' }}>
                   <Row gutter={16}>
                     <Col xs={24} md={12}>
                       <FormContainer>


### PR DESCRIPTION
### SUMMARY

- Vertically centers the dataset editor modal using viewport-relative sizing (`90vh` height, `5vh` top margin) instead of a fixed pixel height, and fixes the centering math by removing antd's default `padding-bottom` and `margin-top` offsets that were adding to the effective modal height
- Fixes resize support by moving the top offset from `.ant-modal-content` (which conflicted with the resizable container) to the modal root level
- Adds spacing between the tab bar and tab panel content
- Fixes horizontal scroll in the Settings tab caused by antd `Row` gutter negative margins bleeding outside the tab content area

Fixes https://github.com/apache/superset/issues/38982

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1913" height="866" alt="Screenshot 2026-04-01 at 10 22 48" src="https://github.com/user-attachments/assets/848ce0ee-f85c-4425-9e0e-41a2a6e70e36" />


https://github.com/user-attachments/assets/1fbd8459-236f-420c-95af-ae992d80ee6f


### TESTING INSTRUCTIONS

1. Open the dataset editor modal (Edit Dataset)
2. Verify the modal opens vertically centered with equal space above and below
3. Verify the modal can be resized from the bottom and right edges
4. Switch to the **Settings** tab and verify no horizontal scrollbar appears at the default modal width
5. Verify the two-column layout in Settings stacks correctly on narrow widths

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API