### PR TITLE
fix(native-filters): prevent infinite recursion in filter scope tree traversal

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
@@ -18,7 +18,7 @@
  */
 import { Layout, LayoutItem, Charts } from 'src/dashboard/types';
 import { VizType } from '@superset-ui/core';
-import { buildTree } from './utils';
+import { buildTree, getTreeCheckedItems } from './utils';
 import type { TreeItem } from './types';
 
 // The types defined for Layout and sub elements is not compatible with the data we get back fro a real dashboard layout
@@ -18044,6 +18044,80 @@ describe('Ensure buildTree does not throw runtime errors when encountering an in
         validNodes,
         initiallyExcludedCharts,
         () => 'Fake title',
+      );
+    }).not.toThrow();
+  });
+
+  test('Does not infinitely recurse when layout contains a cycle (nested tabs circular reference)', () => {
+    // Simulate a corrupted layout where TAB-A → TAB-B → TAB-A (cycle)
+    const circularLayout = {
+      ROOT_ID: {
+        id: 'ROOT_ID',
+        type: 'ROOT',
+        children: ['TAB-A'],
+        parents: [],
+      },
+      'TAB-A': {
+        id: 'TAB-A',
+        type: 'TAB',
+        children: ['TAB-B'],
+        parents: ['ROOT_ID'],
+        meta: { text: 'Tab A' },
+      },
+      'TAB-B': {
+        id: 'TAB-B',
+        type: 'TAB',
+        // Points back to TAB-A, creating a cycle
+        children: ['TAB-A'],
+        parents: ['ROOT_ID', 'TAB-A'],
+        meta: { text: 'Tab B' },
+      },
+    };
+
+    const rootNode = circularLayout.ROOT_ID;
+    const rootTreeItem: TreeItem = { key: 'ROOT_ID', title: 'Root', children: [], nodeType: 'TAB' };
+
+    expect(() => {
+      buildTree(
+        rootNode as unknown as LayoutItem,
+        rootTreeItem,
+        circularLayout as unknown as Layout,
+        {} as Charts,
+        ['ROOT_ID', 'TAB-A', 'TAB-B'],
+        [],
+        () => 'title',
+      );
+    }).not.toThrow();
+  });
+
+  test('getTreeCheckedItems does not infinitely recurse when scope rootPath creates a cycle', () => {
+    // Simulate a corrupted layout where ROW-A → ROW-B → ROW-A (cycle via children)
+    const circularLayout = {
+      ROOT_ID: {
+        id: 'ROOT_ID',
+        type: 'ROOT',
+        children: ['ROW-A'],
+        parents: [],
+      },
+      'ROW-A': {
+        id: 'ROW-A',
+        type: 'ROW',
+        children: ['ROW-B'],
+        parents: ['ROOT_ID'],
+      },
+      'ROW-B': {
+        id: 'ROW-B',
+        type: 'ROW',
+        // Points back to ROW-A, creating a cycle
+        children: ['ROW-A'],
+        parents: ['ROOT_ID', 'ROW-A'],
+      },
+    };
+
+    expect(() => {
+      getTreeCheckedItems(
+        { rootPath: ['ROOT_ID'], excluded: [] },
+        circularLayout as unknown as Layout,
       );
     }).not.toThrow();
   });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
@@ -100,6 +100,7 @@ export const buildTree = (
   initiallyExcludedCharts: number[],
   buildTreeLeafTitle: BuildTreeLeafTitle,
   sliceEntities?: Record<number, Slice>,
+  visited: Set<string> = new Set(),
 ) => {
   if (!node) {
     return;
@@ -154,6 +155,10 @@ export const buildTree = (
 
   if (node.type !== CHART_TYPE) {
     node?.children?.forEach?.(child => {
+      if (visited.has(child)) {
+        return;
+      }
+      visited.add(child);
       const childNode = layout?.[child];
       if (childNode) {
         buildTree(
@@ -165,6 +170,7 @@ export const buildTree = (
           initiallyExcludedCharts,
           buildTreeLeafTitle,
           sliceEntities,
+          visited,
         );
       } else {
         logging.warn(
@@ -192,13 +198,19 @@ const checkTreeItem = (
   layout: Layout,
   items: string[],
   excluded: number[],
+  visited: Set<string> = new Set(),
 ) => {
   items.forEach(item => {
+    if (visited.has(item)) {
+      return;
+    }
+    visited.add(item);
     checkTreeItem(
       checkedItems,
       layout,
       addInvisibleParents(layout, item),
       excluded,
+      visited,
     );
     if (
       layout[item]?.type === CHART_TYPE &&


### PR DESCRIPTION
### SUMMARY

The `buildTree` and `checkTreeItem` functions in the native filter scope utilities could enter an infinite recursion loop in very specific scenarios involving deeply nested tabs. When a dashboard layout has circular references between tab container nodes (e.g., a nested tab whose children chain eventually points back to an ancestor node).

This fix introduces a `visited` Set to both functions to track already-processed nodes. Before processing each child node, the code checks whether it has been visited and skips it if so, preventing any recursive cycle from causing a stack overflow.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: 
<img width="888" height="232" alt="image" src="https://github.com/user-attachments/assets/41ae0c50-932f-48a4-aa46-d294cedfdb82" />

After: Filter creation modal should appear normally



### TESTING INSTRUCTIONS

1. Open a dashboard that has a native filter configured with filter scope.
2. Manually corrupt the dashboard's `position_json` so that a layout node references a child that creates a cycle (e.g., via deeply nested tabs where a tab container's children chain eventually references an ancestor).
3. **Before fix**: opening the Filters Configuration modal causes a `Maximum call stack size exceeded` error and the UI crashes.
4. **After fix**: the modal opens normally; the circular reference is silently skipped.

Alternatively, run the existing unit tests:
```bash
cd superset-frontend
npm run test -- src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API