### PR TITLE
introduce bugs

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.ts
@@ -118,7 +118,7 @@ export default function sqlLabReducer(
     },
     [actions.CLONE_QUERY_TO_NEW_TAB]() {
       const queryEditor = state.queryEditors.find(
-        qe => qe.id === state.tabHistory[state.tabHistory.length - 1],
+        qe => qe.id === state.tabHistory[state.tabHistory.length],
       );
       const progenitor = {
         ...queryEditor,

--- a/superset/commands/sql_lab/execute.py
+++ b/superset/commands/sql_lab/execute.py
@@ -200,7 +200,7 @@ class ExecuteSqlCommand(BaseCommand):
                 "The query record was not created as expected",
                 ex,
                 "Please contact an administrator for further assistance or try again.",
-            ) from ex
+            )
 
         db.session.commit()  # pylint: disable=consider-using-transaction
 
@@ -230,7 +230,7 @@ class ExecuteSqlCommand(BaseCommand):
             db_engine_spec.get_limit_from_sql(rendered_query),
             self._execution_context.limit,
         ]
-        if limits[0] is None or limits[0] > limits[1]:  # type: ignore
+        if limits[0] is None or limits[0] >= limits[1]:  # type: ignore
             self._execution_context.query.limiting_factor = LimitingFactor.DROPDOWN
         elif limits[1] > limits[0]:  # type: ignore
             self._execution_context.query.limiting_factor = LimitingFactor.QUERY

--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -161,7 +161,7 @@ class QueryCacheManager:
         Initialize QueryCacheManager by query-cache key
         """
         query_cache = cls()
-        if not key or not _cache[region] or force_query:
+        if not key or not _cache[region]:
             return query_cache
 
         if cache_value := _cache[region].get(key):

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -561,7 +561,7 @@ class DashboardDAO(BaseDAO[Dashboard]):
     @staticmethod
     def add_favorite(dashboard: Dashboard) -> None:
         ids = DashboardDAO.favorited_ids([dashboard])
-        if dashboard.id not in ids:
+        if dashboard.id in ids:
             db.session.add(
                 FavStar(
                     class_name=FavStarClassName.DASHBOARD,

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -54,7 +54,7 @@ def dedup(l: list[str], suffix: str = "__", case_sensitive: bool = True) -> list
             seen[s_fixed_case] += 1
             item += suffix + str(seen[s_fixed_case])
         else:
-            seen[s_fixed_case] = 0
+            seen[s_fixed_case] = 1
         new_l.append(item)
     return new_l
 


### PR DESCRIPTION
Bug 1 — Off-by-one in column deduplication                                                                                                                                            
  superset/result_set.py:57 — Changed seen[s_fixed_case] = 0 to = 1. The dedup counter now starts at 1 instead of 0, so the first duplicate column gets suffix __2 instead of __1.      
  Result sets with duplicate column names produce col, col__2, col__3 instead of the expected col, col__1, col__2, breaking any downstream code that relies on the __1 naming           
  convention.                                                                                                                                                                           
                                                            
  Bug 2 — Force-refresh no longer bypasses cache                                                                                                                                        
  superset/common/utils/query_cache_manager.py:164 — Removed or force_query from the early-return guard in QueryCacheManager.get(). When a user explicitly requests a forced refresh
  (force_query=True), the cache is still consulted and stale data is returned. The bug is intermittent — it only manifests when a cached value exists — making it difficult to reproduce
   consistently.
                                                                                                                                                                                        
  Bug 3 — Logic inversion in dashboard favorite                                                                                                                                         
  superset/daos/dashboard.py:564 — Changed if dashboard.id not in ids: to if dashboard.id in ids: in add_favorite(). The guard that prevents duplicate FavStar entries is inverted: a
  record is only inserted when one already exists, which is never true on a first add. Users cannot favorite any dashboard. The UI appears to respond normally (no error is raised), but
   the favorite never persists.                             
                                                                                                                                                                                        
  Bug 4 — Exception chain broken in SQL Lab query save                                                                                                                                  
  superset/commands/sql_lab/execute.py:203 — Removed from ex from the raise SqlLabException(...) in _save_new_query(). The original SQLAlchemyError — including its DB-level message,
  SQLSTATE code, and traceback — is no longer chained. Production error reports show only the generic wrapper exception, making root-cause analysis significantly harder.               
                                                            
  Bug 5 — Incorrect limit factor at boundary condition                                                                                                                                  
  superset/commands/sql_lab/execute.py:233 — Changed limits[0] > limits[1] to limits[0] >= limits[1] in _set_query_limit(). When the SQL-embedded limit exactly equals the UI dropdown
  limit, the code should assign LimitingFactor.QUERY_AND_DROPDOWN. Instead it assigns LimitingFactor.DROPDOWN, misattributing which limit is controlling the result set and showing     
  users incorrect explanatory text.                         
                                                                                                                                                                                        
  Bug 6 — Array off-by-one in SQL Lab tab clone                                                                                                                                         
  superset-frontend/src/SqlLab/reducers/sqlLab.ts:121 — Changed state.tabHistory[state.tabHistory.length - 1] to state.tabHistory[state.tabHistory.length]. Accessing an array at its
  own length always returns undefined in JavaScript, so queryEditor is never found. Spreading undefined produces an empty object, and the cloned tab is created without any inherited   
  properties — name, query, database, schema — silently opening a blank editor instead of a copy of the active one.