### PR TITLE
feat(databricks): add OAuth2 per-user impersonation for Databricks SQL warehouse

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -498,7 +498,7 @@ const ExtraOptions = ({
                     onChange={onInputChange}
                   >
                     {t(
-                      'Impersonate logged in user (Presto, Trino, Drill, Hive, and Google Sheets)',
+                      'Impersonate logged in user (Presto, Trino, Drill, Hive, Databricks, and Google Sheets)',
                     )}
                   </Checkbox>
                   <InfoTooltip
@@ -507,7 +507,8 @@ const ExtraOptions = ({
                         'currently logged on user who must have permission to run them. If Hive ' +
                         'and hive.server2.enable.doAs is enabled, will run the queries as ' +
                         'service account, but impersonate the currently logged on user via ' +
-                        'hive.server2.proxy.user property.',
+                        'hive.server2.proxy.user property. If Databricks with OAuth2 configured, ' +
+                        "queries will execute using each user's personal OAuth2 token.",
                     )}
                   />
                 </div>

--- a/superset/config.py
+++ b/superset/config.py
@@ -2094,6 +2094,15 @@ TEST_DATABASE_CONNECTION_TIMEOUT = timedelta(seconds=30)
 # the existing tokens from the database. This needs to be done by running a query to
 # delete the existing tokens.
 DATABASE_OAUTH2_CLIENTS: dict[str, dict[str, Any]] = {
+    # "Databricks": {
+    #     "id": "<your-databricks-oauth-client-id>",
+    #     "secret": "<your-databricks-oauth-client-secret>",
+    #     "host": "<workspace>.cloud.databricks.com",
+    #     "scope": "sql offline_access",
+    #     # OIDC endpoints are auto-derived from host. Override if needed:
+    #     # "authorization_request_uri": "https://<workspace>.cloud.databricks.com/oidc/v1/authorize",
+    #     # "token_request_uri": "https://<workspace>.cloud.databricks.com/oidc/v1/token",
+    # },
     # "Google Sheets": {
     #     "id": "XXX.apps.googleusercontent.com",
     #     "secret": "GOCSPX-YYY",

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -120,7 +120,9 @@ impersonate_user_description = (
     "currently logged on user who must have permission to run them.<br/>"
     "If Hive and hive.server2.enable.doAs is enabled, will run the queries as "
     "service account, but impersonate the currently logged on user "
-    "via hive.server2.proxy.user property."
+    "via hive.server2.proxy.user property.<br/>"
+    "If Databricks with OAuth2 configured, queries will execute using each "
+    "user's personal OAuth2 access token."
 )
 force_ctas_schema_description = (
     "When allowing CREATE TABLE AS option in SQL Lab, "

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -16,11 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Any, Callable, TYPE_CHECKING, TypedDict, Union
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
+from flask import current_app as app, g, has_request_context, url_for
 from flask_babel import gettext as __
 from marshmallow import fields, Schema
 from marshmallow.validate import Range
@@ -44,6 +46,9 @@ from superset.utils.network import is_hostname_valid, is_port_open
 
 if TYPE_CHECKING:
     from superset.models.core import Database
+    from superset.utils.oauth2 import OAuth2ClientConfig
+
+logger = logging.getLogger(__name__)
 
 
 try:
@@ -52,6 +57,26 @@ except ImportError:
 
     class ParamEscaper:  # type: ignore
         """Dummy class."""
+
+
+try:
+    from databricks.sql.exc import RequestError as DatabricksRequestError
+except ImportError:
+    DatabricksRequestError = Exception
+
+
+class _DatabricksAuthErrorMeta(type):
+    """Metaclass to match Databricks authentication errors (HTTP 401/403)."""
+
+    def __instancecheck__(cls, instance: object) -> bool:
+        return isinstance(instance, DatabricksRequestError) and any(
+            s in str(instance).lower()
+            for s in ("error 401", "error 403", "unauthorized", "invalid access token")
+        )
+
+
+class DatabricksAuthError(Exception, metaclass=_DatabricksAuthErrorMeta):
+    pass
 
 
 class DatabricksStringType(types.TypeDecorator):
@@ -107,13 +132,144 @@ def monkeypatch_dialect() -> None:
         pass
 
 
+class DatabricksOAuth2Mixin:
+    """Mixin adding OAuth2 per-user impersonation to all Databricks engine specs.
+
+    When OAuth2 is configured, each user authenticates individually with the
+    Databricks workspace. Their personal OAuth2 token replaces the shared PAT
+    in the connection URI, so queries execute under the user's identity.
+
+    Databricks OIDC endpoints are auto-derived from a ``host`` key in the
+    ``DATABASE_OAUTH2_CLIENTS`` config, so admins only need to provide
+    client_id, secret, and workspace host.
+    """
+
+    supports_oauth2 = True
+    oauth2_scope = "sql offline_access"
+    oauth2_exception = DatabricksAuthError
+    oauth2_token_request_type = "data"  # noqa: S105
+
+    @classmethod
+    def get_oauth2_config(cls) -> OAuth2ClientConfig | None:
+        oauth2_config = app.config["DATABASE_OAUTH2_CLIENTS"]
+        # Look up by exact engine_name first, then fall back to "Databricks"
+        # so a single config entry works for all Databricks specs (e.g.,
+        # "Databricks SQL Endpoint", "Databricks Interactive Cluster", etc.)
+        spec_config = oauth2_config.get(
+            cls.engine_name,  # type: ignore[attr-defined]
+            oauth2_config.get("Databricks"),
+        )
+        if spec_config is None:
+            return None
+        host = spec_config.get("host", "")
+        redirect_uri = app.config.get(
+            "DATABASE_OAUTH2_REDIRECT_URI",
+            url_for("DatabaseRestApi.oauth2", _external=True),
+        )
+
+        return {
+            "id": spec_config["id"],
+            "secret": spec_config["secret"],
+            "scope": spec_config.get("scope") or cls.oauth2_scope,
+            "redirect_uri": redirect_uri,
+            "authorization_request_uri": spec_config.get(
+                "authorization_request_uri",
+                f"https://{host}/oidc/v1/authorize" if host else None,
+            ),
+            "token_request_uri": spec_config.get(
+                "token_request_uri",
+                f"https://{host}/oidc/v1/token" if host else None,
+            ),
+            "request_content_type": spec_config.get(
+                "request_content_type",
+                cls.oauth2_token_request_type,
+            ),
+        }
+
+    @classmethod
+    def needs_oauth2(cls, ex: Exception) -> bool:
+        """Check if the exception indicates OAuth2 authentication is needed.
+
+        The databricks-sql-connector raises RequestError which gets wrapped
+        by SQLAlchemy into a DBAPIError. We check both the original exception
+        and the string representation for auth failure indicators.
+        """
+        if not has_request_context() or not hasattr(g, "user"):
+            return False
+
+        # Check the full exception chain for auth errors
+        current: BaseException | None = ex
+        while current is not None:
+            if isinstance(current, DatabricksAuthError):
+                return True
+            # Also check string for wrapped exceptions
+            ex_str = str(current).lower()
+            if any(
+                s in ex_str
+                for s in (
+                    "error 401",
+                    "status code 401",
+                    "error 403",
+                    "status code 403",
+                    "unauthorized",
+                    "forbidden",
+                    "credential was not sent",
+                )
+            ):
+                return True
+            current = current.__cause__
+
+        return False
+
+    @classmethod
+    def impersonate_user(
+        cls,
+        database: Database,
+        username: str | None,
+        user_token: str | None,
+        url: URL,
+        engine_kwargs: dict[str, Any],
+    ) -> tuple[URL, dict[str, Any]]:
+        if username is None:
+            return url, engine_kwargs
+
+        if user_token is not None:
+            # Replace the static PAT with the per-user OAuth2 access token.
+            # The databricks-sql-connector accepts OAuth tokens as the password
+            # in the URI: databricks://token:{oauth_token}@host:port
+            url = url.set(password=user_token)
+        elif database.is_oauth2_enabled():
+            # No stored OAuth token for this user yet. Proactively trigger the
+            # OAuth dance instead of falling back to the shared PAT, which would
+            # run queries as the PAT owner rather than the logged-in user.
+            cls.start_oauth2_dance(database)  # type: ignore[attr-defined]
+
+        return url, engine_kwargs
+
+    @staticmethod
+    def update_params_from_encrypted_extra(
+        database: Database,
+        params: dict[str, Any],
+    ) -> None:
+        if not database.encrypted_extra:
+            return
+        try:
+            encrypted_extra = json.loads(database.encrypted_extra)
+            # Strip oauth2_client_info so it doesn't leak into create_engine()
+            encrypted_extra.pop("oauth2_client_info", None)
+            params.update(encrypted_extra)
+        except json.JSONDecodeError as ex:
+            logger.error(ex, exc_info=True)
+            raise
+
+
 class DatabricksBaseSchema(Schema):
     """
     Fields that are required for both Databricks drivers that uses a
     dynamic form.
     """
 
-    access_token = fields.Str(required=True)
+    access_token = fields.Str(required=False, load_default="")
     host = fields.Str(required=True)
     port = fields.Integer(
         required=True,
@@ -221,7 +377,7 @@ time_grain_expressions: dict[str | None, str] = {
 }
 
 
-class DatabricksHiveEngineSpec(HiveEngineSpec):
+class DatabricksHiveEngineSpec(DatabricksOAuth2Mixin, HiveEngineSpec):  # type: ignore[misc]
     """Databricks engine spec using Hive connector for Interactive Clusters."""
 
     engine_name = "Databricks Interactive Cluster"
@@ -239,7 +395,7 @@ class DatabricksHiveEngineSpec(HiveEngineSpec):
     _time_grain_expressions = time_grain_expressions
 
 
-class DatabricksBaseEngineSpec(BaseEngineSpec):
+class DatabricksBaseEngineSpec(DatabricksOAuth2Mixin, BaseEngineSpec):  # type: ignore[misc]
     _time_grain_expressions = time_grain_expressions
 
     @classmethod
@@ -267,10 +423,10 @@ class DatabricksODBCEngineSpec(DatabricksBaseEngineSpec):
     # backwards compatibility with ODBC connections to SQL Endpoints.
 
 
-class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngineSpec):
+class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngineSpec):  # type: ignore[misc]
     default_driver = ""
     encryption_parameters = {"ssl": "1"}
-    required_parameters = {"access_token", "host", "port"}
+    required_parameters = {"host", "port"}
     context_key_mapping = {
         "access_token": "password",
         "host": "hostname",
@@ -359,7 +515,7 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         ]
 
     @classmethod
-    def validate_parameters(  # type: ignore
+    def validate_parameters(  # type: ignore  # noqa: C901
         cls,
         properties: Union[
             DatabricksNativePropertiesType,
@@ -379,7 +535,12 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
 
         present = {key for key in parameters if parameters.get(key, ())}
 
-        if missing := sorted(cls.required_parameters - present):
+        # access_token is required only when OAuth2 is not configured
+        effective_required = set(cls.required_parameters)
+        if not cls.is_oauth2_enabled():
+            effective_required.add("access_token")
+
+        if missing := sorted(effective_required - present):
             errors.append(
                 SupersetError(
                     message=f"One or more parameters are missing: {', '.join(missing)}",

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -15,14 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
+# ruff: noqa: S105, S106
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
+from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy.engine.url import URL
 
-from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.databricks import (
+    DatabricksAuthError,
+    DatabricksBaseEngineSpec,
+    DatabricksHiveEngineSpec,
+    DatabricksNativeEngineSpec,
+    DatabricksODBCEngineSpec,
+    DatabricksPythonConnectorEngineSpec,
+)
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.utils import json
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
@@ -92,7 +103,7 @@ def test_parameters_json_schema() -> None:
     assert json_schema == {
         "type": "object",
         "properties": {
-            "access_token": {"type": "string"},
+            "access_token": {"default": "", "type": "string"},
             "database": {"type": "string"},
             "encryption": {
                 "description": "Use an encrypted connection to the database",
@@ -107,7 +118,7 @@ def test_parameters_json_schema() -> None:
                 "type": "integer",
             },
         },
-        "required": ["access_token", "database", "host", "http_path", "port"],
+        "required": ["database", "host", "http_path", "port"],
     }
 
 
@@ -284,3 +295,296 @@ def test_get_prequeries(mocker: MockerFixture) -> None:
         "USE CATALOG `escaped-hyphen`",
         "USE SCHEMA `hyphen-escaped`",
     ]
+
+
+# ============================================================================
+# OAuth2 and Impersonation Tests
+# ============================================================================
+
+
+ALL_DATABRICKS_SPECS: list[type[BaseEngineSpec]] = [
+    DatabricksHiveEngineSpec,
+    DatabricksBaseEngineSpec,
+    DatabricksODBCEngineSpec,
+    DatabricksNativeEngineSpec,
+    DatabricksPythonConnectorEngineSpec,
+]
+
+
+@pytest.mark.parametrize("spec", ALL_DATABRICKS_SPECS)
+def test_oauth2_class_vars(spec: type[BaseEngineSpec]) -> None:
+    """All Databricks specs should have OAuth2 support enabled."""
+    assert spec.supports_oauth2 is True
+    assert spec.oauth2_scope == "sql offline_access"
+    assert spec.oauth2_exception is DatabricksAuthError
+    assert spec.oauth2_token_request_type == "data"
+
+
+def test_impersonate_user_with_oauth_token() -> None:
+    """When user_token is provided, the URL password should be replaced."""
+    database = MagicMock()
+    url = URL.create(
+        "databricks",
+        username="token",
+        password="original-pat",
+        host="workspace.cloud.databricks.com",
+        port=443,
+        query={"http_path": "sql/1.0/warehouses/abc123", "catalog": "gold"},
+    )
+    engine_kwargs: dict[str, Any] = {
+        "connect_args": {"http_path": "sql/1.0/warehouses/abc123"},
+    }
+
+    new_url, new_kwargs = DatabricksPythonConnectorEngineSpec.impersonate_user(
+        database, "test_user", "oauth-access-token-xyz", url, engine_kwargs
+    )
+
+    assert new_url.password == "oauth-access-token-xyz"
+    assert new_url.username == "token"
+    assert new_url.host == "workspace.cloud.databricks.com"
+    # connect_args should be unchanged
+    assert new_kwargs["connect_args"]["http_path"] == "sql/1.0/warehouses/abc123"
+
+
+def test_impersonate_user_without_token() -> None:
+    """When user_token is None and OAuth not enabled, URL stays."""
+    database = MagicMock()
+    database.is_oauth2_enabled.return_value = False
+    url = URL.create(
+        "databricks",
+        username="token",
+        password="original-pat",
+        host="workspace.cloud.databricks.com",
+        port=443,
+    )
+    engine_kwargs: dict[str, Any] = {}
+
+    new_url, _ = DatabricksPythonConnectorEngineSpec.impersonate_user(
+        database, "test_user", None, url, engine_kwargs
+    )
+
+    assert new_url.password == "original-pat"
+
+
+def test_impersonate_user_no_username() -> None:
+    """When username is None, impersonation should be a no-op."""
+    database = MagicMock()
+    url = URL.create(
+        "databricks",
+        username="token",
+        password="original-pat",
+        host="workspace.cloud.databricks.com",
+        port=443,
+    )
+    engine_kwargs: dict[str, Any] = {"connect_args": {"foo": "bar"}}
+
+    new_url, new_kwargs = DatabricksPythonConnectorEngineSpec.impersonate_user(
+        database, None, "some-token", url, engine_kwargs
+    )
+
+    assert new_url.password == "original-pat"
+    assert new_kwargs == {"connect_args": {"foo": "bar"}}
+
+
+def test_impersonate_user_no_token_triggers_oauth_dance() -> None:
+    """When OAuth is enabled but no token exists, should trigger OAuth dance."""
+    from unittest.mock import patch
+
+    database = MagicMock()
+    database.is_oauth2_enabled.return_value = True
+    url = URL.create(
+        "databricks",
+        username="token",
+        password="valid-pat",
+        host="workspace.cloud.databricks.com",
+        port=443,
+    )
+    engine_kwargs: dict[str, Any] = {}
+
+    with patch.object(
+        DatabricksPythonConnectorEngineSpec, "start_oauth2_dance"
+    ) as mock_dance:
+        DatabricksPythonConnectorEngineSpec.impersonate_user(
+            database, "test_user", None, url, engine_kwargs
+        )
+        mock_dance.assert_called_once_with(database)
+
+
+def test_impersonate_user_no_token_no_oauth_skips_dance() -> None:
+    """When OAuth is NOT enabled and no token exists, should not trigger dance."""
+    database = MagicMock()
+    database.is_oauth2_enabled.return_value = False
+    url = URL.create(
+        "databricks",
+        username="token",
+        password="valid-pat",
+        host="workspace.cloud.databricks.com",
+        port=443,
+    )
+    engine_kwargs: dict[str, Any] = {}
+
+    new_url, _ = DatabricksPythonConnectorEngineSpec.impersonate_user(
+        database, "test_user", None, url, engine_kwargs
+    )
+
+    # PAT should remain unchanged, no dance triggered
+    assert new_url.password == "valid-pat"
+
+
+def test_databricks_auth_error_detection() -> None:
+    """The DatabricksAuthError metaclass should match auth failures."""
+    try:
+        from databricks.sql.exc import RequestError as DatabricksRequestError
+    except ImportError:
+        pytest.skip("databricks-sql-connector not installed")
+
+    # Should match 401
+    error_401 = DatabricksRequestError("Error 401: Unauthorized access")
+    assert isinstance(error_401, DatabricksAuthError)
+
+    # Should match 403
+    error_403 = DatabricksRequestError("Error 403: Forbidden")
+    assert isinstance(error_403, DatabricksAuthError)
+
+    # Should match "unauthorized"
+    error_unauth = DatabricksRequestError("Unauthorized request to endpoint")
+    assert isinstance(error_unauth, DatabricksAuthError)
+
+    # Should match "invalid access token"
+    error_token = DatabricksRequestError("Invalid access token provided")
+    assert isinstance(error_token, DatabricksAuthError)
+
+    # Should NOT match a generic error
+    error_generic = DatabricksRequestError("Connection timeout after 30s")
+    assert not isinstance(error_generic, DatabricksAuthError)
+
+
+def test_get_oauth2_config_with_host(mocker: MockerFixture) -> None:
+    """OIDC endpoints should be auto-derived from the host config key."""
+    mocker.patch(
+        "superset.db_engine_specs.databricks.app.config",
+        {
+            "DATABASE_OAUTH2_CLIENTS": {
+                "Databricks": {
+                    "id": "test-client-id",
+                    "secret": "test-client-secret",
+                    "host": "myworkspace.cloud.databricks.com",
+                },
+            },
+            "DATABASE_OAUTH2_REDIRECT_URI": "http://localhost:8088/api/v1/database/oauth2/",
+        },
+    )
+
+    config = DatabricksPythonConnectorEngineSpec.get_oauth2_config()
+
+    assert config is not None
+    assert config["id"] == "test-client-id"
+    assert config["secret"] == "test-client-secret"
+    assert config["scope"] == "sql offline_access"
+    assert (
+        config["authorization_request_uri"]
+        == "https://myworkspace.cloud.databricks.com/oidc/v1/authorize"
+    )
+    assert (
+        config["token_request_uri"]
+        == "https://myworkspace.cloud.databricks.com/oidc/v1/token"
+    )
+    assert config["redirect_uri"] == "http://localhost:8088/api/v1/database/oauth2/"
+
+
+def test_get_oauth2_config_with_explicit_uris(mocker: MockerFixture) -> None:
+    """Explicit URIs should take precedence over host-derived ones."""
+    mocker.patch(
+        "superset.db_engine_specs.databricks.app.config",
+        {
+            "DATABASE_OAUTH2_CLIENTS": {
+                "Databricks": {
+                    "id": "test-client-id",
+                    "secret": "test-client-secret",
+                    "host": "myworkspace.cloud.databricks.com",
+                    "authorization_request_uri": "https://custom-auth.example.com/authorize",
+                    "token_request_uri": "https://custom-auth.example.com/token",
+                },
+            },
+            "DATABASE_OAUTH2_REDIRECT_URI": "http://localhost:8088/api/v1/database/oauth2/",
+        },
+    )
+
+    config = DatabricksPythonConnectorEngineSpec.get_oauth2_config()
+
+    assert config is not None
+    assert (
+        config["authorization_request_uri"]
+        == "https://custom-auth.example.com/authorize"
+    )
+    assert config["token_request_uri"] == "https://custom-auth.example.com/token"
+
+
+def test_get_oauth2_config_not_configured(mocker: MockerFixture) -> None:
+    """Should return None when Databricks is not in DATABASE_OAUTH2_CLIENTS."""
+    mocker.patch(
+        "superset.db_engine_specs.databricks.app.config",
+        {
+            "DATABASE_OAUTH2_CLIENTS": {},
+        },
+    )
+
+    config = DatabricksPythonConnectorEngineSpec.get_oauth2_config()
+    assert config is None
+
+
+def test_needs_oauth2_with_wrapped_exception() -> None:
+    """needs_oauth2 should detect auth errors in the exception cause chain."""
+    from unittest.mock import patch
+
+    # Simulate SQLAlchemy wrapping a 401 error
+    inner = Exception("Error during request to server: status code 401")
+    outer = Exception("(databricks.sql.exc.RequestError) wrapped")
+    outer.__cause__ = inner
+
+    with patch(
+        "superset.db_engine_specs.databricks.has_request_context", return_value=True
+    ):
+        with patch("superset.db_engine_specs.databricks.g") as mock_g:
+            mock_g.user = MagicMock()
+            assert DatabricksPythonConnectorEngineSpec.needs_oauth2(outer) is True
+
+
+def test_needs_oauth2_no_request_context() -> None:
+    """needs_oauth2 should return False outside request context."""
+    from unittest.mock import patch
+
+    ex = Exception("status code 401")
+    with patch(
+        "superset.db_engine_specs.databricks.has_request_context", return_value=False
+    ):
+        assert DatabricksPythonConnectorEngineSpec.needs_oauth2(ex) is False
+
+
+def test_update_params_strips_oauth2_client_info() -> None:
+    """oauth2_client_info should not leak into engine params."""
+    database = MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "oauth2_client_info": {"id": "secret-id", "secret": "secret-value"},
+            "some_other_param": "keep-this",
+        }
+    )
+
+    params: dict[str, Any] = {}
+    DatabricksPythonConnectorEngineSpec.update_params_from_encrypted_extra(
+        database, params
+    )
+
+    assert "oauth2_client_info" not in params
+    assert params["some_other_param"] == "keep-this"
+
+
+def test_impersonation_capability_detected() -> None:
+    """The impersonation capability should be detected by lib.py's has_custom_method."""
+    from superset.db_engine_specs.lib import has_custom_method
+
+    for spec in ALL_DATABRICKS_SPECS:
+        assert has_custom_method(spec, "impersonate_user"), (
+            f"{spec.__name__} should be detected as having custom impersonate_user"
+        )


### PR DESCRIPTION
feat(databricks): add OAuth2 per-user impersonation for Databricks SQL Warehouses

### SUMMARY

Databricks SQL Warehouses do not support traditional impersonation mechanisms (`DelegationUID`, `hive.server2.proxy.user`). The **only** way to achieve per-user query execution is via OAuth2 per-user tokens — the same mechanism Tableau uses (verified via Databricks audit logs: `system.access.audit`).

This PR adds OAuth2 support to all Databricks engine specs via a `DatabricksOAuth2Mixin`, enabling per-user query execution on SQL Warehouses. Each Superset user authenticates individually with Databricks OIDC, and their personal OAuth2 token replaces the shared PAT at query time.

**Built on top of existing Superset OAuth2 infrastructure:**
- **SIP-85 / #27631** — OAuth2 for databases foundation (`database_user_oauth2_tokens` table, OAuth2 dance flow, PKCE support, frontend redirect handling)
- **#30081** — Trino OAuth2 implementation (used as reference pattern for this PR)
- **#32485** — Consolidated `impersonate_user()` API that this PR targets
- **#36850** — Earlier attempt at Databricks OAuth2 (this PR addresses its code review issues: code duplication via mixin, unsafe `flask.g` access via `has_request_context()`, fragile host extraction via safe `.get()`)

**How it works:**
1. Admin registers Superset as an OAuth app in Databricks Account Console (Settings → App connections)
2. Admin configures `oauth2_client_info` in the database's encrypted extra (or globally via `DATABASE_OAUTH2_CLIENTS`)
3. Admin enables "Impersonate logged in user" on the Databricks connection
4. When a user runs a query and has no stored OAuth token, Superset proactively triggers the OAuth2 dance — redirecting the user to Databricks login
5. After authentication, the token is stored in `database_user_oauth2_tokens` (per-user, per-database, encrypted)
6. Subsequent queries use the stored token (auto-refreshed via refresh_token), replacing the PAT in the connection URI

**Key design decisions:**
- **Mixin pattern** (`DatabricksOAuth2Mixin`) avoids code duplication across the two Databricks inheritance trees (`DatabricksHiveEngineSpec → HiveEngineSpec` and `DatabricksBaseEngineSpec → BaseEngineSpec`) — addresses duplication concern from #36850 review
- **Proactive OAuth dance** — when `impersonate_user=True` and OAuth is configured but no token exists, the dance triggers immediately instead of falling back to the shared PAT (which would run queries as the PAT owner, defeating impersonation)
- **Exception chain walking** in `needs_oauth2` — the `databricks-sql-connector` raises `RequestError` which SQLAlchemy wraps in `DBAPIError`. We walk the `__cause__` chain and check string representations to detect 401/403 errors
- **Safe request context check** — uses `has_request_context()` instead of checking `flask.g` directly (which is a `LocalProxy` and never falsy) — addresses unsafe `flask.g` access from #36850 review
- **OIDC endpoint auto-derivation** — admins only need to provide `host` in the config; authorization and token URLs are derived as `https://{host}/oidc/v1/authorize` and `https://{host}/oidc/v1/token`
- **`update_params_from_encrypted_extra` override** — strips `oauth2_client_info` before passing params to `create_engine()` to prevent SQLAlchemy `Invalid argument` errors

**Changes:**
- `superset/db_engine_specs/databricks.py` — Add `DatabricksAuthError`, `DatabricksOAuth2Mixin` (with `impersonate_user`, `needs_oauth2`, `get_oauth2_config`, `update_params_from_encrypted_extra`), apply mixin to both base classes, make `access_token` optional when OAuth2 is configured
- `superset/databases/schemas.py` — Update `impersonate_user_description` to mention Databricks
- `superset-frontend/.../ExtraOptions.tsx` — Add "Databricks" to impersonation checkbox label and tooltip
- `superset/config.py` — Add commented Databricks example in `DATABASE_OAUTH2_CLIENTS`
- `tests/unit_tests/db_engine_specs/test_databricks.py` — Add 15 unit tests covering OAuth2 class vars, impersonation with/without tokens, proactive OAuth dance, auth error detection, config derivation, encrypted_extra stripping, and capability detection

**Verified via Databricks audit logs** that this produces identical OAuth events (`mintOAuthAuthorizationCode`, `mintOAuthToken`) as Tableau's integration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Impersonation checkbox lists "Presto, Trino, Drill, Hive, and Google Sheets"
**After:** Impersonation checkbox lists "Presto, Trino, Drill, Hive, Databricks, and Google Sheets"

### TESTING INSTRUCTIONS

**Prerequisites:**
- Databricks workspace with a SQL Warehouse
- Superset 4.1.0+ (requires `database_user_oauth2_tokens` table from SIP-85 / #27631)

**Setup:**
1. In Databricks Account Console → Settings → App connections → Add connection:
   - Name: `Superset`
   - Redirect URL: `https://<superset-host>/api/v1/database/oauth2/`
   - Scopes: `SQL`, `All APIs`
   - Generate a client secret
   - Copy client_id and client_secret

2. In Superset, create/edit a Databricks database connection:
   - In **Encrypted Extra**, add:
     ```json
     {
         "oauth2_client_info": {
             "id": "<client-id>",
             "secret": "<client-secret>",
             "scope": "sql offline_access",
             "authorization_request_uri": "https://<workspace>.cloud.databricks.com/oidc/v1/authorize",
             "token_request_uri": "https://<workspace>.cloud.databricks.com/oidc/v1/token"
         }
     }
     ```
   - Enable **"Impersonate logged in user"**
   - Set `DATABASE_OAUTH2_REDIRECT_URI` in `superset_config.py` if needed

**Test flow:**
1. Open SQL Lab → select Databricks database
2. Run `SELECT current_user()`
3. First time: OAuth redirect prompt appears → authenticate with Databricks → query auto-retries
4. Result should show **your Databricks email**, not the service account
5. Subsequent queries should use stored token without re-authentication
6. Verify in Databricks: `SELECT * FROM system.access.audit WHERE request_params.client_id = '<your-client-id>' ORDER BY event_time DESC`

**Unit tests:** `pytest tests/unit_tests/db_engine_specs/test_databricks.py -v` (27 passed, 1 skipped)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
