### PR TITLE
fix(drill-detail): restrict page size options to match fixed PAGE_SIZE

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -314,6 +314,7 @@ export default function DrillDetailPane({
           columns={mappedColumns}
           size={TableSize.Small}
           defaultPageSize={PAGE_SIZE}
+          pageSizeOptions={[`${PAGE_SIZE}`]}
           recordCount={resultsPage?.total}
           usePagination
           loading={isLoading}


### PR DESCRIPTION
## Summary

Fixes #36267

The drill-to-details table uses a fixed page size of 50 (`PAGE_SIZE` constant) for all backend API calls, but the frontend Table component displayed a page size selector with options `[5, 15, 25, 50, 100]`. This mismatch caused bugs when users selected a different page size:

- **Sizes > 50**: Still only showed 50 rows per page
- **Sizes < 50**: Could result in empty pages or database query errors when navigating to the "last" page

## Changes

Added `pageSizeOptions={[\`${PAGE_SIZE}\`]}` to the Table component in `DrillDetailPane.tsx`, restricting the page size selector to only show the valid option (50). This is a minimal, safe fix that aligns the UI with the backend's fixed page size.

## Test Plan

- [ ] Existing DrillDetailPane tests pass (7/7)
- [ ] Open drill-to-details on any chart and verify the page size selector only shows "50"
- [ ] Verify pagination still works correctly with 50 rows per page
- [ ] Verify no visual regression in the drill-detail table

Made with [Cursor](https://cursor.com)