### PR TITLE
fix(a11y): WCAG 3.2.3 — add aria-labels to navigation landmarks

### DIFF
--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -18,6 +18,7 @@
  */
 import { useState, useEffect } from 'react';
 import { styled, css, useTheme } from '@apache-superset/core/theme';
+import { t } from '@apache-superset/core/translation';
 import { ensureStaticPrefix } from 'src/utils/assetUrl';
 import { ensureAppRoot } from 'src/utils/pathUtils';
 import { getUrlParam } from 'src/utils/urlUtils';
@@ -334,7 +335,7 @@ export function Menu({
     return <>{link}</>;
   };
   return (
-    <StyledHeader className="top" id="main-menu" role="navigation" aria-label="Main navigation">
+    <StyledHeader className="top" id="main-menu" role="navigation" aria-label={t('Main navigation')}>
       <StyledRow>
         <StyledCol md={16} xs={24}>
           <Tooltip

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -334,7 +334,7 @@ export function Menu({
     return <>{link}</>;
   };
   return (
-    <StyledHeader className="top" id="main-menu" role="navigation">
+    <StyledHeader className="top" id="main-menu" role="navigation" aria-label="Main navigation">
       <StyledRow>
         <StyledCol md={16} xs={24}>
           <Tooltip

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -210,7 +210,7 @@ const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
 
   return (
     <StyledHeader backgroundColor={props.backgroundColor}>
-      <Row className="menu" role="navigation" aria-label="Page navigation">
+      <Row className="menu" role="navigation" aria-label={t('Page navigation')}>
         {props.name && <div className="header">{props.name}</div>}
         <Menu
           mode={showMenu}

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -210,7 +210,7 @@ const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
 
   return (
     <StyledHeader backgroundColor={props.backgroundColor}>
-      <Row className="menu" role="navigation">
+      <Row className="menu" role="navigation" aria-label="Page navigation">
         {props.name && <div className="header">{props.name}</div>}
         <Menu
           mode={showMenu}


### PR DESCRIPTION
### SUMMARY
Implements WCAG 2.1 criterion 3.2.3 (Consistent Navigation, Level AA).

- Add `aria-label="Main navigation"` to the primary header navigation (`Menu.tsx`)
- Add `aria-label="Page navigation"` to the page-level sub-navigation (`SubMenu.tsx`)
- Screen readers can now distinguish between navigation regions

### TESTING INSTRUCTIONS
1. Open any page with a screen reader
2. Navigate by landmarks → "Main navigation" and "Page navigation" should be announced as distinct regions
3. Verify both labels are present on all pages

### ADDITIONAL INFORMATION
- [x] Changes UI
Part of a series of 16 individual WCAG 2.1 accessibility PRs. See also #38342.