### PR TITLE
fix(sqllab): format_sql to apply db dialect by database_id

### DIFF
--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -241,7 +241,7 @@ class SqlLabRestApi(BaseSupersetApi):
             database_engine = None
 
             # Process Jinja templates if template_params are provided
-            if template_params and database_id is not None:
+            if database_id is not None:
                 database = DatabaseDAO.find_by_id(database_id)
 
                 if database:

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -245,27 +245,27 @@ class SqlLabRestApi(BaseSupersetApi):
                 database = DatabaseDAO.find_by_id(database_id)
 
                 if database:
-                  database_engine = database.db_engine_spec.engine
+                    database_engine = database.db_engine_spec.engine
 
-                  if template_params:
-                      try:
-                          template_params = (
-                              json.loads(template_params)
-                              if isinstance(template_params, str)
-                              else template_params
-                          )
-                          if template_params:
-                              template_processor = get_template_processor(
-                                  database=database
-                              )
-                              sql = template_processor.process_template(
-                                  sql, **template_params
-                              )
-                      except json.JSONDecodeError:
-                          logger.warning(
-                              "Invalid template parameter %s. Skipping processing",
-                              str(template_params),
-                          )
+                    if template_params:
+                        try:
+                            template_params = (
+                                json.loads(template_params)
+                                if isinstance(template_params, str)
+                                else template_params
+                            )
+                            if template_params:
+                                template_processor = get_template_processor(
+                                    database=database
+                                )
+                                sql = template_processor.process_template(
+                                    sql, **template_params
+                                )
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "Invalid template parameter %s. Skipping processing",
+                                str(template_params),
+                            )
 
             result = SQLScript(sql, model.get("engine", database_engine)).format()
             return self.response(200, result=result)

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -238,31 +238,36 @@ class SqlLabRestApi(BaseSupersetApi):
             sql = model["sql"]
             template_params = model.get("template_params")
             database_id = model.get("database_id")
+            database_engine = None
 
-            # Process Jinja templates if template_params and database_id are provided
+            # Process Jinja templates if template_params are provided
             if template_params and database_id is not None:
                 database = DatabaseDAO.find_by_id(database_id)
-                if database:
-                    try:
-                        template_params = (
-                            json.loads(template_params)
-                            if isinstance(template_params, str)
-                            else template_params
-                        )
-                        if template_params:
-                            template_processor = get_template_processor(
-                                database=database
-                            )
-                            sql = template_processor.process_template(
-                                sql, **template_params
-                            )
-                    except json.JSONDecodeError:
-                        logger.warning(
-                            "Invalid template parameter %s. Skipping processing",
-                            str(template_params),
-                        )
 
-            result = SQLScript(sql, model.get("engine")).format()
+                if database:
+                  database_engine = database.db_engine_spec.engine
+
+                  if template_params:
+                      try:
+                          template_params = (
+                              json.loads(template_params)
+                              if isinstance(template_params, str)
+                              else template_params
+                          )
+                          if template_params:
+                              template_processor = get_template_processor(
+                                  database=database
+                              )
+                              sql = template_processor.process_template(
+                                  sql, **template_params
+                              )
+                      except json.JSONDecodeError:
+                          logger.warning(
+                              "Invalid template parameter %s. Skipping processing",
+                              str(template_params),
+                          )
+
+            result = SQLScript(sql, model.get("engine", database_engine)).format()
             return self.response(200, result=result)
         except ValidationError as error:
             return self.response_400(message=error.messages)

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -314,6 +314,13 @@ class TestSqlLabApi(SupersetTestCase):
         self.login(ADMIN_USERNAME)
         example_db = get_example_database()
 
+        # Quoted identifier formatting varies by dialect (e.g., MySQL uses backticks).
+        # Compute the expected result from the actual engine so the test is
+        # environment-independent.
+        rendered_sql = 'select * from "Vehicle Sales"'
+        engine = example_db.db_engine_spec.engine
+        expected = SQLScript(rendered_sql, engine).format()
+
         data = {
             "sql": "select * from {{tbl}}",
             "database_id": example_db.id,
@@ -324,10 +331,10 @@ class TestSqlLabApi(SupersetTestCase):
             json=data,
         )
         resp_data = json.loads(rv.data.decode("utf-8"))
+        assert rv.status_code == 200
         # Verify that Jinja template was processed before formatting
         assert "{{tbl}}" not in resp_data["result"]
-        assert '"Vehicle Sales"' in resp_data["result"]
-        assert rv.status_code == 200
+        assert resp_data["result"] == expected
 
     @mock.patch("superset.commands.sql_lab.results.results_backend_use_msgpack", False)
     def test_execute_required_params(self):

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -39,6 +39,7 @@ from superset.utils.database import (
 from superset.utils import core as utils, json
 from superset.models.sql_lab import Query
 
+from superset.sql.parse import SQLScript
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.constants import (
     ADMIN_USERNAME,
@@ -292,19 +293,22 @@ class TestSqlLabApi(SupersetTestCase):
         self.login(ADMIN_USERNAME)
         example_db = get_example_database()
 
-        data = {
-            "sql": "select IIF(score > 0, 'positive', 'negative') from my_table",
-            "database_id": example_db.id,
-        }
+        # IIF is normalized differently per dialect:
+        # SQLite preserves IIF(), Postgres/base converts to CASE WHEN.
+        # Compute the expected result from the actual engine so the test is
+        # environment-independent.
+        sql = "select IIF(score > 0, 'positive', 'negative') from my_table"
+        engine = example_db.db_engine_spec.engine
+        expected = SQLScript(sql, engine).format()
+
+        data = {"sql": sql, "database_id": example_db.id}
         rv = self.client.post(
             "/api/v1/sqllab/format_sql/",
             json=data,
         )
         resp_data = json.loads(rv.data.decode("utf-8"))
-        # SQLite dialect preserves IIF(); base dialect converts it to CASE WHEN
-        assert "IIF(" in resp_data["result"]
-        assert "CASE WHEN" not in resp_data["result"]
         assert rv.status_code == 200
+        assert resp_data["result"] == expected
 
     def test_format_sql_request_with_jinja(self):
         self.login(ADMIN_USERNAME)

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -288,6 +288,24 @@ class TestSqlLabApi(SupersetTestCase):
         self.assertDictEqual(resp_data, success_resp)  # noqa: PT009
         assert rv.status_code == 200
 
+    def test_format_sql_request_with_db_id(self):
+        self.login(ADMIN_USERNAME)
+        example_db = get_example_database()
+
+        data = {
+            "sql": "select IIF(score > 0, 'positive', 'negative') from my_table",
+            "database_id": example_db.id,
+        }
+        rv = self.client.post(
+            "/api/v1/sqllab/format_sql/",
+            json=data,
+        )
+        resp_data = json.loads(rv.data.decode("utf-8"))
+        # SQLite dialect preserves IIF(); base dialect converts it to CASE WHEN
+        assert "IIF(" in resp_data["result"]
+        assert "CASE WHEN" not in resp_data["result"]
+        assert rv.status_code == 200
+
     def test_format_sql_request_with_jinja(self):
         self.login(ADMIN_USERNAME)
         example_db = get_example_database()


### PR DESCRIPTION
### SUMMARY

Fixes #39100
In the SQL Lab, during the format_sql process, the engine information of the current database was not being passed, which caused the formatting to always fall back to the basic dialect. With the latest update (#36277), the database_id is now being passed, so the code has been updated to extract the engine value based on the database_id and pass it accordingly.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/de96138f-2872-43a3-8ab7-e024f731b30b

After:

https://github.com/user-attachments/assets/a57ce6b5-a1f2-4cda-a2af-14eacb710634



### TESTING INSTRUCTIONS

1. Connect Superset 6.0.0 (or 6.1rc1) to a Trino database (any version)
2. Open SQL Lab, ensure "Format SQL" is ON
3. Run:
SELECT date_diff('day', DATE '2023-01-01', current_date)
4. Observe error:
TrinoUserError: Function 'datediff' not registered

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
