### PR TITLE
fix(mcp): handle stale SSL connections, heatmap duplicate labels, and session rollback

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -434,6 +434,10 @@ def _setup_user_context() -> User | None:
     """
     Set up user context for MCP tool execution.
 
+    Includes retry logic for stale database connections (e.g., SSL dropped
+    by proxy/load balancer after idle periods). On OperationalError, the
+    session is reset and the user lookup is retried once.
+
     Returns:
         User object with roles and groups loaded, or None if no Flask context
     """
@@ -446,31 +450,42 @@ def _setup_user_context() -> User | None:
     if not has_request_context():
         g.pop("user", None)
 
-    try:
-        user = get_user_from_request()
-    except RuntimeError as e:
-        # No Flask application context (e.g., prompts before middleware runs)
-        # This is expected for some FastMCP operations - return None gracefully
-        if "application context" in str(e):
-            logger.debug("No Flask app context available for user setup")
-            return None
-        raise
-    except ValueError as e:
-        # JWT user resolution failed (e.g. SAML subject not in DB).
-        # If middleware already set g.user (request context exists),
-        # use that instead of failing closed.
-        from flask import has_request_context
+    from sqlalchemy.exc import OperationalError
 
-        if has_request_context() and hasattr(g, "user") and g.user:
-            logger.warning(
-                "JWT user resolution failed (%s), using middleware-provided g.user=%s",
-                e,
-                g.user.username,
-            )
-            # Assign to local so relationship validation below runs
-            # (same as the normal path) to prevent detached instance errors.
-            user = g.user
-        else:
+    for attempt in range(2):
+        try:
+            user = get_user_from_request()
+            break
+        except RuntimeError as e:
+            # No Flask application context (e.g., prompts before middleware runs)
+            if "application context" in str(e):
+                logger.debug("No Flask app context available for user setup")
+                return None
+            raise
+        except OperationalError as e:
+            if attempt == 0:
+                logger.warning(
+                    "Stale DB connection during user setup (attempt 1), "
+                    "resetting session and retrying: %s",
+                    e,
+                )
+                _cleanup_session_on_error()
+                continue
+            logger.error("DB connection failed on retry during user setup: %s", e)
+            raise
+        except ValueError as e:
+            # JWT user resolution failed (e.g. SAML subject not in DB).
+            from flask import has_request_context
+
+            if has_request_context() and hasattr(g, "user") and g.user:
+                logger.warning(
+                    "JWT user resolution failed (%s), "
+                    "using middleware-provided g.user=%s",
+                    e,
+                    g.user.username,
+                )
+                user = g.user
+                break
             raise
 
     # Validate user has necessary relationships loaded

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -452,6 +452,8 @@ def _setup_user_context() -> User | None:
 
     from sqlalchemy.exc import OperationalError
 
+    user = None  # Ensure defined before loop in case of unexpected exit
+
     for attempt in range(2):
         try:
             user = get_user_from_request()
@@ -473,6 +475,10 @@ def _setup_user_context() -> User | None:
             raise
         except OperationalError as e:
             if attempt == 0:
+                # Only retry on connection-level errors (SSL drops, server
+                # closed connection). Other OperationalErrors (e.g., lock
+                # timeouts) are unlikely to succeed on immediate retry but
+                # are bounded to one attempt so the cost is acceptable.
                 logger.warning(
                     "Stale DB connection during user setup (attempt 1), "
                     "resetting session and retrying: %s",
@@ -482,11 +488,25 @@ def _setup_user_context() -> User | None:
                 continue
             logger.error("DB connection failed on retry during user setup: %s", e)
             raise
-        except ValueError:
+        except ValueError as e:
             # JWT user resolution failed (e.g. SAML subject not in DB).
-            # Fail closed — never fall back to g.user from middleware,
-            # as that would bypass JWT identity validation and could
-            # allow cross-tenant tool access in multi-tenant deployments.
+            # Log a security warning but fall back to middleware-provided
+            # g.user if available. This handles cases where the JWT
+            # resolver username format doesn't match the DB username
+            # (e.g., SAML subject vs email). A separate story should
+            # investigate whether any deployments hit this path and
+            # migrate them before removing the fallback entirely.
+            if has_request_context() and hasattr(g, "user") and g.user:
+                logger.warning(
+                    "SECURITY: JWT user resolution failed (%s), falling "
+                    "back to middleware-provided g.user=%s. This fallback "
+                    "should be investigated and removed once all "
+                    "deployments use consistent username resolution.",
+                    e,
+                    g.user.username,
+                )
+                user = g.user
+                break
             raise
 
     g.user = user

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -455,6 +455,15 @@ def _setup_user_context() -> User | None:
     for attempt in range(2):
         try:
             user = get_user_from_request()
+
+            # Validate user has necessary relationships loaded.
+            # Force access to ensure they're loaded if lazy.
+            # This is inside the retry loop because relationship loading
+            # also hits the DB and can fail on stale SSL connections.
+            user_roles = user.roles  # noqa: F841
+            if hasattr(user, "groups"):
+                user_groups = user.groups  # noqa: F841
+
             break
         except RuntimeError as e:
             # No Flask application context (e.g., prompts before middleware runs)
@@ -487,12 +496,6 @@ def _setup_user_context() -> User | None:
                 user = g.user
                 break
             raise
-
-    # Validate user has necessary relationships loaded
-    # (Force access to ensure they're loaded if lazy)
-    user_roles = user.roles  # noqa: F841
-    if hasattr(user, "groups"):
-        user_groups = user.groups  # noqa: F841
 
     g.user = user
     return user

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -482,19 +482,11 @@ def _setup_user_context() -> User | None:
                 continue
             logger.error("DB connection failed on retry during user setup: %s", e)
             raise
-        except ValueError as e:
+        except ValueError:
             # JWT user resolution failed (e.g. SAML subject not in DB).
-            from flask import has_request_context
-
-            if has_request_context() and hasattr(g, "user") and g.user:
-                logger.warning(
-                    "JWT user resolution failed (%s), "
-                    "using middleware-provided g.user=%s",
-                    e,
-                    g.user.username,
-                )
-                user = g.user
-                break
+            # Fail closed — never fall back to g.user from middleware,
+            # as that would bypass JWT identity validation and could
+            # allow cross-tenant tool access in multi-tenant deployments.
             raise
 
     g.user = user

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -301,7 +301,13 @@ async def get_chart_data(  # noqa: C901
                     cached_groupby: list[str] = []
                 else:
                     cached_metrics = cached_form_data_dict.get("metrics", [])
-                    cached_groupby = cached_form_data_dict.get("groupby", [])
+                    raw_groupby = cached_form_data_dict.get("groupby", [])
+                    # Guard against string groupby (e.g. heatmap_v2 migrated
+                    # from legacy heatmap where all_columns_y was a string)
+                    if isinstance(raw_groupby, str):
+                        cached_groupby = [raw_groupby]
+                    else:
+                        cached_groupby = list(raw_groupby)
 
                 _apply_extra_form_data(cached_form_data_dict, request.extra_form_data)
 
@@ -443,7 +449,13 @@ async def get_chart_data(  # noqa: C901
                 else:
                     # Standard charts use "metrics" (plural) and "groupby"
                     metrics = form_data.get("metrics", [])
-                    groupby_columns = list(form_data.get("groupby") or [])
+                    raw_groupby = form_data.get("groupby") or []
+                    # Guard against string groupby (e.g. heatmap_v2 migrated
+                    # from legacy heatmap where all_columns_y was a string)
+                    if isinstance(raw_groupby, str):
+                        groupby_columns = [raw_groupby]
+                    else:
+                        groupby_columns = list(raw_groupby)
                     # Some chart types use "columns" instead of "groupby"
                     if not groupby_columns:
                         form_columns = form_data.get("columns")

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -25,9 +25,10 @@ import logging
 from urllib.parse import urlencode
 
 from fastmcp import Context
+from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.extensions import event_logger
+from superset.extensions import db, event_logger
 from superset.mcp_service.sql_lab.schemas import (
     OpenSqlLabRequest,
     SqlLabResponse,
@@ -118,6 +119,12 @@ def open_sql_lab_with_context(
         )
 
     except Exception as e:
+        try:
+            db.session.rollback()
+        except SQLAlchemyError:
+            logger.warning(
+                "Database rollback failed during error handling", exc_info=True
+            )
         logger.error("Error generating SQL Lab URL: %s", e)
         return SqlLabResponse(
             url="",

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -120,7 +120,7 @@ def open_sql_lab_with_context(
 
     except Exception as e:
         try:
-            db.session.rollback()
+            db.session.rollback()  # pylint: disable=consider-using-transaction
         except SQLAlchemyError:
             logger.warning(
                 "Database rollback failed during error handling", exc_info=True

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -25,7 +25,6 @@ import logging
 from urllib.parse import urlencode
 
 from fastmcp import Context
-from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import db, event_logger
@@ -121,7 +120,10 @@ def open_sql_lab_with_context(
     except Exception as e:
         try:
             db.session.rollback()  # pylint: disable=consider-using-transaction
-        except SQLAlchemyError:
+        except Exception:  # noqa: BLE001
+            # Broad catch: the DB connection itself may be broken (e.g.,
+            # SSL drop), so even rollback can fail with non-SQLAlchemy
+            # errors. This is a cleanup path — swallow and log.
             logger.warning(
                 "Database rollback failed during error handling", exc_info=True
             )

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -103,14 +103,18 @@ def get_instance_info(
         )
         try:
             db.session.rollback()  # pylint: disable=consider-using-transaction
-        except Exception:
+        except Exception:  # noqa: BLE001
+            # Broad catch: the DB connection itself may be broken (e.g.,
+            # SSL drop), so even rollback can fail with non-SQLAlchemy
+            # errors. This is a cleanup path — swallow and log.
             logger.warning(
                 "Rollback failed during get_instance_info connection reset",
                 exc_info=True,
             )
         try:
             db.session.remove()  # pylint: disable=consider-using-transaction
-        except Exception:
+        except Exception:  # noqa: BLE001
+            # Same as above — cleanup must not prevent the retry.
             logger.warning(
                 "Session remove failed during get_instance_info connection reset",
                 exc_info=True,

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -101,8 +101,20 @@ def get_instance_info(
             "resetting session and retrying: %s",
             e,
         )
-        db.session.rollback()
-        db.session.remove()
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except Exception:
+            logger.warning(
+                "Rollback failed during get_instance_info connection reset",
+                exc_info=True,
+            )
+        try:
+            db.session.remove()  # pylint: disable=consider-using-transaction
+        except Exception:
+            logger.warning(
+                "Session remove failed during get_instance_info connection reset",
+                exc_info=True,
+            )
 
         try:
             result = _run_instance_info()

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -23,9 +23,10 @@ InstanceInfoCore for flexible, extensible metrics calculation.
 import logging
 
 from fastmcp import Context
+from sqlalchemy.exc import OperationalError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.extensions import event_logger
+from superset.extensions import db, event_logger
 from superset.mcp_service.mcp_core import InstanceInfoCore
 from superset.mcp_service.system.schemas import (
     GetSupersetInstanceInfoRequest,
@@ -92,38 +93,59 @@ def get_instance_info(
     Returns counts, activity metrics, and database types.
     """
     try:
-        # Import DAOs at runtime to avoid circular imports
-        from flask import g
+        return _run_instance_info()
 
-        from superset.daos.chart import ChartDAO
-        from superset.daos.dashboard import DashboardDAO
-        from superset.daos.database import DatabaseDAO
-        from superset.daos.dataset import DatasetDAO
-        from superset.daos.tag import TagDAO
-        from superset.daos.user import UserDAO
+    except OperationalError as e:
+        logger.warning(
+            "Database connection error in get_instance_info, "
+            "resetting session and retrying: %s",
+            e,
+        )
+        db.session.rollback()
+        db.session.remove()
 
-        # Configure DAO classes at runtime
-        _instance_info_core.dao_classes = {
-            "dashboards": DashboardDAO,
-            "charts": ChartDAO,
-            "datasets": DatasetDAO,
-            "databases": DatabaseDAO,
-            "users": UserDAO,
-            "tags": TagDAO,
-        }
-
-        # Run the configurable core
-        with event_logger.log_context(action="mcp.get_instance_info.metrics"):
-            result = _instance_info_core.run_tool()
-
-        # Attach the authenticated user's identity to the response
-        user = getattr(g, "user", None)
-        if user is not None:
-            result.current_user = serialize_user_object(user)
-
-        return result
+        try:
+            result = _run_instance_info()
+            logger.info("get_instance_info retry succeeded after connection reset")
+            return result
+        except OperationalError as retry_error:
+            logger.error(
+                "get_instance_info retry failed after connection reset: %s",
+                retry_error,
+                exc_info=True,
+            )
+            raise
 
     except Exception as e:
         error_msg = f"Unexpected error in instance info: {str(e)}"
         logger.error(error_msg, exc_info=True)
         raise
+
+
+def _run_instance_info() -> InstanceInfo:
+    """Execute the instance info core logic."""
+    from flask import g
+
+    from superset.daos.chart import ChartDAO
+    from superset.daos.dashboard import DashboardDAO
+    from superset.daos.database import DatabaseDAO
+    from superset.daos.dataset import DatasetDAO
+    from superset.daos.tag import TagDAO
+    from superset.daos.user import UserDAO
+
+    _instance_info_core.dao_classes = {
+        "dashboards": DashboardDAO,
+        "charts": ChartDAO,
+        "datasets": DatasetDAO,
+        "databases": DatabaseDAO,
+        "users": UserDAO,
+        "tags": TagDAO,
+    }
+
+    with event_logger.log_context(action="mcp.get_instance_info.metrics"):
+        result = _instance_info_core.run_tool()
+
+    if (user := getattr(g, "user", None)) is not None:
+        result.current_user = serialize_user_object(user)
+
+    return result


### PR DESCRIPTION
### SUMMARY

Fixes four MCP tool resilience issues and adds a security warning:

1. **`get_instance_info` SSL crash**: When PostgreSQL connections go stale (SSL session dropped by proxy/load balancer), the tool crashes with `psycopg2.OperationalError: SSL connection has been closed unexpectedly`. Fix catches `OperationalError`, resets the session, and retries once.

2. **`get_chart_data` heatmap duplicate labels**: For `heatmap_v2` charts (migrated from legacy `heatmap`), the `groupby` field in form_data is a string (renamed from `all_columns_y`) rather than a list. Calling `list("Stage")` splits it into individual characters `['S', 't', 'a', 'g', 'e']`, causing Superset's `QueryObject._validate_no_have_duplicate_labels()` to fail. Fix wraps string groupby values in a list.

3. **`open_sql_lab_with_context` session rollback**: In multi-tenant environments, the tool fails with "Can't reconnect until invalid transaction is rolled back" because the error handler doesn't clean up the session. Fix adds `db.session.rollback()` in the exception handler, matching the pattern applied to other MCP write tools.

4. **Auth layer SSL retry for ALL tools**: Adds `OperationalError` retry logic to `_setup_user_context()` in `auth.py`, protecting ALL MCP tools from stale connections — not just individually patched ones. Previously, tools like `update_chart_preview`, `update_chart`, `generate_chart` would crash on idle workspaces. Relationship loading (`user.roles`, `user.groups`) is inside the retry loop so lazy-load failures are also retried.

5. **JWT `ValueError` fallback — security warning added**: When JWT user resolution fails but middleware-provided `g.user` exists, the fallback is kept for backward compatibility (SAML deployments may depend on it) but now logs a `SECURITY` warning. A separate investigation will determine whether any deployments hit this path before removing the fallback entirely.

**Code review cleanup:**
- Initialize `user = None` before retry loop to prevent potential `UnboundLocalError`
- Consistent broad `Exception` catch in cleanup/rollback paths across all tools (cleanup must not fail when the DB connection itself is broken)
- Added `noqa: BLE001` annotations and explanatory comments for all broad exception catches

### TESTING

- All 15 auth RBAC unit tests pass
- Full eval suite on staging (build `a78d5640`, workspace `bcff9fe0`): 33/33 PASS, 0 failures
- All 3 original bug fixes verified + auth layer retry working
- Datadog logs clean — 0 unexpected errors

### BEFORE/AFTER SCREENSHOTS OR COVERAGE URL

N/A — backend-only changes, no UI impact.