### PR TITLE
fix(ListView): empty state not filling available width

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -188,6 +188,7 @@ const ViewModeContainer = styled.div`
 const EmptyWrapper = styled.div`
   ${({ theme }) => `
     padding: ${theme.sizeUnit * 40}px 0;
+    width: 100%;
 
     &.table {
       background: ${theme.colorBgContainer};


### PR DESCRIPTION
### SUMMARY

The empty state in list views (Dashboards, Charts, Datasets, etc.) was not filling the available horizontal space. It appeared confined to the left portion of the page instead of centering across the full width.

The `EmptyWrapper` styled component was missing `width: 100%`, causing it to be constrained by the antd table's scroll layout (`ant-table-scroll-horizontal`) rather than stretching to fill the full parent container width.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1899" height="860" alt="Screenshot 2026-04-15 at 16 01 33" src="https://github.com/user-attachments/assets/6063e30a-bdd1-4963-ba21-8fa79d1b53cc" />

<img width="1902" height="856" alt="Screenshot 2026-04-15 at 16 13 58" src="https://github.com/user-attachments/assets/ca766957-d3cf-49d8-891c-799aa7d1a135" />

### TESTING INSTRUCTIONS

1. Navigate to Dashboards (or Charts/Datasets)
2. Type a search string that returns no results
3. Verify the empty state ("No results match your filter criteria") fills the full width of the list area and is centered

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)