### PR TITLE
fix(dashboard): move chart fullscreen rendering to document.body port…

### DIFF
--- a/superset-frontend/src/dashboard/components/dnd/__mocks__/DragDroppable.tsx
+++ b/superset-frontend/src/dashboard/components/dnd/__mocks__/DragDroppable.tsx
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { type ReactNode } from 'react';
+import cx from 'classnames';
+
+function MockDraggable(props: Record<string, unknown>) {
+  const { editMode, orientation, children, disableDragDrop } = props as {
+    editMode?: boolean;
+    orientation?: 'row' | 'column';
+    disableDragDrop?: boolean;
+    children: (childProps: Record<string, unknown>) => ReactNode;
+  };
+  const childProps = editMode
+    ? {
+        dragSourceRef: jest.fn(),
+        dropIndicatorProps: null,
+        draggingTabOnTab: false,
+        'data-test': 'dragdroppable-content',
+      }
+    : {
+        dropIndicatorProps: null,
+        'data-test': 'dragdroppable-content',
+      };
+  return (
+    <div
+      data-test="dragdroppable-object"
+      data-disable-drag-drop={String(!!disableDragDrop)}
+      className={cx(
+        'dragdroppable',
+        editMode && 'dragdroppable--edit-mode',
+        orientation === 'row' && 'dragdroppable-row',
+        orientation === 'column' && 'dragdroppable-column',
+      )}
+    >
+      {children(childProps)}
+    </div>
+  );
+}
+
+export { MockDraggable as Draggable };

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -42,57 +42,7 @@ import {
 import ChartHolder, { CHART_MARGIN } from './ChartHolder';
 import { GRID_BASE_UNIT, GRID_GUTTER_SIZE } from '../../../util/constants';
 
-jest.mock('src/dashboard/components/dnd/DragDroppable', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires -- jest.mock factory
-  const React = require('react');
-  const actual = jest.requireActual(
-    'src/dashboard/components/dnd/DragDroppable',
-  );
-  // eslint-disable-next-line @typescript-eslint/no-var-requires -- jest.mock factory
-  const cx = require('classnames');
-
-  function MockDraggable(props: Record<string, unknown>) {
-    const { editMode, orientation, children, disableDragDrop } = props as {
-      editMode?: boolean;
-      orientation?: 'row' | 'column';
-      disableDragDrop?: boolean;
-      children: (childProps: Record<string, unknown>) => unknown;
-    };
-    const childFn = children as (
-      childProps: Record<string, unknown>,
-    ) => unknown;
-    const childProps = editMode
-      ? {
-          dragSourceRef: jest.fn(),
-          dropIndicatorProps: null,
-          draggingTabOnTab: false,
-          'data-test': 'dragdroppable-content',
-        }
-      : {
-          dropIndicatorProps: null,
-          'data-test': 'dragdroppable-content',
-        };
-    return React.createElement(
-      'div',
-      {
-        'data-test': 'dragdroppable-object',
-        'data-disable-drag-drop': String(!!disableDragDrop),
-        className: cx(
-          'dragdroppable',
-          editMode && 'dragdroppable--edit-mode',
-          orientation === 'row' && 'dragdroppable-row',
-          orientation === 'column' && 'dragdroppable-column',
-        ),
-      },
-      childFn(childProps),
-    );
-  }
-
-  return {
-    ...actual,
-    Draggable: MockDraggable,
-  };
-});
+jest.mock('src/dashboard/components/dnd/DragDroppable');
 
 const DEFAULT_HEADER_HEIGHT = 22;
 

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -413,6 +413,20 @@ describe('ChartHolder', () => {
     expect(fullscreenChartHolder.parentElement).toBe(document.body);
   });
 
+  test('should call setFullSizeChartId(null) when exiting fullscreen from chart menu', () => {
+    const setFullSizeChartId = jest.fn();
+    renderWrapper(createMockStore(), {
+      fullSizeChartId: chartId,
+      setFullSizeChartId,
+      editMode: false,
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'More Options' }));
+    userEvent.click(screen.getByText('Exit fullscreen'));
+
+    expect(setFullSizeChartId).toHaveBeenCalledWith(null);
+  });
+
   test('should call deleteComponent when deleted', async () => {
     const deleteComponent = jest.fn();
     const store = createMockStore();

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -397,6 +397,22 @@ describe('ChartHolder', () => {
     expect(computedWidth).toEqual(expectedWidth);
   });
 
+  test('should render fullscreen chart content via portal to document.body', async () => {
+    renderWrapper(createMockStore(), {
+      fullSizeChartId: chartId,
+    });
+
+    const fullscreenChartHolder = screen.getByTestId(
+      'dashboard-component-chart-holder',
+    );
+    const dragDroppable = screen.getByTestId('dragdroppable-object');
+
+    // Fullscreen content should be rendered outside the drag/drop container
+    // to avoid transform clipping in dashboard grid wrappers.
+    expect(dragDroppable.contains(fullscreenChartHolder)).toBe(false);
+    expect(fullscreenChartHolder.parentElement).toBe(document.body);
+  });
+
   test('should call deleteComponent when deleted', async () => {
     const deleteComponent = jest.fn();
     const store = createMockStore();

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -415,6 +415,25 @@ describe('ChartHolder', () => {
     expect(fullscreenChartHolder.parentElement).toBe(document.body);
   });
 
+  test('should return fullscreen chart content to the grid when fullscreen is cleared', () => {
+    const store = createMockStore();
+    const { rerender } = renderWrapper(store, {
+      fullSizeChartId: chartId,
+    });
+
+    expect(
+      screen.getByTestId('dashboard-component-chart-holder').parentElement,
+    ).toBe(document.body);
+
+    rerender(<ChartHolder {...defaultProps} fullSizeChartId={null} isInView />);
+
+    const chartHolder = screen.getByTestId('dashboard-component-chart-holder');
+    expect(
+      screen.getByTestId('dragdroppable-object').contains(chartHolder),
+    ).toBe(true);
+    expect(chartHolder.parentElement).not.toBe(document.body);
+  });
+
   test('should call setFullSizeChartId(null) when exiting fullscreen from chart menu', () => {
     const setFullSizeChartId = jest.fn();
     renderWrapper(createMockStore(), {

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -42,6 +42,58 @@ import {
 import ChartHolder, { CHART_MARGIN } from './ChartHolder';
 import { GRID_BASE_UNIT, GRID_GUTTER_SIZE } from '../../../util/constants';
 
+jest.mock('src/dashboard/components/dnd/DragDroppable', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- jest.mock factory
+  const React = require('react');
+  const actual = jest.requireActual(
+    'src/dashboard/components/dnd/DragDroppable',
+  );
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- jest.mock factory
+  const cx = require('classnames');
+
+  function MockDraggable(props: Record<string, unknown>) {
+    const { editMode, orientation, children, disableDragDrop } = props as {
+      editMode?: boolean;
+      orientation?: 'row' | 'column';
+      disableDragDrop?: boolean;
+      children: (childProps: Record<string, unknown>) => unknown;
+    };
+    const childFn = children as (
+      childProps: Record<string, unknown>,
+    ) => unknown;
+    const childProps = editMode
+      ? {
+          dragSourceRef: jest.fn(),
+          dropIndicatorProps: null,
+          draggingTabOnTab: false,
+          'data-test': 'dragdroppable-content',
+        }
+      : {
+          dropIndicatorProps: null,
+          'data-test': 'dragdroppable-content',
+        };
+    return React.createElement(
+      'div',
+      {
+        'data-test': 'dragdroppable-object',
+        'data-disable-drag-drop': String(!!disableDragDrop),
+        className: cx(
+          'dragdroppable',
+          editMode && 'dragdroppable--edit-mode',
+          orientation === 'row' && 'dragdroppable-row',
+          orientation === 'column' && 'dragdroppable-column',
+        ),
+      },
+      childFn(childProps),
+    );
+  }
+
+  return {
+    ...actual,
+    Draggable: MockDraggable,
+  };
+});
+
 const DEFAULT_HEADER_HEIGHT = 22;
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
@@ -425,6 +477,30 @@ describe('ChartHolder', () => {
     userEvent.click(screen.getByText('Exit fullscreen'));
 
     expect(setFullSizeChartId).toHaveBeenCalledWith(null);
+  });
+
+  test('should disable dashboard drag-and-drop while chart is fullscreen in edit mode', () => {
+    renderWrapper(createMockStore(), {
+      fullSizeChartId: chartId,
+      editMode: true,
+      isInView: true,
+    });
+    expect(screen.getByTestId('dragdroppable-object')).toHaveAttribute(
+      'data-disable-drag-drop',
+      'true',
+    );
+  });
+
+  test('should allow dashboard drag-and-drop when chart is not fullscreen in edit mode', () => {
+    renderWrapper(createMockStore(), {
+      fullSizeChartId: null,
+      editMode: true,
+      isInView: true,
+    });
+    expect(screen.getByTestId('dragdroppable-object')).toHaveAttribute(
+      'data-disable-drag-drop',
+      'false',
+    );
   });
 
   test('should call deleteComponent when deleted', async () => {

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
@@ -320,6 +320,7 @@ const ChartHolder = ({
       extraControls,
       isInView,
       handleDeleteComponent,
+      theme,
     ],
   );
 

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
@@ -373,7 +373,7 @@ const ChartHolder = ({
         index={index}
         depth={depth}
         onDrop={handleComponentDrop}
-        disableDragDrop={false}
+        disableDragDrop={isFullSize}
         editMode={editMode}
       >
         {renderChild}

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useState, useMemo, useCallback, useEffect, memo } from 'react';
+import { createPortal } from 'react-dom';
 
 import { ResizeCallback, ResizeStartCallback } from 're-resizable';
 import cx from 'classnames';
@@ -96,11 +97,14 @@ const ChartHolder = ({
   const theme = useTheme();
   const fullSizeStyle = css`
     && {
-      position: fixed !important;
+      position: fixed;
       z-index: 3000;
       left: 0;
       top: 0;
+      width: 100vw;
+      height: 100vh;
       padding: ${theme.sizeUnit * 2}px;
+      background: ${theme.colorBgContainer};
     }
   `;
   const { chartId } = component.meta;
@@ -238,6 +242,86 @@ const ChartHolder = ({
     }));
   }, []);
 
+  const chartContent = useMemo(
+    () => (
+      <div
+        data-test="dashboard-component-chart-holder"
+        style={isFullSize ? undefined : focusHighlightStyles}
+        css={isFullSize ? fullSizeStyle : undefined}
+        className={cx(
+          'dashboard-component',
+          'dashboard-component-chart-holder',
+          `dashboard-chart-id-${chartId}`,
+          outlinedComponentId ? 'fade-in' : 'fade-out',
+        )}
+      >
+        {!editMode && (
+          <AnchorLink
+            id={component.id}
+            scrollIntoView={outlinedComponentId === component.id}
+          />
+        )}
+        {!!outlinedComponentId && (
+          <style>
+            {`label[for=${outlinedColumnName}] + .Select .Select__control {
+                  border-color: ${theme.colorPrimary};
+                  transition: border-color 1s ease-in-out;
+                }`}
+          </style>
+        )}
+        <Chart
+          componentId={component.id}
+          id={component.meta.chartId ?? 0}
+          dashboardId={dashboardId}
+          width={chartWidth}
+          height={chartHeight}
+          sliceName={
+            component.meta.sliceNameOverride || component.meta.sliceName || ''
+          }
+          updateSliceName={(_sliceId: number, name: string) =>
+            handleUpdateSliceName(name)
+          }
+          isComponentVisible={isComponentVisible}
+          handleToggleFullSize={handleToggleFullSize}
+          isFullSize={isFullSize}
+          setControlValue={handleExtraControl}
+          extraControls={extraControls}
+          isInView={isInView}
+        />
+        {editMode && (
+          <HoverMenu position="top">
+            <div data-test="dashboard-delete-component-button">
+              <DeleteComponentButton onDelete={handleDeleteComponent} />
+            </div>
+          </HoverMenu>
+        )}
+      </div>
+    ),
+    [
+      isFullSize,
+      focusHighlightStyles,
+      fullSizeStyle,
+      chartId,
+      outlinedComponentId,
+      editMode,
+      component.id,
+      component.meta.chartId,
+      component.meta.sliceNameOverride,
+      component.meta.sliceName,
+      outlinedColumnName,
+      dashboardId,
+      chartWidth,
+      chartHeight,
+      handleUpdateSliceName,
+      isComponentVisible,
+      handleToggleFullSize,
+      handleExtraControl,
+      extraControls,
+      isInView,
+      handleDeleteComponent,
+    ],
+  );
+
   const renderChild = useCallback(
     ({ dragSourceRef }) => (
       <ResizableContainer
@@ -256,68 +340,16 @@ const ChartHolder = ({
         onResizeStop={onResizeStop}
         editMode={editMode}
       >
-        <div
-          ref={dragSourceRef}
-          data-test="dashboard-component-chart-holder"
-          style={focusHighlightStyles}
-          css={isFullSize ? fullSizeStyle : undefined}
-          className={cx(
-            'dashboard-component',
-            'dashboard-component-chart-holder',
-            // The following class is added to support custom dashboard styling via the CSS editor
-            `dashboard-chart-id-${chartId}`,
-            outlinedComponentId ? 'fade-in' : 'fade-out',
-          )}
-        >
-          {!editMode && (
-            <AnchorLink
-              id={component.id}
-              scrollIntoView={outlinedComponentId === component.id}
-            />
-          )}
-          {!!outlinedComponentId && (
-            <style>
-              {`label[for=${outlinedColumnName}] + .Select .Select__control {
-                    border-color: ${theme.colorPrimary};
-                    transition: border-color 1s ease-in-out;
-                  }`}
-            </style>
-          )}
-          <Chart
-            componentId={component.id}
-            id={component.meta.chartId ?? 0}
-            dashboardId={dashboardId}
-            width={chartWidth}
-            height={chartHeight}
-            sliceName={
-              component.meta.sliceNameOverride || component.meta.sliceName || ''
-            }
-            updateSliceName={(_sliceId: number, name: string) =>
-              handleUpdateSliceName(name)
-            }
-            isComponentVisible={isComponentVisible}
-            handleToggleFullSize={handleToggleFullSize}
-            isFullSize={isFullSize}
-            setControlValue={handleExtraControl}
-            extraControls={extraControls}
-            isInView={isInView}
-          />
-          {editMode && (
-            <HoverMenu position="top">
-              <div data-test="dashboard-delete-component-button">
-                <DeleteComponentButton onDelete={handleDeleteComponent} />
-              </div>
-            </HoverMenu>
-          )}
-        </div>
+        {isFullSize ? (
+          <div ref={dragSourceRef} />
+        ) : (
+          <div ref={dragSourceRef}>{chartContent}</div>
+        )}
       </ResizableContainer>
     ),
     [
       component.id,
       component.meta.height,
-      component.meta.chartId,
-      component.meta.sliceNameOverride,
-      component.meta.sliceName,
       parentComponent.type,
       columnWidth,
       widthMultiple,
@@ -326,38 +358,27 @@ const ChartHolder = ({
       onResize,
       onResizeStop,
       editMode,
-      focusHighlightStyles,
       isFullSize,
-      fullSizeStyle,
-      chartId,
-      outlinedComponentId,
-      outlinedColumnName,
-      dashboardId,
-      chartWidth,
-      chartHeight,
-      handleUpdateSliceName,
-      isComponentVisible,
-      handleToggleFullSize,
-      handleExtraControl,
-      extraControls,
-      isInView,
-      handleDeleteComponent,
+      chartContent,
     ],
   );
 
   return (
-    <Draggable
-      component={component}
-      parentComponent={parentComponent}
-      orientation={parentComponent.type === ROW_TYPE ? 'column' : 'row'}
-      index={index}
-      depth={depth}
-      onDrop={handleComponentDrop}
-      disableDragDrop={false}
-      editMode={editMode}
-    >
-      {renderChild}
-    </Draggable>
+    <>
+      <Draggable
+        component={component}
+        parentComponent={parentComponent}
+        orientation={parentComponent.type === ROW_TYPE ? 'column' : 'row'}
+        index={index}
+        depth={depth}
+        onDrop={handleComponentDrop}
+        disableDragDrop={false}
+        editMode={editMode}
+      >
+        {renderChild}
+      </Draggable>
+      {isFullSize && createPortal(chartContent, document.body)}
+    </>
   );
 };
 

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.tsx
@@ -103,6 +103,7 @@ const ChartHolder = ({
       top: 0;
       width: 100vw;
       height: 100vh;
+      box-sizing: border-box;
       padding: ${theme.sizeUnit * 2}px;
       background: ${theme.colorBgContainer};
     }


### PR DESCRIPTION
### SUMMARY

#### ISSUE:
Users were unable to view chart tiles from the dashboard in full-screen using the "Enter Fullscreen" option.

#### ROOT CAUSE:
Dashboard chart **Enter fullscreen** used `position: fixed` on a node still under the dashboard grid. Ancestors (e.g. `dragdroppable-column` with `transform: translate3d(0, 0, 0)`) create a new containing block, so `fixed` was relative to that cell instead of the viewport, causing charts to look zoomed but stay clipped in the tile.

#### FIX:
This change **renders fullscreen chart content with `createPortal(..., document.body)`** so it escapes those transforms, keeps a lightweight placeholder in the grid for drag/resize, and adds a full-viewport shell (`100vw` / `100vh`, theme background). A **unit test** asserts the fullscreen holder is attached under `document.body`, not under the drag/drop wrapper.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

 #### BEFORE: Chart enlarges but stays bounded by the dashboard tile / grid.
![superset-fullscreen-before-fix-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/464cadb6-cc39-4cee-ae1a-b5e9084a8381)

#### AFTER: Chart fills the viewport; exit fullscreen returns to normal layout.
![superset-fullscreen-after-fix-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/4cc1b5bf-b3ef-423f-82f2-5f2c64244ef3)

### TESTING INSTRUCTIONS

1. Open a dashboard with at least one chart (try a line/bar chart and a table).
2. Use the chart `…` menu → **Enter fullscreen**.
3. Confirm the chart uses the **full viewport** (not clipped to the original tile).
4. **Exit fullscreen** and confirm the chart returns to its grid position with no layout glitches.
5. Toggle fullscreen several times; optionally resize the browser while fullscreen.
6. _(Optional)_ Run frontend tests:  
   `cd superset-frontend && npx jest --no-coverage src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: **none**
- [x] Changes UI _(fullscreen overlay behavior only)_
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
