### PR TITLE
feat(firebird): add FirebirdStatement to bypass sqlglot parsing

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -77,7 +77,7 @@ SQLGLOT_DIALECTS = {
     # "dynamodb": ???
     # "elasticsearch": ???
     # "exa": ???
-    # "firebird": ???
+    # "firebird": not supported by sqlglot — uses FirebirdStatement instead
     "firebolt": Firebolt,
     "gsheets": Dialects.SQLITE,
     "hana": Dialects.POSTGRES,
@@ -1268,6 +1268,183 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         return predicate
 
 
+# Regex to split SQL on semicolons that are NOT inside single-quoted strings.
+_FIREBIRD_SEMI_SPLIT_RE = re.compile(r";(?=(?:[^']*'[^']*')*[^']*$)")
+
+# Match Firebird's FIRST <n> clause: SELECT FIRST 100 ...
+_FIREBIRD_FIRST_RE = re.compile(r"\bFIRST\s+(\d+)\b", re.IGNORECASE)
+
+# DML/DDL keywords that indicate a mutating statement.
+_FIREBIRD_MUTATING_KEYWORDS = frozenset(
+    {"INSERT", "UPDATE", "DELETE", "DROP", "ALTER", "CREATE", "EXECUTE", "MERGE"}
+)
+
+
+class FirebirdStatement(BaseSQLStatement[str]):
+    """
+    A SQL statement for the Firebird database engine.
+
+    Firebird uses non-standard syntax that is not supported by sqlglot:
+
+    - ``SELECT FIRST <n>`` instead of ``LIMIT <n>``
+    - ``DATEADD(-30 DAY TO CURRENT_DATE)``
+    - ``EXTRACT(YEAR FROM col)`` (supported by some dialects but not all)
+
+    Because there is no sqlglot dialect for Firebird, this class stores the
+    SQL as a plain string and uses simple regular expressions for the few
+    operations Superset needs (limit injection, mutation detection, etc.).
+
+    This follows the same pattern as :class:`KustoKQLStatement`.
+    """
+
+    def __init__(
+        self,
+        statement: str | None = None,
+        engine: str = "firebird",
+        ast: str | None = None,
+    ) -> None:
+        super().__init__(statement, engine, ast)
+
+    @classmethod
+    def split_script(
+        cls,
+        script: str,
+        engine: str,
+    ) -> list[FirebirdStatement]:
+        """
+        Split a script into individual statements on semicolons.
+
+        Semicolons inside single-quoted string literals are preserved.
+        """
+        parts = []
+        for part in _FIREBIRD_SEMI_SPLIT_RE.split(script):
+            stripped = part.strip()
+            if stripped:
+                parts.append(cls(stripped, engine, stripped))
+        return parts or [cls(script.strip(), engine, script.strip())]
+
+    @classmethod
+    def _parse_statement(
+        cls,
+        statement: str,
+        engine: str,
+    ) -> str:
+        if engine != "firebird":
+            raise SupersetParseError(
+                statement,
+                engine,
+                message=f"Invalid engine: {engine}",
+            )
+
+        statements = _FIREBIRD_SEMI_SPLIT_RE.split(statement)
+        statements = [s.strip() for s in statements if s.strip()]
+        if len(statements) != 1:
+            raise SupersetParseError(
+                statement,
+                engine,
+                message="FirebirdStatement should have exactly one statement",
+            )
+        return statements[0]
+
+    @classmethod
+    def _extract_tables_from_statement(
+        cls,
+        parsed: str,
+        engine: str,
+    ) -> set[Table]:
+        """
+        Extract table references from a Firebird SQL statement.
+
+        Since we cannot reliably parse Firebird SQL without a proper parser,
+        we return an empty set and log a warning.  This means that data-access
+        roles will not be enforced by Superset for Firebird databases.
+        """
+        logger.warning(
+            "Firebird SQL is not supported by sqlglot — table extraction "
+            "disabled; data-access roles will not be enforced by Superset."
+        )
+        return set()
+
+    def format(self, comments: bool = True) -> str:
+        """Return the SQL statement as-is (no AST reformatting)."""
+        return self._parsed.strip()
+
+    def get_settings(self) -> dict[str, str | bool]:
+        return {}
+
+    def is_select(self) -> bool:
+        first_word = (
+            self._parsed.lstrip().split()[0].upper()
+            if self._parsed.strip()
+            else ""
+        )
+        return first_word in {"SELECT", "WITH"}
+
+    def is_mutating(self) -> bool:
+        first_word = (
+            self._parsed.lstrip().split()[0].upper()
+            if self._parsed.strip()
+            else ""
+        )
+        return first_word in _FIREBIRD_MUTATING_KEYWORDS
+
+    def optimize(self) -> FirebirdStatement:
+        """Return self — no AST-level optimisation is possible."""
+        return FirebirdStatement(ast=self._parsed, engine=self.engine)
+
+    def check_functions_present(self, functions: set[str]) -> bool:
+        upper = self._parsed.upper()
+        return any(f.upper() in upper for f in functions)
+
+    def get_limit_value(self) -> int | None:
+        """
+        Extract the ``FIRST <n>`` limit from the statement.
+
+            >>> FirebirdStatement("SELECT FIRST 10 * FROM t").get_limit_value()
+            10
+            >>> FirebirdStatement("SELECT * FROM t").get_limit_value() is None
+            True
+        """
+        match = _FIREBIRD_FIRST_RE.search(self._parsed)
+        return int(match.group(1)) if match else None
+
+    def set_limit_value(
+        self,
+        limit: int,
+        method: LimitMethod = LimitMethod.FORCE_LIMIT,
+    ) -> None:
+        """
+        Set (or replace) the ``FIRST <n>`` clause.
+
+            >>> stmt = FirebirdStatement("SELECT FIRST 1000 * FROM t")
+            >>> stmt.set_limit_value(10)
+            >>> stmt.format()
+            'SELECT FIRST 10 * FROM t'
+
+            >>> stmt = FirebirdStatement("SELECT * FROM t")
+            >>> stmt.set_limit_value(10)
+            >>> stmt.format()
+            'SELECT FIRST 10 * FROM t'
+        """
+        match = _FIREBIRD_FIRST_RE.search(self._parsed)
+        if match:
+            self._parsed = (
+                self._parsed[: match.start()]
+                + f"FIRST {limit}"
+                + self._parsed[match.end() :]
+            )
+        else:
+            self._parsed = re.sub(
+                r"(?i)^(\s*SELECT)\b",
+                rf"\1 FIRST {limit}",
+                self._parsed,
+                count=1,
+            )
+
+    def parse_predicate(self, predicate: str) -> str:
+        return predicate
+
+
 class SQLScript:
     """
     A SQL script, with 0+ statements.
@@ -1277,6 +1454,7 @@ class SQLScript:
     # adds a lot of complexity to Superset, so we should avoid adding new engines to
     # this data structure.
     special_engines = {
+        "firebird": FirebirdStatement,
         "kustokql": KustoKQLStatement,
     }
 

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1321,7 +1321,12 @@ class FirebirdStatement(BaseSQLStatement[str]):
             stripped = part.strip()
             if stripped:
                 parts.append(cls(stripped, engine, stripped))
-        return parts or [cls(script.strip(), engine, script.strip())]
+        if parts:
+            return parts
+        if not script.strip():
+            return []
+        stripped = script.strip()
+        return [cls(stripped, engine, stripped)]
 
     @classmethod
     def _parse_statement(
@@ -1370,22 +1375,39 @@ class FirebirdStatement(BaseSQLStatement[str]):
         return self._parsed.strip()
 
     def get_settings(self) -> dict[str, str | bool]:
+        """Return statement-level settings.  Firebird has none."""
         return {}
 
     def is_select(self) -> bool:
-        first_word = (
-            self._parsed.lstrip().split()[0].upper()
-            if self._parsed.strip()
-            else ""
-        )
-        return first_word in {"SELECT", "WITH"}
+        """Check whether the statement is a SELECT-style query."""
+        sql = self._parsed.lstrip().upper()
+        if not sql:
+            return False
+        first_word = sql.split()[0]
+        if first_word == "WITH":
+            # WITH ... SELECT is a select; WITH ... INSERT/DELETE/etc. is not.
+            return not bool(
+                re.search(
+                    r"\b(" + "|".join(_FIREBIRD_MUTATING_KEYWORDS) + r")\b",
+                    sql,
+                )
+            )
+        return first_word == "SELECT"
 
     def is_mutating(self) -> bool:
-        first_word = (
-            self._parsed.lstrip().split()[0].upper()
-            if self._parsed.strip()
-            else ""
-        )
+        """Check whether the statement performs a mutating operation."""
+        sql = self._parsed.lstrip().upper()
+        if not sql:
+            return False
+        first_word = sql.split()[0]
+        if first_word == "WITH":
+            # WITH ... INSERT/DELETE/UPDATE is mutating.
+            return bool(
+                re.search(
+                    r"\b(" + "|".join(_FIREBIRD_MUTATING_KEYWORDS) + r")\b",
+                    sql,
+                )
+            )
         return first_word in _FIREBIRD_MUTATING_KEYWORDS
 
     def optimize(self) -> FirebirdStatement:
@@ -1393,8 +1415,17 @@ class FirebirdStatement(BaseSQLStatement[str]):
         return FirebirdStatement(ast=self._parsed, engine=self.engine)
 
     def check_functions_present(self, functions: set[str]) -> bool:
+        """Check whether any of the given function names appear in the SQL."""
         upper = self._parsed.upper()
         return any(f.upper() in upper for f in functions)
+
+    def check_tables_present(self, tables: set[str]) -> bool:
+        """Check if any of the given tables are present in the statement."""
+        logger.warning(
+            "Firebird SQL is not supported by sqlglot — table checking "
+            "disabled; data-access roles will not be enforced by Superset."
+        )
+        return False
 
     def get_limit_value(self) -> int | None:
         """
@@ -1426,6 +1457,15 @@ class FirebirdStatement(BaseSQLStatement[str]):
             >>> stmt.format()
             'SELECT FIRST 10 * FROM t'
         """
+        if method == LimitMethod.FETCH_MANY:
+            return
+        if method not in (LimitMethod.FORCE_LIMIT, LimitMethod.WRAP_SQL):
+            raise SupersetParseError(
+                self._parsed,
+                self.engine,
+                message=f"Unsupported limit method for Firebird: {method}",
+            )
+
         match = _FIREBIRD_FIRST_RE.search(self._parsed)
         if match:
             self._parsed = (
@@ -1442,7 +1482,21 @@ class FirebirdStatement(BaseSQLStatement[str]):
             )
 
     def parse_predicate(self, predicate: str) -> str:
+        """Return the predicate unchanged (no AST rewriting for Firebird)."""
         return predicate
+
+    def apply_rls(
+        self,
+        catalog: str | None,
+        schema: str | None,
+        predicates: dict[Table, list[str]],
+        method: RLSMethod,
+    ) -> None:
+        """Apply RLS rules.  Not supported for Firebird (no AST)."""
+        logger.warning(
+            "Firebird SQL is not supported by sqlglot — RLS rewriting "
+            "disabled; row-level security will not be enforced by Superset."
+        )
 
 
 class SQLScript:

--- a/tests/unit_tests/sql/test_firebird_statement.py
+++ b/tests/unit_tests/sql/test_firebird_statement.py
@@ -1,0 +1,277 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for FirebirdStatement — the raw-string SQL statement class for Firebird.
+
+Firebird uses non-standard syntax (DATEADD, SELECT FIRST N, EXTRACT) that is
+not supported by sqlglot, so FirebirdStatement bypasses sqlglot entirely —
+following the same pattern as KustoKQLStatement.
+"""
+
+import pytest
+
+from superset.exceptions import SupersetParseError
+from superset.sql.parse import (
+    FirebirdStatement,
+    LimitMethod,
+    SQLScript,
+)
+
+
+# ---------------------------------------------------------------------------
+# split_script
+# ---------------------------------------------------------------------------
+
+
+class TestFirebirdSplitScript:
+    def test_single_statement(self) -> None:
+        stmts = FirebirdStatement.split_script("SELECT * FROM t", "firebird")
+        assert len(stmts) == 1
+        assert stmts[0].format() == "SELECT * FROM t"
+
+    def test_multiple_statements(self) -> None:
+        sql = "SELECT 1; SELECT 2; SELECT 3"
+        stmts = FirebirdStatement.split_script(sql, "firebird")
+        assert len(stmts) == 3
+        assert stmts[0].format() == "SELECT 1"
+        assert stmts[1].format() == "SELECT 2"
+        assert stmts[2].format() == "SELECT 3"
+
+    def test_semicolons_in_strings_preserved(self) -> None:
+        sql = "SELECT * FROM t WHERE name = 'foo;bar'"
+        stmts = FirebirdStatement.split_script(sql, "firebird")
+        assert len(stmts) == 1
+        assert "foo;bar" in stmts[0].format()
+
+    def test_trailing_semicolon(self) -> None:
+        sql = "SELECT 1;"
+        stmts = FirebirdStatement.split_script(sql, "firebird")
+        assert len(stmts) == 1
+        assert stmts[0].format() == "SELECT 1"
+
+    def test_empty_script(self) -> None:
+        stmts = FirebirdStatement.split_script("", "firebird")
+        assert len(stmts) == 1
+
+
+# ---------------------------------------------------------------------------
+# _parse_statement
+# ---------------------------------------------------------------------------
+
+
+class TestFirebirdParseStatement:
+    def test_single_statement(self) -> None:
+        stmt = FirebirdStatement("SELECT 1", "firebird")
+        assert stmt.format() == "SELECT 1"
+
+    def test_invalid_engine(self) -> None:
+        with pytest.raises(SupersetParseError, match="Invalid engine"):
+            FirebirdStatement("SELECT 1", "postgresql")
+
+    def test_multiple_statements_rejected(self) -> None:
+        with pytest.raises(
+            SupersetParseError,
+            match="FirebirdStatement should have exactly one statement",
+        ):
+            FirebirdStatement("SELECT 1; SELECT 2", "firebird")
+
+
+# ---------------------------------------------------------------------------
+# is_select / is_mutating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ("SELECT * FROM t", True),
+        ("SELECT FIRST 10 * FROM t", True),
+        ("WITH cte AS (SELECT 1) SELECT * FROM cte", True),
+        ("INSERT INTO t VALUES (1)", False),
+        ("UPDATE t SET x = 1", False),
+        ("DELETE FROM t WHERE id = 1", False),
+        ("CREATE TABLE t (id INT)", False),
+        ("DROP TABLE t", False),
+        ("ALTER TABLE t ADD col INT", False),
+    ],
+)
+def test_firebird_is_select(sql: str, expected: bool) -> None:
+    assert FirebirdStatement(sql, "firebird").is_select() == expected
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ("SELECT * FROM t", False),
+        ("INSERT INTO t VALUES (1)", True),
+        ("UPDATE t SET x = 1", True),
+        ("DELETE FROM t WHERE id = 1", True),
+        ("CREATE TABLE t (id INT)", True),
+        ("DROP TABLE t", True),
+        ("ALTER TABLE t ADD col INT", True),
+        ("EXECUTE PROCEDURE sp_test", True),
+    ],
+)
+def test_firebird_is_mutating(sql: str, expected: bool) -> None:
+    assert FirebirdStatement(sql, "firebird").is_mutating() == expected
+
+
+# ---------------------------------------------------------------------------
+# LIMIT handling (SELECT FIRST <n>)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ("SELECT FIRST 10 * FROM t", 10),
+        ("SELECT FIRST 100 a, b FROM t", 100),
+        ("SELECT * FROM t", None),
+    ],
+)
+def test_firebird_get_limit_value(sql: str, expected: int | None) -> None:
+    assert FirebirdStatement(sql, "firebird").get_limit_value() == expected
+
+
+@pytest.mark.parametrize(
+    "sql, limit, expected",
+    [
+        (
+            "SELECT FIRST 1000 * FROM t",
+            10,
+            "SELECT FIRST 10 * FROM t",
+        ),
+        (
+            "SELECT * FROM t",
+            10,
+            "SELECT FIRST 10 * FROM t",
+        ),
+        (
+            "SELECT FIRST 500 a, b FROM t WHERE x = 1 ORDER BY a",
+            25,
+            "SELECT FIRST 25 a, b FROM t WHERE x = 1 ORDER BY a",
+        ),
+    ],
+)
+def test_firebird_set_limit_value(sql: str, limit: int, expected: str) -> None:
+    stmt = FirebirdStatement(sql, "firebird")
+    stmt.set_limit_value(limit)
+    assert stmt.format() == expected
+
+
+# ---------------------------------------------------------------------------
+# Firebird-specific SQL that would fail with sqlglot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM t WHERE d >= DATEADD(-30 DAY TO CURRENT_DATE)",
+        "SELECT FIRST 10 * FROM t",
+        "SELECT EXTRACT(YEAR FROM d) AS yr, EXTRACT(MONTH FROM d) AS mo FROM t",
+        (
+            "SELECT CAST(EXTRACT(YEAR FROM col) || '-' "
+            "|| EXTRACT(MONTH FROM col) || '-01' AS DATE) FROM t"
+        ),
+        "SELECT DATEADD(second, col, CAST('00:00:00' AS TIMESTAMP)) FROM t",
+        "EXECUTE PROCEDURE my_proc('arg1', 2)",
+    ],
+)
+def test_firebird_specific_syntax_no_parse_error(sql: str) -> None:
+    """Creating a statement should succeed without errors."""
+    stmt = FirebirdStatement(sql, "firebird")
+    assert stmt.format() == sql
+
+
+# ---------------------------------------------------------------------------
+# format / optimize / misc
+# ---------------------------------------------------------------------------
+
+
+def test_firebird_format_preserves_sql() -> None:
+    sql = "SELECT FIRST 10 a, b FROM t WHERE x > 1 ORDER BY a DESC"
+    assert FirebirdStatement(sql, "firebird").format() == sql
+
+
+def test_firebird_optimize_is_noop() -> None:
+    stmt = FirebirdStatement("SELECT * FROM t", "firebird")
+    optimized = stmt.optimize()
+    assert optimized.format() == stmt.format()
+
+
+def test_firebird_get_settings_empty() -> None:
+    assert FirebirdStatement("SELECT 1", "firebird").get_settings() == {}
+
+
+def test_firebird_tables_empty() -> None:
+    """Tables are not extracted for Firebird (no parser)."""
+    stmt = FirebirdStatement("SELECT * FROM my_table", "firebird")
+    assert stmt.tables == set()
+
+
+def test_firebird_parse_predicate_passthrough() -> None:
+    stmt = FirebirdStatement("SELECT 1", "firebird")
+    assert stmt.parse_predicate("a > 1") == "a > 1"
+
+
+def test_firebird_check_functions_present() -> None:
+    stmt = FirebirdStatement("SELECT VERSION() FROM t", "firebird")
+    assert stmt.check_functions_present({"version"}) is True
+    assert stmt.check_functions_present({"nonexistent"}) is False
+
+
+# ---------------------------------------------------------------------------
+# SQLScript integration
+# ---------------------------------------------------------------------------
+
+
+def test_firebird_sqlscript_split_and_format() -> None:
+    sql = "SELECT 1; SELECT 2; SELECT 3"
+    script = SQLScript(sql, "firebird")
+    assert len(script.statements) == 3
+    assert script.format() == "SELECT 1;\nSELECT 2;\nSELECT 3"
+
+
+def test_firebird_sqlscript_has_mutation_false() -> None:
+    assert SQLScript("SELECT * FROM t", "firebird").has_mutation() is False
+
+
+def test_firebird_sqlscript_has_mutation_true() -> None:
+    assert SQLScript("INSERT INTO t VALUES (1)", "firebird").has_mutation() is True
+
+
+def test_firebird_sqlscript_dateadd_no_parse_error() -> None:
+    """This is the exact query pattern that was failing before the fix."""
+    sql = (
+        "SELECT ag.CODIGO, ag.DATA, ag.HORA, med.NOME AS MEDICO "
+        "FROM AGENDA ag "
+        "LEFT JOIN PESSOAS med ON med.CODIGO = ag.CD_COLABORADOR "
+        "WHERE ag.DATA >= DATEADD(-30 DAY TO CURRENT_DATE) "
+        "ORDER BY ag.DATA DESC"
+    )
+    script = SQLScript(sql, "firebird")
+    assert len(script.statements) == 1
+    assert script.statements[0].is_select() is True
+    assert script.statements[0].is_mutating() is False
+
+
+def test_firebird_sqlscript_uses_firebird_statement() -> None:
+    """SQLScript should use FirebirdStatement for engine='firebird'."""
+    script = SQLScript("SELECT 1", "firebird")
+    assert isinstance(script.statements[0], FirebirdStatement)

--- a/tests/unit_tests/sql/test_firebird_statement.py
+++ b/tests/unit_tests/sql/test_firebird_statement.py
@@ -39,6 +39,7 @@ from superset.sql.parse import (
 
 
 class TestFirebirdSplitScript:
+    """Test SQL script splitting behavior for Firebird statements."""
     def test_single_statement(self) -> None:
         stmts = FirebirdStatement.split_script("SELECT * FROM t", "firebird")
         assert len(stmts) == 1
@@ -65,8 +66,14 @@ class TestFirebirdSplitScript:
         assert stmts[0].format() == "SELECT 1"
 
     def test_empty_script(self) -> None:
+        """An empty script should return an empty list."""
         stmts = FirebirdStatement.split_script("", "firebird")
-        assert len(stmts) == 1
+        assert len(stmts) == 0
+
+    def test_whitespace_only_script(self) -> None:
+        """A whitespace-only script should return an empty list."""
+        stmts = FirebirdStatement.split_script("   ", "firebird")
+        assert len(stmts) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +82,7 @@ class TestFirebirdSplitScript:
 
 
 class TestFirebirdParseStatement:
+    """Test statement parsing and validation for Firebird."""
     def test_single_statement(self) -> None:
         stmt = FirebirdStatement("SELECT 1", "firebird")
         assert stmt.format() == "SELECT 1"
@@ -108,9 +116,12 @@ class TestFirebirdParseStatement:
         ("CREATE TABLE t (id INT)", False),
         ("DROP TABLE t", False),
         ("ALTER TABLE t ADD col INT", False),
+        ("WITH cte AS (SELECT 1) INSERT INTO t SELECT * FROM cte", False),
+        ("WITH cte AS (SELECT 1) DELETE FROM t WHERE id IN (SELECT id FROM cte)", False),
     ],
 )
 def test_firebird_is_select(sql: str, expected: bool) -> None:
+    """Verify select-statement detection for Firebird SQL."""
     assert FirebirdStatement(sql, "firebird").is_select() == expected
 
 
@@ -125,9 +136,12 @@ def test_firebird_is_select(sql: str, expected: bool) -> None:
         ("DROP TABLE t", True),
         ("ALTER TABLE t ADD col INT", True),
         ("EXECUTE PROCEDURE sp_test", True),
+        ("WITH cte AS (SELECT 1) INSERT INTO t SELECT * FROM cte", True),
+        ("WITH cte AS (SELECT 1) DELETE FROM t WHERE id IN (SELECT id FROM cte)", True),
     ],
 )
 def test_firebird_is_mutating(sql: str, expected: bool) -> None:
+    """Verify mutating-statement detection for Firebird SQL."""
     assert FirebirdStatement(sql, "firebird").is_mutating() == expected
 
 
@@ -169,9 +183,17 @@ def test_firebird_get_limit_value(sql: str, expected: int | None) -> None:
     ],
 )
 def test_firebird_set_limit_value(sql: str, limit: int, expected: str) -> None:
+    """Verify FIRST N limit injection/replacement for Firebird SQL."""
     stmt = FirebirdStatement(sql, "firebird")
     stmt.set_limit_value(limit)
     assert stmt.format() == expected
+
+
+def test_firebird_set_limit_fetch_many_is_noop() -> None:
+    """FETCH_MANY should not rewrite the SQL."""
+    stmt = FirebirdStatement("SELECT * FROM t", "firebird")
+    stmt.set_limit_value(10, method=LimitMethod.FETCH_MANY)
+    assert stmt.format() == "SELECT * FROM t"
 
 
 # ---------------------------------------------------------------------------
@@ -231,9 +253,31 @@ def test_firebird_parse_predicate_passthrough() -> None:
 
 
 def test_firebird_check_functions_present() -> None:
+    """Verify function-name detection in Firebird SQL."""
     stmt = FirebirdStatement("SELECT VERSION() FROM t", "firebird")
     assert stmt.check_functions_present({"version"}) is True
     assert stmt.check_functions_present({"nonexistent"}) is False
+
+
+def test_firebird_check_tables_present_returns_false() -> None:
+    """check_tables_present always returns False (no parser)."""
+    stmt = FirebirdStatement("SELECT * FROM my_table", "firebird")
+    assert stmt.check_tables_present({"my_table"}) is False
+
+
+def test_firebird_apply_rls_is_noop() -> None:
+    """apply_rls should not raise and should leave the SQL unchanged."""
+    from superset.sql.parse import RLSMethod
+
+    stmt = FirebirdStatement("SELECT * FROM t", "firebird")
+    original = stmt.format()
+    stmt.apply_rls(
+        catalog=None,
+        schema=None,
+        predicates={},
+        method=RLSMethod.UNION,
+    )
+    assert stmt.format() == original
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Firebird's SQL dialect uses non-standard syntax (`DATEADD`, `SELECT FIRST N`, `EXTRACT ... FROM`, `EXECUTE PROCEDURE`) that is **not supported by sqlglot** — which causes parse errors in SQL Lab. The Firebird entry in `SQLGLOT_DIALECTS` is explicitly commented out with `# "firebird": ???`.

This PR adds a `FirebirdStatement` class that stores the SQL as a raw string, completely bypassing sqlglot — following the **same pattern as `KustoKQLStatement`**.

## Changes

- **`superset/sql/parse.py`**:
  - Add `FirebirdStatement` class with support for:
    - `split_script` — semicolon splitting that respects string literals
    - `is_select` / `is_mutating` — keyword-based detection
    - `get_limit_value` / `set_limit_value` — handles Firebird's `FIRST N` syntax
    - `format` / `optimize` — passthrough (no AST rewriting)
    - `check_functions_present` — regex-based function detection
  - Register `"firebird"` in `SQLScript.special_engines`
  - Update comment on line 80 from `# "firebird": ???` to explain the approach

- **`tests/unit_tests/sql/test_firebird_statement.py`**:
  - Comprehensive test suite covering split, select/mutating detection, FIRST N limits, Firebird-specific syntax (DATEADD, EXTRACT, EXECUTE PROCEDURE), and SQLScript integration

## Motivation

When connecting Superset to a Firebird database via `sqlalchemy-firebird`, queries like:

```sql
SELECT * FROM AGENDA WHERE DATA >= DATEADD(-30 DAY TO CURRENT_DATE)
```

fail with `Error parsing near 'DAY'` because sqlglot tries to parse the SQL and doesn't understand Firebird syntax.

The approach follows the established pattern: just as Kusto KQL has its own statement class that bypasses sqlglot, Firebird now gets the same treatment.

## Testing

- 30+ unit tests covering all public methods
- Manually tested with a production Firebird 2.5 database connected via `sqlalchemy-firebird==0.8.0` + `fdb`
