### PR TITLE
fix(security_manager): custom auth_view issue

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -261,6 +261,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     userstatschartview = None
     register_superset_auth_view = True
     """Set to False in subclasses that provide their own auth view."""
+    register_superset_registeruser_view = True
+    """Set to False in subclasses that provide their own register user view."""
     READ_ONLY_MODEL_VIEWS = {"Database", "DynamicPlugin"}
 
     role_api = SupersetRoleApi
@@ -3171,9 +3173,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         if self.register_superset_auth_view:
             self.auth_view = self.appbuilder.add_view_no_menu(SupersetAuthView)
-        self.registeruser_view = self.appbuilder.add_view_no_menu(
-            SupersetRegisterUserView
-        )
+        if self.register_superset_registeruser_view:
+            self.registeruser_view = self.appbuilder.add_view_no_menu(
+                SupersetRegisterUserView
+            )
 
         # Apply rate limiting to auth view if enabled
         # This needs to be done after the view is added, otherwise the blueprint

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -259,6 +259,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     SecurityManager
 ):
     userstatschartview = None
+    register_superset_auth_view = True
+    """Set to False in subclasses that provide their own auth view."""
     READ_ONLY_MODEL_VIEWS = {"Database", "DynamicPlugin"}
 
     role_api = SupersetRoleApi
@@ -3167,7 +3169,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     def register_views(self) -> None:
         from superset.views.auth import SupersetAuthView, SupersetRegisterUserView
 
-        self.auth_view = self.appbuilder.add_view_no_menu(SupersetAuthView)
+        if self.register_superset_auth_view:
+            self.auth_view = self.appbuilder.add_view_no_menu(SupersetAuthView)
         self.registeruser_view = self.appbuilder.add_view_no_menu(
             SupersetRegisterUserView
         )


### PR DESCRIPTION
### SUMMARY
The theming PR #31590 broke support for overriding the `/login/` endpoint:

<img width="1121" height="421" alt="image" src="https://github.com/user-attachments/assets/c7238e06-3f99-4b73-9fb8-6ae704a829a9" />

This PR makes registering `SupersetAuthView` optional by introducing a new flag `register_superset_auth_view` on the `SupersetSecurityManager`. To provide a custom auth endpoint, e.g. in OAuth providers, just set the following:

```python
...
register_superset_auth_view = False
authoauthview = MyCustomOAuthView
...
```

While we're at it, we add similar logic for `registeruser_view` to provide similar flexibility for custom user registration views.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
