### PR TITLE
fix: revert and restore server-side sorting for value axis sorts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/buildQuery.ts
@@ -19,7 +19,6 @@
 import {
   QueryFormColumn,
   QueryFormData,
-  QueryObject,
   QueryFormOrderBy,
   buildQueryContext,
   ensureIsArray,
@@ -38,13 +37,17 @@ export default function buildQuery(formData: QueryFormData) {
     ...ensureIsArray(groupby),
   ];
   const orderby: QueryFormOrderBy[] = [];
-  if (sort_x_axis && !sort_x_axis.includes('value')) {
-    // Value sorts are applied post-query; SQL orderby biases row_limit truncation.
-    orderby.push([columns[0], sort_x_axis.includes('asc')]);
+  if (sort_x_axis) {
+    orderby.push([
+      sort_x_axis.includes('value') ? metric : columns[0],
+      sort_x_axis.includes('asc'),
+    ]);
   }
-  if (sort_y_axis && !sort_y_axis.includes('value')) {
-    // Value sorts are applied post-query; SQL orderby biases row_limit truncation.
-    orderby.push([columns[1], sort_y_axis.includes('asc')]);
+  if (sort_y_axis) {
+    orderby.push([
+      sort_y_axis.includes('value') ? metric : columns[1],
+      sort_y_axis.includes('asc'),
+    ]);
   }
   const group_by =
     normalize_across === 'x'
@@ -52,7 +55,7 @@ export default function buildQuery(formData: QueryFormData) {
       : normalize_across === 'y'
         ? getColumnLabel(groupby as unknown as QueryFormColumn)
         : undefined;
-  return buildQueryContext(formData, (baseQueryObject: QueryObject) => [
+  return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
       columns,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts
@@ -32,25 +32,7 @@ const getQuery = (formData: QueryFormData) => buildQuery(formData).queries[0];
 const getRankOperation = (formData: QueryFormData) =>
   getQuery(formData).post_processing?.find(isPostProcessingRank);
 
-test('Heatmap buildQuery omits orderby for value-based ascending X-axis sort', () => {
-  const query = getQuery({
-    ...baseFormData,
-    sort_x_axis: 'value_asc',
-  });
-
-  expect(query.orderby).toEqual([]);
-});
-
-test('Heatmap buildQuery omits orderby for value-based descending X-axis sort', () => {
-  const query = getQuery({
-    ...baseFormData,
-    sort_x_axis: 'value_desc',
-  });
-
-  expect(query.orderby).toEqual([]);
-});
-
-test('Heatmap buildQuery adds column orderby for alpha ascending X-axis sort', () => {
+test('adds X axis orderby when sorting alphabetically ascending', () => {
   const query = getQuery({
     ...baseFormData,
     sort_x_axis: 'alpha_asc',
@@ -59,49 +41,7 @@ test('Heatmap buildQuery adds column orderby for alpha ascending X-axis sort', (
   expect(query.orderby).toEqual([['category', true]]);
 });
 
-test('Heatmap buildQuery adds column orderby for alpha descending X-axis sort', () => {
-  const query = getQuery({
-    ...baseFormData,
-    sort_x_axis: 'alpha_desc',
-  });
-
-  expect(query.orderby).toEqual([['category', false]]);
-});
-
-test('Heatmap buildQuery omits X-axis orderby when sort_x_axis is not set', () => {
-  const query = getQuery({ ...baseFormData });
-
-  expect(query.orderby).toEqual([]);
-});
-
-test('Heatmap buildQuery omits orderby for value-based ascending Y-axis sort', () => {
-  const query = getQuery({
-    ...baseFormData,
-    sort_y_axis: 'value_asc',
-  });
-
-  expect(query.orderby).toEqual([]);
-});
-
-test('Heatmap buildQuery omits orderby for value-based descending Y-axis sort', () => {
-  const query = getQuery({
-    ...baseFormData,
-    sort_y_axis: 'value_desc',
-  });
-
-  expect(query.orderby).toEqual([]);
-});
-
-test('Heatmap buildQuery adds column orderby for alpha ascending Y-axis sort', () => {
-  const query = getQuery({
-    ...baseFormData,
-    sort_y_axis: 'alpha_asc',
-  });
-
-  expect(query.orderby).toEqual([['region', true]]);
-});
-
-test('Heatmap buildQuery adds column orderby for alpha descending Y-axis sort', () => {
+test('adds Y axis orderby when sorting alphabetically descending', () => {
   const query = getQuery({
     ...baseFormData,
     sort_y_axis: 'alpha_desc',
@@ -110,13 +50,7 @@ test('Heatmap buildQuery adds column orderby for alpha descending Y-axis sort', 
   expect(query.orderby).toEqual([['region', false]]);
 });
 
-test('Heatmap buildQuery omits Y-axis orderby when sort_y_axis is not set', () => {
-  const query = getQuery({ ...baseFormData });
-
-  expect(query.orderby).toEqual([]);
-});
-
-test('Heatmap buildQuery always includes rank operation when normalized is true', () => {
+test('should ALWAYS include rank operation when normalized=true', () => {
   const rankOperation = getRankOperation({
     ...baseFormData,
     normalized: true,
@@ -126,7 +60,7 @@ test('Heatmap buildQuery always includes rank operation when normalized is true'
   expect(rankOperation?.operation).toBe('rank');
 });
 
-test('Heatmap buildQuery always includes rank operation when normalized is false', () => {
+test('should ALWAYS include rank operation when normalized=false', () => {
   const rankOperation = getRankOperation({
     ...baseFormData,
     normalized: false,
@@ -136,8 +70,11 @@ test('Heatmap buildQuery always includes rank operation when normalized is false
   expect(rankOperation?.operation).toBe('rank');
 });
 
-test('Heatmap buildQuery always includes rank operation when normalized is unset', () => {
-  const rankOperation = getRankOperation({ ...baseFormData });
+test('should ALWAYS include rank operation when normalized is undefined', () => {
+  const rankOperation = getRankOperation({
+    ...baseFormData,
+    // normalized not set
+  });
 
   expect(rankOperation).toBeDefined();
   expect(rankOperation?.operation).toBe('rank');


### PR DESCRIPTION
### SUMMARY
This reverts #39290 and restores SQL `orderby` generation for heatmap value-based axis sorting.

The reverted change moved value sorting to the frontend, but that breaks `row_limit` semantics because sorting must happen before truncation when the result set is partial. This follows the maintainer guidance in https://github.com/apache/superset/pull/39290#issuecomment-4238906012.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
- Run `npm --prefix superset-frontend run test -- plugins/plugin-chart-echarts/test/Heatmap/buildQuery.test.ts plugins/plugin-chart-echarts/test/Heatmap/transformProps.test.ts`
- In Explore, open the sample heatmap (`/explore/?slice_id=89`)
- Set `Sort Y Axis` to `Metric ascending` and `Row limit` to `10`
- Verify the chart data request includes the metric in `orderby`, so sorting happens server-side before `row_limit`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API