### PR TITLE
fix(table): use column label instead of SQL expression for orderby in downloads

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -238,12 +238,6 @@ const buildQuery: BuildQuery<TableChartFormData> = (
         });
 
         if (matchingColumn) {
-          if (
-            typeof matchingColumn === 'object' &&
-            'sqlExpression' in matchingColumn
-          ) {
-            return matchingColumn.sqlExpression;
-          }
           return getColumnLabel(matchingColumn);
         }
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -238,6 +238,11 @@ const buildQuery: BuildQuery<TableChartFormData> = (
         });
 
         if (matchingColumn) {
+          // Return the label, not the raw sqlExpression. The backend
+          // (helpers.py get_sqla_query) resolves orderby strings by
+          // matching adhoc column labels, then uses adhoc_column_to_sqla
+          // to emit the actual SQL expression into ORDER BY — so this
+          // is dialect-safe across all database engines.
           return getColumnLabel(matchingColumn);
         }
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
@@ -90,7 +90,7 @@ describe('plugin-chart-ag-grid-table', () => {
         },
       ).queries[0];
 
-      expect(query.orderby).toEqual([['degree_type', true]]);
+      expect(query.orderby).toEqual([['Highest Degree', true]]);
     });
 
     test('should map string metric colId to backend identifier', () => {
@@ -265,6 +265,25 @@ describe('plugin-chart-ag-grid-table', () => {
         ['state', true],
         ['city', false],
       ]);
+    });
+
+    test('should use label (not sqlExpression) for adhoc column in CSV export sortModel', () => {
+      const adhocColumn = createAdhocColumn('sales / 100', 'Margin');
+
+      const query = buildQuery(
+        {
+          ...basicFormData,
+          groupby: [adhocColumn],
+          result_format: 'csv',
+        },
+        {
+          ownState: {
+            sortModel: [{ colId: 'Margin', sort: 'desc' }],
+          },
+        },
+      ).queries[0];
+
+      expect(query.orderby?.[0]).toEqual(['Margin', false]);
     });
 
     test('should not add tie-breaker for non-download queries with server pagination', () => {


### PR DESCRIPTION
### SUMMARY

When downloading (CSV/Excel) an Interactive Table sorted by a custom column with a SQL expression (e.g., `sales / 100`), the download fails with:

> Unknown column used in orderby: sales / 100

**Root cause:** The AG Grid table's `mapColIdToIdentifier()` in `buildQuery.ts` had a special case that returned the raw `sqlExpression` for adhoc columns instead of their label. The backend resolves orderby strings by matching against adhoc column **labels** (in `helpers.py`), so raw SQL expressions like `sales / 100` didn't match anything and raised a validation error.

**Fix:** Removed the special-case branch that returned `sqlExpression` for adhoc columns, so `getColumnLabel()` is always used — returning the label which the backend can resolve correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend error on download, no visual change.

### TESTING INSTRUCTIONS

1. Create a Table chart (Interactive / AG Grid variant) with a custom SQL column, e.g. `sales / 100` labeled "Margin"
2. Sort by that custom column
3. Download as CSV or Excel
4. **Before:** Error "Unknown column used in orderby: sales / 100"
5. **After:** Download succeeds with correct sort order

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API