### PR TITLE
fix(a11y): WCAG 2.4.7 — ensure visible keyboard focus on all interactive elements

### DIFF
--- a/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
@@ -109,6 +109,14 @@ export const GlobalStyles = () => {
           display: flex;
           margin-top: ${theme.marginXS}px;
         }
+
+        /* WCAG 2.4.7: Focus Visible — ensure all interactive elements have a visible
+           keyboard focus indicator. Uses :focus-visible to avoid showing on mouse clicks.
+           Individual components can override with their own focus styles. */
+        *:focus-visible {
+          outline: 2px solid ${theme.colorPrimary};
+          outline-offset: 2px;
+        }
       `}
     />
   );

--- a/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
@@ -114,8 +114,8 @@ export const GlobalStyles = () => {
            keyboard focus indicator. Uses :focus-visible to avoid showing on mouse clicks.
            Individual components can override with their own focus styles. */
         *:focus-visible {
-          outline: 2px solid ${theme.colorPrimary};
-          outline-offset: 2px;
+          outline: 2px solid ${theme.colorPrimary} !important;
+          outline-offset: 2px !important;
         }
       `}
     />

--- a/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
@@ -130,6 +130,57 @@ export const GlobalStyles = () => {
           .ant-tabs-tab {
           padding-top: 0;
         }
+        /* WCAG 2.4.7: Focus Visible — give every interactive element a visible
+           keyboard focus indicator. Uses :focus-visible so the ring only shows
+           on keyboard navigation, not on mouse clicks.
+
+           Selector scope: limited to actually interactive elements (native
+           focusable elements plus AntD wrappers and common ARIA roles) instead
+           of the universal "*", so non-interactive elements that happen to
+           receive programmatic focus do not pick up an unwanted outline.
+           Wrapped in :where() so the rule keeps specificity (0,0,1,0) and
+           remains easy for component-level styles to override.
+
+           Why !important: AntD ships per-component focus resets such as
+           ".ant-btn:focus { outline: 0 }" with the same (0,0,2,0) specificity
+           as a hypothetical un-flagged ".ant-btn:focus-visible" rule here, and
+           AntD's runtime-injected styles can land after this global block.
+           !important is the only way to guarantee the WCAG focus indicator is
+           not silently reset back to outline:0. Components that genuinely need
+           a different focus treatment must use !important themselves, matching
+           AntD's own pattern. */
+        :where(
+          a,
+          button,
+          input,
+          select,
+          textarea,
+          [tabindex],
+          [role='button'],
+          [role='link'],
+          [role='menuitem'],
+          [role='tab'],
+          [role='checkbox'],
+          [role='option'],
+          [role='combobox'],
+          [role='switch'],
+          .ant-btn,
+          .ant-input,
+          .ant-input-affix-wrapper,
+          .ant-input-number,
+          .ant-select-selector,
+          .ant-checkbox-input,
+          .ant-radio-input,
+          .ant-switch,
+          .ant-picker,
+          .ant-cascader-picker,
+          .ant-dropdown-trigger,
+          .ant-tabs-tab,
+          .ant-menu-item
+        ):focus-visible {
+          outline: 2px solid ${theme.colorPrimary} !important;
+          outline-offset: 2px !important;
+        }
       `}
     />
   );

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -80,9 +80,14 @@ export const FilterItem = styled.button`
     padding: 0;
     border: none;
     background: none;
-    outline: none;
+    outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring with box-shadow */
     width: 100%;
     color: inherit;
+
+    &:focus-visible {
+      box-shadow: inset 0 0 0 2px ${theme.colorPrimary};
+      border-radius: ${theme.borderRadius}px;
+    }
 
     &::-moz-focus-inner {
       border: 0;

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -85,7 +85,7 @@ export const FilterItem = styled.button`
     color: inherit;
 
     &:focus-visible {
-      box-shadow: 0 0 0 2px ${theme.colorPrimary};
+      box-shadow: inset 0 0 0 2px ${theme.colorPrimary};
       border-radius: ${theme.borderRadius}px;
     }
 

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -80,9 +80,14 @@ export const FilterItem = styled.button`
     padding: 0;
     border: none;
     background: none;
-    outline: none;
+    outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring with box-shadow */
     width: 100%;
     color: inherit;
+
+    &:focus-visible {
+      box-shadow: 0 0 0 2px ${theme.colorPrimary};
+      border-radius: ${theme.borderRadius}px;
+    }
 
     &::-moz-focus-inner {
       border: 0;

--- a/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.tsx
+++ b/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.tsx
@@ -210,11 +210,13 @@ const ScopeSelector = styled.div`
         &:hover {
           text-decoration: underline;
         }
+      }
 
-        &:focus-visible {
-          outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring */
-          box-shadow: 0 0 0 2px ${theme.colorPrimary};
-        }
+      /* WCAG 2.4.7: Focus on the clickable button that wraps the rct-icon spans */
+      .react-checkbox-tree button:focus-visible {
+        outline: 2px solid transparent;
+        box-shadow: 0 0 0 2px ${theme.colorPrimary};
+        border-radius: ${theme.borderRadius}px;
       }
 
       .filter-field-pane {

--- a/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.tsx
+++ b/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.tsx
@@ -211,8 +211,9 @@ const ScopeSelector = styled.div`
           text-decoration: underline;
         }
 
-        &:focus {
-          outline: none;
+        &:focus-visible {
+          outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring */
+          box-shadow: 0 0 0 2px ${theme.colorPrimary};
         }
       }
 
@@ -360,7 +361,7 @@ const ScopeSelector = styled.div`
         border: 1px solid ${theme.colorBorder};
         padding: ${theme.sizeUnit}px ${theme.sizeUnit * 2}px;
         font-size: ${theme.fontSize}px;
-        outline: none;
+        outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring; border change on focus provides visible indicator */
 
         &:focus {
           border: 1px solid ${theme.colorPrimary};

--- a/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.tsx
+++ b/superset-frontend/src/dashboard/components/filterscope/FilterScopeSelector.tsx
@@ -191,10 +191,13 @@ const ScopeSelector = styled.div`
         &:hover {
           text-decoration: underline;
         }
+      }
 
-        &:focus {
-          outline: none;
-        }
+      /* WCAG 2.4.7: Focus on the clickable button that wraps the rct-icon spans */
+      .react-checkbox-tree button:focus-visible {
+        outline: 2px solid transparent;
+        box-shadow: 0 0 0 2px ${theme.colorPrimary};
+        border-radius: ${theme.borderRadius}px;
       }
 
       .filter-field-pane {
@@ -341,7 +344,7 @@ const ScopeSelector = styled.div`
         border: 1px solid ${theme.colorBorder};
         padding: ${theme.sizeUnit}px ${theme.sizeUnit * 2}px;
         font-size: ${theme.fontSize}px;
-        outline: none;
+        outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring; border change on focus provides visible indicator */
 
         &:focus {
           border: 1px solid ${theme.colorPrimary};

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
@@ -50,7 +50,9 @@ interface WithPopoverMenuState {
 const WithPopoverMenuStyles = styled.div`
   ${({ theme }) => css`
     position: relative;
-    outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring; :after pseudo-element provides visible focus border */
+    &:focus-visible {
+      outline: 2px solid transparent; /* WCAG 2.4.7: HC Mode fallback only when focused */
+    }
 
     &.with-popover-menu--focused:after {
       content: '';

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
@@ -50,7 +50,7 @@ interface WithPopoverMenuState {
 const WithPopoverMenuStyles = styled.div`
   ${({ theme }) => css`
     position: relative;
-    outline: none;
+    outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring; :after pseudo-element provides visible focus border */
 
     &.with-popover-menu--focused:after {
       content: '';

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
@@ -64,7 +64,9 @@ const defaultShouldFocus = (
 const WithPopoverMenuStyles = styled.div`
   ${({ theme }) => css`
     position: relative;
-    outline: none;
+    &:focus-visible {
+      outline: 2px solid transparent; /* WCAG 2.4.7: HC Mode fallback only when focused */
+    }
 
     &.with-popover-menu--focused:after {
       content: '';

--- a/superset-frontend/src/dashboard/styles.ts
+++ b/superset-frontend/src/dashboard/styles.ts
@@ -96,7 +96,7 @@ export const focusStyle = (theme: SupersetTheme) => css`
     &:focus-visible {
       box-shadow: 0 0 0 2px ${theme.colorPrimaryText};
       border-radius: ${theme.borderRadius}px;
-      outline: none;
+      outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring; box-shadow provides visible focus */
       text-decoration: none;
     }
     &:not(

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
@@ -61,9 +61,13 @@ export const CloseButton = styled.button`
     border: none;
     border-right: solid 1px ${theme.colorBorder};
     padding: 0;
-    outline: none;
+    outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring with global baseline */
     border-bottom-left-radius: 3px;
     border-top-left-radius: 3px;
+
+    &:focus-visible {
+      box-shadow: 0 0 0 2px ${theme.colorPrimary};
+    }
   `}
 `;
 

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -174,8 +174,9 @@ const SelectorLabel = styled.button`
     position: relative;
     color: ${theme.colorText};
 
-    &:focus {
-      outline: initial;
+    &:focus-visible {
+      outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring with box-shadow */
+      box-shadow: 0 0 0 2px ${theme.colorPrimary};
     }
 
     &.selected {
@@ -270,7 +271,12 @@ const thumbnailContainerCss = (theme: SupersetTheme) => css`
   cursor: pointer;
   width: ${theme.sizeUnit * THUMBNAIL_GRID_UNITS}px;
   position: relative;
-  outline: none; /* Remove focus outline to show only selected state */
+  outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring with box-shadow */
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px ${theme.colorPrimary};
+    border-radius: ${theme.borderRadius}px;
+  }
 
   img {
     min-width: ${theme.sizeUnit * THUMBNAIL_GRID_UNITS}px;

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -114,7 +114,7 @@ const FocusContainer = styled.div`
     box-shadow: 0 0 0 2px ${theme.colorPrimary};
   }
   &:focus-visible {
-    outline: none;
+    outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring; box-shadow on :focus provides visible indicator */
   }`}
 `;
 

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -62,8 +62,8 @@ const ControlContainer = styled.div<{
 
   &:focus > div {
     border-color: ${({ theme }) => theme.colorPrimary};
-    box-shadow: ${({ theme }) => `0 0 0 2px ${theme.controlOutline}`};
-    outline: 0;
+    box-shadow: ${({ theme }) => `0 0 0 2px ${theme.colorPrimary}`};
+    outline: 2px solid transparent; /* WCAG 2.4.7: transparent outline prevents double-ring; box-shadow provides visible focus */
   }
 `;
 

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -61,9 +61,19 @@ const ControlContainer = styled.div<{
   }
 
   &:focus > div {
+    /* WCAG 1.4.11: Non-text contrast — the focus indicator needs at least 3:1
+       against the adjacent background. The default "theme.controlOutline"
+       token is a low-alpha tint derived from colorPrimary and typically lands
+       below 3:1, so we use full-saturation "theme.colorPrimary" here instead.
+       Do not revert to "controlOutline" without first confirming the active
+       theme satisfies 3:1 — otherwise this regresses 1.4.11.
+
+       WCAG 2.4.7: The transparent outline keeps a visible focus ring in
+       Windows High Contrast / forced-colors mode, where box-shadows are
+       suppressed but outlines are honoured. */
     border-color: ${({ theme }) => theme.colorPrimary};
-    box-shadow: ${({ theme }) => `0 0 0 2px ${theme.controlOutline}`};
-    outline: 0;
+    box-shadow: ${({ theme }) => `0 0 0 2px ${theme.colorPrimary}`};
+    outline: 2px solid transparent;
   }
 `;
 


### PR DESCRIPTION
### SUMMARY
Implements WCAG 2.1 criterion 2.4.7 (Focus Visible, Level AA).

- Add global `*:focus-visible` rule with `2px solid` outline using theme primary color
- Replace all `outline: none` declarations with `outline: 2px solid transparent` (preserves Windows High Contrast Mode)
- Add component-specific focus indicators (FiltersBadge, VizTypeGallery, FilterScope, Range/Time filters)
- Use `box-shadow` as visible focus ring with transparent outline as baseline

### TESTING INSTRUCTIONS
1. Tab through any page → all interactive elements should show a visible focus indicator
2. Click elements → no focus ring (`:focus-visible` only triggers on keyboard)
3. Enable Windows High Contrast Mode → transparent outlines should become visible

### ADDITIONAL INFORMATION
- [x] Changes UI
Part of a series of 16 individual WCAG 2.1 accessibility PRs. See also #38342.