### PR TITLE
fix(dashboard): Vertical filter bar gradient is extending past the filter bar area

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { OPEN_FILTER_BAR_WIDTH } from 'src/dashboard/constants';
 import { render, screen, userEvent } from 'spec/helpers/testing-library';
 import ActionButtons from './index';
 
@@ -75,31 +74,4 @@ test('should apply', () => {
   expect(mockedProps.onApply).not.toHaveBeenCalled();
   userEvent.click(applyBtn);
   expect(mockedProps.onApply).toHaveBeenCalled();
-});
-
-// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-describe('custom width', () => {
-  test('sets its default width with OPEN_FILTER_BAR_WIDTH', () => {
-    const mockedProps = createProps();
-    render(<ActionButtons {...mockedProps} />, { useRedux: true });
-    const container = screen.getByTestId('filterbar-action-buttons');
-    expect(container).toHaveStyle({
-      width: `${OPEN_FILTER_BAR_WIDTH - 1}px`,
-    });
-  });
-
-  test('sets custom width', () => {
-    const mockedProps = createProps();
-    const expectedWidth = 423;
-    const { getByTestId } = render(
-      <ActionButtons {...mockedProps} width={expectedWidth} />,
-      {
-        useRedux: true,
-      },
-    );
-    const container = getByTestId('filterbar-action-buttons');
-    expect(container).toHaveStyle({
-      width: `${expectedWidth - 1}px`,
-    });
-  });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -52,9 +52,8 @@ const ButtonsContainer = styled.div<{ isVertical: boolean; width: number }>`
       ? css`
           flex-direction: column;
           align-items: center;
-          position: fixed;
+          position: sticky;
           z-index: 100;
-          width: ${width - 1}px;
           bottom: 0;
           padding: ${theme.sizeUnit * 4}px;
           padding-top: ${theme.sizeUnit * 6}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -27,13 +27,11 @@ import {
 } from '@superset-ui/core';
 import { css, SupersetTheme, styled } from '@apache-superset/core/theme';
 import { Button, Tooltip, Icons, Flex } from '@superset-ui/core/components';
-import { OPEN_FILTER_BAR_WIDTH } from 'src/dashboard/constants';
 import tinycolor from 'tinycolor2';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { getFilterBarTestId } from '../utils';
 
 interface ActionButtonsProps {
-  width?: number;
   onApply: () => void;
   onClearAll: () => void;
   dataMaskSelected: DataMaskState;
@@ -44,8 +42,8 @@ interface ActionButtonsProps {
   hasOutOfScopeRequiredFilters?: boolean;
 }
 
-const ButtonsContainer = styled.div<{ isVertical: boolean; width: number }>`
-  ${({ theme, isVertical, width }) => css`
+const ButtonsContainer = styled.div<{ isVertical: boolean }>`
+  ${({ theme, isVertical }) => css`
     display: flex;
 
     ${isVertical
@@ -99,7 +97,6 @@ const clearAllButtonStyle = (theme: SupersetTheme, isVertical: boolean) => css`
 `;
 
 const ActionButtons = ({
-  width = OPEN_FILTER_BAR_WIDTH,
   onApply,
   onClearAll,
   dataMaskApplied,
@@ -142,7 +139,6 @@ const ActionButtons = ({
   return (
     <ButtonsContainer
       isVertical={isVertical}
-      width={width}
       data-test="filterbar-action-buttons"
     >
       <Button

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -600,7 +600,6 @@ const FilterBar: FC<FiltersBarProps> = ({
     () => (
       <ActionButtons
         filterBarOrientation={orientation}
-        width={verticalConfig?.width}
         onApply={handleApply}
         onClearAll={handleClearAll}
         dataMaskSelected={dataMaskSelected}
@@ -612,7 +611,6 @@ const FilterBar: FC<FiltersBarProps> = ({
     ),
     [
       orientation,
-      verticalConfig?.width,
       handleApply,
       handleClearAll,
       dataMaskSelected,


### PR DESCRIPTION
### SUMMARY

The action buttons at the bottom of the vertical filter bar used `position: fixed`, which caused the gradient background to layer on top of the filter bar's right-edge divider and scrollbar, making them appear cut off near the bottom of the bar.

Switch to `position: sticky` so the buttons live in the scroll container's flow rather than overlaying it. The explicit width is no longer needed because sticky elements take their parent's content width naturally.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**

<img width="330" height="255" alt="Screenshot 2026-04-07 at 4 02 18 PM" src="https://github.com/user-attachments/assets/2ac6750b-fc9f-4ba8-b4c5-983e96c6dcb8" />

**After:**

<img width="330" height="255" alt="Screenshot 2026-04-07 at 4 03 20 PM" src="https://github.com/user-attachments/assets/0a7d17fc-eef6-4de2-bbcc-63be492ee84a" />

### TESTING INSTRUCTIONS

1) Open a dashboard such as "Sales Dashboard"
2) Open the "Filters and controls" sidebar on the left
3) Scroll down to the bottom
4) Verify that the faint line on the right of the panel continues to the bottom of the panel, as per the screenshot above

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: [101996](https://app.shortcut.com/preset/story/101996)
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
