### PR TITLE
fix(dashboard): hide "Filters out of scope" section when empty

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.test.tsx
@@ -384,6 +384,19 @@ test('FilterControls should handle empty filters list', () => {
   expect(container).toBeInTheDocument();
 });
 
+test('does not render "Filters out of scope" when all filters are in scope', () => {
+  const state = getDefaultState(FilterBarOrientation.Vertical);
+
+  const { useSelector } = jest.requireMock('react-redux');
+  useSelector.mockImplementation((selector: (s: typeof state) => unknown) =>
+    selector(state),
+  );
+
+  setupWithFilters(state);
+
+  expect(screen.queryByText(/Filters out of scope/)).not.toBeInTheDocument();
+});
+
 test('FilterControls overflowedByIndex updates when filters change scope', () => {
   const state = getDefaultState(FilterBarOrientation.Vertical);
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -222,6 +222,11 @@ const FilterControls: FC<FilterControlsProps> = ({
     chartCustomization: true,
   });
 
+  const showFiltersOutOfScope =
+    showCollapsePanel &&
+    (hideHeader || sectionsOpen.filters) &&
+    filtersOutOfScope.length > 0;
+
   const toggleSection = useCallback((section: keyof typeof sectionsOpen) => {
     setSectionsOpen(prev => ({
       ...prev,
@@ -343,7 +348,7 @@ const FilterControls: FC<FilterControlsProps> = ({
           </SectionContainer>
         )}
 
-        {showCollapsePanel && (hideHeader || sectionsOpen.filters) && (
+        {showFiltersOutOfScope && (
           <FiltersOutOfScopeCollapsible
             filtersOutOfScope={filtersOutOfScope}
             renderer={renderer}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersDropdownContent/FiltersDropdownContent.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersDropdownContent/FiltersDropdownContent.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from 'spec/helpers/testing-library';
+import { Filter } from '@superset-ui/core';
+import { FiltersDropdownContent } from '.';
+
+const buildFilter = (id: string, name: string): Filter =>
+  ({
+    id,
+    name,
+    filterType: 'filter_select',
+    targets: [{ datasetId: 1, column: { name: 'country' } }],
+    defaultDataMask: {},
+    controlValues: {},
+    cascadeParentIds: [],
+    scope: { rootPath: ['ROOT_ID'], excluded: [] as string[] },
+  }) as unknown as Filter;
+
+const baseProps = {
+  overflowedCrossFilters: [],
+  filtersInScope: [buildFilter('filter-1', 'In Scope Filter')],
+  renderer: (filter: any) => <div key={filter.id}>{filter.name}</div>,
+  rendererCrossFilter: () => null,
+  showCollapsePanel: true,
+  forceRenderOutOfScope: false,
+};
+
+test('does not render "Filters out of scope" section when filtersOutOfScope is empty', () => {
+  render(<FiltersDropdownContent {...baseProps} filtersOutOfScope={[]} />);
+
+  expect(screen.queryByText(/Filters out of scope/)).not.toBeInTheDocument();
+});
+
+test('renders "Filters out of scope" section when one or more filters are out of scope', () => {
+  render(
+    <FiltersDropdownContent
+      {...baseProps}
+      filtersOutOfScope={[buildFilter('filter-2', 'Out of Scope Filter')]}
+    />,
+  );
+
+  expect(screen.getByText(/Filters out of scope/)).toBeInTheDocument();
+});
+
+test('does not render "Filters out of scope" section when showCollapsePanel is false', () => {
+  render(
+    <FiltersDropdownContent
+      {...baseProps}
+      showCollapsePanel={false}
+      filtersOutOfScope={[buildFilter('filter-2', 'Out of Scope Filter')]}
+    />,
+  );
+
+  expect(screen.queryByText(/Filters out of scope/)).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersDropdownContent/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersDropdownContent/index.tsx
@@ -61,7 +61,7 @@ export const FiltersDropdownContent = ({
       ),
     )}
     {filtersInScope.map(renderer)}
-    {showCollapsePanel && (
+    {showCollapsePanel && filtersOutOfScope.length > 0 && (
       <FiltersOutOfScopeCollapsible
         filtersOutOfScope={filtersOutOfScope}
         renderer={renderer}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
@@ -37,7 +37,6 @@ export const FiltersOutOfScopeCollapsible = ({
     ghost
     bordered
     expandIconPosition="end"
-    collapsible={filtersOutOfScope.length === 0 ? 'disabled' : undefined}
     items={[
       {
         key: 'out-of-scope-filters',


### PR DESCRIPTION
### SUMMARY

The "Filters out of scope" collapsible was rendered "disabled" when no filters were out of scope, showing "Filters out of scope (0)" in the filter bar. The component now is not rendered at all when `filtersOutOfScope` is an empty array.

- `FilterControls.tsx`: extract showFiltersOutOfScope condition and add `length > 0` check
- `FiltersDropdownContent`: add `length > 0` check at the call site
- `FiltersOutOfScopeCollapsible`: remove now-unreachable `collapsible="disabled"` fallback
- Add unit tests covering empty/non-empty/showCollapsePanel cases

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_Before:_

<img width="258" height="494" alt="Filters out of scope - before 2026-04-08 at 9 37 34 AM" src="https://github.com/user-attachments/assets/aae48bb7-a9c5-413f-83b7-41061f86f913" />

_After:_

<img width="258" height="494" alt="Filters out of scope - after 2026-04-08 at 9 39 30 AM" src="https://github.com/user-attachments/assets/3e77ff46-5fa9-4a6d-b334-4e204035ce62" />

_Invariant:_

<img width="258" height="494" alt="Filters out of scope - visible 2026-04-08 at 9 54 07 AM" src="https://github.com/user-attachments/assets/95d703c7-b050-4395-8ecc-3fe4399f0934" />


### TESTING INSTRUCTIONS

Test that `Filters out of scope (0)` is hidden:

1) Open the Sales Dashboard
2) Scroll down to the bottom of the list of filters
3) You _should not_ see "Filters out of scope (0)" above the "Apply Filters" button

Test that `Filters out of scope (1)` is not hidden:

1) Open the Sales Dashboard (it has two tabs: "Sales Overview" and "Exploratory")
2) Click the gear icon (⚙️ ) at the top of the filter bar to open "Add and edit filters"
3) Pick any existing filter (e.g., "Country")
4) Click the "Scoping" tab in the filter editor
5) Switch from "Apply to all panels" to "Apply to specific panels"
6) Uncheck the "Exploratory" tab so the filter only applies to "Sales Overview"
7) Click Save
8) Now in the filter bar, select a country value (e.g., "USA") — filters need a value to be evaluated
9) Switch to the "Exploratory" tab
10) Scroll down to the bottom of the list of filters
11) You _should_ see "Filters out of scope (1)" above the "Apply Filters" button

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: [98072](https://app.shortcut.com/preset/story/98072)
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
