### PR TITLE
fix(sqllab): demote "Save as new" button from primary to secondary

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -233,7 +233,7 @@ const SaveQuery = ({
               {t('Cancel')}
             </Button>
             <Button
-              buttonStyle={isSaved ? undefined : 'primary'}
+              buttonStyle={isSaved ? 'secondary' : 'primary'}
               onClick={onSaveWrapper}
               cta
             >


### PR DESCRIPTION
### SUMMARY

When a query is already saved, the SaveQuery modal in SQL Lab displays both "Save as new" and "Update" buttons styled as primary (teal). This violates UX best practice — there should only be one primary call-to-action per modal.

**Root cause:** The "Save as new" button used `buttonStyle={isSaved ? undefined : 'primary'}`. The `Button` component defaults `undefined` buttonStyle to `'primary'` (`buttonStyle ?? 'primary'`), so both buttons rendered as primary when `isSaved` was true.

**Fix:** Changed to `buttonStyle={isSaved ? 'secondary' : 'primary'}` so that "Update" is the sole primary button, and "Save as new" is secondary.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Both "Save as new" and "Update" are primary (teal)
**After:** Only "Update" is primary; "Save as new" is secondary

### TESTING INSTRUCTIONS

1. Open SQL Lab
2. Write and run a query
3. Save the query (Ctrl+S or Save button)
4. Open the Save dialog again
5. Verify "Save as new" is secondary styled and "Update" is primary styled
6. For an unsaved query, verify "Save" remains primary

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>