### PR TITLE
feat: add embedded dashboard E2E tests to Playwright CI

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -59,6 +59,15 @@ build-assets() {
   say "::endgroup::"
 }
 
+build-embedded-sdk() {
+  cd "$GITHUB_WORKSPACE/superset-embedded-sdk"
+
+  say "::group::Build embedded SDK bundle for E2E tests"
+  npm ci
+  npm run build
+  say "::endgroup::"
+}
+
 build-instrumented-assets() {
   cd "$GITHUB_WORKSPACE/superset-frontend"
 

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -237,7 +237,12 @@ playwright-run() {
   cd "$GITHUB_WORKSPACE"
   local flasklog="${HOME}/flask-playwright.log"
   local port=8081
-  PLAYWRIGHT_BASE_URL="http://localhost:${port}"
+  # Use 127.0.0.1 explicitly: `flask run` binds IPv4 only, and Node's DNS
+  # resolution for `localhost` can return `::1` first (IPv6), which then
+  # refuses against the IPv4 listener and surfaces as
+  # `connect ECONNREFUSED ::1:<port>` in API helpers driven from Node
+  # (e.g., the embedded test app's exposed token fetcher).
+  PLAYWRIGHT_BASE_URL="http://127.0.0.1:${port}"
   if [ -n "$APP_ROOT" ]; then
     export SUPERSET_APP_ROOT=$APP_ROOT
     PLAYWRIGHT_BASE_URL=${PLAYWRIGHT_BASE_URL}${APP_ROOT}/

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -169,6 +169,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       REDIS_PORT: 16379
       GITHUB_TOKEN: ${{ github.token }}
+      SUPERSET_FEATURE_EMBEDDED_SUPERSET: "true"
     services:
       postgres:
         image: postgres:17-alpine
@@ -239,6 +240,11 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
+      - name: Build embedded SDK
+        if: steps.check.outputs.python || steps.check.outputs.frontend
+        uses: ./.github/actions/cached-dependencies
+        with:
+          run: build-embedded-sdk
       - name: Install Playwright
         if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -169,7 +169,6 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       REDIS_PORT: 16379
       GITHUB_TOKEN: ${{ github.token }}
-      SUPERSET_FEATURE_EMBEDDED_SUPERSET: "true"
     services:
       postgres:
         image: postgres:17-alpine

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -43,6 +43,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       REDIS_PORT: 16379
       GITHUB_TOKEN: ${{ github.token }}
+      SUPERSET_FEATURE_EMBEDDED_SUPERSET: "true"
     services:
       postgres:
         image: postgres:17-alpine
@@ -113,6 +114,11 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
+      - name: Build embedded SDK
+        if: steps.check.outputs.python || steps.check.outputs.frontend
+        uses: ./.github/actions/cached-dependencies
+        with:
+          run: build-embedded-sdk
       - name: Install Playwright
         if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -43,8 +43,6 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       REDIS_PORT: 16379
       GITHUB_TOKEN: ${{ github.token }}
-      SUPERSET_FEATURE_EMBEDDED_SUPERSET: "true"
-      INCLUDE_EMBEDDED: "true"
     services:
       postgres:
         image: postgres:17-alpine
@@ -137,6 +135,14 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
+          # Scope embedded-only env vars to this step. Setting them at the job
+          # level enabled the EMBEDDED_SUPERSET feature flag inside Flask for
+          # the preceding "Required Tests" and "Experimental Tests" steps too,
+          # which loads extra handlers and destabilizes the werkzeug dev
+          # server under the 2-worker Playwright load. Required Tests should
+          # match master's Flask configuration.
+          SUPERSET_FEATURE_EMBEDDED_SUPERSET: "true"
+          INCLUDE_EMBEDDED: "true"
         with:
           run: playwright-run "${{ matrix.app_root }}" embedded
       - name: Set safe app root

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -44,6 +44,7 @@ jobs:
       REDIS_PORT: 16379
       GITHUB_TOKEN: ${{ github.token }}
       SUPERSET_FEATURE_EMBEDDED_SUPERSET: "true"
+      INCLUDE_EMBEDDED: "true"
     services:
       postgres:
         image: postgres:17-alpine
@@ -131,6 +132,13 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096"
         with:
           run: playwright-run "${{ matrix.app_root }}" experimental/
+      - name: Run Playwright (Embedded Tests)
+        if: steps.check.outputs.python || steps.check.outputs.frontend
+        uses: ./.github/actions/cached-dependencies
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+        with:
+          run: playwright-run "${{ matrix.app_root }}" embedded
       - name: Set safe app root
         if: failure()
         id: set-safe-app-root

--- a/docker/pythonpath_dev/superset_config_docker_light.py
+++ b/docker/pythonpath_dev/superset_config_docker_light.py
@@ -36,3 +36,31 @@ THUMBNAIL_CACHE_CONFIG = CACHE_CONFIG
 
 # Disable Celery entirely for lightweight mode
 CELERY_CONFIG = None  # type: ignore[assignment,misc]
+
+# Honor SUPERSET_FEATURE_<NAME> env vars on top of any flags inherited from
+# superset_config. Lets local dev/e2e enable features (e.g. EMBEDDED_SUPERSET)
+# without editing shipped config files.
+import os  # noqa: E402
+
+FEATURE_FLAGS = {
+    **FEATURE_FLAGS,  # noqa: F405
+    **{
+        name[len("SUPERSET_FEATURE_") :]: value.strip().lower() == "true"
+        for name, value in os.environ.items()
+        if name.startswith("SUPERSET_FEATURE_")
+    },
+}
+
+# Disable Talisman so /embedded/<uuid> doesn't return X-Frame-Options:SAMEORIGIN.
+# Without this, browsers refuse to render Superset inside an iframe from a
+# different origin (i.e. the embedded SDK use case). Production/CI configures
+# Talisman with explicit `frame-ancestors`; for the lightweight local stack we
+# just turn it off.
+TALISMAN_ENABLED = False
+
+# Guest tokens (used by the embedded SDK) inherit the "Public" role's perms.
+# Out of the box Public has zero perms, so embedded dashboards immediately fail
+# their first call (`/api/v1/me/roles/`) with 403. Mirror Public to Gamma —
+# the standard read-only viewer role — so the embedded flow can authenticate
+# and load dashboard data in local dev.
+PUBLIC_ROLE_LIKE = "Gamma"

--- a/docker/pythonpath_dev/superset_config_docker_light.py
+++ b/docker/pythonpath_dev/superset_config_docker_light.py
@@ -18,6 +18,8 @@
 # Configuration for docker-compose-light.yml - disables Redis and uses minimal services
 
 # Import all settings from the main config first
+import os
+
 from flask_caching.backends.filesystemcache import FileSystemCache
 
 from superset_config import *  # noqa: F403
@@ -39,9 +41,9 @@ CELERY_CONFIG = None  # type: ignore[assignment,misc]
 
 # Honor SUPERSET_FEATURE_<NAME> env vars on top of any flags inherited from
 # superset_config. Lets local dev/e2e enable features (e.g. EMBEDDED_SUPERSET)
-# without editing shipped config files.
-import os  # noqa: E402
-
+# without editing shipped config files. Only the literal string "true"
+# (case-insensitive) is treated as enabled — "1"/"yes"/"on" are not, matching
+# the strict-string convention used elsewhere in Superset's env parsing.
 FEATURE_FLAGS = {
     **FEATURE_FLAGS,  # noqa: F405
     **{

--- a/docker/pythonpath_dev/superset_config_docker_light.py
+++ b/docker/pythonpath_dev/superset_config_docker_light.py
@@ -53,16 +53,17 @@ FEATURE_FLAGS = {
     },
 }
 
-# Disable Talisman so /embedded/<uuid> doesn't return X-Frame-Options:SAMEORIGIN.
-# Without this, browsers refuse to render Superset inside an iframe from a
-# different origin (i.e. the embedded SDK use case). Production/CI configures
-# Talisman with explicit `frame-ancestors`; for the lightweight local stack we
-# just turn it off.
-TALISMAN_ENABLED = False
+if os.environ.get("SUPERSET_FEATURE_EMBEDDED_SUPERSET", "").strip().lower() == "true":
+    # Disable Talisman so /embedded/<uuid> doesn't return X-Frame-Options:SAMEORIGIN.
+    # Without this, browsers refuse to render Superset inside an iframe from a
+    # different origin (i.e. the embedded SDK use case). Production/CI configures
+    # Talisman with explicit `frame-ancestors`; for the lightweight local stack we
+    # just turn it off.
+    TALISMAN_ENABLED = False
 
-# Guest tokens (used by the embedded SDK) inherit the "Public" role's perms.
-# Out of the box Public has zero perms, so embedded dashboards immediately fail
-# their first call (`/api/v1/me/roles/`) with 403. Mirror Public to Gamma —
-# the standard read-only viewer role — so the embedded flow can authenticate
-# and load dashboard data in local dev.
-PUBLIC_ROLE_LIKE = "Gamma"
+    # Guest tokens (used by the embedded SDK) inherit the "Public" role's perms.
+    # Out of the box Public has zero perms, so embedded dashboards immediately fail
+    # their first call (`/api/v1/me/roles/`) with 403. Mirror Public to Gamma —
+    # the standard read-only viewer role — so the embedded flow can authenticate
+    # and load dashboard data in local dev.
+    PUBLIC_ROLE_LIKE = "Gamma"

--- a/superset-frontend/playwright.config.ts
+++ b/superset-frontend/playwright.config.ts
@@ -95,6 +95,7 @@ export default defineConfig({
       testIgnore: [
         '**/tests/auth/**/*.spec.ts',
         '**/tests/sqllab/**/*.spec.ts',
+        '**/tests/embedded/**/*.spec.ts',
         ...(process.env.INCLUDE_EXPERIMENTAL ? [] : ['**/experimental/**']),
       ],
       use: {
@@ -130,6 +131,18 @@ export default defineConfig({
         browserName: 'chromium',
         testIdAttribute: 'data-test',
         // No storageState = clean browser with no cached cookies
+      },
+    },
+    {
+      // Embedded dashboard tests - validates the full embedding flow:
+      // external app -> SDK -> iframe -> guest token -> dashboard render
+      name: 'chromium-embedded',
+      testMatch: '**/tests/embedded/**/*.spec.ts',
+      use: {
+        browserName: 'chromium',
+        testIdAttribute: 'data-test',
+        // Uses admin auth for API calls to configure embedding and get guest tokens
+        storageState: 'playwright/.auth/user.json',
       },
     },
   ],

--- a/superset-frontend/playwright.config.ts
+++ b/superset-frontend/playwright.config.ts
@@ -135,9 +135,13 @@ export default defineConfig({
     },
     {
       // Embedded dashboard tests - validates the full embedding flow:
-      // external app -> SDK -> iframe -> guest token -> dashboard render
+      // external app -> SDK -> iframe -> guest token -> dashboard render.
+      // Each spec file mutates per-dashboard embedding state (UUID,
+      // allowed_domains) on a single shared Superset, so files must not
+      // run in parallel even if more are added later.
       name: 'chromium-embedded',
       testMatch: '**/tests/embedded/**/*.spec.ts',
+      fullyParallel: false,
       use: {
         browserName: 'chromium',
         testIdAttribute: 'data-test',

--- a/superset-frontend/playwright.config.ts
+++ b/superset-frontend/playwright.config.ts
@@ -133,22 +133,26 @@ export default defineConfig({
         // No storageState = clean browser with no cached cookies
       },
     },
-    {
-      // Embedded dashboard tests - validates the full embedding flow:
-      // external app -> SDK -> iframe -> guest token -> dashboard render.
-      // Each spec file mutates per-dashboard embedding state (UUID,
-      // allowed_domains) on a single shared Superset, so files must not
-      // run in parallel even if more are added later.
-      name: 'chromium-embedded',
-      testMatch: '**/tests/embedded/**/*.spec.ts',
-      fullyParallel: false,
-      use: {
-        browserName: 'chromium',
-        testIdAttribute: 'data-test',
-        // Uses admin auth for API calls to configure embedding and get guest tokens
-        storageState: 'playwright/.auth/user.json',
-      },
-    },
+    ...(process.env.INCLUDE_EMBEDDED
+      ? [
+          {
+            // Embedded dashboard tests - validates the full embedding flow:
+            // external app -> SDK -> iframe -> guest token -> dashboard render.
+            // Each spec file mutates per-dashboard embedding state (UUID,
+            // allowed_domains) on a single shared Superset, so files must not
+            // run in parallel even if more are added later.
+            name: 'chromium-embedded',
+            testMatch: '**/tests/embedded/**/*.spec.ts',
+            fullyParallel: false,
+            use: {
+              browserName: 'chromium' as const,
+              testIdAttribute: 'data-test',
+              // Uses admin auth for API calls to configure embedding and get guest tokens
+              storageState: 'playwright/.auth/user.json',
+            },
+          },
+        ]
+      : []),
   ],
 
   // Web server setup - disabled in CI (Flask started separately in workflow)

--- a/superset-frontend/playwright.config.ts
+++ b/superset-frontend/playwright.config.ts
@@ -133,7 +133,10 @@ export default defineConfig({
         // No storageState = clean browser with no cached cookies
       },
     },
-    ...(process.env.INCLUDE_EMBEDDED
+    // Strict 'true' check: non-empty strings like 'false' or '0' would
+    // otherwise enable the embedded project, matching the env-parsing
+    // convention used in docker/pythonpath_dev/superset_config_docker_light.py.
+    ...(process.env.INCLUDE_EMBEDDED?.toLowerCase() === 'true'
       ? [
           {
             // Embedded dashboard tests - validates the full embedding flow:

--- a/superset-frontend/playwright/components/core/EditableTabs.ts
+++ b/superset-frontend/playwright/components/core/EditableTabs.ts
@@ -32,9 +32,25 @@ import { Tabs } from './Tabs';
 export class EditableTabs extends Tabs {
   /**
    * Clicks the add-tab button rendered by antd in editable-card mode.
+   *
+   * When the tab strip overflows, antd renders two `Add tab` buttons:
+   * one hidden inside `.ant-tabs-nav-list` (visibility: hidden) and one
+   * visible inside `.ant-tabs-nav-operations`. Scope the click to the
+   * visible operations container so we never match the hidden inline copy.
    */
   async addTab(): Promise<void> {
-    await this.element.getByRole('button', { name: 'Add tab' }).click();
+    const operationsButton = this.element
+      .locator('.ant-tabs-nav-operations')
+      .getByRole('button', { name: 'Add tab' });
+    if ((await operationsButton.count()) > 0) {
+      await operationsButton.click();
+      return;
+    }
+    // No overflow yet — the inline nav-list button is the only one rendered.
+    await this.element
+      .locator('.ant-tabs-nav-list')
+      .getByRole('button', { name: 'Add tab' })
+      .click();
   }
 
   /**

--- a/superset-frontend/playwright/components/modals/EditDatasetModal.ts
+++ b/superset-frontend/playwright/components/modals/EditDatasetModal.ts
@@ -32,6 +32,10 @@ export class EditDatasetModal extends Modal {
     UNLOCK_ICON: '[data-test="unlock"]',
   };
 
+  // FAST_DEBOUNCE in @superset-ui/core is 250 ms; pad slightly so the
+  // debounced onChange has reliably flushed before we click Save.
+  private static readonly TEXT_CONTROL_DEBOUNCE_FLUSH_MS = 350;
+
   private readonly tabs: Tabs;
   private readonly specificLocator: Locator;
 
@@ -94,6 +98,7 @@ export class EditDatasetModal extends Modal {
    */
   async fillName(name: string): Promise<void> {
     await this.nameInput.fill(name);
+    await this.waitForTextControlDebounce();
   }
 
   /**
@@ -188,5 +193,17 @@ export class EditDatasetModal extends Modal {
     await dateFormatInput.element.waitFor({ state: 'visible' });
     await dateFormatInput.clear();
     await dateFormatInput.fill(format);
+    await this.waitForTextControlDebounce();
+  }
+
+  /**
+   * TextControl debounces its onChange by FAST_DEBOUNCE (250 ms) before
+   * propagating the value to the parent form. Wait past that window so a
+   * subsequent Save click captures the new value rather than the stale state.
+   */
+  private async waitForTextControlDebounce(): Promise<void> {
+    await this.page.waitForTimeout(
+      EditDatasetModal.TEXT_CONTROL_DEBOUNCE_FLUSH_MS,
+    );
   }
 }

--- a/superset-frontend/playwright/embedded-app/index.html
+++ b/superset-frontend/playwright/embedded-app/index.html
@@ -1,0 +1,96 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Embedded Dashboard Test App</title>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; }
+    #superset-container { width: 100%; height: 100vh; }
+    #superset-container iframe { width: 100%; height: 100%; border: none; }
+    #error { color: red; padding: 20px; display: none; }
+    #status { padding: 10px; font-family: monospace; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <div id="status">Initializing embedded dashboard...</div>
+  <div id="error"></div>
+  <div id="superset-container" data-test="embedded-container"></div>
+
+  <script src="/sdk/index.js"></script>
+  <script>
+    (async function () {
+      const params = new URLSearchParams(window.location.search);
+      const uuid = params.get('uuid');
+      const supersetDomain = params.get('supersetDomain');
+
+      if (!uuid || !supersetDomain) {
+        document.getElementById('error').style.display = 'block';
+        document.getElementById('error').textContent =
+          'Missing required query params: uuid, supersetDomain';
+        return;
+      }
+
+      const statusEl = document.getElementById('status');
+
+      // fetchGuestToken is injected by Playwright via page.exposeFunction()
+      // Falls back to window.__guestToken for simple/static token injection
+      async function fetchGuestToken() {
+        if (typeof window.__fetchGuestToken === 'function') {
+          statusEl.textContent = 'Fetching guest token...';
+          const token = await window.__fetchGuestToken();
+          statusEl.textContent = 'Guest token received, loading dashboard...';
+          return token;
+        }
+        if (window.__guestToken) {
+          return window.__guestToken;
+        }
+        throw new Error('No guest token source available');
+      }
+
+      try {
+        // Parse optional UI config from query params
+        const uiConfig = {};
+        if (params.get('hideTitle') === 'true') uiConfig.hideTitle = true;
+        if (params.get('hideTab') === 'true') uiConfig.hideTab = true;
+        if (params.get('hideChartControls') === 'true') uiConfig.hideChartControls = true;
+
+        const dashboard = await supersetEmbeddedSdk.embedDashboard({
+          id: uuid,
+          supersetDomain: supersetDomain,
+          mountPoint: document.getElementById('superset-container'),
+          fetchGuestToken: fetchGuestToken,
+          dashboardUiConfig: Object.keys(uiConfig).length > 0 ? uiConfig : undefined,
+          debug: params.get('debug') === 'true',
+        });
+
+        statusEl.textContent = 'Dashboard embedded successfully';
+        // Expose dashboard API on window for Playwright assertions
+        window.__embeddedDashboard = dashboard;
+      } catch (err) {
+        document.getElementById('error').style.display = 'block';
+        document.getElementById('error').textContent = 'Embed failed: ' + err.message;
+        statusEl.textContent = 'Error';
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/superset-frontend/playwright/embedded-app/index.html
+++ b/superset-frontend/playwright/embedded-app/index.html
@@ -82,8 +82,11 @@ under the License.
         // Expose dashboard API on window for Playwright assertions
         window.__embeddedDashboard = dashboard;
       } catch (err) {
+        // Browser exceptions can be strings, DOMExceptions, or arbitrary
+        // thrown values; only Error instances reliably expose `.message`.
+        const message = err instanceof Error ? err.message : String(err);
         document.getElementById('error').style.display = 'block';
-        document.getElementById('error').textContent = 'Embed failed: ' + err.message;
+        document.getElementById('error').textContent = 'Embed failed: ' + message;
         statusEl.textContent = 'Error';
       }
     })();

--- a/superset-frontend/playwright/embedded-app/index.html
+++ b/superset-frontend/playwright/embedded-app/index.html
@@ -52,18 +52,14 @@ under the License.
       const statusEl = document.getElementById('status');
 
       // fetchGuestToken is injected by Playwright via page.exposeFunction()
-      // Falls back to window.__guestToken for simple/static token injection
       async function fetchGuestToken() {
-        if (typeof window.__fetchGuestToken === 'function') {
-          statusEl.textContent = 'Fetching guest token...';
-          const token = await window.__fetchGuestToken();
-          statusEl.textContent = 'Guest token received, loading dashboard...';
-          return token;
+        if (typeof window.__fetchGuestToken !== 'function') {
+          throw new Error('No guest token source available');
         }
-        if (window.__guestToken) {
-          return window.__guestToken;
-        }
-        throw new Error('No guest token source available');
+        statusEl.textContent = 'Fetching guest token...';
+        const token = await window.__fetchGuestToken();
+        statusEl.textContent = 'Guest token received, loading dashboard...';
+        return token;
       }
 
       try {

--- a/superset-frontend/playwright/helpers/api/dashboard.ts
+++ b/superset-frontend/playwright/helpers/api/dashboard.ts
@@ -132,26 +132,14 @@ export interface DashboardResult {
   published?: boolean;
 }
 
-/**
- * Get a dashboard by its title
- * @param page - Playwright page instance (provides authentication context)
- * @param title - The dashboard_title to search for
- * @returns Dashboard object if found, null if not found
- */
-export async function getDashboardByName(
+async function getDashboardByFilter(
   page: Page,
-  title: string,
+  col: 'dashboard_title' | 'slug',
+  value: string,
 ): Promise<DashboardResult | null> {
-  const filter = {
-    filters: [
-      {
-        col: 'dashboard_title',
-        opr: 'eq',
-        value: title,
-      },
-    ],
-  };
-  const queryParam = rison.encode(filter);
+  const queryParam = rison.encode({
+    filters: [{ col, opr: 'eq', value }],
+  });
   const response = await apiGet(
     page,
     `${ENDPOINTS.DASHBOARD}?q=${queryParam}`,
@@ -168,4 +156,30 @@ export async function getDashboardByName(
   }
 
   return null;
+}
+
+/**
+ * Get a dashboard by its title
+ * @param page - Playwright page instance (provides authentication context)
+ * @param title - The dashboard_title to search for
+ * @returns Dashboard object if found, null if not found
+ */
+export async function getDashboardByName(
+  page: Page,
+  title: string,
+): Promise<DashboardResult | null> {
+  return getDashboardByFilter(page, 'dashboard_title', title);
+}
+
+/**
+ * Get a dashboard by its slug
+ * @param page - Playwright page instance (provides authentication context)
+ * @param slug - The slug to search for
+ * @returns Dashboard object if found, null if not found
+ */
+export async function getDashboardBySlug(
+  page: Page,
+  slug: string,
+): Promise<DashboardResult | null> {
+  return getDashboardByFilter(page, 'slug', slug);
 }

--- a/superset-frontend/playwright/helpers/api/embedded.ts
+++ b/superset-frontend/playwright/helpers/api/embedded.ts
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Page } from '@playwright/test';
+import { apiPost, apiPut } from './requests';
+import { ENDPOINTS as DASHBOARD_ENDPOINTS } from './dashboard';
+
+export const ENDPOINTS = {
+  SECURITY_LOGIN: 'api/v1/security/login',
+  GUEST_TOKEN: 'api/v1/security/guest_token/',
+} as const;
+
+export interface EmbeddedConfig {
+  uuid: string;
+  allowed_domains: string[];
+  dashboard_id: number;
+}
+
+/**
+ * Enable embedding on a dashboard and return the embedded UUID.
+ * Uses PUT (upsert) to preserve UUID across repeated calls.
+ * @param page - Playwright page instance (provides authentication context)
+ * @param dashboardIdOrSlug - Numeric dashboard id or slug
+ * @param allowedDomains - Domains allowed to embed; empty array allows all
+ * @returns Embedded config with UUID, allowed_domains, and dashboard_id
+ */
+export async function apiEnableEmbedding(
+  page: Page,
+  dashboardIdOrSlug: number | string,
+  allowedDomains: string[] = [],
+): Promise<EmbeddedConfig> {
+  const response = await apiPut(
+    page,
+    `${DASHBOARD_ENDPOINTS.DASHBOARD}${dashboardIdOrSlug}/embedded`,
+    { allowed_domains: allowedDomains },
+  );
+  const body = await response.json();
+  return body.result as EmbeddedConfig;
+}
+
+/**
+ * Get a guest token for an embedded dashboard.
+ * Uses the admin login flow (login → access_token → guest_token).
+ * @param page - Playwright page instance (used for request context)
+ * @param dashboardId - Dashboard id to grant access to
+ * @param options - Optional login credentials and RLS rules
+ * @returns Signed guest token string
+ */
+export async function getGuestToken(
+  page: Page,
+  dashboardId: number | string,
+  options?: {
+    username?: string;
+    password?: string;
+    rls?: Array<{ dataset: number; clause: string }>;
+  },
+): Promise<string> {
+  const username = options?.username ?? 'admin';
+  const password = options?.password ?? 'general';
+  const rls = options?.rls ?? [];
+
+  // Step 1: Login to get access token
+  const loginResponse = await apiPost(
+    page,
+    ENDPOINTS.SECURITY_LOGIN,
+    {
+      username,
+      password,
+      provider: 'db',
+      refresh: true,
+    },
+    { allowMissingCsrf: true },
+  );
+  const loginBody = await loginResponse.json();
+  const accessToken = loginBody.access_token;
+
+  // Step 2: Fetch guest token using the access token.
+  // Uses raw page.request.post() (not apiPost) because the guest token endpoint
+  // requires a JWT Bearer token rather than session+CSRF auth.
+  const guestResponse = await page.request.post(ENDPOINTS.GUEST_TOKEN, {
+    data: {
+      user: {
+        username: 'embedded_test_user',
+        first_name: 'Embedded',
+        last_name: 'TestUser',
+      },
+      resources: [{ type: 'dashboard', id: String(dashboardId) }],
+      rls,
+    },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  const guestBody = await guestResponse.json();
+  return guestBody.token;
+}

--- a/superset-frontend/playwright/helpers/api/embedded.ts
+++ b/superset-frontend/playwright/helpers/api/embedded.ts
@@ -18,7 +18,7 @@
  */
 
 import { Page } from '@playwright/test';
-import { apiPost, apiPut } from './requests';
+import { apiPost, apiPut, getCsrfToken } from './requests';
 import { ENDPOINTS as DASHBOARD_ENDPOINTS } from './dashboard';
 
 export const ENDPOINTS = {
@@ -55,27 +55,21 @@ export async function apiEnableEmbedding(
 }
 
 /**
- * Get a guest token for an embedded dashboard.
- * Uses the admin login flow (login → access_token → guest_token).
- * @param page - Playwright page instance (used for request context)
- * @param dashboardId - Dashboard id to grant access to
- * @param options - Optional login credentials and RLS rules
- * @returns Signed guest token string
+ * Login as admin and return the JWT access token used by the guest_token
+ * endpoint. Cache the result at suite level (`beforeAll`) and pass it into
+ * `getGuestToken` to avoid a fresh login on every test.
+ *
+ * Defaults match `playwright/global-setup.ts` so credentials come from one
+ * source (env vars). Overrides via `options` win.
  */
-export async function getGuestToken(
+export async function getAccessToken(
   page: Page,
-  dashboardId: number | string,
-  options?: {
-    username?: string;
-    password?: string;
-    rls?: Array<{ dataset: number; clause: string }>;
-  },
+  options?: { username?: string; password?: string },
 ): Promise<string> {
-  const username = options?.username ?? 'admin';
-  const password = options?.password ?? 'general';
-  const rls = options?.rls ?? [];
-
-  // Step 1: Login to get access token
+  const username =
+    options?.username ?? process.env.PLAYWRIGHT_ADMIN_USERNAME ?? 'admin';
+  const password =
+    options?.password ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD ?? 'general';
   const loginResponse = await apiPost(
     page,
     ENDPOINTS.SECURITY_LOGIN,
@@ -88,11 +82,39 @@ export async function getGuestToken(
     { allowMissingCsrf: true },
   );
   const loginBody = await loginResponse.json();
-  const accessToken = loginBody.access_token;
+  return loginBody.access_token;
+}
 
-  // Step 2: Fetch guest token using the access token.
-  // Uses raw page.request.post() (not apiPost) because the guest token endpoint
-  // requires a JWT Bearer token rather than session+CSRF auth.
+/**
+ * Get a guest token for an embedded dashboard.
+ * If `accessToken` is provided, the login round-trip is skipped — preferred
+ * for tests that fetch many tokens from a single suite.
+ * @returns Signed guest token string
+ */
+export async function getGuestToken(
+  page: Page,
+  dashboardId: number | string,
+  options?: {
+    accessToken?: string;
+    username?: string;
+    password?: string;
+    rls?: Array<{ dataset: number; clause: string }>;
+  },
+): Promise<string> {
+  const accessToken =
+    options?.accessToken ??
+    (await getAccessToken(page, {
+      username: options?.username,
+      password: options?.password,
+    }));
+  const rls = options?.rls ?? [];
+
+  // The guest_token endpoint authenticates via JWT Bearer, but if the
+  // request also carries a session cookie (which page.request inherits from
+  // storageState), Flask-WTF still requires a matching X-CSRFToken. Send it
+  // unconditionally so this works whether the caller is authenticated via
+  // session, JWT, or both.
+  const { token: csrfToken } = await getCsrfToken(page);
   const guestResponse = await page.request.post(ENDPOINTS.GUEST_TOKEN, {
     data: {
       user: {
@@ -106,6 +128,7 @@ export async function getGuestToken(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
+      ...(csrfToken ? { 'X-CSRFToken': csrfToken } : {}),
     },
   });
   const guestBody = await guestResponse.json();

--- a/superset-frontend/playwright/helpers/api/embedded.ts
+++ b/superset-frontend/playwright/helpers/api/embedded.ts
@@ -18,7 +18,7 @@
  */
 
 import { Page } from '@playwright/test';
-import { apiPost, apiPut, getCsrfToken } from './requests';
+import { apiPost, apiPut } from './requests';
 import { ENDPOINTS as DASHBOARD_ENDPOINTS } from './dashboard';
 
 export const ENDPOINTS = {
@@ -109,15 +109,15 @@ export async function getGuestToken(
     }));
   const rls = options?.rls ?? [];
 
-  // The guest_token endpoint authenticates via JWT Bearer, but if the
-  // request also carries a session cookie (which page.request inherits from
-  // storageState), Flask-WTF still requires a matching X-CSRFToken. Send it
-  // unconditionally so this works whether the caller is authenticated via
-  // session, JWT, or both.
-  const { token: csrfToken } = await getCsrfToken(page);
-  const guestResponse = await page.request.post(ENDPOINTS.GUEST_TOKEN, {
-    failOnStatusCode: true,
-    data: {
+  // The guest_token endpoint authenticates via JWT Bearer, but `page.request`
+  // inherits the session cookie from storageState, so Flask-WTF still requires
+  // a matching X-CSRFToken (plus a same-origin Referer). Route through
+  // `apiPost` so CSRF + Referer headers are built consistently with every
+  // other mutation helper; only the Authorization header is added here.
+  const guestResponse = await apiPost(
+    page,
+    ENDPOINTS.GUEST_TOKEN,
+    {
       user: {
         username: 'embedded_test_user',
         first_name: 'Embedded',
@@ -126,12 +126,8 @@ export async function getGuestToken(
       resources: [{ type: 'dashboard', id: String(dashboardId) }],
       rls,
     },
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-      ...(csrfToken ? { 'X-CSRFToken': csrfToken } : {}),
-    },
-  });
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
   const guestBody = await guestResponse.json();
   return guestBody.token;
 }

--- a/superset-frontend/playwright/helpers/api/embedded.ts
+++ b/superset-frontend/playwright/helpers/api/embedded.ts
@@ -116,6 +116,7 @@ export async function getGuestToken(
   // session, JWT, or both.
   const { token: csrfToken } = await getCsrfToken(page);
   const guestResponse = await page.request.post(ENDPOINTS.GUEST_TOKEN, {
+    failOnStatusCode: true,
     data: {
       user: {
         username: 'embedded_test_user',

--- a/superset-frontend/playwright/helpers/api/embedded.ts
+++ b/superset-frontend/playwright/helpers/api/embedded.ts
@@ -29,7 +29,7 @@ export const ENDPOINTS = {
 export interface EmbeddedConfig {
   uuid: string;
   allowed_domains: string[];
-  dashboard_id: number;
+  dashboard_id: string;
 }
 
 /**

--- a/superset-frontend/playwright/helpers/api/requests.ts
+++ b/superset-frontend/playwright/helpers/api/requests.ts
@@ -39,7 +39,7 @@ function getBaseUrl(): string {
   return url.endsWith('/') ? url : `${url}/`;
 }
 
-interface CsrfResult {
+export interface CsrfResult {
   token: string;
   error?: string;
 }
@@ -49,7 +49,7 @@ interface CsrfResult {
  * Superset provides a CSRF token via api/v1/security/csrf_token/
  * The session cookie is automatically included by page.request
  */
-async function getCsrfToken(page: Page): Promise<CsrfResult> {
+export async function getCsrfToken(page: Page): Promise<CsrfResult> {
   try {
     const response = await page.request.get('api/v1/security/csrf_token/', {
       failOnStatusCode: false,

--- a/superset-frontend/playwright/helpers/api/requests.ts
+++ b/superset-frontend/playwright/helpers/api/requests.ts
@@ -27,6 +27,40 @@ export interface ApiRequestOptions {
 }
 
 /**
+ * Werkzeug (Flask's dev server, used in CI) periodically drops connections
+ * mid-request under concurrent load — surfacing as `socket hang up`,
+ * `ECONNRESET`, or `ERR_EMPTY_RESPONSE`. These are transport-layer
+ * failures, not application errors, so retrying is safe.
+ *
+ * The matcher is intentionally narrow: only retry on signatures that
+ * indicate the server never produced a response. Application errors
+ * (4xx/5xx, HTTP-level CSRF rejection) bubble up unchanged.
+ */
+const TRANSIENT_NETWORK_ERROR =
+  /socket hang up|ECONNRESET|ERR_EMPTY_RESPONSE|ECONNREFUSED|EPIPE/i;
+const TRANSIENT_RETRY_ATTEMPTS = 3;
+const TRANSIENT_RETRY_BACKOFF_MS = 250;
+
+async function withTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < TRANSIENT_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (!TRANSIENT_NETWORK_ERROR.test(String(error))) {
+        throw error;
+      }
+      // Linear backoff — werkzeug recovers in 100–300 ms after a drop.
+      await new Promise(resolve => {
+        setTimeout(resolve, TRANSIENT_RETRY_BACKOFF_MS * (attempt + 1));
+      });
+    }
+  }
+  throw lastError;
+}
+
+/**
  * Get base URL for Referer header
  * Reads from environment variable configured in playwright.config.ts
  * Preserves full base URL including path prefix (e.g., /app/prefix/)
@@ -51,9 +85,11 @@ export interface CsrfResult {
  */
 export async function getCsrfToken(page: Page): Promise<CsrfResult> {
   try {
-    const response = await page.request.get('api/v1/security/csrf_token/', {
-      failOnStatusCode: false,
-    });
+    const response = await withTransientRetry(() =>
+      page.request.get('api/v1/security/csrf_token/', {
+        failOnStatusCode: false,
+      }),
+    );
 
     if (!response.ok()) {
       return {
@@ -107,11 +143,13 @@ export async function apiGet(
   url: string,
   options?: ApiRequestOptions,
 ): Promise<APIResponse> {
-  return page.request.get(url, {
-    headers: options?.headers,
-    params: options?.params,
-    failOnStatusCode: options?.failOnStatusCode ?? true,
-  });
+  return withTransientRetry(() =>
+    page.request.get(url, {
+      headers: options?.headers,
+      params: options?.params,
+      failOnStatusCode: options?.failOnStatusCode ?? true,
+    }),
+  );
 }
 
 /**
@@ -126,12 +164,14 @@ export async function apiPost(
 ): Promise<APIResponse> {
   const headers = await buildHeaders(page, options);
 
-  return page.request.post(url, {
-    data,
-    headers,
-    params: options?.params,
-    failOnStatusCode: options?.failOnStatusCode ?? true,
-  });
+  return withTransientRetry(() =>
+    page.request.post(url, {
+      data,
+      headers,
+      params: options?.params,
+      failOnStatusCode: options?.failOnStatusCode ?? true,
+    }),
+  );
 }
 
 /**
@@ -146,12 +186,14 @@ export async function apiPut(
 ): Promise<APIResponse> {
   const headers = await buildHeaders(page, options);
 
-  return page.request.put(url, {
-    data,
-    headers,
-    params: options?.params,
-    failOnStatusCode: options?.failOnStatusCode ?? true,
-  });
+  return withTransientRetry(() =>
+    page.request.put(url, {
+      data,
+      headers,
+      params: options?.params,
+      failOnStatusCode: options?.failOnStatusCode ?? true,
+    }),
+  );
 }
 
 /**
@@ -166,12 +208,14 @@ export async function apiPatch(
 ): Promise<APIResponse> {
   const headers = await buildHeaders(page, options);
 
-  return page.request.patch(url, {
-    data,
-    headers,
-    params: options?.params,
-    failOnStatusCode: options?.failOnStatusCode ?? true,
-  });
+  return withTransientRetry(() =>
+    page.request.patch(url, {
+      data,
+      headers,
+      params: options?.params,
+      failOnStatusCode: options?.failOnStatusCode ?? true,
+    }),
+  );
 }
 
 /**
@@ -185,9 +229,11 @@ export async function apiDelete(
 ): Promise<APIResponse> {
   const headers = await buildHeaders(page, options);
 
-  return page.request.delete(url, {
-    headers,
-    params: options?.params,
-    failOnStatusCode: options?.failOnStatusCode ?? true,
-  });
+  return withTransientRetry(() =>
+    page.request.delete(url, {
+      headers,
+      params: options?.params,
+      failOnStatusCode: options?.failOnStatusCode ?? true,
+    }),
+  );
 }

--- a/superset-frontend/playwright/helpers/navigation.ts
+++ b/superset-frontend/playwright/helpers/navigation.ts
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Page, Response } from '@playwright/test';
+
+/**
+ * Werkzeug (Flask's dev server, used in CI) periodically drops connections
+ * during page navigation under concurrent load — surfacing as
+ * `ERR_EMPTY_RESPONSE`, `ERR_CONNECTION_RESET`, or a socket hang up. These
+ * are transport-layer failures, not application errors, so retrying the
+ * navigation is safe: the next request hits a fresh werkzeug worker thread.
+ *
+ * Application errors (4xx/5xx, JS exceptions during load) bubble up
+ * unchanged — the matcher is narrow on purpose.
+ */
+const TRANSIENT_NAV_ERROR =
+  /ERR_EMPTY_RESPONSE|ERR_CONNECTION_RESET|ERR_CONNECTION_CLOSED|socket hang up|ECONNRESET/i;
+const NAV_RETRY_ATTEMPTS = 3;
+const NAV_RETRY_BACKOFF_MS = 400;
+
+export async function gotoWithRetry(
+  page: Page,
+  url: string,
+  options?: Parameters<Page['goto']>[1],
+): Promise<Response | null> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < NAV_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      return await page.goto(url, options);
+    } catch (error) {
+      lastError = error;
+      if (!TRANSIENT_NAV_ERROR.test(String(error))) {
+        throw error;
+      }
+      await new Promise(resolve => {
+        setTimeout(resolve, NAV_RETRY_BACKOFF_MS * (attempt + 1));
+      });
+    }
+  }
+  throw lastError;
+}

--- a/superset-frontend/playwright/pages/ChartCreationPage.ts
+++ b/superset-frontend/playwright/pages/ChartCreationPage.ts
@@ -19,6 +19,7 @@
 
 import { expect, Locator, Page } from '@playwright/test';
 import { Button, Select } from '../components/core';
+import { gotoWithRetry } from '../helpers/navigation';
 
 /**
  * Chart Creation Page object for the "Create a new chart" wizard.
@@ -74,7 +75,7 @@ export class ChartCreationPage {
    * Navigate to the chart creation page
    */
   async goto(): Promise<void> {
-    await this.page.goto('chart/add');
+    await gotoWithRetry(this.page, 'chart/add');
   }
 
   /**

--- a/superset-frontend/playwright/pages/ChartListPage.ts
+++ b/superset-frontend/playwright/pages/ChartListPage.ts
@@ -20,6 +20,7 @@
 import { Page, Locator } from '@playwright/test';
 import { Table } from '../components/core';
 import { BulkSelect } from '../components/ListView';
+import { gotoWithRetry } from '../helpers/navigation';
 import { URL } from '../utils/urls';
 
 /**
@@ -52,14 +53,14 @@ export class ChartListPage {
    * (ListviewsDefaultCardView feature flag may enable card view).
    */
   async goto(): Promise<void> {
-    await this.page.goto(`${URL.CHART_LIST}?viewMode=table`);
+    await gotoWithRetry(this.page, `${URL.CHART_LIST}?viewMode=table`);
   }
 
   /**
    * Navigate to the chart list page in card view.
    */
   async gotoCardView(): Promise<void> {
-    await this.page.goto(`${URL.CHART_LIST}?viewMode=card`);
+    await gotoWithRetry(this.page, `${URL.CHART_LIST}?viewMode=card`);
   }
 
   /**

--- a/superset-frontend/playwright/pages/CreateDatasetPage.ts
+++ b/superset-frontend/playwright/pages/CreateDatasetPage.ts
@@ -19,6 +19,7 @@
 
 import { Page } from '@playwright/test';
 import { Button, Select } from '../components/core';
+import { gotoWithRetry } from '../helpers/navigation';
 
 /**
  * Create Dataset Page object for the dataset creation wizard.
@@ -75,7 +76,7 @@ export class CreateDatasetPage {
    * Navigate to the create dataset page
    */
   async goto(): Promise<void> {
-    await this.page.goto('dataset/add/');
+    await gotoWithRetry(this.page, 'dataset/add/');
   }
 
   /**

--- a/superset-frontend/playwright/pages/DashboardListPage.ts
+++ b/superset-frontend/playwright/pages/DashboardListPage.ts
@@ -20,6 +20,7 @@
 import { Page, Locator } from '@playwright/test';
 import { Button, Table } from '../components/core';
 import { BulkSelect } from '../components/ListView';
+import { gotoWithRetry } from '../helpers/navigation';
 import { URL } from '../utils/urls';
 
 /**
@@ -52,7 +53,7 @@ export class DashboardListPage {
    * (ListviewsDefaultCardView feature flag may enable card view).
    */
   async goto(): Promise<void> {
-    await this.page.goto(`${URL.DASHBOARD_LIST}?viewMode=table`);
+    await gotoWithRetry(this.page, `${URL.DASHBOARD_LIST}?viewMode=table`);
   }
 
   /**

--- a/superset-frontend/playwright/pages/DashboardPage.ts
+++ b/superset-frontend/playwright/pages/DashboardPage.ts
@@ -19,6 +19,7 @@
 
 import { Page, Download } from '@playwright/test';
 import { Menu } from '../components/core';
+import { gotoWithRetry } from '../helpers/navigation';
 import { TIMEOUT } from '../utils/constants';
 
 /**
@@ -43,7 +44,7 @@ export class DashboardPage {
    * @param slug - The dashboard slug (e.g., 'world_health')
    */
   async gotoBySlug(slug: string): Promise<void> {
-    await this.page.goto(`superset/dashboard/${slug}/`);
+    await gotoWithRetry(this.page, `superset/dashboard/${slug}/`);
   }
 
   /**
@@ -51,7 +52,7 @@ export class DashboardPage {
    * @param id - The dashboard ID
    */
   async gotoById(id: number): Promise<void> {
-    await this.page.goto(`superset/dashboard/${id}/`);
+    await gotoWithRetry(this.page, `superset/dashboard/${id}/`);
   }
 
   /**

--- a/superset-frontend/playwright/pages/DatasetListPage.ts
+++ b/superset-frontend/playwright/pages/DatasetListPage.ts
@@ -20,6 +20,7 @@
 import { Page, Locator } from '@playwright/test';
 import { Button, Table } from '../components/core';
 import { BulkSelect } from '../components/ListView';
+import { gotoWithRetry } from '../helpers/navigation';
 import { URL } from '../utils/urls';
 
 /**
@@ -54,7 +55,7 @@ export class DatasetListPage {
    * Navigate to the dataset list page
    */
   async goto(): Promise<void> {
-    await this.page.goto(URL.DATASET_LIST);
+    await gotoWithRetry(this.page, URL.DATASET_LIST);
   }
 
   /**

--- a/superset-frontend/playwright/pages/EmbeddedPage.ts
+++ b/superset-frontend/playwright/pages/EmbeddedPage.ts
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Page, FrameLocator } from '@playwright/test';
+import { EMBEDDED } from '../utils/constants';
+
+/**
+ * Page object for the embedded dashboard test app.
+ *
+ * The test app runs on a separate origin (localhost:9000) and uses the
+ * @superset-ui/embedded-sdk to render a Superset dashboard in an iframe.
+ * Playwright's page.exposeFunction() bridges the guest token from Node.js
+ * into the browser page.
+ */
+export class EmbeddedPage {
+  private readonly page: Page;
+
+  private static readonly SELECTORS = {
+    CONTAINER: '[data-test="embedded-container"]',
+    IFRAME: 'iframe[title="Embedded Dashboard"]',
+    STATUS: '#status',
+    ERROR: '#error',
+  } as const;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /**
+   * Set up the guest token bridge before navigating.
+   * Must be called BEFORE goto() since embedDashboard() calls fetchGuestToken
+   * immediately on page load.
+   */
+  async exposeTokenFetcher(tokenFn: () => Promise<string>): Promise<void> {
+    await this.page.exposeFunction('__fetchGuestToken', tokenFn);
+  }
+
+  /**
+   * Navigate to the embedded test app with the given parameters.
+   */
+  async goto(params: {
+    uuid: string;
+    supersetDomain: string;
+    hideTitle?: boolean;
+    hideTab?: boolean;
+    hideChartControls?: boolean;
+    debug?: boolean;
+  }): Promise<void> {
+    const searchParams = new URLSearchParams({
+      uuid: params.uuid,
+      supersetDomain: params.supersetDomain,
+    });
+    if (params.hideTitle) searchParams.set('hideTitle', 'true');
+    if (params.hideTab) searchParams.set('hideTab', 'true');
+    if (params.hideChartControls) searchParams.set('hideChartControls', 'true');
+    if (params.debug) searchParams.set('debug', 'true');
+
+    await this.page.goto(`${EMBEDDED.APP_URL}/?${searchParams.toString()}`);
+  }
+
+  /**
+   * FrameLocator for the embedded dashboard iframe.
+   */
+  get iframe(): FrameLocator {
+    return this.page.frameLocator(EmbeddedPage.SELECTORS.IFRAME);
+  }
+
+  /**
+   * Wait for the iframe to appear in the DOM.
+   */
+  async waitForIframe(options?: { timeout?: number }): Promise<void> {
+    await this.page.locator(EmbeddedPage.SELECTORS.IFRAME).waitFor({
+      state: 'attached',
+      timeout: options?.timeout ?? EMBEDDED.IFRAME_LOAD,
+    });
+  }
+
+  /**
+   * Wait for dashboard content to render inside the iframe.
+   * Looks for the grid-container which indicates charts are loading/loaded.
+   */
+  async waitForDashboardContent(options?: { timeout?: number }): Promise<void> {
+    const frame = this.iframe;
+    await frame
+      .locator('.grid-container, [data-test="grid-container"]')
+      .first()
+      .waitFor({
+        state: 'visible',
+        timeout: options?.timeout ?? EMBEDDED.DASHBOARD_RENDER,
+      });
+  }
+
+  /**
+   * Get the status text from the test app.
+   */
+  async getStatus(): Promise<string> {
+    return (
+      (await this.page.locator(EmbeddedPage.SELECTORS.STATUS).textContent()) ??
+      ''
+    );
+  }
+
+  /**
+   * Get the error text, if any.
+   */
+  async getError(): Promise<string> {
+    const errorEl = this.page.locator(EmbeddedPage.SELECTORS.ERROR);
+    const display = await errorEl.evaluate(el => getComputedStyle(el).display);
+    if (display === 'none') return '';
+    return (await errorEl.textContent()) ?? '';
+  }
+
+  /**
+   * Check if the dashboard title is visible inside the iframe.
+   */
+  async isTitleVisible(): Promise<boolean> {
+    const frame = this.iframe;
+    return frame
+      .locator(
+        '[data-test="dashboard-header-container"] [data-test="editable-title-input"]',
+      )
+      .isVisible();
+  }
+}

--- a/superset-frontend/playwright/pages/EmbeddedPage.ts
+++ b/superset-frontend/playwright/pages/EmbeddedPage.ts
@@ -116,18 +116,27 @@ export class EmbeddedPage {
   }
 
   /**
-   * Wait for at least one chart to finish rendering — proven by the chart
-   * container holding a real viz element (svg, canvas, or table) rather than
-   * just a loading spinner.
+   * Matches a chart cell that has finished loading: it contains a real viz
+   * element (svg, canvas, table) AND no longer hosts the `Loading` spinner
+   * (`data-test="loading-indicator"`). Excluding the spinner matters —
+   * the spinner itself renders an SVG, so a `:has(svg)`-only check can match
+   * a still-loading chart for the wrong reason.
+   */
+  static readonly RENDERED_CHART_SELECTOR =
+    '[data-test="chart-container"]:has(svg, canvas, table):not(:has([data-test="loading-indicator"]))';
+
+  /**
+   * Wait for at least one chart to finish rendering — viz drawn AND no
+   * loading spinner in that cell.
    */
   async waitForChartRendered(options?: { timeout?: number }): Promise<void> {
-    const timeout = options?.timeout ?? EMBEDDED.CHART_RENDER;
     await this.iframe
-      .locator(
-        '[data-test="chart-container"]:has(svg, canvas, table, [class*="big-number"])',
-      )
+      .locator(EmbeddedPage.RENDERED_CHART_SELECTOR)
       .first()
-      .waitFor({ state: 'visible', timeout });
+      .waitFor({
+        state: 'visible',
+        timeout: options?.timeout ?? EMBEDDED.CHART_RENDER,
+      });
   }
 
   /**

--- a/superset-frontend/playwright/pages/EmbeddedPage.ts
+++ b/superset-frontend/playwright/pages/EmbeddedPage.ts
@@ -17,16 +17,16 @@
  * under the License.
  */
 
-import { Page, FrameLocator } from '@playwright/test';
+import { Page, FrameLocator, Locator, expect } from '@playwright/test';
 import { EMBEDDED } from '../utils/constants';
 
 /**
  * Page object for the embedded dashboard test app.
  *
- * The test app runs on a separate origin (localhost:9000) and uses the
- * @superset-ui/embedded-sdk to render a Superset dashboard in an iframe.
- * Playwright's page.exposeFunction() bridges the guest token from Node.js
- * into the browser page.
+ * The test app runs on a separate origin (its origin is assigned per-suite
+ * via an OS-allocated port) and uses the @superset-ui/embedded-sdk to render
+ * a Superset dashboard in an iframe. Playwright's page.exposeFunction()
+ * bridges the guest token from Node.js into the browser page.
  */
 export class EmbeddedPage {
   private readonly page: Page;
@@ -53,8 +53,11 @@ export class EmbeddedPage {
 
   /**
    * Navigate to the embedded test app with the given parameters.
+   * `appUrl` is the origin of the static test app (assigned dynamically by
+   * the spec's beforeAll fixture so workers don't collide on a fixed port).
    */
   async goto(params: {
+    appUrl: string;
     uuid: string;
     supersetDomain: string;
     hideTitle?: boolean;
@@ -71,7 +74,7 @@ export class EmbeddedPage {
     if (params.hideChartControls) searchParams.set('hideChartControls', 'true');
     if (params.debug) searchParams.set('debug', 'true');
 
-    await this.page.goto(`${EMBEDDED.APP_URL}/?${searchParams.toString()}`);
+    await this.page.goto(`${params.appUrl}/?${searchParams.toString()}`);
   }
 
   /**
@@ -82,11 +85,17 @@ export class EmbeddedPage {
   }
 
   /**
-   * Wait for the iframe to appear in the DOM.
+   * Wait for the iframe to appear in the DOM AND have its src set.
+   * The SDK appends the iframe element before assigning src, so a bare
+   * `state: 'attached'` wait races the src read.
    */
   async waitForIframe(options?: { timeout?: number }): Promise<void> {
-    await this.page.locator(EmbeddedPage.SELECTORS.IFRAME).waitFor({
+    const locator = this.page.locator(EmbeddedPage.SELECTORS.IFRAME);
+    await locator.waitFor({
       state: 'attached',
+      timeout: options?.timeout ?? EMBEDDED.IFRAME_LOAD,
+    });
+    await expect(locator).toHaveAttribute('src', /.+/, {
       timeout: options?.timeout ?? EMBEDDED.IFRAME_LOAD,
     });
   }
@@ -107,6 +116,32 @@ export class EmbeddedPage {
   }
 
   /**
+   * Wait for at least one chart to finish rendering — proven by the chart
+   * container holding a real viz element (svg, canvas, or table) rather than
+   * just a loading spinner.
+   */
+  async waitForChartRendered(options?: { timeout?: number }): Promise<void> {
+    const timeout = options?.timeout ?? EMBEDDED.CHART_RENDER;
+    await this.iframe
+      .locator(
+        '[data-test="chart-container"]:has(svg, canvas, table, [class*="big-number"])',
+      )
+      .first()
+      .waitFor({ state: 'visible', timeout });
+  }
+
+  /**
+   * Locator for the dashboard title input inside the iframe.
+   * Returned as a `Locator` so callers can use `expect(...).toBeVisible()` /
+   * `.toBeHidden()` with auto-retry instead of one-shot `.isVisible()`.
+   */
+  get titleLocator(): Locator {
+    return this.iframe.locator(
+      '[data-test="dashboard-header-container"] [data-test="editable-title-input"]',
+    );
+  }
+
+  /**
    * Get the status text from the test app.
    */
   async getStatus(): Promise<string> {
@@ -124,17 +159,5 @@ export class EmbeddedPage {
     const display = await errorEl.evaluate(el => getComputedStyle(el).display);
     if (display === 'none') return '';
     return (await errorEl.textContent()) ?? '';
-  }
-
-  /**
-   * Check if the dashboard title is visible inside the iframe.
-   */
-  async isTitleVisible(): Promise<boolean> {
-    const frame = this.iframe;
-    return frame
-      .locator(
-        '[data-test="dashboard-header-container"] [data-test="editable-title-input"]',
-      )
-      .isVisible();
   }
 }

--- a/superset-frontend/playwright/pages/SqlLabPage.ts
+++ b/superset-frontend/playwright/pages/SqlLabPage.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Page, Locator, Response } from '@playwright/test';
+import { Page, Locator, Response, expect } from '@playwright/test';
 import { AceEditor } from '../components/core/AceEditor';
 import { AgGrid } from '../components/core/AgGrid';
 import { Button } from '../components/core/Button';
@@ -25,6 +25,7 @@ import { EditableTabs } from '../components/core/EditableTabs';
 import { Popover } from '../components/core/Popover';
 import { Select } from '../components/core/Select';
 import { waitForPost } from '../helpers/api/intercepts';
+import { gotoWithRetry } from '../helpers/navigation';
 import { URL } from '../utils/urls';
 import { TIMEOUT } from '../utils/constants';
 
@@ -62,12 +63,17 @@ export class SqlLabPage {
   // ── Navigation ──
 
   async goto(): Promise<void> {
-    await this.page.goto(URL.SQLLAB, { waitUntil: 'domcontentloaded' });
+    await gotoWithRetry(this.page, URL.SQLLAB, {
+      waitUntil: 'domcontentloaded',
+    });
   }
 
   async waitForPageLoad(options?: { timeout?: number }): Promise<void> {
-    // SQL Lab with dev server can be slow on first load (webpack HMR + React hydration)
-    const timeout = options?.timeout ?? TIMEOUT.QUERY_EXECUTION;
+    // SQL Lab is the heaviest bundle in Superset — the editor tabs container
+    // doesn't render until the lazy chunk and async tab state (tabstateview)
+    // both resolve. On cold-cache CI workers under werkzeug load this can
+    // exceed 15 s, so use SLOW_TEST (60 s) rather than QUERY_EXECUTION here.
+    const timeout = options?.timeout ?? TIMEOUT.SLOW_TEST;
     await this.editorTabs.element.waitFor({ state: 'visible', timeout });
   }
 
@@ -310,15 +316,28 @@ export class SqlLabPage {
    */
   async executeQuery(sql: string): Promise<Response> {
     await this.setQuery(sql);
+    // Run Query is disabled until BOTH sql is set (just done) AND a
+    // database is selected. On fresh CI users the default database may
+    // not be populated when ensureEditorReady() returns, so block here
+    // until the button is actually clickable before kicking off the
+    // response/loading watchers — otherwise their 15 s timers run out
+    // before the click can even fire. Use SLOW_TEST: under werkzeug
+    // load default-db bootstrap can take >15 s.
+    await expect(this.runQueryButton.element).toBeEnabled({
+      timeout: TIMEOUT.SLOW_TEST,
+    });
+    // Use SLOW_TEST for /sqllab/execute/ — under werkzeug stress the
+    // round-trip can exceed 15 s even for trivial queries because the
+    // dev server time-shares a single Python thread across all workers.
     const responsePromise = waitForPost(this.page, 'api/v1/sqllab/execute/', {
-      timeout: TIMEOUT.QUERY_EXECUTION,
+      timeout: TIMEOUT.SLOW_TEST,
     });
     // Start observing the loading indicator BEFORE clicking Run so we
     // catch it even for fast queries. QueryStatusBar (.ant-steps) appears
     // when SQL Lab enters the running state and unmounts the results grid.
     const loadingStarted = this.resultsPane
       .locator('.ant-steps')
-      .waitFor({ state: 'visible', timeout: TIMEOUT.QUERY_EXECUTION });
+      .waitFor({ state: 'visible', timeout: TIMEOUT.SLOW_TEST });
     await this.runQueryButton.click();
     const [, response] = await Promise.all([loadingStarted, responsePromise]);
     return response;
@@ -335,7 +354,11 @@ export class SqlLabPage {
     expectHeader: string,
     options?: { timeout?: number },
   ): Promise<void> {
-    const timeout = options?.timeout ?? TIMEOUT.QUERY_EXECUTION;
+    // AG Grid is heavy and lazy-rendered. Under werkzeug stress the FE
+    // sometimes takes >15 s to hydrate results after the query returns.
+    // Default to SLOW_TEST so a slow grid mount doesn't masquerade as a
+    // query failure (the response status was already asserted upstream).
+    const timeout = options?.timeout ?? TIMEOUT.SLOW_TEST;
     // Wait for QueryStatusBar to disappear — proves the loading → ready
     // transition completed. If already hidden (fast query finished before
     // this call), resolves immediately since executeQuery() already observed

--- a/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
+++ b/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
@@ -1,0 +1,303 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test, expect, Browser, BrowserContext, Page } from '@playwright/test';
+import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
+import { readFileSync, existsSync } from 'fs';
+import { join, extname } from 'path';
+import { apiEnableEmbedding, getGuestToken } from '../../helpers/api/embedded';
+import { getDashboardBySlug } from '../../helpers/api/dashboard';
+import { EmbeddedPage } from '../../pages/EmbeddedPage';
+import { EMBEDDED } from '../../utils/constants';
+
+/**
+ * MIME types for the static file server
+ */
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+};
+
+/**
+ * Superset domain (Flask server) — set by CI or defaults to local dev
+ */
+const SUPERSET_DOMAIN = (() => {
+  const url = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8088';
+  return url.replace(/\/+$/, '');
+})();
+
+const SUPERSET_BASE_URL = SUPERSET_DOMAIN.endsWith('/')
+  ? SUPERSET_DOMAIN
+  : `${SUPERSET_DOMAIN}/`;
+
+/**
+ * Path to the SDK bundle built from superset-embedded-sdk/
+ */
+const SDK_BUNDLE_PATH = join(
+  __dirname,
+  '../../../../superset-embedded-sdk/bundle/index.js',
+);
+
+/**
+ * Path to the embedded test app static files
+ */
+const EMBED_APP_DIR = join(__dirname, '../../embedded-app');
+
+/**
+ * Create a minimal static file server for the embedded test app.
+ * Serves HTML from embedded-app/ and the SDK bundle from superset-embedded-sdk/bundle/.
+ */
+function createEmbedAppServer(): Server {
+  return createServer((req: IncomingMessage, res: ServerResponse) => {
+    const urlPath = req.url?.split('?')[0] || '/';
+
+    // Serve SDK bundle at /sdk/index.js
+    if (urlPath === '/sdk/index.js') {
+      if (!existsSync(SDK_BUNDLE_PATH)) {
+        res.writeHead(404);
+        res.end(
+          'SDK bundle not found. Run: cd superset-embedded-sdk && npm ci && npm run build',
+        );
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/javascript' });
+      res.end(readFileSync(SDK_BUNDLE_PATH));
+      return;
+    }
+
+    // Serve static files from embedded-app/
+    const filePath = join(
+      EMBED_APP_DIR,
+      urlPath === '/' ? 'index.html' : urlPath,
+    );
+    if (!existsSync(filePath)) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+
+    const ext = extname(filePath);
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(readFileSync(filePath));
+  });
+}
+
+/**
+ * Create a browser context authenticated as admin for API-only work
+ * (enabling embedding, restoring config). Caller is responsible for closing.
+ */
+function createAdminContext(browser: Browser): Promise<BrowserContext> {
+  return browser.newContext({
+    storageState: 'playwright/.auth/user.json',
+    baseURL: SUPERSET_BASE_URL,
+  });
+}
+
+// ─── Test Suite ────────────────────────────────────────────────────────────
+
+// Describe wrapper is needed for shared server state and serial execution:
+// all tests share a static file server on a fixed port and must not run in parallel.
+test.describe('Embedded Dashboard E2E', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let server: Server;
+  let embedUuid: string;
+  let dashboardId: number;
+
+  /**
+   * Set up a page to render the default embedded dashboard.
+   * Tests that need a different UUID or UI config should not use this helper.
+   */
+  async function setupEmbeddedPage(page: Page): Promise<EmbeddedPage> {
+    const embeddedPage = new EmbeddedPage(page);
+    await embeddedPage.exposeTokenFetcher(async () =>
+      getGuestToken(page, dashboardId),
+    );
+    await embeddedPage.goto({
+      uuid: embedUuid,
+      supersetDomain: SUPERSET_DOMAIN,
+    });
+    await embeddedPage.waitForIframe();
+    await embeddedPage.waitForDashboardContent();
+    return embeddedPage;
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    // Skip all tests if the SDK bundle hasn't been built
+    test.skip(
+      !existsSync(SDK_BUNDLE_PATH),
+      'Embedded SDK bundle not found. Build it with: cd superset-embedded-sdk && npm ci && npm run build',
+    );
+
+    // Start the embedded test app server
+    server = createEmbedAppServer();
+    await new Promise<void>((resolve, reject) => {
+      server.on('error', reject);
+      server.listen(EMBEDDED.APP_PORT, () => resolve());
+    });
+
+    // Use a fresh context with auth to set up test data via API
+    const context = await createAdminContext(browser);
+    const setupPage = await context.newPage();
+
+    try {
+      // Find a well-known example dashboard
+      const dashboard = await getDashboardBySlug(setupPage, 'world_health');
+      if (!dashboard) {
+        throw new Error(
+          'Dashboard "world_health" not found. Ensure load_examples ran in CI setup.',
+        );
+      }
+      dashboardId = dashboard.id;
+
+      // Enable embedding on the dashboard (empty allowed_domains = allow all)
+      const embedded = await apiEnableEmbedding(setupPage, dashboardId);
+      embedUuid = embedded.uuid;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.afterAll(async () => {
+    if (server) {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  test('dashboard renders in embedded iframe', async ({ page }) => {
+    const embeddedPage = await setupEmbeddedPage(page);
+
+    // Verify the iframe src points to Superset's /embedded/ endpoint
+    const iframeSrc = await page
+      .locator('iframe[title="Embedded Dashboard"]')
+      .getAttribute('src');
+    expect(iframeSrc).toContain(`/embedded/${embedUuid}`);
+
+    // Verify no errors in the test app
+    const error = await embeddedPage.getError();
+    expect(error).toBe('');
+
+    // Baseline: title should be visible when hideTitle is not set
+    const titleVisible = await embeddedPage.isTitleVisible();
+    expect(titleVisible).toBe(true);
+  });
+
+  test('UI config hideTitle hides dashboard title', async ({ page }) => {
+    const embeddedPage = new EmbeddedPage(page);
+    await embeddedPage.exposeTokenFetcher(async () =>
+      getGuestToken(page, dashboardId),
+    );
+    await embeddedPage.goto({
+      uuid: embedUuid,
+      supersetDomain: SUPERSET_DOMAIN,
+      hideTitle: true,
+    });
+    await embeddedPage.waitForIframe();
+    await embeddedPage.waitForDashboardContent();
+
+    // The iframe URL should include uiConfig parameter
+    const iframeSrc = await page
+      .locator('iframe[title="Embedded Dashboard"]')
+      .getAttribute('src');
+    expect(iframeSrc).toContain('uiConfig=');
+
+    // Verify the title is actually hidden inside the iframe
+    const titleVisible = await embeddedPage.isTitleVisible();
+    expect(titleVisible).toBe(false);
+  });
+
+  test('charts render inside embedded iframe', async ({ page }) => {
+    const embeddedPage = await setupEmbeddedPage(page);
+
+    // Verify chart containers are present and visible in the iframe
+    const charts = embeddedPage.iframe.locator(
+      '.chart-container, [data-test="chart-container"]',
+    );
+    await expect(charts.first()).toBeVisible({
+      timeout: EMBEDDED.DASHBOARD_RENDER,
+    });
+  });
+
+  test('allowed_domains blocks unauthorized referrer', async ({
+    page,
+    browser,
+  }) => {
+    const context = await createAdminContext(browser);
+    const setupPage = await context.newPage();
+
+    try {
+      // Restrict to a domain that is NOT localhost:9000
+      const restrictedEmbed = await apiEnableEmbedding(setupPage, dashboardId, [
+        'https://allowed.example.com',
+      ]);
+
+      const embeddedPage = new EmbeddedPage(page);
+      await embeddedPage.exposeTokenFetcher(async () =>
+        getGuestToken(page, dashboardId),
+      );
+      await embeddedPage.goto({
+        uuid: restrictedEmbed.uuid,
+        supersetDomain: SUPERSET_DOMAIN,
+      });
+
+      // The iframe should load but get a 403 from Superset's referrer check
+      await embeddedPage.waitForIframe();
+
+      // The dashboard content should NOT render (403 blocks the embedded page)
+      const content = embeddedPage.iframe.locator(
+        '.grid-container, [data-test="grid-container"]',
+      );
+      await expect(content).not.toBeVisible({ timeout: 5000 });
+    } finally {
+      // Restore the open embedding config for other tests
+      await apiEnableEmbedding(setupPage, dashboardId, []);
+      await context.close();
+    }
+  });
+
+  test('guest token enables dashboard data access', async ({ page }) => {
+    const embeddedPage = new EmbeddedPage(page);
+
+    let tokenCallCount = 0;
+    await embeddedPage.exposeTokenFetcher(async () => {
+      tokenCallCount += 1;
+      return getGuestToken(page, dashboardId);
+    });
+
+    await embeddedPage.goto({
+      uuid: embedUuid,
+      supersetDomain: SUPERSET_DOMAIN,
+    });
+    await embeddedPage.waitForIframe();
+    await embeddedPage.waitForDashboardContent();
+
+    // The SDK should have called fetchGuestToken at least once
+    expect(tokenCallCount).toBeGreaterThanOrEqual(1);
+
+    // Verify charts are actually rendering data (not just loading spinners)
+    const charts = embeddedPage.iframe.locator(
+      '.chart-container, [data-test="chart-container"]',
+    );
+    const chartCount = await charts.count();
+    expect(chartCount).toBeGreaterThan(0);
+  });
+});

--- a/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
+++ b/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
@@ -152,7 +152,6 @@ test.describe('Embedded Dashboard E2E', () => {
   test.setTimeout(60000);
 
   let appServer: EmbedAppServer;
-  let appUrl: string;
   let accessToken: string;
   let embedUuid: string;
   let dashboardId: number;
@@ -167,7 +166,7 @@ test.describe('Embedded Dashboard E2E', () => {
       getGuestToken(page, dashboardId, { accessToken }),
     );
     await embeddedPage.goto({
-      appUrl,
+      appUrl: appServer.url,
       uuid: embedUuid,
       supersetDomain: SUPERSET_DOMAIN,
     });
@@ -184,7 +183,6 @@ test.describe('Embedded Dashboard E2E', () => {
     );
 
     appServer = await startEmbedAppServer();
-    appUrl = appServer.url;
 
     // Use a fresh context with auth to set up test data via API
     const context = await createAdminContext(browser);
@@ -236,11 +234,15 @@ test.describe('Embedded Dashboard E2E', () => {
     ).toHaveAttribute('src', new RegExp(`/embedded/${embedUuid}`));
 
     // Verify no errors in the test app
-    const error = await embeddedPage.getError();
-    expect(error).toBe('');
+    expect(await embeddedPage.getError()).toBe('');
 
-    // Baseline: title should be visible when hideTitle is not set
+    // Baseline: title should be visible when hideTitle is not set. This
+    // doubles as a positive existence check the `hideTitle` test relies on
+    // for distinguishing "title was hidden" from "selector is wrong".
     await expect(embeddedPage.titleLocator).toBeVisible();
+
+    // Prove the dashboard actually renders, not just the chrome.
+    await embeddedPage.waitForChartRendered();
   });
 
   test('UI config hideTitle hides dashboard title', async ({ page }) => {
@@ -249,7 +251,7 @@ test.describe('Embedded Dashboard E2E', () => {
       getGuestToken(page, dashboardId, { accessToken }),
     );
     await embeddedPage.goto({
-      appUrl,
+      appUrl: appServer.url,
       uuid: embedUuid,
       supersetDomain: SUPERSET_DOMAIN,
       hideTitle: true,
@@ -262,18 +264,21 @@ test.describe('Embedded Dashboard E2E', () => {
       page.locator('iframe[title="Embedded Dashboard"]'),
     ).toHaveAttribute('src', /uiConfig=/);
 
-    // Verify the title is actually hidden inside the iframe
+    // hideTitle removes the header from the DOM (rather than CSS-hiding it),
+    // so toBeHidden + toHaveCount(0) together assert: not visible AND
+    // confirmed-removed (so the test can't pass for the wrong reason if the
+    // selector ever drifts — the baseline test asserts the selector matches
+    // when hideTitle is off).
     await expect(embeddedPage.titleLocator).toBeHidden();
+    await expect(embeddedPage.titleLocator).toHaveCount(0);
   });
 
   test('charts render inside embedded iframe', async ({ page }) => {
     const embeddedPage = await setupEmbeddedPage(page);
 
-    // Wait for at least one chart to fully render (not just its container).
-    // Superset adds `.rendered` to `.chart-container` after the viz draws.
     await embeddedPage.waitForChartRendered();
     const renderedCharts = embeddedPage.iframe.locator(
-      '[data-test="chart-container"]:has(svg, canvas, table, [class*="big-number"])',
+      EmbeddedPage.RENDERED_CHART_SELECTOR,
     );
     expect(await renderedCharts.count()).toBeGreaterThan(0);
   });
@@ -306,7 +311,7 @@ test.describe('Embedded Dashboard E2E', () => {
       );
 
       await embeddedPage.goto({
-        appUrl,
+        appUrl: appServer.url,
         uuid: restrictedEmbed.uuid,
         supersetDomain: SUPERSET_DOMAIN,
       });
@@ -330,7 +335,7 @@ test.describe('Embedded Dashboard E2E', () => {
     });
 
     await embeddedPage.goto({
-      appUrl,
+      appUrl: appServer.url,
       uuid: embedUuid,
       supersetDomain: SUPERSET_DOMAIN,
     });
@@ -338,12 +343,13 @@ test.describe('Embedded Dashboard E2E', () => {
     await embeddedPage.waitForDashboardContent();
     await embeddedPage.waitForChartRendered();
 
-    // The SDK should have called fetchGuestToken at least once
-    expect(tokenCallCount).toBeGreaterThanOrEqual(1);
+    // The SDK fetches the token exactly once per embed (caching is the
+    // SDK's responsibility, not ours) — assert the stronger invariant.
+    expect(tokenCallCount).toBe(1);
 
     // Confirm at least one chart actually rendered with data, not just its shell
     const renderedCharts = embeddedPage.iframe.locator(
-      '[data-test="chart-container"]:has(svg, canvas, table, [class*="big-number"])',
+      EmbeddedPage.RENDERED_CHART_SELECTOR,
     );
     expect(await renderedCharts.count()).toBeGreaterThan(0);
   });

--- a/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
+++ b/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
@@ -20,21 +20,11 @@
 import { test, expect, Browser, BrowserContext, Page } from '@playwright/test';
 import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { readFileSync, existsSync } from 'fs';
-import { join, extname } from 'path';
+import { join } from 'path';
 import { apiEnableEmbedding, getGuestToken } from '../../helpers/api/embedded';
 import { getDashboardBySlug } from '../../helpers/api/dashboard';
 import { EmbeddedPage } from '../../pages/EmbeddedPage';
 import { EMBEDDED } from '../../utils/constants';
-
-/**
- * MIME types for the static file server
- */
-const MIME_TYPES: Record<string, string> = {
-  '.html': 'text/html',
-  '.js': 'text/javascript',
-  '.css': 'text/css',
-  '.json': 'application/json',
-};
 
 /**
  * Superset domain (Flask server) — set by CI or defaults to local dev
@@ -63,13 +53,15 @@ const EMBED_APP_DIR = join(__dirname, '../../embedded-app');
 
 /**
  * Create a minimal static file server for the embedded test app.
- * Serves HTML from embedded-app/ and the SDK bundle from superset-embedded-sdk/bundle/.
+ * Serves only a fixed allowlist of routes — the test app references just
+ * its index.html and the SDK bundle, so anything else is 404.
  */
+const INDEX_HTML_PATH = join(EMBED_APP_DIR, 'index.html');
+
 function createEmbedAppServer(): Server {
   return createServer((req: IncomingMessage, res: ServerResponse) => {
     const urlPath = req.url?.split('?')[0] || '/';
 
-    // Serve SDK bundle at /sdk/index.js
     if (urlPath === '/sdk/index.js') {
       if (!existsSync(SDK_BUNDLE_PATH)) {
         res.writeHead(404);
@@ -83,21 +75,14 @@ function createEmbedAppServer(): Server {
       return;
     }
 
-    // Serve static files from embedded-app/
-    const filePath = join(
-      EMBED_APP_DIR,
-      urlPath === '/' ? 'index.html' : urlPath,
-    );
-    if (!existsSync(filePath)) {
-      res.writeHead(404);
-      res.end('Not found');
+    if (urlPath === '/' || urlPath === '/index.html') {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(readFileSync(INDEX_HTML_PATH));
       return;
     }
 
-    const ext = extname(filePath);
-    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
-    res.writeHead(200, { 'Content-Type': contentType });
-    res.end(readFileSync(filePath));
+    res.writeHead(404);
+    res.end('Not found');
   });
 }
 

--- a/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
+++ b/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
@@ -19,12 +19,16 @@
 
 import { test, expect, Browser, BrowserContext, Page } from '@playwright/test';
 import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
+import { AddressInfo, Socket } from 'net';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { apiEnableEmbedding, getGuestToken } from '../../helpers/api/embedded';
+import {
+  apiEnableEmbedding,
+  getAccessToken,
+  getGuestToken,
+} from '../../helpers/api/embedded';
 import { getDashboardBySlug } from '../../helpers/api/dashboard';
 import { EmbeddedPage } from '../../pages/EmbeddedPage';
-import { EMBEDDED } from '../../utils/constants';
 
 /**
  * Superset domain (Flask server) — set by CI or defaults to local dev
@@ -58,8 +62,20 @@ const EMBED_APP_DIR = join(__dirname, '../../embedded-app');
  */
 const INDEX_HTML_PATH = join(EMBED_APP_DIR, 'index.html');
 
-function createEmbedAppServer(): Server {
-  return createServer((req: IncomingMessage, res: ServerResponse) => {
+interface EmbedAppServer {
+  server: Server;
+  url: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * Start the static test app on an OS-assigned ephemeral port. Tracks open
+ * sockets so close() doesn't hang on iframe keep-alive connections, and so
+ * different workers/retries never collide on a fixed port.
+ */
+async function startEmbedAppServer(): Promise<EmbedAppServer> {
+  const sockets = new Set<Socket>();
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     const urlPath = req.url?.split('?')[0] || '/';
 
     if (urlPath === '/sdk/index.js') {
@@ -84,6 +100,33 @@ function createEmbedAppServer(): Server {
     res.writeHead(404);
     res.end('Not found');
   });
+
+  server.on('connection', socket => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${address.port}`;
+
+  return {
+    server,
+    url,
+    close: () =>
+      new Promise<void>(resolve => {
+        for (const socket of sockets) socket.destroy();
+        sockets.clear();
+        server.close(() => resolve());
+      }),
+  };
 }
 
 /**
@@ -100,11 +143,17 @@ function createAdminContext(browser: Browser): Promise<BrowserContext> {
 // ─── Test Suite ────────────────────────────────────────────────────────────
 
 // Describe wrapper is needed for shared server state and serial execution:
-// all tests share a static file server on a fixed port and must not run in parallel.
+// all tests share a static file server and must not run in parallel.
 test.describe('Embedded Dashboard E2E', () => {
   test.describe.configure({ mode: 'serial' });
 
-  let server: Server;
+  // The full embedded chain (login → guest token → iframe → dashboard render
+  // → chart render) routinely exceeds the 30s default on cold CI starts.
+  test.setTimeout(60000);
+
+  let appServer: EmbedAppServer;
+  let appUrl: string;
+  let accessToken: string;
   let embedUuid: string;
   let dashboardId: number;
 
@@ -115,9 +164,10 @@ test.describe('Embedded Dashboard E2E', () => {
   async function setupEmbeddedPage(page: Page): Promise<EmbeddedPage> {
     const embeddedPage = new EmbeddedPage(page);
     await embeddedPage.exposeTokenFetcher(async () =>
-      getGuestToken(page, dashboardId),
+      getGuestToken(page, dashboardId, { accessToken }),
     );
     await embeddedPage.goto({
+      appUrl,
       uuid: embedUuid,
       supersetDomain: SUPERSET_DOMAIN,
     });
@@ -133,19 +183,14 @@ test.describe('Embedded Dashboard E2E', () => {
       'Embedded SDK bundle not found. Build it with: cd superset-embedded-sdk && npm ci && npm run build',
     );
 
-    // Start the embedded test app server
-    server = createEmbedAppServer();
-    await new Promise<void>((resolve, reject) => {
-      server.on('error', reject);
-      server.listen(EMBEDDED.APP_PORT, () => resolve());
-    });
+    appServer = await startEmbedAppServer();
+    appUrl = appServer.url;
 
     // Use a fresh context with auth to set up test data via API
     const context = await createAdminContext(browser);
     const setupPage = await context.newPage();
 
     try {
-      // Find a well-known example dashboard
       const dashboard = await getDashboardBySlug(setupPage, 'world_health');
       if (!dashboard) {
         throw new Error(
@@ -157,41 +202,54 @@ test.describe('Embedded Dashboard E2E', () => {
       // Enable embedding on the dashboard (empty allowed_domains = allow all)
       const embedded = await apiEnableEmbedding(setupPage, dashboardId);
       embedUuid = embedded.uuid;
+
+      // Cache the JWT access token so tests don't re-login per guest token.
+      accessToken = await getAccessToken(setupPage);
     } finally {
       await context.close();
     }
   });
 
-  test.afterAll(async () => {
-    if (server) {
-      await new Promise<void>(resolve => server.close(() => resolve()));
+  test.afterAll(async ({ browser }) => {
+    // Defensive restore in case the allowed_domains test failed mid-flight.
+    if (dashboardId !== undefined) {
+      const context = await createAdminContext(browser);
+      try {
+        const setupPage = await context.newPage();
+        await apiEnableEmbedding(setupPage, dashboardId, []);
+      } catch {
+        // Best-effort cleanup — never fail teardown.
+      } finally {
+        await context.close();
+      }
     }
+
+    if (appServer) await appServer.close();
   });
 
   test('dashboard renders in embedded iframe', async ({ page }) => {
     const embeddedPage = await setupEmbeddedPage(page);
 
     // Verify the iframe src points to Superset's /embedded/ endpoint
-    const iframeSrc = await page
-      .locator('iframe[title="Embedded Dashboard"]')
-      .getAttribute('src');
-    expect(iframeSrc).toContain(`/embedded/${embedUuid}`);
+    await expect(
+      page.locator('iframe[title="Embedded Dashboard"]'),
+    ).toHaveAttribute('src', new RegExp(`/embedded/${embedUuid}`));
 
     // Verify no errors in the test app
     const error = await embeddedPage.getError();
     expect(error).toBe('');
 
     // Baseline: title should be visible when hideTitle is not set
-    const titleVisible = await embeddedPage.isTitleVisible();
-    expect(titleVisible).toBe(true);
+    await expect(embeddedPage.titleLocator).toBeVisible();
   });
 
   test('UI config hideTitle hides dashboard title', async ({ page }) => {
     const embeddedPage = new EmbeddedPage(page);
     await embeddedPage.exposeTokenFetcher(async () =>
-      getGuestToken(page, dashboardId),
+      getGuestToken(page, dashboardId, { accessToken }),
     );
     await embeddedPage.goto({
+      appUrl,
       uuid: embedUuid,
       supersetDomain: SUPERSET_DOMAIN,
       hideTitle: true,
@@ -200,26 +258,24 @@ test.describe('Embedded Dashboard E2E', () => {
     await embeddedPage.waitForDashboardContent();
 
     // The iframe URL should include uiConfig parameter
-    const iframeSrc = await page
-      .locator('iframe[title="Embedded Dashboard"]')
-      .getAttribute('src');
-    expect(iframeSrc).toContain('uiConfig=');
+    await expect(
+      page.locator('iframe[title="Embedded Dashboard"]'),
+    ).toHaveAttribute('src', /uiConfig=/);
 
     // Verify the title is actually hidden inside the iframe
-    const titleVisible = await embeddedPage.isTitleVisible();
-    expect(titleVisible).toBe(false);
+    await expect(embeddedPage.titleLocator).toBeHidden();
   });
 
   test('charts render inside embedded iframe', async ({ page }) => {
     const embeddedPage = await setupEmbeddedPage(page);
 
-    // Verify chart containers are present and visible in the iframe
-    const charts = embeddedPage.iframe.locator(
-      '.chart-container, [data-test="chart-container"]',
+    // Wait for at least one chart to fully render (not just its container).
+    // Superset adds `.rendered` to `.chart-container` after the viz draws.
+    await embeddedPage.waitForChartRendered();
+    const renderedCharts = embeddedPage.iframe.locator(
+      '[data-test="chart-container"]:has(svg, canvas, table, [class*="big-number"])',
     );
-    await expect(charts.first()).toBeVisible({
-      timeout: EMBEDDED.DASHBOARD_RENDER,
-    });
+    expect(await renderedCharts.count()).toBeGreaterThan(0);
   });
 
   test('allowed_domains blocks unauthorized referrer', async ({
@@ -230,30 +286,35 @@ test.describe('Embedded Dashboard E2E', () => {
     const setupPage = await context.newPage();
 
     try {
-      // Restrict to a domain that is NOT localhost:9000
+      // Restrict to a domain that is NOT the test app's origin
       const restrictedEmbed = await apiEnableEmbedding(setupPage, dashboardId, [
         'https://allowed.example.com',
       ]);
 
       const embeddedPage = new EmbeddedPage(page);
       await embeddedPage.exposeTokenFetcher(async () =>
-        getGuestToken(page, dashboardId),
+        getGuestToken(page, dashboardId, { accessToken }),
       );
+
+      // The deterministic signal that the referrer check fired is the HTTP
+      // status of the /embedded/<uuid> response — assert that directly rather
+      // than racing against cross-origin iframe rendering.
+      const embeddedResponsePromise = page.waitForResponse(
+        resp =>
+          resp.url().includes(`/embedded/${restrictedEmbed.uuid}`) &&
+          resp.request().resourceType() === 'document',
+      );
+
       await embeddedPage.goto({
+        appUrl,
         uuid: restrictedEmbed.uuid,
         supersetDomain: SUPERSET_DOMAIN,
       });
 
-      // The iframe should load but get a 403 from Superset's referrer check
-      await embeddedPage.waitForIframe();
-
-      // The dashboard content should NOT render (403 blocks the embedded page)
-      const content = embeddedPage.iframe.locator(
-        '.grid-container, [data-test="grid-container"]',
-      );
-      await expect(content).not.toBeVisible({ timeout: 5000 });
+      const response = await embeddedResponsePromise;
+      expect(response.status()).toBe(403);
     } finally {
-      // Restore the open embedding config for other tests
+      // Restore the open embedding config for other tests in this file.
       await apiEnableEmbedding(setupPage, dashboardId, []);
       await context.close();
     }
@@ -265,24 +326,25 @@ test.describe('Embedded Dashboard E2E', () => {
     let tokenCallCount = 0;
     await embeddedPage.exposeTokenFetcher(async () => {
       tokenCallCount += 1;
-      return getGuestToken(page, dashboardId);
+      return getGuestToken(page, dashboardId, { accessToken });
     });
 
     await embeddedPage.goto({
+      appUrl,
       uuid: embedUuid,
       supersetDomain: SUPERSET_DOMAIN,
     });
     await embeddedPage.waitForIframe();
     await embeddedPage.waitForDashboardContent();
+    await embeddedPage.waitForChartRendered();
 
     // The SDK should have called fetchGuestToken at least once
     expect(tokenCallCount).toBeGreaterThanOrEqual(1);
 
-    // Verify charts are actually rendering data (not just loading spinners)
-    const charts = embeddedPage.iframe.locator(
-      '.chart-container, [data-test="chart-container"]',
+    // Confirm at least one chart actually rendered with data, not just its shell
+    const renderedCharts = embeddedPage.iframe.locator(
+      '[data-test="chart-container"]:has(svg, canvas, table, [class*="big-number"])',
     );
-    const chartCount = await charts.count();
-    expect(chartCount).toBeGreaterThan(0);
+    expect(await renderedCharts.count()).toBeGreaterThan(0);
   });
 });

--- a/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
+++ b/superset-frontend/playwright/tests/embedded/embedded-dashboard.spec.ts
@@ -215,8 +215,9 @@ test.describe('Embedded Dashboard E2E', () => {
       try {
         const setupPage = await context.newPage();
         await apiEnableEmbedding(setupPage, dashboardId, []);
-      } catch {
-        // Best-effort cleanup — never fail teardown.
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[embedded teardown] restore failed:', err);
       } finally {
         await context.close();
       }
@@ -320,7 +321,12 @@ test.describe('Embedded Dashboard E2E', () => {
       expect(response.status()).toBe(403);
     } finally {
       // Restore the open embedding config for other tests in this file.
-      await apiEnableEmbedding(setupPage, dashboardId, []);
+      try {
+        await apiEnableEmbedding(setupPage, dashboardId, []);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[embedded teardown] restore failed:', err);
+      }
       await context.close();
     }
   });

--- a/superset-frontend/playwright/utils/constants.ts
+++ b/superset-frontend/playwright/utils/constants.ts
@@ -75,3 +75,18 @@ export const TIMEOUT = {
    */
   SLOW_TEST: 60000, // 60s for tests that chain multiple slow operations
 } as const;
+
+/**
+ * Embedded dashboard test app configuration.
+ * The test app is served by a Node.js http server started in the test fixture.
+ */
+export const EMBEDDED = {
+  /** Port for the embedded test app static server */
+  APP_PORT: 9000,
+  /** Full URL for the embedded test app */
+  APP_URL: 'http://localhost:9000',
+  /** Timeout for iframe to appear in the DOM */
+  IFRAME_LOAD: 15000, // 15s
+  /** Timeout for dashboard content to render inside the iframe */
+  DASHBOARD_RENDER: 30000, // 30s
+} as const;

--- a/superset-frontend/playwright/utils/constants.ts
+++ b/superset-frontend/playwright/utils/constants.ts
@@ -81,12 +81,10 @@ export const TIMEOUT = {
  * The test app is served by a Node.js http server started in the test fixture.
  */
 export const EMBEDDED = {
-  /** Port for the embedded test app static server */
-  APP_PORT: 9000,
-  /** Full URL for the embedded test app */
-  APP_URL: 'http://localhost:9000',
   /** Timeout for iframe to appear in the DOM */
   IFRAME_LOAD: 15000, // 15s
   /** Timeout for dashboard content to render inside the iframe */
   DASHBOARD_RENDER: 30000, // 30s
+  /** Timeout for individual chart cells to finish rendering */
+  CHART_RENDER: 30000, // 30s
 } as const;

--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -78,6 +78,15 @@ FEATURE_FLAGS = {
 
 WEBDRIVER_BASEURL = "http://0.0.0.0:8081/"
 
+# Enable CORS for embedded dashboard E2E tests (test app on port 9000)
+ENABLE_CORS = True
+CORS_OPTIONS: dict = {
+    "origins": [
+        "http://localhost:9000",
+    ],
+    "supports_credentials": True,
+}
+
 
 def GET_FEATURE_FLAGS_FUNC(ff):  # noqa: N802
     ff_copy = copy(ff)
@@ -86,6 +95,7 @@ def GET_FEATURE_FLAGS_FUNC(ff):  # noqa: N802
 
 
 TESTING = True
+TALISMAN_ENABLED = False
 WTF_CSRF_ENABLED = False
 
 FAB_ROLES = {"TestRole": [["Security", "menu_access"], ["List Users", "menu_access"]]}

--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -78,15 +78,6 @@ FEATURE_FLAGS = {
 
 WEBDRIVER_BASEURL = "http://0.0.0.0:8081/"
 
-# Enable CORS for embedded dashboard E2E tests (test app on port 9000)
-ENABLE_CORS = True
-CORS_OPTIONS: dict = {
-    "origins": [
-        "http://localhost:9000",
-    ],
-    "supports_credentials": True,
-}
-
 
 def GET_FEATURE_FLAGS_FUNC(ff):  # noqa: N802
     ff_copy = copy(ff)


### PR DESCRIPTION
### SUMMARY

Adds end-to-end Playwright coverage for the embedded dashboard flow — an external host app loads `@superset-ui/embedded-sdk`, the SDK renders the dashboard inside an iframe authenticated via guest token, and the suite asserts on rendering, UI config, and host-side security controls.

This restores embedded-dashboard E2E coverage that was dropped during the Cypress → Playwright migration.

**What's in the diff:**

- **New `chromium-embedded` Playwright project** in `superset-frontend/playwright.config.ts` — matches `tests/embedded/**/*.spec.ts`, excluded from the default `chromium` project via `testIgnore`, gated on `INCLUDE_EMBEDDED=true`, runs serially (shared static test app).
- **Static test app** at `superset-frontend/playwright/embedded-app/index.html` served by a Node `http.createServer` fixture on port 9000 with a fixed route allowlist (CodeQL-clean). Zero new npm dependencies.
- **Page object & helpers**:
  - `playwright/pages/EmbeddedPage.ts` — iframe interaction, token bridge via `page.exposeFunction()`, content assertions.
  - `playwright/helpers/api/embedded.ts` — `apiEnableEmbedding()`, `getGuestToken()`.
  - `playwright/helpers/api/dashboard.ts` — adds `getDashboardBySlug()` via the shared `getDashboardByFilter()`.
  - `playwright/utils/constants.ts` — `EMBEDDED` timeout/config constants.
- **5 tests** in `playwright/tests/embedded/embedded-dashboard.spec.ts`:
  1. Dashboard renders in embedded iframe
  2. `hideTitle` UI config hides the dashboard title
  3. Charts render inside the embedded iframe
  4. `allowed_domains` blocks an unauthorized referrer (403)
  5. Guest token enables dashboard data access
- **CI integration** in `.github/workflows/superset-playwright.yml` (experimental, shadow mode) — adds a `build-embedded-sdk` step (`bashlib.sh`) and runs the suite with `continue-on-error: true` until stable. Triggered with `INCLUDE_EMBEDDED=true` + `SUPERSET_FEATURE_EMBEDDED_SUPERSET=true`.
- **Test config** in `tests/integration_tests/superset_test_config.py` — `TALISMAN_ENABLED=False` (so `/embedded/<uuid>` doesn't ship `X-Frame-Options: SAMEORIGIN`); the `EMBEDDED_SUPERSET` feature flag is opted in per job via env.
- **Local docker-light support** in `superset_config_docker_light.py` — reads `SUPERSET_FEATURE_<NAME>` env vars into `FEATURE_FLAGS`, disables Talisman, and mirrors `Public` to `Gamma` (`PUBLIC_ROLE_LIKE`) so guest tokens can hit `/api/v1/me/roles/`. Makes the suite runnable against `docker-compose-light` without patching tracked config.

### Architecture

```
Playwright test (Node.js)
  beforeAll: start http server on :9000, enable embedding via API
  exposeFunction(__fetchGuestToken) bridges token to browser
  page.goto("http://localhost:9000/?uuid=...&supersetDomain=...")
    index.html calls embedDashboard()
      SDK creates iframe to /embedded/<uuid>
        SDK posts guest token via MessageChannel
          Dashboard renders
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no user-visible changes; this PR adds tests and CI plumbing only.

### TESTING INSTRUCTIONS

Locally (against a Superset instance with `load_examples` data):

```bash
# 1. Build the embedded SDK bundle (one-time per change to the SDK)
cd superset-embedded-sdk && npm ci && npm run build && cd -

# 2. Run the embedded suite (assumes Superset on :8088 with EMBEDDED_SUPERSET enabled
#    and TALISMAN_ENABLED=False — the docker-light config in this PR sets both)
cd superset-frontend
INCLUDE_EMBEDDED=true \
PLAYWRIGHT_BASE_URL=http://localhost:8088 \
  npx playwright test --project=chromium-embedded
```

Expected: all 5 tests pass. The default `chromium` and `chromium-unauth` projects are unchanged.

CI: the suite runs in the experimental `superset-playwright.yml` workflow only; the main blocking Playwright job is unaffected.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `EMBEDDED_SUPERSET` (test-only; activated per job via `SUPERSET_FEATURE_EMBEDDED_SUPERSET=true`)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
