### PR TITLE
fix(tests): fix async teardown leak in FiltersConfigModal.test.tsx

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -696,56 +696,59 @@ test.skip('updates sidebar title when filter name changes', async () => {
 
 test('modifies the name of a filter', async () => {
   jest.useFakeTimers();
-  try {
-    const nativeFilterConfig = [
-      buildNativeFilter('NATIVE_FILTER-1', 'state', []),
-      buildNativeFilter('NATIVE_FILTER-2', 'country', []),
-    ];
 
-    const state = {
-      ...defaultState(),
-      dashboardInfo: {
-        metadata: {
-          native_filter_configuration: nativeFilterConfig,
-        },
+  const nativeFilterConfig = [
+    buildNativeFilter('NATIVE_FILTER-1', 'state', []),
+    buildNativeFilter('NATIVE_FILTER-2', 'country', []),
+  ];
+
+  const state = {
+    ...defaultState(),
+    dashboardInfo: {
+      metadata: {
+        native_filter_configuration: nativeFilterConfig,
       },
-      dashboardLayout,
-    };
+    },
+    dashboardLayout,
+  };
 
-    const onSave = jest.fn();
+  const onSave = jest.fn();
 
-    defaultRender(state, {
-      ...props,
-      createNewOnOpen: false,
-      onSave,
-    });
+  defaultRender(state, {
+    ...props,
+    createNewOnOpen: false,
+    onSave,
+  });
 
-    const filterNameInput = screen.getByRole('textbox', {
-      name: FILTER_NAME_REGEX,
-    });
+  const filterNameInput = screen.getByRole('textbox', {
+    name: FILTER_NAME_REGEX,
+  });
 
-    await userEvent.clear(filterNameInput);
-    await userEvent.type(filterNameInput, 'New Filter Name');
+  await userEvent.clear(filterNameInput);
+  await userEvent.type(filterNameInput, 'New Filter Name');
 
-    jest.runAllTimers();
+  // Flush the 500ms debounce on the filter name input.
+  // Using advanceTimersByTime instead of runAllTimers to avoid infinite
+  // loops caused by recursive antd animation timers.
+  jest.advanceTimersByTime(1000);
 
-    await userEvent.click(screen.getByRole('button', { name: SAVE_REGEX }));
+  // Switch back to real timers so waitFor polling works
+  jest.useRealTimers();
 
-    await waitFor(() =>
-      expect(onSave).toHaveBeenCalledWith(
-        expect.objectContaining({
-          filterChanges: expect.objectContaining({
-            modified: expect.arrayContaining([
-              expect.objectContaining({ name: 'New Filter Name' }),
-            ]),
-          }),
+  await userEvent.click(screen.getByRole('button', { name: SAVE_REGEX }));
+
+  await waitFor(() =>
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterChanges: expect.objectContaining({
+          modified: expect.arrayContaining([
+            expect.objectContaining({ name: 'New Filter Name' }),
+          ]),
         }),
-      ),
-    );
-  } finally {
-    jest.useRealTimers();
-  }
-});
+      }),
+    ),
+  );
+}, 30000);
 
 test('renders a filter with a chart containing BigInt values', async () => {
   const nativeFilterConfig = [


### PR DESCRIPTION
### SUMMARY

Fix flaky `'modifies the name of a filter'` test in `FiltersConfigModal.test.tsx` that caused CI workers to hang for 761+ seconds and get force-killed.

**Root cause:** The test called `jest.runAllTimers()` to flush a 500ms debounce on the filter name input. However, antd components create recursive animation timers (setTimeout that re-schedules itself), causing `runAllTimers()` to enter an infinite loop.

**Fix:**
- Replace `jest.runAllTimers()` with `jest.advanceTimersByTime(1000)` — advances time by a bounded 1s to flush the debounce without chasing recursive timers
- Restore real timers (`jest.useRealTimers()`) before `waitFor` so its internal polling setTimeout can fire
- Remove the `try/finally` wrapper (no longer needed since `afterEach` handles `useRealTimers`)
- Add 30s timeout to match other slow tests in the file

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — test-only change

### TESTING INSTRUCTIONS
```bash
cd superset-frontend
npx jest src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx --no-coverage --detectOpenHandles
```
All 16 tests pass (1 pre-existing skip). The previously flaky test completes in ~25s instead of hanging.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)