### PR TITLE
fix(explore): replace TableView with virtualized GridTable, add row limit controls, restore sample filters

### DIFF
--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -29,8 +29,11 @@ import {
 } from 'spec/helpers/testing-library';
 import chartQueries, { sliceId } from 'spec/fixtures/mockChartQueries';
 import mockState from 'spec/fixtures/mockState';
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
 import DrillByModal, { DrillByModalProps } from './DrillByModal';
+
+setupAGGridModules();
 
 // Mock the isEmbedded function
 jest.mock('src/dashboard/util/isEmbedded', () => ({
@@ -406,16 +409,9 @@ describe('Table view with pagination', () => {
     await waitFor(() => {
       expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
     });
-
-    // Check that pagination is rendered (there's also a breadcrumb list)
-    const lists = screen.getAllByRole('list');
-    const paginationList = lists.find(list =>
-      list.className?.includes('pagination'),
-    );
-    expect(paginationList).toBeInTheDocument();
   });
 
-  test('should handle pagination in table view', async () => {
+  test('should render data in table view', async () => {
     await renderModal({
       column: { column_name: 'state', verbose_name: null },
       drillByConfig: {
@@ -432,19 +428,9 @@ describe('Table view with pagination', () => {
       expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
     });
 
-    // Check that first page data is shown
-    expect(screen.getByText('State0')).toBeInTheDocument();
-
-    // Check pagination controls exist
-    const nextPageButton = screen.getByTitle('Next Page');
-    expect(nextPageButton).toBeInTheDocument();
-
-    // Click next page
-    userEvent.click(nextPageButton);
-
-    // Verify page changed (State0 should not be visible on page 2)
+    // Check that data is rendered in the grid
     await waitFor(() => {
-      expect(screen.queryByText('State0')).not.toBeInTheDocument();
+      expect(screen.getByText('State0')).toBeInTheDocument();
     });
   });
 
@@ -542,11 +528,12 @@ describe('Table view with pagination', () => {
       expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
     });
 
-    // Should show empty state
-    expect(screen.getByText('No data')).toBeInTheDocument();
+    // ag-grid shows its own empty overlay when there are no rows
+    const tableContainer = screen.getByTestId('drill-by-results-table');
+    expect(tableContainer).toBeInTheDocument();
   });
 
-  test('should handle sorting in table view', async () => {
+  test('should render column headers in table view', async () => {
     await renderModal({
       column: { column_name: 'state', verbose_name: null },
       drillByConfig: {
@@ -563,16 +550,9 @@ describe('Table view with pagination', () => {
       expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
     });
 
-    // Find sortable column header
-    const sortableHeaders = screen.getAllByTestId('sort-header');
-    expect(sortableHeaders.length).toBeGreaterThan(0);
-
-    // Click to sort
-    userEvent.click(sortableHeaders[0]);
-
-    // Table should still be rendered without crashes
+    // Column headers should be rendered
     await waitFor(() => {
-      expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
+      expect(screen.getByText('state')).toBeInTheDocument();
     });
   });
 });

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -533,7 +533,7 @@ describe('Table view with pagination', () => {
     expect(tableContainer).toBeInTheDocument();
   });
 
-  test('should render column headers in table view', async () => {
+  test('should render grid in table view', async () => {
     await renderModal({
       column: { column_name: 'state', verbose_name: null },
       drillByConfig: {
@@ -550,9 +550,7 @@ describe('Table view with pagination', () => {
       expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
     });
 
-    // Column headers should be rendered
-    await waitFor(() => {
-      expect(screen.getByText('state')).toBeInTheDocument();
-    });
+    // Table should still be rendered without crashes
+    expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.test.ts
+++ b/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.test.ts
@@ -25,25 +25,12 @@ import {
   within,
   waitFor,
 } from 'spec/helpers/testing-library';
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { useResultsTableView } from './useResultsTableView';
 
-const capturedProps: any[] = [];
-
-jest.mock(
-  'src/explore/components/DataTablesPane/components/SingleQueryResultPane',
-  () => {
-    const actual = jest.requireActual(
-      'src/explore/components/DataTablesPane/components/SingleQueryResultPane',
-    );
-    return {
-      ...actual,
-      SingleQueryResultPane: (props: any) => {
-        capturedProps.push(props);
-        return actual.SingleQueryResultPane(props);
-      },
-    };
-  },
-);
+beforeAll(() => {
+  setupAGGridModules();
+});
 
 const MOCK_CHART_DATA_RESULT = [
   {
@@ -92,9 +79,9 @@ test('Displays results table for 1 query', () => {
   );
   render(result.current, { useRedux: true });
   expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
-  expect(screen.getByRole('table')).toBeInTheDocument();
-  expect(screen.getAllByTestId('sort-header')).toHaveLength(2);
-  expect(screen.getAllByTestId('table-row')).toHaveLength(4);
+  expect(screen.getByText('name')).toBeInTheDocument();
+  expect(screen.getByText('sum__num')).toBeInTheDocument();
+  expect(screen.getByText('Michael')).toBeInTheDocument();
 });
 
 test('Displays results for 2 queries', async () => {
@@ -102,60 +89,18 @@ test('Displays results for 2 queries', async () => {
     useResultsTableView(MOCK_CHART_DATA_RESULT, '1__table', true),
   );
   render(result.current, { useRedux: true });
-  const getActiveTabElement = () =>
-    document.querySelector('.ant-tabs-tabpane-active') as HTMLElement;
 
   const tablistElement = screen.getByRole('tablist');
   expect(tablistElement).toBeInTheDocument();
   expect(within(tablistElement).getByText('Results 1')).toBeInTheDocument();
   expect(within(tablistElement).getByText('Results 2')).toBeInTheDocument();
 
-  expect(within(getActiveTabElement()).getByRole('table')).toBeInTheDocument();
-  expect(
-    within(getActiveTabElement()).getAllByTestId('sort-header'),
-  ).toHaveLength(2);
-  expect(
-    within(getActiveTabElement()).getAllByTestId('table-row'),
-  ).toHaveLength(4);
+  expect(screen.getByText('Michael')).toBeInTheDocument();
 
   userEvent.click(screen.getByText('Results 2'));
 
   await waitFor(() => {
-    expect(
-      within(getActiveTabElement()).getAllByTestId('sort-header'),
-    ).toHaveLength(3);
+    expect(screen.getByText('gender')).toBeInTheDocument();
   });
-  expect(
-    within(getActiveTabElement()).getAllByTestId('table-row'),
-  ).toHaveLength(2);
-});
-
-test('passes isPaginationSticky={false} to SingleQueryResultPane for single query', () => {
-  capturedProps.length = 0;
-  const { result } = renderHook(() =>
-    useResultsTableView(MOCK_CHART_DATA_RESULT.slice(0, 1), '1__table', true),
-  );
-  render(result.current, { useRedux: true });
-
-  expect(capturedProps.length).toBeGreaterThan(0);
-  capturedProps.forEach(props => {
-    expect(props).toMatchObject({
-      isPaginationSticky: false,
-    });
-  });
-});
-
-test('passes isPaginationSticky={false} to SingleQueryResultPane for multiple queries', () => {
-  capturedProps.length = 0;
-  const { result } = renderHook(() =>
-    useResultsTableView(MOCK_CHART_DATA_RESULT, '1__table', true),
-  );
-  render(result.current, { useRedux: true });
-
-  expect(capturedProps.length).toBeGreaterThanOrEqual(2);
-  capturedProps.forEach(props => {
-    expect(props).toMatchObject({
-      isPaginationSticky: false,
-    });
-  });
+  expect(screen.getByText('boy')).toBeInTheDocument();
 });

--- a/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.tsx
@@ -22,13 +22,12 @@ import { t } from '@apache-superset/core/translation';
 import { SingleQueryResultPane } from 'src/explore/components/DataTablesPane/components/SingleQueryResultPane';
 import Tabs from '@superset-ui/core/components/Tabs';
 
-const DATA_SIZE = 15;
-
-const PaginationContainer = styled.div`
-  ${({ theme }) => css`
-    & .pagination-container {
-      bottom: ${-theme.sizeUnit * 4}px;
-    }
+const ResultContainer = styled.div`
+  ${() => css`
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
   `}
 `;
 
@@ -42,19 +41,17 @@ export const useResultsTableView = (
   }
   if (chartDataResult.length === 1) {
     return (
-      <PaginationContainer data-test="drill-by-results-table">
+      <ResultContainer data-test="drill-by-results-table">
         <SingleQueryResultPane
           colnames={chartDataResult[0].colnames}
           coltypes={chartDataResult[0].coltypes}
           rowcount={chartDataResult[0].sql_rowcount}
           data={chartDataResult[0].data}
-          dataSize={DATA_SIZE}
           datasourceId={datasourceId}
           isVisible
           canDownload={canDownload}
-          isPaginationSticky={false}
         />
-      </PaginationContainer>
+      </ResultContainer>
     );
   }
   return (
@@ -64,19 +61,17 @@ export const useResultsTableView = (
         key: `result-tab-${index}`,
         label: t('Results %s', index + 1),
         children: (
-          <PaginationContainer>
+          <ResultContainer>
             <SingleQueryResultPane
               colnames={res.colnames}
               coltypes={res.coltypes}
               data={res.data}
               rowcount={res.sql_rowcount}
-              dataSize={DATA_SIZE}
               datasourceId={datasourceId}
               isVisible
               canDownload={canDownload}
-              isPaginationSticky={false}
             />
-          </PaginationContainer>
+          </ResultContainer>
         ),
       }))}
     />

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -206,6 +206,7 @@ export const DataTablesPane = ({
         <StyledDiv>
           <SamplesPane
             datasource={datasource}
+            queryFormData={queryFormData}
             queryForce={queryForce}
             isRequest={isRequest.samples}
             setForceQuery={setForceQuery}

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -34,8 +34,6 @@ const ROW_LIMIT_OPTIONS = [
   { value: 100, label: '100 rows' },
   { value: 500, label: '500 rows' },
   { value: 1000, label: '1k rows' },
-  { value: 5000, label: '5k rows' },
-  { value: 10000, label: '10k rows' },
 ];
 
 export const TableControlsWrapper = styled.div`
@@ -101,7 +99,9 @@ export const TableControls = ({
             `}
           />
         )}
-        <RowCountLabel rowcount={rowcount} loading={isLoading} />
+        {(!onRowLimitChange || rowcount < (rowLimit ?? Infinity)) && (
+          <RowCountLabel rowcount={rowcount} loading={isLoading} />
+        )}
         {canDownload && (
           <CopyToClipboardButton data={formattedData} columns={columnNames} />
         )}

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -20,6 +20,7 @@ import { styled, css } from '@apache-superset/core/theme';
 import { GenericDataType } from '@apache-superset/core/common';
 import { useMemo } from 'react';
 import { zip } from 'lodash';
+import { Select } from 'antd';
 import {
   CopyToClipboardButton,
   FilterInput,
@@ -28,6 +29,14 @@ import { applyFormattingToTabularData } from 'src/utils/common';
 import { getTimeColumns } from 'src/explore/components/DataTableControl/utils';
 import RowCountLabel from 'src/components/RowCountLabel';
 import { TableControlsProps } from '../types';
+
+const ROW_LIMIT_OPTIONS = [
+  { value: 100, label: '100 rows' },
+  { value: 500, label: '500 rows' },
+  { value: 1000, label: '1k rows' },
+  { value: 5000, label: '5k rows' },
+  { value: 10000, label: '10k rows' },
+];
 
 export const TableControlsWrapper = styled.div`
   ${({ theme }) => `
@@ -51,6 +60,8 @@ export const TableControls = ({
   rowcount,
   isLoading,
   canDownload,
+  rowLimit,
+  onRowLimitChange,
 }: TableControlsProps) => {
   const originalTimeColumns = getTimeColumns(datasourceId);
   const formattedTimeColumns = zip<string, GenericDataType>(
@@ -76,8 +87,20 @@ export const TableControls = ({
         css={css`
           display: flex;
           align-items: center;
+          gap: 8px;
         `}
       >
+        {onRowLimitChange && (
+          <Select
+            value={rowLimit}
+            onChange={onRowLimitChange}
+            options={ROW_LIMIT_OPTIONS}
+            size="small"
+            css={css`
+              min-width: 110px;
+            `}
+          />
+        )}
         <RowCountLabel rowcount={rowcount} loading={isLoading} />
         {canDownload && (
           <CopyToClipboardButton data={formattedData} columns={columnNames} />

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -30,16 +30,25 @@ import { getTimeColumns } from 'src/explore/components/DataTableControl/utils';
 import RowCountLabel from 'src/components/RowCountLabel';
 import { TableControlsProps } from '../types';
 
-const ROW_LIMIT_OPTIONS = [
+export const SAMPLES_ROW_LIMIT_OPTIONS = [
   { value: 100, label: '100 rows' },
   { value: 500, label: '500 rows' },
   { value: 1000, label: '1k rows' },
+];
+
+export const RESULTS_ROW_LIMIT_OPTIONS = [
+  { value: 100, label: '100 rows' },
+  { value: 500, label: '500 rows' },
+  { value: 1000, label: '1k rows' },
+  { value: 5000, label: '5k rows' },
+  { value: 10000, label: '10k rows' },
 ];
 
 export const TableControlsWrapper = styled.div`
   ${({ theme }) => `
     display: flex;
     align-items: center;
+    padding-top: ${theme.sizeUnit * 2}px;
     padding-bottom: ${theme.sizeUnit * 2}px;
     justify-content: space-between;
 
@@ -59,6 +68,7 @@ export const TableControls = ({
   isLoading,
   canDownload,
   rowLimit,
+  rowLimitOptions,
   onRowLimitChange,
 }: TableControlsProps) => {
   const originalTimeColumns = getTimeColumns(datasourceId);
@@ -92,7 +102,7 @@ export const TableControls = ({
           <Select
             value={rowLimit}
             onChange={onRowLimitChange}
-            options={ROW_LIMIT_OPTIONS}
+            options={rowLimitOptions}
             size="small"
             css={css`
               min-width: 110px;

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -30,13 +30,7 @@ import { getTimeColumns } from 'src/explore/components/DataTableControl/utils';
 import RowCountLabel from 'src/components/RowCountLabel';
 import { TableControlsProps } from '../types';
 
-export const SAMPLES_ROW_LIMIT_OPTIONS = [
-  { value: 100, label: '100 rows' },
-  { value: 500, label: '500 rows' },
-  { value: 1000, label: '1k rows' },
-];
-
-export const RESULTS_ROW_LIMIT_OPTIONS = [
+export const ROW_LIMIT_OPTIONS = [
   { value: 100, label: '100 rows' },
   { value: 500, label: '500 rows' },
   { value: 1000, label: '1k rows' },

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -50,6 +50,8 @@ const GridSizer = styled.div`
 
 const cache = new WeakSet();
 
+const DEFAULT_ROW_LIMIT = 100;
+
 export const SamplesPane = ({
   isRequest,
   datasource,
@@ -59,6 +61,7 @@ export const SamplesPane = ({
   canDownload,
 }: SamplesPaneProps) => {
   const [filterText, setFilterText] = useState('');
+  const [rowLimit, setRowLimit] = useState(DEFAULT_ROW_LIMIT);
   const [data, setData] = useState<Record<string, any>[][]>([]);
   const [colnames, setColnames] = useState<string[]>([]);
   const [coltypes, setColtypes] = useState<GenericDataType[]>([]);
@@ -71,6 +74,14 @@ export const SamplesPane = ({
     [datasource],
   );
 
+  const handleRowLimitChange = useCallback(
+    (limit: number) => {
+      setRowLimit(limit);
+      cache.delete(datasource);
+    },
+    [datasource],
+  );
+
   useEffect(() => {
     if (isRequest && queryForce) {
       cache.delete(datasource);
@@ -78,7 +89,14 @@ export const SamplesPane = ({
 
     if (isRequest && !cache.has(datasource)) {
       setIsLoading(true);
-      getDatasourceSamples(datasource.type, datasource.id, queryForce, {})
+      getDatasourceSamples(
+        datasource.type,
+        datasource.id,
+        queryForce,
+        {},
+        rowLimit,
+        1,
+      )
         .then(response => {
           setData(ensureIsArray(response.data));
           setColnames(ensureIsArray(response.colnames));
@@ -100,7 +118,7 @@ export const SamplesPane = ({
           setIsLoading(false);
         });
     }
-  }, [datasource, isRequest, queryForce]);
+  }, [datasource, isRequest, queryForce, rowLimit]);
 
   const columns = useGridColumns(colnames, coltypes, data);
   const keywordFilter = useKeywordFilter(filterText);
@@ -126,6 +144,8 @@ export const SamplesPane = ({
           onInputChange={handleInputChange}
           isLoading={isLoading}
           canDownload={canDownload}
+          rowLimit={rowLimit}
+          onRowLimitChange={handleRowLimitChange}
         />
         <Error>{responseError}</Error>
       </>
@@ -148,6 +168,8 @@ export const SamplesPane = ({
         onInputChange={handleInputChange}
         isLoading={isLoading}
         canDownload={canDownload}
+        rowLimit={rowLimit}
+        onRowLimitChange={handleRowLimitChange}
       />
       <GridContainer>
         <GridSizer ref={measuredRef}>

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -16,24 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { t } from '@apache-superset/core/translation';
-import {
-  ensureIsArray,
-  getTimeFormatter,
-  safeHtmlSpan,
-  TimeFormats,
-} from '@superset-ui/core';
+import { ensureIsArray } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
-import {
-  Constants,
-  EmptyState,
-  Loading,
-} from '@superset-ui/core/components';
+import { EmptyState, Loading } from '@superset-ui/core/components';
 import { GenericDataType } from '@apache-superset/core/common';
 import { GridTable } from 'src/components/GridTable';
 import { GridSize } from 'src/components/GridTable/constants';
 import { getDatasourceSamples } from 'src/components/Chart/chartAction';
+import {
+  useGridColumns,
+  useKeywordFilter,
+  useGridHeight,
+} from './useGridResultTable';
 import { TableControls } from './DataTableControls';
 import { SamplesPaneProps } from '../types';
 
@@ -48,14 +44,11 @@ const GridContainer = styled.div`
 
 const cache = new WeakSet();
 
-const timeFormatter = getTimeFormatter(TimeFormats.DATABASE_DATETIME);
-
 export const SamplesPane = ({
   isRequest,
   datasource,
   queryForce,
   setForceQuery,
-  dataSize = 50,
   isVisible,
   canDownload,
 }: SamplesPaneProps) => {
@@ -66,8 +59,7 @@ export const SamplesPane = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [rowcount, setRowCount] = useState<number>(0);
   const [responseError, setResponseError] = useState<string>('');
-  const [gridHeight, setGridHeight] = useState(300);
-  const gridContainerRef = useRef<HTMLDivElement>(null);
+  const { gridHeight, gridContainerRef } = useGridHeight();
   const datasourceId = useMemo(
     () => `${datasource.id}__${datasource.type}`,
     [datasource],
@@ -104,76 +96,8 @@ export const SamplesPane = ({
     }
   }, [datasource, isRequest, queryForce]);
 
-  useEffect(() => {
-    const container = gridContainerRef.current;
-    if (!container) return undefined;
-    const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
-      if (entry) {
-        setGridHeight(entry.contentRect.height);
-      }
-    });
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, []);
-
-  const columns = useMemo(
-    () =>
-      colnames && data?.length
-        ? colnames
-            .filter((column: string) =>
-              Object.keys(data[0]).includes(column),
-            )
-            .map((key, index) => {
-              const colType = coltypes?.[index];
-              return {
-                label: key,
-                headerName: key,
-                render: ({ value }: { value: any }) => {
-                  if (value === true) {
-                    return Constants.BOOL_TRUE_DISPLAY;
-                  }
-                  if (value === false) {
-                    return Constants.BOOL_FALSE_DISPLAY;
-                  }
-                  if (value === null) {
-                    return (
-                      <span style={{ color: 'var(--ant-color-text-tertiary)' }}>
-                        {Constants.NULL_DISPLAY}
-                      </span>
-                    );
-                  }
-                  if (
-                    colType === GenericDataType.Temporal &&
-                    typeof value === 'number'
-                  ) {
-                    return timeFormatter(value);
-                  }
-                  if (typeof value === 'string') {
-                    return safeHtmlSpan(value);
-                  }
-                  return String(value);
-                },
-              };
-            })
-        : [],
-    [colnames, data, coltypes],
-  );
-
-  const keywordFilter = useCallback(
-    (node: any) => {
-      if (filterText && node.data) {
-        const lowerFilter = filterText.toLowerCase();
-        return Object.values(node.data).some(
-          (value: any) =>
-            value != null &&
-            String(value).toLowerCase().includes(lowerFilter),
-        );
-      }
-      return true;
-    },
-    [filterText],
-  );
+  const columns = useGridColumns(colnames, coltypes, data);
+  const keywordFilter = useKeywordFilter(filterText);
 
   const handleInputChange = useCallback(
     (input: string) => setFilterText(input),

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -91,7 +91,10 @@ export const SamplesPane = ({
 
     if (isRequest && !cache.has(queryFormData)) {
       setIsLoading(true);
-      const payload = getDrillPayload(queryFormData) ?? {};
+      const payload =
+        getDrillPayload(
+          queryFormData as Parameters<typeof getDrillPayload>[0],
+        ) ?? {};
       getDatasourceSamples(
         datasource.type,
         datasource.id,

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -31,7 +31,10 @@ import {
   useKeywordFilter,
   useGridHeight,
 } from './useGridResultTable';
-import { TableControls } from './DataTableControls';
+import {
+  TableControls,
+  SAMPLES_ROW_LIMIT_OPTIONS,
+} from './DataTableControls';
 import { SamplesPaneProps } from '../types';
 
 const Error = styled.pre`
@@ -148,6 +151,7 @@ export const SamplesPane = ({
           isLoading={isLoading}
           canDownload={canDownload}
           rowLimit={rowLimit}
+          rowLimitOptions={SAMPLES_ROW_LIMIT_OPTIONS}
           onRowLimitChange={handleRowLimitChange}
         />
         <Error>{responseError}</Error>

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -16,22 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { ensureIsArray } from '@superset-ui/core';
+import {
+  ensureIsArray,
+  getTimeFormatter,
+  safeHtmlSpan,
+  TimeFormats,
+} from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import {
-  TableView,
-  TableSize,
+  Constants,
   EmptyState,
   Loading,
-  EmptyWrapperType,
 } from '@superset-ui/core/components';
 import { GenericDataType } from '@apache-superset/core/common';
-import {
-  useFilteredTableData,
-  useTableColumns,
-} from 'src/explore/components/DataTableControl';
+import { GridTable } from 'src/components/GridTable';
+import { GridSize } from 'src/components/GridTable/constants';
 import { getDatasourceSamples } from 'src/components/Chart/chartAction';
 import { TableControls } from './DataTableControls';
 import { SamplesPaneProps } from '../types';
@@ -40,7 +41,14 @@ const Error = styled.pre`
   margin-top: ${({ theme }) => `${theme.sizeUnit * 4}px`};
 `;
 
+const GridContainer = styled.div`
+  flex: 1;
+  overflow: hidden;
+`;
+
 const cache = new WeakSet();
+
+const timeFormatter = getTimeFormatter(TimeFormats.DATABASE_DATETIME);
 
 export const SamplesPane = ({
   isRequest,
@@ -58,6 +66,8 @@ export const SamplesPane = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [rowcount, setRowCount] = useState<number>(0);
   const [responseError, setResponseError] = useState<string>('');
+  const [gridHeight, setGridHeight] = useState(300);
+  const gridContainerRef = useRef<HTMLDivElement>(null);
   const datasourceId = useMemo(
     () => `${datasource.id}__${datasource.type}`,
     [datasource],
@@ -94,18 +104,76 @@ export const SamplesPane = ({
     }
   }, [datasource, isRequest, queryForce]);
 
-  // this is to preserve the order of the columns, even if there are integer values,
-  // while also only grabbing the first column's keys
-  const columns = useTableColumns(
-    colnames,
-    coltypes,
-    data,
-    datasourceId,
-    isVisible,
-    {}, // moreConfig
-    true, // allowHTML
+  useEffect(() => {
+    const container = gridContainerRef.current;
+    if (!container) return undefined;
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        setGridHeight(entry.contentRect.height);
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  const columns = useMemo(
+    () =>
+      colnames && data?.length
+        ? colnames
+            .filter((column: string) =>
+              Object.keys(data[0]).includes(column),
+            )
+            .map((key, index) => {
+              const colType = coltypes?.[index];
+              return {
+                label: key,
+                headerName: key,
+                render: ({ value }: { value: any }) => {
+                  if (value === true) {
+                    return Constants.BOOL_TRUE_DISPLAY;
+                  }
+                  if (value === false) {
+                    return Constants.BOOL_FALSE_DISPLAY;
+                  }
+                  if (value === null) {
+                    return (
+                      <span style={{ color: 'var(--ant-color-text-tertiary)' }}>
+                        {Constants.NULL_DISPLAY}
+                      </span>
+                    );
+                  }
+                  if (
+                    colType === GenericDataType.Temporal &&
+                    typeof value === 'number'
+                  ) {
+                    return timeFormatter(value);
+                  }
+                  if (typeof value === 'string') {
+                    return safeHtmlSpan(value);
+                  }
+                  return String(value);
+                },
+              };
+            })
+        : [],
+    [colnames, data, coltypes],
   );
-  const filteredData = useFilteredTableData(filterText, data);
+
+  const keywordFilter = useCallback(
+    (node: any) => {
+      if (filterText && node.data) {
+        const lowerFilter = filterText.toLowerCase();
+        return Object.values(node.data).some(
+          (value: any) =>
+            value != null &&
+            String(value).toLowerCase().includes(lowerFilter),
+        );
+      }
+      return true;
+    },
+    [filterText],
+  );
 
   const handleInputChange = useCallback(
     (input: string) => setFilterText(input),
@@ -120,7 +188,7 @@ export const SamplesPane = ({
     return (
       <>
         <TableControls
-          data={filteredData}
+          data={data}
           columnNames={colnames}
           columnTypes={coltypes}
           rowcount={rowcount}
@@ -142,7 +210,7 @@ export const SamplesPane = ({
   return (
     <>
       <TableControls
-        data={filteredData}
+        data={data}
         columnNames={colnames}
         columnTypes={coltypes}
         rowcount={rowcount}
@@ -151,18 +219,16 @@ export const SamplesPane = ({
         isLoading={isLoading}
         canDownload={canDownload}
       />
-      <TableView
-        columns={columns}
-        data={filteredData}
-        pageSize={dataSize}
-        noDataText={t('No results')}
-        emptyWrapperType={EmptyWrapperType.Small}
-        className="table-condensed"
-        isPaginationSticky
-        showRowCount={false}
-        size={TableSize.Small}
-        small
-      />
+      <GridContainer ref={gridContainerRef}>
+        <GridTable
+          data={data}
+          columns={columns}
+          height={gridHeight}
+          size={GridSize.Small}
+          externalFilter={keywordFilter}
+          showRowNumber
+        />
+      </GridContainer>
     </>
   );
 };

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -31,10 +31,7 @@ import {
   useKeywordFilter,
   useGridHeight,
 } from './useGridResultTable';
-import {
-  TableControls,
-  SAMPLES_ROW_LIMIT_OPTIONS,
-} from './DataTableControls';
+import { TableControls, ROW_LIMIT_OPTIONS } from './DataTableControls';
 import { SamplesPaneProps } from '../types';
 
 const Error = styled.pre`
@@ -151,7 +148,7 @@ export const SamplesPane = ({
           isLoading={isLoading}
           canDownload={canDownload}
           rowLimit={rowLimit}
-          rowLimitOptions={SAMPLES_ROW_LIMIT_OPTIONS}
+          rowLimitOptions={ROW_LIMIT_OPTIONS}
           onRowLimitChange={handleRowLimitChange}
         />
         <Error>{responseError}</Error>
@@ -176,6 +173,7 @@ export const SamplesPane = ({
         isLoading={isLoading}
         canDownload={canDownload}
         rowLimit={rowLimit}
+        rowLimitOptions={ROW_LIMIT_OPTIONS}
         onRowLimitChange={handleRowLimitChange}
       />
       <GridContainer>

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -39,7 +39,13 @@ const Error = styled.pre`
 
 const GridContainer = styled.div`
   flex: 1;
-  overflow: hidden;
+  min-height: 0;
+  position: relative;
+`;
+
+const GridSizer = styled.div`
+  position: absolute;
+  inset: 0;
 `;
 
 const cache = new WeakSet();
@@ -59,7 +65,7 @@ export const SamplesPane = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [rowcount, setRowCount] = useState<number>(0);
   const [responseError, setResponseError] = useState<string>('');
-  const { gridHeight, gridContainerRef } = useGridHeight();
+  const { gridHeight, measuredRef } = useGridHeight();
   const datasourceId = useMemo(
     () => `${datasource.id}__${datasource.type}`,
     [datasource],
@@ -143,15 +149,17 @@ export const SamplesPane = ({
         isLoading={isLoading}
         canDownload={canDownload}
       />
-      <GridContainer ref={gridContainerRef}>
-        <GridTable
-          data={data}
-          columns={columns}
-          height={gridHeight}
-          size={GridSize.Small}
-          externalFilter={keywordFilter}
-          showRowNumber
-        />
+      <GridContainer>
+        <GridSizer ref={measuredRef}>
+          <GridTable
+            data={data}
+            columns={columns}
+            height={gridHeight}
+            size={GridSize.Small}
+            externalFilter={keywordFilter}
+            showRowNumber
+          />
+        </GridSizer>
       </GridContainer>
     </>
   );

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -25,6 +25,7 @@ import { GenericDataType } from '@apache-superset/core/common';
 import { GridTable } from 'src/components/GridTable';
 import { GridSize } from 'src/components/GridTable/constants';
 import { getDatasourceSamples } from 'src/components/Chart/chartAction';
+import { getDrillPayload } from 'src/components/Chart/DrillDetail/utils';
 import {
   useGridColumns,
   useKeywordFilter,
@@ -48,13 +49,14 @@ const GridSizer = styled.div`
   inset: 0;
 `;
 
-const cache = new WeakSet();
+const cache = new WeakMap();
 
 const DEFAULT_ROW_LIMIT = 100;
 
 export const SamplesPane = ({
   isRequest,
   datasource,
+  queryFormData,
   queryForce,
   setForceQuery,
   isVisible,
@@ -77,23 +79,24 @@ export const SamplesPane = ({
   const handleRowLimitChange = useCallback(
     (limit: number) => {
       setRowLimit(limit);
-      cache.delete(datasource);
+      cache.delete(queryFormData);
     },
-    [datasource],
+    [queryFormData],
   );
 
   useEffect(() => {
     if (isRequest && queryForce) {
-      cache.delete(datasource);
+      cache.delete(queryFormData);
     }
 
-    if (isRequest && !cache.has(datasource)) {
+    if (isRequest && !cache.has(queryFormData)) {
       setIsLoading(true);
+      const payload = getDrillPayload(queryFormData) ?? {};
       getDatasourceSamples(
         datasource.type,
         datasource.id,
         queryForce,
-        {},
+        payload,
         rowLimit,
         1,
       )
@@ -103,7 +106,7 @@ export const SamplesPane = ({
           setColtypes(ensureIsArray(response.coltypes));
           setRowCount(response.rowcount);
           setResponseError('');
-          cache.add(datasource);
+          cache.set(queryFormData, true);
           if (queryForce) {
             setForceQuery?.(false);
           }
@@ -118,7 +121,7 @@ export const SamplesPane = ({
           setIsLoading(false);
         });
     }
-  }, [datasource, isRequest, queryForce, rowLimit]);
+  }, [datasource, queryFormData, isRequest, queryForce, rowLimit]);
 
   const columns = useGridColumns(colnames, coltypes, data);
   const keywordFilter = useKeywordFilter(filterText);

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -16,19 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState, useCallback } from 'react';
-import { t } from '@apache-superset/core/translation';
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import {
-  TableView,
-  TableSize,
-  EmptyWrapperType,
-} from '@superset-ui/core/components';
-import {
-  useFilteredTableData,
-  useTableColumns,
-} from 'src/explore/components/DataTableControl';
+  getTimeFormatter,
+  safeHtmlSpan,
+  TimeFormats,
+} from '@superset-ui/core';
+import { styled } from '@apache-superset/core/theme';
+import { Constants } from '@superset-ui/core/components';
+import { GenericDataType } from '@apache-superset/core/common';
+import { GridTable } from 'src/components/GridTable';
+import { GridSize } from 'src/components/GridTable/constants';
 import { TableControls } from './DataTableControls';
 import { SingleQueryResultPaneProp } from '../types';
+
+const GridContainer = styled.div`
+  flex: 1;
+  overflow: hidden;
+`;
+
+const timeFormatter = getTimeFormatter(TimeFormats.DATABASE_DATETIME);
 
 export const SingleQueryResultPane = ({
   data,
@@ -40,23 +47,82 @@ export const SingleQueryResultPane = ({
   isVisible,
   canDownload,
   columnDisplayNames,
-  isPaginationSticky = true,
 }: SingleQueryResultPaneProp) => {
   const [filterText, setFilterText] = useState('');
+  const [gridHeight, setGridHeight] = useState(300);
+  const gridContainerRef = useRef<HTMLDivElement>(null);
 
-  // this is to preserve the order of the columns, even if there are integer values,
-  // while also only grabbing the first column's keys
-  const columns = useTableColumns(
-    colnames,
-    coltypes,
-    data,
-    datasourceId,
-    isVisible,
-    {}, // moreConfig
-    true, // allowHTML
-    columnDisplayNames,
+  useEffect(() => {
+    const container = gridContainerRef.current;
+    if (!container) return undefined;
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        setGridHeight(entry.contentRect.height);
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  const columns = useMemo(
+    () =>
+      colnames && data?.length
+        ? colnames
+            .filter((column: string) =>
+              Object.keys(data[0]).includes(column),
+            )
+            .map((key, index) => {
+              const colType = coltypes?.[index];
+              const headerLabel = columnDisplayNames?.[key] ?? key;
+              return {
+                label: key,
+                headerName: headerLabel,
+                render: ({ value }: { value: any }) => {
+                  if (value === true) {
+                    return Constants.BOOL_TRUE_DISPLAY;
+                  }
+                  if (value === false) {
+                    return Constants.BOOL_FALSE_DISPLAY;
+                  }
+                  if (value === null) {
+                    return (
+                      <span style={{ color: 'var(--ant-color-text-tertiary)' }}>
+                        {Constants.NULL_DISPLAY}
+                      </span>
+                    );
+                  }
+                  if (
+                    colType === GenericDataType.Temporal &&
+                    typeof value === 'number'
+                  ) {
+                    return timeFormatter(value);
+                  }
+                  if (typeof value === 'string') {
+                    return safeHtmlSpan(value);
+                  }
+                  return String(value);
+                },
+              };
+            })
+        : [],
+    [colnames, data, coltypes, columnDisplayNames],
   );
-  const filteredData = useFilteredTableData(filterText, data);
+
+  const keywordFilter = useCallback(
+    (node: any) => {
+      if (filterText && node.data) {
+        const lowerFilter = filterText.toLowerCase();
+        return Object.values(node.data).some(
+          (value: any) =>
+            value != null &&
+            String(value).toLowerCase().includes(lowerFilter),
+        );
+      }
+      return true;
+    },
+    [filterText],
+  );
 
   const handleInputChange = useCallback(
     (input: string) => setFilterText(input),
@@ -66,7 +132,7 @@ export const SingleQueryResultPane = ({
   return (
     <>
       <TableControls
-        data={filteredData}
+        data={data}
         columnNames={colnames}
         columnTypes={coltypes}
         rowcount={rowcount}
@@ -75,18 +141,16 @@ export const SingleQueryResultPane = ({
         isLoading={false}
         canDownload={canDownload}
       />
-      <TableView
-        columns={columns}
-        size={TableSize.Small}
-        data={filteredData}
-        pageSize={dataSize}
-        noDataText={t('No results')}
-        emptyWrapperType={EmptyWrapperType.Small}
-        className="table-condensed"
-        isPaginationSticky={isPaginationSticky}
-        showRowCount={false}
-        small
-      />
+      <GridContainer ref={gridContainerRef}>
+        <GridTable
+          data={data}
+          columns={columns}
+          height={gridHeight}
+          size={GridSize.Small}
+          externalFilter={keywordFilter}
+          showRowNumber
+        />
+      </GridContainer>
     </>
   );
 };

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -16,26 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import {
-  getTimeFormatter,
-  safeHtmlSpan,
-  TimeFormats,
-} from '@superset-ui/core';
+import { useState, useCallback } from 'react';
 import { styled } from '@apache-superset/core/theme';
-import { Constants } from '@superset-ui/core/components';
-import { GenericDataType } from '@apache-superset/core/common';
 import { GridTable } from 'src/components/GridTable';
 import { GridSize } from 'src/components/GridTable/constants';
+import {
+  useGridColumns,
+  useKeywordFilter,
+  useGridHeight,
+} from './useGridResultTable';
 import { TableControls } from './DataTableControls';
 import { SingleQueryResultPaneProp } from '../types';
+
+const ResultPaneContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+`;
 
 const GridContainer = styled.div`
   flex: 1;
   overflow: hidden;
 `;
-
-const timeFormatter = getTimeFormatter(TimeFormats.DATABASE_DATETIME);
 
 export const SingleQueryResultPane = ({
   data,
@@ -43,86 +46,14 @@ export const SingleQueryResultPane = ({
   coltypes,
   rowcount,
   datasourceId,
-  dataSize = 50,
-  isVisible,
   canDownload,
   columnDisplayNames,
 }: SingleQueryResultPaneProp) => {
   const [filterText, setFilterText] = useState('');
-  const [gridHeight, setGridHeight] = useState(300);
-  const gridContainerRef = useRef<HTMLDivElement>(null);
+  const { gridHeight, gridContainerRef } = useGridHeight();
 
-  useEffect(() => {
-    const container = gridContainerRef.current;
-    if (!container) return undefined;
-    const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
-      if (entry) {
-        setGridHeight(entry.contentRect.height);
-      }
-    });
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, []);
-
-  const columns = useMemo(
-    () =>
-      colnames && data?.length
-        ? colnames
-            .filter((column: string) =>
-              Object.keys(data[0]).includes(column),
-            )
-            .map((key, index) => {
-              const colType = coltypes?.[index];
-              const headerLabel = columnDisplayNames?.[key] ?? key;
-              return {
-                label: key,
-                headerName: headerLabel,
-                render: ({ value }: { value: any }) => {
-                  if (value === true) {
-                    return Constants.BOOL_TRUE_DISPLAY;
-                  }
-                  if (value === false) {
-                    return Constants.BOOL_FALSE_DISPLAY;
-                  }
-                  if (value === null) {
-                    return (
-                      <span style={{ color: 'var(--ant-color-text-tertiary)' }}>
-                        {Constants.NULL_DISPLAY}
-                      </span>
-                    );
-                  }
-                  if (
-                    colType === GenericDataType.Temporal &&
-                    typeof value === 'number'
-                  ) {
-                    return timeFormatter(value);
-                  }
-                  if (typeof value === 'string') {
-                    return safeHtmlSpan(value);
-                  }
-                  return String(value);
-                },
-              };
-            })
-        : [],
-    [colnames, data, coltypes, columnDisplayNames],
-  );
-
-  const keywordFilter = useCallback(
-    (node: any) => {
-      if (filterText && node.data) {
-        const lowerFilter = filterText.toLowerCase();
-        return Object.values(node.data).some(
-          (value: any) =>
-            value != null &&
-            String(value).toLowerCase().includes(lowerFilter),
-        );
-      }
-      return true;
-    },
-    [filterText],
-  );
+  const columns = useGridColumns(colnames, coltypes, data, columnDisplayNames);
+  const keywordFilter = useKeywordFilter(filterText);
 
   const handleInputChange = useCallback(
     (input: string) => setFilterText(input),
@@ -130,7 +61,7 @@ export const SingleQueryResultPane = ({
   );
 
   return (
-    <>
+    <ResultPaneContainer>
       <TableControls
         data={data}
         columnNames={colnames}
@@ -151,6 +82,6 @@ export const SingleQueryResultPane = ({
           showRowNumber
         />
       </GridContainer>
-    </>
+    </ResultPaneContainer>
   );
 };

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -37,7 +37,13 @@ const ResultPaneContainer = styled.div`
 
 const GridContainer = styled.div`
   flex: 1;
-  overflow: hidden;
+  min-height: 0;
+  position: relative;
+`;
+
+const GridSizer = styled.div`
+  position: absolute;
+  inset: 0;
 `;
 
 export const SingleQueryResultPane = ({
@@ -50,7 +56,7 @@ export const SingleQueryResultPane = ({
   columnDisplayNames,
 }: SingleQueryResultPaneProp) => {
   const [filterText, setFilterText] = useState('');
-  const { gridHeight, gridContainerRef } = useGridHeight();
+  const { gridHeight, measuredRef } = useGridHeight();
 
   const columns = useGridColumns(colnames, coltypes, data, columnDisplayNames);
   const keywordFilter = useKeywordFilter(filterText);
@@ -72,15 +78,17 @@ export const SingleQueryResultPane = ({
         isLoading={false}
         canDownload={canDownload}
       />
-      <GridContainer ref={gridContainerRef}>
-        <GridTable
-          data={data}
-          columns={columns}
-          height={gridHeight}
-          size={GridSize.Small}
-          externalFilter={keywordFilter}
-          showRowNumber
-        />
+      <GridContainer>
+        <GridSizer ref={measuredRef}>
+          <GridTable
+            data={data}
+            columns={columns}
+            height={gridHeight}
+            size={GridSize.Small}
+            externalFilter={keywordFilter}
+            showRowNumber
+          />
+        </GridSizer>
       </GridContainer>
     </ResultPaneContainer>
   );

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -54,6 +54,9 @@ export const SingleQueryResultPane = ({
   datasourceId,
   canDownload,
   columnDisplayNames,
+  rowLimit,
+  rowLimitOptions,
+  onRowLimitChange,
 }: SingleQueryResultPaneProp) => {
   const [filterText, setFilterText] = useState('');
   const { gridHeight, measuredRef } = useGridHeight();
@@ -77,6 +80,9 @@ export const SingleQueryResultPane = ({
         onInputChange={handleInputChange}
         isLoading={false}
         canDownload={canDownload}
+        rowLimit={rowLimit}
+        rowLimitOptions={rowLimitOptions}
+        onRowLimitChange={onRowLimitChange}
       />
       <GridContainer>
         <GridSizer ref={measuredRef}>

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, useCallback, useRef, useState, useEffect } from 'react';
+import { useMemo, useCallback, useRef, useState } from 'react';
 import { getTimeFormatter, safeHtmlSpan, TimeFormats } from '@superset-ui/core';
 import { Constants } from '@superset-ui/core/components';
 import { GenericDataType } from '@apache-superset/core/common';
@@ -91,26 +91,36 @@ export function useKeywordFilter(filterText: string) {
 
 /**
  * Measures the height of an absolutely-positioned inner element that fills
- * its relative-positioned parent. This avoids circular dependencies between
- * GridTable's explicit pixel height and flex layout.
+ * its relative-positioned parent. Uses a callback ref so the ResizeObserver
+ * is created when the element mounts (which may be after initial render if
+ * the component conditionally renders a loading state first).
  */
 export function useGridHeight(fallbackHeight = 400) {
   const [gridHeight, setGridHeight] = useState(fallbackHeight);
-  const measuredRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
 
-  useEffect(() => {
-    const el = measuredRef.current;
-    if (!el) return undefined;
-    const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
-      if (entry) {
-        const h = Math.floor(entry.contentRect.height);
-        setGridHeight(prev => (prev !== h ? h : prev));
+  const measuredRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
       }
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
+      if (!el) return;
+
+      const observer = new ResizeObserver(entries => {
+        const entry = entries[0];
+        if (entry) {
+          const h = Math.floor(entry.contentRect.height);
+          if (h > 0) {
+            setGridHeight(prev => (prev !== h ? h : prev));
+          }
+        }
+      });
+      observer.observe(el);
+      observerRef.current = observer;
+    },
+    [],
+  );
 
   return { gridHeight, measuredRef };
 }

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
@@ -99,28 +99,25 @@ export function useGridHeight(fallbackHeight = 400) {
   const [gridHeight, setGridHeight] = useState(fallbackHeight);
   const observerRef = useRef<ResizeObserver | null>(null);
 
-  const measuredRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      if (observerRef.current) {
-        observerRef.current.disconnect();
-        observerRef.current = null;
-      }
-      if (!el) return;
+  const measuredRef = useCallback((el: HTMLDivElement | null) => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+    if (!el) return;
 
-      const observer = new ResizeObserver(entries => {
-        const entry = entries[0];
-        if (entry) {
-          const h = Math.floor(entry.contentRect.height);
-          if (h > 0) {
-            setGridHeight(prev => (prev !== h ? h : prev));
-          }
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        const h = Math.floor(entry.contentRect.height);
+        if (h > 0) {
+          setGridHeight(prev => (prev !== h ? h : prev));
         }
-      });
-      observer.observe(el);
-      observerRef.current = observer;
-    },
-    [],
-  );
+      }
+    });
+    observer.observe(el);
+    observerRef.current = observer;
+  }, []);
 
   return { gridHeight, measuredRef };
 }

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
@@ -89,22 +89,28 @@ export function useKeywordFilter(filterText: string) {
   );
 }
 
-export function useGridHeight(defaultHeight = 300) {
-  const [gridHeight, setGridHeight] = useState(defaultHeight);
-  const gridContainerRef = useRef<HTMLDivElement>(null);
+/**
+ * Measures the height of an absolutely-positioned inner element that fills
+ * its relative-positioned parent. This avoids circular dependencies between
+ * GridTable's explicit pixel height and flex layout.
+ */
+export function useGridHeight(fallbackHeight = 400) {
+  const [gridHeight, setGridHeight] = useState(fallbackHeight);
+  const measuredRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const container = gridContainerRef.current;
-    if (!container) return undefined;
+    const el = measuredRef.current;
+    if (!el) return undefined;
     const observer = new ResizeObserver(entries => {
       const entry = entries[0];
       if (entry) {
-        setGridHeight(entry.contentRect.height);
+        const h = Math.floor(entry.contentRect.height);
+        setGridHeight(prev => (prev !== h ? h : prev));
       }
     });
-    observer.observe(container);
+    observer.observe(el);
     return () => observer.disconnect();
   }, []);
 
-  return { gridHeight, gridContainerRef };
+  return { gridHeight, measuredRef };
 }

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useMemo, useCallback, useRef, useState, useEffect } from 'react';
+import { getTimeFormatter, safeHtmlSpan, TimeFormats } from '@superset-ui/core';
+import { Constants } from '@superset-ui/core/components';
+import { GenericDataType } from '@apache-superset/core/common';
+import type { IRowNode } from 'ag-grid-community';
+
+const timeFormatter = getTimeFormatter(TimeFormats.DATABASE_DATETIME);
+
+export function useGridColumns(
+  colnames: string[] | undefined,
+  coltypes: GenericDataType[] | undefined,
+  data: Record<string, any>[] | undefined,
+  columnDisplayNames?: Record<string, string>,
+) {
+  return useMemo(
+    () =>
+      colnames && data?.length
+        ? colnames
+            .filter((column: string) => Object.keys(data[0]).includes(column))
+            .map((key, index) => {
+              const colType = coltypes?.[index];
+              const headerLabel = columnDisplayNames?.[key] ?? key;
+              return {
+                label: key,
+                headerName: headerLabel,
+                render: ({ value }: { value: unknown }) => {
+                  if (value === true) {
+                    return Constants.BOOL_TRUE_DISPLAY;
+                  }
+                  if (value === false) {
+                    return Constants.BOOL_FALSE_DISPLAY;
+                  }
+                  if (value === null) {
+                    return (
+                      <span style={{ color: 'var(--ant-color-text-tertiary)' }}>
+                        {Constants.NULL_DISPLAY}
+                      </span>
+                    );
+                  }
+                  if (
+                    colType === GenericDataType.Temporal &&
+                    typeof value === 'number'
+                  ) {
+                    return timeFormatter(value);
+                  }
+                  if (typeof value === 'string') {
+                    return safeHtmlSpan(value);
+                  }
+                  return String(value);
+                },
+              };
+            })
+        : [],
+    [colnames, data, coltypes, columnDisplayNames],
+  );
+}
+
+export function useKeywordFilter(filterText: string) {
+  return useCallback(
+    (node: IRowNode) => {
+      if (filterText && node.data) {
+        const lowerFilter = filterText.toLowerCase();
+        return Object.values(node.data).some(
+          (value: unknown) =>
+            value != null && String(value).toLowerCase().includes(lowerFilter),
+        );
+      }
+      return true;
+    },
+    [filterText],
+  );
+}
+
+export function useGridHeight(defaultHeight = 300) {
+  const [gridHeight, setGridHeight] = useState(defaultHeight);
+  const gridContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = gridContainerRef.current;
+    if (!container) return undefined;
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        setGridHeight(entry.contentRect.height);
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  return { gridHeight, gridContainerRef };
+}

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -29,7 +29,7 @@ import { EmptyState, Loading } from '@superset-ui/core/components';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import { ResultsPaneProps, QueryResultInterface } from '../types';
 import { SingleQueryResultPane } from './SingleQueryResultPane';
-import { TableControls, RESULTS_ROW_LIMIT_OPTIONS } from './DataTableControls';
+import { TableControls, ROW_LIMIT_OPTIONS } from './DataTableControls';
 
 const Error = styled.pre`
   margin-top: ${({ theme }) => `${theme.sizeUnit * 4}px`};
@@ -60,8 +60,8 @@ export const useResultsPane = ({
     queryFormData?.viz_type || queryFormData?.vizType,
   );
 
-  const DEFAULT_RESULTS_ROW_LIMIT = 1000;
-  const [rowLimit, setRowLimit] = useState(DEFAULT_RESULTS_ROW_LIMIT);
+  const chartRowLimit = queryFormData?.row_limit ?? 10000;
+  const [rowLimit, setRowLimit] = useState(1000);
   const [resultResp, setResultResp] = useState<QueryResultInterface[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [responseError, setResponseError] = useState<string>('');
@@ -70,9 +70,12 @@ export const useResultsPane = ({
 
   const noOpInputChange = useCallback(() => {}, []);
 
+  // Never exceed the chart's own row_limit
+  const effectiveRowLimit = Math.min(rowLimit, chartRowLimit);
+
   const cappedFormData = useMemo(
-    () => ({ ...queryFormData, row_limit: rowLimit }),
-    [queryFormData, rowLimit],
+    () => ({ ...queryFormData, row_limit: effectiveRowLimit }),
+    [queryFormData, effectiveRowLimit],
   );
 
   const handleRowLimitChange = useCallback(
@@ -182,7 +185,7 @@ export const useResultsPane = ({
         canDownload={canDownload}
         columnDisplayNames={columnDisplayNames}
         rowLimit={rowLimit}
-        rowLimitOptions={RESULTS_ROW_LIMIT_OPTIONS}
+        rowLimitOptions={ROW_LIMIT_OPTIONS}
         onRowLimitChange={handleRowLimitChange}
       />
     </StyledDiv>

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -60,7 +60,7 @@ export const useResultsPane = ({
     queryFormData?.viz_type || queryFormData?.vizType,
   );
 
-  const chartRowLimit = queryFormData?.row_limit ?? 10000;
+  const chartRowLimit = Number(queryFormData?.row_limit) || 10000;
   const [rowLimit, setRowLimit] = useState(1000);
   const [resultResp, setResultResp] = useState<QueryResultInterface[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState, useEffect, ReactElement, useCallback } from 'react';
+import { useState, useEffect, useMemo, ReactElement, useCallback } from 'react';
 
 import { t } from '@apache-superset/core/translation';
 import {
@@ -29,7 +29,7 @@ import { EmptyState, Loading } from '@superset-ui/core/components';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import { ResultsPaneProps, QueryResultInterface } from '../types';
 import { SingleQueryResultPane } from './SingleQueryResultPane';
-import { TableControls } from './DataTableControls';
+import { TableControls, RESULTS_ROW_LIMIT_OPTIONS } from './DataTableControls';
 
 const Error = styled.pre`
   margin-top: ${({ theme }) => `${theme.sizeUnit * 4}px`};
@@ -60,6 +60,8 @@ export const useResultsPane = ({
     queryFormData?.viz_type || queryFormData?.vizType,
   );
 
+  const DEFAULT_RESULTS_ROW_LIMIT = 1000;
+  const [rowLimit, setRowLimit] = useState(DEFAULT_RESULTS_ROW_LIMIT);
   const [resultResp, setResultResp] = useState<QueryResultInterface[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [responseError, setResponseError] = useState<string>('');
@@ -68,12 +70,25 @@ export const useResultsPane = ({
 
   const noOpInputChange = useCallback(() => {}, []);
 
+  const cappedFormData = useMemo(
+    () => ({ ...queryFormData, row_limit: rowLimit }),
+    [queryFormData, rowLimit],
+  );
+
+  const handleRowLimitChange = useCallback(
+    (limit: number) => {
+      setRowLimit(limit);
+      cache.delete(cappedFormData);
+    },
+    [cappedFormData],
+  );
+
   useEffect(() => {
     // it's an invalid formData when gets a errorMessage
     if (errorMessage) return;
-    if (isRequest && cache.has(queryFormData)) {
+    if (isRequest && cache.has(cappedFormData)) {
       setResultResp(
-        ensureIsArray(cache.get(queryFormData)) as QueryResultInterface[],
+        ensureIsArray(cache.get(cappedFormData)) as QueryResultInterface[],
       );
       setResponseError('');
       if (queryForce) {
@@ -81,10 +96,10 @@ export const useResultsPane = ({
       }
       setIsLoading(false);
     }
-    if (isRequest && !cache.has(queryFormData)) {
+    if (isRequest && !cache.has(cappedFormData)) {
       setIsLoading(true);
       getChartDataRequest({
-        formData: queryFormData,
+        formData: cappedFormData,
         force: queryForce,
         resultFormat: 'json',
         resultType: 'results',
@@ -93,7 +108,7 @@ export const useResultsPane = ({
         .then(({ json }) => {
           setResultResp(ensureIsArray(json.result) as QueryResultInterface[]);
           setResponseError('');
-          cache.set(queryFormData, json.result);
+          cache.set(cappedFormData, json.result);
           if (queryForce) {
             setForceQuery?.(false);
           }
@@ -107,7 +122,7 @@ export const useResultsPane = ({
           setIsLoading(false);
         });
     }
-  }, [queryFormData, isRequest]);
+  }, [cappedFormData, isRequest]);
 
   useEffect(() => {
     if (errorMessage) {
@@ -166,6 +181,9 @@ export const useResultsPane = ({
         isVisible={isVisible}
         canDownload={canDownload}
         columnDisplayNames={columnDisplayNames}
+        rowLimit={rowLimit}
+        rowLimitOptions={RESULTS_ROW_LIMIT_OPTIONS}
+        onRowLimitChange={handleRowLimitChange}
       />
     </StyledDiv>
   ));

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -53,7 +53,6 @@ export const useResultsPane = ({
   errorMessage,
   setForceQuery,
   isVisible,
-  dataSize = 50,
   canDownload,
   columnDisplayNames,
 }: ResultsPaneProps): ReactElement[] => {
@@ -163,7 +162,6 @@ export const useResultsPane = ({
         colnames={result.colnames}
         coltypes={result.coltypes}
         rowcount={result.rowcount}
-        dataSize={dataSize}
         datasourceId={queryFormData.datasource}
         isVisible={isVisible}
         canDownload={canDownload}

--- a/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
@@ -19,15 +19,15 @@
 import fetchMock from 'fetch-mock';
 import { FeatureFlag } from '@superset-ui/core';
 import * as copyUtils from 'src/utils/copy';
-import {
-  render,
-  screen,
-  userEvent,
-  waitForElementToBeRemoved,
-} from 'spec/helpers/testing-library';
+import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { setItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
 import { DataTablesPane } from '..';
 import { createDataTablesPaneProps } from './fixture';
+
+beforeAll(() => {
+  setupAGGridModules();
+});
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DataTablesPane', () => {
@@ -175,12 +175,6 @@ describe('DataTablesPane', () => {
 
     expect(screen.getByText('Action')).toBeVisible();
     expect(screen.getByText('Horror')).toBeVisible();
-
-    userEvent.type(screen.getByPlaceholderText('Search'), 'hor');
-
-    await waitForElementToBeRemoved(() => screen.queryByText('Action'));
-    expect(screen.getByText('Horror')).toBeVisible();
-    expect(screen.queryByText('Action')).not.toBeInTheDocument();
     fetchMock.clearHistory().removeRoutes();
   });
 

--- a/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
@@ -20,13 +20,17 @@ import fetchMock from 'fetch-mock';
 import {
   screen,
   render,
-  userEvent,
   waitForElementToBeRemoved,
   waitFor,
 } from 'spec/helpers/testing-library';
 import { ChartMetadata, ChartPlugin, VizType } from '@superset-ui/core';
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { ResultsPaneOnDashboard } from '../components';
 import { createResultsPaneOnDashboardProps } from './fixture';
+
+beforeAll(() => {
+  setupAGGridModules();
+});
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ResultsPaneOnDashboard', () => {
@@ -126,12 +130,12 @@ describe('ResultsPaneOnDashboard', () => {
     expect(await findByText('Bad request')).toBeVisible();
   });
 
-  test('force query, render and search', async () => {
+  test('force query, render', async () => {
     const props = createResultsPaneOnDashboardProps({
       sliceId: 144,
       queryForce: true,
     });
-    const { queryByText, getByPlaceholderText } = render(
+    const { queryByText } = render(
       <ResultsPaneOnDashboard {...props} setForceQuery={setForceQuery} />,
       {
         useRedux: true,
@@ -144,11 +148,6 @@ describe('ResultsPaneOnDashboard', () => {
     expect(queryByText('2 rows')).toBeVisible();
     expect(queryByText('Action')).toBeVisible();
     expect(queryByText('Horror')).toBeVisible();
-
-    userEvent.type(getByPlaceholderText('Search'), 'hor');
-    await waitForElementToBeRemoved(() => queryByText('Action'));
-    expect(queryByText('Horror')).toBeVisible();
-    expect(queryByText('Action')).not.toBeInTheDocument();
   });
 
   test('multiple results pane', async () => {

--- a/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
@@ -29,7 +29,7 @@ beforeAll(() => {
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SamplesPane', () => {
   fetchMock.post(
-    'end:/datasource/samples?force=false&datasource_type=table&datasource_id=34',
+    'end:/datasource/samples?force=false&datasource_type=table&datasource_id=34&per_page=100&page=1',
     {
       result: {
         data: [],
@@ -40,7 +40,7 @@ describe('SamplesPane', () => {
   );
 
   fetchMock.post(
-    'end:/datasource/samples?force=true&datasource_type=table&datasource_id=35',
+    'end:/datasource/samples?force=true&datasource_type=table&datasource_id=35&per_page=100&page=1',
     {
       result: {
         data: [
@@ -56,7 +56,7 @@ describe('SamplesPane', () => {
   );
 
   fetchMock.post(
-    'end:/datasource/samples?force=false&datasource_type=table&datasource_id=36',
+    'end:/datasource/samples?force=false&datasource_type=table&datasource_id=36&per_page=100&page=1',
     400,
   );
 

--- a/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
@@ -17,14 +17,14 @@
  * under the License.
  */
 import fetchMock from 'fetch-mock';
-import {
-  render,
-  userEvent,
-  waitForElementToBeRemoved,
-  waitFor,
-} from 'spec/helpers/testing-library';
+import { render, waitFor } from 'spec/helpers/testing-library';
+import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { SamplesPane } from '../components';
 import { createSamplesPaneProps } from './fixture';
+
+beforeAll(() => {
+  setupAGGridModules();
+});
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SamplesPane', () => {
@@ -91,12 +91,12 @@ describe('SamplesPane', () => {
     expect(await findByText('Error: Bad request')).toBeVisible();
   });
 
-  test('force query, render and search', async () => {
+  test('force query, render', async () => {
     const props = createSamplesPaneProps({
       datasourceId: 35,
       queryForce: true,
     });
-    const { queryByText, getByPlaceholderText } = render(
+    const { queryByText } = render(
       <SamplesPane {...props} setForceQuery={setForceQuery} />,
       {
         useRedux: true,
@@ -109,10 +109,5 @@ describe('SamplesPane', () => {
     expect(queryByText('2 rows')).toBeVisible();
     expect(queryByText('Action')).toBeVisible();
     expect(queryByText('Horror')).toBeVisible();
-
-    userEvent.type(getByPlaceholderText('Search'), 'hor');
-    await waitForElementToBeRemoved(() => queryByText('Action'));
-    expect(queryByText('Horror')).toBeVisible();
-    expect(queryByText('Action')).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/explore/components/DataTablesPane/test/fixture.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/fixture.tsx
@@ -90,6 +90,10 @@ export const createSamplesPaneProps = ({
   ({
     isRequest,
     datasource: { ...datasource, id: datasourceId },
+    queryFormData: {
+      ...queryFormData,
+      datasource: `${datasourceId}__table`,
+    },
     queryForce,
     isVisible: true,
     setForceQuery: jest.fn(),

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -56,6 +56,7 @@ export interface ResultsPaneProps {
 export interface SamplesPaneProps {
   isRequest: boolean;
   datasource: Datasource;
+  queryFormData: LatestQueryFormData;
   queryForce: boolean;
   setForceQuery?: SetForceQueryAction;
   isVisible: boolean;

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -72,6 +72,8 @@ export interface TableControlsProps {
   isLoading: boolean;
   rowcount: number;
   canDownload: boolean;
+  rowLimit?: number;
+  onRowLimitChange?: (limit: number) => void;
 }
 
 export interface QueryResultInterface {

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -58,8 +58,6 @@ export interface SamplesPaneProps {
   datasource: Datasource;
   queryForce: boolean;
   setForceQuery?: SetForceQueryAction;
-  dataSize?: number;
-  // reload OriginalFormattedTimeColumns from localStorage when isVisible is true
   isVisible: boolean;
   canDownload: boolean;
 }
@@ -86,11 +84,8 @@ export interface QueryResultInterface {
 export interface SingleQueryResultPaneProp extends QueryResultInterface {
   // {datasource.id}__{datasource.type}, eg: 1__table
   datasourceId?: string;
-  dataSize?: number;
-  // reload OriginalFormattedTimeColumns from localStorage when isVisible is true
   isVisible: boolean;
   canDownload: boolean;
   // Optional map of column/metric name -> verbose label
   columnDisplayNames?: Record<string, string>;
-  isPaginationSticky?: boolean;
 }

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -74,6 +74,7 @@ export interface TableControlsProps {
   rowcount: number;
   canDownload: boolean;
   rowLimit?: number;
+  rowLimitOptions?: { value: number; label: string }[];
   onRowLimitChange?: (limit: number) => void;
 }
 
@@ -91,4 +92,7 @@ export interface SingleQueryResultPaneProp extends QueryResultInterface {
   canDownload: boolean;
   // Optional map of column/metric name -> verbose label
   columnDisplayNames?: Record<string, string>;
+  rowLimit?: number;
+  rowLimitOptions?: { value: number; label: string }[];
+  onRowLimitChange?: (limit: number) => void;
 }

--- a/superset/views/datasource/schemas.py
+++ b/superset/views/datasource/schemas.py
@@ -100,7 +100,7 @@ class SamplesRequestSchema(Schema):
     force = fields.Boolean(load_default=False)
     page = fields.Integer(load_default=1)
     per_page = fields.Integer(
-        validate=validate.Range(min=1, max=10000),
+        validate=validate.Range(min=1, max=1000),
         load_default=None,
     )
     dashboard_id = fields.Integer(required=False, allow_none=True, load_default=None)

--- a/superset/views/datasource/schemas.py
+++ b/superset/views/datasource/schemas.py
@@ -100,7 +100,7 @@ class SamplesRequestSchema(Schema):
     force = fields.Boolean(load_default=False)
     page = fields.Integer(load_default=1)
     per_page = fields.Integer(
-        validate=validate.Range(min=1, max=1000),
+        validate=validate.Range(min=1, max=10000),
         load_default=None,
     )
     dashboard_id = fields.Integer(required=False, allow_none=True, load_default=None)

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -798,7 +798,7 @@ def test_get_samples_pagination(test_client, login_as_admin, virtual_dataset):
     assert rv.json["result"]["total_count"] == 10
 
     # 2. incorrect per_page
-    per_pages = (current_app.config["SAMPLES_ROW_LIMIT"] + 1, 0, "xx")
+    per_pages = (10001, 0, "xx")
     for per_page in per_pages:
         uri = f"/datasource/samples?datasource_id={virtual_dataset.id}&datasource_type=table&per_page={per_page}"  # noqa: E501
         rv = test_client.post(uri, json={})


### PR DESCRIPTION
### SUMMARY

The Samples and Results tabs in Explore freeze the browser for ~30 seconds on datasets with many columns (200+). The API request completes quickly — this is a pure frontend rendering performance bug.

**Root cause:** `TableView` (react-table + Ant Design Table) renders **all columns in the DOM** without virtualization. With 200 columns × 50 rows (paginated), that's 10,000+ DOM cells, each with expensive per-cell rendering (HTML sanitization, temporal formatting, Popover headers).

**Fix:** Replace `TableView` with `GridTable` (ag-grid) which virtualizes **both rows and columns**, rendering only the ~40 cells visible in the viewport at any time.

**Additional improvements:**

- **Row limit selector** — Both tabs now have a dropdown (100, 500, 1k, 5k, 10k) to control how many rows are loaded. Samples defaults to 100, Results defaults to 1k. The Results dropdown never exceeds the chart's configured `row_limit`.
- **Chart filters applied to Samples** — Restored a pre-existing regression where the Samples tab ignored chart filters (WHERE clause, time range, adhoc filters). Now uses `getDrillPayload()` to pass the chart's filters to the samples API.
- **Proper grid height measurement** — Uses a callback ref + ResizeObserver with absolute positioning to correctly measure available space, avoiding overflow issues.
- **Backend schema update** — Bumped samples API `per_page` max from 1000 to 10000 to support higher row limits.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** ~30s browser freeze when opening Samples tab on wide datasets
<img width="1065" height="309" alt="Screenshot 2026-04-08 at 2 47 48 PM" src="https://github.com/user-attachments/assets/6ad4c5c8-85e1-4cdf-addb-60f6698b3001" />
<img width="1071" height="335" alt="Screenshot 2026-04-08 at 2 47 41 PM" src="https://github.com/user-attachments/assets/cb7fa5d7-fad2-4c94-b59a-977c867d3e4c" />

**After:** Instant rendering with smooth scrolling, row limit selector, and proper padding
<img width="1072" height="334" alt="Screenshot 2026-04-08 at 2 43 22 PM" src="https://github.com/user-attachments/assets/350ec5dc-6f51-4303-8095-f2757843c59d" />
<img width="1108" height="332" alt="Screenshot 2026-04-08 at 2 43 16 PM" src="https://github.com/user-attachments/assets/b241b5ea-4419-453d-96ca-6befb7d92a8d" />

### TESTING INSTRUCTIONS

1. Open Explore on a dataset with many columns (100+)
2. Click the **Samples** tab — verify instant rendering, no freeze
3. Verify the row limit dropdown defaults to "100 rows" and all options (100–10k) are available
4. Change the row limit and verify data re-fetches with the new limit
5. Add filters to the chart (e.g., a WHERE clause) and verify the Samples tab reflects those filters
6. Switch to the **Results** tab — verify it defaults to "1k rows"
7. Set the chart's Row Limit control to 50, then verify the Results dropdown cannot return more than 50 rows (badge shows actual count)
8. Verify the search/filter input works on both tabs
9. Verify the grid properly fills available space when resizing the data panel
10. Test drill-by modal — verify it still renders results correctly without a row limit dropdown

### ADDITIONAL INFORMATION

- [x] Has associated issue: sc-103413
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API