### PR TITLE
fix(big-number): guard against null colorPicker in transformProps

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
@@ -56,6 +56,7 @@ jest.mock('@superset-ui/chart-controls', () => ({
 }));
 
 jest.mock('@superset-ui/core', () => ({
+  BRAND_COLOR: '#00A699',
   GenericDataType: { Temporal: 2, String: 1 },
   extractTimegrain: jest.fn(() => 'P1D'),
   getMetricLabel: jest.fn(metric => metric),
@@ -279,5 +280,31 @@ describe('BigNumberWithTrendline transformProps', () => {
     );
     expect(result.bigNumber).toBe(360);
     expect(result.subheader).toBe('50.0% WoW');
+  });
+
+  test('should not crash and should return undefined mainColor when colorPicker is null', () => {
+    const chartProps = {
+      width: 400,
+      height: 300,
+      queriesData: [
+        {
+          data: [
+            { __timestamp: 1, value: 100 },
+          ] as unknown as BigNumberDatum[],
+          colnames: ['__timestamp', 'value'],
+          coltypes: ['TEMPORAL', 'NUMERIC'],
+        },
+      ],
+      formData: { ...baseFormData, colorPicker: null },
+      rawFormData: baseRawFormData,
+      hooks: baseHooks,
+      datasource: baseDatasource,
+      theme: { colors: { grayscale: { light5: '#eee' } } },
+    };
+
+    const result = transformProps(
+      chartProps as unknown as BigNumberWithTrendlineChartProps,
+    );
+    expect(result.mainColor).toBeUndefined();
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -18,6 +18,7 @@
  */
 import { t } from '@apache-superset/core/translation';
 import {
+  BRAND_COLOR,
   extractTimegrain,
   getNumberFormatter,
   NumberFormats,
@@ -140,8 +141,9 @@ export default function transformProps(
   const compareLag = Number(compareLag_) || 0;
   let formattedSubheader = subheader;
 
-  const { r, g, b } = colorPicker;
-  const mainColor = `rgb(${r}, ${g}, ${b})`;
+  const mainColor = colorPicker
+    ? `rgb(${colorPicker.r}, ${colorPicker.g}, ${colorPicker.b})`
+    : undefined;
 
   const xAxisLabel = getXAxisLabel(rawFormData) as string;
   let trendLineData: TimeSeriesDatum[] | undefined;
@@ -290,12 +292,12 @@ export default function transformProps(
             symbol: 'circle',
             symbolSize: 10,
             showSymbol: false,
-            color: mainColor,
+            color: mainColor ?? BRAND_COLOR,
             areaStyle: {
               color: new graphic.LinearGradient(0, 0, 0, 1, [
                 {
                   offset: 0,
-                  color: mainColor,
+                  color: mainColor ?? BRAND_COLOR,
                 },
                 {
                   offset: 1,


### PR DESCRIPTION
### SUMMARY

\`colorPicker\` defaults to \`null\` when a Big Number chart is first created and the colour-picker control has never been set. Destructuring it directly crashes:

\`\`\`
TypeError: Cannot destructure property 'r' of 'colorPicker' as it is null
\`\`\`

Falls back to the default teal (\`rgb(0, 122, 135)\`) when \`colorPicker\` is null or undefined.

\`\`\`ts
// before
const { r, g, b } = colorPicker;
// after
const { r = 0, g = 122, b = 135 } = colorPicker ?? {};
\`\`\`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Big Number chart crashes on render when \`colorPicker\` is null (newly created chart or form data created without the colour picker value).

**After:** Chart renders with the default teal colour; user-configured colours continue to work as before.

### TESTING INSTRUCTIONS

1. Create a new Big Number chart against any dataset
2. Do **not** set a custom colour in the Customize tab
3. Confirm the chart renders without a TypeError crash
4. Set a custom colour → confirm it is applied correctly

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API