### PR TITLE
test(heatmap): restore buildQuery coverage on master

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts
@@ -16,67 +16,66 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryFormData } from '@superset-ui/core';
+import { isPostProcessingRank, QueryFormData } from '@superset-ui/core';
 import buildQuery from '../../src/Heatmap/buildQuery';
 
-describe('Heatmap buildQuery - Rank Operation for Normalized Field', () => {
-  const baseFormData = {
-    datasource: '5__table',
-    granularity_sqla: 'ds',
-    metric: 'count',
-    x_axis: 'category',
-    groupby: ['region'],
-    viz_type: 'heatmap',
-  } as QueryFormData;
+const baseFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  metric: 'count',
+  x_axis: 'category',
+  groupby: ['region'],
+  viz_type: 'heatmap',
+} as QueryFormData;
 
-  test('should ALWAYS include rank operation when normalized=true', () => {
-    const formData = {
-      ...baseFormData,
-      normalized: true,
-    };
+const getQuery = (formData: QueryFormData) => buildQuery(formData).queries[0];
+const getRankOperation = (formData: QueryFormData) =>
+  getQuery(formData).post_processing?.find(isPostProcessingRank);
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-
-    const rankOperation = query.post_processing?.find(
-      op => op?.operation === 'rank',
-    );
-
-    expect(rankOperation).toBeDefined();
-    expect(rankOperation?.operation).toBe('rank');
+test('adds X axis orderby when sorting alphabetically ascending', () => {
+  const query = getQuery({
+    ...baseFormData,
+    sort_x_axis: 'alpha_asc',
   });
 
-  test('should ALWAYS include rank operation when normalized=false', () => {
-    const formData = {
-      ...baseFormData,
-      normalized: false,
-    };
+  expect(query.orderby).toEqual([['category', true]]);
+});
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-
-    const rankOperation = query.post_processing?.find(
-      op => op?.operation === 'rank',
-    );
-
-    expect(rankOperation).toBeDefined();
-    expect(rankOperation?.operation).toBe('rank');
+test('adds Y axis orderby when sorting alphabetically descending', () => {
+  const query = getQuery({
+    ...baseFormData,
+    sort_y_axis: 'alpha_desc',
   });
 
-  test('should ALWAYS include rank operation when normalized is undefined', () => {
-    const formData = {
-      ...baseFormData,
-      // normalized not set
-    };
+  expect(query.orderby).toEqual([['region', false]]);
+});
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-
-    const rankOperation = query.post_processing?.find(
-      op => op?.operation === 'rank',
-    );
-
-    expect(rankOperation).toBeDefined();
-    expect(rankOperation?.operation).toBe('rank');
+test('should ALWAYS include rank operation when normalized=true', () => {
+  const rankOperation = getRankOperation({
+    ...baseFormData,
+    normalized: true,
   });
+
+  expect(rankOperation).toBeDefined();
+  expect(rankOperation?.operation).toBe('rank');
+});
+
+test('should ALWAYS include rank operation when normalized=false', () => {
+  const rankOperation = getRankOperation({
+    ...baseFormData,
+    normalized: false,
+  });
+
+  expect(rankOperation).toBeDefined();
+  expect(rankOperation?.operation).toBe('rank');
+});
+
+test('should ALWAYS include rank operation when normalized is undefined', () => {
+  const rankOperation = getRankOperation({
+    ...baseFormData,
+    // normalized not set
+  });
+
+  expect(rankOperation).toBeDefined();
+  expect(rankOperation?.operation).toBe('rank');
 });


### PR DESCRIPTION
### SUMMARY
This adds the missing Heatmap `buildQuery` tests that were surfaced by the Codecov failure on #39290.

The gap on `master` was the untested X-axis and Y-axis alphabetical `orderby` branches in `plugins/plugin-chart-echarts/src/Heatmap/buildQuery.ts`. Covering those branches brings the file back to 100%% line coverage without changing runtime behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable.

### TESTING INSTRUCTIONS
1. Run `cd superset-frontend`.
2. Run `NODE_ENV=test NODE_OPTIONS="--max-old-space-size=8192" npx jest --config ./jest.config.js --maxWorkers=1 --silent --coverage --collectCoverageFrom="plugins/plugin-chart-echarts/src/Heatmap/buildQuery.ts" --runTestsByPath plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts`.
3. Confirm `plugins/plugin-chart-echarts/src/Heatmap/buildQuery.ts` reports `100%%` line coverage.
4. Optionally run `PYENV_VERSION=superset pre-commit run prettier-frontend --files superset-frontend/plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts`.
5. Optionally run `PYENV_VERSION=superset pre-commit run oxlint-frontend --files superset-frontend/plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts`.
6. Optionally run `PYENV_VERSION=superset pre-commit run custom-rules-frontend --files superset-frontend/plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
