### PR TITLE
fix(explore): prevent spurious "Failed to load chart data" toast on navigation

### DIFF
--- a/superset-frontend/src/pages/Chart/Chart.test.tsx
+++ b/superset-frontend/src/pages/Chart/Chart.test.tsx
@@ -94,6 +94,29 @@ describe('ChartPage', () => {
     );
   });
 
+  test('does not re-fetch when navigating to a non-explore route', async () => {
+    const exploreApiRoute = 'glob:*/api/v1/explore/*';
+    const exploreFormData = getExploreFormData({ viz_type: VizType.Table });
+    fetchMock.get(exploreApiRoute, {
+      result: { dataset: { id: 1 }, form_data: exploreFormData },
+    });
+    render(
+      <>
+        <Link to="/chart/list/">Go to chart list</Link>
+        <ChartPage />
+      </>,
+      { useRouter: true, useRedux: true, useDnd: true },
+    );
+    await waitFor(() =>
+      expect(fetchMock.callHistory.calls(exploreApiRoute).length).toBe(1),
+    );
+    fetchMock.clearHistory();
+    fireEvent.click(screen.getByText('Go to chart list'));
+    // Flush promises — no additional fetch should have been triggered
+    await Promise.resolve();
+    expect(fetchMock.callHistory.calls(exploreApiRoute).length).toBe(0);
+  });
+
   test('displays the dataset name and error when it is prohibited', async () => {
     const chartApiRoute = `glob:*/api/v1/chart/*`;
     const exploreApiRoute = 'glob:*/api/v1/explore/*';
@@ -261,7 +284,7 @@ describe('ChartPage', () => {
         <>
           <Link
             to={{
-              pathname: '/',
+              pathname: '/explore/',
               search: `?${URL_PARAMS.dashboardPageId.name}=${dashboardPageId}`,
               state: { saveAction: 'overwrite' },
             }}
@@ -318,7 +341,7 @@ describe('ChartPage', () => {
       });
       render(
         <>
-          <Link to="/?slice_id=99">Navigate away</Link>
+          <Link to="/explore/?slice_id=99">Navigate away</Link>
           <ChartPage />
         </>,
         {

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -272,6 +272,15 @@ export default function ExplorePage() {
   // Other REPLACE: ignored (URL sync from updateHistory).
   useEffect(() => {
     const unlisten = history.listen((loc: Location, action: Action) => {
+      // Only re-fetch when navigating within explore routes. history.listen fires
+      // before component unmount, so navigating away would trigger a fetch with
+      // invalid params and produce a spurious toast on the destination page.
+      if (
+        !loc.pathname.startsWith('/explore/') &&
+        !loc.pathname.startsWith('/superset/explore/')
+      ) {
+        return;
+      }
       const saveAction = (loc.state as Record<string, unknown>)?.saveAction as
         | SaveActionType
         | undefined;


### PR DESCRIPTION
### SUMMARY
When navigating away from the Explore page to another route (e.g. `/chart/list/`), React Router v5's `history.listen` fires **before** the component unmounts. This caused `loadExploreData` to be called with the destination URL's params (which contain no `slice_id` or form data key), resulting in an `api/v1/explore/` request with invalid params. The response either lacked a dataset or returned an error, throwing `"Failed to load chart data"` — which then appeared as a danger toast on the destination page. Nothing showed in the browser console or server logs because the error was caught internally and the API may return 200 with no dataset.

The fix adds a path guard in the history listener so `loadExploreData` is only called when navigating within explore routes (`/explore/` or `/superset/explore/`), matching the two routes registered in `routes.tsx`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Navigating from any Explore page to the Charts list (or other pages) shows a "Failed to load chart data" danger toast with no corresponding error in the console or server logs.

**After:** No spurious toast when navigating away from the Explore page.

### TESTING INSTRUCTIONS

1. Open any chart in the Explore view (`/explore/?slice_id=<id>`)
2. Navigate to the Charts list (`/chart/list/`)
3. Confirm no "Failed to load chart data" toast appears
4. Navigate back to Explore, make a change, and save — confirm the save flow still works correctly
5. Use browser back/forward buttons while on Explore — confirm chart data still reloads as expected

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
