### PR TITLE
fix(a11y): WCAG 3.3.1 — add error identification with role=alert and aria-describedby

### DIFF
--- a/superset-frontend/packages/superset-core/src/components/Alert/Alert.test.tsx
+++ b/superset-frontend/packages/superset-core/src/components/Alert/Alert.test.tsx
@@ -17,10 +17,44 @@
  * under the License.
  */
 
-import { render } from '../../testing';
+import { render, screen } from '../../testing';
 import { Alert } from '.';
 
 test('renders Alert with default props', async () => {
   const { container } = render(<Alert />);
   expect(container).toHaveTextContent('Default message');
+});
+
+// WCAG 3.3.1 - Error Identification accessibility tests
+test('renders with role="alert" for screen reader announcement', () => {
+  render(<Alert type="error">Error message</Alert>);
+  expect(screen.getByRole('alert')).toBeInTheDocument();
+});
+
+test('renders with aria-atomic="true" so full content is announced', () => {
+  render(<Alert type="error">Error message</Alert>);
+  expect(screen.getByRole('alert')).toHaveAttribute('aria-atomic', 'true');
+});
+
+test('uses aria-live="assertive" for error alerts', () => {
+  render(<Alert type="error">Error message</Alert>);
+  expect(screen.getByRole('alert')).toHaveAttribute(
+    'aria-live',
+    'assertive',
+  );
+});
+
+test('uses aria-live="polite" for warning alerts', () => {
+  render(<Alert type="warning">Warning message</Alert>);
+  expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'polite');
+});
+
+test('uses aria-live="polite" for info alerts', () => {
+  render(<Alert type="info">Info message</Alert>);
+  expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'polite');
+});
+
+test('uses aria-live="polite" for success alerts', () => {
+  render(<Alert type="success">Success message</Alert>);
+  expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'polite');
 });

--- a/superset-frontend/packages/superset-core/src/components/Alert/index.tsx
+++ b/superset-frontend/packages/superset-core/src/components/Alert/index.tsx
@@ -71,6 +71,7 @@ export const Alert = (props: AlertProps) => {
   return (
     <AntdAlert
       role="alert"
+      aria-atomic="true"
       aria-live={type === 'error' ? 'assertive' : 'polite'}
       type={type}
       showIcon={showIcon}

--- a/superset-frontend/packages/superset-ui-core/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Form/LabeledErrorBoundInput.tsx
@@ -65,6 +65,7 @@ export const LabeledErrorBoundInput = ({
   ...props
 }: LabeledErrorBoundInputProps) => {
   const hasError = !!errorMessage;
+  const errorDescriptionId = hasError ? `${id || props.name}-error-description` : undefined;
   return (
     <StyledFormGroup className={className}>
       <Flex align="center">
@@ -78,13 +79,23 @@ export const LabeledErrorBoundInput = ({
         validateStatus={
           isValidating ? 'validating' : hasError ? 'error' : 'success'
         }
-        help={errorMessage || helpText}
+        help={
+          hasError ? (
+            <span id={errorDescriptionId} role="alert">
+              {errorMessage}
+            </span>
+          ) : (
+            helpText
+          )
+        }
         hasFeedback={!!hasError}
       >
         {visibilityToggle || props.name === 'password' ? (
           <StyledInputPassword
             {...props}
             {...validationMethods}
+            aria-invalid={hasError || undefined}
+            aria-describedby={errorDescriptionId}
             iconRender={visible =>
               visible ? (
                 <Tooltip title={t('Hide password.')}>
@@ -99,7 +110,12 @@ export const LabeledErrorBoundInput = ({
             role="textbox"
           />
         ) : (
-          <StyledInput {...props} {...validationMethods} />
+          <StyledInput
+            {...props}
+            {...validationMethods}
+            aria-invalid={hasError || undefined}
+            aria-describedby={errorDescriptionId}
+          />
         )}
         {get_url && description ? (
           <Button

--- a/superset-frontend/packages/superset-ui-core/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Form/LabeledErrorBoundInput.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useId } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
 import { Button, Icons, InfoTooltip, Tooltip, Flex } from '..';
@@ -65,7 +66,12 @@ export const LabeledErrorBoundInput = ({
   ...props
 }: LabeledErrorBoundInputProps) => {
   const hasError = !!errorMessage;
-  const errorDescriptionId = hasError ? `${id || props.name}-error-description` : undefined;
+  // Strip colons from useId output so the id is a valid CSS selector
+  // (React's useId returns ":r1:" style values that break attribute lookups).
+  const uniqueId = useId().replace(/:/g, '');
+  const errorDescriptionId = hasError
+    ? `${uniqueId}-error-description`
+    : undefined;
   return (
     <StyledFormGroup className={className}>
       <Flex align="center">

--- a/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.test.tsx
@@ -90,3 +90,23 @@ test('should render with error theme', () => {
     `,
   );
 });
+
+// WCAG 3.3.1 - Error Identification accessibility tests
+test('should have role="alert" for screen reader announcement', () => {
+  render(<BasicErrorAlert {...mockedProps} />);
+  const alertElement = screen.getByRole('alert');
+  expect(alertElement).toBeInTheDocument();
+});
+
+test('should have aria-atomic="true" so the entire alert is read as a unit', () => {
+  render(<BasicErrorAlert {...mockedProps} />);
+  const alertElement = screen.getByRole('alert');
+  expect(alertElement).toHaveAttribute('aria-atomic', 'true');
+});
+
+test('should contain both title and body text within the alert region', () => {
+  render(<BasicErrorAlert {...mockedProps} />);
+  const alertElement = screen.getByRole('alert');
+  expect(alertElement).toHaveTextContent('Error title');
+  expect(alertElement).toHaveTextContent('Error body');
+});

--- a/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
@@ -61,7 +61,7 @@ export function BasicErrorAlert({
   };
 
   return (
-    <div style={style} role="alert">
+    <div style={style} role="alert" aria-atomic="true">
       <Icons.ExclamationCircleFilled iconColor={variants.text} />
       <StyledContent>
         <StyledTitle>{title}</StyledTitle>

--- a/superset-frontend/src/components/Modal/ModalFormField.tsx
+++ b/superset-frontend/src/components/Modal/ModalFormField.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ReactNode } from 'react';
+import { ReactNode, Children, isValidElement, cloneElement, useId } from 'react';
 import { css, styled } from '@apache-superset/core/theme';
 import { InfoTooltip } from '@superset-ui/core/components';
 
@@ -128,6 +128,22 @@ export function ModalFormField({
   validateStatus,
   hasFeedback = false,
 }: ModalFormFieldProps) {
+  const uniqueId = useId();
+  const errorId = error ? `${uniqueId}-error` : undefined;
+
+  // Clone the first child element to inject aria-invalid and aria-describedby
+  const enhancedChildren = error
+    ? Children.map(children, (child, index) => {
+        if (index === 0 && isValidElement(child)) {
+          return cloneElement(child as React.ReactElement<any>, {
+            'aria-invalid': true,
+            'aria-describedby': errorId,
+          });
+        }
+        return child;
+      })
+    : children;
+
   return (
     <StyledFieldContainer bottomSpacing={bottomSpacing} data-test={testId}>
       <div className="control-label">
@@ -135,9 +151,13 @@ export function ModalFormField({
         {tooltip && <InfoTooltip tooltip={tooltip} />}
         {required && <span className="required">*</span>}
       </div>
-      <div className="input-container">{children}</div>
+      <div className="input-container">{enhancedChildren}</div>
       {helperText && <div className="helper">{helperText}</div>}
-      {error && <div className="error">{error}</div>}
+      {error && (
+        <div className="error" id={errorId} role="alert">
+          {error}
+        </div>
+      )}
     </StyledFieldContainer>
   );
 }

--- a/superset-frontend/src/components/Modal/ModalFormField.tsx
+++ b/superset-frontend/src/components/Modal/ModalFormField.tsx
@@ -132,13 +132,33 @@ export function ModalFormField({
   const errorId = error ? `${uniqueId}-error` : undefined;
 
   // Clone the first child element to inject aria-invalid and aria-describedby
+  // on the real input. Many call sites wrap the input in a FormItem/Row so
+  // the ARIA attrs must hop through wrappers to reach the actual interactive
+  // element, otherwise screen readers never learn about the error.
+  const applyAria = (element: React.ReactElement<any>): React.ReactElement<any> => {
+    const ariaProps = {
+      'aria-invalid': true,
+      'aria-describedby': errorId,
+    };
+    const wrappedChild = element.props?.children;
+    if (
+      isValidElement(wrappedChild) &&
+      Children.count(wrappedChild) === 1
+    ) {
+      return cloneElement(element, {
+        children: cloneElement(
+          wrappedChild as React.ReactElement<any>,
+          ariaProps,
+        ),
+      });
+    }
+    return cloneElement(element, ariaProps);
+  };
+
   const enhancedChildren = error
     ? Children.map(children, (child, index) => {
         if (index === 0 && isValidElement(child)) {
-          return cloneElement(child as React.ReactElement<any>, {
-            'aria-invalid': true,
-            'aria-describedby': errorId,
-          });
+          return applyAria(child as React.ReactElement<any>);
         }
         return child;
       })

--- a/superset-frontend/src/components/Modal/ModalFormField.tsx
+++ b/superset-frontend/src/components/Modal/ModalFormField.tsx
@@ -16,7 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ReactNode, Children, isValidElement, cloneElement, useId } from 'react';
+import {
+  ReactNode,
+  Children,
+  isValidElement,
+  cloneElement,
+  useId,
+} from 'react';
 import { css, styled } from '@apache-superset/core/theme';
 import { InfoTooltip } from '@superset-ui/core/components';
 
@@ -128,23 +134,27 @@ export function ModalFormField({
   validateStatus,
   hasFeedback = false,
 }: ModalFormFieldProps) {
-  const uniqueId = useId();
+  // Strip colons from useId output so the id is a valid CSS selector
+  // (React's useId returns ":r1:" style values that break attribute lookups).
+  const uniqueId = useId().replace(/:/g, '');
   const errorId = error ? `${uniqueId}-error` : undefined;
 
   // Clone the first child element to inject aria-invalid and aria-describedby
   // on the real input. Many call sites wrap the input in a FormItem/Row so
   // the ARIA attrs must hop through wrappers to reach the actual interactive
   // element, otherwise screen readers never learn about the error.
-  const applyAria = (element: React.ReactElement<any>): React.ReactElement<any> => {
-    const ariaProps = {
-      'aria-invalid': true,
-      'aria-describedby': errorId,
-    };
+  // We always run through Children.map so the React tree shape stays stable
+  // across error/no-error transitions; otherwise auto-keyed children would
+  // unmount and remount the underlying input on every toggle, dropping focus
+  // mid-typing.
+  const applyAria = (
+    element: React.ReactElement<any>,
+  ): React.ReactElement<any> => {
+    const ariaProps = error
+      ? { 'aria-invalid': true, 'aria-describedby': errorId }
+      : {};
     const wrappedChild = element.props?.children;
-    if (
-      isValidElement(wrappedChild) &&
-      Children.count(wrappedChild) === 1
-    ) {
+    if (isValidElement(wrappedChild) && Children.count(wrappedChild) === 1) {
       return cloneElement(element, {
         children: cloneElement(
           wrappedChild as React.ReactElement<any>,
@@ -155,14 +165,12 @@ export function ModalFormField({
     return cloneElement(element, ariaProps);
   };
 
-  const enhancedChildren = error
-    ? Children.map(children, (child, index) => {
-        if (index === 0 && isValidElement(child)) {
-          return applyAria(child as React.ReactElement<any>);
-        }
-        return child;
-      })
-    : children;
+  const enhancedChildren = Children.map(children, (child, index) => {
+    if (index === 0 && isValidElement(child)) {
+      return applyAria(child as React.ReactElement<any>);
+    }
+    return child;
+  });
 
   return (
     <StyledFieldContainer bottomSpacing={bottomSpacing} data-test={testId}>

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -37,6 +37,10 @@ export type ControlHeaderProps = {
   tooltipOnClick?: () => void;
   warning?: string;
   danger?: string;
+  // WCAG 3.3.1: error container ID shared with the input's aria-describedby.
+  // Passed in by wrappers like NumberControl/TextControl so there is exactly
+  // one live-region and one DOM id per control (no duplicate ids/alerts).
+  errorId?: string;
   // Allow extra props from control spread patterns (e.g. {...this.props})
   [key: string]: unknown;
 };
@@ -70,10 +74,11 @@ const ControlHeader: FC<ControlHeaderProps> = ({
   tooltipOnClick = () => {},
   warning,
   danger,
+  errorId: providedErrorId,
 }) => {
   const theme = useTheme();
   const uniqueId = useId();
-  const errorId = `${name || uniqueId}-error`;
+  const errorId = providedErrorId ?? `${name || uniqueId}-error`;
 
   if (!label) {
     return null;

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useId } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { css, useTheme, SupersetTheme } from '@apache-superset/core/theme';
 import { FormLabel, InfoTooltip, Tooltip } from '@superset-ui/core/components';
@@ -72,6 +72,8 @@ const ControlHeader: FC<ControlHeaderProps> = ({
   danger,
 }) => {
   const theme = useTheme();
+  const uniqueId = useId();
+  const errorId = `${name || uniqueId}-error`;
 
   if (!label) {
     return null;
@@ -184,7 +186,7 @@ const ControlHeader: FC<ControlHeaderProps> = ({
                 />
               </Tooltip>
               <span
-                id={`${name || 'control'}-error`}
+                id={errorId}
                 role="alert"
                 css={css`
                   position: absolute;

--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -178,8 +178,28 @@ const ControlHeader: FC<ControlHeaderProps> = ({
                 placement="top"
                 title={validationErrors?.join(' ')}
               >
-                <Icons.ExclamationCircleOutlined iconColor={theme.colorError} />
-              </Tooltip>{' '}
+                <Icons.ExclamationCircleOutlined
+                  iconColor={theme.colorError}
+                  aria-hidden="true"
+                />
+              </Tooltip>
+              <span
+                id={`${name || 'control'}-error`}
+                role="alert"
+                css={css`
+                  position: absolute;
+                  width: 1px;
+                  height: 1px;
+                  padding: 0;
+                  margin: -1px;
+                  overflow: hidden;
+                  clip: rect(0, 0, 0, 0);
+                  white-space: nowrap;
+                  border: 0;
+                `}
+              >
+                {validationErrors?.join('. ')}
+              </span>{' '}
             </span>
           )}
           {renderOptionalIcons()}

--- a/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
@@ -76,6 +76,12 @@ export default function NumberControl({
     onChange?.(val);
   };
 
+  const hasErrors =
+    rest.validationErrors && rest.validationErrors.length > 0;
+  const errorId = hasErrors
+    ? `${rest.name || 'number-control'}-error`
+    : undefined;
+
   return (
     <FullWidthDiv>
       <ControlHeader {...rest} />
@@ -90,7 +96,19 @@ export default function NumberControl({
         onStep={handleStep}
         disabled={disabled}
         aria-label={rest.label}
+        aria-invalid={hasErrors || undefined}
+        aria-describedby={errorId}
+        id={rest.name}
       />
+      {hasErrors && (
+        <span
+          id={errorId}
+          role="alert"
+          style={{ color: 'red', fontSize: '12px', display: 'block', marginTop: '4px' }}
+        >
+          {rest.validationErrors!.join('. ')}
+        </span>
+      )}
     </FullWidthDiv>
   );
 }

--- a/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useId, useRef } from 'react';
-import { styled } from '@apache-superset/core/theme';
+import { styled, css, SupersetTheme } from '@apache-superset/core/theme';
 import { InputNumber } from '@superset-ui/core/components/Input';
 import ControlHeader, { ControlHeaderProps } from '../../ControlHeader';
 
@@ -41,6 +41,13 @@ const FullWidthDiv = styled.div`
 
 const FullWidthInputNumber = styled(InputNumber)`
   width: 100%;
+`;
+
+const fieldErrorStyles = (theme: SupersetTheme) => css`
+  color: ${theme.colorError};
+  font-size: ${theme.fontSizeSM}px;
+  display: block;
+  margin-top: ${theme.sizeUnit}px;
 `;
 
 function parseValue(value: string | number | null | undefined) {
@@ -105,9 +112,7 @@ export default function NumberControl({
         id={inputId}
       />
       {hasErrors && (
-        <span
-          style={{ color: 'red', fontSize: '12px', display: 'block', marginTop: '4px' }}
-        >
+        <span css={fieldErrorStyles}>
           {rest.validationErrors!.join('. ')}
         </span>
       )}

--- a/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useRef } from 'react';
+import { useId, useRef } from 'react';
 import { styled } from '@apache-superset/core/theme';
 import { InputNumber } from '@superset-ui/core/components/Input';
 import ControlHeader, { ControlHeaderProps } from '../../ControlHeader';
@@ -62,6 +62,8 @@ export default function NumberControl({
   ...rest
 }: NumberControlProps) {
   const pendingValueRef = useRef<NumberValueType>(value);
+  const uniqueId = useId();
+  const inputId = rest.name || uniqueId;
 
   const handleChange = (val: string | number | null) => {
     pendingValueRef.current = parseValue(val);
@@ -78,13 +80,15 @@ export default function NumberControl({
 
   const hasErrors =
     rest.validationErrors && rest.validationErrors.length > 0;
-  const errorId = hasErrors
-    ? `${rest.name || 'number-control'}-error`
-    : undefined;
+  // WCAG 3.3.1: the visually hidden live-region inside ControlHeader carries
+  // the id and role="alert"; this wrapper only needs to point the input at
+  // that same id via aria-describedby. Sharing one id per control avoids
+  // duplicate DOM ids and duplicate screen-reader announcements.
+  const errorId = hasErrors ? `${inputId}-error` : undefined;
 
   return (
     <FullWidthDiv>
-      <ControlHeader {...rest} />
+      <ControlHeader {...rest} errorId={errorId} />
       <FullWidthInputNumber
         min={min}
         max={max}
@@ -98,12 +102,10 @@ export default function NumberControl({
         aria-label={rest.label}
         aria-invalid={hasErrors || undefined}
         aria-describedby={errorId}
-        id={rest.name}
+        id={inputId}
       />
       {hasErrors && (
         <span
-          id={errorId}
-          role="alert"
           style={{ color: 'red', fontSize: '12px', display: 'block', marginTop: '4px' }}
         >
           {rest.validationErrors!.join('. ')}

--- a/superset-frontend/src/explore/components/controls/TextControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl/index.tsx
@@ -104,6 +104,9 @@ export default class TextControl<
       this.initialValue = this.props.value;
       value = safeStringify(this.props.value);
     }
+    const hasErrors =
+      this.props.validationErrors && this.props.validationErrors.length > 0;
+    const errorId = hasErrors ? `${this.props.controlId || this.props.name || 'text'}-error` : undefined;
     return (
       <div>
         <ControlHeader {...this.props} />
@@ -116,7 +119,19 @@ export default class TextControl<
           value={value}
           disabled={this.props.disabled}
           aria-label={this.props.label}
+          aria-invalid={hasErrors || undefined}
+          aria-describedby={errorId}
+          id={this.props.controlId || this.props.name}
         />
+        {hasErrors && (
+          <span
+            id={errorId}
+            role="alert"
+            style={{ color: 'red', fontSize: '12px', display: 'block', marginTop: '4px' }}
+          >
+            {this.props.validationErrors!.join('. ')}
+          </span>
+        )}
       </div>
     );
   }

--- a/superset-frontend/src/explore/components/controls/TextControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl/index.tsx
@@ -106,10 +106,13 @@ export default class TextControl<
     }
     const hasErrors =
       this.props.validationErrors && this.props.validationErrors.length > 0;
-    const errorId = hasErrors ? `${this.props.controlId || this.props.name || 'text'}-error` : undefined;
+    const inputId = this.props.controlId || this.props.name;
+    // WCAG 3.3.1: share a single error container id with ControlHeader so
+    // the input's aria-describedby resolves to one live-region, not two.
+    const errorId = hasErrors && inputId ? `${inputId}-error` : undefined;
     return (
       <div>
-        <ControlHeader {...this.props} />
+        <ControlHeader {...this.props} errorId={errorId} />
         <Input
           type="text"
           data-test="inline-name"
@@ -121,12 +124,10 @@ export default class TextControl<
           aria-label={this.props.label}
           aria-invalid={hasErrors || undefined}
           aria-describedby={errorId}
-          id={this.props.controlId || this.props.name}
+          id={inputId}
         />
         {hasErrors && (
           <span
-            id={errorId}
-            role="alert"
             style={{ color: 'red', fontSize: '12px', display: 'block', marginTop: '4px' }}
           >
             {this.props.validationErrors!.join('. ')}

--- a/superset-frontend/src/explore/components/controls/TextControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/TextControl/index.tsx
@@ -18,9 +18,17 @@
  */
 import { Component, ChangeEvent } from 'react';
 import { legacyValidateNumber, legacyValidateInteger } from '@superset-ui/core';
+import { css, SupersetTheme } from '@apache-superset/core/theme';
 import { debounce } from 'lodash';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { Constants, Input } from '@superset-ui/core/components';
+
+const fieldErrorStyles = (theme: SupersetTheme) => css`
+  color: ${theme.colorError};
+  font-size: ${theme.fontSizeSM}px;
+  display: block;
+  margin-top: ${theme.sizeUnit}px;
+`;
 
 type InputValueType = string | number;
 
@@ -127,9 +135,7 @@ export default class TextControl<
           id={inputId}
         />
         {hasErrors && (
-          <span
-            style={{ color: 'red', fontSize: '12px', display: 'block', marginTop: '4px' }}
-          >
+          <span css={fieldErrorStyles}>
             {this.props.validationErrors!.join('. ')}
           </span>
         )}

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -2126,8 +2126,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                     label={isReport ? t('Report name') : t('Alert name')}
                     required
                     error={
+                      currentAlert &&
                       validationStatus[Sections.General].hasErrors &&
-                      !currentAlert?.name?.length
+                      !currentAlert.name?.length
                         ? isReport
                           ? t('Report name is required')
                           : t('Alert name is required')
@@ -2149,8 +2150,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                     label={t('Owners')}
                     required
                     error={
+                      currentAlert &&
                       validationStatus[Sections.General].hasErrors &&
-                      !currentAlert?.owners?.length
+                      !currentAlert.owners?.length
                         ? t('At least one owner is required')
                         : undefined
                     }

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -2125,6 +2125,14 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   <ModalFormField
                     label={isReport ? t('Report name') : t('Alert name')}
                     required
+                    error={
+                      validationStatus[Sections.General].hasErrors &&
+                      !currentAlert?.name?.length
+                        ? isReport
+                          ? t('Report name is required')
+                          : t('Alert name is required')
+                        : undefined
+                    }
                   >
                     <Input
                       name="name"
@@ -2137,7 +2145,16 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                       onChange={onInputChange}
                     />
                   </ModalFormField>
-                  <ModalFormField label={t('Owners')} required>
+                  <ModalFormField
+                    label={t('Owners')}
+                    required
+                    error={
+                      validationStatus[Sections.General].hasErrors &&
+                      !currentAlert?.owners?.length
+                        ? t('At least one owner is required')
+                        : undefined
+                    }
+                  >
                     <AsyncSelect
                       ariaLabel={t('Owners')}
                       allowClear

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1746,11 +1746,18 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   };
 
   const validateGeneralSection = () => {
+    // Skip validation while alert data is still loading so the error display
+    // (which is also gated on `currentAlert`) and the disable-save flag stay
+    // consistent. Once the modal initializes `currentAlert`, validation reruns.
+    if (!currentAlert) {
+      updateValidationStatus(Sections.General, []);
+      return;
+    }
     const errors = [];
-    if (!currentAlert?.name?.length) {
+    if (!currentAlert.name?.length) {
       errors.push(TRANSLATIONS.NAME_ERROR_TEXT);
     }
-    if (!currentAlert?.owners?.length) {
+    if (!currentAlert.owners?.length) {
       errors.push(TRANSLATIONS.OWNERS_ERROR_TEXT);
     }
     updateValidationStatus(Sections.General, errors);

--- a/superset-frontend/src/features/alerts/components/NumberInput.tsx
+++ b/superset-frontend/src/features/alerts/components/NumberInput.tsx
@@ -26,6 +26,8 @@ interface NumberInputProps {
   value: string | number;
   placeholder: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  'aria-invalid'?: boolean;
+  'aria-describedby'?: string;
 }
 
 export default function NumberInput({

--- a/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
@@ -62,6 +62,11 @@ const SSHTunnelForm = ({
   setSSHTunnelLoginMethod: (method: AuthType) => void;
 }) => {
   const [usePassword, setUsePassword] = useState<AuthType>(AuthType.Password);
+  const [blurred, setBlurred] = useState<Record<string, boolean>>({});
+  const markBlurred = (field: string) =>
+    setBlurred(prev => ({ ...prev, [field]: true }));
+  const fieldError = (field: string, value: string | number | undefined) =>
+    blurred[field] && !value;
 
   return (
     <Form>
@@ -77,8 +82,23 @@ const SSHTunnelForm = ({
               placeholder={t('e.g. 127.0.0.1')}
               value={db?.ssh_tunnel?.server_address || ''}
               onChange={onSSHTunnelParametersChange}
+              onBlur={() => markBlurred('server_address')}
+              aria-invalid={
+                fieldError('server_address', db?.ssh_tunnel?.server_address) ||
+                undefined
+              }
+              aria-describedby={
+                fieldError('server_address', db?.ssh_tunnel?.server_address)
+                  ? 'server-address-error'
+                  : undefined
+              }
               data-test="ssh-tunnel-server_address-input"
             />
+            {fieldError('server_address', db?.ssh_tunnel?.server_address) && (
+              <span id="server-address-error" role="alert" style={{ color: 'red', fontSize: '12px' }}>
+                {t('SSH Host is required')}
+              </span>
+            )}
           </StyledDiv>
         </Col>
         <Col xs={24} md={12}>
@@ -92,8 +112,23 @@ const SSHTunnelForm = ({
               type="number"
               value={db?.ssh_tunnel?.server_port}
               onChange={onSSHTunnelParametersChange}
+              onBlur={() => markBlurred('server_port')}
+              aria-invalid={
+                fieldError('server_port', db?.ssh_tunnel?.server_port) ||
+                undefined
+              }
+              aria-describedby={
+                fieldError('server_port', db?.ssh_tunnel?.server_port)
+                  ? 'server-port-error'
+                  : undefined
+              }
               data-test="ssh-tunnel-server_port-input"
             />
+            {fieldError('server_port', db?.ssh_tunnel?.server_port) && (
+              <span id="server-port-error" role="alert" style={{ color: 'red', fontSize: '12px' }}>
+                {t('SSH Port is required')}
+              </span>
+            )}
           </StyledDiv>
         </Col>
       </StyledRow>
@@ -109,8 +144,22 @@ const SSHTunnelForm = ({
               placeholder={t('e.g. Analytics')}
               value={db?.ssh_tunnel?.username || ''}
               onChange={onSSHTunnelParametersChange}
+              onBlur={() => markBlurred('username')}
+              aria-invalid={
+                fieldError('username', db?.ssh_tunnel?.username) || undefined
+              }
+              aria-describedby={
+                fieldError('username', db?.ssh_tunnel?.username)
+                  ? 'ssh-username-error'
+                  : undefined
+              }
               data-test="ssh-tunnel-username-input"
             />
+            {fieldError('username', db?.ssh_tunnel?.username) && (
+              <span id="ssh-username-error" role="alert" style={{ color: 'red', fontSize: '12px' }}>
+                {t('Username is required')}
+              </span>
+            )}
           </StyledDiv>
         </Col>
       </StyledRow>

--- a/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
@@ -66,7 +66,11 @@ const SSHTunnelForm = ({
   const markBlurred = (field: string) =>
     setBlurred(prev => ({ ...prev, [field]: true }));
   const fieldError = (field: string, value: string | number | undefined) =>
-    blurred[field] && !value;
+    // WCAG 3.3.1: treat whitespace-only strings as empty so users cannot
+    // bypass required-field validation with a space character.
+    blurred[field] &&
+    (value === undefined ||
+      (typeof value === 'string' && value.trim().length === 0));
 
   return (
     <Form>

--- a/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SSHTunnelForm.tsx
@@ -18,7 +18,7 @@
  */
 import { useState } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { styled } from '@apache-superset/core/theme';
+import { styled, css, SupersetTheme } from '@apache-superset/core/theme';
 import {
   Form,
   FormLabel,
@@ -50,6 +50,13 @@ const StyledFormItem = styled(Form.Item)`
 
 const StyledInputPassword = styled(Input.Password)`
   margin: ${({ theme }) => `${theme.sizeUnit}px 0 ${theme.sizeUnit * 2}px`};
+`;
+
+const fieldErrorStyles = (theme: SupersetTheme) => css`
+  color: ${theme.colorError};
+  font-size: ${theme.fontSizeSM}px;
+  display: block;
+  margin-top: ${theme.sizeUnit}px;
 `;
 
 const SSHTunnelForm = ({
@@ -99,7 +106,7 @@ const SSHTunnelForm = ({
               data-test="ssh-tunnel-server_address-input"
             />
             {fieldError('server_address', db?.ssh_tunnel?.server_address) && (
-              <span id="server-address-error" role="alert" style={{ color: 'red', fontSize: '12px' }}>
+              <span id="server-address-error" role="alert" css={fieldErrorStyles}>
                 {t('SSH Host is required')}
               </span>
             )}
@@ -129,7 +136,7 @@ const SSHTunnelForm = ({
               data-test="ssh-tunnel-server_port-input"
             />
             {fieldError('server_port', db?.ssh_tunnel?.server_port) && (
-              <span id="server-port-error" role="alert" style={{ color: 'red', fontSize: '12px' }}>
+              <span id="server-port-error" role="alert" css={fieldErrorStyles}>
                 {t('SSH Port is required')}
               </span>
             )}
@@ -160,7 +167,7 @@ const SSHTunnelForm = ({
               data-test="ssh-tunnel-username-input"
             />
             {fieldError('username', db?.ssh_tunnel?.username) && (
-              <span id="ssh-username-error" role="alert" style={{ color: 'red', fontSize: '12px' }}>
+              <span id="ssh-username-error" role="alert" css={fieldErrorStyles}>
                 {t('Username is required')}
               </span>
             )}

--- a/superset-frontend/src/features/databases/DatabaseModal/SqlAlchemyForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SqlAlchemyForm.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { EventHandler, ChangeEvent, MouseEvent, ReactNode } from 'react';
+import { EventHandler, ChangeEvent, MouseEvent, ReactNode, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { SupersetTheme } from '@apache-superset/core/theme';
 import SupersetText from 'src/utils/textUtils';
@@ -39,6 +39,10 @@ const SqlAlchemyTab = ({
   testInProgress?: boolean;
   children?: ReactNode;
 }) => {
+  const [nameBlurred, setNameBlurred] = useState(false);
+  const [uriBlurred, setUriBlurred] = useState(false);
+  const nameError = nameBlurred && !db?.database_name;
+  const uriError = uriBlurred && !db?.sqlalchemy_uri;
   const fallbackDocsUrl =
     SupersetText?.DB_MODAL_SQLALCHEMY_FORM?.SQLALCHEMY_DOCS_URL ||
     'https://docs.sqlalchemy.org/en/13/core/engines.html';
@@ -60,8 +64,16 @@ const SqlAlchemyTab = ({
             value={db?.database_name || ''}
             placeholder={t('Name your database')}
             onChange={onInputChange}
+            onBlur={() => setNameBlurred(true)}
+            aria-invalid={nameError || undefined}
+            aria-describedby={nameError ? 'database-name-error' : undefined}
           />
         </div>
+        {nameError && (
+          <div className="helper" id="database-name-error" role="alert" style={{ color: 'var(--ifm-color-danger, #e04f5f)' }}>
+            {t('Display Name is required')}
+          </div>
+        )}
         <div className="helper">
           {t('Pick a name to help you identify this database.')}
         </div>
@@ -82,8 +94,16 @@ const SqlAlchemyTab = ({
               t('dialect+driver://username:password@host:port/database')
             }
             onChange={onInputChange}
+            onBlur={() => setUriBlurred(true)}
+            aria-invalid={uriError || undefined}
+            aria-describedby={uriError ? 'sqlalchemy-uri-error' : undefined}
           />
         </div>
+        {uriError && (
+          <div className="helper" id="sqlalchemy-uri-error" role="alert" style={{ color: 'var(--ifm-color-danger, #e04f5f)' }}>
+            {t('SQLAlchemy URI is required')}
+          </div>
+        )}
         <div className="helper">
           {t('Refer to the')}{' '}
           <a

--- a/superset-frontend/src/features/roles/RoleFormItems.tsx
+++ b/superset-frontend/src/features/roles/RoleFormItems.tsx
@@ -37,7 +37,11 @@ export const RoleNameField = () => (
     label={t('Role Name')}
     rules={[{ required: true, message: t('Role name is required') }]}
   >
-    <Input name="roleName" data-test="role-name-input" />
+    <Input
+      name="roleName"
+      data-test="role-name-input"
+      aria-required="true"
+    />
   </FormItem>
 );
 


### PR DESCRIPTION
### SUMMARY
Implements WCAG 2.1 criterion 3.3.1 (Error Identification, Level A).

- Add `role="alert"` to error containers (BasicErrorAlert, Alert component)
- Add `aria-invalid` and `aria-describedby` to form inputs with validation errors
- Screen readers now announce errors immediately and associate them with the relevant input field
- Covers: ControlHeader, NumberControl, TextControl, ModalFormField, SSH Tunnel form, SQLAlchemy form, Roles form

### TESTING INSTRUCTIONS
1. Open Chart creation → submit without required fields → errors should be announced by screen reader
2. Inspect error messages → should have `role="alert"`
3. Inspect invalid inputs → should have `aria-invalid="true"` and `aria-describedby` pointing to error

### ADDITIONAL INFORMATION
- [x] Changes UI
Part of a series of 16 individual WCAG 2.1 accessibility PRs. See also #38342.