### PR TITLE
fix(a11y): WCAG 1.3.5 — add autocomplete attributes to form inputs

### DIFF
--- a/superset-frontend/src/components/ImportModal/index.tsx
+++ b/superset-frontend/src/components/ImportModal/index.tsx
@@ -259,7 +259,7 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
                 </div>
                 <Input
                   name={`password-${fileName}`}
-                  autoComplete={`password-${fileName}`}
+                  autoComplete="off"
                   type="password"
                   value={passwords[fileName]}
                   onChange={event =>
@@ -279,7 +279,7 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
                 </div>
                 <Input
                   name={`ssh_tunnel_password-${fileName}`}
-                  autoComplete={`ssh_tunnel_password-${fileName}`}
+                  autoComplete="off"
                   type="password"
                   value={sshTunnelPasswords[fileName]}
                   onChange={event =>
@@ -300,7 +300,7 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
                 </div>
                 <Input.TextArea
                   name={`ssh_tunnel_private_key-${fileName}`}
-                  autoComplete={`ssh_tunnel_private_key-${fileName}`}
+                  autoComplete="off"
                   value={sshTunnelPrivateKeys[fileName]}
                   onChange={event =>
                     setSSHTunnelPrivateKeys({
@@ -322,7 +322,7 @@ export const ImportModal: FunctionComponent<ImportModelsModalProps> = ({
                 </div>
                 <Input
                   name={`ssh_tunnel_private_key_password-${fileName}`}
-                  autoComplete={`ssh_tunnel_private_key_password-${fileName}`}
+                  autoComplete="off"
                   type="password"
                   value={sshTunnelPrivateKeyPasswords[fileName]}
                   onChange={event =>

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.tsx
@@ -96,6 +96,7 @@ export const OAuth2ClientField = ({
                 <Input
                   data-test="client-secret"
                   type="password"
+                  autoComplete="off"
                   value={oauth2ClientInfo.secret}
                   onChange={handleChange('secret')}
                 />

--- a/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
@@ -74,6 +74,7 @@ const SSHTunnelForm = ({
             <Input
               name="server_address"
               type="text"
+              autoComplete="off"
               placeholder={t('e.g. 127.0.0.1')}
               value={db?.ssh_tunnel?.server_address || ''}
               onChange={onSSHTunnelParametersChange}
@@ -90,6 +91,7 @@ const SSHTunnelForm = ({
               name="server_port"
               placeholder={t('22')}
               type="number"
+              autoComplete="off"
               value={db?.ssh_tunnel?.server_port}
               onChange={onSSHTunnelParametersChange}
               data-test="ssh-tunnel-server_port-input"
@@ -106,6 +108,7 @@ const SSHTunnelForm = ({
             <Input
               name="username"
               type="text"
+              autoComplete="off"
               placeholder={t('e.g. Analytics')}
               value={db?.ssh_tunnel?.username || ''}
               onChange={onSSHTunnelParametersChange}
@@ -153,6 +156,7 @@ const SSHTunnelForm = ({
               </FormLabel>
               <StyledInputPassword
                 name="password"
+                autoComplete="off"
                 placeholder={t('e.g. ********')}
                 value={db?.ssh_tunnel?.password || ''}
                 onChange={onSSHTunnelParametersChange}
@@ -184,6 +188,7 @@ const SSHTunnelForm = ({
                 </FormLabel>
                 <Input.TextArea
                   name="private_key"
+                  autoComplete="off"
                   placeholder={t('Paste Private Key here')}
                   value={db?.ssh_tunnel?.private_key || ''}
                   onChange={onSSHTunnelParametersChange}
@@ -201,6 +206,7 @@ const SSHTunnelForm = ({
                 </FormLabel>
                 <StyledInputPassword
                   name="private_key_password"
+                  autoComplete="off"
                   placeholder={t('e.g. ********')}
                   value={db?.ssh_tunnel?.private_key_password || ''}
                   onChange={onSSHTunnelParametersChange}

--- a/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
@@ -72,6 +72,7 @@ const SSHTunnelForm = ({
               {t('SSH Host')}
             </FormLabel>
             <Input
+              id="server_address"
               name="server_address"
               type="text"
               autoComplete="off"
@@ -88,6 +89,7 @@ const SSHTunnelForm = ({
               {t('SSH Port')}
             </FormLabel>
             <Input
+              id="server_port"
               name="server_port"
               placeholder={t('22')}
               type="number"
@@ -106,6 +108,7 @@ const SSHTunnelForm = ({
               {t('Username')}
             </FormLabel>
             <Input
+              id="username"
               name="username"
               type="text"
               autoComplete="off"
@@ -155,6 +158,7 @@ const SSHTunnelForm = ({
                 {t('SSH Password')}
               </FormLabel>
               <StyledInputPassword
+                id="password"
                 name="password"
                 autoComplete="off"
                 placeholder={t('e.g. ********')}
@@ -187,6 +191,7 @@ const SSHTunnelForm = ({
                   {t('Private Key')}
                 </FormLabel>
                 <Input.TextArea
+                  id="private_key"
                   name="private_key"
                   autoComplete="off"
                   placeholder={t('Paste Private Key here')}
@@ -205,6 +210,7 @@ const SSHTunnelForm = ({
                   {t('Private Key Password')}
                 </FormLabel>
                 <StyledInputPassword
+                  id="private_key_password"
                   name="private_key_password"
                   autoComplete="off"
                   placeholder={t('e.g. ********')}

--- a/superset-frontend/src/features/userInfo/UserInfoModal.tsx
+++ b/superset-frontend/src/features/userInfo/UserInfoModal.tsx
@@ -73,6 +73,7 @@ function UserInfoModal({
       >
         <Input
           name="first_name"
+          autoComplete="given-name"
           placeholder={t("Enter the user's first name")}
         />
       </FormItem>
@@ -81,7 +82,7 @@ function UserInfoModal({
         label={t('Last name')}
         rules={[{ required: true, message: t('Last name is required') }]}
       >
-        <Input name="last_name" placeholder={t("Enter the user's last name")} />
+        <Input name="last_name" autoComplete="family-name" placeholder={t("Enter the user's last name")} />
       </FormItem>
     </>
   );
@@ -95,6 +96,7 @@ function UserInfoModal({
       >
         <Input.Password
           name="password"
+          autoComplete="new-password"
           placeholder={t("Enter the user's password")}
         />
       </FormItem>
@@ -119,6 +121,7 @@ function UserInfoModal({
       >
         <Input.Password
           name="confirm_password"
+          autoComplete="new-password"
           placeholder={t("Confirm the user's password")}
         />
       </FormItem>

--- a/superset-frontend/src/features/userInfo/UserInfoModal.tsx
+++ b/superset-frontend/src/features/userInfo/UserInfoModal.tsx
@@ -82,7 +82,11 @@ function UserInfoModal({
         label={t('Last name')}
         rules={[{ required: true, message: t('Last name is required') }]}
       >
-        <Input name="last_name" autoComplete="family-name" placeholder={t("Enter the user's last name")} />
+        <Input
+          name="last_name"
+          autoComplete="family-name"
+          placeholder={t("Enter the user's last name")}
+        />
       </FormItem>
     </>
   );

--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -142,6 +142,7 @@ function UserListModal({
           >
             <Input
               name="first_name"
+              autoComplete="given-name"
               placeholder={t("Enter the user's first name")}
             />
           </FormItem>
@@ -152,6 +153,7 @@ function UserListModal({
           >
             <Input
               name="last_name"
+              autoComplete="family-name"
               placeholder={t("Enter the user's last name")}
             />
           </FormItem>
@@ -162,6 +164,7 @@ function UserListModal({
           >
             <Input
               name="username"
+              autoComplete="username"
               placeholder={t("Enter the user's username")}
             />
           </FormItem>
@@ -187,7 +190,7 @@ function UserListModal({
               },
             ]}
           >
-            <Input name="email" placeholder={t("Enter the user's email")} />
+            <Input name="email" autoComplete="email" placeholder={t("Enter the user's email")} />
           </FormItem>
           <FormItem
             name="roles"
@@ -236,6 +239,7 @@ function UserListModal({
               >
                 <Input.Password
                   name="password"
+                  autoComplete="new-password"
                   placeholder={t("Enter the user's password")}
                 />
               </FormItem>
@@ -262,6 +266,7 @@ function UserListModal({
               >
                 <Input.Password
                   name="confirmPassword"
+                  autoComplete="new-password"
                   placeholder={t("Confirm the user's password")}
                 />
               </FormItem>

--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -144,6 +144,7 @@ function UserListModal({
             >
               <Input
                 name="first_name"
+                autoComplete="given-name"
                 placeholder={t("Enter the user's first name")}
               />
             </FormItem>
@@ -154,6 +155,7 @@ function UserListModal({
             >
               <Input
                 name="last_name"
+                autoComplete="family-name"
                 placeholder={t("Enter the user's last name")}
               />
             </FormItem>
@@ -164,6 +166,7 @@ function UserListModal({
             >
               <Input
                 name="username"
+                autoComplete="username"
                 placeholder={t("Enter the user's username")}
               />
             </FormItem>
@@ -185,7 +188,11 @@ function UserListModal({
                 },
               ]}
             >
-              <Input name="email" placeholder={t("Enter the user's email")} />
+              <Input
+                name="email"
+                autoComplete="email"
+                placeholder={t("Enter the user's email")}
+              />
             </FormItem>
             <FormItem
               name="roles"
@@ -236,6 +243,7 @@ function UserListModal({
                 >
                   <Input.Password
                     name="password"
+                    autoComplete="new-password"
                     placeholder={t("Enter the user's password")}
                   />
                 </FormItem>
@@ -262,6 +270,7 @@ function UserListModal({
                 >
                   <Input.Password
                     name="confirmPassword"
+                    autoComplete="new-password"
                     placeholder={t("Confirm the user's password")}
                   />
                 </FormItem>

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -221,6 +221,7 @@ export default function Login() {
               >
                 <Input
                   autoFocus
+                  autoComplete="username"
                   prefix={<Icons.UserOutlined iconSize="l" />}
                   data-test="username-input"
                 />
@@ -233,6 +234,7 @@ export default function Login() {
                 ]}
               >
                 <Input.Password
+                  autoComplete="current-password"
                   prefix={<Icons.KeyOutlined iconSize="l" />}
                   data-test="password-input"
                 />

--- a/superset-frontend/src/pages/Register/index.tsx
+++ b/superset-frontend/src/pages/Register/index.tsx
@@ -218,6 +218,7 @@ export default function Login() {
           >
             <Input.Password
               placeholder={t('Confirm password')}
+              autoComplete="new-password"
               data-test="confirm-password-input"
             />
           </Form.Item>


### PR DESCRIPTION
### SUMMARY
Implements WCAG 2.1 criterion 1.3.5 (Identify Input Purpose, Level AA).

- Add `autocomplete` attributes to Login form (username, current-password)
- Add `autocomplete` to Register form (given-name, family-name, email, new-password)
- Add `autocomplete` to SSH Tunnel form and User Profile modal
- Add `autocomplete="off"` to Import Modal and OAuth2 fields where autofill is inappropriate

### TESTING INSTRUCTIONS
1. Open Login page → inspect username/password fields → verify `autocomplete` attributes
2. Browser password managers should now offer to fill these fields

### ADDITIONAL INFORMATION
- [x] Changes UI
Part of a series of 16 individual WCAG 2.1 accessibility PRs. See also #38342.