### PR TITLE
fix(plugin-chart-handlebars): improve CSS sanitization tooltip and hide when not needed

### DIFF
--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/style.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/style.tsx
@@ -30,10 +30,12 @@ import { debounceFunc } from '../../consts';
 
 interface StyleCustomControlProps {
   value: string;
+  htmlSanitization: boolean;
 }
 
 const StyleControl = (props: CustomControlConfig<StyleCustomControlProps>) => {
   const theme = useTheme();
+  const htmlSanitization = props.htmlSanitization ?? true;
 
   const defaultValue = props?.value
     ? undefined
@@ -48,10 +50,16 @@ const StyleControl = (props: CustomControlConfig<StyleCustomControlProps>) => {
       <ControlHeader>
         <div>
           {props.label}
-          <InfoTooltip
-            iconStyle={{ marginLeft: theme.sizeUnit }}
-            tooltip={t('You need to configure HTML sanitization to use CSS')}
-          />
+          {htmlSanitization && (
+            <InfoTooltip
+              iconStyle={{ marginLeft: theme.sizeUnit }}
+              tooltip={t(
+                'CSS styles may be removed by server-side HTML sanitization. ' +
+                  'If styles are not applying, ask your Superset administrator ' +
+                  'to adjust the HTML sanitization configuration.',
+              )}
+            />
+          )}
         </div>
       </ControlHeader>
       <CodeEditor
@@ -79,8 +87,9 @@ export const styleControlSetItem: ControlSetItem = {
     valueKey: null,
 
     validators: [],
-    mapStateToProps: ({ controls }) => ({
+    mapStateToProps: ({ controls, common }) => ({
       value: controls?.handlebars_template?.value,
+      htmlSanitization: common?.conf?.HTML_SANITIZATION ?? true,
     }),
   },
 };


### PR DESCRIPTION
### SUMMARY

The Handlebars chart's CSS Styles panel displayed a tooltip saying *"You need to configure HTML sanitization to use CSS"*. This was unhelpful because `HTML_SANITIZATION` is a server-side config in `superset_config.py` that end users — especially on managed hosting like Preset — cannot change.

**Changes:**
- **Conditional visibility**: The tooltip now only renders when `HTML_SANITIZATION` is enabled (the default). When sanitization is disabled, there's nothing to warn about, so the tooltip is hidden entirely.
- **Actionable text**: Replaced the vague message with: *"CSS styles may be removed by server-side HTML sanitization. If styles are not applying, ask your Superset administrator to adjust the HTML sanitization configuration."*
- **State wiring**: Updated `mapStateToProps` to read `common.conf.HTML_SANITIZATION` from the Redux store and pass it as a prop.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Tooltip always shown with unhelpful text: "You need to configure HTML sanitization to use CSS"

**After:** Tooltip only shown when sanitization is active, with actionable guidance directing users to their admin. Hidden entirely when sanitization is disabled.

### TESTING INSTRUCTIONS

1. Open the Explore view and select a Handlebars chart
2. Go to the "CSS Styles" control panel
3. With `HTML_SANITIZATION = True` (default): verify the info tooltip appears with the new text
4. With `HTML_SANITIZATION = False` in `superset_config.py`: verify the tooltip is hidden

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/claude-code)