### PR TITLE
test(core): restore 100% TS coverage for core-packages-ts (copy utility)

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -180,6 +180,24 @@ jobs:
           docker run --rm $TAG bash -c \
           "npm run plugins:build"
 
+  core-packages-coverage:
+    needs: frontend-build
+    if: needs.frontend-build.outputs.should-run == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download Docker Image Artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: docker-image
+
+      - name: Load Docker Image
+        run: |
+          zstd -d < docker-image.tar.zst | docker load
+
+      - name: Enforce 100% TS coverage on core packages
+        run: |
+          docker run --rm $TAG bash -c "npm run core:cover"
+
   test-storybook:
     needs: frontend-build
     if: needs.frontend-build.outputs.should-run == 'true'

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -180,24 +180,6 @@ jobs:
           docker run --rm $TAG bash -c \
           "npm run plugins:build"
 
-  core-packages-coverage:
-    needs: frontend-build
-    if: needs.frontend-build.outputs.should-run == 'true'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Download Docker Image Artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: docker-image
-
-      - name: Load Docker Image
-        run: |
-          zstd -d < docker-image.tar.zst | docker load
-
-      - name: Enforce 100% TS coverage on core packages
-        run: |
-          docker run --rm $TAG bash -c "npm run core:cover"
-
   test-storybook:
     needs: frontend-build
     if: needs.frontend-build.outputs.should-run == 'true'

--- a/superset-frontend/packages/superset-ui-core/test/utils/copy.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/copy.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { copyTextToClipboard } from '@superset-ui/core';
+
+const SAFARI_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+const CHROME_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+const makeGetText = (text: string) => () => Promise.resolve(text);
+
+test('uses Clipboard API writeText on non-Safari browsers', async () => {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: CHROME_UA,
+    configurable: true,
+  });
+  const writeText = jest.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+
+  await copyTextToClipboard(makeGetText('hello'));
+
+  expect(writeText).toHaveBeenCalledWith('hello');
+});
+
+test('uses ClipboardItem API on Safari browsers', async () => {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: SAFARI_UA,
+    configurable: true,
+  });
+  const write = jest.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { write },
+    configurable: true,
+  });
+  const MockClipboardItem = jest.fn().mockImplementation(data => ({ data }));
+  (global as any).ClipboardItem = MockClipboardItem;
+
+  await copyTextToClipboard(makeGetText('safari text'));
+
+  expect(MockClipboardItem).toHaveBeenCalled();
+  expect(write).toHaveBeenCalledWith([expect.anything()]);
+
+  delete (global as any).ClipboardItem;
+});
+
+test('falls back to writeText on Safari when ClipboardItem write fails', async () => {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: SAFARI_UA,
+    configurable: true,
+  });
+  const writeText = jest.fn().mockResolvedValue(undefined);
+  const write = jest.fn().mockRejectedValue(new Error('not supported'));
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { write, writeText },
+    configurable: true,
+  });
+  const MockClipboardItem = jest.fn().mockImplementation(data => ({ data }));
+  (global as any).ClipboardItem = MockClipboardItem;
+
+  await copyTextToClipboard(makeGetText('fallback text'));
+
+  expect(writeText).toHaveBeenCalledWith('fallback text');
+
+  delete (global as any).ClipboardItem;
+});
+
+function mockExecCommand(impl: (cmd: string) => boolean) {
+  Object.defineProperty(document, 'execCommand', {
+    value: jest.fn().mockImplementation(impl),
+    configurable: true,
+    writable: true,
+  });
+}
+
+function setupFallbackMocks(options: {
+  selection: Partial<Selection> | null;
+}) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: CHROME_UA,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      writeText: jest.fn().mockRejectedValue(new Error('not allowed')),
+    },
+    configurable: true,
+  });
+
+  const mockRange = { selectNode: jest.fn() };
+  const mockSpan = {
+    style: {} as CSSStyleDeclaration,
+    textContent: '',
+  } as unknown as HTMLSpanElement;
+
+  jest
+    .spyOn(document, 'getSelection')
+    .mockReturnValue(options.selection as Selection | null);
+  jest.spyOn(document, 'createRange').mockReturnValue(mockRange as unknown as Range);
+  jest.spyOn(document, 'createElement').mockReturnValue(mockSpan);
+  jest.spyOn(document.body, 'appendChild').mockImplementation(() => mockSpan);
+  jest.spyOn(document.body, 'removeChild').mockImplementation(() => mockSpan);
+
+  return { mockRange, mockSpan };
+}
+
+test('falls back to execCommand copy when Clipboard API is unavailable', async () => {
+  const removeRange = jest.fn();
+  const { mockRange } = setupFallbackMocks({
+    selection: {
+      removeAllRanges: jest.fn(),
+      addRange: jest.fn(),
+      removeRange,
+    },
+  });
+  mockExecCommand(cmd => cmd === 'copy');
+
+  await copyTextToClipboard(makeGetText('exec text'));
+
+  expect(document.execCommand).toHaveBeenCalledWith('copy');
+  expect(removeRange).toHaveBeenCalledWith(mockRange);
+
+  jest.restoreAllMocks();
+});
+
+test('falls back to removeAllRanges when removeRange is not available', async () => {
+  const removeAllRanges = jest.fn();
+  setupFallbackMocks({
+    selection: {
+      removeAllRanges,
+      addRange: jest.fn(),
+      removeRange: undefined,
+    },
+  });
+  mockExecCommand(cmd => cmd === 'copy');
+
+  await copyTextToClipboard(makeGetText('no removeRange'));
+
+  expect(removeAllRanges).toHaveBeenCalled();
+
+  jest.restoreAllMocks();
+});
+
+test('rejects when execCommand returns false', async () => {
+  setupFallbackMocks({
+    selection: {
+      removeAllRanges: jest.fn(),
+      addRange: jest.fn(),
+      removeRange: jest.fn(),
+    },
+  });
+  mockExecCommand(() => false);
+
+  await expect(copyTextToClipboard(makeGetText('fail'))).rejects.toBeUndefined();
+
+  jest.restoreAllMocks();
+});
+
+test('rejects when execCommand throws', async () => {
+  setupFallbackMocks({
+    selection: {
+      removeAllRanges: jest.fn(),
+      addRange: jest.fn(),
+      removeRange: jest.fn(),
+    },
+  });
+  Object.defineProperty(document, 'execCommand', {
+    value: jest.fn().mockImplementation(() => {
+      throw new Error('execCommand error');
+    }),
+    configurable: true,
+    writable: true,
+  });
+
+  await expect(copyTextToClipboard(makeGetText('throw'))).rejects.toBeUndefined();
+
+  jest.restoreAllMocks();
+});
+
+test('resolves without copying when getSelection returns null', async () => {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: CHROME_UA,
+    configurable: true,
+  });
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      writeText: jest.fn().mockRejectedValue(new Error('not allowed')),
+    },
+    configurable: true,
+  });
+
+  jest.spyOn(document, 'getSelection').mockReturnValue(null);
+
+  await expect(copyTextToClipboard(makeGetText('no selection'))).resolves.toBeUndefined();
+
+  jest.restoreAllMocks();
+});

--- a/superset-frontend/packages/superset-ui-core/test/utils/copy.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/copy.test.ts
@@ -27,6 +27,11 @@ const makeGetText = (text: string) => () => Promise.resolve(text);
 
 const globalWithClipboardItem = global as unknown as { ClipboardItem?: unknown };
 
+afterEach(() => {
+  jest.restoreAllMocks();
+  delete globalWithClipboardItem.ClipboardItem;
+});
+
 test('uses Clipboard API writeText on non-Safari browsers', async () => {
   Object.defineProperty(navigator, 'userAgent', {
     value: CHROME_UA,
@@ -60,8 +65,6 @@ test('uses ClipboardItem API on Safari browsers', async () => {
 
   expect(MockClipboardItem).toHaveBeenCalled();
   expect(write).toHaveBeenCalledWith([expect.anything()]);
-
-  delete globalWithClipboardItem.ClipboardItem;
 });
 
 test('falls back to writeText on Safari when ClipboardItem write fails', async () => {
@@ -81,8 +84,6 @@ test('falls back to writeText on Safari when ClipboardItem write fails', async (
   await copyTextToClipboard(makeGetText('fallback text'));
 
   expect(writeText).toHaveBeenCalledWith('fallback text');
-
-  delete globalWithClipboardItem.ClipboardItem;
 });
 
 function mockExecCommand(impl: (cmd: string) => boolean) {
@@ -139,8 +140,6 @@ test('falls back to execCommand copy when Clipboard API is unavailable', async (
 
   expect(document.execCommand).toHaveBeenCalledWith('copy');
   expect(removeRange).toHaveBeenCalledWith(mockRange);
-
-  jest.restoreAllMocks();
 });
 
 test('falls back to removeAllRanges when removeRange is not available', async () => {
@@ -157,8 +156,6 @@ test('falls back to removeAllRanges when removeRange is not available', async ()
   await copyTextToClipboard(makeGetText('no removeRange'));
 
   expect(removeAllRanges).toHaveBeenCalled();
-
-  jest.restoreAllMocks();
 });
 
 test('rejects when execCommand returns false', async () => {
@@ -172,8 +169,6 @@ test('rejects when execCommand returns false', async () => {
   mockExecCommand(() => false);
 
   await expect(copyTextToClipboard(makeGetText('fail'))).rejects.toBeUndefined();
-
-  jest.restoreAllMocks();
 });
 
 test('rejects when execCommand throws', async () => {
@@ -193,8 +188,6 @@ test('rejects when execCommand throws', async () => {
   });
 
   await expect(copyTextToClipboard(makeGetText('throw'))).rejects.toBeUndefined();
-
-  jest.restoreAllMocks();
 });
 
 test('resolves without copying when getSelection returns null', async () => {
@@ -211,7 +204,7 @@ test('resolves without copying when getSelection returns null', async () => {
 
   jest.spyOn(document, 'getSelection').mockReturnValue(null);
 
-  await expect(copyTextToClipboard(makeGetText('no selection'))).resolves.toBeUndefined();
-
-  jest.restoreAllMocks();
+  await expect(
+    copyTextToClipboard(makeGetText('no selection')),
+  ).resolves.toBeUndefined();
 });

--- a/superset-frontend/packages/superset-ui-core/test/utils/copy.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/copy.test.ts
@@ -25,6 +25,8 @@ const CHROME_UA =
 
 const makeGetText = (text: string) => () => Promise.resolve(text);
 
+const globalWithClipboardItem = global as unknown as { ClipboardItem?: unknown };
+
 test('uses Clipboard API writeText on non-Safari browsers', async () => {
   Object.defineProperty(navigator, 'userAgent', {
     value: CHROME_UA,
@@ -52,14 +54,14 @@ test('uses ClipboardItem API on Safari browsers', async () => {
     configurable: true,
   });
   const MockClipboardItem = jest.fn().mockImplementation(data => ({ data }));
-  (global as any).ClipboardItem = MockClipboardItem;
+  globalWithClipboardItem.ClipboardItem = MockClipboardItem;
 
   await copyTextToClipboard(makeGetText('safari text'));
 
   expect(MockClipboardItem).toHaveBeenCalled();
   expect(write).toHaveBeenCalledWith([expect.anything()]);
 
-  delete (global as any).ClipboardItem;
+  delete globalWithClipboardItem.ClipboardItem;
 });
 
 test('falls back to writeText on Safari when ClipboardItem write fails', async () => {
@@ -74,13 +76,13 @@ test('falls back to writeText on Safari when ClipboardItem write fails', async (
     configurable: true,
   });
   const MockClipboardItem = jest.fn().mockImplementation(data => ({ data }));
-  (global as any).ClipboardItem = MockClipboardItem;
+  globalWithClipboardItem.ClipboardItem = MockClipboardItem;
 
   await copyTextToClipboard(makeGetText('fallback text'));
 
   expect(writeText).toHaveBeenCalledWith('fallback text');
 
-  delete (global as any).ClipboardItem;
+  delete globalWithClipboardItem.ClipboardItem;
 });
 
 function mockExecCommand(impl: (cmd: string) => boolean) {


### PR DESCRIPTION
### SUMMARY

The `copyTextToClipboard` utility (`src/utils/copy.ts`) was introduced in #39246 without a corresponding test file. This caused the `core-packages-ts` Codecov target to drop from 100% to 99.81%, blocking other PRs that contribute to the packages directory.

This PR adds `test/utils/copy.test.ts` with 8 tests that cover every branch in `copy.ts`:

- **Chrome/non-Safari path**: uses `navigator.clipboard.writeText` directly
- **Safari path**: uses `ClipboardItem` + `navigator.clipboard.write`
- **Safari fallback**: falls back to `writeText` when `ClipboardItem.write` throws
- **Legacy `execCommand` fallback** (when Clipboard API is unavailable):
  - Success path with `selection.removeRange`
  - Success path using `selection.removeAllRanges` when `removeRange` is absent
  - Rejection when `execCommand` returns `false`
  - Rejection when `execCommand` throws
- **Null selection guard**: resolves without error when `getSelection()` returns `null`

Also ran `tsc -b` to regenerate the local `lib/` declarations that include `copy.ts` (the `lib/` is gitignored and was stale locally, causing the pre-commit type check to fail before the rebuild).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only change.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest "packages/superset-ui-core/test/utils/copy.test.ts" --coverage \
  --collectCoverageFrom='["packages/superset-ui-core/src/utils/copy.ts"]'
# Expected: 100% statements, branches, functions, lines
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API