### PR TITLE
fix(explore): dispatch onChange immediately on NumberControl stepper arrow clicks

### DIFF
--- a/superset-frontend/src/explore/components/controls/NumberControl/NumberControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/NumberControl/NumberControl.test.tsx
@@ -82,6 +82,21 @@ test('can clear field completely', async () => {
   expect(props.onChange).toHaveBeenLastCalledWith(undefined);
 });
 
+test('stepper arrows trigger onChange immediately', async () => {
+  const props = {
+    ...mockedProps,
+    value: 5,
+    onChange: jest.fn(),
+  };
+  render(<NumberControl {...props} />);
+  const upButton = document.querySelector(
+    '.ant-input-number-handler-up',
+  ) as HTMLElement;
+  expect(upButton).toBeInTheDocument();
+  await userEvent.click(upButton);
+  expect(props.onChange).toHaveBeenCalledWith(6);
+});
+
 test('updates local value when prop changes', () => {
   const props = {
     ...mockedProps,

--- a/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
@@ -71,6 +71,11 @@ export default function NumberControl({
     onChange?.(pendingValueRef.current);
   };
 
+  const handleStep = (val: number) => {
+    pendingValueRef.current = val;
+    onChange?.(val);
+  };
+
   return (
     <FullWidthDiv>
       <ControlHeader {...rest} />
@@ -82,6 +87,7 @@ export default function NumberControl({
         value={value}
         onChange={handleChange}
         onBlur={handleBlur}
+        onStep={handleStep}
         disabled={disabled}
         aria-label={rest.label}
       />


### PR DESCRIPTION
### SUMMARY

PR #37007 refactored `NumberControl` to defer `onChange` dispatch until blur (`onBlur`) to fix a field-clearing issue in matrixify. However, this introduced a regression: clicking the stepper arrows (up/down) updates the internal `pendingValueRef` but never triggers `onChange` because arrow clicks don't blur the input field — making the arrows appear broken.

**Fix:** Add an `onStep` handler that immediately dispatches `onChange` when the stepper arrows are clicked, while preserving the blur-based dispatch for keyboard input.

Fixes #39103

### SCREENSHOTS 
![top n down](https://github.com/user-attachments/assets/20c70be7-dfef-4bd1-9242-45ca1db4f3fb)


**Before:** Clicking stepper arrows updates the displayed value but the change never propagates to the parent component.

**After:** Clicking stepper arrows immediately dispatches `onChange` to the parent component.

### TESTING INSTRUCTIONS

1. Go to Explore view → select any chart that uses matrixify (e.g., a chart with the "Matrixified" tag)
2. Find a `NumberControl` input with stepper arrows (up/down buttons)
3. Click the up/down arrows — verify the value changes **and** the chart re-renders with the new value
4. Also verify typing a value and tabbing away still works correctly
