### PR TITLE
fix(explore): add left-indentation to control panel hierarchy

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ControlSubSectionHeader.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ControlSubSectionHeader.tsx
@@ -21,7 +21,11 @@ import { styled, css } from '@apache-superset/core/theme';
 export const ControlSubSectionHeader = styled.div`
   ${({ theme }) => css`
     font-weight: ${theme.fontWeightStrong};
+    margin-top: ${theme.sizeUnit * 3}px;
     margin-bottom: ${theme.sizeUnit}px;
     font-size: ${theme.fontSizeSM}px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: ${theme.colorTextSecondary};
   `}
 `;

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -648,6 +648,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
       </span>
     );
 
+    let isInSubSection = false;
     const PanelChildren = (
       <>
         <StashFormDataContainer
@@ -665,8 +666,19 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
             .filter(Boolean)}
         />
         {isVisible && (
-          <>
+          <div style={{ paddingLeft: theme.sizeUnit * 2 }}>
             {section.controlSetRows.map((controlSets, i) => {
+              // Detect sub-section header rows (React elements with no name prop)
+              const isSubSectionHeaderRow = controlSets.some(
+                item =>
+                  isValidElement(item) &&
+                  !(item as React.ReactElement<Record<string, unknown>>).props
+                    ?.name,
+              );
+              if (isSubSectionHeaderRow) {
+                isInSubSection = true;
+              }
+
               const renderedControls = controlSets
                 .map(controlItem => {
                   if (!controlItem) {
@@ -715,14 +727,23 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
               if (renderedControls.length === 0) {
                 return null;
               }
-              return (
+              // Indent controls within sub-sections for visual hierarchy
+              const paddingLeft =
+                isInSubSection && !isSubSectionHeaderRow
+                  ? theme.sizeUnit * 3
+                  : 0;
+              return paddingLeft ? (
+                <div key={`controlsetrow-${i}`} style={{ paddingLeft }}>
+                  <ControlRow controls={renderedControls} />
+                </div>
+              ) : (
                 <ControlRow
                   key={`controlsetrow-${i}`}
                   controls={renderedControls}
                 />
               );
             })}
-          </>
+          </div>
         )}
       </>
     );


### PR DESCRIPTION
### SUMMARY

Improves visual hierarchy of the Explore control panel by adding indentation to nested controls within collapsible sections. Previously, all controls rendered at the same indentation level, making it hard to understand the grouping structure.

### BEFORE
<img width="320" height="586" alt="Screenshot 2026-04-07 at 7 43 14 PM" src="https://github.com/user-attachments/assets/645cdd12-fbcf-44e1-9578-c71e643bb4c0" />
<img width="317" height="491" alt="Screenshot 2026-04-07 at 7 43 08 PM" src="https://github.com/user-attachments/assets/39602741-c3c6-4dd2-a20d-f2331db6eee4" />

### AFTER
<img width="318" height="644" alt="Screenshot 2026-04-07 at 7 42 26 PM" src="https://github.com/user-attachments/assets/8858e195-b460-45b4-931e-111f8ba55b14" />
<img width="315" height="530" alt="Screenshot 2026-04-07 at 7 42 17 PM" src="https://github.com/user-attachments/assets/e495021f-37d2-4d9b-942d-7ce59b5878e2" />


**Changes:**
- All section body content (controls inside a collapsed section) gets base indentation (`sizeUnit * 2` = 8px)
- Sub-section headers (e.g., "X Axis", "Y Axis", "Rolling window") are styled as uppercase bold category labels with secondary text color and letter-spacing, visually distinguishing them from both section headers and control labels
- Controls within sub-sections get additional indentation (`sizeUnit * 3` = 12px) for clear nesting

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** All controls are flush-left with no visual nesting hierarchy.

**After:** Clear 3-level visual hierarchy:
1. Section headers (Query, Chart Title) — flush left
2. Sub-section headers (X AXIS, Y AXIS) — uppercase bold, indented
3. Controls under sub-sections (X Axis Title) — further indented

### TESTING INSTRUCTIONS

1. Navigate to Explore view with a Line Chart (e.g., `/explore/?slice_id=94`)
2. In the **Data** tab, expand the **Query** section — controls should be indented from the section header
3. Switch to the **Customize** tab and expand **Chart Title** — "X AXIS" and "Y AXIS" should appear as uppercase bold category labels, with their controls indented further beneath them
4. Expand **Advanced analytics** in the Data tab — "ROLLING WINDOW", "TIME COMPARISON", "RESAMPLE" sub-sections should have the same treatment

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)