### PR TITLE
fix(MCP): fix MCP logs

### DIFF
--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -130,22 +130,17 @@ class LoggingMiddleware(Middleware):
     in on_message().
     """
 
-    def _is_error_response(self, result: Any) -> bool:
-        """Check if a ToolResult contains an error response.
+    def _is_error_response(self, result: ToolResult) -> bool:
+        """Check if a tool result contains an error schema response.
 
-        StructuredContentStripperMiddleware catches exceptions and converts them
-        to ToolResult with content starting with "Error:". This method detects
-        such error responses so we can log them with success=False.
+        MCP tools return error schemas (ChartError, DashboardError, etc.)
+        instead of raising exceptions. These serialize to JSON containing
+        an "error_type" field.
         """
-        if not isinstance(result, ToolResult):
+        try:
+            return '"error_type"' in result.content[0].text
+        except (AttributeError, IndexError):
             return False
-        if not result.content:
-            return False
-        # Check first content item for error prefix
-        first_content = result.content[0]
-        if hasattr(first_content, "text") and first_content.text:
-            return first_content.text.startswith("Error:")
-        return False
 
     def _extract_context_info(
         self, context: MiddlewareContext
@@ -186,11 +181,8 @@ class LoggingMiddleware(Middleware):
 
         start_time = time.time()
         success = False
-        result = None
         try:
             result = await call_next(context)
-            # Check if result is an error response
-            # (converted by StructuredContentStripperMiddleware)
             success = not self._is_error_response(result)
             return result
         except Exception:

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -130,6 +130,23 @@ class LoggingMiddleware(Middleware):
     in on_message().
     """
 
+    def _is_error_response(self, result: Any) -> bool:
+        """Check if a ToolResult contains an error response.
+
+        StructuredContentStripperMiddleware catches exceptions and converts them
+        to ToolResult with content starting with "Error:". This method detects
+        such error responses so we can log them with success=False.
+        """
+        if not isinstance(result, ToolResult):
+            return False
+        if not result.content:
+            return False
+        # Check first content item for error prefix
+        first_content = result.content[0]
+        if hasattr(first_content, "text") and first_content.text:
+            return first_content.text.startswith("Error:")
+        return False
+
     def _extract_context_info(
         self, context: MiddlewareContext
     ) -> tuple[
@@ -169,10 +186,16 @@ class LoggingMiddleware(Middleware):
 
         start_time = time.time()
         success = False
+        result = None
         try:
             result = await call_next(context)
-            success = True
+            # Check if result is an error response
+            # (converted by StructuredContentStripperMiddleware)
+            success = not self._is_error_response(result)
             return result
+        except Exception:
+            success = False
+            raise
         finally:
             duration_ms = int((time.time() - start_time) * 1000)
             if has_app_context():

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -28,6 +28,7 @@ from collections.abc import Sequence
 from typing import Annotated, Any
 
 import uvicorn
+from fastmcp.server.middleware import Middleware
 
 from superset.mcp_service.app import create_mcp_app, init_fastmcp_server
 from superset.mcp_service.mcp_config import (
@@ -374,6 +375,24 @@ def _create_auth_provider(flask_app: Any) -> Any | None:
     return auth_provider
 
 
+def build_middleware_list() -> list[Middleware]:
+    """Build the core MCP middleware list in the correct order.
+
+    FastMCP wraps handlers so that the FIRST-added middleware is
+    outermost.  Order here is outermost → innermost:
+
+    1. StructuredContentStripper — safety net, converts exceptions
+       to safe ToolResult text for transports that can't encode errors
+    2. LoggingMiddleware — logs tool calls with success/failure status
+    3. GlobalErrorHandler — catches tool exceptions, raises ToolError
+    """
+    return [
+        StructuredContentStripperMiddleware(),
+        LoggingMiddleware(),
+        GlobalErrorHandlerMiddleware(),
+    ]
+
+
 def run_server(
     host: str = "127.0.0.1",
     port: int = 5008,
@@ -421,30 +440,15 @@ def run_server(
         flask_app = get_flask_app()
         auth_provider = _create_auth_provider(flask_app)
 
-        # Build middleware list
-        # FastMCP wraps handlers so that the LAST-added middleware is
-        # outermost.  Order here is innermost → outermost.
-        middleware_list = []
+        middleware_list = build_middleware_list()
 
-        # Add caching middleware (innermost – runs closest to the tool)
-        if caching_middleware := create_response_caching_middleware():
-            middleware_list.append(caching_middleware)
-
-        # Add response size guard (protects LLM clients from huge responses)
-        if size_guard_middleware := create_response_size_guard_middleware():
+        # Add optional middleware (innermost, closest to tool)
+        size_guard_middleware = create_response_size_guard_middleware()
+        if size_guard_middleware:
             middleware_list.append(size_guard_middleware)
 
-        # Add logging middleware (logs all tool calls with duration tracking)
-        middleware_list.append(LoggingMiddleware())
-
-        # Add global error handler (catches all exceptions, raises ToolError)
-        middleware_list.append(GlobalErrorHandlerMiddleware())
-
-        # Strip outputSchema from tool definitions and structuredContent from
-        # tool responses to prevent encoding errors on Claude.ai's MCP bridge.
-        # MUST be outermost so it catches ToolError from GlobalErrorHandler
-        # and converts to plain text before the MCP SDK tries to encode it.
-        middleware_list.append(StructuredContentStripperMiddleware())
+        if caching_middleware := create_response_caching_middleware():
+            middleware_list.append(caching_middleware)
 
         mcp_instance = init_fastmcp_server(
             auth=auth_provider,

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -384,6 +384,13 @@ class DBEventLogger(AbstractEventLogger):
         from superset.models.core import Log
 
         records = kwargs.get("records", [])
+        curated_payload = kwargs.get("curated_payload")
+
+        # If no records but curated_payload exists, use it as a single record
+        # This enables MCP middleware logging which passes curated_payload
+        if not records and curated_payload:
+            records = [curated_payload]
+
         logs = []
         for record in records:
             json_string: str | None

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -255,7 +255,7 @@ class TestEventLogger(unittest.TestCase):
             ]
             assert payload["duration_ms"] >= 100
 
-    @patch("superset.utils.log.db")
+    @patch("superset.db")
     def test_curated_payload_used_when_records_empty(self, mock_db):
         """Test that curated_payload is used when records is empty (MCP pattern).
 
@@ -289,7 +289,7 @@ class TestEventLogger(unittest.TestCase):
         assert payload["tool"] == "list_charts"
         assert payload["success"] is True
 
-    @patch("superset.utils.log.db")
+    @patch("superset.db")
     def test_records_takes_precedence_over_curated_payload(self, mock_db):
         """Test that records takes precedence over curated_payload."""
         logger = DBEventLogger()

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -254,3 +254,64 @@ class TestEventLogger(unittest.TestCase):
                 }
             ]
             assert payload["duration_ms"] >= 100
+
+    @patch("superset.utils.log.db")
+    def test_curated_payload_used_when_records_empty(self, mock_db):
+        """Test that curated_payload is used when records is empty (MCP pattern).
+
+        MCP middleware passes curated_payload instead of records. This test verifies
+        that DBEventLogger.log() creates a Log entry from curated_payload when
+        records is empty.
+        """
+        logger = DBEventLogger()
+
+        with app.test_request_context():
+            logger.log(
+                user_id=1,
+                action="mcp_tool_call",
+                dashboard_id=None,
+                duration_ms=100,
+                slice_id=None,
+                referrer=None,
+                curated_payload={"tool": "list_charts", "success": True},
+            )
+
+        # Verify bulk_save_objects was called with one Log object
+        mock_db.session.bulk_save_objects.assert_called_once()
+        logs = mock_db.session.bulk_save_objects.call_args[0][0]
+        assert len(logs) == 1
+        assert logs[0].action == "mcp_tool_call"
+        assert logs[0].duration_ms == 100
+        # Verify JSON contains the curated_payload data
+        from superset.utils import json as json_utils
+
+        payload = json_utils.loads(logs[0].json)
+        assert payload["tool"] == "list_charts"
+        assert payload["success"] is True
+
+    @patch("superset.utils.log.db")
+    def test_records_takes_precedence_over_curated_payload(self, mock_db):
+        """Test that records takes precedence over curated_payload."""
+        logger = DBEventLogger()
+
+        with app.test_request_context():
+            logger.log(
+                user_id=1,
+                action="test_action",
+                dashboard_id=None,
+                duration_ms=50,
+                slice_id=None,
+                referrer=None,
+                records=[{"from_records": True}],
+                curated_payload={"from_curated": True},
+            )
+
+        # Verify only records data is used, not curated_payload
+        mock_db.session.bulk_save_objects.assert_called_once()
+        logs = mock_db.session.bulk_save_objects.call_args[0][0]
+        assert len(logs) == 1
+        from superset.utils import json as json_utils
+
+        payload = json_utils.loads(logs[0].json)
+        assert payload.get("from_records") is True
+        assert "from_curated" not in payload

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -105,6 +105,34 @@ class TestLoggingMiddlewareOnCallTool:
     @patch("superset.mcp_service.middleware.event_logger")
     @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
     @pytest.mark.asyncio
+    async def test_on_call_tool_logs_failure_on_tool_error(
+        self, mock_get_user_id, mock_event_logger
+    ):
+        """on_call_tool records success=False when GlobalErrorHandler raises ToolError.
+
+        This simulates the real middleware chain: GlobalErrorHandler catches
+        tool exceptions and re-raises them as ToolError. Since LoggingMiddleware
+        sits between GlobalErrorHandler and StructuredContentStripper, it
+        catches the ToolError directly.
+        """
+        from fastmcp.exceptions import ToolError
+
+        middleware = LoggingMiddleware()
+        ctx = _make_context(name="get_chart_info")
+        call_next = AsyncMock(side_effect=ToolError("Chart 999999 not found"))
+
+        with pytest.raises(ToolError, match="Chart 999999 not found"):
+            await middleware.on_call_tool(ctx, call_next)
+
+        mock_event_logger.log.assert_called_once()
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["curated_payload"]["success"] is False
+        assert call_kwargs["curated_payload"]["tool"] == "get_chart_info"
+        assert call_kwargs["duration_ms"] >= 0
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
+    @pytest.mark.asyncio
     async def test_on_call_tool_extracts_entity_ids(
         self, mock_get_user_id, mock_event_logger
     ):
@@ -210,17 +238,20 @@ class TestExtractContextInfo:
 class TestIsErrorResponse:
     """Tests for LoggingMiddleware._is_error_response()."""
 
-    def test_detects_error_response_with_error_prefix(self):
-        """Detects ToolResult with content starting with 'Error:'."""
+    def test_detects_error_schema_response(self):
+        """Detects ToolResult containing a serialized error schema
+        (ChartError, DashboardError, etc.) via "error_type" field."""
         from fastmcp.tools.tool import ToolResult
         from mcp import types as mt
 
         middleware = LoggingMiddleware()
-        error_result = ToolResult(
-            content=[mt.TextContent(type="text", text="Error: Chart not found")]
+        error_json = (
+            '{"error": "Chart 999 not found",'
+            ' "error_type": "not_found",'
+            ' "timestamp": "2026-04-09T00:00:00Z"}'
         )
-
-        assert middleware._is_error_response(error_result) is True
+        result = ToolResult(content=[mt.TextContent(type="text", text=error_json)])
+        assert middleware._is_error_response(result) is True
 
     def test_success_response_not_detected_as_error(self):
         """Normal ToolResult is not detected as error."""
@@ -228,49 +259,39 @@ class TestIsErrorResponse:
         from mcp import types as mt
 
         middleware = LoggingMiddleware()
-        success_result = ToolResult(
+        result = ToolResult(
             content=[mt.TextContent(type="text", text="Successfully retrieved data")]
         )
-
-        assert middleware._is_error_response(success_result) is False
-
-    def test_non_tool_result_not_detected_as_error(self):
-        """Non-ToolResult values are not detected as errors."""
-        middleware = LoggingMiddleware()
-
-        assert middleware._is_error_response("string result") is False
-        assert middleware._is_error_response({"key": "value"}) is False
-        assert middleware._is_error_response(None) is False
+        assert middleware._is_error_response(result) is False
 
     def test_empty_content_not_detected_as_error(self):
         """ToolResult with empty content is not detected as error."""
         from fastmcp.tools.tool import ToolResult
 
         middleware = LoggingMiddleware()
-        empty_result = ToolResult(content=[])
-
-        assert middleware._is_error_response(empty_result) is False
+        assert middleware._is_error_response(ToolResult(content=[])) is False
 
     @patch("superset.mcp_service.middleware.event_logger")
     @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
     @pytest.mark.asyncio
-    async def test_on_call_tool_detects_error_response_as_failure(
+    async def test_on_call_tool_logs_failure_for_error_schema(
         self, mock_get_user_id, mock_event_logger
     ):
-        """on_call_tool logs success=False when result is an error response.
-
-        This tests the scenario where StructuredContentStripperMiddleware
-        catches an exception and converts it to a ToolResult with "Error:" prefix.
-        """
+        """on_call_tool logs success=False when tool returns an
+        error schema (e.g. ChartError)."""
         from fastmcp.tools.tool import ToolResult
         from mcp import types as mt
 
         middleware = LoggingMiddleware()
         ctx = _make_context(name="get_chart_info")
 
-        # Simulate error response from StructuredContentStripperMiddleware
+        error_json = (
+            '{"error": "Chart 999999 not found",'
+            ' "error_type": "not_found",'
+            ' "timestamp": "2026-04-09T00:00:00Z"}'
+        )
         error_result = ToolResult(
-            content=[mt.TextContent(type="text", text="Error: Chart 999999 not found")]
+            content=[mt.TextContent(type="text", text=error_json)]
         )
         call_next = AsyncMock(return_value=error_result)
 
@@ -281,3 +302,63 @@ class TestIsErrorResponse:
         call_kwargs = mock_event_logger.log.call_args[1]
         assert call_kwargs["curated_payload"]["success"] is False
         assert call_kwargs["curated_payload"]["tool"] == "get_chart_info"
+
+
+class TestMiddlewareChainOrder:
+    """Test that the middleware order from server.py logs failures correctly.
+
+    If the order is wrong (StructuredContentStripper innermost),
+    it swallows exceptions before LoggingMiddleware can see them,
+    causing success=True for failures.
+    """
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
+    @pytest.mark.asyncio
+    async def test_real_middleware_chain_logs_exception_as_failure(
+        self, mock_get_user_id, mock_event_logger
+    ):
+        """Tool exception is logged as success=False through the
+        real middleware chain from build_middleware_list()."""
+        from functools import partial
+
+        from fastmcp.tools.tool import ToolResult
+
+        from superset.mcp_service.server import build_middleware_list
+
+        middleware_list = build_middleware_list()
+
+        async def failing_tool(context: Any) -> Any:
+            raise ValueError("chart not found")
+
+        # Build chain same way FastMCP does
+        chain = failing_tool
+        for mw in reversed(middleware_list):
+            chain = partial(mw, call_next=chain)
+
+        ctx = _make_context(name="get_chart_info")
+        result = await chain(ctx)
+
+        # StructuredContentStripper (outermost) must catch the re-raised
+        # exception and convert it to a safe ToolResult with "Error:" text.
+        # If it's not outermost, the exception would leak to the MCP SDK.
+        assert isinstance(result, ToolResult)
+        assert result.content[0].text.startswith("Error:")
+
+        # LoggingMiddleware must log
+        # success=False. If the middleware order is wrong
+        # (StructuredContentStripper innermost), this would be
+        # success=True because the exception gets swallowed
+        # before LoggingMiddleware sees it.
+        log_calls = [
+            c
+            for c in mock_event_logger.log.call_args_list
+            if c[1].get("action") == "mcp_tool_call"
+        ]
+        assert len(log_calls) == 1
+        assert log_calls[0][1]["curated_payload"]["success"] is False, (
+            "Middleware order is wrong: StructuredContentStripper is "
+            "swallowing exceptions before LoggingMiddleware can detect "
+            "them. Ensure StructuredContentStripper is outermost "
+            "(first added) in build_middleware_list()."
+        )

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -205,3 +205,79 @@ class TestExtractContextInfo:
         _, _, _, slice_id, _, _ = middleware._extract_context_info(ctx)
 
         assert slice_id == 66
+
+
+class TestIsErrorResponse:
+    """Tests for LoggingMiddleware._is_error_response()."""
+
+    def test_detects_error_response_with_error_prefix(self):
+        """Detects ToolResult with content starting with 'Error:'."""
+        from fastmcp.tools.tool import ToolResult
+        from mcp import types as mt
+
+        middleware = LoggingMiddleware()
+        error_result = ToolResult(
+            content=[mt.TextContent(type="text", text="Error: Chart not found")]
+        )
+
+        assert middleware._is_error_response(error_result) is True
+
+    def test_success_response_not_detected_as_error(self):
+        """Normal ToolResult is not detected as error."""
+        from fastmcp.tools.tool import ToolResult
+        from mcp import types as mt
+
+        middleware = LoggingMiddleware()
+        success_result = ToolResult(
+            content=[mt.TextContent(type="text", text="Successfully retrieved data")]
+        )
+
+        assert middleware._is_error_response(success_result) is False
+
+    def test_non_tool_result_not_detected_as_error(self):
+        """Non-ToolResult values are not detected as errors."""
+        middleware = LoggingMiddleware()
+
+        assert middleware._is_error_response("string result") is False
+        assert middleware._is_error_response({"key": "value"}) is False
+        assert middleware._is_error_response(None) is False
+
+    def test_empty_content_not_detected_as_error(self):
+        """ToolResult with empty content is not detected as error."""
+        from fastmcp.tools.tool import ToolResult
+
+        middleware = LoggingMiddleware()
+        empty_result = ToolResult(content=[])
+
+        assert middleware._is_error_response(empty_result) is False
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
+    @pytest.mark.asyncio
+    async def test_on_call_tool_detects_error_response_as_failure(
+        self, mock_get_user_id, mock_event_logger
+    ):
+        """on_call_tool logs success=False when result is an error response.
+
+        This tests the scenario where StructuredContentStripperMiddleware
+        catches an exception and converts it to a ToolResult with "Error:" prefix.
+        """
+        from fastmcp.tools.tool import ToolResult
+        from mcp import types as mt
+
+        middleware = LoggingMiddleware()
+        ctx = _make_context(name="get_chart_info")
+
+        # Simulate error response from StructuredContentStripperMiddleware
+        error_result = ToolResult(
+            content=[mt.TextContent(type="text", text="Error: Chart 999999 not found")]
+        )
+        call_next = AsyncMock(return_value=error_result)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result == error_result
+        mock_event_logger.log.assert_called_once()
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["curated_payload"]["success"] is False
+        assert call_kwargs["curated_payload"]["tool"] == "get_chart_info"


### PR DESCRIPTION
### SUMMARY

- Fix MCP tool call logging to correctly capture failures (previously all calls showed `success: true`)
- Fix `DBEventLogger.log()` to handle `curated_payload` parameter (issue where MCP logs weren't saved)
- Fix middleware ordering — StructuredContentStripperMiddleware was incorrectly innermost, preventing LoggingMiddleware from catching exceptions directly

#### Changes

| File | Change |
| --- | --- |
| `superset/utils/log.py` | Handle `curated_payload` when `records` is empty |
| `superset/mcp_service/middleware.py` | Add `_is_error_response()` to detect error schema responses, simplify `on_call_tool()` |
| `superset/mcp_service/server.py` | Fix middleware ordering (outermost → innermost: Stripper → Logging → GlobalErrorHandler), extract `build_middleware_list()` for testability |
| `tests/unit_tests/mcp_service/test_middleware_logging.py` | Add tests for error detection, ToolError exception handling, and middleware chain order regression |
| `tests/integration_tests/event_logger_tests.py` | Add tests for `curated_payload` handling in `DBEventLogger` |

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

#### Prerequisites

- Superset running locally with MCP server enabled
- Database access (e.g. `docker exec superset-db-1 psql -U superset -d superset`)

#### 1. Verify successful tool call logs `success: true`

1. Make a valid MCP tool call (e.g. `get_dashboard_info` with a real dashboard ID)
2. Query the logs table:

```
SELECT action, json FROM logs WHERE action = 'mcp_tool_call' ORDER BY dttm DESC LIMIT 5;

```

3. Confirm `"success": true` in the JSON

#### 2. Verify failed tool call logs `success: false`

1. Make an MCP tool call with an invalid ID (e.g. `get_chart_info` with `chart_id: 999999`)
2. Query the logs table (same query as above)
3. Confirm `"success": false` in the JSON for the failed call

#### 3. Verify OSS logs are saved at all (Bug #1)

1. Before the fix, the `logs` table would have **no** `mcp_tool_call` entries
2. After the fix, both successful and failed calls should appear in the table

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
