### PR TITLE
fix(tags): fix Bulk tag modal dropdown clipping and stale tag cache

### DIFF
--- a/superset-frontend/src/components/Tag/utils.tsx
+++ b/superset-frontend/src/components/Tag/utils.tsx
@@ -26,15 +26,6 @@ import {
 import type { TagType } from 'src/types/TagType';
 
 import rison from 'rison';
-import { cacheWrapper } from 'src/utils/cacheWrapper';
-
-const localCache = new Map<string, any>();
-
-const cachedSupersetGet = cacheWrapper(
-  SupersetClient.get,
-  localCache,
-  ({ endpoint }) => endpoint || '',
-);
 
 type SelectTagsValue = {
   value: number | undefined;
@@ -75,7 +66,7 @@ export const loadTags = async (
     return errorText;
   };
 
-  return cachedSupersetGet({
+  return SupersetClient.get({
     endpoint: `/api/v1/tag/?q=${query}`,
   })
     .then(response => {

--- a/superset-frontend/src/features/tags/BulkTagModal.tsx
+++ b/superset-frontend/src/features/tags/BulkTagModal.tsx
@@ -31,8 +31,6 @@ import { loadTags } from 'src/components/Tag/utils';
 import { TaggableResourceOption } from 'src/features/tags/TagModal';
 
 const BulkTagModalContainer = styled.div`
-  min-height: 340px;
-
   .bulk-tag-text {
     margin-bottom: ${({ theme }) => theme.sizeUnit * 2.5}px;
   }
@@ -127,7 +125,7 @@ const BulkTagModal: FC<BulkTagModalProps> = ({
         <div className="bulk-tag-text">
           {t('You are adding tags to %s %ss', selected.length, resourceName)}
         </div>
-        <FormLabel>{t('tags')}</FormLabel>
+        <FormLabel>{t('Tags')}</FormLabel>
         <AsyncSelect
           ariaLabel="tags"
           // @ts-expect-error
@@ -136,6 +134,7 @@ const BulkTagModal: FC<BulkTagModalProps> = ({
           onHide={onHide}
           // @ts-expect-error
           onChange={tags => setTags(tags)}
+          getPopupContainer={() => document.body}
           placeholder={t('Select Tags')}
           mode="multiple"
         />

--- a/superset-frontend/src/features/tags/BulkTagModal.tsx
+++ b/superset-frontend/src/features/tags/BulkTagModal.tsx
@@ -31,6 +31,8 @@ import { loadTags } from 'src/components/Tag/utils';
 import { TaggableResourceOption } from 'src/features/tags/TagModal';
 
 const BulkTagModalContainer = styled.div`
+  min-height: 200px;
+
   .bulk-tag-text {
     margin-bottom: ${({ theme }) => theme.sizeUnit * 2.5}px;
   }

--- a/superset-frontend/src/features/tags/BulkTagModal.tsx
+++ b/superset-frontend/src/features/tags/BulkTagModal.tsx
@@ -31,7 +31,7 @@ import { loadTags } from 'src/components/Tag/utils';
 import { TaggableResourceOption } from 'src/features/tags/TagModal';
 
 const BulkTagModalContainer = styled.div`
-  min-height: 200px;
+  min-height: 340px;
 
   .bulk-tag-text {
     margin-bottom: ${({ theme }) => theme.sizeUnit * 2.5}px;

--- a/superset-frontend/src/features/tags/TagModal.tsx
+++ b/superset-frontend/src/features/tags/TagModal.tsx
@@ -332,6 +332,7 @@ const TagModal: FC<TagModalProps> = ({
           onChange={value =>
             handleOptionChange(TaggableResources.Dashboard, value)
           }
+          getPopupContainer={() => document.body}
           header={<FormLabel>{t('Dashboards')}</FormLabel>}
           allowClear
         />
@@ -344,6 +345,7 @@ const TagModal: FC<TagModalProps> = ({
           value={chartsToTag}
           options={loadCharts}
           onChange={value => handleOptionChange(TaggableResources.Chart, value)}
+          getPopupContainer={() => document.body}
           header={<FormLabel>{t('Charts')}</FormLabel>}
           allowClear
         />
@@ -358,6 +360,7 @@ const TagModal: FC<TagModalProps> = ({
           onChange={value =>
             handleOptionChange(TaggableResources.SavedQuery, value)
           }
+          getPopupContainer={() => document.body}
           header={<FormLabel>{t('Saved queries')}</FormLabel>}
           allowClear
         />


### PR DESCRIPTION
### SUMMARY

Three fixes for the "Bulk tag" modal (used when bulk-selecting charts/dashboards and applying tags):

1. **Dropdown clipping** — The tag dropdown was being clipped by the modal body's `overflow: auto`. Added `getPopupContainer={() => document.body}` to portal the dropdown above the modal, which is the standard antd pattern for selects inside modals.

2. **Stale tag cache** — `loadTags` used a `cachedSupersetGet` backed by an in-memory `Map` with no invalidation, so newly created tags never appeared in the dropdown until page reload. Removed the cache entirely — tag lookups are cheap paginated API calls.

3. **Label capitalization** — Changed `t('tags')` → `t('Tags')` for the form label.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### After
<img width="680" height="502" alt="Screenshot 2026-04-08 at 2 26 12 PM" src="https://github.com/user-attachments/assets/f9b3f712-4374-455a-b522-edaf83538e75" />



### TESTING INSTRUCTIONS

1. Enable the `TAGGING_SYSTEM` feature flag
2. Navigate to Charts list
3. Select multiple charts using the checkboxes
4. Click the "Bulk tag" action
5. Verify the tag dropdown opens fully without being clipped by the modal
6. Create a new tag (via the Tags page), return to Charts, open Bulk tag again — verify the new tag appears in the dropdown without needing a page reload
7. Verify the form label reads "Tags" (capitalized)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)