### PR TITLE
fix(dashboard): allow filter list to scroll in filter config modal sidebar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -40,10 +40,6 @@ import { isFilterId, isChartCustomizationId, isDivider } from '../utils';
 // there are many filters (sc-101839). The parent height chain through the
 // antd Form is unreliable, so a viewport-relative max-height is used instead
 // of height: 100%.
-//
-// TODO: If the height chain through BaseModalBody / BaseForm is ever fixed
-// (so that height: 100% propagates correctly to this element), this
-// max-height workaround can be replaced with `height: 100%; min-height: 0;`.
 const StyledSidebarFlex = styled(Flex)`
   min-width: 290px;
   max-width: 290px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -53,11 +53,11 @@ const StyledHeaderFlex = styled(Flex)`
 
 // min-height: 0 lets the flex item shrink below its content size so that
 // overflow: auto produces a scrollbar when the filter list is taller than
-// the sidebar (sc-101839). Without it, flex items default to
-// min-height: auto and refuse to shrink.
+// the sidebar. Without it, flex items default to min-height: auto and
+// refuse to shrink.
 const BaseStyledCollapse = styled(Collapse)<{ isDragging: boolean }>`
   flex: 1;
-  min-height: 0; /* required for flex item to shrink — see sc-101839 */
+  min-height: 0; /* required for flex item to shrink */
   overflow: auto;
   .ant-collapse-content-box {
     padding: 0;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -36,9 +36,18 @@ import { FilterRemoval } from '../types';
 import { FILTER_TYPE, CUSTOMIZATION_TYPE } from '../DraggableFilter';
 import { isFilterId, isChartCustomizationId, isDivider } from '../utils';
 
+// max-height constrains the sidebar so its inner Collapse can scroll when
+// there are many filters (sc-101839). The parent height chain through the
+// antd Form is unreliable, so a viewport-relative max-height is used instead
+// of height: 100%.
+//
+// TODO: If the height chain through BaseModalBody / BaseForm is ever fixed
+// (so that height: 100% propagates correctly to this element), this
+// max-height workaround can be replaced with `height: 100%; min-height: 0;`.
 const StyledSidebarFlex = styled(Flex)`
   min-width: 290px;
   max-width: 290px;
+  max-height: 70vh;
   border-right: 1px solid ${({ theme }) => theme.colorBorderSecondary};
 `;
 
@@ -46,8 +55,13 @@ const StyledHeaderFlex = styled(Flex)`
   padding: ${({ theme }) => theme.sizeUnit * 3}px;
 `;
 
+// min-height: 0 lets the flex item shrink below its content size so that
+// overflow: auto produces a scrollbar when the filter list is taller than
+// the sidebar (sc-101839). Without it, flex items default to
+// min-height: auto and refuse to shrink.
 const BaseStyledCollapse = styled(Collapse)<{ isDragging: boolean }>`
   flex: 1;
+  min-height: 0; /* required for flex item to shrink — see sc-101839 */
   overflow: auto;
   .ant-collapse-content-box {
     padding: 0;


### PR DESCRIPTION
### SUMMARY

The "Add or edit filters" modal's left sidebar did not scroll when the dashboard had many filters (~10 to 20+), making bottom filters unreachable. Two CSS issues combined:

1. The parent height chain through `BaseModalBody` / antd Form did not propagate `height: 100%` to `StyledSidebarFlex`, so the sidebar grew to fit its content with no upper bound.
2. The inner `Collapse` with `flex: 1; overflow: auto` could not shrink because flex items default to `min-height: auto`, which refuses to go below content size.

### CHANGES
- Add `max-height: 70vh` to `StyledSidebarFlex` to give it a real upper bound regardless of the parent chain.
- Add `min-height: 0` to `BaseStyledCollapse` so the flex item can shrink to fit, allowing `overflow: auto` to actually scroll.

Both rules are accompanied by explanatory comments referencing the ticket and the underlying flexbox quirk.

(see also: [Why don't flex items shrink past content size?](https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size))

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**:

<img width="391" height="605" alt="Screenshot 2026-04-07 at 4 40 01 PM" src="https://github.com/user-attachments/assets/933c7c3e-d367-4917-96ae-816a25804497" />

**After**:

<img width="336" height="593" alt="Screenshot 2026-04-07 at 4 45 39 PM" src="https://github.com/user-attachments/assets/c0bb398b-ab5f-4170-99bb-2eb227721b98" />

### TESTING INSTRUCTIONS

With Example data:

1. Open Superset (http://localhost:8088/)
2. Navigate to Dashboards → open Sales Dashboard
3. In the filter bar (left side), click the gear icon (⚙️ ) to open the Add or edit filters and controls modal
4. The modal will open with a left panel showing existing filters and a right panel for editing
5. Click the + New button
6. Add a new filter:
    - Pick any filter type (e.g., "Value")
    - Pick any dataset and column (e.g., the existing dataset and a column)
    - Give it a generic name like "Test 1"
    - Click Save
7. Repeat steps 5-6 until you exceed the height of the screen.
8. **Expected**: a scrollbar appears so that you can scroll all the way to the end of the list

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: [101839](https://app.shortcut.com/preset/story/101839/)
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
