### PR TITLE
fix(embedded): resolve guest user permissions in user_view_menu_names

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -966,6 +966,21 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             .join(self.role_model)
         )
 
+        # Guest users (embedded dashboards) have is_anonymous=False but no
+        # database identity, so querying by user_id returns nothing. Instead,
+        # resolve permissions directly from the roles attached to the guest
+        # token (typically the Public role).
+        if self.is_guest_user():
+            role_ids = [role.id for role in g.user.roles if role.id is not None]
+            if not role_ids:
+                return set()
+            view_menu_names = (
+                base_query.filter(self.role_model.id.in_(role_ids)).filter(
+                    self.permission_model.name == permission_name
+                )
+            ).all()
+            return {s.name for s in view_menu_names}
+
         if not g.user.is_anonymous:
             user_id = get_user_id()
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -958,14 +958,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         return True
 
     def user_view_menu_names(self, permission_name: str) -> set[str]:
-        base_query = (
-            self.session.query(self.viewmenu_model.name)
-            .join(self.permissionview_model)
-            .join(self.permission_model)
-            .join(assoc_permissionview_role)
-            .join(self.role_model)
-        )
-
         # Guest users (embedded dashboards) have is_anonymous=False but no
         # database identity, so querying by user_id returns nothing. Instead,
         # resolve permissions directly from the roles attached to the guest
@@ -976,12 +968,27 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             ]
             if not role_ids:
                 return set()
+            base_query = (
+                self.session.query(self.viewmenu_model.name)
+                .join(self.permissionview_model)
+                .join(self.permission_model)
+                .join(assoc_permissionview_role)
+                .join(self.role_model)
+            )
             view_menu_names = (
                 base_query.filter(self.role_model.id.in_(role_ids)).filter(
                     self.permission_model.name == permission_name
                 )
             ).all()
             return {s.name for s in view_menu_names}
+
+        base_query = (
+            self.session.query(self.viewmenu_model.name)
+            .join(self.permissionview_model)
+            .join(self.permission_model)
+            .join(assoc_permissionview_role)
+            .join(self.role_model)
+        )
 
         if not g.user.is_anonymous:
             user_id = get_user_id()

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -958,6 +958,14 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         return True
 
     def user_view_menu_names(self, permission_name: str) -> set[str]:
+        base_query = (
+            self.session.query(self.viewmenu_model.name)
+            .join(self.permissionview_model)
+            .join(self.permission_model)
+            .join(assoc_permissionview_role)
+            .join(self.role_model)
+        )
+
         # Guest users (embedded dashboards) have is_anonymous=False but no
         # database identity, so querying by user_id returns nothing. Instead,
         # resolve permissions directly from the roles attached to the guest
@@ -968,27 +976,12 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             ]
             if not role_ids:
                 return set()
-            base_query = (
-                self.session.query(self.viewmenu_model.name)
-                .join(self.permissionview_model)
-                .join(self.permission_model)
-                .join(assoc_permissionview_role)
-                .join(self.role_model)
-            )
             view_menu_names = (
                 base_query.filter(self.role_model.id.in_(role_ids)).filter(
                     self.permission_model.name == permission_name
                 )
             ).all()
             return {s.name for s in view_menu_names}
-
-        base_query = (
-            self.session.query(self.viewmenu_model.name)
-            .join(self.permissionview_model)
-            .join(self.permission_model)
-            .join(assoc_permissionview_role)
-            .join(self.role_model)
-        )
 
         if not g.user.is_anonymous:
             user_id = get_user_id()

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -971,7 +971,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         # resolve permissions directly from the roles attached to the guest
         # token (typically the Public role).
         if self.is_guest_user():
-            role_ids = [role.id for role in g.user.roles if role.id is not None]
+            role_ids = [
+                role.id for role in g.user.roles if role and role.id is not None
+            ]
             if not role_ids:
                 return set()
             view_menu_names = (

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1547,3 +1547,62 @@ def test_validate_child_in_parent_multilayer_null_params(
     assert not sm._validate_child_in_parent_multilayer(
         child_slice_id=1, parent_slice=parent_slice
     )
+
+
+def test_user_view_menu_names_for_guest_user(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """
+    Test that user_view_menu_names resolves permissions from the guest
+    user's roles instead of querying by user_id (which is None for guests).
+    """
+    sm = SupersetSecurityManager(appbuilder)
+
+    mock_role = mocker.MagicMock(spec=Role)
+    mock_role.id = 99
+
+    mock_guest = mocker.MagicMock()
+    mock_guest.is_anonymous = False
+    mock_guest.roles = [mock_role]
+
+    mock_g = SimpleNamespace(user=mock_guest)
+    mocker.patch("superset.security.manager.g", new=mock_g)
+    mocker.patch.object(sm, "is_guest_user", return_value=True)
+
+    mock_result = [SimpleNamespace(name="[PostgreSQL].[my_table](id:1)")]
+    mock_query = mocker.MagicMock()
+    mock_query.join.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.all.return_value = mock_result
+    mocker.patch.object(sm.session, "query", return_value=mock_query)
+
+    result = sm.user_view_menu_names("datasource_access")
+
+    assert result == {"[PostgreSQL].[my_table](id:1)"}
+
+
+def test_user_view_menu_names_for_guest_user_no_roles(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """
+    Test that user_view_menu_names returns empty set when guest user has
+    no roles with valid IDs.
+    """
+    sm = SupersetSecurityManager(appbuilder)
+
+    mock_role = mocker.MagicMock(spec=Role)
+    mock_role.id = None
+
+    mock_guest = mocker.MagicMock()
+    mock_guest.is_anonymous = False
+    mock_guest.roles = [mock_role]
+
+    mock_g = SimpleNamespace(user=mock_guest)
+    mocker.patch("superset.security.manager.g", new=mock_g)
+    mocker.patch.object(sm, "is_guest_user", return_value=True)
+
+    result = sm.user_view_menu_names("datasource_access")
+
+    assert result == set()

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1569,6 +1569,12 @@ def test_user_view_menu_names_for_guest_user(
     mock_g = SimpleNamespace(user=mock_guest)
     mocker.patch("superset.security.manager.g", new=mock_g)
     mocker.patch.object(sm, "is_guest_user", return_value=True)
+    # The regression: guest path must NEVER fall through to get_user_id().
+    # Patching it as an error means an accidental fall-through fails loudly.
+    mock_get_user_id = mocker.patch(
+        "superset.security.manager.get_user_id",
+        side_effect=AssertionError("get_user_id must not be called for guest users"),
+    )
 
     mock_result = [SimpleNamespace(name="[PostgreSQL].[my_table](id:1)")]
     mock_query = mocker.MagicMock()
@@ -1580,6 +1586,8 @@ def test_user_view_menu_names_for_guest_user(
     result = sm.user_view_menu_names("datasource_access")
 
     assert result == {"[PostgreSQL].[my_table](id:1)"}
+    mock_get_user_id.assert_not_called()
+    mock_query.filter.assert_called()
 
 
 def test_user_view_menu_names_for_guest_user_no_roles(
@@ -1602,7 +1610,12 @@ def test_user_view_menu_names_for_guest_user_no_roles(
     mock_g = SimpleNamespace(user=mock_guest)
     mocker.patch("superset.security.manager.g", new=mock_g)
     mocker.patch.object(sm, "is_guest_user", return_value=True)
+    mock_get_user_id = mocker.patch(
+        "superset.security.manager.get_user_id",
+        side_effect=AssertionError("get_user_id must not be called for guest users"),
+    )
 
     result = sm.user_view_menu_names("datasource_access")
 
     assert result == set()
+    mock_get_user_id.assert_not_called()


### PR DESCRIPTION
Guest users (embedded dashboards via guest tokens) have is_anonymous=False but no database identity (user_id is None). The existing code path for authenticated users queries the assoc_user_role table by user_id, which returns nothing for guests. This caused all datasource_access, database_access, and schema_access permissions on the guest role to be invisible, breaking features like chart-based annotation layers that rely on ChartDAO.find_by_id (which applies a datasource access filter via ChartFilter).

Fix: detect guest users before the authenticated user path and resolve permissions directly from the roles attached to the guest token.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

 ### SUMMARY                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                  
  `user_view_menu_names()` in `SupersetSecurityManager` was broken for guest users (embedded dashboards via guest tokens). Guest users have `is_anonymous=False` but no database identity (`user_id` is `None`). The authenticated user code path queries the `assoc_user_role` table by `user_id`, which produces `WHERE user_id IS NULL` — matching nothing.                                    
                                                                                                                                                                                                                                                                                                                                                                                                  
  This caused all role-based permissions (`datasource_access`, `database_access`, `schema_access`) to be invisible to guest users, even when correctly assigned to the guest role. Any code path using `user_view_menu_names()` was affected, most notably `ChartFilter` (via `get_dataset_access_filters`), which broke chart-based annotation layers on embedded dashboards with a misleading   
  "Chart not found" error.
                                                                                                                                                                                                                                                                                                                                                                                                  
  **Fix:** Add a guest user check before the authenticated user path that resolves permissions directly from the roles attached to the guest token, using the same pattern as the existing anonymous user path.

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

  **Before:** Charts with annotation layers on embedded dashboards fail with:                                                                                                                                                                                                                                                                                                                     
  Chart with ID  (referenced by annotation layer '') was not found.
  Please verify that the chart exists and is accessible.                                                                                                                                                                                                                                                                                                                                          
                                                        
  **After:** Annotation layers load correctly because `ChartDAO.find_by_id()` can now see the guest role's datasource permissions through `ChartFilter`.

  ### TESTING INSTRUCTIONS                                                                                                                                                                                                                                                                                                                                                                        
   
  1. Create a chart (Chart A) backed by a datasource                                                                                                                                                                                                                                                                                                                                              
  2. Create a second chart (Chart B) that uses Chart A as an annotation layer source (sourceType "line" or "table")
  3. Add Chart B to a dashboard and enable embedding                                                                                                                                                                                                                                                                                                                                              
  4. Assign `datasource_access` for Chart A's datasource to the Public role (or whichever role is configured via `GUEST_ROLE_NAME`)
  5. Access the embedded dashboard via guest token                                                                                                                                                                                                                                                                                                                                                
  6. Verify Chart B loads with its annotation layer rendered correctly                                                                                                                                                                                                                                                                                                                            
   
  ### ADDITIONAL INFORMATION                                                                                                                                                                                                                                                                                                                                                                      
                  
  - [ ] Has associated issue:
  - [ ] Required feature flags:
  - [ ] Changes UI
  - [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
    - [ ] Migration is atomic, supports rollback & is backwards-compatible                                                                                                                                                                                                                                                                                                                        
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided                                                                                                                                                                                                                                                                                                                                    
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API  