### PR TITLE
fix(reports): log exception traceback in _get_csv_data

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -479,7 +479,7 @@ class BaseReportState:
             raise ReportScheduleCsvTimeout() from ex
         except Exception as ex:
             elapsed_seconds = (datetime.utcnow() - start_time).total_seconds()
-            logger.error(
+            logger.exception(
                 "CSV generation failed after %.2fs - execution_id: %s",
                 elapsed_seconds,
                 self._execution_id,


### PR DESCRIPTION
### SUMMARY

The `except Exception` block in `_get_csv_data` uses `logger.error()` without `exc_info`, which silently drops the exception traceback. This makes it difficult to diagnose CSV generation failures in report schedules since only the timing and execution ID are logged — not *what* went wrong.

This switches to `logger.exception()` to include the full stack trace, consistent with how other `except Exception` blocks in the same file handle logging (e.g. `_update_slack_recipients` at line 174).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — logging-only change, no UI impact.

### TESTING INSTRUCTIONS
1. Trigger a report schedule that generates CSV data from a chart.
2. Force a failure scenario (e.g. invalid chart query context).
3. Verify the Superset logs now include the full exception traceback instead of just `"CSV generation failed after X.XXs - execution_id: ..."`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API