### PR TITLE
fix(mcp): add created_by_fk filter, field validators, and deduplicate defaults for database tools

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -118,11 +118,13 @@ To create a chart:
 3. generate_explore_link(dataset_id, config) -> preview interactively
 4. generate_chart(dataset_id, config, save_chart=True) -> save permanently
 
-To find your own charts/dashboards:
+To find your own charts/dashboards/databases:
 1. get_instance_info -> get current_user.id
 2. list_charts(filters=[{{"col": "created_by_fk",
    "opr": "eq", "value": current_user.id}}])
 3. Or: list_dashboards(filters=[{{"col": "created_by_fk",
+   "opr": "eq", "value": current_user.id}}])
+4. Or: list_databases(filters=[{{"col": "created_by_fk",
    "opr": "eq", "value": current_user.id}}])
 
 To explore data with SQL:
@@ -171,6 +173,8 @@ Query Examples:
 - My charts (use current_user.id from get_instance_info):
   filters=[{{"col": "created_by_fk", "opr": "eq", "value": <user_id>}}]
 - My dashboards:
+  filters=[{{"col": "created_by_fk", "opr": "eq", "value": <user_id>}}]
+- My databases:
   filters=[{{"col": "created_by_fk", "opr": "eq", "value": <user_id>}}]
 
 To modify an existing chart (add filters, change metrics, change dimensions, etc.):

--- a/superset/mcp_service/database/schemas.py
+++ b/superset/mcp_service/database/schemas.py
@@ -274,9 +274,11 @@ class DatabaseError(BaseModel):
     @classmethod
     def create(cls, error: str, error_type: str) -> "DatabaseError":
         """Create a standardized DatabaseError with timestamp."""
-        from datetime import datetime
+        from datetime import datetime, timezone
 
-        return cls(error=error, error_type=error_type, timestamp=datetime.now())
+        return cls(
+            error=error, error_type=error_type, timestamp=datetime.now(timezone.utc)
+        )
 
 
 class GetDatabaseInfoRequest(MetadataCacheControl):
@@ -306,7 +308,8 @@ def _humanize_timestamp(dt: datetime | None) -> str | None:
     """Convert a datetime to a humanized string like '2 hours ago'."""
     if dt is None:
         return None
-    return humanize.naturaltime(datetime.now() - dt)
+    now = datetime.now(dt.tzinfo) if dt.tzinfo else datetime.now()
+    return humanize.naturaltime(now - dt)
 
 
 def serialize_database_object(database: Any) -> DatabaseInfo | None:

--- a/superset/mcp_service/database/schemas.py
+++ b/superset/mcp_service/database/schemas.py
@@ -29,6 +29,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    field_validator,
     model_serializer,
     model_validator,
     PositiveInt,
@@ -38,6 +39,10 @@ from superset.daos.base import ColumnOperator, ColumnOperatorEnum
 from superset.mcp_service.common.cache_schemas import MetadataCacheControl
 from superset.mcp_service.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from superset.mcp_service.system.schemas import PaginationInfo
+from superset.mcp_service.utils.schema_utils import (
+    parse_json_or_list,
+    parse_json_or_model_list,
+)
 from superset.utils import json
 
 
@@ -53,10 +58,14 @@ class DatabaseFilter(ColumnOperator):
         "database_name",
         "expose_in_sqllab",
         "allow_file_upload",
+        "created_by_fk",
+        "changed_by_fk",
     ] = Field(
         ...,
         description="Column to filter on. Use get_schema(model_type='database') for "
-        "available filter columns.",
+        "available filter columns. Use created_by_fk with the user "
+        "ID from get_instance_info's current_user to find "
+        "databases created by a specific user.",
     )
     opr: ColumnOperatorEnum = Field(
         ...,
@@ -230,6 +239,18 @@ class ListDatabasesRequest(MetadataCacheControl):
             description=f"Number of items per page (max {MAX_PAGE_SIZE})",
         ),
     ]
+
+    @field_validator("filters", mode="before")
+    @classmethod
+    def parse_filters(cls, v: Any) -> List[DatabaseFilter]:
+        """Accept both JSON string and list of objects."""
+        return parse_json_or_model_list(v, DatabaseFilter, "filters")
+
+    @field_validator("select_columns", mode="before")
+    @classmethod
+    def parse_columns(cls, v: Any) -> List[str]:
+        """Accept JSON array, list, or comma-separated string."""
+        return parse_json_or_list(v, "select_columns")
 
     @model_validator(mode="after")
     def validate_search_and_filters(self) -> "ListDatabasesRequest":

--- a/superset/mcp_service/database/tool/list_databases.py
+++ b/superset/mcp_service/database/tool/list_databases.py
@@ -43,15 +43,6 @@ from superset.mcp_service.mcp_core import ModelListCore
 
 logger = logging.getLogger(__name__)
 
-# Minimal defaults for reduced token usage - users can request more via select_columns
-DEFAULT_DATABASE_COLUMNS = [
-    "id",
-    "database_name",
-    "backend",
-    "expose_in_sqllab",
-    "changed_on_humanized",
-]
-
 
 @tool(
     tags=["core"],
@@ -100,6 +91,7 @@ async def list_databases(request: ListDatabasesRequest, ctx: Context) -> Databas
     try:
         from superset.daos.database import DatabaseDAO
         from superset.mcp_service.common.schema_discovery import (
+            DATABASE_DEFAULT_COLUMNS,
             DATABASE_SORTABLE_COLUMNS,
             get_all_column_names,
             get_database_columns,
@@ -120,7 +112,7 @@ async def list_databases(request: ListDatabasesRequest, ctx: Context) -> Databas
             output_schema=DatabaseInfo,
             item_serializer=_serialize_database,
             filter_type=DatabaseFilter,
-            default_columns=DEFAULT_DATABASE_COLUMNS,
+            default_columns=DATABASE_DEFAULT_COLUMNS,
             search_columns=["database_name"],
             list_field_name="databases",
             output_list_schema=DatabaseList,

--- a/superset/mcp_service/mcp_core.py
+++ b/superset/mcp_service/mcp_core.py
@@ -537,7 +537,7 @@ class ModelGetSchemaCore(BaseCore, Generic[S]):
         Initialize the schema discovery core.
 
         Args:
-            model_type: The type of model (chart, dataset, dashboard)
+            model_type: The type of model (chart, dataset, dashboard, database)
             dao_class: The DAO class to query for filter columns
             output_schema: Pydantic schema for the response (e.g., ModelSchemaInfo)
             select_columns: Column metadata (List[ColumnMetadata] or similar)

--- a/tests/unit_tests/mcp_service/database/tool/test_database_tools.py
+++ b/tests/unit_tests/mcp_service/database/tool/test_database_tools.py
@@ -32,16 +32,16 @@ logger = logging.getLogger(__name__)
 
 
 def create_mock_database(
-    database_id=1,
-    database_name="examples",
-    backend="postgresql",
-    expose_in_sqllab=True,
-    allow_ctas=False,
-    allow_cvas=False,
-    allow_dml=False,
-    allow_file_upload=False,
-    allow_run_async=False,
-):
+    database_id: int = 1,
+    database_name: str = "examples",
+    backend: str = "postgresql",
+    expose_in_sqllab: bool = True,
+    allow_ctas: bool = False,
+    allow_cvas: bool = False,
+    allow_dml: bool = False,
+    allow_file_upload: bool = False,
+    allow_run_async: bool = False,
+) -> MagicMock:
     """Factory function to create mock database objects with sensible defaults."""
     database = MagicMock()
     database.id = database_id


### PR DESCRIPTION
## Summary

Code review improvements for #39111:

- **Add `created_by_fk` and `changed_by_fk` to DatabaseFilter** — Matches the chart/dashboard filter pattern so users can do "find my databases" queries via `get_instance_info` → `list_databases(filters=[{"col": "created_by_fk", ...}])`
- **Add `field_validator` for `filters` and `select_columns`** — Handles JSON string parsing from MCP clients (double-serialization bug workaround), matching the pattern in DashboardFilter/ChartFilter
- **Remove duplicate `DEFAULT_DATABASE_COLUMNS`** — Was defined in both `schema_discovery.py` and `list_databases.py`; now imports from the canonical location
- **Update app.py instructions** — Document the database `created_by_fk` workflow in both "find your own" and "query examples" sections

## Test plan

- [ ] Existing unit tests still pass
- [ ] `list_databases` with `created_by_fk` filter returns only databases created by the specified user
- [ ] JSON string inputs for `filters` and `select_columns` are parsed correctly