### PR TITLE
fix(deck.gl): scatterplot stops rendering points with empty value of categorical color

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/CategoricalDeckGLContainer.test.tsx
@@ -20,6 +20,7 @@ import { QueryFormData } from '@superset-ui/core';
 import { getCategories } from './CategoricalDeckGLContainer';
 import { addColorToFeatures } from './utils/addColor';
 import { COLOR_SCHEME_TYPES } from './utilities/utils';
+import { NULL_CATEGORY_KEY } from './utils';
 
 // Record every (label, sliceId) pair the categorical color scale is asked to
 // resolve, so we can assert the legend and point-color paths key the scale on
@@ -65,4 +66,26 @@ test('legend and point colors resolve from the same slice_id', () => {
   expect(categories.A.color).toEqual(features[0].color);
   expect(categories.B.color).toEqual(features[1].color);
   expect(features[0].color).not.toEqual(features[1].color);
+});
+
+test('rows with a null dimension get their own legend category', () => {
+  const fd = {
+    datasource: '1__table',
+    viz_type: 'deck_scatter',
+    color_scheme_type: COLOR_SCHEME_TYPES.categorical_palette,
+    color_scheme: 'supersetColors',
+    dimension: 'category',
+    slice_id: 42,
+    color_picker: { r: 0, g: 0, b: 0, a: 1 },
+  } as unknown as QueryFormData;
+  const data = [{ cat_color: 'A' }, { cat_color: NULL_CATEGORY_KEY }];
+
+  const categories = getCategories(fd, data);
+
+  expect(categories[NULL_CATEGORY_KEY]?.enabled).toBe(true);
+  expect(categories[NULL_CATEGORY_KEY]?.color).toBeDefined();
+
+  // Without a category entry the container drops the feature entirely, which is
+  // how null-dimension rows used to disappear from the map.
+  expect(data.filter(d => categories[d.cat_color]?.enabled)).toHaveLength(2);
 });

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
+import Legend, { LegendProps } from './Legend';
+
+const renderLegend = (props: Partial<LegendProps> = {}) => {
+  const defaults: LegendProps = {
+    format: null,
+    categories: {},
+    ...props,
+  };
+  return render(
+    <ThemeProvider theme={supersetTheme}>
+      <Legend {...defaults} />
+    </ThemeProvider>,
+  );
+};
+
+test('renders a label for a normal category key', () => {
+  renderLegend({
+    categories: {
+      California: { enabled: true, color: [255, 0, 0, 255] },
+    },
+  });
+
+  expect(screen.getByText('California')).toBeInTheDocument();
+});
+
+test('renders N/A for empty-string category key', () => {
+  renderLegend({
+    categories: {
+      '': { enabled: true, color: [0, 128, 0, 255] },
+    },
+  });
+
+  expect(screen.getByText('N/A')).toBeInTheDocument();
+});
+
+test('renders nothing when categories is empty', () => {
+  const { container } = renderLegend({ categories: {} });
+
+  expect(container.firstChild).toBeNull();
+});
+
+test('renders nothing when position is null', () => {
+  const { container } = renderLegend({
+    position: null,
+    categories: {
+      California: { enabled: true, color: [255, 0, 0, 255] },
+    },
+  });
+
+  expect(container.firstChild).toBeNull();
+});
+
+test('calls toggleCategory when a category link is clicked', async () => {
+  const toggleCategory = jest.fn();
+  renderLegend({
+    toggleCategory,
+    categories: {
+      California: { enabled: true, color: [255, 0, 0, 255] },
+    },
+  });
+
+  await userEvent.click(screen.getByRole('button'));
+
+  expect(toggleCategory).toHaveBeenCalledWith('California');
+});
+
+test('calls toggleCategory with empty string key when N/A link is clicked', async () => {
+  const toggleCategory = jest.fn();
+  renderLegend({
+    toggleCategory,
+    categories: {
+      '': { enabled: true, color: [0, 128, 0, 255] },
+    },
+  });
+
+  await userEvent.click(screen.getByRole('button'));
+
+  expect(toggleCategory).toHaveBeenCalledWith('');
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
@@ -21,6 +21,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
 import Legend, { LegendProps } from './Legend';
+import { NULL_CATEGORY_KEY } from '../utils';
 
 const renderLegend = (props: Partial<LegendProps> = {}) => {
   const defaults: LegendProps = {
@@ -45,10 +46,10 @@ test('renders a label for a normal category key', () => {
   expect(screen.getByText('California')).toBeInTheDocument();
 });
 
-test('renders N/A for empty-string category key', () => {
+test('renders N/A for null category key', () => {
   renderLegend({
     categories: {
-      '': { enabled: true, color: [0, 128, 0, 255] },
+      [NULL_CATEGORY_KEY]: { enabled: true, color: [0, 128, 0, 255] },
     },
   });
 
@@ -86,16 +87,16 @@ test('calls toggleCategory when a category link is clicked', async () => {
   expect(toggleCategory).toHaveBeenCalledWith('California');
 });
 
-test('calls toggleCategory with empty string key when N/A link is clicked', async () => {
+test('calls toggleCategory with NULL_CATEGORY_KEY when N/A link is clicked', async () => {
   const toggleCategory = jest.fn();
   renderLegend({
     toggleCategory,
     categories: {
-      '': { enabled: true, color: [0, 128, 0, 255] },
+      [NULL_CATEGORY_KEY]: { enabled: true, color: [0, 128, 0, 255] },
     },
   });
 
   await userEvent.click(screen.getByRole('button'));
 
-  expect(toggleCategory).toHaveBeenCalledWith('');
+  expect(toggleCategory).toHaveBeenCalledWith(NULL_CATEGORY_KEY);
 });

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
@@ -22,7 +22,9 @@ import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
 import type { ReactElement } from 'react';
+import { Constants } from '@superset-ui/core/components';
 import Legend from './Legend';
+import { NULL_CATEGORY_KEY } from '../utils';
 
 const renderWithTheme = (component: ReactElement) =>
   render(<ThemeProvider theme={supersetTheme}>{component}</ThemeProvider>);
@@ -68,6 +70,18 @@ test('leaves labels untouched when no format is provided', () => {
   );
 
   expect(screen.getByText('[1, 81)')).toBeInTheDocument();
+});
+
+test('shows the null category as N/A instead of its internal key', () => {
+  renderWithTheme(
+    <Legend
+      format=",.2f"
+      categories={{ [NULL_CATEGORY_KEY]: { enabled: true, color: [0, 0, 0] } }}
+    />,
+  );
+
+  expect(screen.getByText(Constants.NULL_DISPLAY)).toBeInTheDocument();
+  expect(screen.queryByText(NULL_CATEGORY_KEY)).not.toBeInTheDocument();
 });
 
 test('clicking a legend item toggles the category without triggering anchor navigation', () => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
@@ -24,6 +24,7 @@ import { formatNumber } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
 import { Color } from '@deck.gl/core';
+import { NULL_CATEGORY_KEY } from '../utils';
 
 const StyledLegend = styled.div`
   ${({ theme }) => `
@@ -88,7 +89,7 @@ const Legend = ({
   };
 
   const formatCategoryLabel = (k: string) => {
-    if (k === '') {
+    if (k === NULL_CATEGORY_KEY) {
       return t('N/A');
     }
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
@@ -22,6 +22,7 @@
 import { memo } from 'react';
 import { formatNumber } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
+import { t } from '@apache-superset/core/translation';
 import { Color } from '@deck.gl/core';
 
 const StyledLegend = styled.div`
@@ -87,6 +88,10 @@ const Legend = ({
   };
 
   const formatCategoryLabel = (k: string) => {
+    if (k === '') {
+      return t('N/A');
+    }
+
     if (!d3Format) {
       return k;
     }

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
@@ -23,6 +23,7 @@ import { memo } from 'react';
 import { formatNumber } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/theme';
 import { Color } from '@deck.gl/core';
+import { NULL_CATEGORY_KEY, formatNullCategory } from '../utils';
 
 const StyledLegend = styled.div`
   ${({ theme }) => `
@@ -114,6 +115,10 @@ const Legend = ({
   };
 
   const formatCategoryLabel = (k: string) => {
+    if (k === NULL_CATEGORY_KEY) {
+      return formatNullCategory(k);
+    }
+
     if (!d3Format) {
       return k;
     }

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ChartProps, DatasourceType } from '@superset-ui/core';
+import transformProps from './transformProps';
+
+interface ArcFeature {
+  sourcePosition: [number, number];
+  targetPosition: [number, number];
+  cat_color?: string;
+  extraProps?: Record<string, unknown>;
+}
+
+jest.mock('../spatialUtils', () => ({
+  ...jest.requireActual('../spatialUtils'),
+  getMapboxApiKey: jest.fn(() => 'mock-mapbox-key'),
+}));
+
+const mockChartProps: Partial<ChartProps> = {
+  rawFormData: {
+    start_spatial: {
+      type: 'latlong',
+      latCol: 'START_LAT',
+      lonCol: 'START_LON',
+    },
+    end_spatial: {
+      type: 'latlong',
+      latCol: 'END_LAT',
+      lonCol: 'END_LON',
+    },
+    viewport: {},
+  },
+  queriesData: [
+    {
+      data: [
+        {
+          START_LAT: 37.8,
+          START_LON: -122.4,
+          END_LAT: 37.9,
+          END_LON: -122.3,
+        },
+        {
+          START_LAT: 38.0,
+          START_LON: -122.2,
+          END_LAT: 38.1,
+          END_LON: -122.1,
+        },
+      ],
+    },
+  ],
+  datasource: {
+    type: DatasourceType.Table,
+    id: 1,
+    name: 'test_datasource',
+    columns: [],
+    metrics: [],
+  },
+  height: 400,
+  width: 600,
+  hooks: {},
+  filterState: {},
+  emitCrossFilters: false,
+};
+
+test('Arc transformProps should set cat_color when dimension is configured', () => {
+  const propsWithDimension = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      dimension: 'category',
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            START_LAT: 37.8,
+            START_LON: -122.4,
+            END_LAT: 37.9,
+            END_LON: -122.3,
+            category: 'A',
+          },
+          {
+            START_LAT: 38.0,
+            START_LON: -122.2,
+            END_LAT: 38.1,
+            END_LON: -122.1,
+            category: 'B',
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = transformProps(propsWithDimension as ChartProps);
+  const features = result.payload.data.features as ArcFeature[];
+
+  expect(features).toHaveLength(2);
+  expect(features[0]?.cat_color).toBe('A');
+  expect(features[1]?.cat_color).toBe('B');
+});
+
+test('Arc transformProps should assign empty string cat_color for null/undefined dimension values', () => {
+  const propsWithNullCategory = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      dimension: 'category',
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            START_LAT: 37.8,
+            START_LON: -122.4,
+            END_LAT: 37.9,
+            END_LON: -122.3,
+            category: 'A',
+          },
+          {
+            START_LAT: 38.0,
+            START_LON: -122.2,
+            END_LAT: 38.1,
+            END_LON: -122.1,
+            category: null,
+          },
+          {
+            START_LAT: 38.2,
+            START_LON: -122.0,
+            END_LAT: 38.3,
+            END_LON: -121.9,
+            category: undefined,
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = transformProps(propsWithNullCategory as ChartProps);
+  const features = result.payload.data.features as ArcFeature[];
+
+  expect(features).toHaveLength(3);
+  expect(features[0]?.cat_color).toBe('A');
+  expect(features[1]?.cat_color).toBe('');
+  expect(features[2]?.cat_color).toBe('');
+});
+
+test('Arc transformProps should not set cat_color when dimension is not configured', () => {
+  const result = transformProps(mockChartProps as ChartProps);
+  const features = result.payload.data.features as ArcFeature[];
+
+  expect(features).toHaveLength(2);
+  expect(features[0]?.cat_color).toBeUndefined();
+  expect(features[1]?.cat_color).toBeUndefined();
+});
+
+test('Arc transformProps should handle no records', () => {
+  const noDataProps = {
+    ...mockChartProps,
+    queriesData: [{ data: [] }],
+  };
+
+  const result = transformProps(noDataProps as ChartProps);
+  const features = result.payload.data.features as ArcFeature[];
+
+  expect(features).toHaveLength(0);
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.test.ts
@@ -19,6 +19,7 @@
 
 import { ChartProps, DatasourceType } from '@superset-ui/core';
 import transformProps from './transformProps';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 interface ArcFeature {
   sourcePosition: [number, number];
@@ -115,7 +116,7 @@ test('Arc transformProps should set cat_color when dimension is configured', () 
   expect(features[1]?.cat_color).toBe('B');
 });
 
-test('Arc transformProps should assign empty string cat_color for null/undefined dimension values', () => {
+test('Arc transformProps should assign NULL_CATEGORY_KEY cat_color for null/undefined dimension values', () => {
   const propsWithNullCategory = {
     ...mockChartProps,
     rawFormData: {
@@ -156,8 +157,8 @@ test('Arc transformProps should assign empty string cat_color for null/undefined
 
   expect(features).toHaveLength(3);
   expect(features[0]?.cat_color).toBe('A');
-  expect(features[1]?.cat_color).toBe('');
-  expect(features[2]?.cat_color).toBe('');
+  expect(features[1]?.cat_color).toBe(NULL_CATEGORY_KEY);
+  expect(features[2]?.cat_color).toBe(NULL_CATEGORY_KEY);
 });
 
 test('Arc transformProps should not set cat_color when dimension is not configured', () => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ChartProps, DatasourceType } from '@superset-ui/core';
+import transformProps from './transformProps';
+import { NULL_CATEGORY_KEY } from '../../utils';
+
+interface ArcFeature {
+  sourcePosition: [number, number];
+  targetPosition: [number, number];
+  cat_color?: string;
+  extraProps?: Record<string, unknown>;
+}
+
+jest.mock('../spatialUtils', () => ({
+  ...jest.requireActual('../spatialUtils'),
+  getMapboxApiKey: jest.fn(() => 'mock-mapbox-key'),
+}));
+
+const mockChartProps: Partial<ChartProps> = {
+  rawFormData: {
+    start_spatial: {
+      type: 'latlong',
+      latCol: 'START_LAT',
+      lonCol: 'START_LON',
+    },
+    end_spatial: {
+      type: 'latlong',
+      latCol: 'END_LAT',
+      lonCol: 'END_LON',
+    },
+    viewport: {},
+  },
+  queriesData: [
+    {
+      data: [
+        {
+          START_LAT: 37.8,
+          START_LON: -122.4,
+          END_LAT: 37.9,
+          END_LON: -122.3,
+          category: 'A',
+        },
+        {
+          START_LAT: 38.0,
+          START_LON: -122.2,
+          END_LAT: 38.1,
+          END_LON: -122.1,
+          category: 'B',
+        },
+      ],
+    },
+  ],
+  datasource: {
+    type: DatasourceType.Table,
+    id: 1,
+    name: 'test_datasource',
+    columns: [],
+    metrics: [],
+  },
+  height: 400,
+  width: 600,
+  hooks: {},
+  filterState: {},
+  emitCrossFilters: false,
+};
+
+test('Arc transformProps should set cat_color from dimension column', () => {
+  const props = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      dimension: 'category',
+    },
+  };
+
+  const result = transformProps(props as ChartProps);
+  const features = result.payload.data.features as ArcFeature[];
+
+  expect(features).toHaveLength(2);
+  expect(features[0]?.cat_color).toBe('A');
+  expect(features[1]?.cat_color).toBe('B');
+});
+
+test('Arc transformProps should fall back to NULL_CATEGORY_KEY for empty dimension values', () => {
+  const props = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      dimension: 'category',
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            START_LAT: 37.8,
+            START_LON: -122.4,
+            END_LAT: 37.9,
+            END_LON: -122.3,
+            category: 'A',
+          },
+          {
+            START_LAT: 38.0,
+            START_LON: -122.2,
+            END_LAT: 38.1,
+            END_LON: -122.1,
+            category: null,
+          },
+          {
+            START_LAT: 38.2,
+            START_LON: -122.0,
+            END_LAT: 38.3,
+            END_LON: -121.9,
+            category: undefined,
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = transformProps(props as ChartProps);
+  const features = result.payload.data.features as ArcFeature[];
+
+  expect(features).toHaveLength(3);
+  expect(features[0]?.cat_color).toBe('A');
+  expect(features[1]?.cat_color).toBe(NULL_CATEGORY_KEY);
+  expect(features[2]?.cat_color).toBe(NULL_CATEGORY_KEY);
+});
+
+test('Arc transformProps should not set cat_color when no dimension is configured', () => {
+  const result = transformProps(mockChartProps as ChartProps);
+  const features = result.payload.data.features as ArcFeature[];
+
+  expect(features).toHaveLength(2);
+  expect(features[0]?.cat_color).toBeUndefined();
+  expect(features[1]?.cat_color).toBeUndefined();
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.ts
@@ -28,6 +28,7 @@ import {
   addPropertiesToFeature,
 } from '../transformUtils';
 import { DeckArcFormData } from './buildQuery';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 interface ArcPoint {
   sourcePosition: [number, number];
@@ -76,7 +77,9 @@ function processArcData(
 
       if (dimension) {
         arcPoint.cat_color =
-          record[dimension] != null ? String(record[dimension]) : '';
+          record[dimension] != null
+            ? String(record[dimension])
+            : NULL_CATEGORY_KEY;
       }
 
       // eslint-disable-next-line no-underscore-dangle

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.ts
@@ -74,8 +74,9 @@ function processArcData(
 
       arcPoint = addJsColumnsToExtraProps(arcPoint, record, jsColumns);
 
-      if (dimension && record[dimension] != null) {
-        arcPoint.cat_color = String(record[dimension]);
+      if (dimension) {
+        arcPoint.cat_color =
+          record[dimension] != null ? String(record[dimension]) : '';
       }
 
       // eslint-disable-next-line no-underscore-dangle

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Arc/transformProps.ts
@@ -24,6 +24,7 @@ import {
   addPropertiesToFeature,
 } from '../transformUtils';
 import { DeckArcFormData } from './buildQuery';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 interface ArcPoint {
   sourcePosition: [number, number];
@@ -65,8 +66,11 @@ function processArcData(
         extraProps: {},
       };
 
-      if (dimension && record[dimension] != null) {
-        arcPoint.cat_color = String(record[dimension]);
+      if (dimension) {
+        arcPoint.cat_color =
+          record[dimension] != null
+            ? String(record[dimension])
+            : NULL_CATEGORY_KEY;
       }
 
       // eslint-disable-next-line no-underscore-dangle

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Path/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Path/transformProps.test.ts
@@ -18,6 +18,7 @@
  */
 import { ChartProps, DatasourceType } from '@superset-ui/core';
 import transformProps from './transformProps';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 interface PathFeature {
   path: [number, number][];
@@ -318,6 +319,35 @@ test('Path transformProps should set cat_color from dimension column', () => {
   expect(features[0]?.cat_color).toBe('express');
   expect(features[1]?.cat_color).toBe('local');
   expect(features[2]?.cat_color).toBe('express');
+});
+
+test('Path transformProps should fall back to NULL_CATEGORY_KEY for empty dimension values', () => {
+  const props = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      dimension: 'route_type',
+    },
+    queriesData: [
+      {
+        data: [
+          { path_json: samplePath1, route_type: 'express' },
+          { path_json: samplePath2, route_type: null },
+          { path_json: samplePath3, route_type: undefined },
+        ],
+      },
+    ],
+  };
+
+  const result = transformProps(props as ChartProps);
+  const features = result.payload.data.features as PathFeature[];
+
+  // Path emits features in reverse record order.
+  expect(features.map(f => f.cat_color)).toEqual([
+    NULL_CATEGORY_KEY,
+    NULL_CATEGORY_KEY,
+    'express',
+  ]);
 });
 
 test('Path transformProps should include metric labels when breakpoint_metric is set', () => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Path/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Path/transformProps.ts
@@ -27,6 +27,7 @@ import {
 } from '../transformUtils';
 import { DeckPathFormData } from './buildQuery';
 import { isFixedValue, getFixedValue } from '../utils/metricUtils';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 declare global {
   interface Window {
@@ -145,8 +146,11 @@ function processPathData(
       }
     }
 
-    if (categoryColumn && record[categoryColumn] != null) {
-      feature.cat_color = String(record[categoryColumn]);
+    if (categoryColumn) {
+      feature.cat_color =
+        record[categoryColumn] != null
+          ? String(record[categoryColumn])
+          : NULL_CATEGORY_KEY;
     }
 
     feature = addPropertiesToFeature(feature, record, excludeKeys);

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
@@ -25,7 +25,7 @@ import { createCategoricalDeckGLComponent, GetLayerType } from '../../factory';
 import { createTooltipContent } from '../../utilities/tooltipUtils';
 import TooltipRow from '../../TooltipRow';
 import { unitToRadius } from '../../utils/geo';
-import { HIGHLIGHT_COLOR_ARRAY } from '../../utils';
+import { HIGHLIGHT_COLOR_ARRAY, formatNullCategory } from '../../utils';
 import { isMetricValue, extractMetricKey } from '../utils/metricUtils';
 
 function getMetricLabel(metric: any) {
@@ -67,7 +67,7 @@ function setTooltipContent(
         {o.object?.cat_color && (
           <TooltipRow
             label={`${t('Category')}: `}
-            value={`${o.object?.cat_color}`}
+            value={formatNullCategory(`${o.object?.cat_color}`)}
           />
         )}
         {o.object?.metric && label && (

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
@@ -19,6 +19,7 @@
 
 import { ChartProps, DatasourceType } from '@superset-ui/core';
 import transformProps from './transformProps';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 interface ScatterFeature {
   position: [number, number];
@@ -194,7 +195,7 @@ test('Scatter transformProps should handle dimension for category colors', () =>
   expect(features[1]?.cat_color).toBe('B');
 });
 
-test('Scatter transformProps should assign empty string cat_color for null/undefined dimension values', () => {
+test('Scatter transformProps should assign NULL_CATEGORY_KEY cat_color for null/undefined dimension values', () => {
   const propsWithNullCategory = {
     ...mockChartProps,
     rawFormData: {
@@ -233,8 +234,8 @@ test('Scatter transformProps should assign empty string cat_color for null/undef
 
   expect(features).toHaveLength(3);
   expect(features[0]?.cat_color).toBe('A');
-  expect(features[1]?.cat_color).toBe('');
-  expect(features[2]?.cat_color).toBe('');
+  expect(features[1]?.cat_color).toBe(NULL_CATEGORY_KEY);
+  expect(features[2]?.cat_color).toBe(NULL_CATEGORY_KEY);
 });
 
 test('Scatter transformProps should not include metric labels for fixed radius', () => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
@@ -194,6 +194,49 @@ test('Scatter transformProps should handle dimension for category colors', () =>
   expect(features[1]?.cat_color).toBe('B');
 });
 
+test('Scatter transformProps should assign empty string cat_color for null/undefined dimension values', () => {
+  const propsWithNullCategory = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      dimension: 'category',
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            LATITUDE: 37.8,
+            LONGITUDE: -122.4,
+            category: 'A',
+          },
+          {
+            LATITUDE: 37.9,
+            LONGITUDE: -122.3,
+            category: null,
+          },
+          {
+            LATITUDE: 38.0,
+            LONGITUDE: -122.2,
+            category: undefined,
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = transformProps(propsWithNullCategory as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(3);
+  expect(features[0]?.cat_color).toBe('A');
+  expect(features[1]?.cat_color).toBe('');
+  expect(features[2]?.cat_color).toBe('');
+});
+
 test('Scatter transformProps should not include metric labels for fixed radius', () => {
   const fixedProps = {
     ...mockChartProps,

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
@@ -19,6 +19,7 @@
 
 import { ChartProps, DatasourceType } from '@superset-ui/core';
 import transformProps from './transformProps';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 interface ScatterFeature {
   position: [number, number];
@@ -192,6 +193,49 @@ test('Scatter transformProps should handle dimension for category colors', () =>
   expect(features).toHaveLength(2);
   expect(features[0]?.cat_color).toBe('A');
   expect(features[1]?.cat_color).toBe('B');
+});
+
+test('Scatter transformProps should fall back to NULL_CATEGORY_KEY for empty dimension values', () => {
+  const propsWithNullCategory = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      dimension: 'category',
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            LATITUDE: 37.8,
+            LONGITUDE: -122.4,
+            category: 'A',
+          },
+          {
+            LATITUDE: 37.9,
+            LONGITUDE: -122.3,
+            category: null,
+          },
+          {
+            LATITUDE: 38.0,
+            LONGITUDE: -122.2,
+            category: undefined,
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = transformProps(propsWithNullCategory as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(3);
+  expect(features[0]?.cat_color).toBe('A');
+  expect(features[1]?.cat_color).toBe(NULL_CATEGORY_KEY);
+  expect(features[2]?.cat_color).toBe(NULL_CATEGORY_KEY);
 });
 
 test('Scatter transformProps should not include metric labels for fixed radius', () => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.ts
@@ -27,6 +27,7 @@ import {
 } from '../transformUtils';
 import { DeckScatterFormData } from './buildQuery';
 import { isFixedValue, getFixedValue } from '../utils/metricUtils';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 interface ScatterPoint {
   position: [number, number];
@@ -92,7 +93,9 @@ function processScatterData(
 
     if (categoryColumn) {
       scatterPoint.cat_color =
-        feature[categoryColumn] != null ? String(feature[categoryColumn]) : '';
+        feature[categoryColumn] != null
+          ? String(feature[categoryColumn])
+          : NULL_CATEGORY_KEY;
     }
 
     scatterPoint = addPropertiesToFeature(

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.ts
@@ -90,8 +90,9 @@ function processScatterData(
       }
     }
 
-    if (categoryColumn && feature[categoryColumn] != null) {
-      scatterPoint.cat_color = String(feature[categoryColumn]);
+    if (categoryColumn) {
+      scatterPoint.cat_color =
+        feature[categoryColumn] != null ? String(feature[categoryColumn]) : '';
     }
 
     scatterPoint = addPropertiesToFeature(

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Scatter/transformProps.ts
@@ -27,6 +27,7 @@ import {
 } from '../transformUtils';
 import { DeckScatterFormData } from './buildQuery';
 import { isFixedValue, getFixedValue } from '../utils/metricUtils';
+import { NULL_CATEGORY_KEY } from '../../utils';
 
 interface ScatterPoint {
   position: [number, number];
@@ -88,8 +89,11 @@ function processScatterData(
       }
     }
 
-    if (categoryColumn && feature[categoryColumn] != null) {
-      scatterPoint.cat_color = String(feature[categoryColumn]);
+    if (categoryColumn) {
+      scatterPoint.cat_color =
+        feature[categoryColumn] != null
+          ? String(feature[categoryColumn])
+          : NULL_CATEGORY_KEY;
     }
 
     scatterPoint = addPropertiesToFeature(

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utilities/tooltipUtils.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utilities/tooltipUtils.test.tsx
@@ -18,8 +18,21 @@
  */
 
 import { JsonObject, QueryFormData } from '@superset-ui/core';
+import { Constants } from '@superset-ui/core/components';
 import { render } from '@testing-library/react';
-import { createTooltipContent } from './tooltipUtils';
+import { createTooltipContent, CommonTooltipRows } from './tooltipUtils';
+import { NULL_CATEGORY_KEY } from '../utils';
+
+test('category row shows the null category as N/A, matching the legend', () => {
+  const { container } = render(
+    <>
+      {CommonTooltipRows.category({ object: { cat_color: NULL_CATEGORY_KEY } })}
+    </>,
+  );
+
+  expect(container.textContent).toContain(Constants.NULL_DISPLAY);
+  expect(container.textContent).not.toContain(NULL_CATEGORY_KEY);
+});
 
 test('buildFieldBasedTooltipItems does not append configured metric when tooltip_contents already has string metric', () => {
   const formData = {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utilities/tooltipUtils.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utilities/tooltipUtils.tsx
@@ -23,6 +23,7 @@ import { useMemo, memo } from 'react';
 import { HandlebarsRenderer } from './HandlebarsRenderer';
 import TooltipRow from '../TooltipRow';
 import { createDefaultTemplateWithLimits } from './multiValueUtils';
+import { formatNullCategory } from '../utils';
 
 const MemoizedHandlebarsRenderer = memo(HandlebarsRenderer);
 
@@ -58,7 +59,7 @@ export const CommonTooltipRows = {
     o.object?.cat_color ? (
       <TooltipRow
         label={`${t('Category')}: `}
-        value={`${o.object.cat_color}`}
+        value={formatNullCategory(`${o.object.cat_color}`)}
       />
     ) : null,
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils.ts
@@ -31,6 +31,7 @@ import { ColorBreakpointType } from './types';
 
 export const TRANSPARENT_COLOR_ARRAY = [0, 0, 0, 0] as Color;
 export const HIGHLIGHT_COLOR_ARRAY = [255, 0, 0, 255] as Color;
+export const NULL_CATEGORY_KEY = '__NULL__';
 
 const DEFAULT_NUM_BUCKETS = 10;
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils.ts
@@ -25,12 +25,20 @@ import {
   QueryFormData,
   SequentialScheme,
 } from '@superset-ui/core';
+import { Constants } from '@superset-ui/core/components';
 import { Color } from '@deck.gl/core';
 import { hexToRGB } from './utils/colors';
 import { ColorBreakpointType } from './types';
 
 export const TRANSPARENT_COLOR_ARRAY = [0, 0, 0, 0] as Color;
 export const HIGHLIGHT_COLOR_ARRAY = [255, 0, 0, 255] as Color;
+// Stands in for a null dimension value so those rows still get a category, a
+// color and a legend entry. Kept distinct from NULL_DISPLAY so the key stays
+// stable across locales.
+export const NULL_CATEGORY_KEY = '<NULL>';
+
+export const formatNullCategory = (value: string) =>
+  value === NULL_CATEGORY_KEY ? Constants.NULL_DISPLAY : value;
 
 const DEFAULT_NUM_BUCKETS = 10;
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Include empty results for categorical color column in Scatterplot and Arc charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="1732" height="1038" alt="image" src="https://github.com/user-attachments/assets/c60c7d82-9014-4a6f-96cc-33a1c63c2d6f" />

After
<img width="2316" height="1361" alt="Screenshot 2026-04-17 at 09 14 00" src="https://github.com/user-attachments/assets/b5319d96-78e1-4a99-a606-37773f8098b8" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
