### PR TITLE
fix(deps): revert simple-zstd from 2.1.0 back to 1.4.2

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -142,7 +142,7 @@
         "redux-undo": "^1.0.0-beta9-9-7",
         "rison": "^0.1.1",
         "scroll-into-view-if-needed": "^3.1.0",
-        "simple-zstd": "^2.1.0",
+        "simple-zstd": "^1.4.2",
         "stream-browserify": "^3.0.0",
         "tinycolor2": "^1.4.2",
         "urijs": "^1.19.8",
@@ -23118,6 +23118,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplex-maker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/duplex-maker/-/duplex-maker-1.0.0.tgz",
+      "integrity": "sha512-KoHuzggxg7f+vvjqOHfXxaQYI1POzBm+ah0eec7YDssZmbt6QFBI8d1nl5GQwAgR2f+VQCPvyvZtmWWqWuFtlA==",
+      "license": "MIT"
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -23155,6 +23161,54 @@
       "license": "MIT"
     },
     "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
@@ -23333,7 +23387,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -38903,6 +38956,17 @@
         "pbf": "bin/pbf"
       }
     },
+    "node_modules/peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -39958,6 +40022,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/process-streams": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/process-streams/-/process-streams-1.0.3.tgz",
+      "integrity": "sha512-xkIaM5vYnyekB88WyET78YEqXiaJRy0xcvIdE22n+myhvBT7LlLmX6iAtq7jDvVH8CUx2rqQsd32JdRyJMV3NA==",
+      "funding": [
+        "https://www.paypal.com/donate/?hosted_button_id=GB656ZSAEQEXN",
+        "https://de.liberapay.com/nils.knappmeier/"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "duplex-maker": "^1.0.0"
       }
     },
     "node_modules/proggy": {
@@ -44267,17 +44344,24 @@
       "license": "MIT"
     },
     "node_modules/simple-zstd": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/simple-zstd/-/simple-zstd-2.1.0.tgz",
-      "integrity": "sha512-pYzmKWl167db0EHoczlsSpmyjvZ7OinXciHicDEtlHjSKZlo1hPz6tXSyOfS84QIrbWPYT0XW9tx24YtGdQ6cA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/simple-zstd/-/simple-zstd-1.4.2.tgz",
+      "integrity": "sha512-kGYEvT33M5XfyQvvW4wxl3eKcWbdbCc1V7OZzuElnaXft0qbVzoIIXHXiCm3JCUki+MZKKmvjl8p2VGLJc5Y/A==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.4",
         "is-zst": "^1.0.0",
-        "tmp-promise": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=22.0.0"
+        "peek-stream": "^1.1.3",
+        "process-streams": "^1.0.1",
+        "through2": "^4.0.2"
+      }
+    },
+    "node_modules/simple-zstd/node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/sirv": {
@@ -45188,6 +45272,12 @@
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
     },
     "node_modules/streamx": {
       "version": "2.21.1",
@@ -46204,18 +46294,10 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/tmp-promise": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
-      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tmp": "^0.2.0"
       }
     },
     "node_modules/tmpl": {
@@ -50827,7 +50909,7 @@
         "react-js-cron": "^5.2.0",
         "react-markdown": "^8.0.7",
         "react-resize-detector": "^7.1.2",
-        "react-syntax-highlighter": "^16.1.0",
+        "react-syntax-highlighter": "^16.1.1",
         "react-ultimate-pagination": "^1.3.2",
         "regenerator-runtime": "^0.14.1",
         "rehype-raw": "^7.0.0",
@@ -52107,7 +52189,7 @@
         "@deck.gl/geo-layers": "~9.2.5",
         "@deck.gl/layers": "~9.2.5",
         "@deck.gl/mesh-layers": "~9.2.5",
-        "@deck.gl/react": "~9.2.9",
+        "@deck.gl/react": "~9.2.11",
         "@luma.gl/constants": "~9.2.5",
         "@luma.gl/core": "~9.2.5",
         "@luma.gl/engine": "~9.2.6",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -223,7 +223,7 @@
     "redux-undo": "^1.0.0-beta9-9-7",
     "rison": "^0.1.1",
     "scroll-into-view-if-needed": "^3.1.0",
-    "simple-zstd": "^2.1.0",
+    "simple-zstd": "^1.4.2",
     "stream-browserify": "^3.0.0",
     "tinycolor2": "^1.4.2",
     "urijs": "^1.19.8",


### PR DESCRIPTION
### SUMMARY

Reverts apache/superset#38662.

The v2 bump introduced breaking API changes (`ZSTDDecompress` renamed to `decompress`, now async) that caused `npm run dev-server` to stop working. Even with the fixes attempted in apache/superset#39138, the application was still freezing when navigating between pages.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. Run `npm ci` in `superset-frontend/`
2. Start the Superset backend
3. Run `npm run dev-server`
4. Navigate between pages — no freezing or proxy errors

### ADDITIONAL INFORMATION

- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API