### PR TITLE
fix(mcp): resolve null fields in list_datasets, list_databases, and save_sql_query

### DIFF
--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -623,6 +623,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
 
         column_attrs = []
         relationship_loads = []
+        needs_full_model = False
         if columns is None:
             columns = []
         for name in columns:
@@ -634,11 +635,13 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
                 column_attrs.append(attr)
             elif isinstance(prop, RelationshipProperty):
                 relationship_loads.append(joinedload(attr))
-            # Ignore properties and other non-queryable attributes
+            else:
+                # Python @property or other descriptor — requires a full
+                # model instance (Row objects don't support descriptors)
+                needs_full_model = True
 
-        if relationship_loads:
-            # If any relationships are requested, query the full model
-            # but don't add the joins yet - we'll add them after counting
+        if relationship_loads or needs_full_model:
+            # Need full model for relationships or Python @property access
             query = data_model.session.query(cls.model_cls)
         elif column_attrs:
             # Only columns requested

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -40,13 +40,7 @@ from sqlalchemy import asc, cast, desc, or_, Text
 from sqlalchemy.exc import SQLAlchemyError, StatementError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import (
-    ColumnProperty,
-    joinedload,
-    load_only,
-    Query,
-    RelationshipProperty,
-)
+from sqlalchemy.orm import ColumnProperty, joinedload, Query, RelationshipProperty
 from superset_core.common.daos import BaseDAO as CoreBaseDAO
 from superset_core.common.models import CoreModel
 
@@ -648,11 +642,10 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
 
         if relationship_loads or needs_full_model:
             # Need full model for relationships or Python @property access.
-            # Apply load_only() when we know the exact columns needed so
-            # SQLAlchemy skips loading unused heavy columns.
+            # Do NOT apply load_only() here — @property descriptors and
+            # serializers may access columns beyond the explicitly requested
+            # set (e.g., Slice.datasource_type accessed during serialization).
             query = data_model.session.query(cls.model_cls)
-            if column_attrs:
-                query = query.options(load_only(*column_attrs))
         elif column_attrs:
             # Only columns requested
             query = data_model.session.query(*column_attrs)

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -40,7 +40,13 @@ from sqlalchemy import asc, cast, desc, or_, Text
 from sqlalchemy.exc import SQLAlchemyError, StatementError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import ColumnProperty, joinedload, Query, RelationshipProperty
+from sqlalchemy.orm import (
+    ColumnProperty,
+    joinedload,
+    load_only,
+    Query,
+    RelationshipProperty,
+)
 from superset_core.common.daos import BaseDAO as CoreBaseDAO
 from superset_core.common.models import CoreModel
 
@@ -641,8 +647,12 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
                 needs_full_model = True
 
         if relationship_loads or needs_full_model:
-            # Need full model for relationships or Python @property access
+            # Need full model for relationships or Python @property access.
+            # Apply load_only() when we know the exact columns needed so
+            # SQLAlchemy skips loading unused heavy columns.
             query = data_model.session.query(cls.model_cls)
+            if column_attrs:
+                query = query.options(load_only(*column_attrs))
         elif column_attrs:
             # Only columns requested
             query = data_model.session.query(*column_attrs)

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -44,10 +44,15 @@ from superset.mcp_service.mcp_core import ModelListCore
 logger = logging.getLogger(__name__)
 
 # Minimal defaults for reduced token usage - users can request more via select_columns
+# NOTE: "database" (relationship) is included so the DAO eagerly loads it
+# via joinedload, which avoids N+1 lazy-load queries when the serializer
+# accesses dataset.database.database_name.
 DEFAULT_DATASET_COLUMNS = [
     "id",
     "table_name",
     "schema",
+    "database_name",
+    "database",
     "description",
     "certified_by",
     "certification_details",

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # Minimal defaults for reduced token usage - users can request more via select_columns
 # NOTE: "database" (relationship) is included so the DAO eagerly loads it
 # via joinedload, which avoids N+1 lazy-load queries when the serializer
-# accesses dataset.database.database_name.
+# accesses dataset.database.name (via the database_name @property).
 DEFAULT_DATASET_COLUMNS = [
     "id",
     "table_name",

--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -17,9 +17,16 @@
 
 """Schemas for SQL Lab MCP tools."""
 
-from typing import Any
+from typing import Any, Dict
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_serializer,
+)
 
 
 class ExecuteSqlRequest(BaseModel):
@@ -151,6 +158,8 @@ class ExecuteSqlResponse(BaseModel):
 class SaveSqlQueryRequest(BaseModel):
     """Request schema for saving a SQL query."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     database_id: int = Field(
         ..., description="Database connection ID the query runs against"
     )
@@ -192,6 +201,8 @@ class SaveSqlQueryRequest(BaseModel):
 class SaveSqlQueryResponse(BaseModel):
     """Response schema for a saved SQL query."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: int = Field(..., description="Saved query ID")
     label: str = Field(..., description="Query name")
     sql: str = Field(..., description="SQL query text")
@@ -205,6 +216,14 @@ class SaveSqlQueryResponse(BaseModel):
             "URL to open this saved query in SQL Lab (e.g., /sqllab?savedQueryId=42)"
         ),
     )
+
+    @model_serializer(mode="wrap", when_used="json")
+    def _normalize_schema_field(self, serializer: Any, info: Any) -> Dict[str, Any]:
+        """Rename schema_name → schema so the JSON key matches the alias."""
+        data = serializer(self)
+        if "schema_name" in data:
+            data["schema"] = data.pop("schema_name")
+        return data
 
 
 class OpenSqlLabRequest(BaseModel):
@@ -241,3 +260,11 @@ class SqlLabResponse(BaseModel):
     schema_name: str | None = Field(None, description="Schema selected", alias="schema")
     title: str | None = Field(None, description="Query title")
     error: str | None = Field(None, description="Error message if failed")
+
+    @model_serializer(mode="wrap", when_used="json")
+    def _normalize_schema_field(self, serializer: Any, info: Any) -> Dict[str, Any]:
+        """Rename schema_name → schema so the JSON key matches the alias."""
+        data = serializer(self)
+        if "schema_name" in data:
+            data["schema"] = data.pop("schema_name")
+        return data

--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -29,6 +29,23 @@ from pydantic import (
 )
 
 
+class _SchemaFieldNormalizer(BaseModel):
+    """Mixin that renames schema_name → schema in JSON output.
+
+    Pydantic serializes using field names by default, but the MCP/API
+    convention uses the alias ``schema``.  Adding this as a base class
+    to any response model that carries a ``schema_name`` field with
+    ``alias="schema"`` keeps the JSON key consistent.
+    """
+
+    @model_serializer(mode="wrap", when_used="json")
+    def _normalize_schema_field(self, serializer: Any, _info: Any) -> Dict[str, Any]:
+        data = serializer(self)
+        if "schema_name" in data:
+            data["schema"] = data.pop("schema_name")
+        return data
+
+
 class ExecuteSqlRequest(BaseModel):
     """Request schema for executing SQL queries."""
 
@@ -198,7 +215,7 @@ class SaveSqlQueryRequest(BaseModel):
         return v.strip()
 
 
-class SaveSqlQueryResponse(BaseModel):
+class SaveSqlQueryResponse(_SchemaFieldNormalizer):
     """Response schema for a saved SQL query."""
 
     model_config = ConfigDict(populate_by_name=True)
@@ -216,14 +233,6 @@ class SaveSqlQueryResponse(BaseModel):
             "URL to open this saved query in SQL Lab (e.g., /sqllab?savedQueryId=42)"
         ),
     )
-
-    @model_serializer(mode="wrap", when_used="json")
-    def _normalize_schema_field(self, serializer: Any, info: Any) -> Dict[str, Any]:
-        """Rename schema_name → schema so the JSON key matches the alias."""
-        data = serializer(self)
-        if "schema_name" in data:
-            data["schema"] = data.pop("schema_name")
-        return data
 
 
 class OpenSqlLabRequest(BaseModel):
@@ -250,7 +259,7 @@ class OpenSqlLabRequest(BaseModel):
     title: str | None = Field(None, description="Title for the SQL Lab tab/query")
 
 
-class SqlLabResponse(BaseModel):
+class SqlLabResponse(_SchemaFieldNormalizer):
     """Response schema for SQL Lab URL generation."""
 
     model_config = ConfigDict(populate_by_name=True)
@@ -260,11 +269,3 @@ class SqlLabResponse(BaseModel):
     schema_name: str | None = Field(None, description="Schema selected", alias="schema")
     title: str | None = Field(None, description="Query title")
     error: str | None = Field(None, description="Error message if failed")
-
-    @model_serializer(mode="wrap", when_used="json")
-    def _normalize_schema_field(self, serializer: Any, info: Any) -> Dict[str, Any]:
-        """Rename schema_name → schema so the JSON key matches the alias."""
-        data = serializer(self)
-        if "schema_name" in data:
-            data["schema"] = data.pop("schema_name")
-        return data

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -1293,6 +1293,8 @@ class TestDatasetDefaultColumnFiltering:
                 "id",
                 "table_name",
                 "schema",
+                "database_name",
+                "database",
                 "description",
                 "certified_by",
                 "certification_details",
@@ -1380,10 +1382,15 @@ class TestDatasetDefaultColumnFiltering:
             dataset_item = data["datasets"][0]
 
             # Verify ONLY default columns are present in the response item
+            # Note: "database" is in DEFAULT_DATASET_COLUMNS to trigger eager
+            # loading of the relationship, but it's not a field on DatasetInfo
+            # so it won't appear in the serialized output. "database_name" IS
+            # a field and will appear.
             expected_keys = {
                 "id",
                 "table_name",
                 "schema",
+                "database_name",
                 "description",
                 "certified_by",
                 "certification_details",
@@ -1402,7 +1409,6 @@ class TestDatasetDefaultColumnFiltering:
 
             # Verify non-default columns are NOT present (not even with null values)
             non_default_columns = [
-                "database_name",
                 "changed_by",
                 "columns",
                 "metrics",


### PR DESCRIPTION
## Summary

Fixes three MCP tool bugs where fields are returned as `null` instead of their actual values:

1. **`list_datasets` returns `database_name=null`** — `SqlaTable.database_name` is a Python `@property` accessing `self.database.name`. The DAO's `list()` method returns Row objects (not model instances) when only `ColumnProperty` columns are requested, and Row objects don't support `@property` descriptors. Fixed by detecting `@property` columns in the DAO and falling back to full model loading. Also added the `database` relationship to default dataset columns for eager loading (avoids N+1 queries).

2. **`list_databases` returns `backend=null`** — Same root cause. `Database.backend` is a `@property` computed from `sqlalchemy_uri`. The DAO fix resolves this for all models with `@property` fields.

3. **`save_sql_query` silently drops schema field** — `SaveSqlQueryRequest` lacked `populate_by_name=True`, and `SaveSqlQueryResponse` serialized `schema_name` instead of `schema` in JSON output. Added `populate_by_name` config and `_SchemaFieldNormalizer` mixin to normalize `schema_name` → `schema` in responses (matching the pattern used by `DatasetInfo`). Also fixed the same issue in `SqlLabResponse`.

### Root cause in the DAO

In `BaseDAO.list()`, the column classification loop only recognizes `ColumnProperty` and `RelationshipProperty`. Python `@property` descriptors (like `database_name`, `backend`, `changed_on_humanized`) were silently ignored with a comment `# Ignore properties and other non-queryable attributes`. When all resolved columns are `ColumnProperty`, the DAO uses `session.query(*column_attrs)` which returns Row objects that cannot access `@property` descriptors.

The fix adds `needs_full_model = True` when a column resolves to a descriptor that is neither `ColumnProperty` nor `RelationshipProperty`, ensuring the DAO returns proper model instances.

**Note:** An earlier iteration added `load_only()` as a performance optimization per Copilot review, but this was reverted because serializers access columns beyond the explicitly requested set (e.g., `Slice.datasource_type` during chart serialization), causing `"Could not locate column in row"` errors.

## Testing

- Updated existing unit tests for new default columns
- All 1150 MCP + DAO unit tests pass
- Verified against live staging MCP: `list_datasets` returns `database_name`, `list_databases` returns `backend`, `save_sql_query` preserves `schema`