### PR TITLE
fix: `do_ping` takes a connection, not engine

### DIFF
--- a/superset/commands/database/utils.py
+++ b/superset/commands/database/utils.py
@@ -47,7 +47,8 @@ def ping(engine: Engine) -> bool:
     except (sqlite3.ProgrammingError, RuntimeError):
         # SQLite can't run on a separate thread, so ``utils.timeout`` fails
         # RuntimeError catches the equivalent error from duckdb.
-        return engine.dialect.do_ping(engine)
+        with closing(engine.raw_connection()) as conn:
+            return engine.dialect.do_ping(conn)
 
 
 def add_permissions(database: Database) -> None:

--- a/tests/unit_tests/commands/databases/utils_test.py
+++ b/tests/unit_tests/commands/databases/utils_test.py
@@ -77,7 +77,7 @@ def test_ping_sqlite_exception(mocker: MockerFixture, mock_engine: MockerFixture
     assert result is True
 
     mock_dialect.do_ping.assert_has_calls(
-        [mocker.call(mock_connection), mocker.call(mock_engine)]
+        [mocker.call(mock_connection), mocker.call(mock_connection)]
     )
 
 
@@ -85,7 +85,7 @@ def test_ping_runtime_exception(mocker: MockerFixture, mock_engine: MockerFixtur
     """
     Test the ``ping`` method when a RuntimeError is raised.
     """
-    mock_engine, _, mock_dialect = mock_engine
+    mock_engine, mock_connection, mock_dialect = mock_engine
     mock_timeout = mocker.patch("superset.commands.database.utils.timeout")
     mock_timeout.side_effect = RuntimeError("timeout")
     mock_dialect.do_ping.return_value = True
@@ -93,7 +93,7 @@ def test_ping_runtime_exception(mocker: MockerFixture, mock_engine: MockerFixtur
     result = ping(mock_engine)
 
     assert result is True
-    mock_dialect.do_ping.assert_called_once_with(mock_engine)
+    mock_dialect.do_ping.assert_called_once_with(mock_connection)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`do_ping` takes a raw connection, not an engine.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
