### PR TITLE
fix(dashboard): prevent horizontal overflow when vertical filter bar is open

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -119,6 +119,7 @@ const StyledContent = styled.div<{
 }>`
   grid-column: 2;
   grid-row: 2;
+  min-width: 0;
   // @z-index-above-dashboard-header (100) + 1 = 101
   ${({ fullSizeChartId }) => fullSizeChartId && `z-index: 101;`}
 `;


### PR DESCRIPTION
### Summary

Fixes a layout bug where opening the left-hand vertical filter bar on a dashboard causes the dashboard content area to overflow horizontally, adding an unwanted horizontal scroll bar.

Fixes: https://app.shortcut.com/preset/story/101995

### Testing

- Load a dashboard with the vertical filter bar enabled
- Open the filter bar — no horizontal scroll bar should appear
- Dashboard content should fill the remaining width correctly