### PR TITLE
fix(a11y): WCAG 3.1.2 — set HTML lang attribute dynamically from locale

### DIFF
--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -51,10 +51,11 @@ const bootstrapData = getBootstrapData();
 
 // WCAG 3.1.2: Set the HTML lang attribute based on the current locale
 // so screen readers announce the correct language for the page content.
-// Converts locale formats like "pt_BR" or "de-DE" to BCP-47 primary tag ("pt", "de").
+// Normalize to BCP-47 format by replacing underscores with hyphens
+// so region subtags like "pt_BR" become valid "pt-BR" rather than being dropped.
 const locale =
   bootstrapData.common?.locale || window.navigator.language || 'en';
-document.documentElement.lang = String(locale).split(/[_-]/)[0];
+document.documentElement.lang = String(locale).replace(/_/g, '-');
 
 let lastLocationPathname: string;
 

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -49,6 +49,13 @@ setupAGGridModules();
 
 const bootstrapData = getBootstrapData();
 
+// WCAG 3.1.2: Set the HTML lang attribute based on the current locale
+// so screen readers announce the correct language for the page content.
+// Converts locale formats like "pt_BR" or "de-DE" to BCP-47 primary tag ("pt", "de").
+const locale =
+  bootstrapData.common?.locale || window.navigator.language || 'en';
+document.documentElement.lang = String(locale).split(/[_-]/)[0];
+
 let lastLocationPathname: string;
 
 const boundActions = bindActionCreators({ logEvent }, store.dispatch);


### PR DESCRIPTION
### SUMMARY
Implements WCAG 2.1 criterion 3.1.2 (Language of Parts, Level AA).

- Set `document.documentElement.lang` from `bootstrapData.common.locale` on app initialization
- Converts locale formats like `pt_BR` or `de-DE` to BCP-47 primary subtag (`pt`, `de`)
- Falls back to `window.navigator.language` or `en`
- Screen readers now select the correct pronunciation engine

### TESTING INSTRUCTIONS
1. Open Superset with a non-English locale configured
2. Inspect `<html>` element → `lang` attribute should match the configured locale
3. Screen reader should announce content in the correct language

### ADDITIONAL INFORMATION
- [x] Changes UI
Part of a series of 16 individual WCAG 2.1 accessibility PRs. See also #38342.