### PR TITLE
fix(dev): fix simple-zstd v2 API breakage in webpack proxy config

### DIFF
--- a/superset-frontend/webpack.proxy-config.js
+++ b/superset-frontend/webpack.proxy-config.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 const zlib = require('zlib');
-const { ZSTDDecompress } = require('simple-zstd');
+const { decompress: zstdDecompress } = require('simple-zstd');
 
 const yargs = require('yargs');
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -116,13 +116,13 @@ function copyHeaders(originalResponse, response) {
  * Manipulate HTML server response to replace asset files with
  * local webpack-dev-server build.
  */
-function processHTML(proxyResponse, response) {
+async function processHTML(proxyResponse, response) {
   let body = Buffer.from([]);
   let originalResponse = proxyResponse;
-  let uncompress;
   const responseEncoding = originalResponse.headers['content-encoding'];
 
   // decode GZIP response
+  let uncompress;
   if (responseEncoding === 'gzip') {
     uncompress = zlib.createGunzip();
   } else if (responseEncoding === 'br') {
@@ -130,7 +130,7 @@ function processHTML(proxyResponse, response) {
   } else if (responseEncoding === 'deflate') {
     uncompress = zlib.createInflate();
   } else if (responseEncoding === 'zstd') {
-    uncompress = ZSTDDecompress();
+    uncompress = await zstdDecompress();
   }
   if (uncompress) {
     originalResponse.pipe(uncompress);
@@ -177,7 +177,13 @@ module.exports = newManifest => {
           // For HTML responses, flush headers before processing starts
           // processHTML sets up async handlers that will call response.end()
           response.flushHeaders();
-          processHTML(proxyResponse, response);
+          processHTML(proxyResponse, response).catch(e => {
+            // eslint-disable-next-line no-console
+            console.error(`Error requesting ${request.path} from proxy:`, e);
+            if (!response.writableEnded) {
+              response.end(`Error requesting ${request.path} from proxy: ${e.message}`);
+            }
+          });
         } else {
           const isCSV = (proxyResponse.headers['content-type'] || '').includes(
             'text/csv',


### PR DESCRIPTION
### SUMMARY

apache/superset#38662 bumped `simple-zstd` from 1.4.2 to 2.1.0. That version is a breaking release that renamed `ZSTDDecompress` to `decompress` and made it async (returns a `Promise<stream>` instead of a stream directly).

This caused the webpack dev proxy to crash when the backend responds with `content-encoding: zstd`:
- `TypeError: ZSTDDecompress is not a function`
- Then `TypeError: dest.on is not a function` (when trying to pipe into a Promise)

**Fix:**
- Update import from `ZSTDDecompress` to `decompress`
- Make `processHTML` async and `await` the `decompress()` call so a proper stream is returned before piping

Caused by: apache/superset#38662

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. Start the Superset backend
2. Run `npm run dev` in `superset-frontend/`
3. Navigate to `http://localhost:9000/login/` — should load without proxy errors in the console

### ADDITIONAL INFORMATION

- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API