### PR TITLE
chore: Bump core packages to 0.1.0 RC2

### DIFF
--- a/superset-core/pyproject.toml
+++ b/superset-core/pyproject.toml
@@ -24,14 +24,14 @@ readme = "README.md"
 authors = [
     { name = "Apache Software Foundation", email = "dev@superset.apache.org" },
 ]
-license = { file="LICENSE.txt" }
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 requires-python = ">=3.10"
 keywords = ["superset", "apache", "analytics", "business-intelligence", "extensions", "visualization"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Web Environment",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/superset-core/pyproject.toml
+++ b/superset-core/pyproject.toml
@@ -18,7 +18,7 @@
 
 [project]
 name = "apache-superset-core"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 description = "Core Python package for building Apache Superset backend extensions and integrations"
 readme = "README.md"
 authors = [

--- a/superset-extensions-cli/pyproject.toml
+++ b/superset-extensions-cli/pyproject.toml
@@ -23,14 +23,14 @@ readme = "README.md"
 authors = [
     { name = "Apache Software Foundation", email = "dev@superset.apache.org" },
 ]
-license = { file="LICENSE.txt" }
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 requires-python = ">=3.10"
 keywords = ["superset", "apache", "cli", "extensions", "analytics", "business-intelligence", "development-tools"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -51071,8 +51071,8 @@
     },
     "packages/superset-core": {
       "name": "@apache-superset/core",
-      "version": "0.1.0-rc1",
-      "license": "ISC",
+      "version": "0.1.0-rc2",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.28.6",
         "@babel/core": "^7.29.0",

--- a/superset-frontend/packages/superset-core/package.json
+++ b/superset-frontend/packages/superset-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apache-superset/core",
-  "version": "0.1.0-rc1",
+  "version": "0.1.0-rc2",
   "description": "This package contains UI elements, APIs, and utility functions used by Superset.",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -70,8 +70,8 @@
   "files": [
     "lib"
   ],
-  "author": "",
-  "license": "ISC",
+  "author": "Apache Software Foundation",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@babel/cli": "^7.28.6",
     "@babel/core": "^7.29.0",


### PR DESCRIPTION
### SUMMARY
Bump `@apache-superset/core` and `superset-core` to 0.1.0 RC2. `superset-extensions-cli` was already bumped.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
