### PR TITLE
fix(dashboard): restore list bullet points in markdown components

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -23,7 +23,21 @@ import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 // Currently pinned to v3.0.1 for compatibility with react-markdown v8 and React 17.
 import remarkGfm from 'remark-gfm';
 import { mergeWith } from 'lodash';
+import { styled } from '@apache-superset/core/theme';
 import { FeatureFlag, isFeatureEnabled } from '../../utils';
+
+const MarkdownContainer = styled.div`
+  ul,
+  ol {
+    list-style: revert;
+    padding: revert;
+    margin: revert;
+  }
+
+  li {
+    list-style: revert;
+  }
+`;
 
 interface SafeMarkdownProps {
   source: string;
@@ -78,13 +92,15 @@ export function SafeMarkdown({
 
   // React Markdown escapes HTML by default
   return (
-    <ReactMarkdown
-      rehypePlugins={rehypePlugins}
-      remarkPlugins={[remarkGfm]}
-      skipHtml={false}
-      transformLinkUri={null}
-    >
-      {source}
-    </ReactMarkdown>
+    <MarkdownContainer>
+      <ReactMarkdown
+        rehypePlugins={rehypePlugins}
+        remarkPlugins={[remarkGfm]}
+        skipHtml={false}
+        transformLinkUri={null}
+      >
+        {source}
+      </ReactMarkdown>
+    </MarkdownContainer>
   );
 }


### PR DESCRIPTION
### SUMMARY

Markdown bullet points (unordered and ordered lists) don't render in dashboard markdown components. The root cause is antd's global `resetComponent` style which sets `listStyle: 'none'` on all elements, stripping browser default list styling from `<ul>`, `<ol>`, and `<li>` elements rendered by `react-markdown`.

**Fix:** Add `list-style: revert`, `padding: revert`, and `margin: revert` to list elements in the `SafeMarkdown` component, restoring browser default list rendering. This fix applies globally to all SafeMarkdown usages (dashboards, chart descriptions, etc.).

Fixes #39174

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**

**After:**

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #39174
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API