### PR TITLE
fix(a11y): WCAG 1.4.10 — add responsive reflow for 320px viewport width

### DIFF
--- a/superset-frontend/src/dashboard/components/BuilderComponentPane/index.tsx
+++ b/superset-frontend/src/dashboard/components/BuilderComponentPane/index.tsx
@@ -53,9 +53,9 @@ const BuilderComponentPane = ({ topOffset = 0 }) => (
         position: fixed;
         width: 100%;
         z-index: 100;
-        top: 0;
+        top: ${topOffset}px;
         right: 0;
-        height: 100vh;
+        height: calc(100vh - ${topOffset}px);
       }
     `}
   >

--- a/superset-frontend/src/dashboard/components/BuilderComponentPane/index.tsx
+++ b/superset-frontend/src/dashboard/components/BuilderComponentPane/index.tsx
@@ -47,6 +47,16 @@ const BuilderComponentPane = ({ topOffset = 0 }) => (
       top: ${topOffset}px;
       height: calc(100vh - ${topOffset}px);
       width: ${BUILDER_PANE_WIDTH}px;
+
+      /* WCAG 1.4.10 Reflow: overlay as full-width panel at narrow viewports */
+      @media (max-width: 768px) {
+        position: fixed;
+        width: 100%;
+        z-index: 100;
+        top: 0;
+        right: 0;
+        height: 100vh;
+      }
     `}
   >
     <div
@@ -54,6 +64,11 @@ const BuilderComponentPane = ({ topOffset = 0 }) => (
         position: absolute;
         height: 100%;
         width: ${BUILDER_PANE_WIDTH}px;
+
+        /* WCAG 1.4.10 Reflow: full width at narrow viewports */
+        @media (max-width: 768px) {
+          width: 100%;
+        }
         box-shadow: -${theme.sizeUnit}px 0 ${theme.sizeUnit}px 0
           ${tinycolor(theme.colorBorder).setAlpha(0.1).toRgbString()};
         background-color: ${theme.colorBgBase};

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -80,6 +80,11 @@ const FiltersPanel = styled.div<{ width: number; hidden: boolean }>`
   z-index: 11;
   width: ${({ width }) => width}px;
   ${({ hidden }) => hidden && `display: none;`}
+
+  /* WCAG 1.4.10 Reflow: auto-collapse filter bar at narrow viewports */
+  @media (max-width: 768px) {
+    display: none;
+  }
 `;
 
 const StickyPanel = styled.div<{ width: number }>`
@@ -87,6 +92,11 @@ const StickyPanel = styled.div<{ width: number }>`
   top: -1px;
   width: ${({ width }) => width}px;
   flex: 0 0 ${({ width }) => width}px;
+
+  /* WCAG 1.4.10 Reflow: hide with filter panel at narrow viewports */
+  @media (max-width: 768px) {
+    display: none;
+  }
 `;
 
 // @z-index-above-dashboard-popovers (99) + 1 = 100
@@ -98,6 +108,11 @@ const StyledHeader = styled.div<{ filterBarWidth: number }>`
     top: 0;
     z-index: 99;
     max-width: calc(100vw - ${filterBarWidth}px);
+
+    /* WCAG 1.4.10 Reflow: full width when filter bar is hidden */
+    @media (max-width: 768px) {
+      max-width: 100vw;
+    }
 
     .empty-droptarget:before {
       position: absolute;
@@ -295,6 +310,11 @@ const StyledDashboardContent = styled.div<{
       max-width: calc(100% - ${
         BUILDER_SIDEPANEL_WIDTH + theme.sizeUnit * 16
       }px);
+
+      /* WCAG 1.4.10 Reflow: full width when sidepanel overlays */
+      @media (max-width: 768px) {
+        max-width: 100%;
+      }
     `}
 
       /* this is the ParentSize wrapper */
@@ -306,6 +326,16 @@ const StyledDashboardContent = styled.div<{
     .dashboard-builder-sidepane {
       width: ${BUILDER_SIDEPANEL_WIDTH}px;
       z-index: 1;
+
+      /* WCAG 1.4.10 Reflow: overlay as full-width panel at narrow viewports */
+      @media (max-width: 768px) {
+        width: 100%;
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 100;
+        height: 100vh;
+      }
     }
 
     .dashboard-component-chart-holder {

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -81,9 +81,11 @@ const FiltersPanel = styled.div<{ width: number; hidden: boolean }>`
   width: ${({ width }) => width}px;
   ${({ hidden }) => hidden && `display: none;`}
 
-  /* WCAG 1.4.10 Reflow: auto-collapse filter bar at narrow viewports */
+  /* WCAG 1.4.10 Reflow: collapse filter bar at narrow viewports but keep accessible */
   @media (max-width: 768px) {
-    display: none;
+    width: 0;
+    min-width: 0;
+    overflow: hidden;
   }
 `;
 
@@ -111,7 +113,7 @@ const StyledHeader = styled.div<{ filterBarWidth: number }>`
 
     /* WCAG 1.4.10 Reflow: full width when filter bar is hidden */
     @media (max-width: 768px) {
-      max-width: 100vw;
+      max-width: 100%;
     }
 
     .empty-droptarget:before {
@@ -331,10 +333,10 @@ const StyledDashboardContent = styled.div<{
       @media (max-width: 768px) {
         width: 100%;
         position: fixed;
-        top: 0;
+        top: 64px;
         left: 0;
         z-index: 100;
-        height: 100vh;
+        height: calc(100vh - 64px);
       }
     }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
@@ -97,8 +97,12 @@ export const BaseModalBody = styled.div<BaseModalBodyProps>`
 
   /* WCAG 1.4.10 Reflow: stack sidebar above content at narrow viewports */
   @media (max-width: 768px) {
-    flex-direction: column;
     height: auto;
+
+    /* Apply column layout to the nested Flex container (StyledMainFlex) */
+    .ant-flex {
+      flex-direction: column;
+    }
   }
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
@@ -39,6 +39,18 @@ export const BaseModalWrapper = styled(StyledModal)<BaseModalWrapperProps>`
     min-width: auto;
   }
 
+  /* WCAG 1.4.10 Reflow: full-width modal at narrow viewports */
+  @media (max-width: 768px) {
+    min-width: 100%;
+    width: 100% !important;
+    padding: 0;
+    margin: 0;
+  }
+
+  @media (max-width: 480px) {
+    min-width: 100%;
+  }
+
   .ant-modal-header {
     margin-bottom: 0;
   }
@@ -82,6 +94,12 @@ export const BaseModalBody = styled.div<BaseModalBodyProps>`
     display: flex;
     flex-direction: column;
   }
+
+  /* WCAG 1.4.10 Reflow: stack sidebar above content at narrow viewports */
+  @media (max-width: 768px) {
+    flex-direction: column;
+    height: auto;
+  }
 `;
 
 export const BaseForm = styled(Form)`
@@ -94,14 +112,29 @@ export const BaseExpandButtonWrapper = styled.div`
 
 export const BaseFormItem = styled(Form.Item)<{ expanded?: boolean }>`
   width: ${({ expanded }) => (expanded ? '49%' : '260px')};
+
+  /* WCAG 1.4.10 Reflow */
+  @media (max-width: 480px) {
+    width: 100%;
+  }
 `;
 
 export const BaseRowFormItem = styled(Form.Item)<{ expanded?: boolean }>`
   min-width: ${({ expanded }) => (expanded ? '50%' : '260px')};
+
+  /* WCAG 1.4.10 Reflow */
+  @media (max-width: 480px) {
+    min-width: 100%;
+  }
 `;
 
 export const BaseRowSubFormItem = styled(Form.Item)<{ expanded?: boolean }>`
   min-width: ${({ expanded }) => (expanded ? '50%' : '260px')};
+
+  /* WCAG 1.4.10 Reflow */
+  @media (max-width: 480px) {
+    min-width: 100%;
+  }
 `;
 
 export const BaseLabel = styled.span`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
@@ -61,6 +61,11 @@ const HorizontalDivider = ({ title, description }: FilterDividerProps) => {
             font-weight: ${theme.fontWeightNormal};
             margin: 0;
             color: ${theme.colorText};
+
+            /* WCAG 1.4.10 Reflow: allow full width at narrow viewports */
+            @media (max-width: 480px) {
+              max-width: 100%;
+            }
           `}
         >
           {title}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -161,6 +161,18 @@ const HorizontalFormItem = styled(FormItem)`
     min-width: 200px !important;
     max-width: 400px !important;
   }
+
+  /* WCAG 1.4.10 Reflow: full-width filter controls at narrow viewports */
+  @media (max-width: 480px) {
+    .ant-form-item-control {
+      min-width: 100%;
+    }
+
+    .ant-select-dropdown {
+      min-width: 100% !important;
+      max-width: 100% !important;
+    }
+  }
 `;
 
 const ToolTipContainer = styled.div`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -43,7 +43,7 @@ const StyledSidebarFlex = styled(Flex)`
 
   /* WCAG 1.4.10 Reflow: stack sidebar above content at narrow viewports */
   @media (max-width: 768px) {
-    min-width: 100%;
+    width: 100%;
     max-width: 100%;
     border-right: none;
     border-bottom: 1px solid ${({ theme }) => theme.colorBorderSecondary};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -40,6 +40,14 @@ const StyledSidebarFlex = styled(Flex)`
   min-width: 290px;
   max-width: 290px;
   border-right: 1px solid ${({ theme }) => theme.colorBorderSecondary};
+
+  /* WCAG 1.4.10 Reflow: stack sidebar above content at narrow viewports */
+  @media (max-width: 768px) {
+    min-width: 100%;
+    max-width: 100%;
+    border-right: none;
+    border-bottom: 1px solid ${({ theme }) => theme.colorBorderSecondary};
+  }
 `;
 
 const StyledHeaderFlex = styled(Flex)`

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -60,7 +60,6 @@ const StyledHeader = styled.header`
     /* WCAG 1.4.10 Reflow: prevent horizontal overflow at narrow viewports */
     @media (max-width: 768px) {
       padding: 0 ${theme.sizeUnit * 2}px;
-      overflow-x: hidden;
     }
   `}
 `;

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -56,6 +56,12 @@ const StyledHeader = styled.header`
     .caret {
       display: none;
     }
+
+    /* WCAG 1.4.10 Reflow: prevent horizontal overflow at narrow viewports */
+    @media (max-width: 768px) {
+      padding: 0 ${theme.sizeUnit * 2}px;
+      overflow-x: hidden;
+    }
   `}
 `;
 
@@ -81,6 +87,11 @@ const StyledBrandText = styled.div`
     }
 
     @media (max-width: 1127px) {
+      display: none;
+    }
+
+    /* WCAG 1.4.10 Reflow: allow wrapping at narrow viewports */
+    @media (max-width: 768px) {
       display: none;
     }
   `}
@@ -141,6 +152,19 @@ const StyledMainNav = styled(MainNav)`
     .ant-menu-submenu-selected.ant-menu-submenu-horizontal::after {
       transform: scale(1);
     }
+
+    /* WCAG 1.4.10 Reflow: allow menu items to wrap at narrow viewports */
+    @media (max-width: 768px) {
+      flex-wrap: wrap;
+
+      .ant-menu-submenu.ant-menu-submenu-horizontal {
+        .ant-menu-submenu-title {
+          padding: 0 ${theme.sizeUnit * 2}px;
+          min-height: 44px;
+          min-width: 44px;
+        }
+      }
+    }
   `}
 `;
 
@@ -177,6 +201,12 @@ const StyledCol = styled(Col)`
     display: flex;
     gap: ${theme.sizeUnit * 4}px;
     flex-wrap: wrap;
+
+    /* WCAG 1.4.10 Reflow: allow stacking at narrow viewports */
+    @media (max-width: 768px) {
+      gap: ${theme.sizeUnit * 2}px;
+      max-width: 100%;
+    }
   `}
 `;
 

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -117,6 +117,24 @@ const StyledHeader = styled.div<{ backgroundColor?: string }>`
       margin-left: ${({ theme }) => theme.sizeUnit * 2}px;
     }
   }
+
+  /* WCAG 1.4.10 Reflow: wrap menu and buttons at narrow viewports */
+  @media (max-width: 480px) {
+    .menu {
+      flex-wrap: wrap;
+    }
+
+    .nav-right,
+    .nav-right-collapse {
+      position: relative;
+      right: auto;
+      float: none;
+      flex-wrap: wrap;
+      width: 100%;
+      justify-content: flex-start;
+      gap: ${({ theme }) => theme.sizeUnit}px;
+    }
+  }
 `;
 
 const styledDisabled = (theme: SupersetTheme) => css`

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -131,6 +131,7 @@ const StyledHeader = styled.div<{ backgroundColor?: string }>`
       float: none;
       flex-wrap: wrap;
       width: 100%;
+      margin-left: 0;
       justify-content: flex-start;
       gap: ${({ theme }) => theme.sizeUnit}px;
     }


### PR DESCRIPTION
### SUMMARY
Implements WCAG 2.1 criterion 1.4.10 (Reflow, Level AA).

- Add responsive CSS for filter panels, sidepanes, and modals at 320px viewport width
- Fix menu overflow and wrapping at narrow viewports
- Add media queries for filter config modal, sidebar, and SubMenu
- Known limitation: Dashboard grid (react-grid-layout) is not responsive by design

### TESTING INSTRUCTIONS
1. Resize browser to 320px width
2. Navigate through Dashboard list, Chart list, SQL Lab
3. Verify no horizontal scrollbar appears and content reflows correctly

### ADDITIONAL INFORMATION
- [x] Changes UI
Part of a series of 16 individual WCAG 2.1 accessibility PRs. See also #38342.