### PR TITLE
fix(mcp): default XY chart x-axis to dataset primary datetime column

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -611,6 +611,35 @@ def _ensure_temporal_adhoc_filter(form_data: Dict[str, Any], column: str) -> Non
     form_data["adhoc_filters"] = existing
 
 
+def _resolve_default_x_axis(
+    config: XYChartConfig, dataset_id: int | str | None
+) -> XYChartConfig:
+    """Resolve x-axis to the dataset's main_dttm_col when x is omitted."""
+    if config.x is not None:
+        return config
+
+    if not dataset_id:
+        raise ValueError("x-axis column is required when dataset_id is not provided")
+    from superset.daos.dataset import DatasetDAO
+
+    if isinstance(dataset_id, int) or (
+        isinstance(dataset_id, str) and dataset_id.isdigit()
+    ):
+        dataset = DatasetDAO.find_by_id(int(dataset_id))
+    else:
+        dataset = DatasetDAO.find_by_id(dataset_id, id_column="uuid")
+
+    if not dataset or not dataset.main_dttm_col:
+        raise ValueError(
+            "x-axis column is required: dataset has no primary datetime "
+            "column (main_dttm_col). Please specify the x-axis column "
+            "explicitly."
+        )
+    from superset.mcp_service.chart.schemas import ColumnRef
+
+    return config.model_copy(update={"x": ColumnRef(name=dataset.main_dttm_col)})
+
+
 def map_xy_config(
     config: XYChartConfig, dataset_id: int | str | None = None
 ) -> Dict[str, Any]:
@@ -618,6 +647,9 @@ def map_xy_config(
     # Early validation to prevent empty charts
     if not config.y:
         raise ValueError("XY chart must have at least one Y-axis metric")
+
+    # Resolve x-axis default: use dataset's main_dttm_col when x is omitted
+    config = _resolve_default_x_axis(config, dataset_id)
 
     # Check if x-axis column is truly temporal (based on actual SQL type)
     x_is_temporal = is_column_truly_temporal(config.x.name, dataset_id)

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -650,6 +650,7 @@ def map_xy_config(
 
     # Resolve x-axis default: use dataset's main_dttm_col when x is omitted
     config = _resolve_default_x_axis(config, dataset_id)
+    assert config.x is not None  # _resolve_default_x_axis guarantees x is set
 
     # Check if x-axis column is truly temporal (based on actual SQL type)
     x_is_temporal = is_column_truly_temporal(config.x.name, dataset_id)
@@ -1033,7 +1034,7 @@ def _table_chart_what(config: TableChartConfig, dataset_name: str | None) -> str
 def _xy_chart_what(config: XYChartConfig) -> str:
     """Build the descriptive fragment for an XY chart."""
     primary_metric = _humanize_column(config.y[0]) if config.y else "Value"
-    dimension = _humanize_column(config.x)
+    dimension = _humanize_column(config.x) if config.x else "Dimension"
 
     if config.kind in ("line", "area") and not config.group_by:
         return f"{primary_metric} Over Time"

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1119,44 +1119,13 @@ class XYChartConfig(UnknownFieldCheckMixin):
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "XYChartConfig":
         """Ensure all column labels are unique across x, y, and group_by."""
-        if self.x is None:
-            labels_seen: dict[str, str] = {}
-            duplicates: list[str] = []
-
-            # Still validate Y labels even when x will be resolved later
-            for i, col in enumerate(self.y):
-                label = _metric_display_label(col)
-                if label in labels_seen:
-                    duplicates.append(f"y[{i}]: '{label}' (conflicts with {labels_seen[label]})")
-                else:
-                    labels_seen[label] = f"y[{i}]"
-
-            # Validate group_by labels against Y labels
-            if self.group_by:
-                for i, col in enumerate(self.group_by):
-                    group_label = col.label or col.name
-                    if group_label in labels_seen:
-                        duplicates.append(
-                            f"group_by[{i}]: '{group_label}' "
-                            f"(conflicts with {labels_seen[group_label]})"
-                        )
-                    else:
-                        labels_seen[group_label] = f"group_by[{i}]"
-
-            if duplicates:
-                raise ValueError(
-                    f"Duplicate column/metric labels: {', '.join(duplicates)}. "
-                    f"Please make sure all columns and metrics have a unique label. "
-                    f"Use the 'label' field to provide custom names for columns."
-                )
-
-            return self
-
         labels_seen: dict[str, str] = {}
         duplicates: list[str] = []
 
-        x_label = self.x.label or self.x.name
-        labels_seen[x_label] = "x"
+        # Add x-axis label if present (x may be None, resolved later)
+        if self.x is not None:
+            x_label = self.x.label or self.x.name
+            labels_seen[x_label] = "x"
 
         # Check Y-axis labels
         for i, col in enumerate(self.y):
@@ -1171,7 +1140,7 @@ class XYChartConfig(UnknownFieldCheckMixin):
         # Check group_by labels if present
         if self.group_by:
             for i, col in enumerate(self.group_by):
-                if col.name == self.x.name:
+                if self.x is not None and col.name == self.x.name:
                     # map_xy_config() strips group_by entries that match x
                     # to prevent Superset "duplicate label" errors, so
                     # we allow them through validation.

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1054,13 +1054,25 @@ class TableChartConfig(UnknownFieldCheckMixin):
         return self
 
 
+def _metric_display_label(col: ColumnRef) -> str:
+    """Return the display label for a metric column reference."""
+    if col.saved_metric:
+        return col.label or col.name
+    if col.aggregate:
+        return col.label or f"{col.aggregate}({col.name})"
+    return col.label or col.name
+
+
 class XYChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     chart_type: Literal["xy"] = "xy"
-    x: ColumnRef = Field(
-        ...,
-        description="X-axis column",
+    x: ColumnRef | None = Field(
+        None,
+        description=(
+            "X-axis column. If omitted, defaults to the dataset's "
+            "primary datetime column (main_dttm_col)."
+        ),
         validation_alias=AliasChoices("x", "x_axis", "x_column"),
     )
     y: List[ColumnRef] = Field(
@@ -1107,22 +1119,20 @@ class XYChartConfig(UnknownFieldCheckMixin):
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "XYChartConfig":
         """Ensure all column labels are unique across x, y, and group_by."""
-        labels_seen = {}  # label -> field_name for error reporting
-        duplicates = []
+        # When x is None it will be resolved later via main_dttm_col;
+        # skip duplicate-label validation since the final x is unknown.
+        if self.x is None:
+            return self
 
-        # Check X-axis label
+        labels_seen: dict[str, str] = {}
+        duplicates: list[str] = []
+
         x_label = self.x.label or self.x.name
         labels_seen[x_label] = "x"
 
         # Check Y-axis labels
         for i, col in enumerate(self.y):
-            if col.saved_metric:
-                label = col.label or col.name
-            elif col.aggregate:
-                label = col.label or f"{col.aggregate}({col.name})"
-            else:
-                label = col.label or col.name
-
+            label = _metric_display_label(col)
             if label in labels_seen:
                 duplicates.append(
                     f"y[{i}]: '{label}' (conflicts with {labels_seen[label]})"

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1119,9 +1119,37 @@ class XYChartConfig(UnknownFieldCheckMixin):
     @model_validator(mode="after")
     def validate_unique_column_labels(self) -> "XYChartConfig":
         """Ensure all column labels are unique across x, y, and group_by."""
-        # When x is None it will be resolved later via main_dttm_col;
-        # skip duplicate-label validation since the final x is unknown.
         if self.x is None:
+            labels_seen: dict[str, str] = {}
+            duplicates: list[str] = []
+
+            # Still validate Y labels even when x will be resolved later
+            for i, col in enumerate(self.y):
+                label = _metric_display_label(col)
+                if label in labels_seen:
+                    duplicates.append(f"y[{i}]: '{label}' (conflicts with {labels_seen[label]})")
+                else:
+                    labels_seen[label] = f"y[{i}]"
+
+            # Validate group_by labels against Y labels
+            if self.group_by:
+                for i, col in enumerate(self.group_by):
+                    group_label = col.label or col.name
+                    if group_label in labels_seen:
+                        duplicates.append(
+                            f"group_by[{i}]: '{group_label}' "
+                            f"(conflicts with {labels_seen[group_label]})"
+                        )
+                    else:
+                        labels_seen[group_label] = f"group_by[{i}]"
+
+            if duplicates:
+                raise ValueError(
+                    f"Duplicate column/metric labels: {', '.join(duplicates)}. "
+                    f"Please make sure all columns and metrics have a unique label. "
+                    f"Use the 'label' field to provide custom names for columns."
+                )
+
             return self
 
         labels_seen: dict[str, str] = {}

--- a/superset/mcp_service/chart/validation/dataset_validator.py
+++ b/superset/mcp_service/chart/validation/dataset_validator.py
@@ -204,7 +204,8 @@ class DatasetValidator:
         if isinstance(config, TableChartConfig):
             refs.extend(config.columns)
         elif isinstance(config, XYChartConfig):
-            refs.append(config.x)
+            if config.x is not None:
+                refs.append(config.x)
             refs.extend(config.y)
             if config.group_by:
                 refs.extend(config.group_by)

--- a/superset/mcp_service/chart/validation/runtime/__init__.py
+++ b/superset/mcp_service/chart/validation/runtime/__init__.py
@@ -134,6 +134,8 @@ class RuntimeValidator:
             chart_type = config.kind if hasattr(config, "kind") else "default"
 
             # Check X-axis cardinality
+            if config.x is None:
+                return warnings, suggestions
             is_ok, cardinality_info = CardinalityValidator.check_cardinality(
                 dataset_id=dataset_id,
                 x_column=config.x.name,

--- a/superset/mcp_service/chart/validation/runtime/chart_type_suggester.py
+++ b/superset/mcp_service/chart/validation/runtime/chart_type_suggester.py
@@ -150,6 +150,7 @@ class ChartTypeSuggester:
         config: XYChartConfig, x_analysis: Dict[str, Any], y_analysis: Dict[str, Any]
     ) -> Tuple[List[str], List[str]]:
         """Check for chart type specific issues."""
+        assert config.x is not None  # caller guards for None
         issues = []
         suggestions = []
 
@@ -198,6 +199,7 @@ class ChartTypeSuggester:
         x_is_id: bool,
     ) -> Tuple[List[str], List[str]]:
         """Check line chart specific issues."""
+        assert config.x is not None
         issues = []
         suggestions = []
 
@@ -231,6 +233,7 @@ class ChartTypeSuggester:
         config: XYChartConfig, x_is_categorical: bool, num_metrics: int
     ) -> Tuple[List[str], List[str]]:
         """Check scatter chart specific issues."""
+        assert config.x is not None
         issues = []
         suggestions = []
 
@@ -261,6 +264,7 @@ class ChartTypeSuggester:
         config: XYChartConfig, x_is_temporal: bool
     ) -> Tuple[List[str], List[str]]:
         """Check area chart specific issues."""
+        assert config.x is not None
         issues = []
         suggestions = []
 
@@ -298,6 +302,7 @@ class ChartTypeSuggester:
         config: XYChartConfig, x_is_id: bool
     ) -> Tuple[List[str], List[str]]:
         """Check bar chart specific issues."""
+        assert config.x is not None
         issues = []
         suggestions = []
 

--- a/superset/mcp_service/chart/validation/runtime/chart_type_suggester.py
+++ b/superset/mcp_service/chart/validation/runtime/chart_type_suggester.py
@@ -68,6 +68,9 @@ class ChartTypeSuggester:
         issues = []
         suggestions = []
 
+        if config.x is None:
+            return True, None
+
         x_analysis = ChartTypeSuggester._analyze_x_axis(config.x.name)
         y_analysis = ChartTypeSuggester._analyze_y_axis(config.y)
 

--- a/superset/mcp_service/chart/validation/runtime/format_validator.py
+++ b/superset/mcp_service/chart/validation/runtime/format_validator.py
@@ -84,10 +84,6 @@ class FormatTypeValidator:
                 config.x_axis.format, x_column
             )
             warnings.extend(x_warnings)
-            x_warnings = FormatTypeValidator._validate_x_axis_format(
-                config.x_axis.format, config.x
-            )
-            warnings.extend(x_warnings)
 
         return len(warnings) == 0, warnings if warnings else None
 

--- a/superset/mcp_service/chart/validation/runtime/format_validator.py
+++ b/superset/mcp_service/chart/validation/runtime/format_validator.py
@@ -78,7 +78,12 @@ class FormatTypeValidator:
             warnings.extend(y_warnings)
 
         # Validate X-axis format (usually temporal or categorical)
-        if config.x_axis and config.x_axis.format and config.x is not None:
+        if config.x_axis and config.x_axis.format:
+            x_column = config.x or ColumnRef(name="default_x_axis")
+            x_warnings = FormatTypeValidator._validate_x_axis_format(
+                config.x_axis.format, x_column
+            )
+            warnings.extend(x_warnings)
             x_warnings = FormatTypeValidator._validate_x_axis_format(
                 config.x_axis.format, config.x
             )

--- a/superset/mcp_service/chart/validation/runtime/format_validator.py
+++ b/superset/mcp_service/chart/validation/runtime/format_validator.py
@@ -78,7 +78,7 @@ class FormatTypeValidator:
             warnings.extend(y_warnings)
 
         # Validate X-axis format (usually temporal or categorical)
-        if config.x_axis and config.x_axis.format:
+        if config.x_axis and config.x_axis.format and config.x is not None:
             x_warnings = FormatTypeValidator._validate_x_axis_format(
                 config.x_axis.format, config.x
             )

--- a/superset/mcp_service/chart/validation/schema_validator.py
+++ b/superset/mcp_service/chart/validation/schema_validator.py
@@ -185,22 +185,15 @@ class SchemaValidator:
         config: Dict[str, Any],
     ) -> Tuple[bool, ChartGenerationError | None]:
         """Pre-validate XY chart configuration."""
-        missing_fields = []
-
-        if "x" not in config:
-            missing_fields.append("'x' (X-axis column)")
+        # x is optional — defaults to dataset's main_dttm_col in map_xy_config
         if "y" not in config:
-            missing_fields.append("'y' (Y-axis metrics)")
-
-        if missing_fields:
             return False, ChartGenerationError(
                 error_type="missing_xy_fields",
-                message=f"XY chart missing required "
-                f"fields: {', '.join(missing_fields)}",
-                details="XY charts require both X-axis (dimension) and Y-axis ("
-                "metrics) specifications",
+                message="XY chart missing required field: 'y' (Y-axis metrics)",
+                details="XY charts require Y-axis (metrics) specifications. "
+                "X-axis is optional and defaults to the dataset's primary "
+                "datetime column when omitted.",
                 suggestions=[
-                    "Add 'x' field: {'name': 'column_name'} for X-axis",
                     "Add 'y' field: [{'name': 'metric_column', 'aggregate': 'SUM'}] "
                     "for Y-axis",
                     "Example: {'chart_type': 'xy', 'x': {'name': 'date'}, "

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -826,6 +826,62 @@ class TestMapConfigToFormData:
         with pytest.raises(ValueError, match="Unsupported config type"):
             map_config_to_form_data("invalid_config")  # type: ignore
 
+    @patch(
+        "superset.mcp_service.chart.chart_utils.is_column_truly_temporal",
+        return_value=True,
+    )
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
+    def test_map_xy_config_x_none_defaults_to_main_dttm_col(
+        self, mock_find_by_id: Any, mock_is_temporal: Any
+    ) -> None:
+        """When x is None, map_xy_config resolves it from dataset.main_dttm_col."""
+        mock_dataset = MagicMock()
+        mock_dataset.main_dttm_col = "order_date"
+        mock_find_by_id.return_value = mock_dataset
+
+        config = XYChartConfig(
+            chart_type="xy",
+            x=None,
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="bar",
+        )
+
+        result = map_xy_config(config, dataset_id=42)
+
+        assert result["x_axis"] == "order_date"
+        mock_find_by_id.assert_called_once_with(42)
+
+    def test_map_xy_config_x_none_no_dataset_id_raises(self) -> None:
+        """When x is None and no dataset_id, raise ValueError."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=None,
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+        )
+
+        with pytest.raises(ValueError, match="x-axis column is required"):
+            map_xy_config(config, dataset_id=None)
+
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
+    def test_map_xy_config_x_none_no_main_dttm_col_raises(
+        self, mock_find_by_id: Any
+    ) -> None:
+        """When x is None and dataset has no main_dttm_col, raise ValueError."""
+        mock_dataset = MagicMock()
+        mock_dataset.main_dttm_col = None
+        mock_find_by_id.return_value = mock_dataset
+
+        config = XYChartConfig(
+            chart_type="xy",
+            x=None,
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+        )
+
+        with pytest.raises(ValueError, match="no primary datetime column"):
+            map_xy_config(config, dataset_id=42)
+
 
 class TestGenerateChartName:
     """Test generate_chart_name function"""


### PR DESCRIPTION
## Summary

When an LLM creates an XY chart via MCP without specifying the x-axis column, the tool now defaults to the dataset's `main_dttm_col` (primary datetime column) instead of failing validation.

- Make `XYChartConfig.x` optional (defaults to `None`)
- Add `_resolve_default_x_axis()` helper that looks up the dataset's `main_dttm_col` when x is omitted
- Extract `_metric_display_label()` to reduce cyclomatic complexity in the label validator
- Guard `validate_unique_column_labels` for `x is None` (deferred until resolution)
- Add 3 unit tests: successful resolution, missing dataset_id error, missing main_dttm_col error

## Before

LLMs must always specify the x-axis column explicitly. If omitted, Pydantic validation fails immediately. If the LLM picks a non-primary datetime column, the chart shows a time filter error when opened in Explore (addressed by #38978).

## After

When x is omitted, the tool automatically uses the dataset's primary datetime column. This ensures the most common datetime column is used and the TEMPORAL_RANGE filter matches correctly.

## Test plan

- [x] 543 existing MCP chart unit tests pass
- [x] 3 new tests for x=None defaulting (success, no dataset_id, no main_dttm_col)
- [x] ruff check passes with no errors

<img width="1726" height="1006" alt="Screenshot 2026-04-17 at 11 57 54 AM" src="https://github.com/user-attachments/assets/18ada2b0-ef57-43c8-84d4-2935a5db0aaa" />
