### PR TITLE
fix(echarts): fix stacked horizontal bar chart clipping and duplicate x-axis labels

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -685,14 +685,17 @@ export default function transformProps(
 
   // For horizontal bar charts, set max/min from calculated data bounds
   if (shouldCalculateDataBounds) {
-    // For stacked charts, use the max stacked total to avoid clipping bars;
-    // for non-stacked charts, use the individual series max.
+    // For stacked charts, clamp against the per-row stacked total to avoid
+    // clipping bars. Also keep dataMax so that mixed-sign stacks (where
+    // positive and negative values cancel in the algebraic row sum) cannot
+    // produce an axis max smaller than the largest individual positive segment.
+    const stackedTotalMax = Math.max(
+      ...sortedTotalValues.filter(
+        (v): v is number => typeof v === 'number' && !Number.isNaN(v),
+      ),
+    );
     const effectiveDataMax = stack
-      ? Math.max(
-          ...sortedTotalValues.filter(
-            (v): v is number => typeof v === 'number' && !Number.isNaN(v),
-          ),
-        )
+      ? Math.max(dataMax ?? Number.NEGATIVE_INFINITY, stackedTotalMax)
       : dataMax;
     if (
       effectiveDataMax !== undefined &&

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -659,7 +659,10 @@ export default function transformProps(
     for (const s of series) {
       if (s.id) {
         const columnsArr = labelMap[s.id];
-        (s as any).stack = columnsArr[idxSelectedDimension];
+        const dimensionValue = columnsArr?.[idxSelectedDimension];
+        if (dimensionValue !== undefined) {
+          (s as any).stack = dimensionValue;
+        }
       }
     }
   }
@@ -682,9 +685,21 @@ export default function transformProps(
 
   // For horizontal bar charts, set max/min from calculated data bounds
   if (shouldCalculateDataBounds) {
-    // Set max to actual data max to avoid gaps and ensure labels are visible
-    if (dataMax !== undefined && yAxisMax === undefined) {
-      yAxisMax = dataMax;
+    // For stacked charts, use the max stacked total to avoid clipping bars;
+    // for non-stacked charts, use the individual series max.
+    const effectiveDataMax = stack
+      ? Math.max(
+          ...sortedTotalValues.filter(
+            (v): v is number => typeof v === 'number' && !Number.isNaN(v),
+          ),
+        )
+      : dataMax;
+    if (
+      effectiveDataMax !== undefined &&
+      Number.isFinite(effectiveDataMax) &&
+      yAxisMax === undefined
+    ) {
+      yAxisMax = effectiveDataMax;
     }
     // Set min to actual data min for diverging bars
     if (dataMin !== undefined && yAxisMin === undefined && dataMin < 0) {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -24,6 +24,7 @@ import {
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import { supersetTheme } from '@apache-superset/core/theme';
+import { StackControlsValue } from '../../../src/constants';
 import type {
   GridComponentOption,
   LegendComponentOption,
@@ -724,6 +725,97 @@ describe('Bar Chart X-axis Time Formatting', () => {
       );
       // One hidden series per unique category (A, B, C)
       expect(hiddenSeries.length).toBe(3);
+    });
+  });
+
+  describe('Horizontal stacked bar chart axis bounds', () => {
+    // Dataset where each series max = 4 but stacked total max = 8
+    const stackedData: ChartDataResponseResult[] = [
+      createTestQueryData(
+        [
+          { team: 'Team A', High: 2, Low: 2, Medium: 4 },
+          { team: 'Team B', High: null, Low: null, Medium: 3 },
+          { team: 'Team C', High: null, Low: null, Medium: 1 },
+        ],
+        {
+          colnames: ['team', 'High', 'Low', 'Medium'],
+          coltypes: [
+            GenericDataType.String,
+            GenericDataType.Numeric,
+            GenericDataType.Numeric,
+            GenericDataType.Numeric,
+          ],
+        },
+      ),
+    ];
+
+    const horizontalStackedFormData: EchartsTimeseriesFormData = {
+      ...(baseFormData as EchartsTimeseriesFormData),
+      x_axis: 'team',
+      metric: ['High', 'Low', 'Medium'],
+      groupby: [],
+      orientation: OrientationType.Horizontal,
+      seriesType: EchartsTimeseriesSeriesType.Bar,
+      stack: StackControlsValue.Stack,
+      truncateYAxis: true,
+    };
+
+    test('xAxis.max uses stacked total, not individual series max', () => {
+      // Individual series max = 4 (Medium), stacked total for Team A = 8
+      // Without the fix, xAxis.max would be 4, clipping bars and duplicating labels
+      const chartProps = createEchartsTimeseriesTestChartProps<
+        EchartsTimeseriesFormData,
+        EchartsTimeseriesChartProps
+      >({
+        defaultFormData: horizontalStackedFormData,
+        defaultVizType: 'echarts_timeseries_bar',
+        defaultQueriesData: stackedData,
+      });
+
+      const { echartOptions } = transformProps(chartProps);
+      const xAxis = echartOptions.xAxis as any;
+
+      // xAxis.max must be >= stacked total (8), not capped at individual series max (4)
+      expect(xAxis.max).toBeGreaterThanOrEqual(8);
+    });
+
+    test('xAxis.max is not set to individual series max when stacking', () => {
+      const chartProps = createEchartsTimeseriesTestChartProps<
+        EchartsTimeseriesFormData,
+        EchartsTimeseriesChartProps
+      >({
+        defaultFormData: horizontalStackedFormData,
+        defaultVizType: 'echarts_timeseries_bar',
+        defaultQueriesData: stackedData,
+      });
+
+      const { echartOptions } = transformProps(chartProps);
+      const xAxis = echartOptions.xAxis as any;
+
+      // 4 is the individual series max — the axis should not be clipped there
+      expect(xAxis.max).not.toBe(4);
+    });
+
+    test('non-stacked horizontal bar chart still uses individual series max', () => {
+      const nonStackedFormData: EchartsTimeseriesFormData = {
+        ...horizontalStackedFormData,
+        stack: null,
+      };
+
+      const chartProps = createEchartsTimeseriesTestChartProps<
+        EchartsTimeseriesFormData,
+        EchartsTimeseriesChartProps
+      >({
+        defaultFormData: nonStackedFormData,
+        defaultVizType: 'echarts_timeseries_bar',
+        defaultQueriesData: stackedData,
+      });
+
+      const { echartOptions } = transformProps(chartProps);
+      const xAxis = echartOptions.xAxis as any;
+
+      // Without stacking, xAxis.max should be based on individual series values
+      expect(xAxis.max).toBe(4);
     });
   });
 


### PR DESCRIPTION
## **User description**
## SUMMARY

Fixes two related bugs in the ECharts horizontal stacked bar chart (`echarts_timeseries_bar` with horizontal orientation and `truncateYAxis` enabled):

1. **Bars appear not stacked** — stacked bars beyond the individual series max were clipped, making the chart look like bars were rendering individually rather than stacked.
2. **Duplicate x-axis labels** — with an artificially low `xAxis.max`, ECharts generated ticks at sub-integer intervals (e.g. 0.5 steps), and the integer formatter produced labels like `1 2 2 3 3 4 4`.

### Root cause

`shouldCalculateDataBounds` computes `yAxisMax` from individual per-series values (`dataMax`). For a stacked chart this is incorrect — the axis maximum must accommodate the *stacked total* per row, not any single series value.

**Example**: with series `High=2`, `Low=2`, `Medium=4`, `dataMax=4` but the stacked total is `8`. Setting `xAxis.max=4` clips bars at half their height and produces a cramped axis range that triggers duplicate tick labels.

### Fix

When `stack` is truthy, use the max of `sortedTotalValues` (per-row stacked totals already computed by `extractSeries`) as the effective axis max instead of `dataMax`.

Additionally, guard the `stackDimension` series assignment to skip `undefined` dimension values, preventing accidental overwrite of the `stack` property with `undefined`.

Fixes https://github.com/apache/superset/issues/38989
Fixes https://github.com/apache/superset/issues/38988

## BEFORE / AFTER

<img width="667" height="380" alt="Screenshot 2026-04-01 at 15 20 05" src="https://github.com/user-attachments/assets/eeef4edf-1820-47f8-95b7-e029c2d183ed" />

<img width="635" height="336" alt="Screenshot 2026-04-01 at 15 20 17" src="https://github.com/user-attachments/assets/bae31633-1243-46bd-92b9-1b87e460c78e" />

## TESTING INSTRUCTIONS

1. Create a horizontal bar chart (`echarts_timeseries_bar`, orientation = Horizontal) with multiple metrics and `Stack` enabled.
2. Enable `Truncate Y Axis` (or set y-axis bounds).
3. Verify bars stack correctly to their full combined height.
4. Verify x-axis labels show clean integer ticks without duplicates.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Fix stacked horizontal bar charts so bars are fully visible and axis labels stay clean**

### What Changed
- Stacked horizontal bar charts now use the full stacked total when setting the axis range, so bars are no longer cut off.
- This also prevents cramped axis spacing that caused duplicate number labels.
- Series grouping no longer gets overwritten when the selected grouping value is missing.

### Impact
`✅ Fewer clipped stacked bars`
`✅ Clearer axis labels on horizontal charts`
`✅ More reliable stacked bar grouping`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
