### PR TITLE
fix(sqllab): Relocate schema display on table preview

### DIFF
--- a/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
@@ -286,7 +286,6 @@ const TablePreview: FC<Props> = ({ dbId, catalog, schema, tableName }) => {
         <Breadcrumb.Item>{backend}</Breadcrumb.Item>
         <Breadcrumb.Item>{databaseName}</Breadcrumb.Item>
         {catalog && <Breadcrumb.Item>{catalog}</Breadcrumb.Item>}
-        {schema && <Breadcrumb.Item>{schema}</Breadcrumb.Item>}
         <Breadcrumb.Item> </Breadcrumb.Item>
       </Breadcrumb>
       <div style={{ display: 'none' }} aria-hidden="true">
@@ -314,6 +313,7 @@ const TablePreview: FC<Props> = ({ dbId, catalog, schema, tableName }) => {
       </div>
       <Title>
         <Icons.InsertRowAboveOutlined iconSize="l" />
+        {schema ? `${schema}.` : ''}
         {tableName}
         {titleActions()}
       </Title>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Moved the schema name display in the SQL Lab table preview from the breadcrumb navigation to the title section.
This makes the schema context more visually associated with the table name itself, following the conventional schema.table SQL notation, rather than burying it in the breadcrumb trail.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="465" height="416" alt="Screenshot 2026-04-16 at 5 46 51 PM" src="https://github.com/user-attachments/assets/efd412b2-6e79-4717-a470-74290eac3f79" />


After:

<img width="459" height="397" alt="Screenshot 2026-04-16 at 5 49 37 PM" src="https://github.com/user-attachments/assets/40a7a434-e322-444b-b0b0-c5cead871823" />



### TESTING INSTRUCTIONS

screenshot

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
