### PR TITLE
chore(mcp): update CLAUDE.md to reflect current codebase patterns

### DIFF
--- a/superset/mcp_service/CLAUDE.md
+++ b/superset/mcp_service/CLAUDE.md
@@ -180,15 +180,15 @@ async def my_new_prompt_handler(
 
 ### How to Add a New Resource
 
-Resources still use direct FastMCP decorators plus `@mcp_auth_hook` for authentication:
+Resources use direct FastMCP decorators and **must include `@mcp_auth_hook`** for authentication:
 
 ```python
 # superset/mcp_service/chart/resources/my_new_resource.py
 from superset.mcp_service.app import mcp
-from superset.mcp_service.auth import mcp_auth_hook
+from superset.mcp_service.auth import mcp_auth_hook  # REQUIRED for resources
 
 @mcp.resource("superset://chart/my_resource")
-@mcp_auth_hook
+@mcp_auth_hook  # Always add this decorator to resources
 def get_my_resource() -> str:
     """Resource description for LLMs."""
     return "Resource data here..."
@@ -200,13 +200,11 @@ def get_my_resource() -> str:
 
 The `@tool` decorator from `superset_core.mcp.decorators` accepts:
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `tags` | List of tags (e.g., `["core"]`, `["mutate"]`) | `[]` |
-| `class_permission_name` | FAB permission class (e.g., `"Chart"`, `"Dashboard"`) | `None` |
-| `method_permission_name` | Permission action (e.g., `"read"`, `"write"`) | Auto: `"write"` if `"mutate"` in tags, else `"read"` |
-| `protect` | Enable authentication wrapping | `True` |
-| `annotations` | MCP `ToolAnnotations` object | `None` |
+- **`tags`**: List of tags (e.g., `["core"]`, `["mutate"]`). Default: `[]`
+- **`class_permission_name`**: FAB permission class (e.g., `"Chart"`, `"Dashboard"`). Default: `None`
+- **`method_permission_name`**: Permission action (e.g., `"read"`, `"write"`). Default: Auto — `"write"` if `"mutate"` in tags, else `"read"`
+- **`protect`**: Enable authentication wrapping. Default: `True`
+- **`annotations`**: MCP `ToolAnnotations` object. Default: `None`
 
 **ToolAnnotations** (from `superset_core.mcp.decorators`):
 ```python
@@ -421,13 +419,11 @@ These are used internally by `ModelListCore` for `filters` and `select_columns`.
 
 The MCP service uses FastMCP middleware (registered in `server.py`):
 
-| Middleware | Purpose |
-|-----------|---------|
-| `LoggingMiddleware` | Logs tool calls with duration, entity IDs, sanitizes sensitive data |
-| `GlobalErrorHandlerMiddleware` | Catches unhandled exceptions, converts to ToolError |
-| `StructuredContentStripperMiddleware` | Strips structuredContent from responses (Claude.ai compatibility) |
-| `ResponseSizeGuardMiddleware` | Prevents oversized responses from crashing clients |
-| `ResponseCachingMiddleware` | Optional response caching (in-memory by default, Redis when store enabled) |
+- **`LoggingMiddleware`**: Logs tool calls with duration, entity IDs, sanitizes sensitive data
+- **`GlobalErrorHandlerMiddleware`**: Catches unhandled exceptions, converts to ToolError
+- **`StructuredContentStripperMiddleware`**: Strips structuredContent from responses (Claude.ai compatibility)
+- **`ResponseSizeGuardMiddleware`**: Prevents oversized responses from crashing clients
+- **`ResponseCachingMiddleware`**: Optional response caching (in-memory by default, Redis when store enabled)
 
 Middleware is applied in `server.py` and should NOT be modified in individual tools.
 

--- a/superset/mcp_service/CLAUDE.md
+++ b/superset/mcp_service/CLAUDE.md
@@ -67,9 +67,6 @@ superset/mcp_service/
 ├── dataset/                   # Dataset tools and schemas
 │   ├── schemas.py
 │   └── tool/
-├── database/                  # Database connection tools and schemas
-│   ├── schemas.py
-│   └── tool/
 ├── explore/                   # Explore link generation
 │   ├── schemas.py
 │   └── tool/
@@ -300,6 +297,8 @@ dashboard = db.session.query(Dashboard).filter_by(id=dashboard_id).first()
 
 ```python
 # GOOD - Modern Python 3.10+ syntax
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 class MySchema(BaseModel):
@@ -340,7 +339,7 @@ Use the FastMCP `Context` object for structured logging within tools:
 ```python
 async def my_tool(request: MyRequest, ctx: Context) -> MyResponse:
     await ctx.info("Starting: param=%s" % (request.param,))
-    await ctx.debug("Details: keys=%s" % (sorted(request.dict().keys()),))
+    await ctx.debug("Details: keys=%s" % (sorted(request.model_dump().keys()),))
     await ctx.warning("Something unexpected: %s" % (warning_msg,))
     await ctx.error("Failed: %s" % (str(exc),))
     await ctx.report_progress(1, 5, "Step 1 of 5")
@@ -428,7 +427,7 @@ The MCP service uses FastMCP middleware (registered in `server.py`):
 | `GlobalErrorHandlerMiddleware` | Catches unhandled exceptions, converts to ToolError |
 | `StructuredContentStripperMiddleware` | Strips structuredContent from responses (Claude.ai compatibility) |
 | `ResponseSizeGuardMiddleware` | Prevents oversized responses from crashing clients |
-| `ResponseCachingMiddleware` | Optional response caching (Redis-backed) |
+| `ResponseCachingMiddleware` | Optional response caching (in-memory by default, Redis when store enabled) |
 
 Middleware is applied in `server.py` and should NOT be modified in individual tools.
 
@@ -452,7 +451,7 @@ MCP_RBAC_ENABLED = True          # Enable permission checking (default: True)
 # Request Parsing
 MCP_PARSE_REQUEST_ENABLED = True # Accept JSON string requests (workaround for client bugs)
 
-# Response Caching (optional, requires Redis)
+# Response Caching (optional, uses in-memory store by default; Redis when MCP_STORE_CONFIG enabled)
 MCP_CACHE_CONFIG = {
     "enabled": False,
     "list_tools_ttl": 300,
@@ -485,7 +484,6 @@ tests/unit_tests/mcp_service/
 │       └── ...
 ├── dashboard/tool/
 ├── dataset/tool/
-├── database/tool/
 ├── sql_lab/tool/
 ├── system/tool/
 ├── test_auth_*.py                 # Auth/RBAC tests

--- a/superset/mcp_service/CLAUDE.md
+++ b/superset/mcp_service/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This guide helps LLM agents understand the Superset MCP (Model Context Protocol) service architecture and development conventions.
 
-## ⚠️ CRITICAL: Apache License Headers
+## CRITICAL: Apache License Headers
 
 **EVERY Python file in the MCP service MUST have the Apache Software Foundation license header.**
 
@@ -39,33 +39,62 @@ Use this exact template at the top of EVERY Python file:
 
 ## Architecture Overview
 
-The MCP service provides programmatic access to Superset via the Model Context Protocol, allowing AI assistants to interact with dashboards, charts, datasets, SQL Lab, and instance metadata.
+The MCP service provides programmatic access to Superset via the Model Context Protocol, allowing AI assistants to interact with dashboards, charts, datasets, databases, SQL Lab, and instance metadata.
 
 ### Key Components
 
 ```
 superset/mcp_service/
 ├── app.py                      # FastMCP app factory and tool registration
-├── auth.py                     # Authentication and authorization
+├── auth.py                     # Authentication, authorization, and RBAC
 ├── mcp_config.py              # Default configuration
 ├── mcp_core.py                # Reusable core classes for tools
 ├── flask_singleton.py         # Flask app singleton for MCP context
-├── chart/                     # Chart-related tools
-│   ├── schemas.py            # Pydantic schemas for chart responses
-│   └── tool/                 # Chart tool implementations
-│       ├── __init__.py       # Tool exports
-│       ├── list_charts.py
-│       └── get_chart_info.py
-├── dashboard/                 # Dashboard-related tools
+├── middleware.py              # FastMCP middleware (logging, errors, size guards)
+├── server.py                  # Server startup (streamable-http, multi-pod)
+├── jwt_verifier.py            # JWT token validation
+├── chart/                     # Chart tools, schemas, prompts, resources
+│   ├── schemas.py
+│   ├── chart_utils.py
+│   ├── preview_utils.py
+│   ├── validation.py
+│   ├── tool/
+│   ├── prompts/
+│   └── resources/
+├── dashboard/                 # Dashboard tools and schemas
 │   ├── schemas.py
 │   └── tool/
-├── dataset/                   # Dataset-related tools
+├── dataset/                   # Dataset tools and schemas
 │   ├── schemas.py
 │   └── tool/
-└── system/                    # System/instance tools
-    ├── schemas.py
-    └── tool/
+├── database/                  # Database connection tools and schemas
+│   ├── schemas.py
+│   └── tool/
+├── explore/                   # Explore link generation
+│   ├── schemas.py
+│   └── tool/
+├── sql_lab/                   # SQL Lab tools (execute, save, open)
+│   ├── schemas.py
+│   └── tool/
+├── system/                    # System tools (health, instance info, schema)
+│   ├── schemas.py
+│   ├── tool/
+│   ├── prompts/
+│   └── resources/
+├── common/                    # Shared error schemas
+├── commands/                  # MCP-specific command classes
+└── utils/                     # Utilities (URL, schema parsing, error builders)
 ```
+
+### Dependency Injection Architecture
+
+The `@tool` and `@prompt` decorators are defined as stubs in the `superset-core` package (`superset_core.mcp.decorators`). At startup, `app.py` calls `initialize_core_mcp_dependencies()` which replaces these stubs with concrete implementations that register tools/prompts with the FastMCP instance. This avoids circular imports between `superset_core` and `superset`.
+
+**Startup flow**:
+1. `app.py` creates the FastMCP `mcp` instance
+2. `initialize_core_mcp_dependencies()` injects the real decorator implementations
+3. Tool/prompt/resource imports at the bottom of `app.py` trigger registration
+4. `server.py` adds middleware and starts the transport
 
 ## Critical Convention: Tool, Prompt, and Resource Registration
 
@@ -74,23 +103,55 @@ superset/mcp_service/
 ### How to Add a New Tool
 
 1. **Create the tool file** in the appropriate directory (e.g., `chart/tool/my_new_tool.py`)
-2. **Decorate with `@tool`** to register it with the decorator
-3. **Add import to `app.py`** at the bottom of the file where other tools are imported (around line 210-242)
+2. **Decorate with `@tool`** using the decorator from `superset_core.mcp.decorators`
+3. **Export from the module's `__init__.py`** (e.g., `chart/tool/__init__.py`)
+4. **Add import to `app.py`** at the bottom of the file where other tools are imported
 
-**Example**:
+**Example (read-only tool)**:
 ```python
 # superset/mcp_service/chart/tool/my_new_tool.py
-from superset_core.api.mcp import tool
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
-@tool
-def my_new_tool(param: str) -> dict:
+from superset.extensions import event_logger
+
+@tool(
+    tags=["core"],
+    class_permission_name="Chart",
+    annotations=ToolAnnotations(
+        title="My new tool",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
+async def my_new_tool(request: MyRequest, ctx: Context) -> MyResponse:
     """Tool description for LLMs."""
-    return {"result": "success"}
+    await ctx.info("Doing something: param=%s" % (request.param,))
+    with event_logger.log_context(action="mcp.my_new_tool"):
+        result = do_something()
+    return MyResponse(data=result)
+```
+
+**Example (mutating tool)**:
+```python
+@tool(
+    tags=["mutate"],
+    class_permission_name="Chart",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Create something",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_something(request: CreateRequest, ctx: Context) -> CreateResponse:
+    """Creates a new resource."""
+    ...
 ```
 
 **Then add to app.py**:
 ```python
-# superset/mcp_service/app.py (at the bottom, around line 207-224)
+# superset/mcp_service/app.py (at the bottom, after initialize_core_mcp_dependencies())
 from superset.mcp_service.chart.tool import (  # noqa: F401, E402
     get_chart_info,
     list_charts,
@@ -98,47 +159,32 @@ from superset.mcp_service.chart.tool import (  # noqa: F401, E402
 )
 ```
 
-**Why this matters**: Tools use `@tool` decorators and register automatically on import. The import MUST be in `app.py` at the bottom of the file (after dependency injection is initialized). If you don't import the tool in `app.py`, it won't be available to MCP clients. DO NOT add imports to `server.py` - that file is for running the server only.
+**Why this matters**: Tools register automatically on import via the `@tool` decorator. The import MUST be in `app.py` at the bottom (after `initialize_core_mcp_dependencies()` is called). DO NOT add imports to `server.py`.
 
 ### How to Add a New Prompt
 
 1. **Create the prompt file** in the appropriate directory (e.g., `chart/prompts/my_new_prompt.py`)
-2. **Decorate with `@prompt`** to register it with the unified decorator
+2. **Decorate with `@prompt`** from `superset_core.mcp.decorators`
 3. **Add import to module's `__init__.py`** (e.g., `chart/prompts/__init__.py`)
-4. **Ensure module is imported in `app.py`** (around line 244-253)
+4. **Ensure module is imported in `app.py`**
 
 **Example**:
 ```python
 # superset/mcp_service/chart/prompts/my_new_prompt.py
-from superset_core.api.mcp import prompt
+from superset_core.mcp.decorators import prompt
 
 @prompt("my_new_prompt")
-async def my_new_prompt_handler(ctx: Context) -> str:
+async def my_new_prompt_handler(
+    chart_type: str = "auto", business_goal: str = "exploration"
+) -> str:
     """Interactive prompt for doing something."""
     return "Prompt instructions here..."
 ```
 
-**Then add to `chart/prompts/__init__.py`**:
-```python
-# superset/mcp_service/chart/prompts/__init__.py
-from . import create_chart_guided  # existing
-from . import my_new_prompt  # ADD YOUR PROMPT HERE
-```
-
-**Verify module import exists in `app.py`** (around line 248):
-```python
-# superset/mcp_service/app.py
-from superset.mcp_service.chart import prompts as chart_prompts  # This imports all prompts
-```
-
 ### How to Add a New Resource
 
-1. **Create the resource file** in the appropriate directory (e.g., `chart/resources/my_new_resource.py`)
-2. **Decorate with `@mcp.resource`** to register it with FastMCP (resources still use direct FastMCP)
-3. **Add import to module's `__init__.py`** (e.g., `chart/resources/__init__.py`)
-4. **Ensure module is imported in `app.py`** (around line 244-253)
+Resources still use direct FastMCP decorators plus `@mcp_auth_hook` for authentication:
 
-**Example**:
 ```python
 # superset/mcp_service/chart/resources/my_new_resource.py
 from superset.mcp_service.app import mcp
@@ -151,97 +197,90 @@ def get_my_resource() -> str:
     return "Resource data here..."
 ```
 
-**Note**: Resources continue to use the direct FastMCP decorators (`@mcp.resource`) rather than the unified `@tool()` decorator.
-
-**Then add to `chart/resources/__init__.py`**:
-```python
-# superset/mcp_service/chart/resources/__init__.py
-from . import chart_configs  # existing
-from . import my_new_resource  # ADD YOUR RESOURCE HERE
-```
-
-**Verify module import exists in `app.py`** (around line 249):
-```python
-# superset/mcp_service/app.py
-from superset.mcp_service.chart import resources as chart_resources  # This imports all resources
-```
-
-**Why this matters**: Prompts and resources work similarly to tools - they use decorators and register on import. The module-level imports (`chart/prompts/__init__.py`, `chart/resources/__init__.py`) ensure individual files are imported when the module is imported. The `app.py` imports ensure the modules are loaded when the MCP service starts.
-
 ## Tool Development Patterns
 
-### 1. Use Core Classes for Reusability
+### 1. Tool Decorator Parameters
+
+The `@tool` decorator from `superset_core.mcp.decorators` accepts:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `tags` | List of tags (e.g., `["core"]`, `["mutate"]`) | `[]` |
+| `class_permission_name` | FAB permission class (e.g., `"Chart"`, `"Dashboard"`) | `None` |
+| `method_permission_name` | Permission action (e.g., `"read"`, `"write"`) | Auto: `"write"` if `"mutate"` in tags, else `"read"` |
+| `protect` | Enable authentication wrapping | `True` |
+| `annotations` | MCP `ToolAnnotations` object | `None` |
+
+**ToolAnnotations** (from `superset_core.mcp.decorators`):
+```python
+annotations=ToolAnnotations(
+    title="Human-readable title",
+    readOnlyHint=True,   # Whether tool only reads data
+    destructiveHint=False, # Whether tool has destructive side effects
+)
+```
+
+### 2. Use Core Classes for Reusability
 
 The `mcp_core.py` module provides reusable patterns:
 
-- **`ModelListCore`**: For listing resources (dashboards, charts, datasets)
-- **`ModelGetInfoCore`**: For getting resource details by ID/UUID
-- **`ModelGetSchemaCore`**: For retrieving comprehensive schema metadata (columns, filters, sortable columns)
+- **`ModelListCore`**: For listing resources with filtering, search, and pagination
+  - Used by: `list_charts`, `list_dashboards`, `list_datasets`, `list_databases`
+- **`ModelGetInfoCore`**: For getting resource details by ID, UUID, or slug
+  - Used by: `get_chart_info`, `get_dashboard_info`, `get_dataset_info`, `get_database_info`
+- **`ModelGetSchemaCore`**: For schema discovery (columns, filters, sortable columns)
+  - Used by: `get_schema`
+- **`InstanceInfoCore`**: For instance statistics and metadata
+  - Used by: `get_instance_info`
 
-**Example**:
+### 3. Authentication and RBAC
+
+Authentication is handled automatically by the `@tool` decorator (via `mcp_auth_hook` internally). RBAC permission checking uses `class_permission_name` and `method_permission_name`.
+
 ```python
-from superset_core.api.mcp import tool
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.mcp_service.mcp_core import ModelListCore
-from superset.daos.dashboard import DashboardDAO
-from superset.mcp_service.dashboard.schemas import DashboardList
-
-list_core = ModelListCore(
-    dao_class=DashboardDAO,
-    output_schema=DashboardList,
-    logger=logger,
+# Authentication + RBAC enabled (default)
+@tool(
+    class_permission_name="Chart",  # Checks user has Chart access
 )
+async def my_tool(request: MyRequest, ctx: Context) -> MyResponse:
+    # g.user is set automatically before this runs
+    ...
 
-@tool
-def list_dashboards(filters: List[DashboardFilter], page: int = 1) -> DashboardList:
-    return list_core.run_tool(filters=filters, page=page, page_size=10)
+# Public tool (no auth) - use sparingly
+@tool(protect=False)
+async def health_check(ctx: Context) -> dict:
+    return {"status": "healthy"}
 ```
 
-### 2. Always Use Authentication
+**Authentication priority order** (in `auth.py`):
+1. JWT context (per-request ContextVar from FastMCP)
+2. API Key authentication (via FAB SecurityManager)
+3. `MCP_DEV_USERNAME` config (development only)
+4. `g.user` fallback (set by external middleware)
 
-**Every tool must use `@tool`** with authentication enabled (default) to ensure:
-- User authentication from JWT or configured admin user
-- Permission checking via JWT scopes
-- Audit logging of tool access
+**`@mcp_auth_hook`** is only used directly on **resources** — tools get auth wrapping from `@tool(protect=True)`.
 
-```python
-from superset_core.api.mcp import tool
+### 4. Use Pydantic Schemas
 
-@tool  # REQUIRED - secure=True by default
-def my_tool() -> dict:
-    # g.user is set by tool decorator
-    return {"user": g.user.username}
-
-@tool(protect=False)  # Only for truly public tools
-def public_tool() -> dict:
-    # No authentication required
-    return {"status": "public"}
-```
-
-### 3. Use Pydantic Schemas
-
-**All tool inputs and outputs must be Pydantic models** for:
-- Automatic validation
-- LLM-friendly schema generation
-- Type safety
-
-**Convention**: Place schemas in `{module}/schemas.py`
+**All tool inputs and outputs must be Pydantic models**. Place schemas in `{module}/schemas.py`.
 
 ```python
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class MyToolRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     param: str = Field(..., description="Parameter description for LLMs")
+    optional_param: str | None = Field(None, description="Optional parameter")
 
 class MyToolResponse(BaseModel):
     result: str = Field(..., description="Result description")
-    timestamp: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
-        description="Response timestamp"
-    )
+    error: str | None = Field(None, description="Error message if failed")
 ```
 
-### 4. Follow the DAO Pattern
+### 5. Follow the DAO Pattern
 
 **Use Superset's DAO (Data Access Object) layer** instead of direct database queries:
 
@@ -255,185 +294,95 @@ dashboard = DashboardDAO.find_by_id(dashboard_id)
 dashboard = db.session.query(Dashboard).filter_by(id=dashboard_id).first()
 ```
 
-### 5. Python Type Hints (Python 3.10+ Style)
+### 6. Python Type Hints (Python 3.10+ Style)
 
 **CRITICAL**: Always use modern Python 3.10+ union syntax for type hints.
 
 ```python
 # GOOD - Modern Python 3.10+ syntax
-from typing import List, Dict, Any
 from pydantic import BaseModel, Field
 
 class MySchema(BaseModel):
     name: str | None = Field(None, description="Optional name")
-    tags: List[str] = Field(default_factory=list)
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 def my_function(
     id: int,
-    filters: List[str] | None = None,
-    options: Dict[str, Any] | None = None
+    filters: list[str] | None = None,
 ) -> MySchema | None:
     pass
 
-# BAD - Old-style Optional (DO NOT USE)
-from typing import Optional, List, Dict, Any
-
-class MySchema(BaseModel):
-    name: Optional[str] = Field(None, description="Optional name")  # Wrong!
-
-def my_function(
-    id: int,
-    filters: Optional[List[str]] = None,  # Wrong!
-    options: Optional[Dict[str, Any]] = None  # Wrong!
-) -> Optional[MySchema]:  # Wrong!
-    pass
+# BAD - Old-style (DO NOT USE)
+from typing import Optional, List, Dict
+name: Optional[str]  # Wrong! Use str | None
+tags: List[str]      # Wrong! Use list[str]
 ```
 
-**Key rules:**
-- Use `T | None` instead of `Optional[T]`
-- Do NOT import `Optional`, `List`, `Dict` from typing, prefer `| None`, `list[]` etc
-- All new code must follow this pattern
+### 7. Event Logger Instrumentation
 
-### 6. Flexible Input Parsing (JSON String or Object)
-
-**MCP tools accept both JSON string and native object formats for parameters** using utilities from `superset.mcp_service.utils.schema_utils`. This makes tools flexible for different client types (LLM clients send objects, CLI tools send JSON strings).
-
-**PREFERRED: Use the `@parse_request` decorator** for tool functions to automatically handle request parsing:
+**All tool operations should use `event_logger`** for observability:
 
 ```python
-from superset.mcp_service.utils.schema_utils import parse_request
+from superset.extensions import event_logger
 
-@mcp.tool
-@mcp_auth_hook
-@parse_request(ListChartsRequest)  # Automatically parses string requests!
-async def list_charts(request: ListChartsRequest | str, ctx: Context) -> ChartList:
-    """List charts with filtering and search."""
-    # request is guaranteed to be ListChartsRequest here - no manual parsing needed!
-    await ctx.info(f"Listing charts: page={request.page}")
-    ...
+@tool(...)
+async def my_tool(request: MyRequest, ctx: Context) -> MyResponse:
+    with event_logger.log_context(action="mcp.my_tool.step_name"):
+        result = do_something()
+    return MyResponse(data=result)
 ```
 
-**Benefits:**
-- Eliminates 5 lines of boilerplate code per tool
-- Handles both async and sync functions automatically
-- Works with Claude Code bug (GitHub issue #5504)
-- Cleaner, more maintainable code
+### 8. Context Logging
 
-**Available utilities for other use cases:**
-
-#### parse_json_or_passthrough
-Parse JSON string or return object as-is:
+Use the FastMCP `Context` object for structured logging within tools:
 
 ```python
-from superset.mcp_service.utils.schema_utils import parse_json_or_passthrough
-
-# Accepts both formats
-config = parse_json_or_passthrough(value, param_name="config")
-# value can be: '{"key": "value"}' (JSON string) OR {"key": "value"} (dict)
+async def my_tool(request: MyRequest, ctx: Context) -> MyResponse:
+    await ctx.info("Starting: param=%s" % (request.param,))
+    await ctx.debug("Details: keys=%s" % (sorted(request.dict().keys()),))
+    await ctx.warning("Something unexpected: %s" % (warning_msg,))
+    await ctx.error("Failed: %s" % (str(exc),))
+    await ctx.report_progress(1, 5, "Step 1 of 5")
 ```
 
-#### parse_json_or_list
-Parse to list from JSON, list, or comma-separated string:
+### 9. Error Handling
+
+**Pattern**: Catch specific exceptions for known failure modes, use broad `Exception` only as the outermost safety net that re-raises:
 
 ```python
-from superset.mcp_service.utils.schema_utils import parse_json_or_list
+from superset.commands.dataset.exceptions import DatasetInvalidError, DatasetCreateFailedError
 
-# Accepts multiple formats
-items = parse_json_or_list(value, param_name="items")
-# value can be:
-#   '["a", "b"]' (JSON array)
-#   ["a", "b"] (Python list)
-#   "a, b, c" (comma-separated string)
-```
-
-#### parse_json_or_model
-Parse to Pydantic model from JSON or dict:
-
-```python
-from superset.mcp_service.utils.schema_utils import parse_json_or_model
-
-# Accepts JSON string or dict
-config = parse_json_or_model(value, ConfigModel, param_name="config")
-# value can be: '{"name": "test"}' OR {"name": "test"}
-```
-
-#### parse_json_or_model_list
-Parse to list of Pydantic models:
-
-```python
-from superset.mcp_service.utils.schema_utils import parse_json_or_model_list
-
-# Accepts JSON array or list of dicts
-filters = parse_json_or_model_list(value, FilterModel, param_name="filters")
-# value can be: '[{"col": "name"}]' OR [{"col": "name"}]
-```
-
-**Using with Pydantic validators:**
-
-```python
-from pydantic import BaseModel, field_validator
-from superset.mcp_service.utils.schema_utils import parse_json_or_list
-
-class MyToolRequest(BaseModel):
-    filters: List[FilterModel] = Field(default_factory=list)
-    select_columns: List[str] = Field(default_factory=list)
-
-    @field_validator("filters", mode="before")
-    @classmethod
-    def parse_filters(cls, v):
-        """Accept both JSON string and list of objects."""
-        return parse_json_or_model_list(v, FilterModel, "filters")
-
-    @field_validator("select_columns", mode="before")
-    @classmethod
-    def parse_columns(cls, v):
-        """Accept JSON array, list, or comma-separated string."""
-        return parse_json_or_list(v, "select_columns")
-```
-
-**Core classes already use these utilities:**
-- `ModelListCore` uses them for `filters` and `select_columns`
-- No need to add parsing logic in individual tools that use core classes
-
-**When to use:**
-- Tool parameters that accept complex objects (dicts, lists)
-- Parameters that may come from CLI tools (JSON strings) or LLM clients (objects)
-- Any field where you want maximum flexibility
-
-### 7. Error Handling
-
-**Use consistent error schemas**:
-
-```python
-class MyError(BaseModel):
-    error: str = Field(..., description="Error message")
-    error_type: str = Field(..., description="Type of error")
-    timestamp: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
-        description="Error timestamp"
-    )
-
-@tool
-def my_tool(id: int) -> MyResponse:
+@tool(...)
+async def my_tool(request: MyRequest, ctx: Context) -> MyResponse:
     try:
-        result = process_data(id)
+        # Specific exception handling for known failure modes
+        with event_logger.log_context(action="mcp.my_tool"):
+            result = SomeCommand(properties).run()
         return MyResponse(data=result)
-    except NotFound:
-        raise ValueError(f"Resource {id} not found")
+
+    except DatasetInvalidError as exc:
+        # Return structured error response (don't raise)
+        await ctx.error("Validation failed: %s" % (exc.normalized_messages(),))
+        return MyResponse(error=str(exc.normalized_messages()))
+
+    except DatasetCreateFailedError as exc:
+        await ctx.error("Creation failed: %s" % (str(exc),))
+        return MyResponse(error=f"Failed: {exc}")
+
+    except Exception as exc:
+        # Outermost safety net: log and re-raise (middleware handles it)
+        await ctx.error("Unexpected: %s: %s" % (type(exc).__name__, str(exc)))
+        raise
 ```
 
-### 8. Dataset Validation for Chart Tools
+### 10. Dataset Validation for Chart Tools
 
-**IMPORTANT**: All chart-related tools must validate that the chart's dataset is accessible before performing operations. Use the shared `validate_chart_dataset` utility from `chart_utils.py`.
+All chart-related tools must validate that the chart's dataset is accessible:
 
-**Why this matters**: Charts can reference datasets that have been deleted or become inaccessible. Without validation, users may see confusing errors when trying to preview or get data from charts with missing datasets.
-
-**Usage pattern**:
 ```python
 from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 
-# After retrieving a chart, validate its dataset
 validation_result = validate_chart_dataset(chart, check_access=True)
 if not validation_result.is_valid:
     await ctx.warning("Dataset not accessible: %s" % (validation_result.error,))
@@ -441,232 +390,221 @@ if not validation_result.is_valid:
         error=validation_result.error or "Chart's dataset is not accessible",
         error_type="DatasetNotAccessible",
     )
-
-# Log any warnings (e.g., virtual dataset warnings)
-for warning in validation_result.warnings:
-    await ctx.warning("Dataset warning: %s" % (warning,))
 ```
 
-**Tools that use this pattern**:
-- `get_chart_info` - Validates after retrieving chart metadata
-- `get_chart_preview` - Validates before generating preview
-- `get_chart_data` - Validates before querying data
-- `generate_chart` - Validates after chart creation (post-creation validation)
+Used by: `get_chart_info`, `get_chart_preview`, `get_chart_data`, `generate_chart`
 
-**The `DatasetValidationResult` contains**:
-- `is_valid`: Whether the dataset exists and is accessible
-- `dataset_id`: The dataset ID being validated
-- `dataset_name`: The dataset name (if found)
-- `warnings`: List of warnings (e.g., "virtual dataset may be deleted")
-- `error`: Error message if validation failed
+### 11. Compile Check for Chart Creation
 
-## Testing Conventions
-
-### Unit Tests
-
-Place unit tests in `tests/unit_tests/mcp_service/{module}/tool/test_{tool_name}.py`
-
-**Test structure**:
-```python
-from unittest.mock import MagicMock, patch
-import pytest
-
-class TestMyTool:
-    @pytest.fixture
-    def mock_dao(self):
-        """Create mock DAO for testing."""
-        dao = MagicMock()
-        dao.find_by_id.return_value = create_mock_object()
-        return dao
-
-    @patch("superset.mcp_service.chart.tool.my_tool.ChartDAO")
-    def test_my_tool_success(self, mock_dao_class, mock_dao):
-        """Test successful tool execution."""
-        mock_dao_class.return_value = mock_dao
-
-        result = my_tool(id=1)
-
-        assert result.data is not None
-        mock_dao.find_by_id.assert_called_once_with(1)
-```
-
-### Integration Tests
-
-Use Flask test client for integration tests:
+When creating or saving charts, run a compile check to verify the query executes:
 
 ```python
-def test_tool_with_flask_context(app):
-    """Test tool with full Flask app context."""
-    with app.app_context():
-        result = my_tool(id=1)
-        assert result is not None
+from superset.mcp_service.chart.tool.generate_chart import _compile_chart
+
+compile_result = _compile_chart(form_data, dataset.id)
+if not compile_result.success:
+    # Delete broken chart, return error
+    ...
 ```
 
-## Common Pitfalls to Avoid
+### 12. Flexible Input Parsing
 
-### 1. ❌ Forgetting Tool Import in app.py
-**Problem**: Tool exists but isn't available to MCP clients.
-**Solution**: Always add tool import to `app.py` (at the bottom) after creating it. Never add to `server.py`.
+`ModelListCore` handles JSON string vs. native object parsing automatically via utilities in `superset.mcp_service.utils.schema_utils`:
 
-### 2. ❌ Adding Tool Imports to server.py
-**Problem**: Tools won't register properly, causing runtime errors.
-**Solution**: Tool imports must be in `app.py` at the bottom of the file, not in `server.py`. The `server.py` file is only for running the server.
+- `parse_json_or_passthrough(value, param_name)` - JSON string or dict
+- `parse_json_or_list(value, param_name)` - JSON array, list, or comma-separated string
+- `parse_json_or_model(value, model_class, param_name)` - JSON string or dict to Pydantic model
+- `parse_json_or_model_list(value, model_class, param_name)` - JSON array to list of Pydantic models
 
-### 3. ❌ Missing Authentication
-**Problem**: Tool bypasses authentication and authorization.
-**Solution**: Always use `@tool` with default protect=True, or explicitly set protect=False only for public tools.
+These are used internally by `ModelListCore` for `filters` and `select_columns`. Individual tools using core classes do NOT need to add parsing logic.
 
-### 4. ❌ Using `Optional` Instead of Union Syntax
-**Problem**: Old-style Optional[T] is not Python 3.10+ style.
-**Solution**: Use `T | None` instead of `Optional[T]` for all type hints.
-```python
-# GOOD - Modern Python 3.10+ syntax
-def my_function(param: str | None = None) -> int | None:
-    pass
+## Middleware
 
-# BAD - Old-style Optional
-from typing import Optional
-def my_function(param: Optional[str] = None) -> Optional[int]:
-    pass
-```
+The MCP service uses FastMCP middleware (registered in `server.py`):
 
-### 5. ❌ Using `any` Types in Schemas
-**Problem**: Violates TypeScript modernization goals, no validation.
-**Solution**: Use proper Pydantic types with Field descriptions.
+| Middleware | Purpose |
+|-----------|---------|
+| `LoggingMiddleware` | Logs tool calls with duration, entity IDs, sanitizes sensitive data |
+| `GlobalErrorHandlerMiddleware` | Catches unhandled exceptions, converts to ToolError |
+| `StructuredContentStripperMiddleware` | Strips structuredContent from responses (Claude.ai compatibility) |
+| `ResponseSizeGuardMiddleware` | Prevents oversized responses from crashing clients |
+| `ResponseCachingMiddleware` | Optional response caching (Redis-backed) |
 
-### 6. ❌ Direct Database Queries
-**Problem**: Bypasses Superset's security and caching layers.
-**Solution**: Use DAO classes (ChartDAO, DashboardDAO, etc.).
-
-### 7. ❌ Not Using Core Classes
-**Problem**: Duplicating list/get_info/schema logic across tools.
-**Solution**: Use ModelListCore, ModelGetInfoCore, ModelGetSchemaCore.
-
-### 8. ❌ Missing Apache License Headers
-**Problem**: CI fails on license check.
-**Solution**: Add Apache license header to all new .py files. Use this exact template at the top of every new Python file:
-
-```python
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-```
-
-**Note**: LLM instruction files like `CLAUDE.md`, `AGENTS.md`, etc. are excluded from this requirement (listed in `.rat-excludes`) to avoid token overhead.
-
-### 9. ❌ Using `@tool()` with Empty Parentheses
-**Problem**: Inconsistent decorator style.
-**Solution**: Use `@tool` without parentheses unless passing arguments.
-```python
-# GOOD
-from superset_core.api.mcp import tool
-
-@tool
-def my_tool():
-    pass
-
-# BAD
-from superset_core.api.mcp import tool
-
-@tool
-def my_tool():
-    pass
-```
-
-### 10. ❌ Circular Imports
-**Problem**: Importing too many things from `app.py` can create circular dependencies.
-**Solution**: Use the unified `@tool` decorator from `superset_core.api.mcp`:
-```python
-# GOOD - New pattern
-from superset_core.api.mcp import tool
-
-@tool
-def my_tool():
-    pass
-
-# ACCEPTABLE - For prompts/resources (when needed)
-from superset.mcp_service.app import mcp
-
-@prompt
-def my_prompt():
-    pass
-
-# BAD - causes circular import
-from superset.mcp_service.app import mcp, some_other_function
-```
+Middleware is applied in `server.py` and should NOT be modified in individual tools.
 
 ## Configuration
 
-Default configuration is in `mcp_config.py`. Users can override in `superset_config.py`:
+Default configuration is in `mcp_config.py`. Override in `superset_config.py`:
 
 ```python
-# superset_config.py
-MCP_ADMIN_USERNAME = "your_admin"
-MCP_AUTH_ENABLED = True
-MCP_JWT_PUBLIC_KEY = "your_public_key"
+# Authentication
+MCP_DEV_USERNAME = None          # Fallback username for dev mode
+MCP_AUTH_ENABLED = False         # Enable JWT/API key auth
+MCP_AUTH_FACTORY = None          # Custom auth factory function
+MCP_JWT_PUBLIC_KEY = None
+MCP_JWT_SECRET = None
+MCP_JWKS_URI = None
+MCP_USER_RESOLVER = None         # Custom function to extract username from JWT
+
+# RBAC
+MCP_RBAC_ENABLED = True          # Enable permission checking (default: True)
+
+# Request Parsing
+MCP_PARSE_REQUEST_ENABLED = True # Accept JSON string requests (workaround for client bugs)
+
+# Response Caching (optional, requires Redis)
+MCP_CACHE_CONFIG = {
+    "enabled": False,
+    "list_tools_ttl": 300,
+    "call_tool_ttl": 3600,
+    "excluded_tools": ["execute_sql", "generate_dashboard", ...],
+}
+
+# Multi-pod Storage (optional, requires Redis)
+MCP_STORE_CONFIG = {
+    "enabled": False,
+    "CACHE_REDIS_URL": None,
+    "event_store_ttl": 3600,
+}
 ```
 
-## Tool Discovery
+## Testing Conventions
 
-MCP clients discover tools via:
-1. **Tool listing**: All tools with `@tool` are automatically listed
-2. **Schema introspection**: Pydantic schemas generate JSON Schema for LLMs
-3. **Instructions**: `DEFAULT_INSTRUCTIONS` in `app.py` documents available tools
+### Test Organization
 
-## Resources for Learning
+Tests mirror the MCP service module structure:
+```
+tests/unit_tests/mcp_service/
+├── conftest.py                    # Global fixtures (disable_mcp_rbac)
+├── chart/
+│   ├── test_chart_utils.py
+│   ├── test_chart_schemas.py
+│   └── tool/
+│       ├── test_list_charts.py
+│       ├── test_generate_chart.py
+│       └── ...
+├── dashboard/tool/
+├── dataset/tool/
+├── database/tool/
+├── sql_lab/tool/
+├── system/tool/
+├── test_auth_*.py                 # Auth/RBAC tests
+└── test_middleware*.py            # Middleware tests
+```
 
-- **MCP Specification**: https://modelcontextprotocol.io/
-- **FastMCP Documentation**: https://github.com/jlowin/fastmcp
-- **Superset DAO Patterns**: See `superset/daos/` for examples
-- **Pydantic Documentation**: https://docs.pydantic.dev/
+### Async Tool Tests (primary pattern)
+
+```python
+from unittest.mock import MagicMock, patch
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+from superset.utils import json
+
+@pytest.fixture
+def mcp_server():
+    return mcp
+
+@pytest.mark.asyncio
+async def test_my_tool_success(mcp_server):
+    mock_obj = MagicMock()
+    mock_obj.id = 1
+    mock_obj.name = "test"
+
+    with patch("superset.daos.chart.ChartDAO.find_by_id", return_value=mock_obj):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "my_tool", {"request": {"id": 1}}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 1
+```
+
+### Key Testing Patterns
+
+- **RBAC is disabled globally** via `conftest.py` autouse fixture (`MCP_RBAC_ENABLED = False`)
+- **RBAC tests** are separate in `test_auth_rbac.py` with their own `enable_mcp_rbac` fixture
+- **Auth is mocked** via `mock_auth` fixture that patches `get_user_from_request`
+- **Mock objects** must have all attributes set explicitly (no auto-generation)
+- **Patch at the DAO level**: `patch("superset.daos.chart.ChartDAO.find_by_id", ...)`
+- **Schema validation tests** are synchronous (no Client needed)
+
+## Common Pitfalls to Avoid
+
+### 1. Forgetting Tool Import in app.py
+**Problem**: Tool exists but isn't available to MCP clients.
+**Solution**: Add tool import to `app.py` at the bottom (after `initialize_core_mcp_dependencies()`).
+
+### 2. Adding Tool Imports to server.py
+**Problem**: Tools won't register properly.
+**Solution**: Tool imports MUST be in `app.py`, not `server.py`.
+
+### 3. Wrong Decorator Import Path
+**Problem**: Using stale import path.
+**Solution**: Use `from superset_core.mcp.decorators import tool, ToolAnnotations` (NOT `superset_core.api.mcp`).
+
+### 4. Missing ToolAnnotations
+**Problem**: Tool lacks MCP directory compliance metadata.
+**Solution**: Always include `annotations=ToolAnnotations(title=..., readOnlyHint=..., destructiveHint=...)`.
+
+### 5. Using `Optional` Instead of Union Syntax
+**Problem**: Old-style `Optional[T]` is not Python 3.10+ style.
+**Solution**: Use `T | None` and `list[str]` instead of `Optional[T]` and `List[str]`.
+
+### 6. Direct Database Queries
+**Problem**: Bypasses Superset's security and caching layers.
+**Solution**: Use DAO classes (ChartDAO, DashboardDAO, DatasetDAO, DatabaseDAO).
+
+### 7. Not Using Core Classes
+**Problem**: Duplicating list/get_info logic across tools.
+**Solution**: Use `ModelListCore`, `ModelGetInfoCore`, `ModelGetSchemaCore`.
+
+### 8. Missing Apache License Headers
+**Problem**: CI fails on license check.
+**Solution**: Add ASF license header to all new `.py` files (see template at top of this doc).
+
+### 9. Circular Imports
+**Problem**: Importing from `app.py` in tool files causes circular dependencies.
+**Solution**: Use `from superset_core.mcp.decorators import tool` for tools/prompts. Only import `from superset.mcp_service.app import mcp` in resource files.
+
+### 10. Missing event_logger Instrumentation
+**Problem**: Tool operations are invisible to observability.
+**Solution**: Wrap key operations with `event_logger.log_context(action="mcp.tool_name.step")`.
 
 ## Quick Checklist for New Tools
 
 - [ ] Created tool file in `{module}/tool/{tool_name}.py`
-- [ ] Added `@tool` decorator
+- [ ] Added ASF license header
+- [ ] Used `@tool(tags=[...], class_permission_name="...", annotations=ToolAnnotations(...))` decorator
+- [ ] Import: `from superset_core.mcp.decorators import tool, ToolAnnotations`
 - [ ] Created Pydantic request/response schemas in `{module}/schemas.py`
-- [ ] Used DAO classes instead of direct queries when querying Superset entities
-- [ ] Added tool import to `app.py` (around line 210-242)
-- [ ] Added Apache license header to new files
-- [ ] Created unit tests in `tests/unit_tests/mcp_service/{module}/tool/test_{tool_name}.py`
+- [ ] Used DAO classes instead of direct queries
+- [ ] Added `event_logger.log_context()` instrumentation
+- [ ] Used `await ctx.info/error/debug()` for context logging
+- [ ] Exported from `{module}/tool/__init__.py`
+- [ ] Added tool import to `app.py` at the bottom
+- [ ] Created async unit tests in `tests/unit_tests/mcp_service/{module}/tool/`
 - [ ] Updated `DEFAULT_INSTRUCTIONS` in `app.py` if adding new capability
-- [ ] Tested locally with MCP client (e.g., Claude Desktop)
 
 ## Quick Checklist for New Prompts
 
 - [ ] Created prompt file in `{module}/prompts/{prompt_name}.py`
-- [ ] Added `@prompt("prompt_name")` decorator
-- [ ] Made function async: `async def prompt_handler(ctx: Context) -> str`
+- [ ] Added ASF license header
+- [ ] Used `@prompt("prompt_name")` from `superset_core.mcp.decorators`
+- [ ] Made function async: `async def prompt_handler(...) -> str`
 - [ ] Added import to `{module}/prompts/__init__.py`
-- [ ] Verified module import exists in `app.py` (around line 244-253)
-- [ ] Added Apache license header to new file
-- [ ] Updated `DEFAULT_INSTRUCTIONS` in `app.py` to list the new prompt
-- [ ] Tested locally with MCP client (e.g., Claude Desktop)
+- [ ] Verified module import exists in `app.py`
 
 ## Quick Checklist for New Resources
 
 - [ ] Created resource file in `{module}/resources/{resource_name}.py`
-- [ ] Added `@mcp.resource("superset://{path}")` decorator with unique URI
+- [ ] Added ASF license header
+- [ ] Used `@mcp.resource("superset://{path}")` decorator
 - [ ] Added `@mcp_auth_hook` decorator
-- [ ] Implemented resource data retrieval logic
 - [ ] Added import to `{module}/resources/__init__.py`
-- [ ] Verified module import exists in `app.py` (around line 244-253)
-- [ ] Added Apache license header to new file
-- [ ] Updated `DEFAULT_INSTRUCTIONS` in `app.py` to list the new resource
-- [ ] Tested locally with MCP client (e.g., Claude Desktop)
+- [ ] Verified module import exists in `app.py`
 
 ## Getting Help
 

--- a/superset/mcp_service/CLAUDE.md
+++ b/superset/mcp_service/CLAUDE.md
@@ -456,7 +456,7 @@ MCP_CACHE_CONFIG = {
     "enabled": False,
     "list_tools_ttl": 300,
     "call_tool_ttl": 3600,
-    "excluded_tools": ["execute_sql", "generate_dashboard", ...],
+    "excluded_tools": ["execute_sql", "generate_dashboard"],  # add tools to exclude
 }
 
 # Multi-pod Storage (optional, requires Redis)


### PR DESCRIPTION
### SUMMARY

Updates `superset/mcp_service/CLAUDE.md` to reflect the current state of the MCP codebase after 90+ merged PRs since Jan 2025. This doc is used by LLM agents to understand MCP service conventions.

**Key changes:**
- Remove stale `@parse_request` decorator references (removed in #38918)
- Fix decorator import path to `superset_core.mcp.decorators` (was incorrectly documented as `superset_core.api.mcp`)
- Add `ToolAnnotations` pattern (required since #38641)
- Add RBAC permission checking docs (#38407)
- Add `event_logger` instrumentation pattern (#37859)
- Add middleware documentation (#38523)
- Add compile check pattern for chart creation (#38408)
- Update auth docs: `mcp_auth_hook` is only for resources, `@tool` handles tool auth
- Update config section with `MCP_RBAC_ENABLED`, cache, and store configs
- Update testing conventions: async `Client` pattern, `conftest` fixtures
- Update architecture tree with all current modules (database, sql_lab, explore, etc.)
- Add dependency injection architecture explanation
- Remove stale line number references that break on every PR
- Fix broken pitfall #9 (had identical good/bad examples)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - documentation only

### TESTING INSTRUCTIONS

1. Read through the updated `superset/mcp_service/CLAUDE.md`
2. Verify the documented patterns match what exists in the codebase (e.g., grep for `from superset_core.mcp.decorators import tool`)
3. Confirm no references to removed patterns like `@parse_request` or `superset_core.api.mcp`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API