### PR TITLE
fix(native-filter): infinite filter loading by deps

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -128,9 +128,8 @@ const FilterValue: FC<FilterValueProps> = ({
     [isCustomization],
   );
   const [state, setState] = useState<ChartDataResponseResult[]>([]);
-  const [hasDepsFilterValue, setHasDepsFilterValue] = useState(
-    Boolean(filter.cascadeParentIds?.length),
-  );
+  const hasDeps = Boolean(filter.cascadeParentIds?.length);
+  const [hasDepsFilterValue, setHasDepsFilterValue] = useState(hasDeps);
   const dashboardId = useSelector<RootState, number>(
     state => state.dashboardInfo.id,
   );
@@ -164,6 +163,10 @@ const FilterValue: FC<FilterValueProps> = ({
   }, [dispatch, shouldRefresh]);
 
   useEffect(() => {
+    setHasDepsFilterValue(hasDeps);
+  }, [hasDeps]);
+
+  useEffect(() => {
     if (!inViewFirstTime && inView) {
       setInViewFirstTime(true);
     }
@@ -193,7 +196,8 @@ const FilterValue: FC<FilterValueProps> = ({
         const extraFormData = dataMaskSelected?.[pId]?.extraFormData;
         if (extraFormData?.filters?.length) {
           selectedParentFilterValueCounts += extraFormData.filters.length;
-        } else if (extraFormData?.time_range) {
+        }
+        if (extraFormData?.time_range) {
           isTimeRangeSelected = true;
         }
       });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -128,7 +128,9 @@ const FilterValue: FC<FilterValueProps> = ({
     [isCustomization],
   );
   const [state, setState] = useState<ChartDataResponseResult[]>([]);
-  const hasDepsFilterValue = Boolean(filter.cascadeParentIds?.length);
+  const [hasDepsFilterValue, setHasDepsFilterValue] = useState(
+    Boolean(filter.cascadeParentIds?.length),
+  );
   const dashboardId = useSelector<RootState, number>(
     state => state.dashboardInfo.id,
   );
@@ -209,6 +211,7 @@ const FilterValue: FC<FilterValueProps> = ({
         // has all the required information from parent filters
         return;
       }
+      setHasDepsFilterValue(false);
     }
 
     // TODO: We should try to improve our useEffect hooks to depend more on
@@ -283,6 +286,7 @@ const FilterValue: FC<FilterValueProps> = ({
     isRefreshing,
     shouldRefresh,
     dataMaskSelected,
+    setHasDepsFilterValue,
   ]);
 
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -46,7 +46,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { isEqual, isEqualWith } from 'lodash';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import { ErrorAlert, ErrorMessageWithStackTrace } from 'src/components';
-import { Loading, Constants } from '@superset-ui/core/components';
+import { Loading, Constants, Flex } from '@superset-ui/core/components';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
 import { FilterBarOrientation, RootState } from 'src/dashboard/types';
 import {
@@ -128,6 +128,7 @@ const FilterValue: FC<FilterValueProps> = ({
     [isCustomization],
   );
   const [state, setState] = useState<ChartDataResponseResult[]>([]);
+  const hasDepsFilterValue = Boolean(filter.cascadeParentIds?.length);
   const dashboardId = useSelector<RootState, number>(
     state => state.dashboardInfo.id,
   );
@@ -185,24 +186,25 @@ const FilterValue: FC<FilterValueProps> = ({
       // Prevent unnecessary backend requests by validating parent filter selections first
 
       let selectedParentFilterValueCounts = 0;
-
+      let isTimeRangeSelected = false;
       (filter.cascadeParentIds ?? []).forEach(pId => {
         const extraFormData = dataMaskSelected?.[pId]?.extraFormData;
         if (extraFormData?.filters?.length) {
           selectedParentFilterValueCounts += extraFormData.filters.length;
         } else if (extraFormData?.time_range) {
-          selectedParentFilterValueCounts += 1;
+          isTimeRangeSelected = true;
         }
       });
 
       // check if all parent filters with defaults have a value selected
 
-      let depsCount = dependencies.filters?.length ?? 0;
+      const depsCount = dependencies.filters?.length ?? 0;
+      const hasTimeRangeDeps = Boolean(dependencies?.time_range);
 
-      if (dependencies?.time_range) {
-        depsCount += 1;
-      }
-      if (selectedParentFilterValueCounts !== depsCount) {
+      if (
+        selectedParentFilterValueCounts !== depsCount ||
+        (hasTimeRangeDeps && !isTimeRangeSelected)
+      ) {
         // child filter should not request backend until it
         // has all the required information from parent filters
         return;
@@ -397,7 +399,12 @@ const FilterValue: FC<FilterValueProps> = ({
       overflow={overflow}
     >
       {isLoading ? (
-        <Loading position="inline-centered" size="s" muted />
+        <Flex align="center">
+          <Loading position="inline" size="s" muted />
+          {hasDepsFilterValue
+            ? t('Awaiting filter selection')
+            : t('Loading filter values')}
+        </Flex>
       ) : (
         <SuperChart
           height={HEIGHT}


### PR DESCRIPTION
### SUMMARY
  Fixes an infinite loading state in native filters with cascade dependencies when a parent filter has multiple time_range.

  #### Problem

  When a child filter depends on a parent time_range filter, the loading state would never resolve.
  The issue was in the dependency validation logic:
  - time_range was being added to selectedParentFilterValueCounts but compared against depsCount which only counted filters.length
  - This mismatch caused the validation selectedParentFilterValueCounts !== depsCount to always fail when "multiple" time_range was involved

  #### Solution

  - Separated time_range validation from filter count comparison
  - Added explicit isTimeRangeSelected and hasTimeRangeDeps checks
  - Now validates: filter counts match AND (if time_range dep exists, it must be selected)

#### Additional Improvement

  - Added contextual loading messages:
    - "Awaiting filter selection" - when waiting for parent filter values
    - "Loading filter values" - when fetching data from backend

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/892daee8-79e8-4419-a076-5a91562fa04c

After:

https://github.com/user-attachments/assets/feff7cd3-fbc2-48bd-9520-8968ec6c5f73


### TESTING INSTRUCTIONS
  1. Create a dashboard with cascading native filters has "two" dependant "time range" filter
  2. Verify child filter loads correctly after selecting parent time_range
  3. Verify appropriate loading message displays based on state

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
