### PR TITLE
fix(tests): improve ShareMenuItems test isolation to fix intermittent suite failure

### DIFF
--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/ShareMenuItems.test.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/ShareMenuItems.test.tsx
@@ -54,8 +54,7 @@ beforeEach(() => {
   // @ts-expect-error
   delete window.location;
   window.location = { href: '' } as any;
-  fetchMock.removeRoutes();
-  fetchMock.clearHistory();
+  fetchMock.clearHistory().removeRoutes();
   fetchMock.post(
     postDashboardPermalinkMockUrl,
     { key: '123', url: 'http://localhost/superset/dashboard/p/123/' },
@@ -65,9 +64,8 @@ beforeEach(() => {
 
 afterEach(() => {
   window.location = originalLocation;
-  delete window.featureFlags;
-  fetchMock.removeRoutes();
-  fetchMock.clearHistory();
+  window.featureFlags = {};
+  fetchMock.clearHistory().removeRoutes();
 });
 
 const MenuWrapper = (

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/ShareMenuItems.test.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/ShareMenuItems.test.tsx
@@ -45,13 +45,17 @@ const createProps = () => ({
   submenuKey: 'share',
 });
 
-const { location } = window;
+const originalLocation = window.location;
 
 const postDashboardPermalinkMockUrl = `http://localhost/api/v1/dashboard/${DASHBOARD_ID}/permalink`;
 
-beforeAll((): void => {
+beforeEach(() => {
+  jest.clearAllMocks();
   // @ts-expect-error
   delete window.location;
+  window.location = { href: '' } as any;
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
   fetchMock.post(
     postDashboardPermalinkMockUrl,
     { key: '123', url: 'http://localhost/superset/dashboard/p/123/' },
@@ -59,15 +63,11 @@ beforeAll((): void => {
   );
 });
 
-beforeEach(() => {
-  jest.clearAllMocks();
-  window.location = {
-    href: '',
-  } as any;
-});
-
-afterAll((): void => {
-  window.location = location;
+afterEach(() => {
+  window.location = originalLocation;
+  delete window.featureFlags;
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
 });
 
 const MenuWrapper = (
@@ -113,7 +113,7 @@ test('Click on "Copy dashboard URL" and succeed', async () => {
     expect(props.addDangerToast).toHaveBeenCalledTimes(0);
   });
 
-  userEvent.click(screen.getByText('Copy dashboard URL'));
+  await userEvent.click(screen.getByText('Copy dashboard URL'));
 
   await waitFor(async () => {
     expect(spy).toHaveBeenCalledTimes(1);
@@ -145,7 +145,7 @@ test('Click on "Copy dashboard URL" and fail', async () => {
     expect(props.addDangerToast).toHaveBeenCalledTimes(0);
   });
 
-  userEvent.click(screen.getByText('Copy dashboard URL'));
+  await userEvent.click(screen.getByText('Copy dashboard URL'));
 
   await waitFor(async () => {
     expect(spy).toHaveBeenCalledTimes(1);
@@ -177,7 +177,7 @@ test('Click on "Share dashboard by email" and succeed', async () => {
     expect(window.location.href).toBe('');
   });
 
-  userEvent.click(screen.getByText('Share dashboard by email'));
+  await userEvent.click(screen.getByText('Share dashboard by email'));
 
   await waitFor(() => {
     expect(props.addDangerToast).toHaveBeenCalledTimes(0);
@@ -189,11 +189,7 @@ test('Click on "Share dashboard by email" and succeed', async () => {
 
 test('Click on "Share dashboard by email" and fail', async () => {
   fetchMock.removeRoute(postDashboardPermalinkMockUrl);
-  fetchMock.post(
-    `http://localhost/api/v1/dashboard/${DASHBOARD_ID}/permalink`,
-    { status: 404 },
-    { name: postDashboardPermalinkMockUrl },
-  );
+  fetchMock.post(postDashboardPermalinkMockUrl, { status: 404 });
   const props = createProps();
   render(
     <MenuWrapper
@@ -211,7 +207,7 @@ test('Click on "Share dashboard by email" and fail', async () => {
     expect(window.location.href).toBe('');
   });
 
-  userEvent.click(screen.getByText('Share dashboard by email'));
+  await userEvent.click(screen.getByText('Share dashboard by email'));
 
   await waitFor(() => {
     expect(window.location.href).toBe('');


### PR DESCRIPTION
### SUMMARY

Fixes flaky `ShareMenuItems.test.tsx` test suite that was intermittently crashing Jest workers in CI (sharded-jest-tests shard 3) with "Test suite failed to run" errors.

**Root causes:**
- **`window.location` leaked across suites** — Was deleted in `beforeAll` and only restored in `afterAll`. If the Jest worker reused the environment after a prior suite crash, `window.location` stayed deleted, causing setup failure.
- **`window.featureFlags` never cleaned up** — 5 tests set it but never removed it, leaking state to other suites in the same worker.
- **`fetchMock` routes accumulated** — Routes set once in `beforeAll`; the last test modified them without restoring. Stale route state could corrupt subsequent test runs.
- **Missing `await` on `userEvent.click()`** — Fire-and-forget clicks could race with async state updates.

**Fixes:**
- Move `window.location` setup/teardown to `beforeEach`/`afterEach` for per-test isolation
- Clean up `window.featureFlags` in `afterEach`
- Reset fetchMock routes and history in `beforeEach`/`afterEach`
- Add `await` to all `userEvent.click()` calls

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only change

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest src/dashboard/components/menu/ShareMenuItems/ShareMenuItems.test.tsx --no-coverage
```

All 10 tests should pass. The fix addresses non-deterministic failures that only manifest when Jest workers carry polluted state from prior test suites.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API