### PR TITLE
fix(colors): reassign colliding series when dashboard locks shared dimension color

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
@@ -145,19 +145,13 @@ class CategoricalColorScale extends ExtensibleFunction {
         this.incrementColorRange();
       }
       if (
-        // feature flag to be deprecated (will become standard behaviour)
         isFeatureEnabled(FeatureFlag.AvoidColorsCollision) &&
         this.isColorUsed(color)
       ) {
-        // fallback to least used color
         color = this.getNextAvailableColor(cleanedValue, color);
       }
     }
 
-    // Dashboard: a label may take a forced or synced color that matches another
-    // series in this chart that already consumed the same ordinal slot (e.g. shared
-    // dimension "Trains" locked to red while "Classic Cars" was assigned red first).
-    // Reassign other non-forced labels in this slice so the locked label keeps its color.
     if (
       isFeatureEnabled(FeatureFlag.AvoidColorsCollision) &&
       source === LabelsColorMapSource.Dashboard &&

--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
@@ -154,6 +154,37 @@ class CategoricalColorScale extends ExtensibleFunction {
       }
     }
 
+    // Dashboard: a label may take a forced or synced color that matches another
+    // series in this chart that already consumed the same ordinal slot (e.g. shared
+    // dimension "Trains" locked to red while "Classic Cars" was assigned red first).
+    // Reassign other non-forced labels in this slice so the locked label keeps its color.
+    if (
+      isFeatureEnabled(FeatureFlag.AvoidColorsCollision) &&
+      source === LabelsColorMapSource.Dashboard
+    ) {
+      const colliding = [...this.chartLabelsColorMap.entries()].filter(
+        ([labelKey, c]) => c === color && labelKey !== cleanedValue,
+      );
+      if (colliding.length > 0 && isFeatureEnabled(FeatureFlag.UseAnalogousColors)) {
+        this.incrementColorRange();
+      }
+      for (const [otherLabel] of colliding) {
+        if (Object.prototype.hasOwnProperty.call(this.forcedColors, otherLabel)) {
+          continue;
+        }
+        const newColor = this.getNextAvailableColor(otherLabel, color);
+        this.chartLabelsColorMap.set(otherLabel, newColor);
+        if (sliceId) {
+          this.labelsColorMapInstance.addSlice(
+            otherLabel,
+            newColor,
+            sliceId,
+            appliedColorScheme,
+          );
+        }
+      }
+    }
+
     // keep track of values in this slice
     this.chartLabelsColorMap.set(cleanedValue, color);
 

--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
@@ -94,11 +94,20 @@ class CategoricalColorScale extends ExtensibleFunction {
 
   /**
    * Increment the color range with analogous colors
+   *
+   * @param forceMinimumExpansion When true, expand at least once even if the
+   * ordinal domain is still shorter than the palette. Shared dashboard labels
+   * can resolve from the global map without entering the scale domain, so
+   * domain-based sizing alone would skip expansion while collision resolution
+   * still needs analogous colors.
    */
-  incrementColorRange() {
-    const multiple = Math.floor(
+  incrementColorRange(forceMinimumExpansion = false) {
+    const domainBasedMultiple = Math.floor(
       this.domain().length / this.originColors.length,
     );
+    const multiple = forceMinimumExpansion
+      ? Math.max(domainBasedMultiple, 1)
+      : domainBasedMultiple;
     // the domain has grown larger than the original range
     // increments the range with analogous colors
     if (multiple > this.multiple) {
@@ -164,7 +173,7 @@ class CategoricalColorScale extends ExtensibleFunction {
         colliding.length > 0 &&
         isFeatureEnabled(FeatureFlag.UseAnalogousColors)
       ) {
-        this.incrementColorRange();
+        this.incrementColorRange(true);
       }
       for (const [otherLabel] of colliding) {
         if (

--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
@@ -166,11 +166,16 @@ class CategoricalColorScale extends ExtensibleFunction {
       const colliding = [...this.chartLabelsColorMap.entries()].filter(
         ([labelKey, c]) => c === color && labelKey !== cleanedValue,
       );
-      if (colliding.length > 0 && isFeatureEnabled(FeatureFlag.UseAnalogousColors)) {
+      if (
+        colliding.length > 0 &&
+        isFeatureEnabled(FeatureFlag.UseAnalogousColors)
+      ) {
         this.incrementColorRange();
       }
       for (const [otherLabel] of colliding) {
-        if (Object.prototype.hasOwnProperty.call(this.forcedColors, otherLabel)) {
+        if (
+          Object.prototype.hasOwnProperty.call(this.forcedColors, otherLabel)
+        ) {
           continue;
         }
         const newColor = this.getNextAvailableColor(otherLabel, color);

--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
@@ -160,7 +160,8 @@ class CategoricalColorScale extends ExtensibleFunction {
     // Reassign other non-forced labels in this slice so the locked label keeps its color.
     if (
       isFeatureEnabled(FeatureFlag.AvoidColorsCollision) &&
-      source === LabelsColorMapSource.Dashboard
+      source === LabelsColorMapSource.Dashboard &&
+      (forcedColor || isExistingLabel)
     ) {
       const colliding = [...this.chartLabelsColorMap.entries()].filter(
         ([labelKey, c]) => c === color && labelKey !== cleanedValue,

--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
@@ -153,10 +153,13 @@ class CategoricalColorScale extends ExtensibleFunction {
       if (isFeatureEnabled(FeatureFlag.UseAnalogousColors)) {
         this.incrementColorRange();
       }
+
       if (
+        // feature flag to be deprecated (will become standard behaviour)
         isFeatureEnabled(FeatureFlag.AvoidColorsCollision) &&
         this.isColorUsed(color)
       ) {
+        // fallback to least used color
         color = this.getNextAvailableColor(cleanedValue, color);
       }
     }

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -211,7 +211,8 @@ describe('CategoricalColorScale', () => {
       chartBScale.getColor('Classic Cars', undefined, 'testScheme');
       chartBScale.getColor('Trains', undefined, 'testScheme');
 
-      const classicCarsColor = chartBScale.chartLabelsColorMap.get('Classic Cars');
+      const classicCarsColor =
+        chartBScale.chartLabelsColorMap.get('Classic Cars');
       const trainsColor = chartBScale.chartLabelsColorMap.get('Trains');
 
       expect(trainsColor).toBe('red');

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -225,6 +225,28 @@ describe('CategoricalColorScale', () => {
 
       expect(getNextAvailableColorSpy).not.toHaveBeenCalled();
     });
+    test('reassigns non-forced labels when a dashboard-synced label would duplicate their color', () => {
+      window.featureFlags = {
+        [FeatureFlag.AvoidColorsCollision]: true,
+      };
+
+      const dashScale = new CategoricalColorScale(['red', 'blue', 'green']);
+      const sliceId = 501;
+      const colorScheme = 'preset';
+
+      dashScale.labelsColorMapInstance.source = LabelsColorMapSource.Dashboard;
+      jest
+        .spyOn(dashScale.labelsColorMapInstance, 'getColorMap')
+        .mockReturnValue(new Map([['Trains', 'red']]));
+
+      // Ordinal assigns first range color (red) before the synced "Trains" label is applied.
+      dashScale.getColor('Classic Cars', sliceId, colorScheme);
+      dashScale.getColor('Trains', sliceId, colorScheme);
+
+      expect(dashScale.chartLabelsColorMap.get('Trains')).toBe('red');
+      expect(dashScale.chartLabelsColorMap.get('Classic Cars')).not.toBe('red');
+      expect(dashScale.chartLabelsColorMap.get('Classic Cars')).toBeDefined();
+    });
   });
 
   describe('.setColor(value, forcedColor)', () => {
@@ -476,6 +498,135 @@ describe('CategoricalColorScale', () => {
       expect(scale.getColorUsageCount('red')).toBe(1);
       expect(scale.getColorUsageCount('green')).toBe(1);
       expect(scale.getColorUsageCount('yellow')).toBe(1);
+    });
+  });
+
+  describe('dashboard color collision — shared dimension across charts (SC bug)', () => {
+    /**
+     * Reproduces: Dashboard color collision — shared dimension names cause
+     * duplicate colors across charts.
+     *
+     * Steps from the bug report:
+     *   Chart A: only "Trains" → palette assigns red (slot 0)
+     *            → dashboard singleton locks Trains = red
+     *   Chart B: "Classic Cars" + "Trains"
+     *            → ordinal assigns Classic Cars = red (slot 0, same as Trains)
+     *            → dashboard sync forces Trains = red
+     *            → BUG: both Classic Cars and Trains render as red
+     *
+     * The fix (AvoidColorsCollision flag) detects the collision when Trains
+     * locks to red and reassigns Classic Cars to a different color.
+     */
+
+    let labelsColorMap: ReturnType<
+      CategoricalColorScale['labelsColorMapInstance']['constructor']
+    >;
+
+    beforeEach(() => {
+      window.featureFlags = {
+        [FeatureFlag.AvoidColorsCollision]: true,
+      };
+      // Reset the shared dashboard singleton before each scenario
+      const sentinel = new CategoricalColorScale(['red', 'blue', 'green']);
+      labelsColorMap = sentinel.labelsColorMapInstance;
+      labelsColorMap.reset();
+      labelsColorMap.source = LabelsColorMapSource.Dashboard;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      labelsColorMap.reset();
+    });
+
+    test('reproduces the bug without the fix: Classic Cars and Trains would both be red', () => {
+      // Disable the fix so the raw collision is observable
+      window.featureFlags = {
+        [FeatureFlag.AvoidColorsCollision]: false,
+      };
+
+      const PALETTE = ['red', 'blue', 'green'];
+
+      // Chart A: Trains → red (ordinal slot 0), stored in dashboard singleton
+      const chartAScale = new CategoricalColorScale(PALETTE);
+      chartAScale.getColor('Trains', 101, 'testScheme');
+      expect(labelsColorMap.getColorMap().get('Trains')).toBe('red');
+
+      // Chart B: Classic Cars renders first → ordinal assigns red (slot 0)
+      // Then Trains renders → dashboard map returns red (locked from Chart A)
+      const chartBScale = new CategoricalColorScale(PALETTE);
+      chartBScale.getColor('Classic Cars', 102, 'testScheme');
+      chartBScale.getColor('Trains', 102, 'testScheme');
+
+      const classicCarsColor =
+        chartBScale.chartLabelsColorMap.get('Classic Cars');
+      const trainsColor = chartBScale.chartLabelsColorMap.get('Trains');
+
+      // Without the fix both are red — this is the bug
+      expect(trainsColor).toBe('red');
+      expect(classicCarsColor).toBe('red'); // collision!
+    });
+
+    test('fix: Classic Cars is reassigned when Trains locks red from the dashboard', () => {
+      const PALETTE = ['red', 'blue', 'green'];
+
+      // Chart A: Trains → red (ordinal slot 0), stored in dashboard singleton
+      const chartAScale = new CategoricalColorScale(PALETTE);
+      chartAScale.getColor('Trains', 101, 'testScheme');
+      expect(labelsColorMap.getColorMap().get('Trains')).toBe('red');
+
+      // Chart B: Classic Cars renders first → ordinal assigns red (slot 0)
+      // Then Trains renders → dashboard map returns red (locked from Chart A)
+      // Fix: collision detected, Classic Cars reassigned away from red
+      const chartBScale = new CategoricalColorScale(PALETTE);
+      chartBScale.getColor('Classic Cars', 102, 'testScheme');
+      chartBScale.getColor('Trains', 102, 'testScheme');
+
+      const classicCarsColor =
+        chartBScale.chartLabelsColorMap.get('Classic Cars');
+      const trainsColor = chartBScale.chartLabelsColorMap.get('Trains');
+
+      // Trains keeps its dashboard-locked color
+      expect(trainsColor).toBe('red');
+      // Classic Cars must be reassigned to something other than red
+      expect(classicCarsColor).toBeDefined();
+      expect(classicCarsColor).not.toBe('red');
+    });
+
+    test('fix: no series in Chart B share a color when palette has enough colors', () => {
+      const PALETTE = ['red', 'blue', 'green'];
+
+      // Chart A locks Trains = red
+      const chartAScale = new CategoricalColorScale(PALETTE);
+      chartAScale.getColor('Trains', 101, 'testScheme');
+
+      // Chart B has Classic Cars + Trains
+      const chartBScale = new CategoricalColorScale(PALETTE);
+      chartBScale.getColor('Classic Cars', 102, 'testScheme');
+      chartBScale.getColor('Trains', 102, 'testScheme');
+
+      const colors = Array.from(chartBScale.chartLabelsColorMap.values());
+      const uniqueColors = new Set(colors);
+
+      // Both series should have distinct colors
+      expect(uniqueColors.size).toBe(colors.length);
+    });
+
+    test('fix: forced colors (user-set in dashboard JSON) are never reassigned', () => {
+      const PALETTE = ['red', 'blue', 'green'];
+      // Simulate the user having set "Classic Cars" = red in dashboard metadata
+      const forcedColors = { 'Classic Cars': 'red' };
+
+      // Chart A locks Trains = red
+      const chartAScale = new CategoricalColorScale(PALETTE);
+      chartAScale.getColor('Trains', 101, 'testScheme');
+
+      // Chart B: Classic Cars is forced to red, Trains is dashboard-locked to red
+      const chartBScale = new CategoricalColorScale(PALETTE, forcedColors);
+      chartBScale.getColor('Classic Cars', 102, 'testScheme');
+      chartBScale.getColor('Trains', 102, 'testScheme');
+
+      // Classic Cars must keep its forced color even if it collides
+      expect(chartBScale.chartLabelsColorMap.get('Classic Cars')).toBe('red');
     });
   });
 

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -21,6 +21,7 @@ import { ScaleOrdinal } from 'd3-scale';
 import {
   CategoricalColorScale,
   FeatureFlag,
+  getLabelsColorMap,
   LabelsColorMapSource,
 } from '@superset-ui/core';
 
@@ -518,9 +519,7 @@ describe('CategoricalColorScale', () => {
      * locks to red and reassigns Classic Cars to a different color.
      */
 
-    let labelsColorMap: ReturnType<
-      CategoricalColorScale['labelsColorMapInstance']['constructor']
-    >;
+    let labelsColorMap: ReturnType<typeof getLabelsColorMap>;
 
     beforeEach(() => {
       window.featureFlags = {

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -600,7 +600,9 @@ describe('CategoricalColorScale', () => {
 
       expect(chartBScale.chartLabelsColorMap.get('Trains')).toBe('red');
       expect(chartBScale.chartLabelsColorMap.get('Classic Cars')).toBeDefined();
-      expect(chartBScale.chartLabelsColorMap.get('Classic Cars')).not.toBe('red');
+      expect(chartBScale.chartLabelsColorMap.get('Classic Cars')).not.toBe(
+        'red',
+      );
       expect(chartBScale.range()).toHaveLength(6);
       expect(
         addSliceSpy.mock.calls.some(

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -240,7 +240,6 @@ describe('CategoricalColorScale', () => {
         .spyOn(dashScale.labelsColorMapInstance, 'getColorMap')
         .mockReturnValue(new Map([['Trains', 'red']]));
 
-      // Ordinal assigns first range color (red) before the synced "Trains" label is applied.
       dashScale.getColor('Classic Cars', sliceId, colorScheme);
       dashScale.getColor('Trains', sliceId, colorScheme);
 
@@ -502,30 +501,13 @@ describe('CategoricalColorScale', () => {
     });
   });
 
-  describe('dashboard color collision — shared dimension across charts (SC bug)', () => {
-    /**
-     * Reproduces: Dashboard color collision — shared dimension names cause
-     * duplicate colors across charts.
-     *
-     * Steps from the bug report:
-     *   Chart A: only "Trains" → palette assigns red (slot 0)
-     *            → dashboard singleton locks Trains = red
-     *   Chart B: "Classic Cars" + "Trains"
-     *            → ordinal assigns Classic Cars = red (slot 0, same as Trains)
-     *            → dashboard sync forces Trains = red
-     *            → BUG: both Classic Cars and Trains render as red
-     *
-     * The fix (AvoidColorsCollision flag) detects the collision when Trains
-     * locks to red and reassigns Classic Cars to a different color.
-     */
-
+  describe('dashboard shared-dimension color collision', () => {
     let labelsColorMap: ReturnType<typeof getLabelsColorMap>;
 
     beforeEach(() => {
       window.featureFlags = {
         [FeatureFlag.AvoidColorsCollision]: true,
       };
-      // Reset the shared dashboard singleton before each scenario
       const sentinel = new CategoricalColorScale(['red', 'blue', 'green']);
       labelsColorMap = sentinel.labelsColorMapInstance;
       labelsColorMap.reset();
@@ -538,20 +520,16 @@ describe('CategoricalColorScale', () => {
     });
 
     test('reproduces the bug without the fix: Classic Cars and Trains would both be red', () => {
-      // Disable the fix so the raw collision is observable
       window.featureFlags = {
         [FeatureFlag.AvoidColorsCollision]: false,
       };
 
       const PALETTE = ['red', 'blue', 'green'];
 
-      // Chart A: Trains → red (ordinal slot 0), stored in dashboard singleton
       const chartAScale = new CategoricalColorScale(PALETTE);
       chartAScale.getColor('Trains', 101, 'testScheme');
       expect(labelsColorMap.getColorMap().get('Trains')).toBe('red');
 
-      // Chart B: Classic Cars renders first → ordinal assigns red (slot 0)
-      // Then Trains renders → dashboard map returns red (locked from Chart A)
       const chartBScale = new CategoricalColorScale(PALETTE);
       chartBScale.getColor('Classic Cars', 102, 'testScheme');
       chartBScale.getColor('Trains', 102, 'testScheme');
@@ -560,22 +538,17 @@ describe('CategoricalColorScale', () => {
         chartBScale.chartLabelsColorMap.get('Classic Cars');
       const trainsColor = chartBScale.chartLabelsColorMap.get('Trains');
 
-      // Without the fix both are red — this is the bug
       expect(trainsColor).toBe('red');
-      expect(classicCarsColor).toBe('red'); // collision!
+      expect(classicCarsColor).toBe('red');
     });
 
     test('fix: Classic Cars is reassigned when Trains locks red from the dashboard', () => {
       const PALETTE = ['red', 'blue', 'green'];
 
-      // Chart A: Trains → red (ordinal slot 0), stored in dashboard singleton
       const chartAScale = new CategoricalColorScale(PALETTE);
       chartAScale.getColor('Trains', 101, 'testScheme');
       expect(labelsColorMap.getColorMap().get('Trains')).toBe('red');
 
-      // Chart B: Classic Cars renders first → ordinal assigns red (slot 0)
-      // Then Trains renders → dashboard map returns red (locked from Chart A)
-      // Fix: collision detected, Classic Cars reassigned away from red
       const chartBScale = new CategoricalColorScale(PALETTE);
       chartBScale.getColor('Classic Cars', 102, 'testScheme');
       chartBScale.getColor('Trains', 102, 'testScheme');
@@ -584,9 +557,7 @@ describe('CategoricalColorScale', () => {
         chartBScale.chartLabelsColorMap.get('Classic Cars');
       const trainsColor = chartBScale.chartLabelsColorMap.get('Trains');
 
-      // Trains keeps its dashboard-locked color
       expect(trainsColor).toBe('red');
-      // Classic Cars must be reassigned to something other than red
       expect(classicCarsColor).toBeDefined();
       expect(classicCarsColor).not.toBe('red');
     });
@@ -594,11 +565,9 @@ describe('CategoricalColorScale', () => {
     test('fix: no series in Chart B share a color when palette has enough colors', () => {
       const PALETTE = ['red', 'blue', 'green'];
 
-      // Chart A locks Trains = red
       const chartAScale = new CategoricalColorScale(PALETTE);
       chartAScale.getColor('Trains', 101, 'testScheme');
 
-      // Chart B has Classic Cars + Trains
       const chartBScale = new CategoricalColorScale(PALETTE);
       chartBScale.getColor('Classic Cars', 102, 'testScheme');
       chartBScale.getColor('Trains', 102, 'testScheme');
@@ -606,25 +575,20 @@ describe('CategoricalColorScale', () => {
       const colors = Array.from(chartBScale.chartLabelsColorMap.values());
       const uniqueColors = new Set(colors);
 
-      // Both series should have distinct colors
       expect(uniqueColors.size).toBe(colors.length);
     });
 
     test('fix: forced colors (user-set in dashboard JSON) are never reassigned', () => {
       const PALETTE = ['red', 'blue', 'green'];
-      // Simulate the user having set "Classic Cars" = red in dashboard metadata
       const forcedColors = { 'Classic Cars': 'red' };
 
-      // Chart A locks Trains = red
       const chartAScale = new CategoricalColorScale(PALETTE);
       chartAScale.getColor('Trains', 101, 'testScheme');
 
-      // Chart B: Classic Cars is forced to red, Trains is dashboard-locked to red
       const chartBScale = new CategoricalColorScale(PALETTE, forcedColors);
       chartBScale.getColor('Classic Cars', 102, 'testScheme');
       chartBScale.getColor('Trains', 102, 'testScheme');
 
-      // Classic Cars must keep its forced color even if it collides
       expect(chartBScale.chartLabelsColorMap.get('Classic Cars')).toBe('red');
     });
   });

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -578,6 +578,37 @@ describe('CategoricalColorScale', () => {
       expect(uniqueColors.size).toBe(colors.length);
     });
 
+    test('fix: increments analogous color range for dashboard collisions when UseAnalogousColors is enabled', () => {
+      window.featureFlags = {
+        [FeatureFlag.AvoidColorsCollision]: true,
+        [FeatureFlag.UseAnalogousColors]: true,
+      };
+
+      const PALETTE = ['red', 'blue', 'green'];
+
+      const chartAScale = new CategoricalColorScale(PALETTE);
+      chartAScale.getColor('Trains', 101, 'testScheme');
+
+      const chartBScale = new CategoricalColorScale(PALETTE);
+      const addSliceSpy = jest.spyOn(
+        chartBScale.labelsColorMapInstance,
+        'addSlice',
+      );
+      chartBScale.getColor('Classic Cars', 102, 'testScheme');
+      chartBScale.getColor('Model T', 102, 'testScheme');
+      chartBScale.getColor('Trains', 102, 'testScheme');
+
+      expect(chartBScale.chartLabelsColorMap.get('Trains')).toBe('red');
+      expect(chartBScale.chartLabelsColorMap.get('Classic Cars')).toBeDefined();
+      expect(chartBScale.chartLabelsColorMap.get('Classic Cars')).not.toBe('red');
+      expect(chartBScale.range()).toHaveLength(6);
+      expect(
+        addSliceSpy.mock.calls.some(
+          ([label, color]) => label === 'Classic Cars' && color !== 'red',
+        ),
+      ).toBe(true);
+    });
+
     test('fix: forced colors (user-set in dashboard JSON) are never reassigned', () => {
       const PALETTE = ['red', 'blue', 'green'];
       const forcedColors = { 'Classic Cars': 'red' };

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -201,28 +201,41 @@ describe('CategoricalColorScale', () => {
       expect(returnedColor).toBe(expectedColor);
     });
     test('reassigns colliding colors when no sliceId is provided', () => {
+      window.featureFlags = {
+        [FeatureFlag.AvoidColorsCollision]: true,
+      };
       const PALETTE = ['red', 'blue', 'green'];
 
       const chartAScale = new CategoricalColorScale(PALETTE);
-      chartAScale.getColor('Trains', 101, 'testScheme');
+      const labelsColorMap = chartAScale.labelsColorMapInstance;
+      labelsColorMap.reset();
+      labelsColorMap.source = LabelsColorMapSource.Dashboard;
 
-      const chartBScale = new CategoricalColorScale(PALETTE);
-      // Call getColor without sliceId (or with undefined)
-      chartBScale.getColor('Classic Cars', undefined, 'testScheme');
-      chartBScale.getColor('Trains', undefined, 'testScheme');
+      try {
+        chartAScale.getColor('Trains', 101, 'testScheme');
 
-      const classicCarsColor =
-        chartBScale.chartLabelsColorMap.get('Classic Cars');
-      const trainsColor = chartBScale.chartLabelsColorMap.get('Trains');
+        const chartBScale = new CategoricalColorScale(PALETTE);
+        // Call getColor without sliceId (or with undefined)
+        chartBScale.getColor('Classic Cars', undefined, 'testScheme');
+        chartBScale.getColor('Trains', undefined, 'testScheme');
 
-      expect(trainsColor).toBe('red');
-      expect(classicCarsColor).toBeDefined();
-      expect(classicCarsColor).not.toBe('red');
+        const classicCarsColor =
+          chartBScale.chartLabelsColorMap.get('Classic Cars');
+        const trainsColor = chartBScale.chartLabelsColorMap.get('Trains');
+
+        expect(trainsColor).toBe('red');
+        expect(classicCarsColor).toBeDefined();
+        expect(classicCarsColor).not.toBe('red');
+      } finally {
+        labelsColorMap.reset();
+        labelsColorMap.source = LabelsColorMapSource.Dashboard;
+      }
     });
     test('conditionally calls getNextAvailableColor', () => {
       window.featureFlags = {
         [FeatureFlag.AvoidColorsCollision]: true,
       };
+      scale.labelsColorMapInstance.source = LabelsColorMapSource.Explore;
 
       scale.getColor('testValue1');
       scale.getColor('testValue2');

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -200,6 +200,24 @@ describe('CategoricalColorScale', () => {
       const returnedColor = scale.getColor(value, sliceId);
       expect(returnedColor).toBe(expectedColor);
     });
+    test('reassigns colliding colors when no sliceId is provided', () => {
+      const PALETTE = ['red', 'blue', 'green'];
+
+      const chartAScale = new CategoricalColorScale(PALETTE);
+      chartAScale.getColor('Trains', 101, 'testScheme');
+
+      const chartBScale = new CategoricalColorScale(PALETTE);
+      // Call getColor without sliceId (or with undefined)
+      chartBScale.getColor('Classic Cars', undefined, 'testScheme');
+      chartBScale.getColor('Trains', undefined, 'testScheme');
+
+      const classicCarsColor = chartBScale.chartLabelsColorMap.get('Classic Cars');
+      const trainsColor = chartBScale.chartLabelsColorMap.get('Trains');
+
+      expect(trainsColor).toBe('red');
+      expect(classicCarsColor).toBeDefined();
+      expect(classicCarsColor).not.toBe('red');
+    });
     test('conditionally calls getNextAvailableColor', () => {
       window.featureFlags = {
         [FeatureFlag.AvoidColorsCollision]: true,


### PR DESCRIPTION
### SUMMARY
Fixes a dashboard color collision where a label’s color is forced or synced from dashboard metadata (e.g. shared dimension “Trains”
  locked after another chart rendered first) while another series in the same chart had already taken that color from the ordinal
  palette. Both series could end up with the same color (bad for line/stacked charts).

  #### Root cause
  AvoidColorsCollision only adjusted colors for new labels coming from the scale. Forced / globally synced colors skipped that path
  (“forced color will always be used…”), so a later label could reuse the same swatch already assigned to a different series in this
  slice (e.g. Classic Cars gets the first palette color, then Trains is forced to that same color).


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="2166" height="780" alt="color-collision-before" src="https://github.com/user-attachments/assets/231061c1-519f-4df3-b537-0bc5da100167" />

#### AFTER
<img width="2166" height="647" alt="color-collision-after" src="https://github.com/user-attachments/assets/dbe5fe60-5812-4411-bc23-ddea00df267d" />

### TESTING INSTRUCTIONS
#### Create two line charts:
- Chart A: uses only the Trains dimension
- Chart B: uses both Classic Cars and Trains dimensions (red = Classic Cars, blue = Trains per its own palette assignment)
- Add Chart A to a dashboard first → the dashboard locks red to the Trains dimension in its metadata
- Add Chart B to the same dashboard
#### Result: 
Chart B now shows both Classic Cars and Trains in red, because the dashboard-level color lock for "Trains" = red overrides Chart B's own color assignment for that slot

#### Expected Behavior
- After applying consistent same-series-same-color logic across charts, the remaining series should use a "least picked" palette strategy to avoid collisions within any individual chart.
- Users can set colors in the dashboard json.
- Any unspecified colors should be assigned colors from the palette. We should avoid the same colors being on charts as much as possible and should also avoid the same colors touching each other on charts.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
