### PR TITLE
fix(re-encrypt-secrets): use db.Model.metadata to discover encrypted …

### DIFF
--- a/superset/utils/encrypt.py
+++ b/superset/utils/encrypt.py
@@ -99,14 +99,29 @@ class SecretsMigrator:
 
     def discover_encrypted_fields(self) -> dict[str, dict[str, EncryptedType]]:
         """
-        Iterates over SqlAlchemy's metadata, looking for EncryptedType
-        columns along the way. Builds up a dict of
+        Iterates over ORM-mapped tables, looking for EncryptedType columns
+        along the way. Builds up a dict of
         table_name -> dict of col_name: enc type instance
-        :return:
+
+        Superset's ORM models inherit from Flask-AppBuilder's declarative base
+        (`flask_appbuilder.Model`), whose MetaData is distinct from
+        `db.metadata`. We combine both sources so encrypted columns are found
+        regardless of which base a model uses. FAB's metadata takes precedence
+        when a table name appears in both registries.
+
+        :return: mapping of table name to a dict of {column name: EncryptedType}
         """
+        from flask_appbuilder import (  # pylint: disable=import-outside-toplevel
+            Model as FABModel,
+        )
+
         meta_info: dict[str, Any] = {}
 
+        tables: dict[str, Any] = dict(FABModel.metadata.tables)
         for table_name, table in self._db.metadata.tables.items():
+            tables.setdefault(table_name, table)
+
+        for table_name, table in tables.items():
             for col_name, col in table.columns.items():
                 if isinstance(col.type, EncryptedType):
                     cols = meta_info.get(table_name, {})

--- a/tests/integration_tests/utils/encrypt_tests.py
+++ b/tests/integration_tests/utils/encrypt_tests.py
@@ -89,6 +89,21 @@ class EncryptedFieldTest(SupersetTestCase):
                         " encrypted_field_factory"
                     )
 
+    def test_discover_encrypted_fields_finds_dbs_table(self):
+        """
+        Ensure discover_encrypted_fields finds the encrypted columns on the
+        dbs table (password, encrypted_extra, server_cert). This guards
+        against db.metadata diverging from db.Model.metadata.
+        """
+        migrator = SecretsMigrator("")
+        encrypted_fields = migrator.discover_encrypted_fields()
+        assert "dbs" in encrypted_fields, (
+            "dbs table not found in encrypted fields — "
+            "discover_encrypted_fields may be using the wrong MetaData instance"
+        )
+        dbs_cols = set(encrypted_fields["dbs"].keys())
+        assert {"password", "encrypted_extra", "server_cert"}.issubset(dbs_cols)
+
     def test_lazy_key_resolution(self):
         """
         Verify that the encryption key is resolved lazily at runtime,


### PR DESCRIPTION
Closes: https://github.com/apache/superset/issues/39391 and https://github.com/apache/superset/issues/38413

### SUMMARY

`superset re-encrypt-secrets` silently does nothing — it logs "All tables processed" but never re-encrypts any rows, leaving databases unreadable after a `SECRET_KEY` rotation.

**Not a duplicate of #37842 / #37982.** That fix made `EncryptedType` resolve the key lazily. This PR fixes a separate bug with the same symptom: `discover_encrypted_fields()` finds zero encrypted columns because it looks in the wrong `MetaData`. Both fixes are needed for `re-encrypt-secrets` to actually work end-to-end.

### ROOT CAUSE

`SecretsMigrator.discover_encrypted_fields()` iterates `db.metadata.tables`. Superset's ORM models inherit from `flask_appbuilder.Model`, which uses its own `declarative_base()` — a separate `MetaData` instance from both `db.metadata` and `db.Model.metadata`. `db.metadata.tables` contains none of the ORM-mapped tables, so the discovery loop returns an empty dict and `run()` exits without doing anything.

### FIX

Merge `flask_appbuilder.Model.metadata.tables` with `db.metadata.tables` so encrypted columns are found regardless of which declarative base a model uses.

### TESTING

Reproduced locally: (1) Start Superset with `SECRET_KEY = "key-a"`; let init scripts create database connections. (2) Rotate: `SECRET_KEY = "key-b"`, `PREVIOUS_SECRET_KEY = "key-a"`. (3) Run `superset re-encrypt-secrets` → reports success but does nothing. (4) Browse any chart → `Invalid decryption key`.

After the fix, step 3 re-encrypts all `EncryptedType` columns (`dbs.password`, `dbs.encrypted_extra`, `dbs.server_cert`, `database_user_oauth2_tokens.access_token`, `database_user_oauth2_tokens.refresh_token`) and step 4 works.

Added a regression test that asserts the `dbs` table and its encrypted columns are discovered.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI:
- [ ] Includes DB Migration:
- [ ] Introduces new feature or API:
- [ ] Removes existing feature or API:
