### PR TITLE
fix(css-templates): add missing height to CSS editor in CssTemplateModal

### DIFF
--- a/superset-frontend/src/features/cssTemplates/CssTemplateModal.tsx
+++ b/superset-frontend/src/features/cssTemplates/CssTemplateModal.tsx
@@ -268,6 +268,7 @@ const CssTemplateModal: FunctionComponent<CssTemplateModalProps> = ({
           onChange={onCssChange}
           value={currentCssTemplate?.css ?? ''}
           language="css"
+          height="250px"
           width="100%"
         />
       </TemplateContainer>


### PR DESCRIPTION
### SUMMARY

The CSS editor in the "Add CSS Template" modal (`Settings → CSS Templates → + CSS Template`) is invisible/collapsed because the `EditorHost` component has no `height` prop specified. This was introduced when #37499 refactored the modal — the `height` property was not carried over to `StyledEditorHost`.

**Fix:** Add `height="250px"` to the `StyledEditorHost` component, consistent with how other `EditorHost` usages in the codebase specify height (e.g., `TemplateParamsEditor`).

Fixes #38963

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**
![before-field](https://github.com/user-attachments/assets/d89af354-0116-4803-a1c3-7d3776931ed3)


**After:**
![after field](https://github.com/user-attachments/assets/2af87d73-9326-48c0-b8db-3e75c7260539)


### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #38963
- [x] Changes UI
