### PR TITLE
fix(dataset-editor): fix SQL expression editor extra spaces and height expansion

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncEsmComponent/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncEsmComponent/index.tsx
@@ -33,20 +33,22 @@ import type { PlaceholderProps } from './types';
 function DefaultPlaceholder({
   width,
   height,
-  showLoadingForImport = false,
+  showLoadingForImport = true,
   placeholderStyle: style,
 }: PlaceholderProps) {
-  return (
-    // since `width` defaults to 100%, we can display the placeholder once
-    // height is specified.
-    (height && (
+  if (showLoadingForImport) {
+    return (
       <div key="async-asm-placeholder" style={{ width, height, ...style }}>
-        {showLoadingForImport && <Loading position="floating" />}
+        <Loading position="floating" size="s" />
       </div>
-    )) ||
-    // `|| null` is for in case of height=0.
-    null
-  );
+    );
+  }
+  if (height) {
+    return (
+      <div key="async-asm-placeholder" style={{ width, height, ...style }} />
+    );
+  }
+  return null;
 }
 
 /**

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -66,6 +66,7 @@ import {
   Loading,
   Row,
   Select,
+  Tooltip,
   Typography,
   Label,
 } from '@superset-ui/core/components';
@@ -394,6 +395,7 @@ const EditLockContainer = styled.div`
   font-size: ${({ theme }) => theme.fontSizeSM}px;
   display: flex;
   align-items: center;
+  padding: ${({ theme }) => theme.paddingSM}px 0;
   a {
     padding: 0 10px;
   }
@@ -578,7 +580,8 @@ function ColumnCollectionTable({
                   <TextAreaControl
                     language="sql"
                     offerEditInModal={false}
-                    resize="vertical"
+                    maxLines={25}
+                    debounceDelay={300}
                   />
                 }
               />
@@ -2181,6 +2184,19 @@ class DatasourceEditor extends PureComponent<
             <FormContainer>
               <Fieldset compact>
                 <Field
+                  fieldKey="expression"
+                  label={t('SQL expression')}
+                  control={
+                    <TextAreaControl
+                      language="sql"
+                      offerEditInModal={false}
+                      minLines={3}
+                      maxLines={25}
+                      debounceDelay={300}
+                    />
+                  }
+                />
+                <Field
                   fieldKey="description"
                   label={t('Description')}
                   control={
@@ -2262,7 +2278,10 @@ class DatasourceEditor extends PureComponent<
           })}
           itemCellProps={{
             expression: () => ({
-              width: '240px',
+              style: {
+                maxWidth: '240px',
+                overflow: 'hidden',
+              },
             }),
           }}
           itemRenderers={{
@@ -2290,18 +2309,18 @@ class DatasourceEditor extends PureComponent<
             verbose_name: (v, onChange) => (
               <TextControl value={v as string} onChange={onChange} />
             ),
-            expression: (v, onChange) => (
-              <TextAreaControl
-                canEdit
-                initialValue={v as string}
-                onChange={onChange}
-                extraClasses={['datasource-sql-expression']}
-                language="sql"
-                offerEditInModal={false}
-                minLines={5}
-                textAreaStyles={{ minWidth: '200px', maxWidth: '450px' }}
-                resize="both"
-              />
+            expression: (v: unknown) => (
+              <Tooltip title={t('Expand row to edit')}>
+                <Typography.Text
+                  code
+                  ellipsis
+                  css={css`
+                    cursor: default;
+                  `}
+                >
+                  {v as string}
+                </Typography.Text>
+              </Tooltip>
             ),
             description: (v, onChange, label) => (
               <StackedField

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.tsx
@@ -82,7 +82,6 @@ interface TextAreaControlProps {
 
 const defaultProps = {
   onChange: () => {},
-  initialValue: '',
   height: 250,
   minLines: 3,
   maxLines: 10,
@@ -136,7 +135,7 @@ class TextAreaControl extends Component<TextAreaControlProps> {
 
   componentWillUnmount() {
     if (this.debouncedOnChange) {
-      this.debouncedOnChange.cancel();
+      this.debouncedOnChange.flush();
     }
   }
 
@@ -160,6 +159,7 @@ class TextAreaControl extends Component<TextAreaControlProps> {
       readOnly,
       name,
       onChange,
+      value,
       minLines: minLinesProp,
       maxLines: maxLinesProp,
       ...editorProps
@@ -176,6 +176,7 @@ class TextAreaControl extends Component<TextAreaControlProps> {
       };
       if (resize) {
         style.resize = resize;
+        style.overflow = 'auto';
       }
       if (readOnly) {
         style.backgroundColor = theme?.colorBgMask;
@@ -206,7 +207,7 @@ class TextAreaControl extends Component<TextAreaControlProps> {
             maxLines={inModal ? 1000 : maxLinesProp}
             editorProps={{ $blockScrolling: true }}
             onLoad={onEditorLoad}
-            defaultValue={initialValue}
+            defaultValue={initialValue ?? value}
             readOnly={readOnly}
             key={name}
             {...editorProps}


### PR DESCRIPTION
### SUMMARY

Fixes multiple UX issues with the SQL expression editor in the dataset editor:

1. **Extra spaces on input**: The `value` prop from the `Field`/`Fieldset` component chain was leaking through `...editorProps` spread into ReactAce, causing it to operate in controlled mode. This produced extra spaces, cursor jumping, and sluggish input. Fixed by destructuring `value` out of the rest props and using it only as a fallback for `defaultValue`.

2. **Height expansion**: `maxLines` defaulted to 10 for both computed column and metric expression editors, severely limiting the editor height. Increased to 25 so the editor auto-expands with content.

3. **Sluggish input**: Added `debounceDelay={300}` to both expression editors to prevent full component tree re-renders on every keystroke.

4. **Metrics expression moved to expand form**: The inline expression editor in the metrics table was cramped (240px wide). Replaced it with a read-only `Typography.Text code ellipsis` preview in the table cell, and added a full-width editable expression editor to the expanded form. Hovering the preview shows an "Expand row to edit" tooltip.

5. **Lock icon spacing**: Added vertical padding to the `EditLockContainer` so the lock icon/text has proper spacing from the tab bar divider.

6. **Debounce flush on unmount**: Changed `componentWillUnmount` from `cancel()` to `flush()` so pending debounced edits are persisted when the editor unmounts (e.g., collapsing an expanded row).

7. **AsyncEsmComponent loading spinner**: Decoupled the loading spinner from requiring a `height` prop. The `showLoadingForImport` placeholder prop now defaults to `true` and uses a small spinner size, so async-loaded editors (like SQL expression) show a loading indicator while importing.

8. **initialValue default fix**: Removed `initialValue: ''` from `TextAreaControl.defaultProps` so the `initialValue ?? value` fallback correctly uses `value` from the Field/Fieldset chain when no explicit `initialValue` is passed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - UI changes are self-evident when testing

### TESTING INSTRUCTIONS
1. Open a dataset's settings (Edit Dataset modal)
2. Go to **Metrics** tab:
   - Expression column should show truncated SQL in monospace `code` style
   - Hover should show "Expand row to edit" tooltip
   - Expand a metric row — the SQL expression editor should appear at the top of the form with the expression loaded
   - Edit the expression — should be responsive (no lag or extra spaces)
   - The preview in the table should update when you collapse the row
3. Go to **Calculated columns** tab:
   - Expand a computed column — the SQL expression editor should auto-expand up to 25 lines
   - Typing should be responsive
4. Go to **Source** tab:
   - Lock icon and text should have proper spacing from the tab bar
5. Any async-loaded Ace editor should show a small loading spinner while importing

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)