### PR TITLE
fix(pandas): resolve SettingWithCopyWarning across post-processing utils

### DIFF
--- a/superset/utils/pandas_postprocessing/boxplot.py
+++ b/superset/utils/pandas_postprocessing/boxplot.py
@@ -125,6 +125,8 @@ def boxplot(  # noqa: C901
 
     # nanpercentile needs numeric values, otherwise the isnan function
     # that's used in the underlying function will fail
+    if any(df.dtypes[column] == np.object_ for column in metrics):
+        df = df.copy()
     for column in metrics:
         if df.dtypes[column] == np.object_:
             df[column] = to_numeric(df[column], errors="coerce")

--- a/superset/utils/pandas_postprocessing/compare.py
+++ b/superset/utils/pandas_postprocessing/compare.py
@@ -60,9 +60,9 @@ def compare(  # pylint: disable=too-many-arguments
         return df
 
     for s_col, c_col in zip(source_columns, compare_columns, strict=False):
-        s_df = df.loc[:, [s_col]]
+        s_df = df.loc[:, [s_col]].copy()
         s_df.rename(columns={s_col: "__intermediate"}, inplace=True)
-        c_df = df.loc[:, [c_col]]
+        c_df = df.loc[:, [c_col]].copy()
         c_df.rename(columns={c_col: "__intermediate"}, inplace=True)
         if compare_type == PandasPostprocessingCompare.DIFF:
             diff_df = s_df - c_df

--- a/superset/utils/pandas_postprocessing/geography.py
+++ b/superset/utils/pandas_postprocessing/geography.py
@@ -65,7 +65,7 @@ def geohash_encode(
     :return: DataFrame with decoded longitudes and latitudes
     """
     try:
-        encode_df = df[[latitude, longitude]]
+        encode_df = df[[latitude, longitude]].copy()
         encode_df.columns = ["latitude", "longitude"]
         encode_df["geohash"] = encode_df.apply(
             lambda row: geohash_lib.encode(

--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -54,6 +54,7 @@ def histogram(
         return df
 
     # convert to numeric, coercing errors to NaN
+    df = df.copy()
     df[column] = to_numeric(df[column], errors="coerce")
 
     # check if the column contains non-numeric values

--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -71,6 +71,7 @@ def pivot(  # pylint: disable=too-many-arguments
         )
 
     if columns and column_fill_value:
+        df = df.copy()
         df[columns] = df[columns].fillna(value=column_fill_value)
 
     aggregate_funcs = _get_aggregate_funcs(df, aggregates)

--- a/superset/utils/pandas_postprocessing/prophet.py
+++ b/superset/utils/pandas_postprocessing/prophet.py
@@ -70,6 +70,7 @@ def _prophet_fit_and_predict(  # pylint: disable=too-many-arguments
         daily_seasonality=daily_seasonality,
     )
     if df["ds"].dt.tz:
+        df = df.copy()
         df["ds"] = df["ds"].dt.tz_convert(None)
     model.fit(df)
     future = model.make_future_dataframe(periods=periods, freq=freq)

--- a/superset/utils/pandas_postprocessing/rank.py
+++ b/superset/utils/pandas_postprocessing/rank.py
@@ -32,6 +32,7 @@ def rank(
     :param group_by: The column to group by.
     :return: a flat DataFrame
     """
+    df = df.copy()
     if group_by:
         gb = df.groupby(group_by, group_keys=False)
         df["rank"] = gb.apply(lambda x: x[metric].rank(pct=True))


### PR DESCRIPTION
## Summary

Fixes #36530

When loading dashboards with Histogram charts, a `SettingWithCopyWarning` appears in Python logs because DataFrame mutation operations are performed on potential views/slices without making an explicit copy first.

This PR adds `.copy()` calls before mutating DataFrames across all affected pandas post-processing utilities:

- **histogram.py**: `df = df.copy()` before `to_numeric` assignment
- **boxplot.py**: `df = df.copy()` before `to_numeric` loop over metrics
- **rank.py**: `df = df.copy()` before rank column assignment
- **pivot.py**: `df = df.copy()` before `fillna` on columns
- **prophet.py**: `df = df.copy()` before timezone conversion
- **geography.py**: `.copy()` before geohash operations
- **compare.py**: `.copy()` before in-place rename

## Root Cause

The pandas `SettingWithCopyWarning` is triggered when assigning to a column of a DataFrame that may be a slice/view rather than an owned copy. While functionally correct in most cases, this is a pandas anti-pattern that can mask subtle bugs and pollutes application logs.

## Test Plan

- [ ] Existing tests continue to pass (`pytest tests/unit_tests/pandas_postprocessing/`)
- [ ] Load a dashboard with a Histogram chart and verify no `SettingWithCopyWarning` in logs
- [ ] Verify histogram, boxplot, rank, pivot, prophet, geography, and compare post-processing outputs are unchanged

Made with [Cursor](https://cursor.com)