### PR TITLE
fix(table): ensure dimensions appear before metrics in column order

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -431,6 +431,11 @@ const processColumns = memoizeOne(function processColumns(
         formatter,
         config,
       };
+    })
+    .sort((a, b) => {
+      const aIsMetric = a.isMetric || a.isPercentMetric ? 1 : 0;
+      const bIsMetric = b.isMetric || b.isPercentMetric ? 1 : 0;
+      return aIsMetric - bIsMetric;
     });
   return [metrics, percentMetrics, columns] as [
     typeof metrics,


### PR DESCRIPTION
### SUMMARY

In Interactive Table V2 (AG Grid) charts, newly added dimensions (e.g. via interactive groupby) appear after metric columns instead of being grouped with other dimensions.

**Root cause**: When a new dimension is added, `buildQuery.ts` appends it to the end of `queryObject.columns` (after metrics). The query result's `colnames` thus has the new dimension last. While AG Grid's `reconcileColumnState` (introduced in #39333) correctly sets `applyOrder: false` when the column set changes (falling back to `columnDefs` order), the `columnDefs` order reflected the query result order — dimensions after metrics.

**Fix**: Added a stable sort in `processColumns` (`transformProps.ts`) so that dimension columns always precede metrics in the `columnDefs` passed to AG Grid. This works in concert with `reconcileColumnState`, which defers to `columnDefs` order when new columns are detected.

User-driven column reordering (drag-and-drop) is unaffected — the sort only determines the initial column order. When the column set is unchanged, `reconcileColumnState` restores the saved order with `applyOrder: true`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**: Adding `is_admin` dimension → appears after `COUNT(*)` metric:
| tz | COUNT(*) | is_admin |

**After**: Adding `is_admin` dimension → appears before `COUNT(*)` metric:
| tz | is_admin | COUNT(*) |

### TESTING INSTRUCTIONS

1. Enable the `AG_GRID_TABLE_ENABLED` feature flag
2. Create or open a Table V2 chart with at least one dimension and one metric (e.g. `tz` and `COUNT(*)`)
3. Add a new dimension (e.g. `is_admin`) via the Dimensions control panel
4. Click "Update chart"
5. **Verify**: The new dimension column appears before the metric column(s)
6. **Verify**: Drag-and-drop column reordering still works after the initial render
7. **Verify**: Removing and re-adding a dimension still places it before metrics

**Tested via Playwright against a running dev instance:**
- Logged in as admin
- Opened a saved Table V2 chart (slice_id=104) with `tz` dimension and `COUNT(*)` metric
- Added `is_admin` dimension via the Dimensions "Drop columns here or click" control
- Clicked "Update chart"
- Confirmed column order: `tz | is_admin | COUNT(*)` (correct)
- Confirmed `processColumns` sort output via console logs: `[tz(metric=false), is_admin(metric=false), count(metric=true)]` (correct)

### ADDITIONAL INFORMATION
- [x] Has associated issue: sc-102572
- [x] Required feature flags: `AG_GRID_TABLE_ENABLED`
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API