### PR TITLE
fix(mcp): remove JWT ValueError g.user fallback in auth layer

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -487,12 +487,17 @@ def _setup_user_context() -> User | None:
                 _cleanup_session_on_error()
                 continue
             logger.error("DB connection failed on retry during user setup: %s", e)
+            _cleanup_session_on_error()
             raise
         except ValueError as e:
             # User resolution failed — fail closed. Do not fall back to
             # g.user from middleware, as that could allow a request to
             # proceed as a different user in multi-tenant deployments.
+            # Clear g.user so error/audit logging doesn't attribute
+            # the denied request to the middleware-provided identity.
             logger.error("MCP user resolution failed, denying request: %s", e)
+            if has_request_context():
+                g.pop("user", None)
             raise
 
     g.user = user

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -489,11 +489,10 @@ def _setup_user_context() -> User | None:
             logger.error("DB connection failed on retry during user setup: %s", e)
             raise
         except ValueError as e:
-            # JWT user resolution failed (e.g. SAML subject not in DB).
-            # Fail closed — do not fall back to g.user from middleware,
-            # as that could allow a request to proceed as a different
-            # user in multi-tenant deployments.
-            logger.error("JWT user resolution failed, denying request: %s", e)
+            # User resolution failed — fail closed. Do not fall back to
+            # g.user from middleware, as that could allow a request to
+            # proceed as a different user in multi-tenant deployments.
+            logger.error("MCP user resolution failed, denying request: %s", e)
             raise
 
     g.user = user

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -490,23 +490,10 @@ def _setup_user_context() -> User | None:
             raise
         except ValueError as e:
             # JWT user resolution failed (e.g. SAML subject not in DB).
-            # Log a security warning but fall back to middleware-provided
-            # g.user if available. This handles cases where the JWT
-            # resolver username format doesn't match the DB username
-            # (e.g., SAML subject vs email). A separate story should
-            # investigate whether any deployments hit this path and
-            # migrate them before removing the fallback entirely.
-            if has_request_context() and hasattr(g, "user") and g.user:
-                logger.warning(
-                    "SECURITY: JWT user resolution failed (%s), falling "
-                    "back to middleware-provided g.user=%s. This fallback "
-                    "should be investigated and removed once all "
-                    "deployments use consistent username resolution.",
-                    e,
-                    g.user.username,
-                )
-                user = g.user
-                break
+            # Fail closed — do not fall back to g.user from middleware,
+            # as that could allow a request to proceed as a different
+            # user in multi-tenant deployments.
+            logger.error("JWT user resolution failed, denying request: %s", e)
             raise
 
     g.user = user

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -435,12 +435,16 @@ def test_setup_user_context_propagates_valueerror(app) -> None:
     This is a security-critical test: when JWT resolution explicitly fails
     (user not in DB), the request must be denied. The auth layer must NOT
     silently fall back to g.user from middleware.
+
+    Uses test_request_context() so g.user is preserved (not cleared by
+    the no-request-context guard), validating that the ValueError still
+    propagates even when middleware has set g.user.
     """
     from superset.mcp_service.auth import _setup_user_context
 
     fallback_user = _make_mock_user("middleware_user")
 
-    with app.app_context():
+    with app.test_request_context():
         g.user = fallback_user
         with patch(
             "superset.mcp_service.auth.get_user_from_request",
@@ -448,3 +452,5 @@ def test_setup_user_context_propagates_valueerror(app) -> None:
         ):
             with pytest.raises(ValueError, match="User 'ghost' not found"):
                 _setup_user_context()
+            # g.user should be cleared after ValueError (no misleading audit)
+            assert not hasattr(g, "user") or g.user is None

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -427,3 +427,24 @@ def test_default_resolver_preferred_username_takes_priority() -> None:
         }
     )
     assert default_user_resolver(None, token) == "alice"
+
+
+def test_setup_user_context_propagates_valueerror(app) -> None:
+    """ValueError from get_user_from_request propagates — no g.user fallback.
+
+    This is a security-critical test: when JWT resolution explicitly fails
+    (user not in DB), the request must be denied. The auth layer must NOT
+    silently fall back to g.user from middleware.
+    """
+    from superset.mcp_service.auth import _setup_user_context
+
+    fallback_user = _make_mock_user("middleware_user")
+
+    with app.app_context():
+        g.user = fallback_user
+        with patch(
+            "superset.mcp_service.auth.get_user_from_request",
+            side_effect=ValueError("User 'ghost' not found"),
+        ):
+            with pytest.raises(ValueError, match="User 'ghost' not found"):
+                _setup_user_context()


### PR DESCRIPTION
## Summary

Remove the unsafe fallback in `_setup_user_context()` that caught `ValueError` from `get_user_from_request()` and silently fell back to `g.user` from middleware. This could allow a request to proceed as a different user when JWT resolution fails (e.g., SAML subject not in DB).

## Why

- 30 days of Datadog monitoring across all environments showed **zero hits** on the `SECURITY: JWT user resolution failed` warning log added in #39015
- No deployments depend on this fallback path
- The fallback poses a theoretical security risk in multi-tenant deployments — if JWT says "user A" but the DB lookup fails, the request could proceed as whoever `g.user` was set to by middleware

## What changed

- Removed the `except ValueError` handler in `_setup_user_context()` that caught JWT resolution failures and fell back to `g.user`
- ValueError now propagates (fail closed), denying the request with a logged error
- The normal `g.user` fallback in `get_user_from_request()` Priority 4 is **unchanged** — that's the correct path for Preset middleware when no JWT/API key is present

## Test plan

- [x] All 1052 MCP unit tests pass
- [x] Pre-commit hooks pass (mypy, ruff, pylint)
- [x] Auth-specific tests pass (test_auth_user_resolution.py, test_auth_api_key.py)
- [ ] E2E staging verification