### PR TITLE
fix(mcp): handle OAuth-authenticated databases in execute_sql

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -656,11 +656,6 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
         tab_id = str(uuid4())
         default_redirect_uri = get_oauth2_redirect_uri()
-        if not default_redirect_uri:
-            raise OAuth2Error(
-                "Unable to determine the OAuth2 redirect URI. "
-                "Set DATABASE_OAUTH2_REDIRECT_URI in the configuration."
-            )
 
         # Generate PKCE code verifier (RFC 7636)
         code_verifier = generate_code_verifier()

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -656,6 +656,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
         tab_id = str(uuid4())
         default_redirect_uri = get_oauth2_redirect_uri()
+        if not default_redirect_uri:
+            raise OAuth2Error(
+                "Unable to determine the OAuth2 redirect URI. "
+                "Set DATABASE_OAUTH2_REDIRECT_URI in the configuration."
+            )
 
         # Generate PKCE code verifier (RFC 7636)
         code_verifier = generate_code_verifier()

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -43,7 +43,7 @@ import requests
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from deprecation import deprecated
-from flask import current_app as app, g, url_for
+from flask import current_app as app, g
 from flask_appbuilder.security.sqla.models import User
 from flask_babel import gettext as __, lazy_gettext as _
 from marshmallow import fields, Schema

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -88,6 +88,7 @@ from superset.utils.oauth2 import (
     encode_oauth2_state,
     generate_code_challenge,
     generate_code_verifier,
+    get_oauth2_redirect_uri,
 )
 
 if TYPE_CHECKING:
@@ -654,10 +655,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         from superset.daos.key_value import KeyValueDAO
 
         tab_id = str(uuid4())
-        default_redirect_uri = app.config.get(
-            "DATABASE_OAUTH2_REDIRECT_URI",
-            url_for("DatabaseRestApi.oauth2", _external=True),
-        )
+        default_redirect_uri = get_oauth2_redirect_uri()
 
         # Generate PKCE code verifier (RFC 7636)
         code_verifier = generate_code_verifier()
@@ -720,10 +718,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             return None
 
         db_engine_spec_config = oauth2_config[cls.engine_name]
-        redirect_uri = app.config.get(
-            "DATABASE_OAUTH2_REDIRECT_URI",
-            url_for("DatabaseRestApi.oauth2", _external=True),
-        )
+        redirect_uri = get_oauth2_redirect_uri()
 
         config: OAuth2ClientConfig = {
             "id": db_engine_spec_config["id"],

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -29,6 +29,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException
+from superset.exceptions import OAuth2Error, OAuth2RedirectError
 from superset.extensions import event_logger
 from superset.mcp_service.auth import has_dataset_access
 from superset.mcp_service.chart.chart_utils import (
@@ -45,6 +46,10 @@ from superset.mcp_service.chart.schemas import (
     GenerateChartResponse,
     parse_chart_config,
     PerformanceMetadata,
+)
+from superset.mcp_service.utils.oauth2_utils import (
+    build_oauth2_redirect_message,
+    OAUTH2_CONFIG_ERROR_MESSAGE,
 )
 from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.utils import json
@@ -826,6 +831,35 @@ async def generate_chart(  # noqa: C901
         )
         return GenerateChartResponse.model_validate(result)
 
+    except OAuth2RedirectError as ex:
+        await ctx.error(
+            "Chart generation requires OAuth authentication: dataset_id=%s"
+            % request.dataset_id
+        )
+        return GenerateChartResponse.model_validate(
+            {
+                "chart": None,
+                "success": False,
+                "error": {
+                    "error_type": "OAUTH2_REDIRECT",
+                    "message": build_oauth2_redirect_message(ex),
+                },
+            }
+        )
+    except OAuth2Error:
+        await ctx.error(
+            "OAuth2 configuration error: dataset_id=%s" % request.dataset_id
+        )
+        return GenerateChartResponse.model_validate(
+            {
+                "chart": None,
+                "success": False,
+                "error": {
+                    "error_type": "OAUTH2_REDIRECT_ERROR",
+                    "message": OAUTH2_CONFIG_ERROR_MESSAGE,
+                },
+            }
+        )
     except (CommandException, SQLAlchemyError, KeyError, ValueError) as e:
         from superset import db
 

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -843,6 +843,7 @@ async def generate_chart(  # noqa: C901
                 "error": {
                     "error_type": "OAUTH2_REDIRECT",
                     "message": build_oauth2_redirect_message(ex),
+                    "details": "OAuth2 authentication required",
                 },
             }
         )
@@ -857,6 +858,7 @@ async def generate_chart(  # noqa: C901
                 "error": {
                     "error_type": "OAUTH2_REDIRECT_ERROR",
                     "message": OAUTH2_CONFIG_ERROR_MESSAGE,
+                    "details": "OAuth2 configuration or provider error",
                 },
             }
         )

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
-from superset.exceptions import SupersetException
+from superset.exceptions import OAuth2Error, OAuth2RedirectError, SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 from superset.mcp_service.chart.schemas import (
@@ -43,6 +43,10 @@ from superset.mcp_service.chart.schemas import (
     PerformanceMetadata,
 )
 from superset.mcp_service.utils.cache_utils import get_cache_status_from_result
+from superset.mcp_service.utils.oauth2_utils import (
+    build_oauth2_redirect_message,
+    OAUTH2_CONFIG_ERROR_MESSAGE,
+)
 from superset.utils.core import merge_extra_filters
 
 logger = logging.getLogger(__name__)
@@ -797,6 +801,23 @@ async def get_chart_data(  # noqa: C901
                 error_type="DataError",
             )
 
+    except OAuth2RedirectError as ex:
+        await ctx.error(
+            "Chart data requires OAuth authentication: identifier=%s"
+            % request.identifier
+        )
+        return ChartError(
+            error=build_oauth2_redirect_message(ex),
+            error_type="OAUTH2_REDIRECT",
+        )
+    except OAuth2Error:
+        await ctx.error(
+            "OAuth2 configuration error: identifier=%s" % request.identifier
+        )
+        return ChartError(
+            error=OAUTH2_CONFIG_ERROR_MESSAGE,
+            error_type="OAUTH2_REDIRECT_ERROR",
+        )
     except Exception as e:
         await ctx.error(
             "Chart data retrieval failed: identifier=%s, error=%s, error_type=%s"

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -26,7 +26,7 @@ from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException
-from superset.exceptions import SupersetException
+from superset.exceptions import OAuth2Error, OAuth2RedirectError, SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 from superset.mcp_service.chart.schemas import (
@@ -40,6 +40,10 @@ from superset.mcp_service.chart.schemas import (
     TablePreview,
     URLPreview,
     VegaLitePreview,
+)
+from superset.mcp_service.utils.oauth2_utils import (
+    build_oauth2_redirect_message,
+    OAUTH2_CONFIG_ERROR_MESSAGE,
 )
 from superset.mcp_service.utils.url_utils import get_superset_base_url
 
@@ -2247,6 +2251,23 @@ async def get_chart_preview(
             )
 
         return result
+    except OAuth2RedirectError as ex:
+        await ctx.error(
+            "Chart preview requires OAuth authentication: identifier=%s"
+            % request.identifier
+        )
+        return ChartError(
+            error=build_oauth2_redirect_message(ex),
+            error_type="OAUTH2_REDIRECT",
+        )
+    except OAuth2Error:
+        await ctx.error(
+            "OAuth2 configuration error: identifier=%s" % request.identifier
+        )
+        return ChartError(
+            error=OAUTH2_CONFIG_ERROR_MESSAGE,
+            error_type="OAUTH2_REDIRECT_ERROR",
+        )
     except Exception as e:
         await ctx.error(
             "Chart preview generation failed: identifier=%s, error=%s, error_type=%s"

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -330,6 +330,7 @@ async def update_chart(  # noqa: C901
                 "error": {
                     "error_type": "OAUTH2_REDIRECT",
                     "message": build_oauth2_redirect_message(ex),
+                    "details": "OAuth2 authentication required",
                 },
             }
         )
@@ -342,6 +343,7 @@ async def update_chart(  # noqa: C901
                 "error": {
                     "error_type": "OAUTH2_REDIRECT_ERROR",
                     "message": OAUTH2_CONFIG_ERROR_MESSAGE,
+                    "details": "OAuth2 configuration or provider error",
                 },
             }
         )

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -320,7 +320,8 @@ async def update_chart(  # noqa: C901
 
     except OAuth2RedirectError as ex:
         await ctx.error(
-            "Chart update requires OAuth authentication: chart_id=%s" % request.chart_id
+            "Chart update requires OAuth authentication: chart_id=%s"
+            % request.identifier
         )
         return GenerateChartResponse.model_validate(
             {
@@ -333,7 +334,7 @@ async def update_chart(  # noqa: C901
             }
         )
     except OAuth2Error:
-        await ctx.error("OAuth2 configuration error: chart_id=%s" % request.chart_id)
+        await ctx.error("OAuth2 configuration error: chart_id=%s" % request.identifier)
         return GenerateChartResponse.model_validate(
             {
                 "chart": None,

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException
+from superset.exceptions import OAuth2Error, OAuth2RedirectError
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import (
     analyze_chart_capabilities,
@@ -41,6 +42,10 @@ from superset.mcp_service.chart.schemas import (
     parse_chart_config,
     PerformanceMetadata,
     UpdateChartRequest,
+)
+from superset.mcp_service.utils.oauth2_utils import (
+    build_oauth2_redirect_message,
+    OAUTH2_CONFIG_ERROR_MESSAGE,
 )
 from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.utils import json
@@ -118,7 +123,7 @@ def _build_update_payload(
         destructiveHint=True,
     ),
 )
-async def update_chart(
+async def update_chart(  # noqa: C901
     request: UpdateChartRequest, ctx: Context
 ) -> GenerateChartResponse:
     """Update existing chart with new configuration.
@@ -313,6 +318,32 @@ async def update_chart(
         }
         return GenerateChartResponse.model_validate(result)
 
+    except OAuth2RedirectError as ex:
+        await ctx.error(
+            "Chart update requires OAuth authentication: chart_id=%s" % request.chart_id
+        )
+        return GenerateChartResponse.model_validate(
+            {
+                "chart": None,
+                "success": False,
+                "error": {
+                    "error_type": "OAUTH2_REDIRECT",
+                    "message": build_oauth2_redirect_message(ex),
+                },
+            }
+        )
+    except OAuth2Error:
+        await ctx.error("OAuth2 configuration error: chart_id=%s" % request.chart_id)
+        return GenerateChartResponse.model_validate(
+            {
+                "chart": None,
+                "success": False,
+                "error": {
+                    "error_type": "OAUTH2_REDIRECT_ERROR",
+                    "message": OAUTH2_CONFIG_ERROR_MESSAGE,
+                },
+            }
+        )
     except (
         CommandException,
         SQLAlchemyError,

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -320,7 +320,7 @@ async def update_chart(  # noqa: C901
 
     except OAuth2RedirectError as ex:
         await ctx.error(
-            "Chart update requires OAuth authentication: chart_id=%s"
+            "Chart update requires OAuth authentication: identifier=%s"
             % request.identifier
         )
         return GenerateChartResponse.model_validate(

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -181,9 +181,9 @@ def update_chart_preview(
         return result
 
     except OAuth2RedirectError as ex:
-        await ctx.error(
-            "Chart preview update requires OAuth authentication: chart_id=%s"
-            % request.chart_id
+        logger.warning(
+            "Chart preview update requires OAuth authentication: chart_id=%s",
+            request.chart_id,
         )
         return {
             "chart": None,
@@ -191,7 +191,7 @@ def update_chart_preview(
             "success": False,
         }
     except OAuth2Error:
-        await ctx.error("OAuth2 configuration error: chart_id=%s" % request.chart_id)
+        logger.warning("OAuth2 configuration error: chart_id=%s", request.chart_id)
         return {
             "chart": None,
             "error": OAUTH2_CONFIG_ERROR_MESSAGE,

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -182,7 +182,7 @@ def update_chart_preview(
 
     except OAuth2RedirectError as ex:
         logger.warning(
-            "Chart preview update requires OAuth authentication: chart_id=%s",
+            "Chart preview update requires OAuth authentication: form_data_key=%s",
             request.form_data_key,
         )
         return {
@@ -191,7 +191,9 @@ def update_chart_preview(
             "success": False,
         }
     except OAuth2Error:
-        logger.warning("OAuth2 configuration error: chart_id=%s", request.form_data_key)
+        logger.warning(
+            "OAuth2 configuration error: form_data_key=%s", request.form_data_key
+        )
         return {
             "chart": None,
             "error": OAUTH2_CONFIG_ERROR_MESSAGE,

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -26,6 +26,7 @@ from typing import Any, Dict
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
+from superset.exceptions import OAuth2Error, OAuth2RedirectError
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import (
     analyze_chart_capabilities,
@@ -39,6 +40,10 @@ from superset.mcp_service.chart.schemas import (
     parse_chart_config,
     PerformanceMetadata,
     UpdateChartPreviewRequest,
+)
+from superset.mcp_service.utils.oauth2_utils import (
+    build_oauth2_redirect_message,
+    OAUTH2_CONFIG_ERROR_MESSAGE,
 )
 from superset.utils import json as utils_json
 
@@ -175,6 +180,23 @@ def update_chart_preview(
         }
         return result
 
+    except OAuth2RedirectError as ex:
+        await ctx.error(
+            "Chart preview update requires OAuth authentication: chart_id=%s"
+            % request.chart_id
+        )
+        return {
+            "chart": None,
+            "error": build_oauth2_redirect_message(ex),
+            "success": False,
+        }
+    except OAuth2Error:
+        await ctx.error("OAuth2 configuration error: chart_id=%s" % request.chart_id)
+        return {
+            "chart": None,
+            "error": OAUTH2_CONFIG_ERROR_MESSAGE,
+            "success": False,
+        }
     except Exception as e:
         execution_time = int((time.time() - start_time) * 1000)
         return {

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -183,7 +183,7 @@ def update_chart_preview(
     except OAuth2RedirectError as ex:
         logger.warning(
             "Chart preview update requires OAuth authentication: chart_id=%s",
-            request.chart_id,
+            request.form_data_key,
         )
         return {
             "chart": None,
@@ -191,7 +191,7 @@ def update_chart_preview(
             "success": False,
         }
     except OAuth2Error:
-        logger.warning("OAuth2 configuration error: chart_id=%s", request.chart_id)
+        logger.warning("OAuth2 configuration error: chart_id=%s", request.form_data_key)
         return {
             "chart": None,
             "error": OAUTH2_CONFIG_ERROR_MESSAGE,

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -37,7 +37,7 @@ from superset_core.queries.types import (
 )
 
 from superset.errors import SupersetErrorType
-from superset.exceptions import OAuth2RedirectError
+from superset.exceptions import OAuth2Error, OAuth2RedirectError
 from superset.extensions import event_logger
 from superset.mcp_service.sql_lab.schemas import (
     ColumnInfo,
@@ -148,7 +148,7 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
 
         return response
 
-    except OAuth2RedirectError:
+    except (OAuth2RedirectError, OAuth2Error):
         await ctx.error(
             "Database requires OAuth authentication: database_id=%s"
             % request.database_id

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -148,7 +148,7 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
 
         return response
 
-    except (OAuth2RedirectError, OAuth2Error):
+    except OAuth2RedirectError:
         await ctx.error(
             "Database requires OAuth authentication: database_id=%s"
             % request.database_id
@@ -162,6 +162,19 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
                 "then retry this request."
             ),
             error_type=SupersetErrorType.OAUTH2_REDIRECT.value,
+        )
+    except OAuth2Error:
+        await ctx.error(
+            "OAuth2 configuration/flow error: database_id=%s" % request.database_id
+        )
+        return ExecuteSqlResponse(
+            success=False,
+            error=(
+                "OAuth authentication failed due to a configuration "
+                "or provider error. "
+                "Please contact your Superset administrator."
+            ),
+            error_type=SupersetErrorType.OAUTH2_REDIRECT_ERROR.value,
         )
     except Exception as e:
         await ctx.error(

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -46,6 +46,10 @@ from superset.mcp_service.sql_lab.schemas import (
     StatementData,
     StatementInfo,
 )
+from superset.mcp_service.utils.oauth2_utils import (
+    build_oauth2_redirect_message,
+    OAUTH2_CONFIG_ERROR_MESSAGE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -148,19 +152,14 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
 
         return response
 
-    except OAuth2RedirectError:
+    except OAuth2RedirectError as ex:
         await ctx.error(
             "Database requires OAuth authentication: database_id=%s"
             % request.database_id
         )
         return ExecuteSqlResponse(
             success=False,
-            error=(
-                "This database uses OAuth for authentication. "
-                "Please authenticate via the Superset UI first "
-                "(run any query in SQL Lab to trigger the OAuth flow), "
-                "then retry this request."
-            ),
+            error=build_oauth2_redirect_message(ex),
             error_type=SupersetErrorType.OAUTH2_REDIRECT.value,
         )
     except OAuth2Error:
@@ -169,11 +168,7 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
         )
         return ExecuteSqlResponse(
             success=False,
-            error=(
-                "OAuth authentication failed due to a configuration "
-                "or provider error. "
-                "Please contact your Superset administrator."
-            ),
+            error=OAUTH2_CONFIG_ERROR_MESSAGE,
             error_type=SupersetErrorType.OAUTH2_REDIRECT_ERROR.value,
         )
     except Exception as e:

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -37,6 +37,7 @@ from superset_core.queries.types import (
 )
 
 from superset.errors import SupersetErrorType
+from superset.exceptions import OAuth2RedirectError
 from superset.extensions import event_logger
 from superset.mcp_service.sql_lab.schemas import (
     ColumnInfo,
@@ -147,6 +148,21 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
 
         return response
 
+    except OAuth2RedirectError:
+        await ctx.error(
+            "Database requires OAuth authentication: database_id=%s"
+            % request.database_id
+        )
+        return ExecuteSqlResponse(
+            success=False,
+            error=(
+                "This database uses OAuth for authentication. "
+                "Please authenticate via the Superset UI first "
+                "(run any query in SQL Lab to trigger the OAuth flow), "
+                "then retry this request."
+            ),
+            error_type=SupersetErrorType.OAUTH2_REDIRECT.value,
+        )
     except Exception as e:
         await ctx.error(
             "SQL execution failed: error=%s, database_id=%s"

--- a/superset/mcp_service/utils/oauth2_utils.py
+++ b/superset/mcp_service/utils/oauth2_utils.py
@@ -19,19 +19,18 @@
 Utilities for handling OAuth2 errors in MCP tools.
 """
 
+from superset.exceptions import OAuth2RedirectError
 
-def build_oauth2_redirect_message(ex: Exception) -> str:
+
+def build_oauth2_redirect_message(ex: OAuth2RedirectError) -> str:
     """
     Build a user-facing message for OAuth2RedirectError.
 
     If the exception contains an authorization URL, include it so
     the MCP client can present it to the user for authentication.
     """
-    oauth_url = ""
-    if hasattr(ex, "error") and hasattr(ex.error, "extra") and ex.error.extra:
-        oauth_url = ex.error.extra.get("url", "")
 
-    if oauth_url:
+    if oauth_url := ex.error.extra.get("redirect_uri", ""):
         return (
             "This database uses OAuth for authentication. "
             "Please open the following URL in your browser to "

--- a/superset/mcp_service/utils/oauth2_utils.py
+++ b/superset/mcp_service/utils/oauth2_utils.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Utilities for handling OAuth2 errors in MCP tools.
+"""
+
+
+def build_oauth2_redirect_message(ex: Exception) -> str:
+    """
+    Build a user-facing message for OAuth2RedirectError.
+
+    If the exception contains an authorization URL, include it so
+    the MCP client can present it to the user for authentication.
+    """
+    oauth_url = ""
+    if hasattr(ex, "error") and hasattr(ex.error, "extra") and ex.error.extra:
+        oauth_url = ex.error.extra.get("url", "")
+
+    if oauth_url:
+        return (
+            "This database uses OAuth for authentication. "
+            "Please open the following URL in your browser to "
+            "authorize access, then retry this request:\n\n"
+            f"{oauth_url}"
+        )
+    return (
+        "This database uses OAuth for authentication. "
+        "Please authenticate via the Superset UI first, "
+        "then retry this request."
+    )
+
+
+OAUTH2_CONFIG_ERROR_MESSAGE = (
+    "OAuth authentication failed due to a configuration "
+    "or provider error. "
+    "Please contact your Superset administrator."
+)

--- a/superset/mcp_service/utils/oauth2_utils.py
+++ b/superset/mcp_service/utils/oauth2_utils.py
@@ -26,21 +26,15 @@ def build_oauth2_redirect_message(ex: OAuth2RedirectError) -> str:
     """
     Build a user-facing message for OAuth2RedirectError.
 
-    If the exception contains an authorization URL, include it so
-    the MCP client can present it to the user for authentication.
+    Extracts the authorization URL from the exception and includes it
+    so the MCP client can present it to the user for authentication.
     """
-
-    if oauth_url := (ex.error.extra or {}).get("url", ""):
-        return (
-            "This database uses OAuth for authentication. "
-            "Please open the following URL in your browser to "
-            "authorize access, then retry this request:\n\n"
-            f"{oauth_url}"
-        )
+    oauth_url = ex.error.extra["url"]
     return (
         "This database uses OAuth for authentication. "
-        "Please authenticate via the Superset UI first, "
-        "then retry this request."
+        "Please open the following URL in your browser to "
+        "authorize access, then retry this request:\n\n"
+        f"{oauth_url}"
     )
 
 

--- a/superset/mcp_service/utils/oauth2_utils.py
+++ b/superset/mcp_service/utils/oauth2_utils.py
@@ -30,7 +30,7 @@ def build_oauth2_redirect_message(ex: OAuth2RedirectError) -> str:
     the MCP client can present it to the user for authentication.
     """
 
-    if oauth_url := ex.error.extra.get("redirect_uri", ""):
+    if oauth_url := (ex.error.extra or {}).get("redirect_uri", ""):
         return (
             "This database uses OAuth for authentication. "
             "Please open the following URL in your browser to "

--- a/superset/mcp_service/utils/oauth2_utils.py
+++ b/superset/mcp_service/utils/oauth2_utils.py
@@ -30,7 +30,7 @@ def build_oauth2_redirect_message(ex: OAuth2RedirectError) -> str:
     the MCP client can present it to the user for authentication.
     """
 
-    if oauth_url := (ex.error.extra or {}).get("redirect_uri", ""):
+    if oauth_url := (ex.error.extra or {}).get("url", ""):
         return (
             "This database uses OAuth for authentication. "
             "Please open the following URL in your browser to "

--- a/superset/mcp_service/utils/oauth2_utils.py
+++ b/superset/mcp_service/utils/oauth2_utils.py
@@ -29,6 +29,8 @@ def build_oauth2_redirect_message(ex: OAuth2RedirectError) -> str:
     Extracts the authorization URL from the exception and includes it
     so the MCP client can present it to the user for authentication.
     """
+    # extra is always set by OAuth2RedirectError.__init__
+    assert ex.error.extra is not None  # noqa: S101
     oauth_url = ex.error.extra["url"]
     return (
         "This database uses OAuth for authentication. "

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -69,6 +69,8 @@ from flask import current_app as app, g, has_app_context
 from superset import db
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
+    OAuth2Error,
+    OAuth2RedirectError,
     SupersetSecurityException,
     SupersetTimeoutException,
 )
@@ -318,6 +320,10 @@ class SQLExecutor:
             )
         except SupersetSecurityException as ex:
             return self._create_error_result(QueryStatus.FAILED, str(ex), start_time)
+        except (OAuth2RedirectError, OAuth2Error):
+            # Let OAuth2 exceptions propagate so callers (MCP, API) can
+            # handle them with context-appropriate responses.
+            raise
         except Exception as ex:
             error_msg = self.database.db_engine_spec.extract_error_message(ex)
             return self._create_error_result(QueryStatus.FAILED, error_msg, start_time)

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -33,7 +33,7 @@ from werkzeug.routing import BuildError
 
 from superset import db
 from superset.distributed_lock import DistributedLock
-from superset.exceptions import AcquireDistributedLockFailedException
+from superset.exceptions import AcquireDistributedLockFailedException, OAuth2Error
 from superset.superset_typing import OAuth2ClientConfig, OAuth2State
 
 if TYPE_CHECKING:
@@ -252,9 +252,8 @@ def get_oauth2_redirect_uri() -> str:
 
     Tries the explicit config first, then falls back to url_for().
     If url_for() fails (e.g. in headless/MCP contexts where the
-    DatabaseRestApi blueprint may not be registered), returns an
-    empty string so that callers can detect the missing URI
-    instead of crashing.
+    DatabaseRestApi blueprint may not be registered), raises
+    OAuth2Error so callers don't silently proceed with an invalid URI.
     """
     if configured := app.config.get("DATABASE_OAUTH2_REDIRECT_URI"):
         return configured
@@ -262,11 +261,10 @@ def get_oauth2_redirect_uri() -> str:
     try:
         return url_for("DatabaseRestApi.oauth2", _external=True)
     except (BuildError, RuntimeError):
-        logger.warning(
-            "Could not build OAuth2 redirect URI via url_for(); "
-            "set DATABASE_OAUTH2_REDIRECT_URI in the config."
-        )
-        return ""
+        raise OAuth2Error(
+            "Unable to determine the OAuth2 redirect URI. "
+            "Set DATABASE_OAUTH2_REDIRECT_URI in the configuration."
+        ) from None
 
 
 class OAuth2ClientConfigSchema(Schema):

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -256,8 +256,7 @@ def get_oauth2_redirect_uri() -> str:
     empty string so that callers can detect the missing URI
     instead of crashing.
     """
-    configured = app.config.get("DATABASE_OAUTH2_REDIRECT_URI")
-    if configured:
+    if configured := app.config.get("DATABASE_OAUTH2_REDIRECT_URI"):
         return configured
 
     try:

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -273,7 +273,7 @@ class OAuth2ClientConfigSchema(Schema):
     scope = fields.String(required=True)
     redirect_uri = fields.String(
         required=False,
-        load_default=lambda: get_oauth2_redirect_uri(),
+        load_default=get_oauth2_redirect_uri,
     )
     authorization_request_uri = fields.String(required=True)
     token_request_uri = fields.String(required=True)

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -29,6 +29,7 @@ import backoff
 import jwt
 from flask import current_app as app, url_for
 from marshmallow import EXCLUDE, fields, post_load, Schema, validate
+from werkzeug.routing import BuildError
 
 from superset import db
 from superset.distributed_lock import DistributedLock
@@ -245,16 +246,37 @@ def decode_oauth2_state(encoded_state: str) -> OAuth2State:
     return state
 
 
+def get_oauth2_redirect_uri() -> str:
+    """
+    Return the OAuth2 redirect URI.
+
+    Tries the explicit config first, then falls back to url_for().
+    If url_for() fails (e.g. in headless/MCP contexts where the
+    DatabaseRestApi blueprint may not be registered), returns an
+    empty string so that callers can detect the missing URI
+    instead of crashing.
+    """
+    configured = app.config.get("DATABASE_OAUTH2_REDIRECT_URI")
+    if configured:
+        return configured
+
+    try:
+        return url_for("DatabaseRestApi.oauth2", _external=True)
+    except BuildError:
+        logger.warning(
+            "Could not build OAuth2 redirect URI via url_for(); "
+            "set DATABASE_OAUTH2_REDIRECT_URI in the config."
+        )
+        return ""
+
+
 class OAuth2ClientConfigSchema(Schema):
     id = fields.String(required=True)
     secret = fields.String(required=True)
     scope = fields.String(required=True)
     redirect_uri = fields.String(
         required=False,
-        load_default=lambda: app.config.get(
-            "DATABASE_OAUTH2_REDIRECT_URI",
-            url_for("DatabaseRestApi.oauth2", _external=True),
-        ),
+        load_default=lambda: get_oauth2_redirect_uri(),
     )
     authorization_request_uri = fields.String(required=True)
     token_request_uri = fields.String(required=True)

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -262,7 +262,7 @@ def get_oauth2_redirect_uri() -> str:
 
     try:
         return url_for("DatabaseRestApi.oauth2", _external=True)
-    except BuildError:
+    except (BuildError, RuntimeError):
         logger.warning(
             "Could not build OAuth2 redirect URI via url_for(); "
             "set DATABASE_OAUTH2_REDIRECT_URI in the config."

--- a/tests/unit_tests/db_engine_specs/test_base.py
+++ b/tests/unit_tests/db_engine_specs/test_base.py
@@ -1196,7 +1196,7 @@ def test_start_oauth2_dance_falls_back_to_url_for(mocker: MockerFixture) -> None
         },
     )
     mocker.patch(
-        "superset.db_engine_specs.base.url_for",
+        "superset.utils.oauth2.url_for",
         return_value=fallback_uri,
     )
     mocker.patch("superset.daos.key_value.KeyValueDAO")

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -1130,7 +1130,7 @@ class TestExecuteSqlOAuth2:
             data = result.structured_content
             assert data["success"] is False
             assert "OAuth" in data["error"]
-            assert "https://superset.example.com/callback" in data["error"]
+            assert "https://oauth.example.com/authorize" in data["error"]
             assert data["error_type"] == "OAUTH2_REDIRECT"
 
     @patch("superset.security_manager")

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -1130,7 +1130,7 @@ class TestExecuteSqlOAuth2:
             data = result.structured_content
             assert data["success"] is False
             assert "OAuth" in data["error"]
-            assert "oauth.example.com" in data["error"]
+            assert "https://superset.example.com/callback" in data["error"]
             assert data["error_type"] == "OAUTH2_REDIRECT"
 
     @patch("superset.security_manager")

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -1162,5 +1162,5 @@ class TestExecuteSqlOAuth2:
 
             data = result.structured_content
             assert data["success"] is False
-            assert "OAuth" in data["error"]
-            assert data["error_type"] == "OAUTH2_REDIRECT"
+            assert "configuration" in data["error"]
+            assert data["error_type"] == "OAUTH2_REDIRECT_ERROR"

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -1130,7 +1130,7 @@ class TestExecuteSqlOAuth2:
             data = result.structured_content
             assert data["success"] is False
             assert "OAuth" in data["error"]
-            assert "Superset UI" in data["error"]
+            assert "oauth.example.com" in data["error"]
             assert data["error_type"] == "OAUTH2_REDIRECT"
 
     @patch("superset.security_manager")

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -1093,3 +1093,74 @@ class TestSanitizeRowValues:
         assert rows[0]["name"] == "test"
         assert rows[0]["price"] == 9.99
         assert rows[0]["blob"] == "000102ff"
+
+
+class TestExecuteSqlOAuth2:
+    """Tests for OAuth2 error handling in execute_sql."""
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_execute_sql_oauth2_redirect_error(
+        self, mock_db, mock_security_manager, mcp_server
+    ):
+        """Test that OAuth2RedirectError is caught and returns a clear message."""
+        from superset.exceptions import OAuth2RedirectError
+
+        mock_database = _mock_database()
+        mock_database.execute.side_effect = OAuth2RedirectError(
+            url="https://oauth.example.com/authorize",
+            tab_id="test-tab-id",
+            redirect_uri="https://superset.example.com/callback",
+        )
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {
+            "database_id": 1,
+            "sql": "SELECT 1",
+            "limit": 100,
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+
+            data = result.structured_content
+            assert data["success"] is False
+            assert "OAuth" in data["error"]
+            assert "Superset UI" in data["error"]
+            assert data["error_type"] == "OAUTH2_REDIRECT"
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_execute_sql_oauth2_error(
+        self, mock_db, mock_security_manager, mcp_server
+    ):
+        """Test that OAuth2Error is caught and returns a clear message."""
+        from superset.exceptions import OAuth2Error
+
+        mock_database = _mock_database()
+        mock_database.execute.side_effect = OAuth2Error(
+            "Unable to determine the OAuth2 redirect URI."
+        )
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {
+            "database_id": 1,
+            "sql": "SELECT 1",
+            "limit": 100,
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+
+            data = result.structured_content
+            assert data["success"] is False
+            assert "OAuth" in data["error"]
+            assert data["error_type"] == "OAUTH2_REDIRECT"

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -644,6 +644,78 @@ def test_execute_error(
     assert "Database error" in result.error_message
 
 
+def test_execute_oauth2_redirect_error_propagates(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """Test that OAuth2RedirectError propagates instead of being swallowed."""
+    from superset.exceptions import OAuth2RedirectError
+
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mocker.patch.object(database, "get_raw_connection", return_value=mock_conn)
+    mocker.patch.object(
+        database, "mutate_sql_based_on_config", side_effect=lambda sql, **kw: sql
+    )
+    mocker.patch.object(
+        database.db_engine_spec,
+        "execute",
+        side_effect=OAuth2RedirectError(
+            url="https://oauth.example.com/authorize",
+            tab_id="test-tab",
+            redirect_uri="https://superset.example.com/callback",
+        ),
+    )
+    mocker.patch.dict(
+        current_app.config,
+        {
+            "SQL_QUERY_MUTATOR": None,
+            "SQLLAB_TIMEOUT": 30,
+            "SQL_MAX_ROW": None,
+            "QUERY_LOGGER": None,
+        },
+    )
+
+    with pytest.raises(OAuth2RedirectError):
+        database.execute("SELECT 1")
+
+
+def test_execute_oauth2_error_propagates(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """Test that OAuth2Error propagates instead of being swallowed."""
+    from superset.exceptions import OAuth2Error
+
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mocker.patch.object(database, "get_raw_connection", return_value=mock_conn)
+    mocker.patch.object(
+        database, "mutate_sql_based_on_config", side_effect=lambda sql, **kw: sql
+    )
+    mocker.patch.object(
+        database.db_engine_spec,
+        "execute",
+        side_effect=OAuth2Error("No configuration found for OAuth2"),
+    )
+    mocker.patch.dict(
+        current_app.config,
+        {
+            "SQL_QUERY_MUTATOR": None,
+            "SQLLAB_TIMEOUT": 30,
+            "SQL_MAX_ROW": None,
+            "QUERY_LOGGER": None,
+        },
+    )
+
+    with pytest.raises(OAuth2Error):
+        database.execute("SELECT 1")
+
+
 # =============================================================================
 # Async Execution Tests
 # =============================================================================

--- a/tests/unit_tests/utils/oauth2_tests.py
+++ b/tests/unit_tests/utils/oauth2_tests.py
@@ -33,6 +33,7 @@ from superset.utils.oauth2 import (
     generate_code_challenge,
     generate_code_verifier,
     get_oauth2_access_token,
+    get_oauth2_redirect_uri,
     refresh_oauth2_token,
 )
 
@@ -335,3 +336,60 @@ def test_encode_decode_oauth2_state(
     assert "code_verifier" not in decoded
     assert decoded["database_id"] == 1
     assert decoded["user_id"] == 2
+
+
+def test_get_oauth2_redirect_uri_from_config(mocker: MockerFixture) -> None:
+    """
+    Test that get_oauth2_redirect_uri returns the configured value when set.
+    """
+    custom_uri = "https://proxy.example.com/oauth2/"
+    mocker.patch(
+        "flask.current_app.config",
+        {"DATABASE_OAUTH2_REDIRECT_URI": custom_uri},
+    )
+    assert get_oauth2_redirect_uri() == custom_uri
+
+
+def test_get_oauth2_redirect_uri_falls_back_to_url_for(mocker: MockerFixture) -> None:
+    """
+    Test that get_oauth2_redirect_uri falls back to url_for when config is not set.
+    """
+    fallback_uri = "http://localhost:8088/api/v1/database/oauth2/"
+    mocker.patch("flask.current_app.config", {})
+    mocker.patch(
+        "superset.utils.oauth2.url_for",
+        return_value=fallback_uri,
+    )
+    assert get_oauth2_redirect_uri() == fallback_uri
+
+
+def test_get_oauth2_redirect_uri_returns_empty_on_build_error(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that get_oauth2_redirect_uri returns empty string when url_for raises
+    BuildError (e.g. in headless/MCP contexts).
+    """
+    from werkzeug.routing import BuildError
+
+    mocker.patch("flask.current_app.config", {})
+    mocker.patch(
+        "superset.utils.oauth2.url_for",
+        side_effect=BuildError("DatabaseRestApi.oauth2", {}, ("GET",)),
+    )
+    assert get_oauth2_redirect_uri() == ""
+
+
+def test_get_oauth2_redirect_uri_returns_empty_on_runtime_error(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that get_oauth2_redirect_uri returns empty string when url_for raises
+    RuntimeError (e.g. no request context and no SERVER_NAME).
+    """
+    mocker.patch("flask.current_app.config", {})
+    mocker.patch(
+        "superset.utils.oauth2.url_for",
+        side_effect=RuntimeError("Unable to build URL outside of request context"),
+    )
+    assert get_oauth2_redirect_uri() == ""

--- a/tests/unit_tests/utils/oauth2_tests.py
+++ b/tests/unit_tests/utils/oauth2_tests.py
@@ -363,33 +363,39 @@ def test_get_oauth2_redirect_uri_falls_back_to_url_for(mocker: MockerFixture) ->
     assert get_oauth2_redirect_uri() == fallback_uri
 
 
-def test_get_oauth2_redirect_uri_returns_empty_on_build_error(
+def test_get_oauth2_redirect_uri_raises_on_build_error(
     mocker: MockerFixture,
 ) -> None:
     """
-    Test that get_oauth2_redirect_uri returns empty string when url_for raises
+    Test that get_oauth2_redirect_uri raises OAuth2Error when url_for raises
     BuildError (e.g. in headless/MCP contexts).
     """
     from werkzeug.routing import BuildError
+
+    from superset.exceptions import OAuth2Error
 
     mocker.patch("flask.current_app.config", {})
     mocker.patch(
         "superset.utils.oauth2.url_for",
         side_effect=BuildError("DatabaseRestApi.oauth2", {}, ("GET",)),
     )
-    assert get_oauth2_redirect_uri() == ""
+    with pytest.raises(OAuth2Error):
+        get_oauth2_redirect_uri()
 
 
-def test_get_oauth2_redirect_uri_returns_empty_on_runtime_error(
+def test_get_oauth2_redirect_uri_raises_on_runtime_error(
     mocker: MockerFixture,
 ) -> None:
     """
-    Test that get_oauth2_redirect_uri returns empty string when url_for raises
+    Test that get_oauth2_redirect_uri raises OAuth2Error when url_for raises
     RuntimeError (e.g. no request context and no SERVER_NAME).
     """
+    from superset.exceptions import OAuth2Error
+
     mocker.patch("flask.current_app.config", {})
     mocker.patch(
         "superset.utils.oauth2.url_for",
         side_effect=RuntimeError("Unable to build URL outside of request context"),
     )
-    assert get_oauth2_redirect_uri() == ""
+    with pytest.raises(OAuth2Error):
+        get_oauth2_redirect_uri()


### PR DESCRIPTION
### SUMMARY

Databases using OAuth for authentication (e.g. Snowflake with external OAuth) crash when accessed via the MCP service because `url_for("DatabaseRestApi.oauth2")` raises a `BuildError` in headless contexts where the REST API blueprint may not be registered.

This PR:
1. Centralizes the OAuth2 redirect URI resolution into a safe helper (`get_oauth2_redirect_uri()` in `superset/utils/oauth2.py`) that catches `BuildError` instead of crashing. This replaces 3 separate inline `url_for()` calls that were all vulnerable to the same crash.
2. Updates the MCP `execute_sql` tool to catch `OAuth2RedirectError` and return a clear error message telling the user to authenticate via the Superset UI first, instead of raising an unhandled exception.

With this fix, users who have already authenticated via the Superset UI (and have stored OAuth tokens) can use the MCP service to query OAuth-authenticated databases. Users without tokens get a clear error message instead of a crash.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - backend only change

### TESTING INSTRUCTIONS

1. Configure a database with OAuth authentication (e.g. Snowflake with external OAuth)
2. Authenticate via the Superset UI (run a query in SQL Lab to trigger the OAuth flow)
3. Use the MCP `execute_sql` tool to run a query against that database
4. Verify the query succeeds using the stored OAuth token
5. For a user who has NOT authenticated via the UI, verify they get a clear error message instead of a crash

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API