### PR TITLE
fix: add comments to SQL clause validation

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1557,7 +1557,7 @@ def sanitize_clause(clause: str, engine: str) -> str:
         return Dialect.get_or_raise(dialect).generate(
             statement._parsed,  # pylint: disable=protected-access
             copy=True,
-            comments=False,
+            comments=True,
             pretty=False,
         )
     except SupersetParseError as ex:

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2693,9 +2693,19 @@ def test_is_valid_cvas(sql: str, engine: str, expected: bool) -> None:
         ),  # Compact format
         (
             "col = 'abc' -- comment",
-            "col = 'abc'",
+            "col = 'abc' /* comment */",
             "base",
-        ),  # Comments removed for compact format
+        ),  # Line comments converted to block comments
+        (
+            "TRUE /* precise_count_distinct=true */",
+            "TRUE /* precise_count_distinct=true */",
+            "base",
+        ),  # Block comments preserved
+        (
+            "col > 1 /* hint=value */",
+            "col > 1 /* hint=value */",
+            "base",
+        ),  # Block comments preserved
         ("col = 'col1 = 1) AND (col2 = 2'", "col = 'col1 = 1) AND (col2 = 2'", "base"),
         ("col = 'select 1; select 2'", "col = 'select 1; select 2'", "base"),
         ("col = 'abc -- comment'", "col = 'abc -- comment'", "base"),


### PR DESCRIPTION
### SUMMARY

Preserves SQL comments in adhoc filters during query generation.

Previously, when users added filters with SQL comments in the Custom SQL tab, the comments were stripped when the query was generated. This happened because `sanitize_clause()` in `superset/sql/parse.py` used SQLGlot's `generate()` with `comments=False`.

This change sets `comments=True` to preserve user-provided annotations, which are used by teams for:
- Query hints and optimizer directives
- Annotation metadata 
- Audit trail information

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** 

https://github.com/user-attachments/assets/b9320bd5-7714-4475-aa32-5dde7a55ba93



**After:** 

https://github.com/user-attachments/assets/a01cb59b-166d-4f13-83cd-ca25770cabe1





### TESTING INSTRUCTIONS

1. Create a chart with a Custom SQL filter containing a comment: `TRUE /* my_annotation */`
2. Run the chart query
3. Click the kebab menu → "View query"
4. Verify the comment appears in the generated SQL

Or run the unit tests:
```bash
pytest tests/unit_tests/sql/parse_tests.py::test_sanitize_clause -v
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: #39169 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Fixes: #39169 