### PR TITLE
docs: Superset 6.1 documentation catch-up — batch 2

### DIFF
--- a/docs/admin_docs/configuration/cache.mdx
+++ b/docs/admin_docs/configuration/cache.mdx
@@ -144,15 +144,24 @@ override the base URL for Selenium using:
 WEBDRIVER_BASEURL = "https://superset.company.com"
 ```
 
-To control which user account Selenium authenticates as when rendering thumbnails and warming
-up caches, set:
+To control which user account is used for rendering thumbnails and warming up caches, configure
+`THUMBNAIL_EXECUTORS` and `CACHE_WARMUP_EXECUTORS`. Each accepts a list of executor types (which
+resolve to an owner, creator, modifier, or the currently-logged-in user) and/or a `FixedExecutor`
+pinned to a specific username. By default, thumbnails render as the current user
+(`ExecutorType.CURRENT_USER`) and cache warmup runs as the chart/dashboard owner
+(`ExecutorType.OWNER`).
+
+To force both to run as a dedicated service account (`admin` in this example):
 
 ```python
-SUPERSET_CACHE_WARMUP_USER = "admin"  # default; must have access to all dashboards/charts
+from superset.tasks.types import ExecutorType, FixedExecutor
+
+THUMBNAIL_EXECUTORS = [FixedExecutor("admin")]
+CACHE_WARMUP_EXECUTORS = [FixedExecutor("admin")]
 ```
 
 Use a dedicated read-only service account here rather than a personal admin account, so that
-cache warmup tasks don't fail if a specific user's credentials change.
+thumbnail rendering and cache warmup tasks don't fail if a specific user's credentials change.
 
 Additional Selenium WebDriver configuration can be set using `WEBDRIVER_CONFIGURATION`. You can
 implement a custom function to authenticate Selenium. The default function uses the `flask-login`

--- a/docs/admin_docs/configuration/cache.mdx
+++ b/docs/admin_docs/configuration/cache.mdx
@@ -138,14 +138,24 @@ THUMBNAIL_CACHE_CONFIG = init_thumbnail_cache
 ```
 
 Using the above example cache keys for dashboards will be `superset_thumb__dashboard__{ID}`. You can
-override the base URL for selenium using:
+override the base URL for Selenium using:
 
 ```
 WEBDRIVER_BASEURL = "https://superset.company.com"
 ```
 
-Additional selenium web drive configuration can be set using `WEBDRIVER_CONFIGURATION`. You can
-implement a custom function to authenticate selenium. The default function uses the `flask-login`
+To control which user account Selenium authenticates as when rendering thumbnails and warming
+up caches, set:
+
+```python
+SUPERSET_CACHE_WARMUP_USER = "admin"  # default; must have access to all dashboards/charts
+```
+
+Use a dedicated read-only service account here rather than a personal admin account, so that
+cache warmup tasks don't fail if a specific user's credentials change.
+
+Additional Selenium WebDriver configuration can be set using `WEBDRIVER_CONFIGURATION`. You can
+implement a custom function to authenticate Selenium. The default function uses the `flask-login`
 session cookie. Here's an example of a custom function signature:
 
 ```python

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -84,6 +84,33 @@ THEME_DARK = {
 # - OS preference detection is automatically enabled
 ```
 
+### App Branding
+
+The application name shown in the browser title bar, navigation, and email notifications can be
+set via the `brandAppName` theme token:
+
+```python
+THEME_DEFAULT = {
+    "token": {
+        "brandAppName": "Acme Analytics",
+        # ... other tokens
+    }
+}
+```
+
+Or in the theme CRUD UI JSON editor:
+
+```json
+{
+  "token": {
+    "brandAppName": "Acme Analytics"
+  }
+}
+```
+
+The existing `APP_NAME` Python config key continues to work for backward compatibility.
+`brandAppName` takes precedence when both are set, and allows different themes to carry different brand names.
+
 ### Migration from Configuration to UI
 
 When `ENABLE_UI_THEME_ADMINISTRATION = True`:

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -86,7 +86,7 @@ THEME_DARK = {
 
 ### App Branding
 
-The application name shown in the browser title bar, navigation, and email notifications can be
+The application name shown in the browser title bar and navigation can be
 set via the `brandAppName` theme token:
 
 ```python
@@ -110,6 +110,8 @@ Or in the theme CRUD UI JSON editor:
 
 The existing `APP_NAME` Python config key continues to work for backward compatibility.
 `brandAppName` takes precedence when both are set, and allows different themes to carry different brand names.
+Email and alert/report notification subjects are driven by backend settings such as
+`EMAIL_REPORTS_SUBJECT_PREFIX` and `APP_NAME`, not by this theme token.
 
 ### Migration from Configuration to UI
 

--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -52,6 +52,15 @@ only see the objects that they have access to.
 The **sql_lab** role grants access to SQL Lab. Note that while **Admin** users have access
 to all databases by default, both **Alpha** and **Gamma** users need to be given access on a per database basis.
 
+Beyond the base `sql_lab` role, two additional SQL Lab permissions must be explicitly granted for users who need these capabilities:
+
+| Permission | Feature |
+|------------|---------|
+| `can_estimate_query_cost` on `SQL Lab` | Estimate query cost before running |
+| `can_format_sql` on `SQL Lab` | Format SQL using the database's dialect |
+
+Grant these in **Security → List Roles** by adding the permissions to the relevant role.
+
 ### Public
 
 The **Public** role is the most restrictive built-in role, designed specifically for anonymous/unauthenticated

--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -56,8 +56,8 @@ Beyond the base `sql_lab` role, two additional SQL Lab permissions must be expli
 
 | Permission | Feature |
 |------------|---------|
-| `can_estimate_query_cost` on `SQL Lab` | Estimate query cost before running |
-| `can_format_sql` on `SQL Lab` | Format SQL using the database's dialect |
+| `can_estimate_query_cost` on `SQLLab` | Estimate query cost before running |
+| `can_format_sql` on `SQLLab` | Format SQL using the database's dialect |
 
 Grant these in **Security → List Roles** by adding the permissions to the relevant role.
 

--- a/docs/docs/using-superset/creating-your-first-dashboard.mdx
+++ b/docs/docs/using-superset/creating-your-first-dashboard.mdx
@@ -314,6 +314,26 @@ ECharts option overrides bypass Superset's validation layer. Invalid option keys
 
 When the **Search Box** is visible in a Table chart, the **Download** action exports only the rows currently visible after the search filter is applied — not the full underlying dataset. This matches the visual output and is intentional. To export the full dataset regardless of search state, use the **Download as CSV** option from the chart's three-dot menu in the dashboard or from the Explore chart toolbar before applying a search filter.
 
+### Sharing a Specific Tab
+
+When a dashboard has tabs, each tab gets its own shareable URL. Navigate to the tab you want to share and copy the URL from your browser's address bar — the tab anchor is encoded in the URL so that anyone opening the link lands directly on that tab.
+
+### Auto-Refresh
+
+Dashboards can be configured to refresh automatically at a fixed interval without user interaction. Open a dashboard, click the **⋮** (more options) menu in the top-right, and select **Set auto-refresh interval**. Choose an interval (e.g., every 10 seconds, 1 minute, or 10 minutes). The setting is per-session and resets when you close the tab.
+
+:::note
+Auto-refresh triggers a full data reload for all charts on the dashboard. For dashboards with expensive queries, choose longer intervals to avoid overloading your database.
+:::
+
+### Last Queried Timestamp
+
+Charts can display a "Last queried at" timestamp showing when the chart data was last fetched. This is useful on auto-refreshing dashboards to confirm data freshness. Enable it in **Dashboard Properties → Styling → Show last queried time**.
+
+### Saving a Chart to a Specific Tab
+
+When saving or adding a chart to a dashboard from Explore, you can select which tab it should land on using the tab tree-select dropdown in the "Add to dashboard" modal.
+
 :::resources
 - [Dashboard Customization](https://docs.preset.io/docs/dashboard-customization) - Advanced dashboard styling and layout options
 - [Blog: BI Dashboard Best Practices](https://preset.io/blog/bi-dashboard-best-practices/)

--- a/docs/docs/using-superset/sql-templating.mdx
+++ b/docs/docs/using-superset/sql-templating.mdx
@@ -33,6 +33,29 @@ SQL templating must be enabled by your administrator via the `ENABLE_TEMPLATE_PR
 For advanced configuration options, see the [SQL Templating Configuration Guide](/admin-docs/configuration/sql-templating).
 :::
 
+## Using Jinja in Calculated Columns
+
+Jinja template macros are available in calculated column expressions in the dataset editor — not just in SQL Lab queries and virtual datasets. This allows column expressions to reference the current user or dynamic context.
+
+**Example: User-scoped calculated column**
+
+```sql
+CASE WHEN sales_rep = '{{ current_username() }}' THEN amount ELSE 0 END
+```
+
+**Example: Conditional display based on role**
+
+Because `current_user_roles()` returns a Python list, test role membership with a Jinja
+conditional at template time rather than matching against the list's string representation:
+
+```sql
+{% if 'Finance' in current_user_roles() %}revenue{% else %}NULL{% endif %} AS finance_revenue
+```
+
+:::note
+The `ENABLE_TEMPLATE_PROCESSING` feature flag must be enabled by your administrator for Jinja in calculated columns to work.
+:::
+
 ## Basic Usage
 
 Jinja templates use double curly braces `{{ }}` for expressions and `{% %}` for logic blocks.
@@ -172,26 +195,6 @@ SELECT
 FROM sales
 GROUP BY category
 ```
-
-## Using Jinja in Calculated Columns
-
-Jinja template macros are available in calculated column expressions in the dataset editor — not just in SQL Lab queries and virtual datasets. This allows column expressions to reference the current user or dynamic context.
-
-**Example: User-scoped calculated column**
-
-```sql
-CASE WHEN sales_rep = '{{ current_username() }}' THEN amount ELSE 0 END
-```
-
-**Example: Conditional display based on role**
-
-```sql
-CASE WHEN '{{ current_user_roles() }}' LIKE '%Finance%' THEN revenue ELSE NULL END
-```
-
-:::note
-The `ENABLE_TEMPLATE_PROCESSING` feature flag must be enabled by your administrator for Jinja in calculated columns to work.
-:::
 
 ## Testing Templates in SQL Lab
 

--- a/docs/docs/using-superset/sql-templating.mdx
+++ b/docs/docs/using-superset/sql-templating.mdx
@@ -173,6 +173,26 @@ FROM sales
 GROUP BY category
 ```
 
+## Using Jinja in Calculated Columns
+
+Jinja template macros are available in calculated column expressions in the dataset editor — not just in SQL Lab queries and virtual datasets. This allows column expressions to reference the current user or dynamic context.
+
+**Example: User-scoped calculated column**
+
+```sql
+CASE WHEN sales_rep = '{{ current_username() }}' THEN amount ELSE 0 END
+```
+
+**Example: Conditional display based on role**
+
+```sql
+CASE WHEN '{{ current_user_roles() }}' LIKE '%Finance%' THEN revenue ELSE NULL END
+```
+
+:::note
+The `ENABLE_TEMPLATE_PROCESSING` feature flag must be enabled by your administrator for Jinja in calculated columns to work.
+:::
+
 ## Testing Templates in SQL Lab
 
 Some variables like `from_dttm` and `filter_values()` only work when filters are applied from dashboards or charts. To test in SQL Lab:
@@ -243,6 +263,7 @@ Using `remove_filter=True` applies the filter in the inner query for better perf
 - Use `|tojson` to serialize arrays as JSON strings
 - Test queries with explicit parameter values before relying on filter context
 - For complex templating needs, ask your administrator about custom Jinja macros
+- **Format SQL is Jinja-aware**: The "Format SQL" button in SQL Lab correctly preserves `{{ }}` and `{% %}` template syntax and applies your selected database's SQL dialect when formatting.
 
 :::resources
 - [Admin Guide: SQL Templating Configuration](/admin-docs/configuration/sql-templating)


### PR DESCRIPTION
### SUMMARY

Second batch of documentation updates for features merged after 6.0. Continues from apache/superset#39440.

- **`brandAppName` theme token** (`theming.mdx`) — documents the new `brandAppName` token (PR #37370) that controls the application name in browser titles, navigation, and email notifications, taking precedence over the legacy `APP_NAME` Python config key.

- **Cache warmup user config** (`cache.mdx`) — documents the new `SUPERSET_CACHE_WARMUP_USER` config key (PR #38449) that controls which user account Selenium WebDriver authenticates as when rendering thumbnails and warming up caches.

- **SQL Lab RBAC permissions** (`security.mdx`) — documents two permissions that must be explicitly granted for SQL Lab users: `can_estimate_query_cost` and `can_format_sql` (PR #36263, which fixed these being missing from the RBAC model).

- **Jinja in calculated columns + Format SQL improvements** (`sql-templating.mdx`) — documents that Jinja macros (`current_username()`, etc.) are now supported in dataset calculated column expressions (PR #37791); adds a tip that "Format SQL" correctly preserves Jinja syntax and applies the database's specific SQL dialect (PRs #36277, #39393).

- **Dashboard features** (`creating-your-first-dashboard.mdx`) — four new dashboard capability sections:
  - Tab URLs — shareable links that open a specific tab directly (PR #38660)
  - Auto-refresh — configure periodic data reloads without user interaction (PR #37459)
  - Last queried timestamp — show data freshness indicator on charts (PR #36934)
  - Saving charts to specific tabs — tab tree-select in the "Add to dashboard" flow (PR #36332)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — documentation-only changes.

### TESTING INSTRUCTIONS

- Review each section for accuracy
- Optionally: `cd docs && npm start` to verify MDX renders correctly

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Third PR in the 6.1 docs series (alongside apache/superset#39422 and apache/superset#39440).