### PR TITLE
fix(migrations): check pre-existing foreign keys on create util

### DIFF
--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -199,6 +199,18 @@ def has_table(table_name: str) -> bool:
     return table_exists
 
 
+def get_foreign_key_names(table_name: str) -> set[str]:
+    """
+    Get the set of foreign key constraint names for a table.
+
+    :param table_name: The table name
+    :returns: A set of foreign key constraint names
+    """
+    connection = op.get_bind()
+    inspector = Inspector.from_engine(connection)
+    return {fk["name"] for fk in inspector.get_foreign_keys(table_name)}
+
+
 def drop_fks_for_table(
     table_name: str, foreign_key_names: list[str] | None = None
 ) -> None:
@@ -211,13 +223,12 @@ def drop_fks_for_table(
     If None is provided, all will be dropped.
     """
     connection = op.get_bind()
-    inspector = Inspector.from_engine(connection)
 
     if isinstance(connection.dialect, SQLiteDialect):
         return  # sqlite doesn't like constraints
 
     if has_table(table_name):
-        existing_fks = {fk["name"] for fk in inspector.get_foreign_keys(table_name)}
+        existing_fks = get_foreign_key_names(table_name)
 
         # What to delete based on whether the list was passed
         if foreign_key_names is not None:
@@ -523,9 +534,7 @@ def create_fks_for_table(
         )
         return
 
-    inspector = Inspector.from_engine(connection)
-    existing_fks = {fk["name"] for fk in inspector.get_foreign_keys(table_name)}
-    if foreign_key_name in existing_fks:
+    if foreign_key_name in get_foreign_key_names(table_name):
         logger.info(
             f"Foreign key {GREEN}{foreign_key_name}{RESET} already exists on table "
             f"{GREEN}{table_name}{RESET}. Skipping..."

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -536,8 +536,13 @@ def create_fks_for_table(
 
     if foreign_key_name in get_foreign_key_names(table_name):
         logger.info(
-            f"Foreign key {GREEN}{foreign_key_name}{RESET} already exists on table "
-            f"{GREEN}{table_name}{RESET}. Skipping..."
+            "Foreign key %s%s%s already exists on table %s%s%s. Skipping...",
+            GREEN,
+            foreign_key_name,
+            RESET,
+            GREEN,
+            table_name,
+            RESET,
         )
         return
 

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -523,6 +523,15 @@ def create_fks_for_table(
         )
         return
 
+    inspector = Inspector.from_engine(connection)
+    existing_fks = {fk["name"] for fk in inspector.get_foreign_keys(table_name)}
+    if foreign_key_name in existing_fks:
+        logger.info(
+            f"Foreign key {GREEN}{foreign_key_name}{RESET} already exists on table "
+            f"{GREEN}{table_name}{RESET}. Skipping..."
+        )
+        return
+
     if isinstance(connection.dialect, SQLiteDialect):
         # SQLite requires batch mode since ALTER TABLE is limited
         with op.batch_alter_table(table_name) as batch_op:


### PR DESCRIPTION
### SUMMARY
Currently only the `drop_fks_for_table` util gracefully handles pre-existing foreign keys, but not `create_fks_for_table`. This breaks out a util for retrieving all foreign keys on a table, and also adds graceful handling of pre-existing foreign keys to `create_fks_for_table`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
