### PR TITLE
fix(chart): word cloud secondary sort prevents Druid TopN optimization when sort_by_metric enabled

### DIFF
--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/buildQuery.ts
@@ -28,8 +28,7 @@ export default function buildQuery(formData: WordCloudFormData) {
 
   if (sort_by_metric && metric) {
     orderby.push([metric, false]);
-  }
-  if (series) {
+  } else if (series) {
     orderby.push([series, true]);
   }
 

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/buildQuery.ts
@@ -21,14 +21,16 @@ import { buildQueryContext, QueryFormOrderBy } from '@superset-ui/core';
 import { WordCloudFormData } from '../types';
 
 export default function buildQuery(formData: WordCloudFormData) {
-  const { metric, sort_by_metric, series, row_limit } = formData;
+  const { metric, sort_by_metric, sort_by_series, series, row_limit } =
+    formData;
   const orderby: QueryFormOrderBy[] = [];
   const shouldApplyOrderBy =
     row_limit !== undefined && row_limit !== null && row_limit !== 0;
 
   if (sort_by_metric && metric) {
     orderby.push([metric, false]);
-  } else if (series) {
+  }
+  if (sort_by_series && series) {
     orderby.push([series, true]);
   }
 

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.tsx
@@ -35,6 +35,21 @@ const config: ControlPanelConfig = {
         ['adhoc_filters'],
         ['row_limit'],
         ['sort_by_metric'],
+        [
+          {
+            name: 'sort_by_series',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Sort by series'),
+              default: false,
+              description: t(
+                'Include a secondary sort by series name (ascending). '
+                  + 'This produces consistent ordering when multiple series have the '
+                  + 'same metric value, but may reduce query performance on some databases.',
+              ),
+            },
+          },
+        ],
       ],
     },
     {

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.tsx
@@ -43,9 +43,10 @@ const config: ControlPanelConfig = {
               label: t('Sort by series'),
               default: false,
               description: t(
-                'Include a secondary sort by series name (ascending). '
-                  + 'This produces consistent ordering when multiple series have the '
-                  + 'same metric value, but may reduce query performance on some databases.',
+                'Sort results by series name in ascending order. ' +
+                  'When combined with "Sort by metric", this acts as a tiebreaker ' +
+                  'for equal metric values. Adding this sort may reduce query ' +
+                  'performance on some databases.',
               ),
             },
           },

--- a/superset-frontend/plugins/plugin-chart-word-cloud/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/test/buildQuery.test.ts
@@ -21,17 +21,52 @@ import { VizType } from '@superset-ui/core';
 import { WordCloudFormData } from '../src';
 import buildQuery from '../src/plugin/buildQuery';
 
-describe('WordCloud buildQuery', () => {
-  const formData: WordCloudFormData = {
-    datasource: '5__table',
-    granularity_sqla: 'ds',
-    series: 'foo',
-    viz_type: VizType.WordCloud,
-  };
+const basicFormData: WordCloudFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  series: 'foo',
+  viz_type: VizType.WordCloud,
+};
 
-  test('should build columns from series in form data', () => {
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    expect(query.columns).toEqual(['foo']);
+describe('plugin-chart-word-cloud', () => {
+  describe('buildQuery', () => {
+    test('should build columns from series in form data', () => {
+      const queryContext = buildQuery(basicFormData);
+      const [query] = queryContext.queries;
+      expect(query.columns).toEqual(['foo']);
+    });
+
+    test('should order by series ASC when sort_by_metric is false', () => {
+      const queryContext = buildQuery({
+        ...basicFormData,
+        metric: 'count',
+        sort_by_metric: false,
+        row_limit: 100,
+      });
+      const [query] = queryContext.queries;
+      expect(query.orderby).toEqual([['foo', true]]);
+    });
+
+    test('should order by metric DESC only when sort_by_metric is true', () => {
+      const queryContext = buildQuery({
+        ...basicFormData,
+        metric: 'count',
+        sort_by_metric: true,
+        row_limit: 100,
+      });
+      const [query] = queryContext.queries;
+      expect(query.orderby).toEqual([['count', false]]);
+    });
+
+    test('should not include secondary series sort when sort_by_metric is true', () => {
+      const queryContext = buildQuery({
+        ...basicFormData,
+        metric: 'count',
+        sort_by_metric: true,
+        row_limit: 100,
+      });
+      const [query] = queryContext.queries;
+      expect(query.orderby).toHaveLength(1);
+    });
   });
 });

--- a/superset-frontend/plugins/plugin-chart-word-cloud/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/test/buildQuery.test.ts
@@ -36,15 +36,16 @@ describe('plugin-chart-word-cloud', () => {
       expect(query.columns).toEqual(['foo']);
     });
 
-    test('should order by series ASC when sort_by_metric is false', () => {
+    test('should not include orderby when neither sort option is enabled', () => {
       const queryContext = buildQuery({
         ...basicFormData,
         metric: 'count',
         sort_by_metric: false,
+        sort_by_series: false,
         row_limit: 100,
       });
       const [query] = queryContext.queries;
-      expect(query.orderby).toEqual([['foo', true]]);
+      expect(query.orderby).toBeUndefined();
     });
 
     test('should order by metric DESC only when sort_by_metric is true', () => {
@@ -52,21 +53,38 @@ describe('plugin-chart-word-cloud', () => {
         ...basicFormData,
         metric: 'count',
         sort_by_metric: true,
+        sort_by_series: false,
         row_limit: 100,
       });
       const [query] = queryContext.queries;
       expect(query.orderby).toEqual([['count', false]]);
     });
 
-    test('should not include secondary series sort when sort_by_metric is true', () => {
+    test('should order by series ASC only when sort_by_series is true', () => {
+      const queryContext = buildQuery({
+        ...basicFormData,
+        metric: 'count',
+        sort_by_metric: false,
+        sort_by_series: true,
+        row_limit: 100,
+      });
+      const [query] = queryContext.queries;
+      expect(query.orderby).toEqual([['foo', true]]);
+    });
+
+    test('should order by metric DESC then series ASC when both are true', () => {
       const queryContext = buildQuery({
         ...basicFormData,
         metric: 'count',
         sort_by_metric: true,
+        sort_by_series: true,
         row_limit: 100,
       });
       const [query] = queryContext.queries;
-      expect(query.orderby).toHaveLength(1);
+      expect(query.orderby).toEqual([
+        ['count', false],
+        ['foo', true],
+      ]);
     });
   });
 });

--- a/superset/migrations/versions/2026-04-13_19-28_fd0c8583b46d_add_sort_by_series_to_word_cloud_charts.py
+++ b/superset/migrations/versions/2026-04-13_19-28_fd0c8583b46d_add_sort_by_series_to_word_cloud_charts.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add sort_by_series to word_cloud charts
+
+Revision ID: fd0c8583b46d
+Revises: ce6bd21901ab
+Create Date: 2026-04-13 19:28:19.021839
+
+"""
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+from superset.migrations.shared.utils import paginated_update
+from superset.utils import json
+
+# revision identifiers, used by Alembic.
+revision = "fd0c8583b46d"
+down_revision = "ce6bd21901ab"
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+    id = Column(Integer, primary_key=True)
+    viz_type = Column(String(250))
+    params = Column(Text)
+
+
+def upgrade_params(params: dict) -> dict:
+    if "sort_by_series" not in params:
+        params["sort_by_series"] = True
+    return params
+
+
+def downgrade_params(params: dict) -> dict:
+    params.pop("sort_by_series", None)
+    return params
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in paginated_update(
+        session.query(Slice).filter(Slice.viz_type == "word_cloud")
+    ):
+        params = json.loads(slc.params or "{}")
+        slc.params = json.dumps(upgrade_params(params))
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in paginated_update(
+        session.query(Slice).filter(Slice.viz_type == "word_cloud")
+    ):
+        params = json.loads(slc.params or "{}")
+        slc.params = json.dumps(downgrade_params(params))
+    session.close()

--- a/superset/migrations/versions/2026-04-13_19-28_fd0c8583b46d_add_sort_by_series_to_word_cloud_charts.py
+++ b/superset/migrations/versions/2026-04-13_19-28_fd0c8583b46d_add_sort_by_series_to_word_cloud_charts.py
@@ -62,8 +62,13 @@ def upgrade():
     for slc in paginated_update(
         session.query(Slice).filter(Slice.viz_type == "word_cloud")
     ):
-        params = json.loads(slc.params or "{}")
-        slc.params = json.dumps(upgrade_params(params))
+        try:
+            params = json.loads(slc.params or "{}")
+            if not isinstance(params, dict):
+                continue
+            slc.params = json.dumps(upgrade_params(params))
+        except (json.JSONDecodeError, TypeError):
+            continue
     session.close()
 
 
@@ -74,6 +79,11 @@ def downgrade():
     for slc in paginated_update(
         session.query(Slice).filter(Slice.viz_type == "word_cloud")
     ):
-        params = json.loads(slc.params or "{}")
-        slc.params = json.dumps(downgrade_params(params))
+        try:
+            params = json.loads(slc.params or "{}")
+            if not isinstance(params, dict):
+                continue
+            slc.params = json.dumps(downgrade_params(params))
+        except (json.JSONDecodeError, TypeError):
+            continue
     session.close()


### PR DESCRIPTION
### SUMMARY

When `sort_by_metric` is enabled on a Word Cloud chart, `buildQuery.ts` unconditionally appended a secondary `ORDER BY [series, ASC]` alongside the metric sort. On Apache Druid, any multi-column `ORDER BY` prevents the native TopN query optimization, forcing a full GroupBy scan over the entire dataset before applying `LIMIT`. On high-cardinality dimensions this can cause dramatic query slowdowns and timeouts.

**Root cause** — in `buildQuery.ts`, the series sort was always appended when `series` was set, regardless of `sort_by_metric`:
```typescript
if (sort_by_metric && metric) {
  orderby.push([metric, false]);
}
if (series) {
  orderby.push([series, true]);  // ← always added
}
```

**Fix** — add an independent `sort_by_series` control so users can choose whether to include the secondary dimension sort:
```typescript
if (sort_by_metric && metric) {
  orderby.push([metric, false]);
}
if (sort_by_series && series) {
  orderby.push([series, true]);
}
```

This gives users full control over sorting behavior:
- **Metric only** (new default for new charts): enables Druid TopN optimization
- **Series only**: alphabetical ordering by dimension
- **Both**: metric sort with series tiebreaker (previous behavior, preserved for existing charts)
- **Neither**: no explicit ordering

**Changes:**
- `buildQuery.ts`: `sort_by_metric` and `sort_by_series` are now independent controls
- `controlPanel.tsx`: new "Sort by series" checkbox (default: `false` for new charts)
- `buildQuery.test.ts`: test coverage for all four sort combinations
- DB migration: sets `sort_by_series=true` for all existing `word_cloud` charts to preserve backward compatibility

Fixes #39072

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — no visual change to the word cloud rendering. The new "Sort by series" checkbox appears in the Query section of the word cloud control panel, below "Sort by metric".

### TESTING INSTRUCTIONS

1. Create a new Word Cloud chart — verify "Sort by series" is **unchecked** by default
2. Enable "Sort by metric" only — verify the generated query has a single `ORDER BY <metric> DESC`
3. Enable both "Sort by metric" and "Sort by series" — verify the query has `ORDER BY <metric> DESC, <series> ASC`
4. Open an existing word cloud chart — verify "Sort by series" is **checked** (set by migration)

Unit tests:
```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-word-cloud/test/buildQuery.test.ts --no-coverage
```

Migration test:
```bash
superset db upgrade   # sets sort_by_series=true for existing word_cloud charts
superset db downgrade # removes sort_by_series from word_cloud charts
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: #39072
- [ ] Required feature flags:
- [x] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Runtime estimate:** Migration processes only `word_cloud` charts (typically a small number). Tested against 6 charts in < 1 second. No downtime required.