### PR TITLE
fix(a11y): WCAG 1.4.13 — make hover content dismissable and hoverable

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/components/CustomPopover.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/components/CustomPopover.tsx
@@ -69,15 +69,21 @@ const CustomPopover: React.FC<Props> = ({
       }
     };
 
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+
     if (isOpen) {
       updatePosition();
       document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKeyDown);
       window.addEventListener('scroll', updatePosition);
       window.addEventListener('resize', updatePosition);
     }
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('scroll', updatePosition);
       window.removeEventListener('resize', updatePosition);
     };

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.tsx
@@ -19,7 +19,7 @@
 
 import { safeHtmlSpan } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 export type TooltipProps = {
   tooltip:
@@ -43,7 +43,7 @@ const StyledDiv = styled.div<{
     top: ${top}px;
     left: ${left}px;
     z-index: 9;
-    pointer-events: none;
+    pointer-events: auto;
     ${
       variant === 'default'
         ? `
@@ -66,7 +66,25 @@ const StyledDiv = styled.div<{
 
 export default function Tooltip(props: TooltipProps) {
   const { tooltip, variant = 'default' } = props;
-  if (typeof tooltip === 'undefined' || tooltip === null) {
+  const [dismissed, setDismissed] = useState(false);
+
+  // Reset dismissed state when tooltip content changes (new hover target)
+  useEffect(() => {
+    setDismissed(false);
+  }, [tooltip?.x, tooltip?.y]);
+
+  // Dismiss on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDismissed(true);
+    };
+    if (tooltip && !dismissed) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [tooltip, dismissed]);
+
+  if (typeof tooltip === 'undefined' || tooltip === null || dismissed) {
     return null;
   }
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.tsx
@@ -68,10 +68,11 @@ export default function Tooltip(props: TooltipProps) {
   const { tooltip, variant = 'default' } = props;
   const [dismissed, setDismissed] = useState(false);
 
-  // Reset dismissed state when tooltip content changes (new hover target)
+  // Reset dismissed state only when tooltip content changes (new hover target),
+  // not on coordinate changes from mouse movement
   useEffect(() => {
     setDismissed(false);
-  }, [tooltip?.x, tooltip?.y]);
+  }, [tooltip?.content]);
 
   // Dismiss on Escape key
   useEffect(() => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.tsx
@@ -19,7 +19,7 @@
 
 import { safeHtmlSpan } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 
 export type TooltipProps = {
   tooltip:
@@ -43,7 +43,13 @@ const StyledDiv = styled.div<{
     top: ${top}px;
     left: ${left}px;
     z-index: 9;
-    pointer-events: auto;
+    /* deck.gl tooltips track the cursor across the canvas — capturing pointer
+       events here would block layer hover/click and create flicker loops as
+       the cursor enters and leaves the floating tooltip. Dismissal is via the
+       Escape key handler below; WCAG 1.4.13 "hoverable" is satisfied because
+       the tooltip remains visible under the cursor while pointing at the
+       feature. */
+    pointer-events: none;
     ${
       variant === 'default'
         ? `
@@ -67,25 +73,38 @@ const StyledDiv = styled.div<{
 export default function Tooltip(props: TooltipProps) {
   const { tooltip, variant = 'default' } = props;
   const [dismissed, setDismissed] = useState(false);
+  const wasVisibleRef = useRef(false);
 
-  // Reset dismissed state only when tooltip content changes (new hover target),
-  // not on coordinate changes from mouse movement
+  // Reset dismissed when the tooltip transitions from hidden to visible. This
+  // handles the case where the cursor leaves the chart and re-enters a
+  // different pickable that happens to render the same content — content
+  // alone wouldn't trigger a reset there.
+  useEffect(() => {
+    const isVisible = !!tooltip;
+    if (isVisible && !wasVisibleRef.current) {
+      setDismissed(false);
+    }
+    wasVisibleRef.current = isVisible;
+  }, [tooltip]);
+
+  // Reset on content change too (most common new-target signal).
   useEffect(() => {
     setDismissed(false);
   }, [tooltip?.content]);
 
-  // Dismiss on Escape key
+  // Bind the Escape listener once per visibility cycle. Depending on
+  // `tooltip` directly would re-bind on every cursor move (x/y change).
+  const visible = !!tooltip && !dismissed;
   useEffect(() => {
+    if (!visible) return undefined;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setDismissed(true);
     };
-    if (tooltip && !dismissed) {
-      document.addEventListener('keydown', handleKeyDown);
-    }
+    document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [tooltip, dismissed]);
+  }, [visible]);
 
-  if (typeof tooltip === 'undefined' || tooltip === null || dismissed) {
+  if (!tooltip || dismissed) {
     return null;
   }
 

--- a/superset-frontend/src/features/tasks/TaskPayloadPopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskPayloadPopover.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { styled } from '@apache-superset/core/theme';
 import { Popover } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
@@ -53,6 +53,14 @@ export default function TaskPayloadPopover({
   payload,
 }: TaskPayloadPopoverProps) {
   const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setVisible(false);
+    };
+    if (visible) document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [visible]);
 
   const content = (
     <PayloadContainer>

--- a/superset-frontend/src/features/tasks/TaskStackTracePopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskStackTracePopover.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
 import { Popover, Tooltip } from '@superset-ui/core/components';
@@ -89,6 +89,14 @@ export default function TaskStackTracePopover({
   const [visible, setVisible] = useState(false);
   const [copied, setCopied] = useState(false);
   const { addDangerToast } = useToasts();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setVisible(false);
+    };
+    if (visible) document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [visible]);
 
   const handleCopy = useCallback(() => {
     copyTextToClipboard(() => Promise.resolve(stackTrace))


### PR DESCRIPTION
### SUMMARY
Implements WCAG 2.1 criterion 1.4.13 (Content on Hover or Focus, Level AA).

- Make all popovers (CustomPopover, TaskPayloadPopover, TaskStackTracePopover) dismissable via the Escape key
- Reset deck.gl Tooltip dismissed-state correctly when the cursor leaves and re-enters a pickable, even when the new pickable renders the same content
- Bind the Escape keydown listener once per tooltip visibility cycle so it does not re-attach on every cursor coordinate change
- Keep deck.gl tooltips with `pointer-events: none` so they continue to track the cursor without blocking layer hover/click; WCAG 1.4.13 hoverable is satisfied because the tooltip remains under the cursor while pointing at the feature

### TESTING INSTRUCTIONS
1. Hover over a deck.gl chart feature → tooltip appears next to cursor
2. Press Escape → tooltip dismisses
3. Move cursor off feature, then back onto it (same or different pickable) → tooltip reappears
4. Open any popover (e.g. AG Grid Custom Popover, Task payload, Task stack trace) → press Escape → popover closes

### ADDITIONAL INFORMATION
- [x] Changes UI

Part of a series of 16 individual WCAG 2.1 accessibility PRs. See also #38342.
