### PR TITLE
fix(dashboard): preserve dynamic group by column order

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
@@ -56,6 +56,7 @@ import SearchSelectDropdown from './components/SearchSelectDropdown';
 import { SearchOption, SortByItem } from '../types';
 import getInitialSortState, { shouldSort } from '../utils/getInitialSortState';
 import getInitialFilterModel from '../utils/getInitialFilterModel';
+import reconcileColumnState from '../utils/reconcileColumnState';
 import { PAGE_SIZE_OPTIONS } from '../consts';
 import { getCompleteFilterState } from '../utils/filterStateManager';
 
@@ -429,10 +430,17 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
       // Note: filterModel is now handled via gridInitialState for better performance
       if (chartState?.columnState && params.api) {
         try {
-          params.api.applyColumnState?.({
-            state: chartState.columnState as ColumnState[],
-            applyOrder: true,
-          });
+          const reconciledColumnState = reconcileColumnState(
+            chartState.columnState as ColumnState[],
+            colDefsFromProps as ColDef[],
+          );
+
+          if (reconciledColumnState) {
+            params.api.applyColumnState?.({
+              state: reconciledColumnState.columnState,
+              applyOrder: reconciledColumnState.applyOrder,
+            });
+          }
         } catch {
           // Silently fail if state restoration fails
         }

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  type ColDef,
+  type ColumnState,
+} from '@superset-ui/core/components/ThemedAgGridReact';
+import reconcileColumnState, { getLeafColumnIds } from './reconcileColumnState';
+
+test('getLeafColumnIds flattens grouped column defs in visual order', () => {
+  const colDefs: ColDef[] = [
+    { field: 'Manufacture_Date' },
+    {
+      headerName: 'Metrics',
+      children: [
+        { field: 'SUM(Sales_Amount)' },
+        { field: 'SUM(Discount_Applied)' },
+      ],
+    } as ColDef,
+    { field: 'SUM(Quantity_Sold)' },
+  ];
+
+  expect(getLeafColumnIds(colDefs)).toEqual([
+    'Manufacture_Date',
+    'SUM(Sales_Amount)',
+    'SUM(Discount_Applied)',
+    'SUM(Quantity_Sold)',
+  ]);
+});
+
+test('preserves saved order when the current column set is unchanged', () => {
+  const colDefs: ColDef[] = [
+    { field: 'Transaction_Timestamp' },
+    { field: 'SUM(Sales_Amount)' },
+    { field: 'SUM(Discount_Applied)' },
+  ];
+  const savedColumnState: ColumnState[] = [
+    { colId: 'SUM(Sales_Amount)' },
+    { colId: 'Transaction_Timestamp' },
+    { colId: 'SUM(Discount_Applied)' },
+  ];
+
+  expect(reconcileColumnState(savedColumnState, colDefs)).toEqual({
+    applyOrder: true,
+    columnState: savedColumnState,
+  });
+});
+
+test('drops stale order when a dynamic group by swaps the dimension column', () => {
+  const currentColDefs: ColDef[] = [
+    { field: 'Manufacture_Date' },
+    { field: 'SUM(Sales_Amount)' },
+    { field: 'SUM(Discount_Applied)' },
+    { field: 'SUM(Quantity_Sold)' },
+  ];
+  const savedColumnState: ColumnState[] = [
+    { colId: 'Transaction_Timestamp' },
+    { colId: 'SUM(Sales_Amount)' },
+    { colId: 'SUM(Discount_Applied)' },
+    { colId: 'SUM(Quantity_Sold)' },
+  ];
+
+  expect(reconcileColumnState(savedColumnState, currentColDefs)).toEqual({
+    applyOrder: false,
+    columnState: [
+      { colId: 'SUM(Sales_Amount)' },
+      { colId: 'SUM(Discount_Applied)' },
+      { colId: 'SUM(Quantity_Sold)' },
+    ],
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.ts
@@ -69,10 +69,12 @@ export default function reconcileColumnState(
     return null;
   }
 
-  const savedColumnIds = filteredColumnState.map(column => column.colId);
+  const savedColumnIdSet = new Set(
+    filteredColumnState.map(column => column.colId),
+  );
   const hasSameColumnSet =
-    currentColumnIds.length === savedColumnIds.length &&
-    currentColumnIds.every(columnId => savedColumnIds.includes(columnId));
+    currentColumnIds.length === savedColumnIdSet.size &&
+    currentColumnIds.every(columnId => savedColumnIdSet.has(columnId));
 
   return {
     columnState: filteredColumnState,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.ts
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  type ColDef,
+  type ColumnState,
+} from '@superset-ui/core/components/ThemedAgGridReact';
+
+type ColumnGroupDef = ColDef & {
+  children?: ColumnDefLike[];
+};
+
+type ColumnDefLike = ColDef | ColumnGroupDef;
+
+function hasChildren(colDef: ColumnDefLike): colDef is ColumnGroupDef {
+  return 'children' in colDef;
+}
+
+export interface ReconciledColumnState {
+  applyOrder: boolean;
+  columnState: ColumnState[];
+}
+
+export function getLeafColumnIds(colDefs: ColumnDefLike[]): string[] {
+  return colDefs.flatMap(colDef => {
+    if (
+      hasChildren(colDef) &&
+      Array.isArray(colDef.children) &&
+      colDef.children.length > 0
+    ) {
+      return getLeafColumnIds(colDef.children);
+    }
+
+    return typeof colDef.field === 'string' ? [colDef.field] : [];
+  });
+}
+
+export default function reconcileColumnState(
+  savedColumnState: ColumnState[] | undefined,
+  colDefs: ColumnDefLike[],
+): ReconciledColumnState | null {
+  if (!Array.isArray(savedColumnState) || savedColumnState.length === 0) {
+    return null;
+  }
+
+  const currentColumnIds = getLeafColumnIds(colDefs);
+  const currentColumnIdSet = new Set(currentColumnIds);
+  const filteredColumnState = savedColumnState.filter(
+    column =>
+      typeof column.colId === 'string' && currentColumnIdSet.has(column.colId),
+  );
+
+  if (filteredColumnState.length === 0) {
+    return null;
+  }
+
+  const savedColumnIds = filteredColumnState.map(column => column.colId);
+  const hasSameColumnSet =
+    currentColumnIds.length === savedColumnIds.length &&
+    currentColumnIds.every(columnId => savedColumnIds.includes(columnId));
+
+  return {
+    columnState: filteredColumnState,
+    applyOrder: hasSameColumnSet,
+  };
+}


### PR DESCRIPTION
### SUMMARY
This fixes a `Table V2` dashboard bug where changing a `Dynamic Group By` control could move the selected dimension column to the end of the table.

What was happening:
- The dashboard control updated correctly.
- The next `chart/data` request also updated correctly.
- The backend returned the new dimension first, as expected.
- But AG Grid still restored the old saved column order from the previous table shape.

Because of that, when the grouped dimension changed, the old metric columns kept their previous positions and the new dimension column was appended to the end.

This fix keeps the saved column order only when the current column set matches the saved one. If the schema changed, stale column ids are dropped and AG Grid stops forcing the old order, so the table follows the current query order again.

This is a frontend rendering fix only. It does not change SQL, sorting logic, row limits, or query results.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before

![Before](https://raw.githubusercontent.com/richardfogaca/superset/pr-assets/39333/pr-assets/dynamic-groupby/dynamic-groupby-clean-dashboard-unpatched-bug.png)

After

![After](https://raw.githubusercontent.com/richardfogaca/superset/pr-assets/39333/pr-assets/dynamic-groupby/dynamic-groupby-clean-dashboard-patched.png)

### TESTING INSTRUCTIONS
1. Create an AG Grid `Table V2` chart with one grouped dimension and a few metrics.
2. Add the chart to a dashboard.
3. Add a `Dynamic group by` display control scoped to that chart.
4. Change the selected dimension and click `Apply filters`.
5. Confirm the selected dimension is rendered as the first table column instead of being appended to the end.

Automated checks:
- `npm --prefix superset-frontend run test -- plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.test.ts plugins/plugin-chart-ag-grid-table/test/AgGridTableChart.test.tsx plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts`
- `pre-commit run --files superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.ts superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/reconcileColumnState.test.ts`

Note:
- `pre-commit run --all-files` was also run, but this local environment still has unrelated repo-wide failures on `master` (`eslint-docs` requires `yarn`, and some Python lint hooks report unrelated existing files outside this change).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
