### PR TITLE
fix(sqllab): show schema refresh icon only on hover

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
@@ -234,17 +234,19 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
       </Typography.Text>
       {identifier === 'schema' && (
         <div className="side-action-container" role="menu">
-          <RefreshLabel
-            onClick={e => {
-              e.stopPropagation();
-              handleRefreshTables({
-                dbId: Number(_dbId),
-                catalog,
-                schema,
-              });
-            }}
-            tooltipContent={t('Force refresh table list')}
-          />
+          <div className="action-hover">
+            <RefreshLabel
+              onClick={e => {
+                e.stopPropagation();
+                handleRefreshTables({
+                  dbId: Number(_dbId),
+                  catalog,
+                  schema,
+                });
+              }}
+              tooltipContent={t('Force refresh table list')}
+            />
+          </div>
         </div>
       )}
       {identifier === 'table' &&


### PR DESCRIPTION
### SUMMARY
The schema refresh icon in SQL Lab's left panel was always visible for every schema row. This change wraps it in the existing `action-hover` CSS class so it only appears when hovering over a schema node, consistent with how table action buttons behave.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Refresh icon visible on every schema row at all times.
**After:** Refresh icon only appears when hovering over a schema row.

### TESTING INSTRUCTIONS
1. Open SQL Lab
2. Select a database with schemas in the left panel
3. Verify the refresh icon is hidden by default on schema rows
4. Hover over a schema row and verify the refresh icon appears
5. Click the refresh icon and verify it triggers a table list refresh

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)