### PR TITLE
fix(sqllab): Update style for code viewer container

### DIFF
--- a/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled, useTheme } from '@apache-superset/core/theme';
+import { css, styled, useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { ModalTrigger } from '@superset-ui/core/components';
 import CodeSyntaxHighlighter from '@superset-ui/core/components/CodeSyntaxHighlighter';
@@ -81,7 +81,11 @@ function HighlightSqlModal({ rawSql, sql }: HighlightedSqlModalTypes) {
   };
 
   return (
-    <div>
+    <div
+      css={css`
+        margin: -${theme.sizeUnit * 6}px;
+      `}
+    >
       <Title>{t('Source SQL')}</Title>
       <CodeSyntaxHighlighter language="sql" customStyle={codeBlockStyle}>
         {sql}

--- a/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useTheme } from '@apache-superset/core/theme';
+import { styled, useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { ModalTrigger } from '@superset-ui/core/components';
 import CodeSyntaxHighlighter from '@superset-ui/core/components/CodeSyntaxHighlighter';
@@ -40,6 +40,12 @@ interface TriggerNodeProps {
   maxLines: number;
   maxWidth: number;
 }
+
+const Title = styled.h4`
+  font-size: ${({ theme }) => theme.fontSizeLG}px;
+  margin: ${({ theme }) => theme.sizeUnit * 2}px 0;
+  font-weight: ${({ theme }) => theme.fontWeightStrong};
+`;
 
 const shrinkSql = (sql: string, maxLines: number, maxWidth: number) => {
   const ssql = sql || '';
@@ -69,17 +75,20 @@ function HighlightSqlModal({ rawSql, sql }: HighlightedSqlModalTypes) {
     border: 1,
     borderColor: theme.colorBorder,
     borderStyle: 'solid',
+    backgroundColor: theme.colorBgLayout,
+    fontSize: theme.fontSize * 0.9,
+    padding: theme.sizeUnit * 2,
   };
 
   return (
     <div>
-      <h4>{t('Source SQL')}</h4>
+      <Title>{t('Source SQL')}</Title>
       <CodeSyntaxHighlighter language="sql" customStyle={codeBlockStyle}>
         {sql}
       </CodeSyntaxHighlighter>
       {rawSql && rawSql !== sql && (
         <div>
-          <h4>{t('Executed SQL')}</h4>
+          <Title>{t('Executed SQL')}</Title>
           <CodeSyntaxHighlighter language="sql" customStyle={codeBlockStyle}>
             {rawSql}
           </CodeSyntaxHighlighter>

--- a/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { ModalTrigger } from '@superset-ui/core/components';
 import CodeSyntaxHighlighter from '@superset-ui/core/components/CodeSyntaxHighlighter';
@@ -63,14 +64,25 @@ function TriggerNode({ shrink, sql, maxLines, maxWidth }: TriggerNodeProps) {
 }
 
 function HighlightSqlModal({ rawSql, sql }: HighlightedSqlModalTypes) {
+  const theme = useTheme();
+  const codeBlockStyle = {
+    border: 1,
+    borderColor: theme.colorBorder,
+    borderStyle: 'solid',
+  };
+
   return (
     <div>
       <h4>{t('Source SQL')}</h4>
-      <CodeSyntaxHighlighter language="sql">{sql}</CodeSyntaxHighlighter>
+      <CodeSyntaxHighlighter language="sql" customStyle={codeBlockStyle}>
+        {sql}
+      </CodeSyntaxHighlighter>
       {rawSql && rawSql !== sql && (
         <div>
           <h4>{t('Executed SQL')}</h4>
-          <CodeSyntaxHighlighter language="sql">{rawSql}</CodeSyntaxHighlighter>
+          <CodeSyntaxHighlighter language="sql" customStyle={codeBlockStyle}>
+            {rawSql}
+          </CodeSyntaxHighlighter>
         </div>
       )}
     </div>

--- a/superset-frontend/src/features/queries/QueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/QueryPreviewModal.tsx
@@ -65,6 +65,7 @@ const TabButton = styled.div`
 const StyledModal = styled(Modal)`
   .ant-modal-body {
     padding: ${({ theme }) => theme.sizeUnit * 6}px;
+    padding-top: 0;
   }
 `;
 

--- a/superset-frontend/src/features/queries/QueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/QueryPreviewModal.tsx
@@ -99,8 +99,8 @@ function QueryPreviewModal({
     borderColor: theme.colorBorder,
     borderStyle: 'solid',
     marginTop: theme.sizeUnit * 4,
-    fontSize: '0.75em',
-    height: 375,
+    fontSize: theme.fontSize * 0.75,
+    height: theme.sizeUnit * 100,
   };
 
   const [currentTab, setCurrentTab] = useState<'user' | 'executed'>('user');

--- a/superset-frontend/src/features/queries/QueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/QueryPreviewModal.tsx
@@ -18,7 +18,7 @@
  */
 import { useState } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { styled } from '@apache-superset/core/theme';
+import { useTheme, styled } from '@apache-superset/core/theme';
 import cx from 'classnames';
 import { Button, Modal } from '@superset-ui/core/components';
 import withToasts, {
@@ -93,6 +93,15 @@ function QueryPreviewModal({
       currentQueryId: query.id,
       fetchData,
     });
+  const theme = useTheme();
+  const codeBlockStyle = {
+    border: 1,
+    borderColor: theme.colorBorder,
+    borderStyle: 'solid',
+    marginTop: theme.sizeUnit * 4,
+    fontSize: '0.75em',
+    height: 375,
+  };
 
   const [currentTab, setCurrentTab] = useState<'user' | 'executed'>('user');
 
@@ -157,6 +166,7 @@ function QueryPreviewModal({
           addDangerToast={addDangerToast}
           addSuccessToast={addSuccessToast}
           language="sql"
+          customStyle={codeBlockStyle}
         >
           {(currentTab === 'user' ? sql : executed_sql) || ''}
         </SyntaxHighlighterCopy>

--- a/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
@@ -41,6 +41,7 @@ const QueryLabel = styled.div`
 const StyledModal = styled(Modal)`
   .ant-modal-body {
     padding: 24px;
+    padding-top: 0;
   }
 `;
 

--- a/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
@@ -83,8 +83,8 @@ const SavedQueryPreviewModal: FunctionComponent<
     borderColor: theme.colorBorder,
     borderStyle: 'solid',
     marginTop: theme.sizeUnit * 4,
-    fontSize: '0.75em',
-    height: 375,
+    fontSize: theme.fontSize * 0.75,
+    height: theme.sizeUnit * 100,
   };
 
   return (

--- a/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
@@ -18,7 +18,7 @@
  */
 import { FunctionComponent } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { styled } from '@apache-superset/core/theme';
+import { useTheme, styled } from '@apache-superset/core/theme';
 import { Button, Modal } from '@superset-ui/core/components';
 import SyntaxHighlighterCopy from 'src/features/queries/SyntaxHighlighterCopy';
 import withToasts, {
@@ -77,6 +77,15 @@ const SavedQueryPreviewModal: FunctionComponent<
       currentQueryId: savedQuery.id,
       fetchData,
     });
+  const theme = useTheme();
+  const codeBlockStyle = {
+    border: 1,
+    borderColor: theme.colorBorder,
+    borderStyle: 'solid',
+    marginTop: theme.sizeUnit * 4,
+    fontSize: '0.75em',
+    height: 375,
+  };
 
   return (
     <div role="none" onKeyUp={handleKeyPress}>
@@ -123,6 +132,7 @@ const SavedQueryPreviewModal: FunctionComponent<
           language="sql"
           addDangerToast={addDangerToast}
           addSuccessToast={addSuccessToast}
+          customStyle={codeBlockStyle}
         >
           {savedQuery.sql || ''}
         </SyntaxHighlighterCopy>


### PR DESCRIPTION
### SUMMARY

Fixes #39076

This commit updates the style for code viewer matching with the previous version.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="749" height="658" alt="●_Superset_6_1_-_SQL_Lab_view_query_looks_bad_-_Asana" src="https://github.com/user-attachments/assets/af7e092d-a380-48ac-a594-55c2c2f3c415" />

After:

<img width="856" height="665" alt="Screenshot 2026-04-02 at 5 25 16 PM" src="https://github.com/user-attachments/assets/188733e5-1da9-4470-8b30-45bfa1e340af" />


### TESTING INSTRUCTIONS

Screenshot

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
