### PR TITLE
fix: add template_processor so Jinja gets rendered before SQLGlot parse

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3012,7 +3012,11 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 col_obj = dttm_col
             elif is_adhoc_column(flt_col):
                 try:
-                    sqla_col = self.adhoc_column_to_sqla(flt_col, force_type_check=True)
+                    sqla_col = self.adhoc_column_to_sqla(
+                        flt_col,
+                        force_type_check=True,
+                        template_processor=template_processor,
+                    )
                     applied_adhoc_filters_columns.append(flt_col)
                 except ColumnNotFoundException:
                     rejected_adhoc_filters_columns.append(flt_col)


### PR DESCRIPTION
### SUMMARY

Fixes a bug where Jinja templates in virtual dataset SQL were not being rendered when used with cross-filters (adhoc filter columns).

The `adhoc_column_to_sqla` method requires a `template_processor` parameter to render Jinja templates before SQLGlot parses the SQL. While other calls to this method (lines 2829, 2880) correctly pass `template_processor`, the call in the filter processing logic was missing it. This caused SQLGlot to receive unparsed Jinja syntax like `{{ current_username() }}`, resulting in parse errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before: 

<img width="517" height="365" alt="image" src="https://github.com/user-attachments/assets/54eb34e6-6bcd-4b8a-925a-5a61239aaf33" />


#### After:

<img width="518" height="291" alt="image" src="https://github.com/user-attachments/assets/76c8f903-3eb4-4439-9a17-3a3c9005e328" />


### TESTING INSTRUCTIONS

1. Create a virtual dataset with Jinja templates in the SQL (e.g., `{{ current_username() }}`)
2. Create a chart using this virtual dataset
3. Add a cross-filter (adhoc column filter) to the chart
4. Before this fix: SQLGlot parse error due to unrendered Jinja template
5. After this fix: Jinja template is rendered before parsing, filter works correctly

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API