### PR TITLE
fix(sqllab): enhance table explore tree with schema pinning, column sorting, and table schema refresh

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
@@ -79,6 +79,7 @@ export interface TreeNodeRendererProps extends NodeRendererProps<TreeNodeData> {
   searchTerm: string;
   catalog: string | null | undefined;
   pinnedTableKeys: Set<string>;
+  pinnedSchemas: Set<string>;
   selectStarMap: Record<string, string>;
   handleRefreshTables: (params: {
     dbId: number;
@@ -91,6 +92,11 @@ export interface TreeNodeRendererProps extends NodeRendererProps<TreeNodeData> {
     catalogName: string | null,
   ) => void;
   handleUnpinTable: (tableName: string, schemaName: string) => void;
+  handlePinSchema: (schemaName: string) => void;
+  handleUnpinSchema: (schemaName: string) => void;
+  refreshTableSchema: (id: string) => void;
+  sortedTables: Record<string, boolean>;
+  toggleSortColumns: (tableId: string) => void;
 }
 
 const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
@@ -101,19 +107,23 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
   searchTerm,
   catalog,
   pinnedTableKeys,
+  pinnedSchemas,
   selectStarMap,
   handleRefreshTables,
   handlePinTable,
   handleUnpinTable,
+  handlePinSchema,
+  handleUnpinSchema,
+  refreshTableSchema,
+  sortedTables,
+  toggleSortColumns,
 }) => {
   const theme = useTheme();
   const { data } = node;
   const parts = data.id.split(':');
   const [identifier, _dbId, schema, tableName] = parts;
 
-  // Use manually tracked open state for icon display
-  // This prevents search auto-expansion from affecting the icon
-  const isManuallyOpen = manuallyOpenedNodes[data.id] ?? false;
+  const isManuallyOpen = node.isOpen && !node.data.disableCheckbox;
   const isLoading = loadingNodes[data.id] ?? false;
 
   const renderIcon = () => {
@@ -135,12 +145,7 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
           ? Icons.FunctionOutlined
           : Icons.TableOutlined;
       if (isLoading) {
-        return (
-          <>
-            <Icons.LoadingOutlined iconSize="l" />
-            <TableTypeIcon iconSize="l" />
-          </>
-        );
+        return <Icons.LoadingOutlined iconSize="l" />;
       }
       return <TableTypeIcon iconSize="l" />;
     }
@@ -233,7 +238,27 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
         {highlightText(data.name, searchTerm)}
       </Typography.Text>
       {identifier === 'schema' && (
-        <div className="side-action-container" role="menu">
+        <div
+          className="side-action-container"
+          role="menu"
+          onClick={e => e.stopPropagation()}
+        >
+          {pinnedSchemas.has(schema) && (
+            <div className="action-static">
+              <ActionButton
+                label={`pinned-schema-${schema}`}
+                icon={
+                  <Icons.PushpinFilled
+                    iconSize="m"
+                    css={css`
+                      color: ${theme.colorTextDescription};
+                    `}
+                  />
+                }
+                onClick={() => handleUnpinSchema(schema)}
+              />
+            </div>
+          )}
           <div className="action-hover">
             <RefreshLabel
               onClick={e => {
@@ -245,6 +270,30 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
                 });
               }}
               tooltipContent={t('Force refresh table list')}
+            />
+            <ActionButton
+              label={
+                pinnedSchemas.has(schema)
+                  ? `unpin-schema-${schema}`
+                  : `pin-schema-${schema}`
+              }
+              tooltip={
+                pinnedSchemas.has(schema)
+                  ? t('Unpin from top')
+                  : t('Pin to top')
+              }
+              icon={
+                pinnedSchemas.has(schema) ? (
+                  <Icons.PushpinFilled iconSize="m" />
+                ) : (
+                  <Icons.PushpinOutlined iconSize="m" />
+                )
+              }
+              onClick={() =>
+                pinnedSchemas.has(schema)
+                  ? handleUnpinSchema(schema)
+                  : handlePinSchema(schema)
+              }
             />
           </div>
         </div>
@@ -288,6 +337,31 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
                     }
                   />
                 )}
+                <ActionButton
+                  label={`sort-cols-${schema}-${tableName}`}
+                  tooltip={
+                    sortedTables[data.id]
+                      ? t('Sort by original table order')
+                      : t('Sort columns alphabetically')
+                  }
+                  icon={
+                    <Icons.SortAscendingOutlined
+                      iconSize="m"
+                      css={css`
+                        color: ${sortedTables[data.id]
+                          ? theme.colorPrimary
+                          : 'inherit'};
+                      `}
+                    />
+                  }
+                  onClick={() => toggleSortColumns(data.id)}
+                />
+                <ActionButton
+                  label={`refresh-schema-${schema}-${tableName}`}
+                  tooltip={t('Refresh table schema')}
+                  icon={<Icons.SyncOutlined iconSize="m" />}
+                  onClick={() => refreshTableSchema(data.id)}
+                />
                 <ActionButton
                   label={
                     isPinned

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
@@ -280,6 +280,11 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
   }, [treeData, pinnedSchemas]);
 
   const [sortedTables, setSortedTables] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setSortedTables({});
+  }, [dbId, catalog]);
+
   const toggleSortColumns = useCallback((tableId: string) => {
     setSortedTables(prev => ({ ...prev, [tableId]: !prev[tableId] }));
   }, []);

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
@@ -41,6 +41,11 @@ import {
 import type { SqlLabRootState } from 'src/SqlLab/types';
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 import { addTable, removeTables } from 'src/SqlLab/actions/sqlLab';
+import {
+  getItem,
+  setItem,
+  LocalStorageKeys,
+} from 'src/utils/localStorageHelpers';
 import PanelToolbar from 'src/components/PanelToolbar';
 import { ViewLocations } from 'src/SqlLab/contributions';
 import TreeNodeRenderer from './TreeNodeRenderer';
@@ -126,6 +131,25 @@ const StyledTreeContainer = styled.div`
 
 const ROW_HEIGHT = 28;
 
+const getPinnedSchemasFromStorage = (dbId: number | undefined): Set<string> => {
+  if (!dbId) return new Set();
+  const stored = getItem(LocalStorageKeys.SqllabPinnedSchemas, {});
+  const schemas = stored[dbId];
+  return Array.isArray(schemas) ? new Set<string>(schemas) : new Set();
+};
+
+const savePinnedSchemasToStorage = (
+  dbId: number | undefined,
+  schemas: Set<string>,
+) => {
+  if (!dbId) return;
+  const stored = getItem(LocalStorageKeys.SqllabPinnedSchemas, {});
+  setItem(LocalStorageKeys.SqllabPinnedSchemas, {
+    ...stored,
+    [dbId]: [...schemas],
+  });
+};
+
 const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
   const dispatch = useDispatch();
   const theme = useTheme();
@@ -200,7 +224,19 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
     },
     [dispatch, tables, editorId, dbId],
   );
-  const [pinnedSchemas, setPinnedSchemas] = useState<Set<string>>(new Set());
+  const [pinnedSchemas, setPinnedSchemas] = useState<Set<string>>(() =>
+    getPinnedSchemasFromStorage(dbId),
+  );
+
+  // Reload pinned schemas from localStorage when the database changes
+  useEffect(() => {
+    setPinnedSchemas(getPinnedSchemasFromStorage(dbId));
+  }, [dbId]);
+
+  // Persist pinned schemas to localStorage keyed by database_id
+  useEffect(() => {
+    savePinnedSchemasToStorage(dbId, pinnedSchemas);
+  }, [dbId, pinnedSchemas]);
 
   const handlePinSchema = useCallback((schemaName: string) => {
     setPinnedSchemas(prev => new Set([...prev, schemaName]));

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
@@ -161,6 +161,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
     selectStarMap,
     handleToggle,
     handleRefreshTables,
+    refreshTableSchema,
     errorPayload,
   } = useTreeData({
     dbId,
@@ -199,6 +200,55 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
     },
     [dispatch, tables, editorId, dbId],
   );
+  const [pinnedSchemas, setPinnedSchemas] = useState<Set<string>>(new Set());
+
+  const handlePinSchema = useCallback((schemaName: string) => {
+    setPinnedSchemas(prev => new Set([...prev, schemaName]));
+  }, []);
+
+  const handleUnpinSchema = useCallback((schemaName: string) => {
+    setPinnedSchemas(prev => {
+      const next = new Set(prev);
+      next.delete(schemaName);
+      return next;
+    });
+  }, []);
+
+  const sortedTreeData = useMemo(() => {
+    if (pinnedSchemas.size === 0) return treeData;
+    const pinned = treeData.filter(node => pinnedSchemas.has(node.name));
+    const rest = treeData.filter(node => !pinnedSchemas.has(node.name));
+    return [...pinned, ...rest];
+  }, [treeData, pinnedSchemas]);
+
+  const [sortedTables, setSortedTables] = useState<Record<string, boolean>>({});
+  const toggleSortColumns = useCallback((tableId: string) => {
+    setSortedTables(prev => ({ ...prev, [tableId]: !prev[tableId] }));
+  }, []);
+
+  const displayTreeData = useMemo(() => {
+    const activeSorted = Object.keys(sortedTables).filter(
+      id => sortedTables[id],
+    );
+    if (activeSorted.length === 0) return sortedTreeData;
+
+    const sortedSet = new Set(activeSorted);
+    return sortedTreeData.map(schemaNode => ({
+      ...schemaNode,
+      children: schemaNode.children?.map(tableNode => {
+        if (tableNode.type !== 'table' || !sortedSet.has(tableNode.id)) {
+          return tableNode;
+        }
+        const { children } = tableNode;
+        if (!children || children.length <= 1) return tableNode;
+        return {
+          ...tableNode,
+          children: [...children].sort((a, b) => a.name.localeCompare(b.name)),
+        };
+      }),
+    }));
+  }, [sortedTreeData, sortedTables]);
+
   const [searchTerm, setSearchTerm] = useState('');
   const handleSearchChange = useCallback(
     ({ target }: ChangeEvent<HTMLInputElement>) => setSearchTerm(target.value),
@@ -270,8 +320,8 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
       return false;
     };
 
-    return treeData.some(node => checkNode(node));
-  }, [searchTerm, treeData]);
+    return displayTreeData.some(node => checkNode(node));
+  }, [searchTerm, displayTreeData]);
 
   // Node renderer for react-arborist
   const renderNode = useCallback(
@@ -283,19 +333,31 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
         searchTerm={searchTerm}
         catalog={catalog}
         pinnedTableKeys={pinnedTableKeys}
+        pinnedSchemas={pinnedSchemas}
         selectStarMap={selectStarMap}
         handleRefreshTables={handleRefreshTables}
         handlePinTable={handlePinTable}
         handleUnpinTable={handleUnpinTable}
+        handlePinSchema={handlePinSchema}
+        handleUnpinSchema={handleUnpinSchema}
+        refreshTableSchema={refreshTableSchema}
+        sortedTables={sortedTables}
+        toggleSortColumns={toggleSortColumns}
       />
     ),
     [
       catalog,
       pinnedTableKeys,
+      pinnedSchemas,
       selectStarMap,
       handleRefreshTables,
       handlePinTable,
       handleUnpinTable,
+      handlePinSchema,
+      handleUnpinSchema,
+      refreshTableSchema,
+      sortedTables,
+      toggleSortColumns,
       loadingNodes,
       manuallyOpenedNodes,
       searchTerm,
@@ -369,7 +431,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
             return (
               <Tree<TreeNodeData>
                 ref={treeRef}
-                data={treeData}
+                data={displayTreeData}
                 width="100%"
                 height={height || 500}
                 rowHeight={ROW_HEIGHT}

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
@@ -131,22 +131,33 @@ const StyledTreeContainer = styled.div`
 
 const ROW_HEIGHT = 28;
 
-const getPinnedSchemasFromStorage = (dbId: number | undefined): Set<string> => {
+const getPinnedSchemasStorageKey = (
+  dbId: number | undefined,
+  catalog: string | null | undefined,
+): string => `${dbId ?? ''}:${catalog ?? ''}`;
+
+const getPinnedSchemasFromStorage = (
+  dbId: number | undefined,
+  catalog: string | null | undefined,
+): Set<string> => {
   if (!dbId) return new Set();
   const stored = getItem(LocalStorageKeys.SqllabPinnedSchemas, {});
-  const schemas = stored[dbId];
+  const key = getPinnedSchemasStorageKey(dbId, catalog);
+  const schemas = stored[key];
   return Array.isArray(schemas) ? new Set<string>(schemas) : new Set();
 };
 
 const savePinnedSchemasToStorage = (
   dbId: number | undefined,
+  catalog: string | null | undefined,
   schemas: Set<string>,
 ) => {
   if (!dbId) return;
   const stored = getItem(LocalStorageKeys.SqllabPinnedSchemas, {});
+  const key = getPinnedSchemasStorageKey(dbId, catalog);
   setItem(LocalStorageKeys.SqllabPinnedSchemas, {
     ...stored,
-    [dbId]: [...schemas],
+    [key]: [...schemas],
   });
 };
 
@@ -225,18 +236,29 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
     [dispatch, tables, editorId, dbId],
   );
   const [pinnedSchemas, setPinnedSchemas] = useState<Set<string>>(() =>
-    getPinnedSchemasFromStorage(dbId),
+    getPinnedSchemasFromStorage(dbId, catalog),
   );
 
-  // Reload pinned schemas from localStorage when the database changes
-  useEffect(() => {
-    setPinnedSchemas(getPinnedSchemasFromStorage(dbId));
-  }, [dbId]);
+  const previousDbIdRef = useRef<number | undefined>(dbId);
+  const previousCatalogRef = useRef<string | null | undefined>(catalog);
 
-  // Persist pinned schemas to localStorage keyed by database_id
+  // Single effect handles both loading and persisting pinned schemas.
+  // Using refs to detect source changes avoids the race condition where the
+  // persist branch would run with stale pinnedSchemas right after a dbId/catalog
+  // change, corrupting the new source's stored pins.
   useEffect(() => {
-    savePinnedSchemasToStorage(dbId, pinnedSchemas);
-  }, [dbId, pinnedSchemas]);
+    const dbChanged = previousDbIdRef.current !== dbId;
+    const catalogChanged = previousCatalogRef.current !== catalog;
+
+    if (dbChanged || catalogChanged) {
+      previousDbIdRef.current = dbId;
+      previousCatalogRef.current = catalog;
+      setPinnedSchemas(getPinnedSchemasFromStorage(dbId, catalog));
+      return;
+    }
+
+    savePinnedSchemasToStorage(dbId, catalog, pinnedSchemas);
+  }, [dbId, catalog, pinnedSchemas]);
 
   const handlePinSchema = useCallback((schemaName: string) => {
     setPinnedSchemas(prev => new Set([...prev, schemaName]));

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/useTreeData.ts
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/useTreeData.ts
@@ -151,6 +151,8 @@ const useTreeData = ({
   // preferCacheValue=false on explicit refresh (bypass cache).
   const fetchAndStoreTableSchema = useCallback(
     (id: string, preferCacheValue: boolean) => {
+      if (loadingNodes[id]) return;
+
       const parts = id.split(':');
       const [, databaseId, schema, table] = parts;
       const parsedDbId = Number(databaseId);
@@ -193,7 +195,13 @@ const useTreeData = ({
           dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: false });
         });
     },
-    [catalog, fetchTableExtendedMetadata, fetchTableMetadata, reduxDispatch],
+    [
+      catalog,
+      fetchTableExtendedMetadata,
+      fetchTableMetadata,
+      loadingNodes,
+      reduxDispatch,
+    ],
   );
 
   // Handle async loading when node is toggled open

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/useTreeData.ts
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/useTreeData.ts
@@ -146,6 +146,56 @@ const useTreeData = ({
   const [state, dispatch] = useReducer(treeDataReducer, initialState);
   const { tableData, tableSchemaData, loadingNodes, errorPayload } = state;
 
+  // Shared helper: fetch table metadata + extended metadata and store in state.
+  // preferCacheValue=true on initial open (use cached data if available),
+  // preferCacheValue=false on explicit refresh (bypass cache).
+  const fetchAndStoreTableSchema = useCallback(
+    (id: string, preferCacheValue: boolean) => {
+      const parts = id.split(':');
+      const [, databaseId, schema, table] = parts;
+      const parsedDbId = Number(databaseId);
+      const tableKey = `${parsedDbId}:${schema}:${table}`;
+
+      dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: true });
+
+      // .unwrap() causes RTK Query to reject on error so .catch() fires.
+      // Without it RTK Query resolves with { error } instead of rejecting.
+      Promise.all([
+        fetchTableMetadata(
+          { dbId: parsedDbId, catalog, schema, table },
+          preferCacheValue,
+        ).unwrap(),
+        fetchTableExtendedMetadata(
+          { dbId: parsedDbId, catalog, schema, table },
+          preferCacheValue,
+        ).unwrap(),
+      ])
+        .then(([tableMetadata, tableExtendedMetadata]) => {
+          if (tableMetadata) {
+            dispatch({
+              type: 'SET_TABLE_SCHEMA_DATA',
+              key: tableKey,
+              data: { ...tableMetadata, ...tableExtendedMetadata },
+            });
+          }
+        })
+        .catch(() => {
+          reduxDispatch(
+            addDangerToast(
+              t(
+                'An error occurred while fetching table metadata for %s',
+                table,
+              ),
+            ),
+          );
+        })
+        .finally(() => {
+          dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: false });
+        });
+    },
+    [catalog, fetchTableExtendedMetadata, fetchTableMetadata, reduxDispatch],
+  );
+
   // Handle async loading when node is toggled open
   const handleToggle = useCallback(
     async (id: string, isOpen: boolean) => {
@@ -159,17 +209,10 @@ const useTreeData = ({
       if (identifier === 'schema') {
         const schemaKey = `${parsedDbId}:${schema}`;
         if (!tableData?.[schemaKey]) {
-          // Set loading state
           dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: true });
 
-          // Fetch tables asynchronously
           fetchLazyTables(
-            {
-              dbId: parsedDbId,
-              catalog,
-              schema,
-              forceRefresh: false,
-            },
+            { dbId: parsedDbId, catalog, schema, forceRefresh: false },
             true,
           )
             .then(({ data }) => {
@@ -200,71 +243,15 @@ const useTreeData = ({
         if (pinnedTables[tableKey]) return;
 
         if (!tableSchemaData[tableKey]) {
-          // Set loading state
-          dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: true });
-
-          // Fetch metadata asynchronously
-          // .unwrap() causes RTK Query to reject on error so .catch() fires.
-          // Without it RTK Query resolves with { error } instead of rejecting.
-          Promise.all([
-            fetchTableMetadata(
-              {
-                dbId: parsedDbId,
-                catalog,
-                schema,
-                table,
-              },
-              true,
-            ).unwrap(),
-            fetchTableExtendedMetadata(
-              {
-                dbId: parsedDbId,
-                catalog,
-                schema,
-                table,
-              },
-              true,
-            ).unwrap(),
-          ])
-            .then(([tableMetadata, tableExtendedMetadata]) => {
-              if (tableMetadata) {
-                dispatch({
-                  type: 'SET_TABLE_SCHEMA_DATA',
-                  key: tableKey,
-                  data: {
-                    ...tableMetadata,
-                    ...tableExtendedMetadata,
-                  },
-                });
-              }
-            })
-            .catch(() => {
-              reduxDispatch(
-                addDangerToast(
-                  t(
-                    'An error occurred while fetching table metadata for %s',
-                    table,
-                  ),
-                ),
-              );
-            })
-            .finally(() => {
-              dispatch({
-                type: 'SET_LOADING_NODE',
-                nodeId: id,
-                loading: false,
-              });
-            });
+          fetchAndStoreTableSchema(id, true);
         }
       }
     },
     [
       catalog,
+      fetchAndStoreTableSchema,
       fetchLazyTables,
-      fetchTableExtendedMetadata,
-      fetchTableMetadata,
       pinnedTables,
-      reduxDispatch,
       tableData,
       tableSchemaData,
     ],
@@ -317,45 +304,9 @@ const useTreeData = ({
       const tableKey = `${parsedDbId}:${schema}:${table}`;
 
       dispatch({ type: 'CLEAR_TABLE_SCHEMA_DATA', key: tableKey });
-      dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: true });
-
-      Promise.all([
-        fetchTableMetadata(
-          { dbId: parsedDbId, catalog, schema, table },
-          false,
-        ).unwrap(),
-        fetchTableExtendedMetadata(
-          { dbId: parsedDbId, catalog, schema, table },
-          false,
-        ).unwrap(),
-      ])
-        .then(([tableMetadata, tableExtendedMetadata]) => {
-          if (tableMetadata) {
-            dispatch({
-              type: 'SET_TABLE_SCHEMA_DATA',
-              key: tableKey,
-              data: {
-                ...tableMetadata,
-                ...tableExtendedMetadata,
-              },
-            });
-          }
-        })
-        .catch(() => {
-          reduxDispatch(
-            addDangerToast(
-              t(
-                'An error occurred while refreshing table metadata for %s',
-                table,
-              ),
-            ),
-          );
-        })
-        .finally(() => {
-          dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: false });
-        });
+      fetchAndStoreTableSchema(id, false);
     },
-    [catalog, fetchTableExtendedMetadata, fetchTableMetadata, reduxDispatch],
+    [fetchAndStoreTableSchema],
   );
 
   // Build tree data

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/useTreeData.ts
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/useTreeData.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useMemo, useReducer, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import { t } from '@apache-superset/core/translation';
 import {
   Table,
@@ -26,6 +27,7 @@ import {
   useLazyTableMetadataQuery,
   useLazyTableExtendedMetadataQuery,
 } from 'src/hooks/apiResources';
+import { addDangerToast } from 'src/SqlLab/actions/sqlLab';
 import type { TreeNodeData } from './types';
 import { SupersetError } from '@superset-ui/core';
 
@@ -42,6 +44,7 @@ interface TreeDataState {
 type TreeDataAction =
   | { type: 'SET_TABLE_DATA'; key: string; data: { options: Table[] } }
   | { type: 'SET_TABLE_SCHEMA_DATA'; key: string; data: TableMetaData }
+  | { type: 'CLEAR_TABLE_SCHEMA_DATA'; key: string }
   | { type: 'SET_LOADING_NODE'; nodeId: string; loading: boolean }
   | { type: 'SET_ERROR'; errorPayload: SupersetError | null };
 
@@ -71,6 +74,10 @@ function treeDataReducer(
           [action.key]: action.data,
         },
       };
+    case 'CLEAR_TABLE_SCHEMA_DATA': {
+      const { [action.key]: _, ...rest } = state.tableSchemaData;
+      return { ...state, tableSchemaData: rest };
+    }
     case 'SET_LOADING_NODE':
       return {
         ...state,
@@ -108,6 +115,7 @@ interface UseTreeDataResult {
     catalog: string | null | undefined;
     schema: string;
   }) => void;
+  refreshTableSchema: (id: string) => void;
   errorPayload: SupersetError | null;
 }
 
@@ -122,6 +130,7 @@ const useTreeData = ({
   catalog,
   pinnedTables,
 }: UseTreeDataParams): UseTreeDataResult => {
+  const reduxDispatch = useDispatch();
   // Schema data from API
   const {
     currentData: schemaData,
@@ -195,6 +204,8 @@ const useTreeData = ({
           dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: true });
 
           // Fetch metadata asynchronously
+          // .unwrap() causes RTK Query to reject on error so .catch() fires.
+          // Without it RTK Query resolves with { error } instead of rejecting.
           Promise.all([
             fetchTableMetadata(
               {
@@ -204,7 +215,7 @@ const useTreeData = ({
                 table,
               },
               true,
-            ),
+            ).unwrap(),
             fetchTableExtendedMetadata(
               {
                 dbId: parsedDbId,
@@ -213,22 +224,30 @@ const useTreeData = ({
                 table,
               },
               true,
-            ),
+            ).unwrap(),
           ])
-            .then(
-              ([{ data: tableMetadata }, { data: tableExtendedMetadata }]) => {
-                if (tableMetadata) {
-                  dispatch({
-                    type: 'SET_TABLE_SCHEMA_DATA',
-                    key: tableKey,
-                    data: {
-                      ...tableMetadata,
-                      ...tableExtendedMetadata,
-                    },
-                  });
-                }
-              },
-            )
+            .then(([tableMetadata, tableExtendedMetadata]) => {
+              if (tableMetadata) {
+                dispatch({
+                  type: 'SET_TABLE_SCHEMA_DATA',
+                  key: tableKey,
+                  data: {
+                    ...tableMetadata,
+                    ...tableExtendedMetadata,
+                  },
+                });
+              }
+            })
+            .catch(() => {
+              reduxDispatch(
+                addDangerToast(
+                  t(
+                    'An error occurred while fetching table metadata for %s',
+                    table,
+                  ),
+                ),
+              );
+            })
             .finally(() => {
               dispatch({
                 type: 'SET_LOADING_NODE',
@@ -245,6 +264,7 @@ const useTreeData = ({
       fetchTableExtendedMetadata,
       fetchTableMetadata,
       pinnedTables,
+      reduxDispatch,
       tableData,
       tableSchemaData,
     ],
@@ -287,6 +307,55 @@ const useTreeData = ({
         });
     },
     [fetchLazyTables],
+  );
+
+  const refreshTableSchema = useCallback(
+    (id: string) => {
+      const parts = id.split(':');
+      const [, databaseId, schema, table] = parts;
+      const parsedDbId = Number(databaseId);
+      const tableKey = `${parsedDbId}:${schema}:${table}`;
+
+      dispatch({ type: 'CLEAR_TABLE_SCHEMA_DATA', key: tableKey });
+      dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: true });
+
+      Promise.all([
+        fetchTableMetadata(
+          { dbId: parsedDbId, catalog, schema, table },
+          false,
+        ).unwrap(),
+        fetchTableExtendedMetadata(
+          { dbId: parsedDbId, catalog, schema, table },
+          false,
+        ).unwrap(),
+      ])
+        .then(([tableMetadata, tableExtendedMetadata]) => {
+          if (tableMetadata) {
+            dispatch({
+              type: 'SET_TABLE_SCHEMA_DATA',
+              key: tableKey,
+              data: {
+                ...tableMetadata,
+                ...tableExtendedMetadata,
+              },
+            });
+          }
+        })
+        .catch(() => {
+          reduxDispatch(
+            addDangerToast(
+              t(
+                'An error occurred while refreshing table metadata for %s',
+                table,
+              ),
+            ),
+          );
+        })
+        .finally(() => {
+          dispatch({ type: 'SET_LOADING_NODE', nodeId: id, loading: false });
+        });
+    },
+    [catalog, fetchTableExtendedMetadata, fetchTableMetadata, reduxDispatch],
   );
 
   // Build tree data
@@ -378,6 +447,7 @@ const useTreeData = ({
     selectStarMap,
     handleToggle,
     handleRefreshTables,
+    refreshTableSchema,
     errorPayload,
   };
 };

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/useTreeData.ts
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/useTreeData.ts
@@ -215,7 +215,8 @@ const useTreeData = ({
             { dbId: parsedDbId, catalog, schema, forceRefresh: false },
             true,
           )
-            .then(({ data }) => {
+            .unwrap()
+            .then(data => {
               if (data) {
                 dispatch({ type: 'SET_TABLE_DATA', key: schemaKey, data });
               }
@@ -298,12 +299,6 @@ const useTreeData = ({
 
   const refreshTableSchema = useCallback(
     (id: string) => {
-      const parts = id.split(':');
-      const [, databaseId, schema, table] = parts;
-      const parsedDbId = Number(databaseId);
-      const tableKey = `${parsedDbId}:${schema}:${table}`;
-
-      dispatch({ type: 'CLEAR_TABLE_SCHEMA_DATA', key: tableKey });
       fetchAndStoreTableSchema(id, false);
     },
     [fetchAndStoreTableSchema],

--- a/superset-frontend/src/utils/localStorageHelpers.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.ts
@@ -51,6 +51,7 @@ export enum LocalStorageKeys {
    */
   SqllabIsAutocompleteEnabled = 'sqllab__is_autocomplete_enabled',
   SqllabIsRenderHtmlEnabled = 'sqllab__is_render_html_enabled',
+  SqllabPinnedSchemas = 'sqllab__pinned_schemas',
   ExploreDataTableOriginalFormattedTimeColumns = 'explore__data_table_original_formatted_time_columns',
   DashboardCustomFilterBarWidths = 'dashboard__custom_filter_bar_widths',
   DashboardExploreContext = 'dashboard__explore_context',
@@ -71,6 +72,7 @@ export type LocalStorageValues = {
   homepage_activity_filter: TableTab | null;
   sqllab__is_autocomplete_enabled: boolean;
   sqllab__is_render_html_enabled: boolean;
+  sqllab__pinned_schemas: Record<number, string[]>;
   explore__data_table_original_formatted_time_columns: Record<string, string[]>;
   dashboard__custom_filter_bar_widths: Record<string, number>;
   dashboard__explore_context: Record<string, DashboardContextForExplore>;

--- a/superset-frontend/src/utils/localStorageHelpers.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.ts
@@ -72,7 +72,7 @@ export type LocalStorageValues = {
   homepage_activity_filter: TableTab | null;
   sqllab__is_autocomplete_enabled: boolean;
   sqllab__is_render_html_enabled: boolean;
-  sqllab__pinned_schemas: Record<number, string[]>;
+  sqllab__pinned_schemas: Record<string, string[]>;
   explore__data_table_original_formatted_time_columns: Record<string, string[]>;
   dashboard__custom_filter_bar_widths: Record<string, number>;
   dashboard__explore_context: Record<string, DashboardContextForExplore>;


### PR DESCRIPTION
## **User description**
### SUMMARY


  Adds three new interactive features to the SQL Lab Table Explore Tree sidebar and improves error handling for table metadata fetching.

  ### New Features

  #### 📌 Schema Pin to Top
  - Adds a **Pin to top** action in each schema node's hover action menu
  - Pinned schemas are sorted to the front of the schema list; unpinned schemas follow in their original order
  - A persistent pin indicator (`PushpinFilled`) is shown on pinned schemas when not hovered
  - Pin/unpin state is managed locally with a `Set<string>` in `TableExploreTree`

  #### 🔤 Column Sort Toggle (per table)
  - Adds a sort button (`SortAscendingOutlined`) to each table node's hover actions
  - Toggles alphabetical sorting of columns for that specific table; the button highlights in primary color when active
  - Sort state is independent per table and applied in `displayTreeData` via `useMemo`, keeping source data intact

  #### 🔄 Refresh Table Schema
  - Adds a refresh button (`SyncOutlined`) to each table node's hover actions
  - Clears the cached column data for the table and re-fetches metadata + extended metadata via `Promise.all`
  - Shows a danger toast notification on fetch failure

  ### Bug Fix

  #### Folder icon not reflecting actual open state
  Fixed a mismatch between the folder open/close icon and the actual visual expansion state
  of schema nodes after a search → pin → unpin sequence.

  - `isManuallyOpen` is now derived from `node.isOpen` (the tree's own state) instead of
    a separate `manuallyOpenedNodes` tracking map
  - Eliminates the stale-state divergence that caused the icon to show the wrong state

  ### Error Handling Improvement

  - Added `.unwrap()` to RTK Query lazy query calls in `handleToggle` and `refreshTableSchema`
  - Without `.unwrap()`, RTK Query resolves with `{ error }` on failure rather than rejecting,
    so `.catch()` was never reached
  - Failures now show a localized danger toast:
    - `"An error occurred while fetching table metadata for <table>"`
    - `"An error occurred while refreshing table metadata for <table>"`
  - Added `CLEAR_TABLE_SCHEMA_DATA` reducer action to remove stale cache entries before re-fetching

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/a427ffb4-7407-4feb-8ff2-3a5fd7aa0a92

### TESTING INSTRUCTIONS

Go to Sqll Lab and then pin a couple of schema

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Pin schemas, sort table columns, and refresh table metadata from the SQL Lab tree**

### What Changed
- Schemas can now be pinned to the top of the SQL Lab tree, with pinned state saved per database and catalog so it stays after reloads.
- Tables now include actions to sort their columns alphabetically and to refresh table schema data on demand.
- Refreshing a table now reloads its metadata and shows a clear error message if the fetch fails.
- The folder open/closed icon now matches the tree’s actual expanded state after search and pin/unpin changes.

### Impact
`✅ Saved schema pins across reloads`
`✅ Faster access to frequently used schemas`
`✅ Clearer table metadata refresh errors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ax8GFoOLjW08Hcgg1aqihMZtruKALhkgHgii4ZDCIBg&org=apache)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
