### PR TITLE
fix(docs): read capability flags from engine specs in database docs generator

### DIFF
--- a/docs/scripts/generate-database-docs.mjs
+++ b/docs/scripts/generate-database-docs.mjs
@@ -197,6 +197,21 @@ CAP_ATTR_DEFAULTS = {
     'allows_subqueries': True,
 }
 
+# Maps source capability attribute -> output field name used in databases.json.
+# When a cap attr is assigned an unevaluable expression (e.g.
+# allows_joins = is_feature_enabled("DRUID_JOINS")), the JS layer uses this
+# mapping to preserve the corresponding field from the previously-generated
+# JSON rather than silently inheriting an incorrect parent default.
+CAP_ATTR_TO_OUTPUT_FIELD = {
+    'allows_joins': 'joins',
+    'allows_subqueries': 'subqueries',
+    'supports_dynamic_schema': 'supports_dynamic_schema',
+    'supports_catalog': 'supports_catalog',
+    'supports_dynamic_catalog': 'supports_dynamic_catalog',
+    'disable_ssh_tunneling': 'ssh_tunneling',
+    'supports_file_upload': 'supports_file_upload',
+}
+
 # Methods that indicate a capability when overridden by a non-BaseEngineSpec class.
 # Mirrors the has_custom_method checks in superset/db_engine_specs/lib.py.
 # cancel_query / get_cancel_query_id / has_implicit_cancel -> query_cancelation
@@ -249,6 +264,11 @@ for filename in sorted(os.listdir(specs_dir)):
             engine_attr = None
             metadata = None
             cap_attrs = {}   # capability flag attributes defined directly in this class
+            # Cap attrs assigned via expressions we can't statically resolve
+            # (e.g. is_feature_enabled("FLAG")). Tracked so the JS layer can
+            # fall back to the previously-generated databases.json value
+            # rather than inherit a parent default that would be wrong.
+            unresolved_cap_attrs = set()
             direct_methods = set()  # capability methods defined directly in this class
 
             for item in node.body:
@@ -268,9 +288,11 @@ for filename in sorted(os.listdir(specs_dir)):
                             metadata = eval_node(item.value)
                         elif target.id in CAP_ATTR_DEFAULTS:
                             val = eval_node(item.value)
-                            # Only store if we got a concrete bool value (not None/unevaluable)
                             if isinstance(val, bool):
                                 cap_attrs[target.id] = val
+                            else:
+                                # Unevaluable expression — defer to JS fallback.
+                                unresolved_cap_attrs.add(target.id)
                 elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     if item.name in CAP_METHODS:
                         direct_methods.add(item.name)
@@ -294,6 +316,7 @@ for filename in sorted(os.listdir(specs_dir)):
                 'filename': filename,
                 'is_base_or_mixin': is_true_base,
                 'cap_attrs': cap_attrs,
+                'unresolved_cap_attrs': unresolved_cap_attrs,
                 'direct_methods': direct_methods,
             }
     except Exception as e:
@@ -330,42 +353,59 @@ def get_resolved_caps(class_name, visited=None):
     """
     Resolve capability flags and method overrides with inheritance.
 
-    Cap attrs: child values override parent values (same as Python MRO).
-    Methods: track which non-BaseEngineSpec classes define them directly,
-    matching the has_custom_method() logic in superset/db_engine_specs/lib.py.
+    Returns (attr_values, unresolved, methods):
+      - attr_values: {attr: bool} for attrs where the nearest MRO assignment
+        was a literal bool. Defaults are applied at the call site.
+      - unresolved: attrs where the nearest MRO assignment was an unevaluable
+        expression (e.g. is_feature_enabled("FLAG")). The JS layer falls
+        back to the previously-generated JSON value for these.
+      - methods: capability methods defined directly in some non-base ancestor,
+        matching the has_custom_method() logic in db_engine_specs/lib.py.
+
+    attr_values and unresolved are disjoint — an attr is in at most one.
     """
     if visited is None:
         visited = set()
     if class_name in visited:
-        return dict(CAP_ATTR_DEFAULTS), set()
+        return {}, set(), set()
     visited.add(class_name)
 
     info = class_info.get(class_name)
     if not info:
-        return dict(CAP_ATTR_DEFAULTS), set()
+        return {}, set(), set()
 
-    # Start from base defaults
-    resolved_attrs = dict(CAP_ATTR_DEFAULTS)
+    attr_values = {}
+    unresolved = set()
     resolved_methods = set()
 
     # Collect from parents, iterating right-to-left so leftmost bases win
     # (matches Python MRO: for class C(A, B), A's attributes take precedence).
-    # update() keeps the LAST value written, so reversing makes the leftmost
-    # base the final writer.
     for base_name in reversed(info['bases']):
-        parent_attrs, parent_methods = get_resolved_caps(base_name, visited.copy())
-        resolved_attrs.update(parent_attrs)
-        resolved_methods.update(parent_methods)
+        p_vals, p_unres, p_meth = get_resolved_caps(base_name, visited.copy())
+        # A parent's literal assignments overwrite whatever we inherited so far.
+        for attr, val in p_vals.items():
+            attr_values[attr] = val
+            unresolved.discard(attr)
+        # A parent's unresolved assignments likewise take precedence.
+        for attr in p_unres:
+            unresolved.add(attr)
+            attr_values.pop(attr, None)
+        resolved_methods.update(p_meth)
 
-    # Apply this class's own cap_attrs (override parent values)
-    resolved_attrs.update(info['cap_attrs'])
+    # Apply this class's own assignments (override parents).
+    for attr, val in info['cap_attrs'].items():
+        attr_values[attr] = val
+        unresolved.discard(attr)
+    for attr in info['unresolved_cap_attrs']:
+        unresolved.add(attr)
+        attr_values.pop(attr, None)
 
     # Accumulate method overrides, but skip the literal BaseEngineSpec
-    # (its implementations are stubs; only non-base overrides count)
+    # (its implementations are stubs; only non-base overrides count).
     if class_name != TRUE_BASE_CLASS:
         resolved_methods.update(info['direct_methods'])
 
-    return resolved_attrs, resolved_methods
+    return attr_values, unresolved, resolved_methods
 
 for class_name, info in class_info.items():
     # Skip base classes and mixins
@@ -393,10 +433,12 @@ for class_name, info in class_info.items():
         debug_info["classes_with_metadata"] += 1
 
         # Resolve capability flags from Python source
-        cap_attrs, cap_methods = get_resolved_caps(class_name)
+        attr_values, unresolved_caps, cap_methods = get_resolved_caps(class_name)
+        cap_attrs = dict(CAP_ATTR_DEFAULTS)
+        cap_attrs.update(attr_values)
         engine_attr = info.get('engine') or ''
 
-        databases[display_name] = {
+        entry = {
             'engine': display_name.lower().replace(' ', '_'),
             'engine_name': display_name,
             'module': info['filename'][:-3],  # Remove .py extension
@@ -421,6 +463,19 @@ for class_name, info in class_info.items():
                 {'impersonate_user', 'update_impersonation_config', 'get_url_for_impersonation'} & cap_methods
             ),
         }
+
+        # Tell the JS layer which output fields were populated from the
+        # BaseEngineSpec default because the source assignment was an
+        # unevaluable expression; those get overridden from existing JSON.
+        unresolved_fields = sorted(
+            CAP_ATTR_TO_OUTPUT_FIELD[attr]
+            for attr in unresolved_caps
+            if attr in CAP_ATTR_TO_OUTPUT_FIELD
+        )
+        if unresolved_fields:
+            entry['_unresolved_cap_fields'] = unresolved_fields
+
+        databases[display_name] = entry
 
 if errors and not databases:
     print(json.dumps({"error": "Parse errors", "details": errors, "debug": debug_info}), file=sys.stderr)
@@ -943,11 +998,40 @@ function loadExistingData() {
 }
 
 /**
+ * Fall back to the previously-generated databases.json for capability flags
+ * whose source assignment couldn't be statically resolved (e.g.
+ * `allows_joins = is_feature_enabled("DRUID_JOINS")`). The Python extractor
+ * flags these via the internal `_unresolved_cap_fields` marker; without this
+ * fallback those fields would silently inherit the BaseEngineSpec default
+ * and disagree with runtime behavior. The marker is stripped before output.
+ */
+function fallbackUnresolvedCaps(newDatabases, existingData) {
+  for (const [name, db] of Object.entries(newDatabases)) {
+    const unresolved = db._unresolved_cap_fields;
+    if (!unresolved || unresolved.length === 0) {
+      delete db._unresolved_cap_fields;
+      continue;
+    }
+    const existingDb = existingData?.databases?.[name];
+    if (existingDb) {
+      for (const field of unresolved) {
+        if (existingDb[field] !== undefined) {
+          db[field] = existingDb[field];
+        }
+      }
+    }
+    delete db._unresolved_cap_fields;
+  }
+  return newDatabases;
+}
+
+/**
  * Merge new documentation with existing diagnostics
  * Preserves score, max_score, and time_grains from existing data (these require
  * Flask context to generate and cannot be derived from static source analysis).
  * Capability flags (joins, supports_catalog, etc.) are NOT preserved here — they
- * are now read fresh from the Python engine spec source by extractEngineSpecMetadata().
+ * are read fresh from the Python engine spec source by extractEngineSpecMetadata(),
+ * with a separate fallback for expression-based assignments (see fallbackUnresolvedCaps).
  */
 function mergeWithExistingDiagnostics(newDatabases, existingData) {
   if (!existingData?.databases) return newDatabases;
@@ -1016,6 +1100,12 @@ async function main() {
   if (!hasNewScores && existingData) {
     databases = mergeWithExistingDiagnostics(databases, existingData);
   }
+
+  // For cap flags assigned via unevaluable expressions (e.g.
+  // `is_feature_enabled(...)`), prefer the value from a previously-generated
+  // JSON. Runs regardless of scores since it addresses static-analysis gaps,
+  // not missing Flask diagnostics. Always strips the internal marker.
+  databases = fallbackUnresolvedCaps(databases, existingData);
 
   // Extract and merge custom_errors for troubleshooting documentation
   const customErrors = extractCustomErrors();

--- a/docs/scripts/generate-database-docs.mjs
+++ b/docs/scripts/generate-database-docs.mjs
@@ -156,11 +156,16 @@ def static_return_bool(func_node):
     """
     returns = []
     other_logic = False
+    docstring_skipped = False
     for stmt in func_node.body:
-        # Skip docstring (first expression statement that's a string constant)
-        if (isinstance(stmt, ast.Expr)
+        # Skip docstring (only the FIRST expression statement that is a
+        # string constant — later bare string literals are not docstrings
+        # and should count as non-trivial logic).
+        if (not docstring_skipped
+                and isinstance(stmt, ast.Expr)
                 and isinstance(stmt.value, ast.Constant)
                 and isinstance(stmt.value.value, str)):
+            docstring_skipped = True
             continue
         if isinstance(stmt, ast.Pass):
             continue

--- a/docs/scripts/generate-database-docs.mjs
+++ b/docs/scripts/generate-database-docs.mjs
@@ -141,6 +141,42 @@ def eval_node(node):
         return "<f-string>"
     return None
 
+def static_return_bool(func_node):
+    """
+    Statically resolve a method's return value to a bool when possible.
+
+    Returns True/False for functions whose body is (effectively) a single
+    \`return True\` / \`return False\` — allowing a leading docstring and
+    ignoring pure-comment/pass statements. Returns None for anything more
+    complex (conditional returns, computed values, no return, etc.).
+
+    Used by \`has_implicit_cancel\` handling: \`diagnose()\` in lib.py calls
+    the method and checks the return value, so an override that explicitly
+    returns False must NOT be treated as enabling query cancelation.
+    """
+    returns = []
+    other_logic = False
+    for stmt in func_node.body:
+        # Skip docstring (first expression statement that's a string constant)
+        if (isinstance(stmt, ast.Expr)
+                and isinstance(stmt.value, ast.Constant)
+                and isinstance(stmt.value.value, str)):
+            continue
+        if isinstance(stmt, ast.Pass):
+            continue
+        if isinstance(stmt, ast.Return):
+            returns.append(stmt)
+            continue
+        # Any other statement (if/for/assign/etc.) means control flow is
+        # non-trivial; bail out to be conservative.
+        other_logic = True
+        break
+    if other_logic or len(returns) != 1:
+        return None
+    val = eval_node(returns[0].value)
+    return val if isinstance(val, bool) else None
+
+
 def deep_merge(base, override):
     """Deep merge two dictionaries. Override values take precedence."""
     if base is None:
@@ -299,6 +335,15 @@ for filename in sorted(os.listdir(specs_dir)):
                                 unresolved_cap_attrs.add(target.id)
                 elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     if item.name in CAP_METHODS:
+                        # has_implicit_cancel is special: diagnose() uses the
+                        # method's RETURN VALUE, not just its presence. If the
+                        # override statically returns False, treat it as if
+                        # the method weren't overridden so query_cancelation
+                        # matches diagnose(). Unresolvable / True / anything
+                        # else falls through as an override (conservative).
+                        if item.name == 'has_implicit_cancel':
+                            if static_return_bool(item) is False:
+                                continue
                         direct_methods.add(item.name)
 
             # Check for engine attribute with non-empty value to distinguish

--- a/docs/scripts/generate-database-docs.mjs
+++ b/docs/scripts/generate-database-docs.mjs
@@ -186,8 +186,36 @@ if not os.path.isdir(specs_dir):
     print(json.dumps({"error": f"Directory not found: {specs_dir}", "cwd": os.getcwd()}))
     sys.exit(1)
 
-# First pass: collect all class info (name, bases, metadata)
-class_info = {}  # class_name -> {bases: [], metadata: {}, engine_name: str, filename: str}
+# Capability flag attributes with their defaults from BaseEngineSpec
+CAP_ATTR_DEFAULTS = {
+    'supports_dynamic_schema': False,
+    'supports_catalog': False,
+    'supports_dynamic_catalog': False,
+    'disable_ssh_tunneling': False,
+    'supports_file_upload': True,
+    'allows_joins': True,
+    'allows_subqueries': True,
+}
+
+# Methods that indicate a capability when overridden by a non-BaseEngineSpec class.
+# Mirrors the has_custom_method checks in superset/db_engine_specs/lib.py.
+# cancel_query / get_cancel_query_id / has_implicit_cancel -> query_cancelation
+# estimate_statement_cost / estimate_query_cost -> query_cost_estimation
+# impersonate_user / update_impersonation_config / get_url_for_impersonation -> user_impersonation
+# validate_sql -> sql_validation (not used yet; validation is engine-based)
+CAP_METHODS = {
+    'cancel_query', 'get_cancel_query_id', 'has_implicit_cancel',
+    'estimate_statement_cost', 'estimate_query_cost',
+    'impersonate_user', 'update_impersonation_config', 'get_url_for_impersonation',
+    'validate_sql',
+}
+
+# Only the literal BaseEngineSpec is excluded from method-override tracking.
+# Intermediate base classes (e.g. PrestoBaseEngineSpec) do count as overrides.
+TRUE_BASE_CLASS = 'BaseEngineSpec'
+
+# First pass: collect all class info (name, bases, metadata, cap_attrs, direct_methods)
+class_info = {}  # class_name -> {bases: [], metadata: {}, engine_name: str, filename: str, ...}
 
 for filename in sorted(os.listdir(specs_dir)):
     if not filename.endswith('.py') or filename in ('__init__.py', 'lib.py', 'lint_metadata.py'):
@@ -218,30 +246,38 @@ for filename in sorted(os.listdir(specs_dir)):
 
             # Extract class attributes
             engine_name = None
+            engine_attr = None
             metadata = None
+            cap_attrs = {}   # capability flag attributes defined directly in this class
+            direct_methods = set()  # capability methods defined directly in this class
 
             for item in node.body:
                 if isinstance(item, ast.Assign):
                     for target in item.targets:
-                        if isinstance(target, ast.Name):
-                            if target.id == 'engine_name':
-                                val = eval_node(item.value)
-                                if isinstance(val, str):
-                                    engine_name = val
-                            elif target.id == 'metadata':
-                                metadata = eval_node(item.value)
+                        if not isinstance(target, ast.Name):
+                            continue
+                        if target.id == 'engine_name':
+                            val = eval_node(item.value)
+                            if isinstance(val, str):
+                                engine_name = val
+                        elif target.id == 'engine':
+                            val = eval_node(item.value)
+                            if isinstance(val, str):
+                                engine_attr = val
+                        elif target.id == 'metadata':
+                            metadata = eval_node(item.value)
+                        elif target.id in CAP_ATTR_DEFAULTS:
+                            val = eval_node(item.value)
+                            # Only store if we got a concrete bool value (not None/unevaluable)
+                            if isinstance(val, bool):
+                                cap_attrs[target.id] = val
+                elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if item.name in CAP_METHODS:
+                        direct_methods.add(item.name)
 
             # Check for engine attribute with non-empty value to distinguish
             # true base classes from product classes like OceanBaseEngineSpec
-            has_non_empty_engine = False
-            for item in node.body:
-                if isinstance(item, ast.Assign):
-                    for target in item.targets:
-                        if isinstance(target, ast.Name) and target.id == 'engine':
-                            # Check if engine value is non-empty string
-                            if isinstance(item.value, ast.Constant):
-                                has_non_empty_engine = bool(item.value.value)
-                            break
+            has_non_empty_engine = engine_attr is not None and bool(engine_attr)
 
             # True base classes: end with BaseEngineSpec AND don't define engine
             # or have empty engine (like PostgresBaseEngineSpec with engine = "")
@@ -254,13 +290,17 @@ for filename in sorted(os.listdir(specs_dir)):
                 'bases': base_names,
                 'metadata': metadata,
                 'engine_name': engine_name,
+                'engine': engine_attr,
                 'filename': filename,
                 'is_base_or_mixin': is_true_base,
+                'cap_attrs': cap_attrs,
+                'direct_methods': direct_methods,
             }
     except Exception as e:
         errors.append(f"{filename}: {str(e)}")
 
-# Second pass: resolve inheritance and build final metadata
+# Second pass: resolve inheritance and build final metadata + capability flags
+
 def get_inherited_metadata(class_name, visited=None):
     """Recursively get metadata from parent classes."""
     if visited is None:
@@ -286,6 +326,44 @@ def get_inherited_metadata(class_name, visited=None):
 
     return inherited
 
+def get_resolved_caps(class_name, visited=None):
+    """
+    Resolve capability flags and method overrides with inheritance.
+
+    Cap attrs: child values override parent values (same as Python MRO).
+    Methods: track which non-BaseEngineSpec classes define them directly,
+    matching the has_custom_method() logic in superset/db_engine_specs/lib.py.
+    """
+    if visited is None:
+        visited = set()
+    if class_name in visited:
+        return dict(CAP_ATTR_DEFAULTS), set()
+    visited.add(class_name)
+
+    info = class_info.get(class_name)
+    if not info:
+        return dict(CAP_ATTR_DEFAULTS), set()
+
+    # Start from base defaults
+    resolved_attrs = dict(CAP_ATTR_DEFAULTS)
+    resolved_methods = set()
+
+    # Collect from parents first
+    for base_name in info['bases']:
+        parent_attrs, parent_methods = get_resolved_caps(base_name, visited.copy())
+        resolved_attrs.update(parent_attrs)
+        resolved_methods.update(parent_methods)
+
+    # Apply this class's own cap_attrs (override parent values)
+    resolved_attrs.update(info['cap_attrs'])
+
+    # Accumulate method overrides, but skip the literal BaseEngineSpec
+    # (its implementations are stubs; only non-base overrides count)
+    if class_name != TRUE_BASE_CLASS:
+        resolved_methods.update(info['direct_methods'])
+
+    return resolved_attrs, resolved_methods
+
 for class_name, info in class_info.items():
     # Skip base classes and mixins
     if info['is_base_or_mixin']:
@@ -310,6 +388,11 @@ for class_name, info in class_info.items():
 
     if final_metadata and isinstance(final_metadata, dict) and display_name:
         debug_info["classes_with_metadata"] += 1
+
+        # Resolve capability flags from Python source
+        cap_attrs, cap_methods = get_resolved_caps(class_name)
+        engine_attr = info.get('engine') or ''
+
         databases[display_name] = {
             'engine': display_name.lower().replace(' ', '_'),
             'engine_name': display_name,
@@ -318,17 +401,22 @@ for class_name, info in class_info.items():
             'time_grains': {},
             'score': 0,
             'max_score': 0,
-            'joins': True,
-            'subqueries': True,
-            'supports_dynamic_schema': False,
-            'supports_catalog': False,
-            'supports_dynamic_catalog': False,
-            'ssh_tunneling': False,
-            'query_cancelation': False,
-            'supports_file_upload': False,
-            'user_impersonation': False,
-            'query_cost_estimation': False,
-            'sql_validation': False,
+            # Capability flags read from engine spec class attributes/methods
+            'joins': cap_attrs['allows_joins'],
+            'subqueries': cap_attrs['allows_subqueries'],
+            'supports_dynamic_schema': cap_attrs['supports_dynamic_schema'],
+            'supports_catalog': cap_attrs['supports_catalog'],
+            'supports_dynamic_catalog': cap_attrs['supports_dynamic_catalog'],
+            'ssh_tunneling': not cap_attrs['disable_ssh_tunneling'],
+            'supports_file_upload': cap_attrs['supports_file_upload'],
+            # Method-based flags: True only when a non-base class overrides them
+            'query_cancelation': bool({'cancel_query', 'get_cancel_query_id', 'has_implicit_cancel'} & cap_methods),
+            'query_cost_estimation': bool({'estimate_statement_cost', 'estimate_query_cost'} & cap_methods),
+            # SQL validation is implemented in external validator classes keyed by engine name
+            'sql_validation': engine_attr in {'presto', 'postgresql'},
+            'user_impersonation': bool(
+                {'impersonate_user', 'update_impersonation_config', 'get_url_for_impersonation'} & cap_methods
+            ),
         }
 
 if errors and not databases:
@@ -853,22 +941,21 @@ function loadExistingData() {
 
 /**
  * Merge new documentation with existing diagnostics
- * Preserves score, time_grains, and feature flags from existing data
+ * Preserves score, max_score, and time_grains from existing data (these require
+ * Flask context to generate and cannot be derived from static source analysis).
+ * Capability flags (joins, supports_catalog, etc.) are NOT preserved here — they
+ * are now read fresh from the Python engine spec source by extractEngineSpecMetadata().
  */
 function mergeWithExistingDiagnostics(newDatabases, existingData) {
   if (!existingData?.databases) return newDatabases;
 
-  const diagnosticFields = [
-    'score', 'max_score', 'time_grains', 'joins', 'subqueries',
-    'supports_dynamic_schema', 'supports_catalog', 'supports_dynamic_catalog',
-    'ssh_tunneling', 'query_cancelation', 'supports_file_upload',
-    'user_impersonation', 'query_cost_estimation', 'sql_validation'
-  ];
+  // Only preserve fields that require Flask/runtime context to generate
+  const diagnosticFields = ['score', 'max_score', 'time_grains'];
 
   for (const [name, db] of Object.entries(newDatabases)) {
     const existingDb = existingData.databases[name];
     if (existingDb && existingDb.score > 0) {
-      // Preserve diagnostics from existing data
+      // Preserve score/time_grain diagnostics from existing data
       for (const field of diagnosticFields) {
         if (existingDb[field] !== undefined) {
           db[field] = existingDb[field];
@@ -879,7 +966,7 @@ function mergeWithExistingDiagnostics(newDatabases, existingData) {
 
   const preserved = Object.values(newDatabases).filter(d => d.score > 0).length;
   if (preserved > 0) {
-    console.log(`Preserved diagnostics for ${preserved} databases from existing data`);
+    console.log(`Preserved score/time_grains for ${preserved} databases from existing data`);
   }
 
   return newDatabases;

--- a/docs/scripts/generate-database-docs.mjs
+++ b/docs/scripts/generate-database-docs.mjs
@@ -214,12 +214,16 @@ CAP_ATTR_TO_OUTPUT_FIELD = {
 
 # Methods that indicate a capability when overridden by a non-BaseEngineSpec class.
 # Mirrors the has_custom_method checks in superset/db_engine_specs/lib.py.
-# cancel_query / get_cancel_query_id / has_implicit_cancel -> query_cancelation
+# cancel_query / has_implicit_cancel -> query_cancelation
+#   (diagnose() checks cancel_query override OR has_implicit_cancel() == True;
+#    base has_implicit_cancel returns False, so overriding it is the static
+#    equivalent of that method returning True. get_cancel_query_id is NOT
+#    part of the diagnose() heuristic and is intentionally excluded.)
 # estimate_statement_cost / estimate_query_cost -> query_cost_estimation
 # impersonate_user / update_impersonation_config / get_url_for_impersonation -> user_impersonation
 # validate_sql -> sql_validation (not used yet; validation is engine-based)
 CAP_METHODS = {
-    'cancel_query', 'get_cancel_query_id', 'has_implicit_cancel',
+    'cancel_query', 'has_implicit_cancel',
     'estimate_statement_cost', 'estimate_query_cost',
     'impersonate_user', 'update_impersonation_config', 'get_url_for_impersonation',
     'validate_sql',
@@ -454,8 +458,11 @@ for class_name, info in class_info.items():
             'supports_dynamic_catalog': cap_attrs['supports_dynamic_catalog'],
             'ssh_tunneling': not cap_attrs['disable_ssh_tunneling'],
             'supports_file_upload': cap_attrs['supports_file_upload'],
-            # Method-based flags: True only when a non-base class overrides them
-            'query_cancelation': bool({'cancel_query', 'get_cancel_query_id', 'has_implicit_cancel'} & cap_methods),
+            # Method-based flags: True only when a non-base class overrides them.
+            # Matches diagnose() in lib.py: cancel_query override OR
+            # has_implicit_cancel() returning True (which, given the base
+            # returns False, is equivalent to overriding has_implicit_cancel).
+            'query_cancelation': bool({'cancel_query', 'has_implicit_cancel'} & cap_methods),
             'query_cost_estimation': bool({'estimate_statement_cost', 'estimate_query_cost'} & cap_methods),
             # SQL validation is implemented in external validator classes keyed by engine name
             'sql_validation': engine_attr in {'presto', 'postgresql'},

--- a/docs/scripts/generate-database-docs.mjs
+++ b/docs/scripts/generate-database-docs.mjs
@@ -348,8 +348,11 @@ def get_resolved_caps(class_name, visited=None):
     resolved_attrs = dict(CAP_ATTR_DEFAULTS)
     resolved_methods = set()
 
-    # Collect from parents first
-    for base_name in info['bases']:
+    # Collect from parents, iterating right-to-left so leftmost bases win
+    # (matches Python MRO: for class C(A, B), A's attributes take precedence).
+    # update() keeps the LAST value written, so reversing makes the leftmost
+    # base the final writer.
+    for base_name in reversed(info['bases']):
         parent_attrs, parent_methods = get_resolved_caps(base_name, visited.copy())
         resolved_attrs.update(parent_attrs)
         resolved_methods.update(parent_methods)

--- a/docs/src/data/databases.json
+++ b/docs/src/data/databases.json
@@ -1,96 +1,18 @@
 {
-  "generated": "2026-04-25T02:18:43.905Z",
+  "generated": "2026-04-17T17:08:35.132Z",
   "statistics": {
-    "totalDatabases": 73,
-    "withDocumentation": 73,
-    "withConnectionString": 73,
-    "withDrivers": 36,
+    "totalDatabases": 80,
+    "withDocumentation": 80,
+    "withConnectionString": 80,
+    "withDrivers": 28,
     "withAuthMethods": 5,
-    "supportsJoins": 69,
-    "supportsSubqueries": 70,
-    "supportsDynamicSchema": 15,
-    "supportsCatalog": 9,
-    "averageScore": 31,
+    "supportsJoins": 74,
+    "supportsSubqueries": 77,
+    "supportsDynamicSchema": 29,
+    "supportsCatalog": 20,
+    "averageScore": 54,
     "maxScore": 201,
     "byCategory": {
-      "Other Databases": [
-        "Arc",
-        "Shillelagh",
-        "Superset meta database"
-      ],
-      "Proprietary": [
-        "Arc",
-        "Amazon Athena",
-        "Google BigQuery",
-        "Databend",
-        "Google Datastore",
-        "IBM Db2",
-        "Denodo",
-        "Dremio",
-        "Amazon DynamoDB",
-        "Exasol",
-        "Firebolt",
-        "SAP HANA",
-        "Hologres",
-        "IBM Db2 for i",
-        "Azure Data Explorer",
-        "MongoDB",
-        "Microsoft SQL Server",
-        "Azure Synapse",
-        "IBM Netezza Performance Server",
-        "Ocient",
-        "Oracle",
-        "Amazon Redshift",
-        "SingleStore",
-        "Snowflake",
-        "SAP Sybase",
-        "Teradata",
-        "Vertica"
-      ],
-      "Cloud Data Warehouses": [
-        "Ascend",
-        "Cloudflare D1",
-        "Databend",
-        "Databricks",
-        "MotherDuck",
-        "Firebolt",
-        "Hologres",
-        "Azure Synapse",
-        "Snowflake",
-        "YugabyteDB"
-      ],
-      "Analytical Databases": [
-        "Ascend",
-        "Google BigQuery",
-        "ClickHouse",
-        "Databend",
-        "Databricks",
-        "Apache Doris",
-        "DuckDB",
-        "MotherDuck",
-        "Exasol",
-        "Firebolt",
-        "Hologres",
-        "Azure Data Explorer",
-        "Apache Kylin",
-        "Azure Synapse",
-        "Ocient",
-        "Apache Phoenix",
-        "Amazon Redshift",
-        "RisingWave",
-        "SingleStore",
-        "Snowflake",
-        "StarRocks",
-        "TimescaleDB",
-        "Vertica"
-      ],
-      "Hosted Open Source": [
-        "Ascend",
-        "Cloudflare D1",
-        "Databricks",
-        "MotherDuck",
-        "Google Sheets"
-      ],
       "Cloud - AWS": [
         "Amazon Athena",
         "Amazon DynamoDB",
@@ -98,77 +20,128 @@
       ],
       "Query Engines": [
         "Amazon Athena",
-        "Databricks Interactive Cluster",
-        "Denodo",
-        "Dremio",
         "Apache Drill",
         "Apache Hive",
         "Apache Impala",
-        "Presto",
         "Apache Spark SQL",
+        "Databricks Interactive Cluster",
+        "Denodo",
+        "Dremio",
+        "Presto",
         "Trino"
       ],
-      "Traditional RDBMS": [
-        "Aurora MySQL (Data API)",
-        "Aurora PostgreSQL (Data API)",
-        "Aurora MySQL",
-        "Aurora PostgreSQL",
-        "CockroachDB",
-        "Cloudflare D1",
+      "Proprietary": [
+        "Amazon Athena",
+        "Amazon DynamoDB",
+        "Amazon Redshift",
+        "Arc",
+        "Azure Data Explorer",
+        "Azure Synapse",
+        "Databend",
+        "Denodo",
+        "Dremio",
+        "Exasol",
+        "Firebolt",
+        "Google BigQuery",
+        "Google Datastore",
+        "Hologres",
         "IBM Db2",
-        "Firebird",
-        "Greenplum",
-        "SAP HANA",
         "IBM Db2 for i",
-        "MariaDB",
-        "MonetDB",
-        "Microsoft SQL Server",
-        "MySQL",
         "IBM Netezza Performance Server",
-        "OceanBase",
+        "Microsoft SQL Server",
+        "MongoDB",
+        "Ocient",
         "Oracle",
-        "PostgreSQL",
-        "SQLite",
+        "SAP HANA",
         "SAP Sybase",
+        "SingleStore",
+        "Snowflake",
         "Teradata",
-        "YDB",
-        "YugabyteDB"
+        "Vertica"
+      ],
+      "Search & NoSQL": [
+        "Amazon DynamoDB",
+        "Apache Solr",
+        "Couchbase",
+        "Elasticsearch",
+        "Google Datastore",
+        "MongoDB",
+        "Parseable"
+      ],
+      "Analytical Databases": [
+        "Amazon Redshift",
+        "Apache Doris",
+        "Apache Kylin",
+        "Apache Phoenix",
+        "Ascend",
+        "Azure Data Explorer",
+        "Azure Synapse",
+        "ClickHouse",
+        "Databend",
+        "Databricks",
+        "DuckDB",
+        "Exasol",
+        "Firebolt",
+        "Google BigQuery",
+        "Hologres",
+        "MotherDuck",
+        "Ocient",
+        "RisingWave",
+        "SingleStore",
+        "Snowflake",
+        "StarRocks",
+        "TimescaleDB",
+        "Vertica"
+      ],
+      "Apache Projects": [
+        "Apache Doris",
+        "Apache Drill",
+        "Apache Druid",
+        "Apache Hive",
+        "Apache Impala",
+        "Apache IoTDB",
+        "Apache Kylin",
+        "Apache Phoenix",
+        "Apache Pinot",
+        "Apache Solr",
+        "Apache Spark SQL",
+        "Databricks Interactive Cluster"
       ],
       "Open Source": [
-        "Aurora MySQL (Data API)",
-        "Aurora PostgreSQL (Data API)",
+        "Apache Doris",
+        "Apache Drill",
+        "Apache Druid",
+        "Apache Hive",
+        "Apache Impala",
+        "Apache IoTDB",
+        "Apache Kylin",
+        "Apache Phoenix",
+        "Apache Pinot",
+        "Apache Solr",
+        "Apache Spark SQL",
         "Aurora MySQL",
+        "Aurora MySQL (Data API)",
         "Aurora PostgreSQL",
+        "Aurora PostgreSQL (Data API)",
         "ClickHouse",
         "CockroachDB",
         "Couchbase",
         "CrateDB",
         "Databricks Interactive Cluster",
-        "Apache Doris",
-        "Apache Drill",
-        "Apache Druid",
         "DuckDB",
         "Elasticsearch",
         "Firebird",
         "Greenplum",
-        "Apache Hive",
-        "Apache Impala",
-        "Apache IoTDB",
-        "Apache Kylin",
         "MariaDB",
         "MonetDB",
         "MySQL",
         "OceanBase",
         "Parseable",
-        "Apache Phoenix",
-        "Apache Pinot",
         "PostgreSQL",
         "Presto",
         "RisingWave",
-        "Shillelagh",
-        "Apache Solr",
-        "Apache Spark SQL",
         "SQLite",
+        "Shillelagh",
         "StarRocks",
         "TDengine",
         "TimescaleDB",
@@ -176,146 +149,148 @@
         "YDB",
         "YugabyteDB"
       ],
+      "Time Series Databases": [
+        "Apache Druid",
+        "Apache IoTDB",
+        "Apache Pinot",
+        "CrateDB",
+        "TDengine"
+      ],
+      "Other Databases": [
+        "Arc",
+        "Azure Data Explorer (KQL)",
+        "ClickHouse (sqlalchemy)",
+        "Databend (legacy)",
+        "Databricks (legacy)",
+        "Databricks SQL Endpoint",
+        "OpenSearch (OpenDistro)",
+        "Shillelagh",
+        "Superset meta database",
+        "base"
+      ],
+      "Cloud Data Warehouses": [
+        "Ascend",
+        "Azure Synapse",
+        "Cloudflare D1",
+        "Databend",
+        "Databricks",
+        "Firebolt",
+        "Hologres",
+        "MotherDuck",
+        "Snowflake",
+        "YugabyteDB"
+      ],
+      "Hosted Open Source": [
+        "Ascend",
+        "Cloudflare D1",
+        "Databricks",
+        "Google Sheets",
+        "MotherDuck"
+      ],
+      "Traditional RDBMS": [
+        "Aurora MySQL",
+        "Aurora MySQL (Data API)",
+        "Aurora PostgreSQL",
+        "Aurora PostgreSQL (Data API)",
+        "Cloudflare D1",
+        "CockroachDB",
+        "Firebird",
+        "Greenplum",
+        "IBM Db2",
+        "IBM Db2 for i",
+        "IBM Netezza Performance Server",
+        "MariaDB",
+        "Microsoft SQL Server",
+        "MonetDB",
+        "MySQL",
+        "OceanBase",
+        "Oracle",
+        "PostgreSQL",
+        "SAP HANA",
+        "SAP Sybase",
+        "SQLite",
+        "Teradata",
+        "YDB",
+        "YugabyteDB"
+      ],
+      "Cloud - Azure": [
+        "Azure Data Explorer"
+      ],
       "Cloud - Google": [
         "Google BigQuery",
         "Google Datastore",
         "Google Sheets"
-      ],
-      "Search & NoSQL": [
-        "Couchbase",
-        "Google Datastore",
-        "Amazon DynamoDB",
-        "Elasticsearch",
-        "MongoDB",
-        "Parseable",
-        "Apache Solr"
-      ],
-      "Time Series Databases": [
-        "CrateDB",
-        "Apache Druid",
-        "Apache IoTDB",
-        "Apache Pinot",
-        "TDengine"
-      ],
-      "Apache Projects": [
-        "Databricks Interactive Cluster",
-        "Apache Doris",
-        "Apache Drill",
-        "Apache Druid",
-        "Apache Hive",
-        "Apache Impala",
-        "Apache IoTDB",
-        "Apache Kylin",
-        "Apache Phoenix",
-        "Apache Pinot",
-        "Apache Solr",
-        "Apache Spark SQL"
-      ],
-      "Cloud - Azure": [
-        "Azure Data Explorer"
       ]
     }
   },
   "databases": {
-    "Arc": {
-      "engine": "arc",
-      "engine_name": "Arc",
-      "module": "arc",
-      "documentation": {
-        "description": "Arc is a data platform with multiple connection options.",
-        "categories": [
-          "OTHER",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "arc-superset-arrow"
-        ],
-        "connection_string": "arc+arrow://{api_key}@{hostname}:{port}/{database}",
-        "parameters": {
-          "api_key": "Arc API key",
-          "hostname": "Arc hostname",
-          "port": "Arc port",
-          "database": "Database name"
-        },
-        "drivers": [
-          {
-            "name": "Apache Arrow (Recommended)",
-            "pypi_package": "arc-superset-arrow",
-            "connection_string": "arc+arrow://{api_key}@{hostname}:{port}/{database}",
-            "is_recommended": true,
-            "notes": "Recommended for production. Provides 3-5x better performance using Apache Arrow IPC."
-          },
-          {
-            "name": "JSON",
-            "pypi_package": "arc-superset-dialect",
-            "connection_string": "arc+json://{api_key}@{hostname}:{port}/{database}",
-            "is_recommended": false
-          }
-        ],
-        "notes": "Arc supports multiple databases (schemas) within a single instance. Each Arc database appears as a schema in SQL Lab."
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Ascend": {
-      "engine": "ascend",
-      "engine_name": "Ascend",
-      "module": "ascend",
-      "documentation": {
-        "description": "Ascend.io is a data automation platform for building data pipelines.",
-        "logo": "ascend.webp",
-        "homepage_url": "https://www.ascend.io/",
-        "pypi_packages": [
-          "impyla",
-          "impyla"
-        ],
-        "connection_string": "ascend://{username}:{password}@{hostname}:{port}/{database}?auth_mechanism=PLAIN;use_ssl=true",
-        "default_port": 21050,
-        "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "ANALYTICAL_DATABASES",
-          "HOSTED_OPEN_SOURCE"
-        ]
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
     "Amazon Athena": {
-      "engine": "amazon_athena",
-      "engine_name": "Amazon Athena",
-      "module": "athena",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.athena",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": false,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": false,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 30,
+      "max_score": 201,
       "documentation": {
         "description": "Amazon Athena is an interactive query service for analyzing data in S3 using SQL.",
         "logo": "amazon-athena.jpg",
         "homepage_url": "https://aws.amazon.com/athena/",
         "categories": [
-          "CLOUD_AWS",
-          "QUERY_ENGINES",
-          "PROPRIETARY"
+          "Cloud - AWS",
+          "Query Engines",
+          "Proprietary"
         ],
         "pypi_packages": [
           "pyathena[pandas]"
@@ -349,6 +324,7 @@
           }
         ],
         "notes": "URL-encode special characters in s3_staging_dir (e.g., s3:// becomes s3%3A//).",
+        "category": "Cloud - AWS",
         "custom_errors": [
           {
             "regex_name": "SYNTAX_ERROR_REGEX",
@@ -362,361 +338,475 @@
           }
         ]
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
+      "engine": "awsathena",
+      "engine_name": "Amazon Athena",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Amazon DynamoDB": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.dynamodb",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
       "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Aurora MySQL (Data API)": {
-      "engine": "aurora_mysql_(data_api)",
-      "engine_name": "Aurora MySQL (Data API)",
-      "module": "aurora",
+      "sql_validation": false,
+      "score": 32,
+      "max_score": 201,
       "documentation": {
-        "description": "MySQL is a popular open-source relational database.",
-        "logo": "mysql.png",
-        "homepage_url": "https://www.mysql.com/",
+        "description": "Amazon DynamoDB is a serverless NoSQL database with SQL via PartiQL.",
+        "logo": "aws.png",
+        "homepage_url": "https://aws.amazon.com/dynamodb/",
         "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
+          "Cloud - AWS",
+          "Search & NoSQL",
+          "Proprietary"
         ],
         "pypi_packages": [
-          "mysqlclient"
+          "pydynamodb"
         ],
-        "connection_string": "mysql://{username}:{password}@{host}/{database}",
-        "default_port": 3306,
+        "connection_string": "dynamodb://{aws_access_key_id}:{aws_secret_access_key}@dynamodb.{region}.amazonaws.com:443?connector=superset",
+        "parameters": {
+          "aws_access_key_id": "AWS access key ID",
+          "aws_secret_access_key": "AWS secret access key",
+          "region": "AWS region (e.g., us-east-1)"
+        },
+        "notes": "Uses PartiQL for SQL queries. Requires connector=superset parameter.",
+        "docs_url": "https://github.com/passren/PyDynamoDB",
+        "category": "Cloud - AWS"
+      },
+      "engine": "dynamodb",
+      "engine_name": "Amazon DynamoDB",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Amazon Redshift": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.redshift",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 127,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 44,
+      "max_score": 201,
+      "documentation": {
+        "description": "Amazon Redshift is a fully managed data warehouse service.",
+        "logo": "redshift.png",
+        "homepage_url": "https://aws.amazon.com/redshift/",
+        "categories": [
+          "Cloud - AWS",
+          "Analytical Databases",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "sqlalchemy-redshift"
+        ],
+        "connection_string": "redshift+psycopg2://{username}:{password}@{host}:5439/{database}",
+        "default_port": 5439,
         "parameters": {
           "username": "Database username",
           "password": "Database password",
-          "host": "localhost, 127.0.0.1, IP address, or hostname",
+          "host": "AWS Endpoint",
+          "port": "Default 5439",
           "database": "Database name"
         },
-        "host_examples": [
-          {
-            "platform": "Localhost",
-            "host": "localhost or 127.0.0.1"
-          },
-          {
-            "platform": "Docker on Linux",
-            "host": "172.18.0.1"
-          },
-          {
-            "platform": "Docker on macOS",
-            "host": "docker.for.mac.host.internal"
-          },
-          {
-            "platform": "On-premise",
-            "host": "IP address or hostname"
-          }
-        ],
         "drivers": [
           {
-            "name": "mysqlclient",
-            "pypi_package": "mysqlclient",
-            "connection_string": "mysql://{username}:{password}@{host}/{database}",
-            "is_recommended": true,
-            "notes": "Recommended driver. May fail with caching_sha2_password auth."
+            "name": "psycopg2",
+            "pypi_package": "psycopg2",
+            "connection_string": "redshift+psycopg2://{username}:{password}@{host}:5439/{database}",
+            "is_recommended": true
           },
           {
-            "name": "mysql-connector-python",
-            "pypi_package": "mysql-connector-python",
-            "connection_string": "mysql+mysqlconnector://{username}:{password}@{host}/{database}",
+            "name": "redshift_connector",
+            "pypi_package": "redshift_connector",
+            "connection_string": "redshift+redshift_connector://{username}:{password}@{host}:5439/{database}",
             "is_recommended": false,
-            "notes": "Required for newer MySQL databases using caching_sha2_password authentication."
-          }
-        ]
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Aurora PostgreSQL (Data API)": {
-      "engine": "aurora_postgresql_(data_api)",
-      "engine_name": "Aurora PostgreSQL (Data API)",
-      "module": "aurora",
-      "documentation": {
-        "description": "PostgreSQL is an advanced open-source relational database.",
-        "logo": "postgresql.svg",
-        "homepage_url": "https://www.postgresql.org/",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "psycopg2"
-        ],
-        "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
-        "default_port": 5432,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "For localhost: localhost or 127.0.0.1. For AWS: endpoint URL",
-          "port": "Default 5432",
-          "database": "Database name"
-        },
-        "notes": "The psycopg2 library comes bundled with Superset Docker images.",
-        "connection_examples": [
-          {
-            "description": "Basic connection",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}"
-          },
-          {
-            "description": "With SSL required",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
+            "notes": "Supports IAM-based credentials for clusters and serverless."
           }
         ],
-        "docs_url": "https://www.postgresql.org/docs/",
-        "sqlalchemy_docs_url": "https://docs.sqlalchemy.org/en/13/dialects/postgresql.html"
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Aurora MySQL": {
-      "engine": "aurora_mysql",
-      "engine_name": "Aurora MySQL",
-      "module": "aurora",
-      "documentation": {
-        "description": "MySQL is a popular open-source relational database.",
-        "logo": "mysql.png",
-        "homepage_url": "https://www.mysql.com/",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "mysqlclient"
-        ],
-        "connection_string": "mysql://{username}:{password}@{host}/{database}",
-        "default_port": 3306,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "localhost, 127.0.0.1, IP address, or hostname",
-          "database": "Database name"
-        },
-        "host_examples": [
-          {
-            "platform": "Localhost",
-            "host": "localhost or 127.0.0.1"
-          },
-          {
-            "platform": "Docker on Linux",
-            "host": "172.18.0.1"
-          },
-          {
-            "platform": "Docker on macOS",
-            "host": "docker.for.mac.host.internal"
-          },
-          {
-            "platform": "On-premise",
-            "host": "IP address or hostname"
-          }
-        ],
-        "drivers": [
-          {
-            "name": "mysqlclient",
-            "pypi_package": "mysqlclient",
-            "connection_string": "mysql://{username}:{password}@{host}/{database}",
-            "is_recommended": true,
-            "notes": "Recommended driver. May fail with caching_sha2_password auth."
-          },
-          {
-            "name": "mysql-connector-python",
-            "pypi_package": "mysql-connector-python",
-            "connection_string": "mysql+mysqlconnector://{username}:{password}@{host}/{database}",
-            "is_recommended": false,
-            "notes": "Required for newer MySQL databases using caching_sha2_password authentication."
-          }
-        ]
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Aurora PostgreSQL": {
-      "engine": "aurora_postgresql",
-      "engine_name": "Aurora PostgreSQL",
-      "module": "aurora",
-      "documentation": {
-        "description": "PostgreSQL is an advanced open-source relational database.",
-        "logo": "postgresql.svg",
-        "homepage_url": "https://www.postgresql.org/",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "psycopg2"
-        ],
-        "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
-        "default_port": 5432,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "For localhost: localhost or 127.0.0.1. For AWS: endpoint URL",
-          "port": "Default 5432",
-          "database": "Database name"
-        },
-        "notes": "The psycopg2 library comes bundled with Superset Docker images.",
-        "connection_examples": [
-          {
-            "description": "Basic connection",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}"
-          },
-          {
-            "description": "With SSL required",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
-          }
-        ],
-        "docs_url": "https://www.postgresql.org/docs/",
-        "sqlalchemy_docs_url": "https://docs.sqlalchemy.org/en/13/dialects/postgresql.html"
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Google BigQuery": {
-      "engine": "google_bigquery",
-      "engine_name": "Google BigQuery",
-      "module": "bigquery",
-      "documentation": {
-        "description": "Google BigQuery is a serverless, highly scalable data warehouse.",
-        "logo": "google-big-query.svg",
-        "homepage_url": "https://cloud.google.com/bigquery/",
-        "categories": [
-          "CLOUD_GCP",
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "sqlalchemy-bigquery"
-        ],
-        "connection_string": "bigquery://{project_id}",
-        "install_instructions": "echo \"sqlalchemy-bigquery\" >> ./docker/requirements-local.txt",
         "authentication_methods": [
           {
-            "name": "Service Account JSON",
-            "description": "Upload service account credentials JSON or paste in Secure Extra",
-            "secure_extra": {
-              "credentials_info": {
-                "type": "service_account",
-                "project_id": "...",
-                "private_key_id": "...",
-                "private_key": "...",
-                "client_email": "...",
-                "client_id": "...",
-                "auth_uri": "...",
-                "token_uri": "..."
+            "name": "IAM Credentials (Cluster)",
+            "description": "Use IAM-based temporary database credentials for Redshift clusters",
+            "requirements": "IAM role must have redshift:GetClusterCredentials permission",
+            "connection_string": "redshift+redshift_connector://",
+            "engine_parameters": {
+              "connect_args": {
+                "iam": true,
+                "database": "<database>",
+                "cluster_identifier": "<cluster_identifier>",
+                "db_user": "<db_user>"
+              }
+            }
+          },
+          {
+            "name": "IAM Role (Serverless)",
+            "description": "Authenticate using the IAM role attached to the environment (EC2 instance profile, ECS task role, etc.). No credentials needed.",
+            "requirements": "The attached IAM role must have redshift-serverless:GetCredentials and redshift-serverless:GetWorkgroup permissions.",
+            "connection_string": "redshift+redshift_connector://",
+            "engine_parameters": {
+              "connect_args": {
+                "iam": true,
+                "is_serverless": true,
+                "serverless_acct_id": "<aws account number>",
+                "serverless_work_group": "<redshift work group>",
+                "database": "<database>",
+                "user": "IAMR:<superset iam role name>"
+              }
+            }
+          },
+          {
+            "name": "IAM Access Key (Serverless)",
+            "description": "Authenticate using explicit AWS access key and secret. Suitable for local development or CI environments without an attached IAM role.",
+            "requirements": "The IAM user must have redshift-serverless:GetCredentials and redshift-serverless:GetWorkgroup permissions.",
+            "connection_string": "redshift+redshift_connector://",
+            "engine_parameters": {
+              "connect_args": {
+                "iam": true,
+                "is_serverless": true,
+                "serverless_acct_id": "<aws account number>",
+                "serverless_work_group": "<redshift work group>",
+                "database": "<database>",
+                "host": "<endpoint>",
+                "port": 5439,
+                "region": "<aws region>",
+                "access_key_id": "<aws access key id>",
+                "secret_access_key": "<aws secret access key>"
               }
             }
           }
         ],
-        "notes": "Create a Service Account via GCP console with access to BigQuery datasets. For CSV/Excel uploads, also install pandas_gbq.",
-        "warnings": [
-          "Google BigQuery Python SDK is not compatible with gevent. Use a worker type other than gevent when deploying with gunicorn."
-        ],
-        "docs_url": "https://github.com/googleapis/python-bigquery-sqlalchemy",
+        "category": "Cloud - AWS",
         "custom_errors": [
           {
-            "regex_name": "CONNECTION_DATABASE_PERMISSIONS_REGEX",
-            "message_template": "Unable to connect. Verify that the following roles are set on the service account: \"BigQuery Data Viewer\", \"BigQuery Metadata Viewer\", \"BigQuery Job User\" and the following permissions are set \"bigquery.readsessions.create\", \"bigquery.readsessions.getData\"",
-            "error_type": "CONNECTION_DATABASE_PERMISSIONS_ERROR",
-            "category": "Permissions",
-            "description": "Insufficient permissions",
+            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
+            "message_template": "Either the username \"%(username)s\" or the password is incorrect.",
+            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
+            "category": "Authentication",
+            "description": "Access denied",
             "issue_codes": [
-              1017
+              1014,
+              1015
+            ],
+            "invalid_fields": [
+              "username",
+              "password"
             ]
           },
           {
-            "regex_name": "TABLE_DOES_NOT_EXIST_REGEX",
-            "message_template": "The table \"%(table)s\" does not exist. A valid table must be used to run this query.",
-            "error_type": "TABLE_DOES_NOT_EXIST_ERROR",
-            "category": "Query",
-            "description": "Table not found",
+            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
+            "message_template": "The hostname \"%(hostname)s\" cannot be resolved.",
+            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
+            "category": "Connection",
+            "description": "Invalid hostname",
             "issue_codes": [
-              1003,
-              1005
+              1007
+            ],
+            "invalid_fields": [
+              "host"
             ]
           },
           {
-            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
-            "message_template": "We can't seem to resolve column \"%(column)s\" at line %(location)s.",
-            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
-            "category": "Query",
-            "description": "Column not found",
+            "regex_name": "CONNECTION_PORT_CLOSED_REGEX",
+            "message_template": "Port %(port)s on hostname \"%(hostname)s\" refused the connection.",
+            "error_type": "CONNECTION_PORT_CLOSED_ERROR",
+            "category": "Connection",
+            "description": "Port closed or refused",
             "issue_codes": [
-              1003,
-              1004
+              1008
+            ],
+            "invalid_fields": [
+              "host",
+              "port"
             ]
           },
           {
-            "regex_name": "SCHEMA_DOES_NOT_EXIST_REGEX",
-            "message_template": "The schema \"%(schema)s\" does not exist. A valid schema must be used to run this query.",
-            "error_type": "SCHEMA_DOES_NOT_EXIST_ERROR",
-            "category": "Query",
-            "description": "Schema not found",
+            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
+            "message_template": "The host \"%(hostname)s\" might be down, and can't be reached on port %(port)s.",
+            "error_type": "CONNECTION_HOST_DOWN_ERROR",
+            "category": "Connection",
+            "description": "Host unreachable",
             "issue_codes": [
-              1003,
-              1016
+              1009
+            ],
+            "invalid_fields": [
+              "host",
+              "port"
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_UNKNOWN_DATABASE_REGEX",
+            "message_template": "We were unable to connect to your database named \"%(database)s\". Please verify your database name and try again.",
+            "error_type": "CONNECTION_UNKNOWN_DATABASE_ERROR",
+            "category": "Connection",
+            "description": "Unknown database",
+            "issue_codes": [
+              1015
+            ],
+            "invalid_fields": [
+              "database"
+            ]
+          }
+        ]
+      },
+      "engine": "redshift",
+      "engine_name": "Amazon Redshift",
+      "engine_aliases": [],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache Doris": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.doris",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 64,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 79,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Doris is a high-performance real-time analytical database.",
+        "logo": "doris.png",
+        "homepage_url": "https://doris.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Analytical Databases",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "pydoris"
+        ],
+        "connection_string": "doris://{username}:{password}@{host}:{port}/{catalog}.{database}",
+        "default_port": 9030,
+        "parameters": {
+          "username": "User name",
+          "password": "Password",
+          "host": "Doris FE Host",
+          "port": "Doris FE port",
+          "catalog": "Catalog name",
+          "database": "Database name"
+        },
+        "category": "Apache Projects",
+        "custom_errors": [
+          {
+            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
+            "message_template": "Either the username \"%(username)s\" or the password is incorrect.",
+            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
+            "category": "Authentication",
+            "description": "Access denied",
+            "issue_codes": [
+              1014,
+              1015
+            ],
+            "invalid_fields": [
+              "username",
+              "password"
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
+            "message_template": "Unknown Doris server host \"%(hostname)s\".",
+            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
+            "category": "Connection",
+            "description": "Invalid hostname",
+            "issue_codes": [
+              1007
+            ],
+            "invalid_fields": [
+              "host"
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
+            "message_template": "The host \"%(hostname)s\" might be down and can't be reached.",
+            "error_type": "CONNECTION_HOST_DOWN_ERROR",
+            "category": "Connection",
+            "description": "Host unreachable",
+            "issue_codes": [
+              1009
+            ],
+            "invalid_fields": [
+              "host",
+              "port"
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_UNKNOWN_DATABASE_REGEX",
+            "message_template": "Unable to connect to database \"%(database)s\".",
+            "error_type": "CONNECTION_UNKNOWN_DATABASE_ERROR",
+            "category": "Connection",
+            "description": "Unknown database",
+            "issue_codes": [
+              1015
+            ],
+            "invalid_fields": [
+              "database"
             ]
           },
           {
             "regex_name": "SYNTAX_ERROR_REGEX",
-            "message_template": "Please check your query for syntax errors at or near \"%(syntax_error)s\". Then, try running your query again.",
+            "message_template": "Please check your query for syntax errors near \"%(server_error)s\". Then, try running your query again.",
             "error_type": "SYNTAX_ERROR",
             "category": "Query",
             "description": "SQL syntax error",
@@ -726,32 +816,2350 @@
           }
         ]
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
+      "engine": "pydoris",
+      "engine_name": "Apache Doris",
+      "engine_aliases": [
+        "doris"
+      ],
+      "default_driver": "pydoris",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Apache Drill": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.drill",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": true,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 50,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Drill is a schema-free SQL query engine for Hadoop and NoSQL.",
+        "logo": "apache-drill.png",
+        "homepage_url": "https://drill.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Query Engines",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "sqlalchemy-drill"
+        ],
+        "connection_string": "drill+sadrill://{username}:{password}@{host}:{port}/{storage_plugin}?use_ssl=True",
+        "default_port": 8047,
+        "drivers": [
+          {
+            "name": "SQLAlchemy (REST)",
+            "pypi_package": "sqlalchemy-drill",
+            "connection_string": "drill+sadrill://{username}:{password}@{host}:{port}/{storage_plugin}?use_ssl=True",
+            "is_recommended": true
+          },
+          {
+            "name": "JDBC",
+            "pypi_package": "sqlalchemy-drill",
+            "connection_string": "drill+jdbc://{username}:{password}@{host}:{port}",
+            "is_recommended": false,
+            "notes": "Requires Drill JDBC Driver installation.",
+            "docs_url": "https://drill.apache.org/docs/using-the-jdbc-driver/"
+          },
+          {
+            "name": "ODBC",
+            "pypi_package": "sqlalchemy-drill",
+            "is_recommended": false,
+            "notes": "See Apache Drill documentation for ODBC setup.",
+            "docs_url": "https://drill.apache.org/docs/installing-the-driver-on-linux/"
+          }
+        ],
+        "connection_examples": [
+          {
+            "description": "Local embedded mode",
+            "connection_string": "drill+sadrill://localhost:8047/dfs?use_ssl=False"
+          }
+        ],
+        "category": "Apache Projects"
+      },
+      "engine": "drill",
+      "engine_name": "Apache Drill",
+      "engine_aliases": [],
+      "default_driver": "sadrill",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache Druid": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": true,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.druid",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": false,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 47,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Druid is a high performance real-time analytics database.",
+        "logo": "druid.png",
+        "homepage_url": "https://druid.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Time Series Databases",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "pydruid"
+        ],
+        "connection_string": "druid://{username}:{password}@{host}:{port}/druid/v2/sql",
+        "default_port": 9088,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "IP address or URL of the host",
+          "port": "Default 9088"
+        },
+        "ssl_configuration": {
+          "custom_certificate": "Add certificate in Root Certificate field. pydruid will automatically use https.",
+          "disable_ssl_verification": {
+            "engine_params": {
+              "connect_args": {
+                "scheme": "https",
+                "ssl_verify_cert": false
+              }
+            }
+          }
+        },
+        "advanced_features": {
+          "aggregations": "Define common aggregations in datasource edit view under List Druid Column tab.",
+          "post_aggregations": "Create metrics with postagg as Metric Type and provide valid JSON post-aggregation definition."
+        },
+        "notes": "A native Druid connector ships with Superset (behind DRUID_IS_ACTIVE flag) but SQLAlchemy connector via pydruid is preferred.",
+        "compatible_databases": [
+          {
+            "name": "Imply",
+            "description": "Imply is a fully-managed cloud platform and enterprise distribution built on Apache Druid. It provides real-time analytics with enterprise security and support.",
+            "logo": "imply.png",
+            "homepage_url": "https://imply.io/",
+            "categories": [
+              "Time Series Databases",
+              "Cloud Data Warehouses",
+              "Hosted Open Source"
+            ],
+            "pypi_packages": [
+              "pydruid"
+            ],
+            "connection_string": "druid://{username}:{password}@{host}/druid/v2/sql",
+            "docs_url": "https://docs.imply.io/"
+          }
+        ],
+        "category": "Apache Projects"
+      },
+      "engine": "druid",
+      "engine_name": "Apache Druid",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache Hive": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.hive",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": false,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 767,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": true,
+      "file_upload": true,
+      "get_extra_table_metadata": true,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": true,
+      "expand_data": true,
+      "query_cost_estimation": true,
+      "sql_validation": false,
+      "score": 140,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Hive is a data warehouse infrastructure built on Hadoop.",
+        "logo": "apache-hive.svg",
+        "homepage_url": "https://hive.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Query Engines",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "pyhive"
+        ],
+        "connection_string": "hive://hive@{hostname}:{port}/{database}",
+        "default_port": 10000,
+        "category": "Apache Projects"
+      },
+      "engine": "hive",
+      "engine_name": "Apache Hive",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Apache Impala": {
+      "time_grains": {
+        "SECOND": false,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.impala",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
       "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 37,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Impala is an open-source massively parallel processing SQL query engine.",
+        "logo": "apache-impala.png",
+        "homepage_url": "https://impala.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Query Engines",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "impyla"
+        ],
+        "connection_string": "impala://{hostname}:{port}/{database}",
+        "default_port": 21050,
+        "category": "Apache Projects"
+      },
+      "engine": "impala",
+      "engine_name": "Apache Impala",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache IoTDB": {
+      "time_grains": {
+        "SECOND": false,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": false,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": false,
+        "SIX_HOURS": false,
+        "DAY": false,
+        "WEEK": false,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": false,
+        "QUARTER": false,
+        "QUARTER_YEAR": false,
+        "YEAR": false
+      },
+      "module": "superset.db_engine_specs.iotdb",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 20,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache IoTDB is a time series database designed for IoT data, with efficient storage and query capabilities for massive time series data.",
+        "logo": "apache-iotdb.svg",
+        "homepage_url": "https://iotdb.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Time Series Databases",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "apache-iotdb"
+        ],
+        "connection_string": "iotdb://{username}:{password}@{hostname}:{port}",
+        "default_port": 6667,
+        "parameters": {
+          "username": "Database username (default: root)",
+          "password": "Database password (default: root)",
+          "hostname": "IP address or hostname",
+          "port": "Default 6667"
+        },
+        "notes": "The IoTDB SQLAlchemy dialect was written to integrate with Apache Superset. IoTDB uses a hierarchical data model, which is reorganized into a relational model for SQL queries.",
+        "category": "Apache Projects"
+      },
+      "engine": "iotdb",
+      "engine_name": "Apache IoTDB",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache Kylin": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.kylin",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Kylin is an open-source OLAP engine for big data.",
+        "logo": "apache-kylin.png",
+        "homepage_url": "https://kylin.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Analytical Databases",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "kylinpy"
+        ],
+        "connection_string": "kylin://{username}:{password}@{hostname}:{port}/{project}?{param1}={value1}&{param2}={value2}",
+        "default_port": 7070,
+        "category": "Apache Projects"
+      },
+      "engine": "kylin",
+      "engine_name": "Apache Kylin",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache Phoenix": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.phoenix",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Phoenix is a relational database layer over Apache HBase, providing low-latency SQL queries over HBase data.",
+        "logo": "apache-phoenix.png",
+        "homepage_url": "https://phoenix.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Analytical Databases",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "phoenixdb"
+        ],
+        "connection_string": "phoenix://{hostname}:{port}/",
+        "default_port": 8765,
+        "notes": "Phoenix provides a SQL interface to Apache HBase. The phoenixdb driver connects via the Phoenix Query Server and supports a subset of SQLAlchemy.",
+        "category": "Apache Projects"
+      },
+      "engine": "phoenix",
+      "engine_name": "Apache Phoenix",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache Pinot": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.pinot",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": false,
+      "subqueries": false,
+      "alias_in_select": false,
+      "alias_in_orderby": false,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 32,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Pinot is a real-time distributed OLAP datastore.",
+        "logo": "apache-pinot.svg",
+        "homepage_url": "https://pinot.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Time Series Databases",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "pinotdb"
+        ],
+        "connection_string": "pinot+http://{broker_host}:{broker_port}/query?controller=http://{controller_host}:{controller_port}/",
+        "default_port": 8099,
+        "connection_examples": [
+          {
+            "description": "With authentication",
+            "connection_string": "pinot://{username}:{password}@{broker_host}:{broker_port}/query/sql?controller=http://{controller_host}:{controller_port}/verify_ssl=true"
+          }
+        ],
+        "engine_parameters": [
+          {
+            "name": "Multi-stage Query Engine",
+            "description": "Enable for Explore view, joins, window functions",
+            "json": {
+              "connect_args": {
+                "use_multistage_engine": "true"
+              }
+            },
+            "docs_url": "https://docs.pinot.apache.org/reference/multi-stage-engine"
+          }
+        ],
+        "category": "Apache Projects"
+      },
+      "engine": "pinot",
+      "engine_name": "Apache Pinot",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache Solr": {
+      "time_grains": {
+        "SECOND": false,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": false,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": false,
+        "SIX_HOURS": false,
+        "DAY": false,
+        "WEEK": false,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": false,
+        "QUARTER": false,
+        "QUARTER_YEAR": false,
+        "YEAR": false
+      },
+      "module": "superset.db_engine_specs.solr",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": false,
+      "subqueries": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 20,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Solr is an open-source enterprise search platform.",
+        "logo": "apache-solr.png",
+        "homepage_url": "https://solr.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Search & NoSQL",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "sqlalchemy-solr"
+        ],
+        "connection_string": "solr://{username}:{password}@{host}:{port}/{server_path}/{collection}[/?use_ssl=true|false]",
+        "default_port": 8983,
+        "category": "Apache Projects"
+      },
+      "engine": "solr",
+      "engine_name": "Apache Solr",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Apache Spark SQL": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.spark",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": false,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 767,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": true,
+      "file_upload": true,
+      "get_extra_table_metadata": true,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": true,
+      "expand_data": true,
+      "query_cost_estimation": true,
+      "sql_validation": false,
+      "score": 140,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Spark SQL is a module for structured data processing.",
+        "logo": "apache-spark.png",
+        "homepage_url": "https://spark.apache.org/sql/",
+        "categories": [
+          "Apache Projects",
+          "Query Engines",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "pyhive"
+        ],
+        "connection_string": "hive://hive@{hostname}:{port}/{database}",
+        "default_port": 10000,
+        "category": "Apache Projects"
+      },
+      "engine": "hive",
+      "engine_name": "Apache Spark SQL",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Arc": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.arc",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
+      "documentation": {
+        "description": "Arc is a data platform with multiple connection options.",
+        "categories": [
+          "Other Databases",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "arc-superset-arrow"
+        ],
+        "connection_string": "arc+arrow://{api_key}@{hostname}:{port}/{database}",
+        "parameters": {
+          "api_key": "Arc API key",
+          "hostname": "Arc hostname",
+          "port": "Arc port",
+          "database": "Database name"
+        },
+        "drivers": [
+          {
+            "name": "Apache Arrow (Recommended)",
+            "pypi_package": "arc-superset-arrow",
+            "connection_string": "arc+arrow://{api_key}@{hostname}:{port}/{database}",
+            "is_recommended": true,
+            "notes": "Recommended for production. Provides 3-5x better performance using Apache Arrow IPC."
+          },
+          {
+            "name": "JSON",
+            "pypi_package": "arc-superset-dialect",
+            "connection_string": "arc+json://{api_key}@{hostname}:{port}/{database}",
+            "is_recommended": false
+          }
+        ],
+        "notes": "Arc supports multiple databases (schemas) within a single instance. Each Arc database appears as a schema in SQL Lab.",
+        "category": "Other Databases"
+      },
+      "engine": "arc",
+      "engine_name": "Arc",
+      "engine_aliases": [],
+      "default_driver": "arrow",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Ascend": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.ascend",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 38,
+      "max_score": 201,
+      "documentation": {
+        "description": "Ascend.io is a data automation platform for building data pipelines.",
+        "logo": "ascend.webp",
+        "homepage_url": "https://www.ascend.io/",
+        "categories": [
+          "Cloud Data Warehouses",
+          "Analytical Databases",
+          "Hosted Open Source"
+        ],
+        "pypi_packages": [
+          "impyla"
+        ],
+        "connection_string": "ascend://{username}:{password}@{hostname}:{port}/{database}?auth_mechanism=PLAIN;use_ssl=true",
+        "category": "Other Databases"
+      },
+      "engine": "ascend",
+      "engine_name": "Ascend",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Aurora MySQL": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.aurora",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 64,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 59,
+      "max_score": 201,
+      "documentation": {
+        "description": "MySQL is a popular open-source relational database.",
+        "logo": "mysql.png",
+        "homepage_url": "https://www.mysql.com/",
+        "categories": [
+          "Traditional RDBMS",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "mysqlclient"
+        ],
+        "connection_string": "mysql://{username}:{password}@{host}/{database}",
+        "default_port": 3306,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "localhost, 127.0.0.1, IP address, or hostname",
+          "database": "Database name"
+        },
+        "host_examples": [
+          {
+            "platform": "Localhost",
+            "host": "localhost or 127.0.0.1"
+          },
+          {
+            "platform": "Docker on Linux",
+            "host": "172.18.0.1"
+          },
+          {
+            "platform": "Docker on macOS",
+            "host": "docker.for.mac.host.internal"
+          },
+          {
+            "platform": "On-premise",
+            "host": "IP address or hostname"
+          }
+        ],
+        "drivers": [
+          {
+            "name": "mysqlclient",
+            "pypi_package": "mysqlclient",
+            "connection_string": "mysql://{username}:{password}@{host}/{database}",
+            "is_recommended": true,
+            "notes": "Recommended driver. May fail with caching_sha2_password auth."
+          },
+          {
+            "name": "mysql-connector-python",
+            "pypi_package": "mysql-connector-python",
+            "connection_string": "mysql+mysqlconnector://{username}:{password}@{host}/{database}",
+            "is_recommended": false,
+            "notes": "Required for newer MySQL databases using caching_sha2_password authentication."
+          }
+        ],
+        "compatible_databases": [
+          {
+            "name": "MariaDB",
+            "description": "MariaDB is a community-developed fork of MySQL, fully compatible with MySQL.",
+            "logo": "mariadb.png",
+            "homepage_url": "https://mariadb.org/",
+            "pypi_packages": [
+              "mysqlclient"
+            ],
+            "connection_string": "mysql://{username}:{password}@{host}:{port}/{database}",
+            "categories": [
+              "Open Source"
+            ]
+          },
+          {
+            "name": "Amazon Aurora MySQL",
+            "description": "Amazon Aurora MySQL is a fully managed, MySQL-compatible relational database with up to 5x the throughput of standard MySQL.",
+            "logo": "aws-aurora.jpg",
+            "homepage_url": "https://aws.amazon.com/rds/aurora/",
+            "pypi_packages": [
+              "sqlalchemy-aurora-data-api"
+            ],
+            "connection_string": "mysql+auroradataapi://{aws_access_id}:{aws_secret_access_key}@/{database_name}?aurora_cluster_arn={aurora_cluster_arn}&secret_arn={secret_arn}&region_name={region_name}",
+            "parameters": {
+              "aws_access_id": "AWS Access Key ID",
+              "aws_secret_access_key": "AWS Secret Access Key",
+              "database_name": "Database name",
+              "aurora_cluster_arn": "Aurora cluster ARN",
+              "secret_arn": "Secrets Manager ARN for credentials",
+              "region_name": "AWS region (e.g., us-east-1)"
+            },
+            "notes": "Uses the Data API for serverless access. Standard MySQL connections also work with mysqlclient.",
+            "categories": [
+              "Cloud - AWS",
+              "Hosted Open Source"
+            ]
+          }
+        ],
+        "category": "Traditional RDBMS"
+      },
+      "engine": "mysql",
+      "engine_name": "Aurora MySQL",
+      "engine_aliases": [],
+      "default_driver": "mysqldb",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Aurora MySQL (Data API)": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.aurora",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 64,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 59,
+      "max_score": 201,
+      "documentation": {
+        "description": "MySQL is a popular open-source relational database.",
+        "logo": "mysql.png",
+        "homepage_url": "https://www.mysql.com/",
+        "categories": [
+          "Traditional RDBMS",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "mysqlclient"
+        ],
+        "connection_string": "mysql://{username}:{password}@{host}/{database}",
+        "default_port": 3306,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "localhost, 127.0.0.1, IP address, or hostname",
+          "database": "Database name"
+        },
+        "host_examples": [
+          {
+            "platform": "Localhost",
+            "host": "localhost or 127.0.0.1"
+          },
+          {
+            "platform": "Docker on Linux",
+            "host": "172.18.0.1"
+          },
+          {
+            "platform": "Docker on macOS",
+            "host": "docker.for.mac.host.internal"
+          },
+          {
+            "platform": "On-premise",
+            "host": "IP address or hostname"
+          }
+        ],
+        "drivers": [
+          {
+            "name": "mysqlclient",
+            "pypi_package": "mysqlclient",
+            "connection_string": "mysql://{username}:{password}@{host}/{database}",
+            "is_recommended": true,
+            "notes": "Recommended driver. May fail with caching_sha2_password auth."
+          },
+          {
+            "name": "mysql-connector-python",
+            "pypi_package": "mysql-connector-python",
+            "connection_string": "mysql+mysqlconnector://{username}:{password}@{host}/{database}",
+            "is_recommended": false,
+            "notes": "Required for newer MySQL databases using caching_sha2_password authentication."
+          }
+        ],
+        "compatible_databases": [
+          {
+            "name": "MariaDB",
+            "description": "MariaDB is a community-developed fork of MySQL, fully compatible with MySQL.",
+            "logo": "mariadb.png",
+            "homepage_url": "https://mariadb.org/",
+            "pypi_packages": [
+              "mysqlclient"
+            ],
+            "connection_string": "mysql://{username}:{password}@{host}:{port}/{database}",
+            "categories": [
+              "Open Source"
+            ]
+          },
+          {
+            "name": "Amazon Aurora MySQL",
+            "description": "Amazon Aurora MySQL is a fully managed, MySQL-compatible relational database with up to 5x the throughput of standard MySQL.",
+            "logo": "aws-aurora.jpg",
+            "homepage_url": "https://aws.amazon.com/rds/aurora/",
+            "pypi_packages": [
+              "sqlalchemy-aurora-data-api"
+            ],
+            "connection_string": "mysql+auroradataapi://{aws_access_id}:{aws_secret_access_key}@/{database_name}?aurora_cluster_arn={aurora_cluster_arn}&secret_arn={secret_arn}&region_name={region_name}",
+            "parameters": {
+              "aws_access_id": "AWS Access Key ID",
+              "aws_secret_access_key": "AWS Secret Access Key",
+              "database_name": "Database name",
+              "aurora_cluster_arn": "Aurora cluster ARN",
+              "secret_arn": "Secrets Manager ARN for credentials",
+              "region_name": "AWS region (e.g., us-east-1)"
+            },
+            "notes": "Uses the Data API for serverless access. Standard MySQL connections also work with mysqlclient.",
+            "categories": [
+              "Cloud - AWS",
+              "Hosted Open Source"
+            ]
+          }
+        ],
+        "category": "Traditional RDBMS"
+      },
+      "engine": "mysql",
+      "engine_name": "Aurora MySQL (Data API)",
+      "engine_aliases": [],
+      "default_driver": "auroradataapi",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Aurora PostgreSQL": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.aurora",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 63,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": true,
+      "sql_validation": true,
+      "score": 104,
+      "max_score": 201,
+      "documentation": {
+        "description": "PostgreSQL is an advanced open-source relational database.",
+        "logo": "postgresql.svg",
+        "homepage_url": "https://www.postgresql.org/",
+        "categories": [
+          "Traditional RDBMS",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "psycopg2"
+        ],
+        "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+        "default_port": 5432,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "For localhost: localhost or 127.0.0.1. For AWS: endpoint URL",
+          "port": "Default 5432",
+          "database": "Database name"
+        },
+        "notes": "The psycopg2 library comes bundled with Superset Docker images.",
+        "connection_examples": [
+          {
+            "description": "Basic connection",
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}"
+          },
+          {
+            "description": "With SSL required",
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
+          }
+        ],
+        "docs_url": "https://www.postgresql.org/docs/",
+        "sqlalchemy_docs_url": "https://docs.sqlalchemy.org/en/13/dialects/postgresql.html",
+        "compatible_databases": [
+          {
+            "name": "Hologres",
+            "description": "Alibaba Cloud real-time interactive analytics service, fully compatible with PostgreSQL 11.",
+            "logo": "hologres.png",
+            "homepage_url": "https://www.alibabacloud.com/product/hologres",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql+psycopg2://{username}:{password}@{host}:{port}/{database}",
+            "parameters": {
+              "username": "AccessKey ID of your Alibaba Cloud account",
+              "password": "AccessKey secret of your Alibaba Cloud account",
+              "host": "Public endpoint of the Hologres instance",
+              "port": "Port number of the Hologres instance",
+              "database": "Name of the Hologres database"
+            },
+            "categories": [
+              "Proprietary"
+            ]
+          },
+          {
+            "name": "TimescaleDB",
+            "description": "Open-source relational database for time-series and analytics, built on PostgreSQL.",
+            "logo": "timescale.png",
+            "homepage_url": "https://www.timescale.com/",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+            "connection_examples": [
+              {
+                "description": "Timescale Cloud (SSL required)",
+                "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
+              }
+            ],
+            "notes": "psycopg2 comes bundled with Superset Docker images.",
+            "docs_url": "https://docs.timescale.com/",
+            "categories": [
+              "Open Source"
+            ]
+          },
+          {
+            "name": "YugabyteDB",
+            "description": "Distributed SQL database built on top of PostgreSQL.",
+            "logo": "yugabyte.png",
+            "homepage_url": "https://www.yugabyte.com/",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+            "notes": "psycopg2 comes bundled with Superset Docker images.",
+            "docs_url": "https://www.yugabyte.com/",
+            "categories": [
+              "Open Source"
+            ]
+          },
+          {
+            "name": "Supabase",
+            "description": "Open-source Firebase alternative built on top of PostgreSQL, providing a full backend-as-a-service with a hosted Postgres database.",
+            "logo": "supabase.svg",
+            "homepage_url": "https://supabase.com/",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+            "connection_examples": [
+              {
+                "description": "Supabase project (connection pooler)",
+                "connection_string": "postgresql://{username}.{project_ref}:{password}@aws-0-{region}.pooler.supabase.com:6543/{database}"
+              }
+            ],
+            "parameters": {
+              "username": "Database user (default: postgres)",
+              "password": "Database password",
+              "host": "Supabase project host (from project settings)",
+              "port": "Default 5432 (direct) or 6543 (pooler)",
+              "database": "Database name (default: postgres)",
+              "project_ref": "Supabase project reference (from project settings)",
+              "region": "Supabase project region (e.g., us-east-1)"
+            },
+            "notes": "Find connection details in your Supabase project dashboard under Settings > Database. Use the connection pooler (port 6543) for better connection management.",
+            "docs_url": "https://supabase.com/docs/guides/database/connecting-to-postgres",
+            "categories": [
+              "Hosted Open Source"
+            ]
+          },
+          {
+            "name": "Google AlloyDB",
+            "description": "Google Cloud's PostgreSQL-compatible database service for demanding transactional and analytical workloads.",
+            "logo": "alloydb.png",
+            "homepage_url": "https://cloud.google.com/alloydb",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+            "parameters": {
+              "username": "Database user (default: postgres)",
+              "password": "Database password",
+              "host": "AlloyDB instance IP or Auth Proxy address",
+              "port": "Default 5432",
+              "database": "Database name"
+            },
+            "notes": "For public IP connections, use the AlloyDB Auth Proxy for secure access. Private IP connections can connect directly.",
+            "docs_url": "https://cloud.google.com/alloydb/docs",
+            "categories": [
+              "Cloud - Google",
+              "Hosted Open Source"
+            ]
+          },
+          {
+            "name": "Neon",
+            "description": "Serverless PostgreSQL with branching, scale-to-zero, and bottomless storage.",
+            "logo": "neon.png",
+            "homepage_url": "https://neon.tech/",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}/{database}?sslmode=require",
+            "parameters": {
+              "username": "Neon role name",
+              "password": "Neon role password",
+              "host": "Neon hostname (e.g., ep-cool-name-123456.us-east-2.aws.neon.tech)",
+              "database": "Database name (default: neondb)"
+            },
+            "notes": "SSL is required for all connections. Find connection details in the Neon console under Connection Details.",
+            "docs_url": "https://neon.tech/docs/connect/connect-from-any-app",
+            "categories": [
+              "Hosted Open Source"
+            ]
+          },
+          {
+            "name": "Amazon Aurora PostgreSQL",
+            "description": "Amazon Aurora PostgreSQL is a fully managed, PostgreSQL-compatible relational database with up to 5x the throughput of standard PostgreSQL.",
+            "logo": "aws-aurora.jpg",
+            "homepage_url": "https://aws.amazon.com/rds/aurora/",
+            "pypi_packages": [
+              "sqlalchemy-aurora-data-api"
+            ],
+            "connection_string": "postgresql+auroradataapi://{aws_access_id}:{aws_secret_access_key}@/{database_name}?aurora_cluster_arn={aurora_cluster_arn}&secret_arn={secret_arn}&region_name={region_name}",
+            "parameters": {
+              "aws_access_id": "AWS Access Key ID",
+              "aws_secret_access_key": "AWS Secret Access Key",
+              "database_name": "Database name",
+              "aurora_cluster_arn": "Aurora cluster ARN",
+              "secret_arn": "Secrets Manager ARN for credentials",
+              "region_name": "AWS region (e.g., us-east-1)"
+            },
+            "notes": "Uses the Data API for serverless access. Standard PostgreSQL connections also work with psycopg2.",
+            "categories": [
+              "Cloud - AWS",
+              "Hosted Open Source"
+            ]
+          }
+        ],
+        "category": "Traditional RDBMS"
+      },
+      "engine": "postgresql",
+      "engine_name": "Aurora PostgreSQL",
+      "engine_aliases": [
+        "postgres"
+      ],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Aurora PostgreSQL (Data API)": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.aurora",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 63,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": true,
+      "sql_validation": true,
+      "score": 104,
+      "max_score": 201,
+      "documentation": {
+        "description": "PostgreSQL is an advanced open-source relational database.",
+        "logo": "postgresql.svg",
+        "homepage_url": "https://www.postgresql.org/",
+        "categories": [
+          "Traditional RDBMS",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "psycopg2"
+        ],
+        "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+        "default_port": 5432,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "For localhost: localhost or 127.0.0.1. For AWS: endpoint URL",
+          "port": "Default 5432",
+          "database": "Database name"
+        },
+        "notes": "The psycopg2 library comes bundled with Superset Docker images.",
+        "connection_examples": [
+          {
+            "description": "Basic connection",
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}"
+          },
+          {
+            "description": "With SSL required",
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
+          }
+        ],
+        "docs_url": "https://www.postgresql.org/docs/",
+        "sqlalchemy_docs_url": "https://docs.sqlalchemy.org/en/13/dialects/postgresql.html",
+        "compatible_databases": [
+          {
+            "name": "Hologres",
+            "description": "Alibaba Cloud real-time interactive analytics service, fully compatible with PostgreSQL 11.",
+            "logo": "hologres.png",
+            "homepage_url": "https://www.alibabacloud.com/product/hologres",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql+psycopg2://{username}:{password}@{host}:{port}/{database}",
+            "parameters": {
+              "username": "AccessKey ID of your Alibaba Cloud account",
+              "password": "AccessKey secret of your Alibaba Cloud account",
+              "host": "Public endpoint of the Hologres instance",
+              "port": "Port number of the Hologres instance",
+              "database": "Name of the Hologres database"
+            },
+            "categories": [
+              "Proprietary"
+            ]
+          },
+          {
+            "name": "TimescaleDB",
+            "description": "Open-source relational database for time-series and analytics, built on PostgreSQL.",
+            "logo": "timescale.png",
+            "homepage_url": "https://www.timescale.com/",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+            "connection_examples": [
+              {
+                "description": "Timescale Cloud (SSL required)",
+                "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
+              }
+            ],
+            "notes": "psycopg2 comes bundled with Superset Docker images.",
+            "docs_url": "https://docs.timescale.com/",
+            "categories": [
+              "Open Source"
+            ]
+          },
+          {
+            "name": "YugabyteDB",
+            "description": "Distributed SQL database built on top of PostgreSQL.",
+            "logo": "yugabyte.png",
+            "homepage_url": "https://www.yugabyte.com/",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+            "notes": "psycopg2 comes bundled with Superset Docker images.",
+            "docs_url": "https://www.yugabyte.com/",
+            "categories": [
+              "Open Source"
+            ]
+          },
+          {
+            "name": "Supabase",
+            "description": "Open-source Firebase alternative built on top of PostgreSQL, providing a full backend-as-a-service with a hosted Postgres database.",
+            "logo": "supabase.svg",
+            "homepage_url": "https://supabase.com/",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+            "connection_examples": [
+              {
+                "description": "Supabase project (connection pooler)",
+                "connection_string": "postgresql://{username}.{project_ref}:{password}@aws-0-{region}.pooler.supabase.com:6543/{database}"
+              }
+            ],
+            "parameters": {
+              "username": "Database user (default: postgres)",
+              "password": "Database password",
+              "host": "Supabase project host (from project settings)",
+              "port": "Default 5432 (direct) or 6543 (pooler)",
+              "database": "Database name (default: postgres)",
+              "project_ref": "Supabase project reference (from project settings)",
+              "region": "Supabase project region (e.g., us-east-1)"
+            },
+            "notes": "Find connection details in your Supabase project dashboard under Settings > Database. Use the connection pooler (port 6543) for better connection management.",
+            "docs_url": "https://supabase.com/docs/guides/database/connecting-to-postgres",
+            "categories": [
+              "Hosted Open Source"
+            ]
+          },
+          {
+            "name": "Google AlloyDB",
+            "description": "Google Cloud's PostgreSQL-compatible database service for demanding transactional and analytical workloads.",
+            "logo": "alloydb.png",
+            "homepage_url": "https://cloud.google.com/alloydb",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
+            "parameters": {
+              "username": "Database user (default: postgres)",
+              "password": "Database password",
+              "host": "AlloyDB instance IP or Auth Proxy address",
+              "port": "Default 5432",
+              "database": "Database name"
+            },
+            "notes": "For public IP connections, use the AlloyDB Auth Proxy for secure access. Private IP connections can connect directly.",
+            "docs_url": "https://cloud.google.com/alloydb/docs",
+            "categories": [
+              "Cloud - Google",
+              "Hosted Open Source"
+            ]
+          },
+          {
+            "name": "Neon",
+            "description": "Serverless PostgreSQL with branching, scale-to-zero, and bottomless storage.",
+            "logo": "neon.png",
+            "homepage_url": "https://neon.tech/",
+            "pypi_packages": [
+              "psycopg2"
+            ],
+            "connection_string": "postgresql://{username}:{password}@{host}/{database}?sslmode=require",
+            "parameters": {
+              "username": "Neon role name",
+              "password": "Neon role password",
+              "host": "Neon hostname (e.g., ep-cool-name-123456.us-east-2.aws.neon.tech)",
+              "database": "Database name (default: neondb)"
+            },
+            "notes": "SSL is required for all connections. Find connection details in the Neon console under Connection Details.",
+            "docs_url": "https://neon.tech/docs/connect/connect-from-any-app",
+            "categories": [
+              "Hosted Open Source"
+            ]
+          },
+          {
+            "name": "Amazon Aurora PostgreSQL",
+            "description": "Amazon Aurora PostgreSQL is a fully managed, PostgreSQL-compatible relational database with up to 5x the throughput of standard PostgreSQL.",
+            "logo": "aws-aurora.jpg",
+            "homepage_url": "https://aws.amazon.com/rds/aurora/",
+            "pypi_packages": [
+              "sqlalchemy-aurora-data-api"
+            ],
+            "connection_string": "postgresql+auroradataapi://{aws_access_id}:{aws_secret_access_key}@/{database_name}?aurora_cluster_arn={aurora_cluster_arn}&secret_arn={secret_arn}&region_name={region_name}",
+            "parameters": {
+              "aws_access_id": "AWS Access Key ID",
+              "aws_secret_access_key": "AWS Secret Access Key",
+              "database_name": "Database name",
+              "aurora_cluster_arn": "Aurora cluster ARN",
+              "secret_arn": "Secrets Manager ARN for credentials",
+              "region_name": "AWS region (e.g., us-east-1)"
+            },
+            "notes": "Uses the Data API for serverless access. Standard PostgreSQL connections also work with psycopg2.",
+            "categories": [
+              "Cloud - AWS",
+              "Hosted Open Source"
+            ]
+          }
+        ],
+        "category": "Traditional RDBMS"
+      },
+      "engine": "postgresql",
+      "engine_name": "Aurora PostgreSQL (Data API)",
+      "engine_aliases": [
+        "postgres"
+      ],
+      "default_driver": "auroradataapi",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Azure Data Explorer": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": true,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.kusto",
+      "limit_method": 2,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": true,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": false,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 54,
+      "max_score": 201,
+      "documentation": {
+        "description": "Azure Data Explorer (Kusto) is a fast, fully managed data analytics service from Microsoft Azure. Query data using SQL or native KQL syntax.",
+        "logo": "kusto.png",
+        "homepage_url": "https://azure.microsoft.com/en-us/products/data-explorer/",
+        "categories": [
+          "Cloud - Azure",
+          "Analytical Databases",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "sqlalchemy-kusto"
+        ],
+        "connection_string": "kustosql+https://{cluster}.kusto.windows.net/{database}?msi=False&azure_ad_client_id={client_id}&azure_ad_client_secret={client_secret}&azure_ad_tenant_id={tenant_id}",
+        "parameters": {
+          "cluster": "Azure Data Explorer cluster name",
+          "database": "Database name",
+          "client_id": "Azure AD application (client) ID",
+          "client_secret": "Azure AD application secret",
+          "tenant_id": "Azure AD tenant ID"
+        },
+        "drivers": [
+          {
+            "name": "SQL Interface (Recommended)",
+            "pypi_package": "sqlalchemy-kusto",
+            "connection_string": "kustosql+https://{cluster}.kusto.windows.net/{database}?msi=False&azure_ad_client_id={client_id}&azure_ad_client_secret={client_secret}&azure_ad_tenant_id={tenant_id}",
+            "is_recommended": true,
+            "notes": "Use familiar SQL syntax to query Azure Data Explorer."
+          },
+          {
+            "name": "KQL (Kusto Query Language)",
+            "pypi_package": "sqlalchemy-kusto",
+            "connection_string": "kustokql+https://{cluster}.kusto.windows.net/{database}?msi=False&azure_ad_client_id={client_id}&azure_ad_client_secret={client_secret}&azure_ad_tenant_id={tenant_id}",
+            "is_recommended": false,
+            "notes": "Use native Kusto Query Language for advanced analytics."
+          }
+        ],
+        "category": "Cloud - Azure"
+      },
+      "engine": "kustosql",
+      "engine_name": "Azure Data Explorer",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Azure Data Explorer (KQL)": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": false,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.kusto",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": true,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": false,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 40,
+      "max_score": 201,
+      "documentation": {
+        "pypi_packages": [],
+        "connection_string": "engine+driver://user:password@host:port/dbname[?key=value&key=value...]",
+        "category": "Cloud - Azure"
+      },
+      "engine": "kustokql",
+      "engine_name": "Azure Data Explorer (KQL)",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Azure Synapse": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.mssql",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": false,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 44,
+      "max_score": 201,
+      "documentation": {
+        "description": "Azure Synapse Analytics is a cloud-based enterprise data warehouse from Microsoft that combines big data and data warehousing.",
+        "logo": "azure.svg",
+        "homepage_url": "https://azure.microsoft.com/en-us/products/synapse-analytics/",
+        "categories": [
+          "Cloud Data Warehouses",
+          "Analytical Databases",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "pymssql"
+        ],
+        "connection_string": "mssql+pymssql://{username}@{server}:{password}@{server}.database.windows.net:1433/{database}",
+        "category": "Cloud - Azure",
+        "custom_errors": [
+          {
+            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
+            "message_template": "Either the username \"%(username)s\", password, or database name \"%(database)s\" is incorrect.",
+            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
+            "category": "Authentication",
+            "description": "Access denied",
+            "issue_codes": [
+              1014,
+              1015
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
+            "message_template": "The hostname \"%(hostname)s\" cannot be resolved.",
+            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
+            "category": "Connection",
+            "description": "Invalid hostname",
+            "issue_codes": [
+              1007
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_PORT_CLOSED_REGEX",
+            "message_template": "Port %(port)s on hostname \"%(hostname)s\" refused the connection.",
+            "error_type": "CONNECTION_PORT_CLOSED_ERROR",
+            "category": "Connection",
+            "description": "Port closed or refused",
+            "issue_codes": [
+              1008
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
+            "message_template": "The host \"%(hostname)s\" might be down, and can't be reached on port %(port)s.",
+            "error_type": "CONNECTION_HOST_DOWN_ERROR",
+            "category": "Connection",
+            "description": "Host unreachable",
+            "issue_codes": [
+              1009
+            ]
+          }
+        ]
+      },
+      "engine": "mssql",
+      "engine_name": "Azure Synapse",
+      "engine_aliases": [],
+      "default_driver": "pyodbc",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "ClickHouse": {
-      "engine": "clickhouse",
-      "engine_name": "ClickHouse",
-      "module": "clickhouse",
+      "time_grains": {
+        "SECOND": false,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.clickhouse",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": true,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": false,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 61,
+      "max_score": 201,
       "documentation": {
         "description": "ClickHouse is an open-source column-oriented database for real-time analytics using SQL. It's known for extremely fast query performance on large datasets.",
         "logo": "clickhouse.png",
         "homepage_url": "https://clickhouse.com/",
         "categories": [
-          "ANALYTICAL_DATABASES",
-          "OPEN_SOURCE"
+          "Analytical Databases",
+          "Open Source"
         ],
         "pypi_packages": [
           "clickhouse-connect>=0.13.0"
@@ -792,9 +3200,9 @@
             "logo": "clickhouse.png",
             "homepage_url": "https://clickhouse.cloud/",
             "categories": [
-              "ANALYTICAL_DATABASES",
-              "CLOUD_DATA_WAREHOUSES",
-              "HOSTED_OPEN_SOURCE"
+              "Analytical Databases",
+              "Cloud Data Warehouses",
+              "Hosted Open Source"
             ],
             "pypi_packages": [
               "clickhouse-connect>=0.13.0"
@@ -814,9 +3222,9 @@
             "logo": "altinity.png",
             "homepage_url": "https://altinity.cloud/",
             "categories": [
-              "ANALYTICAL_DATABASES",
-              "CLOUD_DATA_WAREHOUSES",
-              "HOSTED_OPEN_SOURCE"
+              "Analytical Databases",
+              "Cloud Data Warehouses",
+              "Hosted Open Source"
             ],
             "pypi_packages": [
               "clickhouse-connect>=0.13.0"
@@ -824,8 +3232,19 @@
             "connection_string": "clickhousedb://{username}:{password}@{host}/{database}?secure=true",
             "docs_url": "https://docs.altinity.com/"
           }
-        ]
+        ],
+        "category": "Analytical Databases"
       },
+      "engine": "clickhousedb",
+      "engine_name": "ClickHouse",
+      "engine_aliases": [],
+      "default_driver": "connect",
+      "supports_file_upload": false,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "ClickHouse (sqlalchemy)": {
       "time_grains": {
         "SECOND": false,
         "FIVE_SECONDS": false,
@@ -849,59 +3268,145 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 51,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.clickhouse",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": true,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": false,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 51,
+      "max_score": 201,
+      "documentation": {
+        "pypi_packages": [],
+        "connection_string": "engine+driver://user:password@host:port/dbname[?key=value&key=value...]",
+        "category": "Analytical Databases"
+      },
+      "engine": "clickhouse",
+      "engine_name": "ClickHouse (sqlalchemy)",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": false,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Cloudflare D1": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": true,
+        "HOUR": true,
+        "SIX_HOURS": true,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": true,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.d1",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": false,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 41,
+      "max_score": 201,
+      "documentation": {
+        "description": "Cloudflare D1 is a serverless SQLite database.",
+        "logo": "cloudflare.png",
+        "homepage_url": "https://developers.cloudflare.com/d1/",
+        "categories": [
+          "Cloud Data Warehouses",
+          "Traditional RDBMS",
+          "Hosted Open Source"
+        ],
+        "pypi_packages": [
+          "superset-engine-d1"
+        ],
+        "connection_string": "d1://{cloudflare_account_id}:{cloudflare_api_token}@{cloudflare_d1_database_id}",
+        "parameters": {
+          "cloudflare_account_id": "Cloudflare account ID",
+          "cloudflare_api_token": "Cloudflare API token",
+          "cloudflare_d1_database_id": "D1 database ID"
+        },
+        "install_instructions": "pip install superset-engine-d1",
+        "category": "Other Databases"
+      },
+      "engine": "d1",
+      "engine_name": "Cloudflare D1",
+      "engine_aliases": [],
+      "default_driver": "d1",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "CockroachDB": {
-      "engine": "cockroachdb",
-      "engine_name": "CockroachDB",
-      "module": "cockroachdb",
-      "documentation": {
-        "description": "CockroachDB is a distributed SQL database built for cloud applications.",
-        "logo": "cockroachdb.png",
-        "homepage_url": "https://www.cockroachlabs.com/",
-        "pypi_packages": [
-          "psycopg2",
-          "cockroachdb"
-        ],
-        "connection_string": "cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable",
-        "default_port": 26257,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "For localhost: localhost or 127.0.0.1. For AWS: endpoint URL",
-          "port": "Default 5432",
-          "database": "Database name"
-        },
-        "notes": "The psycopg2 library comes bundled with Superset Docker images.",
-        "connection_examples": [
-          {
-            "description": "Basic connection",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}"
-          },
-          {
-            "description": "With SSL required",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
-          }
-        ],
-        "docs_url": "https://github.com/cockroachdb/sqlalchemy-cockroachdb",
-        "sqlalchemy_docs_url": "https://docs.sqlalchemy.org/en/13/dialects/postgresql.html",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
-        ]
-      },
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": true,
@@ -925,53 +3430,69 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 94,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.cockroachdb",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": true,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 63,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
       "ssh_tunneling": true,
       "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": true,
-      "sql_validation": false
-    },
-    "Couchbase": {
-      "engine": "couchbase",
-      "engine_name": "Couchbase",
-      "module": "couchbase",
+      "sql_validation": false,
+      "score": 94,
+      "max_score": 201,
       "documentation": {
-        "description": "Couchbase is a distributed NoSQL document database with SQL++ support.",
-        "logo": "couchbase.svg",
-        "homepage_url": "https://www.couchbase.com/",
+        "description": "CockroachDB is a distributed SQL database built for cloud applications.",
+        "logo": "cockroachdb.png",
+        "homepage_url": "https://www.cockroachlabs.com/",
         "categories": [
-          "SEARCH_NOSQL",
-          "OPEN_SOURCE"
+          "Traditional RDBMS",
+          "Open Source"
         ],
         "pypi_packages": [
-          "couchbase-sqlalchemy"
+          "cockroachdb"
         ],
-        "connection_string": "couchbase://{username}:{password}@{host}:{port}?ssl=true",
-        "default_port": 8091,
-        "parameters": {
-          "username": "Couchbase username",
-          "password": "Couchbase password",
-          "host": "Couchbase host or connection string for cloud",
-          "port": "Couchbase port (default 8091)",
-          "database": "Couchbase database/bucket name"
-        },
-        "drivers": [
-          {
-            "name": "couchbase-sqlalchemy",
-            "pypi_package": "couchbase-sqlalchemy",
-            "connection_string": "couchbase://{username}:{password}@{host}:{port}?ssl=true",
-            "is_recommended": true
-          }
-        ]
+        "connection_string": "cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable",
+        "default_port": 26257,
+        "docs_url": "https://github.com/cockroachdb/sqlalchemy-cockroachdb",
+        "category": "Other Databases"
       },
+      "engine": "cockroachdb",
+      "engine_name": "CockroachDB",
+      "engine_aliases": [
+        "postgres"
+      ],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Couchbase": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -995,51 +3516,83 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 27,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.couchbase",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": false,
       "subqueries": false,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "CrateDB": {
-      "engine": "cratedb",
-      "engine_name": "CrateDB",
-      "module": "crate",
+      "sql_validation": false,
+      "score": 27,
+      "max_score": 201,
       "documentation": {
-        "description": "CrateDB is a distributed SQL database for machine data and IoT workloads.",
-        "logo": "cratedb.svg",
-        "homepage_url": "https://cratedb.com",
+        "description": "Couchbase is a distributed NoSQL document database with SQL++ support.",
+        "logo": "couchbase.svg",
+        "homepage_url": "https://www.couchbase.com/",
         "categories": [
-          "TIME_SERIES",
-          "OPEN_SOURCE"
+          "Search & NoSQL",
+          "Open Source"
         ],
         "pypi_packages": [
-          "crate",
-          "sqlalchemy-cratedb"
+          "couchbase-sqlalchemy"
         ],
-        "connection_string": "crate://{host}:{port}",
-        "default_port": 4200,
+        "connection_string": "couchbase://{username}:{password}@{host}:{port}?ssl=true",
+        "default_port": 8091,
         "parameters": {
-          "host": "CrateDB host",
-          "port": "CrateDB HTTP port (default 4200)"
+          "username": "Couchbase username",
+          "password": "Couchbase password",
+          "host": "Couchbase host or connection string for cloud",
+          "port": "Couchbase port (default 8091)",
+          "database": "Couchbase database/bucket name"
         },
         "drivers": [
           {
-            "name": "crate",
-            "pypi_package": "crate[sqlalchemy]",
-            "connection_string": "crate://{host}:{port}",
+            "name": "couchbase-sqlalchemy",
+            "pypi_package": "couchbase-sqlalchemy",
+            "connection_string": "couchbase://{username}:{password}@{host}:{port}?ssl=true",
             "is_recommended": true
           }
-        ]
+        ],
+        "category": "Search & NoSQL"
       },
+      "engine": "couchbase",
+      "engine_name": "Couchbase",
+      "engine_aliases": [
+        "couchbasedb"
+      ],
+      "default_driver": "couchbase",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "CrateDB": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -1063,86 +3616,79 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 28,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.crate",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Cloudflare D1": {
-      "engine": "cloudflare_d1",
-      "engine_name": "Cloudflare D1",
-      "module": "d1",
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
       "documentation": {
-        "description": "Cloudflare D1 is a serverless SQLite database.",
-        "logo": "cloudflare.png",
-        "homepage_url": "https://developers.cloudflare.com/d1/",
-        "pypi_packages": [
-          "superset-engine-d1"
-        ],
-        "connection_string": "d1://{cloudflare_account_id}:{cloudflare_api_token}@{cloudflare_d1_database_id}",
-        "notes": "No additional library needed. SQLite is bundled with Python.",
+        "description": "CrateDB is a distributed SQL database for machine data and IoT workloads.",
+        "logo": "cratedb.svg",
+        "homepage_url": "https://cratedb.com",
         "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "TRADITIONAL_RDBMS",
-          "HOSTED_OPEN_SOURCE"
+          "Time Series Databases",
+          "Open Source"
         ],
+        "pypi_packages": [
+          "crate",
+          "sqlalchemy-cratedb"
+        ],
+        "connection_string": "crate://{host}:{port}",
+        "default_port": 4200,
         "parameters": {
-          "cloudflare_account_id": "Cloudflare account ID",
-          "cloudflare_api_token": "Cloudflare API token",
-          "cloudflare_d1_database_id": "D1 database ID"
+          "host": "CrateDB host",
+          "port": "CrateDB HTTP port (default 4200)"
         },
-        "install_instructions": "pip install superset-engine-d1"
+        "drivers": [
+          {
+            "name": "crate",
+            "pypi_package": "crate[sqlalchemy]",
+            "connection_string": "crate://{host}:{port}",
+            "is_recommended": true
+          }
+        ],
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "crate",
+      "engine_name": "CrateDB",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "Databend": {
-      "engine": "databend",
-      "engine_name": "Databend",
-      "module": "databend",
-      "documentation": {
-        "description": "Databend is a modern cloud-native data warehouse with instant elasticity and pay-as-you-go pricing. Built in Rust for high performance.",
-        "logo": "databend.png",
-        "homepage_url": "https://www.databend.com/",
-        "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "databend-sqlalchemy"
-        ],
-        "connection_string": "databend://{username}:{password}@{host}:{port}/{database}?secure=true",
-        "default_port": 443,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "Databend host",
-          "port": "Databend port (default 443 for HTTPS)",
-          "database": "Database name"
-        }
-      },
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -1166,81 +3712,213 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 51,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.databend",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": true,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": false,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Databricks Interactive Cluster": {
-      "engine": "databricks_interactive_cluster",
-      "engine_name": "Databricks Interactive Cluster",
-      "module": "databricks",
+      "sql_validation": false,
+      "score": 51,
+      "max_score": 201,
       "documentation": {
-        "description": "Apache Hive is a data warehouse infrastructure built on Hadoop.",
-        "logo": "apache-hive.svg",
-        "homepage_url": "https://hive.apache.org/",
-        "pypi_packages": [
-          "pyhive",
-          "pyhive"
-        ],
-        "install_instructions": "pip install \"apache-superset[presto]\"",
-        "connection_string": "hive://hive@{hostname}:{port}/{database}",
-        "default_port": 10000,
-        "parameters": {
-          "hostname": "Presto coordinator hostname",
-          "port": "Presto coordinator port (default 8080)",
-          "database": "Catalog name"
-        },
-        "drivers": [
-          {
-            "name": "PyHive",
-            "pypi_package": "pyhive",
-            "connection_string": "presto://{hostname}:{port}/{database}",
-            "is_recommended": true
-          }
-        ],
+        "description": "Databend is a modern cloud-native data warehouse with instant elasticity and pay-as-you-go pricing. Built in Rust for high performance.",
+        "logo": "databend.png",
+        "homepage_url": "https://www.databend.com/",
         "categories": [
-          "APACHE_PROJECTS",
-          "QUERY_ENGINES",
-          "OPEN_SOURCE"
-        ]
+          "Cloud Data Warehouses",
+          "Analytical Databases",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "databend-sqlalchemy"
+        ],
+        "connection_string": "databend://{username}:{password}@{host}:{port}/{database}?secure=true",
+        "default_port": 443,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "Databend host",
+          "port": "Databend port (default 443 for HTTPS)",
+          "database": "Database name"
+        },
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "databend",
+      "engine_name": "Databend",
+      "engine_aliases": [],
+      "default_driver": "databend",
+      "supports_file_upload": false,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
+      "supports_dynamic_catalog": false
+    },
+    "Databend (legacy)": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.databend",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": true,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
       "user_impersonation": false,
+      "file_upload": false,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 51,
+      "max_score": 201,
+      "documentation": {
+        "pypi_packages": [],
+        "connection_string": "engine+driver://user:password@host:port/dbname[?key=value&key=value...]",
+        "category": "Other Databases"
+      },
+      "engine": "databend",
+      "engine_name": "Databend (legacy)",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": false,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "Databricks": {
-      "engine": "databricks",
-      "engine_name": "Databricks",
-      "module": "databricks",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.databricks",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": true,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 70,
+      "max_score": 201,
       "documentation": {
         "description": "Databricks is a unified analytics platform built on Apache Spark, providing data engineering, data science, and machine learning capabilities in the cloud. Use the Python Connector for SQL warehouses and clusters.",
         "logo": "databricks.png",
         "homepage_url": "https://www.databricks.com/",
         "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "ANALYTICAL_DATABASES",
-          "HOSTED_OPEN_SOURCE"
+          "Cloud Data Warehouses",
+          "Analytical Databases",
+          "Hosted Open Source"
         ],
         "pypi_packages": [
           "apache-superset[databricks]"
@@ -1282,187 +3960,251 @@
             "is_recommended": false,
             "notes": "Legacy connector. Use Python Connector for new deployments."
           }
-        ]
+        ],
+        "category": "Cloud Data Warehouses"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "engine": "databricks",
+      "engine_name": "Databricks",
+      "engine_aliases": [],
+      "default_driver": "databricks-sql-python",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
     },
-    "Google Datastore": {
-      "engine": "google_datastore",
-      "engine_name": "Google Datastore",
-      "module": "datastore",
-      "documentation": {
-        "description": "Google Cloud Datastore is a highly scalable NoSQL database for your applications.",
-        "logo": "datastore.png",
-        "homepage_url": "https://cloud.google.com/datastore/",
-        "categories": [
-          "CLOUD_GCP",
-          "SEARCH_NOSQL",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "python-datastore-sqlalchemy"
-        ],
-        "connection_string": "datastore://{project_id}/?database={database_id}",
-        "authentication_methods": [
-          {
-            "name": "Service Account JSON",
-            "description": "Upload service account credentials JSON or paste in Secure Extra",
-            "secure_extra": {
-              "credentials_info": {
-                "type": "service_account",
-                "project_id": "...",
-                "private_key_id": "...",
-                "private_key": "...",
-                "client_email": "...",
-                "client_id": "...",
-                "auth_uri": "...",
-                "token_uri": "..."
-              }
-            }
-          }
-        ],
-        "notes": "Create a Service Account via GCP console with access to datastore datasets.",
-        "docs_url": "https://github.com/splasky/Python-datastore-sqlalchemy",
-        "custom_errors": [
-          {
-            "regex_name": "CONNECTION_DATABASE_PERMISSIONS_REGEX",
-            "message_template": "Unable to connect. Verify that the following roles are set on the service account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud Datastore Creator\"",
-            "error_type": "CONNECTION_DATABASE_PERMISSIONS_ERROR",
-            "category": "Permissions",
-            "description": "Insufficient permissions",
-            "issue_codes": [
-              1017
-            ]
-          },
-          {
-            "regex_name": "TABLE_DOES_NOT_EXIST_REGEX",
-            "message_template": "The table \"%(table)s\" does not exist. A valid table must be used to run this query.",
-            "error_type": "TABLE_DOES_NOT_EXIST_ERROR",
-            "category": "Query",
-            "description": "Table not found",
-            "issue_codes": [
-              1003,
-              1005
-            ]
-          },
-          {
-            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
-            "message_template": "We can't seem to resolve column \"%(column)s\" at line %(location)s.",
-            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
-            "category": "Query",
-            "description": "Column not found",
-            "issue_codes": [
-              1003,
-              1004
-            ]
-          },
-          {
-            "regex_name": "SCHEMA_DOES_NOT_EXIST_REGEX",
-            "message_template": "The schema \"%(schema)s\" does not exist. A valid schema must be used to run this query.",
-            "error_type": "SCHEMA_DOES_NOT_EXIST_ERROR",
-            "category": "Query",
-            "description": "Schema not found",
-            "issue_codes": [
-              1003,
-              1016
-            ]
-          },
-          {
-            "regex_name": "SYNTAX_ERROR_REGEX",
-            "message_template": "Please check your query for syntax errors at or near \"%(syntax_error)s\". Then, try running your query again.",
-            "error_type": "SYNTAX_ERROR",
-            "category": "Query",
-            "description": "SQL syntax error",
-            "issue_codes": [
-              1030
-            ]
-          }
-        ]
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "IBM Db2": {
-      "engine": "ibm_db2",
-      "engine_name": "IBM Db2",
-      "module": "db2",
-      "documentation": {
-        "description": "IBM Db2 is a family of data management products for enterprise workloads, available on-premises, in containers, and across cloud platforms.",
-        "logo": "ibm-db2.svg",
-        "homepage_url": "https://www.ibm.com/db2",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "ibm_db_sa"
-        ],
-        "connection_string": "db2+ibm_db://{username}:{password}@{hostname}:{port}/{database}",
-        "default_port": 50000,
-        "drivers": [
-          {
-            "name": "ibm_db_sa (with LIMIT)",
-            "connection_string": "db2+ibm_db://{username}:{password}@{hostname}:{port}/{database}",
-            "is_recommended": true
-          },
-          {
-            "name": "ibm_db_sa (without LIMIT syntax)",
-            "connection_string": "ibm_db_sa://{username}:{password}@{hostname}:{port}/{database}",
-            "is_recommended": false,
-            "notes": "Use for older DB2 versions without LIMIT [n] syntax. Recommended for SQL Lab."
-          }
-        ],
-        "compatible_databases": [
-          {
-            "name": "IBM Db2 for i (AS/400)",
-            "description": "Db2 for i is a fully integrated database engine on IBM i (AS/400) systems. Uses a different SQLAlchemy driver optimized for IBM i.",
-            "logo": "ibm-db2.svg",
-            "homepage_url": "https://www.ibm.com/products/db2-for-i",
-            "pypi_packages": [
-              "sqlalchemy-ibmi"
-            ],
-            "connection_string": "ibmi://{username}:{password}@{host}/{database}",
-            "parameters": {
-              "username": "IBM i username",
-              "password": "IBM i password",
-              "host": "IBM i system host",
-              "database": "Library/schema name"
-            },
-            "docs_url": "https://github.com/IBM/sqlalchemy-ibmi",
-            "categories": [
-              "PROPRIETARY"
-            ]
-          }
-        ],
-        "docs_url": "https://github.com/ibmdb/python-ibmdbsa"
-      },
+    "Databricks (legacy)": {
       "time_grains": {
         "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.databricks",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": true,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 70,
+      "max_score": 201,
+      "documentation": {
+        "pypi_packages": [],
+        "connection_string": "databricks+connector://token:{access_token}@{host}:{port}/{database_name}",
+        "category": "Cloud Data Warehouses"
+      },
+      "engine": "databricks",
+      "engine_name": "Databricks (legacy)",
+      "engine_aliases": [],
+      "default_driver": "connector",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Databricks Interactive Cluster": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.databricks",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": false,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 767,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": true,
+      "file_upload": true,
+      "get_extra_table_metadata": true,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": true,
+      "expand_data": true,
+      "query_cost_estimation": true,
+      "sql_validation": false,
+      "score": 140,
+      "max_score": 201,
+      "documentation": {
+        "description": "Apache Hive is a data warehouse infrastructure built on Hadoop.",
+        "logo": "apache-hive.svg",
+        "homepage_url": "https://hive.apache.org/",
+        "categories": [
+          "Apache Projects",
+          "Query Engines",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "pyhive"
+        ],
+        "connection_string": "hive://hive@{hostname}:{port}/{database}",
+        "default_port": 10000,
+        "category": "Cloud Data Warehouses"
+      },
+      "engine": "databricks",
+      "engine_name": "Databricks Interactive Cluster",
+      "engine_aliases": [],
+      "default_driver": "pyhive",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Databricks SQL Endpoint": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.databricks",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 30,
+      "max_score": 201,
+      "documentation": {
+        "pypi_packages": [],
+        "connection_string": "engine+driver://user:password@host:port/dbname[?key=value&key=value...]",
+        "category": "Cloud Data Warehouses"
+      },
+      "engine": "databricks",
+      "engine_name": "Databricks SQL Endpoint",
+      "engine_aliases": [],
+      "default_driver": "pyodbc",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Denodo": {
+      "time_grains": {
+        "SECOND": false,
         "FIVE_SECONDS": false,
         "THIRTY_SECONDS": false,
         "MINUTE": true,
@@ -1484,31 +4226,48 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 38,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.denodo",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Denodo": {
-      "engine": "denodo",
-      "engine_name": "Denodo",
-      "module": "denodo",
+      "sql_validation": false,
+      "score": 27,
+      "max_score": 201,
       "documentation": {
         "description": "Denodo is a data virtualization platform for logical data management.",
         "logo": "denodo.png",
         "homepage_url": "https://www.denodo.com/",
         "categories": [
-          "QUERY_ENGINES",
-          "PROPRIETARY"
+          "Query Engines",
+          "Proprietary"
         ],
         "pypi_packages": [
           "psycopg2"
@@ -1531,6 +4290,7 @@
             "notes": "Uses PostgreSQL wire protocol."
           }
         ],
+        "category": "Other Databases",
         "custom_errors": [
           {
             "message_template": "Incorrect username or password.",
@@ -1646,8 +4406,18 @@
           }
         ]
       },
+      "engine": "denodo",
+      "engine_name": "Denodo",
+      "engine_aliases": [],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Dremio": {
       "time_grains": {
-        "SECOND": false,
+        "SECOND": true,
         "FIVE_SECONDS": false,
         "THIRTY_SECONDS": false,
         "MINUTE": true,
@@ -1669,197 +4439,48 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 27,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.dremio",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache Doris": {
-      "engine": "apache_doris",
-      "engine_name": "Apache Doris",
-      "module": "doris",
-      "documentation": {
-        "description": "Apache Doris is a high-performance real-time analytical database.",
-        "logo": "doris.png",
-        "homepage_url": "https://doris.apache.org/",
-        "pypi_packages": [
-          "mysqlclient",
-          "pydoris"
-        ],
-        "connection_string": "doris://{username}:{password}@{host}:{port}/{catalog}.{database}",
-        "default_port": 9030,
-        "parameters": {
-          "username": "User name",
-          "password": "Password",
-          "host": "Doris FE Host",
-          "database": "Database name",
-          "port": "Doris FE port",
-          "catalog": "Catalog name"
-        },
-        "host_examples": [
-          {
-            "platform": "Localhost",
-            "host": "localhost or 127.0.0.1"
-          },
-          {
-            "platform": "Docker on Linux",
-            "host": "172.18.0.1"
-          },
-          {
-            "platform": "Docker on macOS",
-            "host": "docker.for.mac.host.internal"
-          },
-          {
-            "platform": "On-premise",
-            "host": "IP address or hostname"
-          }
-        ],
-        "drivers": [
-          {
-            "name": "mysqlclient",
-            "pypi_package": "mysqlclient",
-            "connection_string": "mysql://{username}:{password}@{host}/{database}",
-            "is_recommended": true,
-            "notes": "Recommended driver. May fail with caching_sha2_password auth."
-          },
-          {
-            "name": "mysql-connector-python",
-            "pypi_package": "mysql-connector-python",
-            "connection_string": "mysql+mysqlconnector://{username}:{password}@{host}/{database}",
-            "is_recommended": false,
-            "notes": "Required for newer MySQL databases using caching_sha2_password authentication."
-          }
-        ],
-        "categories": [
-          "APACHE_PROJECTS",
-          "ANALYTICAL_DATABASES",
-          "OPEN_SOURCE"
-        ],
-        "custom_errors": [
-          {
-            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
-            "message_template": "Either the username \"%(username)s\" or the password is incorrect.",
-            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
-            "category": "Authentication",
-            "description": "Access denied",
-            "issue_codes": [
-              1014,
-              1015
-            ],
-            "invalid_fields": [
-              "username",
-              "password"
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
-            "message_template": "Unknown Doris server host \"%(hostname)s\".",
-            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
-            "category": "Connection",
-            "description": "Invalid hostname",
-            "issue_codes": [
-              1007
-            ],
-            "invalid_fields": [
-              "host"
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
-            "message_template": "The host \"%(hostname)s\" might be down and can't be reached.",
-            "error_type": "CONNECTION_HOST_DOWN_ERROR",
-            "category": "Connection",
-            "description": "Host unreachable",
-            "issue_codes": [
-              1009
-            ],
-            "invalid_fields": [
-              "host",
-              "port"
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_UNKNOWN_DATABASE_REGEX",
-            "message_template": "Unable to connect to database \"%(database)s\".",
-            "error_type": "CONNECTION_UNKNOWN_DATABASE_ERROR",
-            "category": "Connection",
-            "description": "Unknown database",
-            "issue_codes": [
-              1015
-            ],
-            "invalid_fields": [
-              "database"
-            ]
-          },
-          {
-            "regex_name": "SYNTAX_ERROR_REGEX",
-            "message_template": "Please check your query for syntax errors near \"%(server_error)s\". Then, try running your query again.",
-            "error_type": "SYNTAX_ERROR",
-            "category": "Query",
-            "description": "SQL syntax error",
-            "issue_codes": [
-              1030
-            ]
-          }
-        ]
-      },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": true,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": false,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": false,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": true,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 79,
+      "sql_validation": false,
+      "score": 28,
       "max_score": 201,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": true,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Dremio": {
-      "engine": "dremio",
-      "engine_name": "Dremio",
-      "module": "dremio",
       "documentation": {
         "description": "Dremio is a data lakehouse platform for fast, self-service analytics.",
         "logo": "dremio.png",
         "homepage_url": "https://www.dremio.com/",
         "categories": [
-          "QUERY_ENGINES",
-          "PROPRIETARY"
+          "Query Engines",
+          "Proprietary"
         ],
         "pypi_packages": [
           "sqlalchemy_dremio"
@@ -1882,8 +4503,21 @@
             "is_recommended": false,
             "notes": "Requires Dremio ODBC drivers installed."
           }
-        ]
+        ],
+        "category": "Other Databases"
       },
+      "engine": "dremio",
+      "engine_name": "Dremio",
+      "engine_aliases": [
+        "dremio+flight"
+      ],
+      "default_driver": "flight",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "DuckDB": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -1907,212 +4541,48 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 28,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.duckdb",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": false,
-      "supports_file_upload": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
       "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache Drill": {
-      "engine": "apache_drill",
-      "engine_name": "Apache Drill",
-      "module": "drill",
-      "documentation": {
-        "description": "Apache Drill is a schema-free SQL query engine for Hadoop and NoSQL.",
-        "logo": "apache-drill.png",
-        "homepage_url": "https://drill.apache.org/",
-        "categories": [
-          "APACHE_PROJECTS",
-          "QUERY_ENGINES",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "sqlalchemy-drill"
-        ],
-        "connection_string": "drill+sadrill://{username}:{password}@{host}:{port}/{storage_plugin}?use_ssl=True",
-        "default_port": 8047,
-        "drivers": [
-          {
-            "name": "SQLAlchemy (REST)",
-            "pypi_package": "sqlalchemy-drill",
-            "connection_string": "drill+sadrill://{username}:{password}@{host}:{port}/{storage_plugin}?use_ssl=True",
-            "is_recommended": true
-          },
-          {
-            "name": "JDBC",
-            "pypi_package": "sqlalchemy-drill",
-            "connection_string": "drill+jdbc://{username}:{password}@{host}:{port}",
-            "is_recommended": false,
-            "notes": "Requires Drill JDBC Driver installation.",
-            "docs_url": "https://drill.apache.org/docs/using-the-jdbc-driver/"
-          },
-          {
-            "name": "ODBC",
-            "pypi_package": "sqlalchemy-drill",
-            "is_recommended": false,
-            "notes": "See Apache Drill documentation for ODBC setup.",
-            "docs_url": "https://drill.apache.org/docs/installing-the-driver-on-linux/"
-          }
-        ],
-        "connection_examples": [
-          {
-            "description": "Local embedded mode",
-            "connection_string": "drill+sadrill://localhost:8047/dfs?use_ssl=False"
-          }
-        ]
-      },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": true,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": true,
-        "THIRTY_MINUTES": true,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": false,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 50,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache Druid": {
-      "engine": "apache_druid",
-      "engine_name": "Apache Druid",
-      "module": "druid",
-      "documentation": {
-        "description": "Apache Druid is a high performance real-time analytics database.",
-        "logo": "druid.png",
-        "homepage_url": "https://druid.apache.org/",
-        "categories": [
-          "APACHE_PROJECTS",
-          "TIME_SERIES",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "pydruid"
-        ],
-        "connection_string": "druid://{username}:{password}@{host}:{port}/druid/v2/sql",
-        "default_port": 9088,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "IP address or URL of the host",
-          "port": "Default 9088"
-        },
-        "ssl_configuration": {
-          "custom_certificate": "Add certificate in Root Certificate field. pydruid will automatically use https.",
-          "disable_ssl_verification": {
-            "engine_params": {
-              "connect_args": {
-                "scheme": "https",
-                "ssl_verify_cert": false
-              }
-            }
-          }
-        },
-        "advanced_features": {
-          "aggregations": "Define common aggregations in datasource edit view under List Druid Column tab.",
-          "post_aggregations": "Create metrics with postagg as Metric Type and provide valid JSON post-aggregation definition."
-        },
-        "notes": "A native Druid connector ships with Superset (behind DRUID_IS_ACTIVE flag) but SQLAlchemy connector via pydruid is preferred.",
-        "compatible_databases": [
-          {
-            "name": "Imply",
-            "description": "Imply is a fully-managed cloud platform and enterprise distribution built on Apache Druid. It provides real-time analytics with enterprise security and support.",
-            "logo": "imply.png",
-            "homepage_url": "https://imply.io/",
-            "categories": [
-              "TIME_SERIES",
-              "CLOUD_DATA_WAREHOUSES",
-              "HOSTED_OPEN_SOURCE"
-            ],
-            "pypi_packages": [
-              "pydruid"
-            ],
-            "connection_string": "druid://{username}:{password}@{host}/druid/v2/sql",
-            "docs_url": "https://docs.imply.io/"
-          }
-        ]
-      },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": true,
-        "THIRTY_SECONDS": true,
-        "MINUTE": true,
-        "FIVE_MINUTES": true,
-        "TEN_MINUTES": true,
-        "FIFTEEN_MINUTES": true,
-        "THIRTY_MINUTES": true,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": true,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": true,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": true,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 47,
+      "sql_validation": false,
+      "score": 38,
       "max_score": 201,
-      "joins": false,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "DuckDB": {
-      "engine": "duckdb",
-      "engine_name": "DuckDB",
-      "module": "duckdb",
       "documentation": {
         "description": "DuckDB is an in-process OLAP database designed for fast analytical queries on local data. Supports CSV, Parquet, JSON, and many other file formats.",
         "logo": "duckdb.png",
         "homepage_url": "https://duckdb.org/",
         "categories": [
-          "ANALYTICAL_DATABASES",
-          "OPEN_SOURCE"
+          "Analytical Databases",
+          "Open Source"
         ],
         "pypi_packages": [
           "duckdb-engine"
@@ -2144,10 +4614,11 @@
             },
             "notes": "Cloud-hosted DuckDB with collaboration features.",
             "categories": [
-              "HOSTED_OPEN_SOURCE"
+              "Hosted Open Source"
             ]
           }
         ],
+        "category": "Other Databases",
         "custom_errors": [
           {
             "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
@@ -2162,6 +4633,16 @@
           }
         ]
       },
+      "engine": "duckdb",
+      "engine_name": "DuckDB",
+      "engine_aliases": [],
+      "default_driver": "duckdb_engine",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Elasticsearch": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -2181,143 +4662,52 @@
         "WEEK_ENDING_SATURDAY": false,
         "WEEK_ENDING_SUNDAY": false,
         "MONTH": true,
-        "QUARTER": true,
+        "QUARTER": false,
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 38,
-      "max_score": 201,
-      "joins": true,
+      "module": "superset.db_engine_specs.elasticsearch",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": false,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": true,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": false,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "MotherDuck": {
-      "engine": "motherduck",
-      "engine_name": "MotherDuck",
-      "module": "duckdb",
-      "documentation": {
-        "description": "MotherDuck is a serverless cloud analytics platform built on DuckDB. It combines the simplicity of DuckDB with cloud-scale data sharing and collaboration.",
-        "logo": "motherduck.png",
-        "homepage_url": "https://motherduck.com/",
-        "pypi_packages": [
-          "duckdb-engine",
-          "duckdb",
-          "duckdb-engine"
-        ],
-        "connection_string": "duckdb:///md:{database}?motherduck_token={token}",
-        "drivers": [
-          {
-            "name": "duckdb-engine",
-            "pypi_package": "duckdb-engine",
-            "connection_string": "duckdb:////path/to/duck.db",
-            "is_recommended": true
-          },
-          {
-            "name": "duckdb-engine",
-            "pypi_package": "duckdb-engine",
-            "connection_string": "duckdb:///md:{database}?motherduck_token={token}",
-            "is_recommended": true
-          }
-        ],
-        "notes": "DuckDB supports both local file and in-memory databases. Use `:memory:` for in-memory database.",
-        "categories": [
-          "ANALYTICAL_DATABASES",
-          "CLOUD_DATA_WAREHOUSES",
-          "HOSTED_OPEN_SOURCE"
-        ],
-        "parameters": {
-          "database": "MotherDuck database name",
-          "token": "Service token from MotherDuck dashboard"
-        },
-        "docs_url": "https://motherduck.com/docs/getting-started/",
-        "custom_errors": [
-          {
-            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
-            "message_template": "We can't seem to resolve the column \"%(column_name)s\"",
-            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
-            "category": "Query",
-            "description": "Column not found",
-            "issue_codes": [
-              1003,
-              1004
-            ]
-          }
-        ]
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Amazon DynamoDB": {
-      "engine": "amazon_dynamodb",
-      "engine_name": "Amazon DynamoDB",
-      "module": "dynamodb",
-      "documentation": {
-        "description": "Amazon DynamoDB is a serverless NoSQL database with SQL via PartiQL.",
-        "logo": "aws.png",
-        "homepage_url": "https://aws.amazon.com/dynamodb/",
-        "categories": [
-          "CLOUD_AWS",
-          "SEARCH_NOSQL",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "pydynamodb"
-        ],
-        "connection_string": "dynamodb://{aws_access_key_id}:{aws_secret_access_key}@dynamodb.{region}.amazonaws.com:443?connector=superset",
-        "parameters": {
-          "aws_access_key_id": "AWS access key ID",
-          "aws_secret_access_key": "AWS secret access key",
-          "region": "AWS region (e.g., us-east-1)"
-        },
-        "notes": "Uses PartiQL for SQL queries. Requires connector=superset parameter.",
-        "docs_url": "https://github.com/passren/PyDynamoDB"
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Elasticsearch": {
-      "engine": "elasticsearch",
-      "engine_name": "Elasticsearch",
-      "module": "elasticsearch",
+      "sql_validation": false,
+      "score": 37,
+      "max_score": 201,
       "documentation": {
         "description": "Elasticsearch is a distributed search and analytics engine. Query data using Elasticsearch SQL or OpenSearch SQL syntax.",
         "logo": "elasticsearch.png",
         "homepage_url": "https://www.elastic.co/elasticsearch/",
         "categories": [
-          "SEARCH_NOSQL",
-          "OPEN_SOURCE"
+          "Search & NoSQL",
+          "Open Source"
         ],
         "pypi_packages": [
           "elasticsearch-dbapi"
@@ -2352,8 +4742,8 @@
             "logo": "elasticsearch.png",
             "homepage_url": "https://www.elastic.co/cloud/",
             "categories": [
-              "SEARCH_NOSQL",
-              "HOSTED_OPEN_SOURCE"
+              "Search & NoSQL",
+              "Hosted Open Source"
             ],
             "pypi_packages": [
               "elasticsearch-dbapi"
@@ -2367,9 +4757,9 @@
             "logo": "elasticsearch.png",
             "homepage_url": "https://aws.amazon.com/opensearch-service/",
             "categories": [
-              "SEARCH_NOSQL",
-              "CLOUD_AWS",
-              "HOSTED_OPEN_SOURCE"
+              "Search & NoSQL",
+              "Cloud - AWS",
+              "Hosted Open Source"
             ],
             "pypi_packages": [
               "elasticsearch-dbapi"
@@ -2377,34 +4767,84 @@
             "connection_string": "odelasticsearch+https://{user}:{password}@{host}:443/",
             "docs_url": "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/"
           }
-        ]
+        ],
+        "category": "Search & NoSQL"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "elasticsearch",
+      "engine_name": "Elasticsearch",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "Exasol": {
-      "engine": "exasol",
-      "engine_name": "Exasol",
-      "module": "exasol",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.exasol",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
       "documentation": {
         "description": "Exasol is a high-performance, in-memory, MPP analytical database.",
         "logo": "exasol.png",
         "homepage_url": "https://www.exasol.com/",
         "categories": [
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
+          "Analytical Databases",
+          "Proprietary"
         ],
         "pypi_packages": [
           "sqlalchemy-exasol"
@@ -2438,70 +4878,19 @@
             "is_recommended": false,
             "notes": "Pure Python, no ODBC required."
           }
-        ]
+        ],
+        "category": "Other Databases"
       },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": true,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": false,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": false,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 28,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
+      "engine": "exa",
+      "engine_name": "Exasol",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "Firebird": {
-      "engine": "firebird",
-      "engine_name": "Firebird",
-      "module": "firebird",
-      "documentation": {
-        "description": "Firebird is an open-source relational database.",
-        "logo": "firebird.png",
-        "homepage_url": "https://firebirdsql.org/",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "sqlalchemy-firebird"
-        ],
-        "version_requirements": "sqlalchemy-firebird>=0.7.0,<0.8",
-        "connection_string": "firebird+fdb://{username}:{password}@{host}:{port}//{path_to_db_file}",
-        "default_port": 3050,
-        "connection_examples": [
-          {
-            "description": "Local database",
-            "connection_string": "firebird+fdb://SYSDBA:masterkey@192.168.86.38:3050//Library/Frameworks/Firebird.framework/Versions/A/Resources/examples/empbuild/employee.fdb"
-          }
-        ]
-      },
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -2525,53 +4914,73 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 26,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.firebird",
+      "limit_method": 3,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Firebolt": {
-      "engine": "firebolt",
-      "engine_name": "Firebolt",
-      "module": "firebolt",
+      "sql_validation": false,
+      "score": 26,
+      "max_score": 201,
       "documentation": {
-        "description": "Firebolt is a cloud data warehouse designed for high-performance analytics.",
-        "logo": "firebolt.png",
-        "homepage_url": "https://www.firebolt.io/",
+        "description": "Firebird is an open-source relational database.",
+        "logo": "firebird.png",
+        "homepage_url": "https://firebirdsql.org/",
         "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
+          "Traditional RDBMS",
+          "Open Source"
         ],
         "pypi_packages": [
-          "firebolt-sqlalchemy"
+          "sqlalchemy-firebird"
         ],
-        "connection_string": "firebolt://{client_id}:{client_secret}@{database}/{engine_name}?account_name={account_name}",
-        "parameters": {
-          "client_id": "Service account client ID",
-          "client_secret": "Service account client secret",
-          "database": "Database name",
-          "engine_name": "Engine name",
-          "account_name": "Account name"
-        },
-        "drivers": [
+        "version_requirements": "sqlalchemy-firebird>=0.7.0,<0.8",
+        "connection_string": "firebird+fdb://{username}:{password}@{host}:{port}//{path_to_db_file}",
+        "default_port": 3050,
+        "connection_examples": [
           {
-            "name": "firebolt-sqlalchemy",
-            "pypi_package": "firebolt-sqlalchemy",
-            "connection_string": "firebolt://{client_id}:{client_secret}@{database}/{engine_name}?account_name={account_name}",
-            "is_recommended": true
+            "description": "Local database",
+            "connection_string": "firebird+fdb://SYSDBA:masterkey@192.168.86.38:3050//Library/Frameworks/Firebird.framework/Versions/A/Resources/examples/empbuild/employee.fdb"
           }
-        ]
+        ],
+        "category": "Other Databases"
       },
+      "engine": "firebird",
+      "engine_name": "Firebird",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Firebolt": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -2595,98 +5004,224 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 28,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.firebolt",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Greenplum": {
-      "engine": "greenplum",
-      "engine_name": "Greenplum",
-      "module": "greenplum",
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
       "documentation": {
-        "description": "VMware Greenplum is a massively parallel processing (MPP) database built on PostgreSQL.",
-        "logo": "greenplum.png",
-        "homepage_url": "https://greenplum.org/",
-        "pypi_packages": [
-          "psycopg2",
-          "sqlalchemy-greenplum",
-          "psycopg2"
+        "description": "Firebolt is a cloud data warehouse designed for high-performance analytics.",
+        "logo": "firebolt.png",
+        "homepage_url": "https://www.firebolt.io/",
+        "categories": [
+          "Cloud Data Warehouses",
+          "Analytical Databases",
+          "Proprietary"
         ],
-        "connection_string": "greenplum://{username}:{password}@{host}:{port}/{database}",
-        "default_port": 5432,
+        "pypi_packages": [
+          "firebolt-sqlalchemy"
+        ],
+        "connection_string": "firebolt://{client_id}:{client_secret}@{database}/{engine_name}?account_name={account_name}",
         "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "Greenplum coordinator host",
-          "port": "Default 5432",
-          "database": "Database name"
+          "client_id": "Service account client ID",
+          "client_secret": "Service account client secret",
+          "database": "Database name",
+          "engine_name": "Engine name",
+          "account_name": "Account name"
         },
-        "notes": "The psycopg2 library comes bundled with Superset Docker images.",
-        "connection_examples": [
+        "drivers": [
           {
-            "description": "Basic connection",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}"
-          },
-          {
-            "description": "With SSL required",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
+            "name": "firebolt-sqlalchemy",
+            "pypi_package": "firebolt-sqlalchemy",
+            "connection_string": "firebolt://{client_id}:{client_secret}@{database}/{engine_name}?account_name={account_name}",
+            "is_recommended": true
           }
         ],
-        "docs_url": "https://docs.vmware.com/en/VMware-Greenplum/",
-        "sqlalchemy_docs_url": "https://docs.sqlalchemy.org/en/13/dialects/postgresql.html",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
-        ]
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "firebolt",
+      "engine_name": "Firebolt",
+      "engine_aliases": [],
+      "default_driver": "firebolt",
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Google BigQuery": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.bigquery",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": true,
+      "cte_in_subquery": true,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": true,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": true,
+      "dynamic_catalog": true,
       "ssh_tunneling": false,
       "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Google Sheets": {
-      "engine": "google_sheets",
-      "engine_name": "Google Sheets",
-      "module": "gsheets",
+      "get_metrics": false,
+      "where_latest_partition": true,
+      "expand_data": false,
+      "query_cost_estimation": true,
+      "sql_validation": false,
+      "score": 83,
+      "max_score": 201,
       "documentation": {
-        "description": "Google Sheets allows querying spreadsheets as SQL tables via shillelagh.",
-        "logo": "google-sheets.svg",
-        "homepage_url": "https://www.google.com/sheets/about/",
-        "pypi_packages": [
-          "shillelagh[gsheetsapi]",
-          "shillelagh[gsheetsapi]"
-        ],
-        "connection_string": "gsheets://",
-        "notes": "Requires Google service account credentials or OAuth2 authentication. See docs for setup instructions.",
+        "description": "Google BigQuery is a serverless, highly scalable data warehouse.",
+        "logo": "google-big-query.svg",
+        "homepage_url": "https://cloud.google.com/bigquery/",
         "categories": [
-          "CLOUD_GCP",
-          "HOSTED_OPEN_SOURCE"
+          "Cloud - Google",
+          "Analytical Databases",
+          "Proprietary"
         ],
-        "install_instructions": "pip install \"apache-superset[gsheets]\"",
+        "pypi_packages": [
+          "sqlalchemy-bigquery"
+        ],
+        "connection_string": "bigquery://{project_id}",
+        "install_instructions": "echo \"sqlalchemy-bigquery\" >> ./docker/requirements-local.txt",
+        "authentication_methods": [
+          {
+            "name": "Service Account JSON",
+            "description": "Upload service account credentials JSON or paste in Secure Extra",
+            "secure_extra": {
+              "credentials_info": {
+                "type": "service_account",
+                "project_id": "...",
+                "private_key_id": "...",
+                "private_key": "...",
+                "client_email": "...",
+                "client_id": "...",
+                "auth_uri": "...",
+                "token_uri": "..."
+              }
+            }
+          }
+        ],
+        "notes": "Create a Service Account via GCP console with access to BigQuery datasets. For CSV/Excel uploads, also install pandas_gbq.",
+        "warnings": [
+          "Google BigQuery Python SDK is not compatible with gevent. Use a worker type other than gevent when deploying with gunicorn."
+        ],
+        "docs_url": "https://github.com/googleapis/python-bigquery-sqlalchemy",
+        "category": "Cloud - Google",
         "custom_errors": [
           {
+            "regex_name": "CONNECTION_DATABASE_PERMISSIONS_REGEX",
+            "message_template": "Unable to connect. Verify that the following roles are set on the service account: \"BigQuery Data Viewer\", \"BigQuery Metadata Viewer\", \"BigQuery Job User\" and the following permissions are set \"bigquery.readsessions.create\", \"bigquery.readsessions.getData\"",
+            "error_type": "CONNECTION_DATABASE_PERMISSIONS_ERROR",
+            "category": "Permissions",
+            "description": "Insufficient permissions",
+            "issue_codes": [
+              1017
+            ]
+          },
+          {
+            "regex_name": "TABLE_DOES_NOT_EXIST_REGEX",
+            "message_template": "The table \"%(table)s\" does not exist. A valid table must be used to run this query.",
+            "error_type": "TABLE_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Table not found",
+            "issue_codes": [
+              1003,
+              1005
+            ]
+          },
+          {
+            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
+            "message_template": "We can't seem to resolve column \"%(column)s\" at line %(location)s.",
+            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Column not found",
+            "issue_codes": [
+              1003,
+              1004
+            ]
+          },
+          {
+            "regex_name": "SCHEMA_DOES_NOT_EXIST_REGEX",
+            "message_template": "The schema \"%(schema)s\" does not exist. A valid schema must be used to run this query.",
+            "error_type": "SCHEMA_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Schema not found",
+            "issue_codes": [
+              1003,
+              1016
+            ]
+          },
+          {
             "regex_name": "SYNTAX_ERROR_REGEX",
-            "message_template": "Please check your query for syntax errors near \"%(server_error)s\". Then, try running your query again.",
+            "message_template": "Please check your query for syntax errors at or near \"%(syntax_error)s\". Then, try running your query again.",
             "error_type": "SYNTAX_ERROR",
             "category": "Query",
             "description": "SQL syntax error",
@@ -2696,6 +5231,174 @@
           }
         ]
       },
+      "engine": "bigquery",
+      "engine_name": "Google BigQuery",
+      "engine_aliases": [],
+      "default_driver": "bigquery",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Google Datastore": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.datastore",
+      "limit_method": 3,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": true,
+      "cte_in_subquery": true,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": false,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 73,
+      "max_score": 201,
+      "documentation": {
+        "description": "Google Cloud Datastore is a highly scalable NoSQL database for your applications.",
+        "logo": "datastore.png",
+        "homepage_url": "https://cloud.google.com/datastore/",
+        "categories": [
+          "Cloud - Google",
+          "Search & NoSQL",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "python-datastore-sqlalchemy"
+        ],
+        "connection_string": "datastore://{project_id}/?database={database_id}",
+        "authentication_methods": [
+          {
+            "name": "Service Account JSON",
+            "description": "Upload service account credentials JSON or paste in Secure Extra",
+            "secure_extra": {
+              "credentials_info": {
+                "type": "service_account",
+                "project_id": "...",
+                "private_key_id": "...",
+                "private_key": "...",
+                "client_email": "...",
+                "client_id": "...",
+                "auth_uri": "...",
+                "token_uri": "..."
+              }
+            }
+          }
+        ],
+        "notes": "Create a Service Account via GCP console with access to datastore datasets.",
+        "docs_url": "https://github.com/splasky/Python-datastore-sqlalchemy",
+        "category": "Cloud - Google",
+        "custom_errors": [
+          {
+            "regex_name": "CONNECTION_DATABASE_PERMISSIONS_REGEX",
+            "message_template": "Unable to connect. Verify that the following roles are set on the service account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud Datastore Creator\"",
+            "error_type": "CONNECTION_DATABASE_PERMISSIONS_ERROR",
+            "category": "Permissions",
+            "description": "Insufficient permissions",
+            "issue_codes": [
+              1017
+            ]
+          },
+          {
+            "regex_name": "TABLE_DOES_NOT_EXIST_REGEX",
+            "message_template": "The table \"%(table)s\" does not exist. A valid table must be used to run this query.",
+            "error_type": "TABLE_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Table not found",
+            "issue_codes": [
+              1003,
+              1005
+            ]
+          },
+          {
+            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
+            "message_template": "We can't seem to resolve column \"%(column)s\" at line %(location)s.",
+            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Column not found",
+            "issue_codes": [
+              1003,
+              1004
+            ]
+          },
+          {
+            "regex_name": "SCHEMA_DOES_NOT_EXIST_REGEX",
+            "message_template": "The schema \"%(schema)s\" does not exist. A valid schema must be used to run this query.",
+            "error_type": "SCHEMA_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Schema not found",
+            "issue_codes": [
+              1003,
+              1016
+            ]
+          },
+          {
+            "regex_name": "SYNTAX_ERROR_REGEX",
+            "message_template": "Please check your query for syntax errors at or near \"%(syntax_error)s\". Then, try running your query again.",
+            "error_type": "SYNTAX_ERROR",
+            "category": "Query",
+            "description": "SQL syntax error",
+            "issue_codes": [
+              1030
+            ]
+          }
+        ]
+      },
+      "engine": "datastore",
+      "engine_name": "Google Datastore",
+      "engine_aliases": [],
+      "default_driver": "datastore",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Google Sheets": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": true,
@@ -2719,55 +5422,93 @@
         "QUARTER_YEAR": true,
         "YEAR": true
       },
-      "score": 61,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.gsheets",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": true,
+      "user_impersonation": true,
+      "file_upload": true,
+      "get_extra_table_metadata": true,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": false,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "SAP HANA": {
-      "engine": "sap_hana",
-      "engine_name": "SAP HANA",
-      "module": "hana",
+      "sql_validation": false,
+      "score": 61,
+      "max_score": 201,
       "documentation": {
-        "description": "SAP HANA is an in-memory relational database and application platform.",
-        "logo": "sap-hana.png",
-        "homepage_url": "https://www.sap.com/products/technology-platform/hana.html",
+        "description": "Google Sheets allows querying spreadsheets as SQL tables via shillelagh.",
+        "logo": "google-sheets.svg",
+        "homepage_url": "https://www.google.com/sheets/about/",
         "categories": [
-          "TRADITIONAL_RDBMS",
-          "PROPRIETARY"
+          "Cloud - Google",
+          "Hosted Open Source"
         ],
         "pypi_packages": [
-          "hdbcli",
-          "sqlalchemy-hana"
+          "shillelagh[gsheetsapi]"
         ],
-        "install_instructions": "pip install apache_superset[hana]",
-        "connection_string": "hana://{username}:{password}@{host}:{port}",
-        "default_port": 30015,
-        "docs_url": "https://github.com/SAP/sqlalchemy-hana"
+        "install_instructions": "pip install \"apache-superset[gsheets]\"",
+        "connection_string": "gsheets://",
+        "notes": "Requires Google service account credentials or OAuth2 authentication. See docs for setup instructions.",
+        "category": "Cloud - Google",
+        "custom_errors": [
+          {
+            "regex_name": "SYNTAX_ERROR_REGEX",
+            "message_template": "Please check your query for syntax errors near \"%(server_error)s\". Then, try running your query again.",
+            "error_type": "SYNTAX_ERROR",
+            "category": "Query",
+            "description": "SQL syntax error",
+            "issue_codes": [
+              1030
+            ]
+          }
+        ]
       },
+      "engine": "gsheets",
+      "engine_name": "Google Sheets",
+      "engine_aliases": [],
+      "default_driver": "apsw",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Greenplum": {
       "time_grains": {
         "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
         "MINUTE": true,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": false,
-        "THIRTY_MINUTES": false,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
         "HALF_HOUR": false,
         "HOUR": true,
         "SIX_HOURS": false,
         "DAY": true,
-        "WEEK": false,
+        "WEEK": true,
         "WEEK_STARTING_SUNDAY": false,
         "WEEK_STARTING_MONDAY": false,
         "WEEK_ENDING_SATURDAY": false,
@@ -2777,54 +5518,169 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 27,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.greenplum",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 63,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": true,
+      "sql_validation": false,
+      "score": 94,
+      "max_score": 201,
+      "documentation": {
+        "description": "VMware Greenplum is a massively parallel processing (MPP) database built on PostgreSQL.",
+        "logo": "greenplum.png",
+        "homepage_url": "https://greenplum.org/",
+        "categories": [
+          "Traditional RDBMS",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "sqlalchemy-greenplum",
+          "psycopg2"
+        ],
+        "connection_string": "greenplum://{username}:{password}@{host}:{port}/{database}",
+        "default_port": 5432,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "Greenplum coordinator host",
+          "port": "Default 5432",
+          "database": "Database name"
+        },
+        "docs_url": "https://docs.vmware.com/en/VMware-Greenplum/",
+        "category": "Other Databases"
+      },
+      "engine": "greenplum",
+      "engine_name": "Greenplum",
+      "engine_aliases": [
+        "postgres"
+      ],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Hologres": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.hologres",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache Hive": {
-      "engine": "apache_hive",
-      "engine_name": "Apache Hive",
-      "module": "hive",
+      "sql_validation": false,
+      "score": 34,
+      "max_score": 201,
       "documentation": {
-        "description": "Apache Hive is a data warehouse infrastructure built on Hadoop.",
-        "logo": "apache-hive.svg",
-        "homepage_url": "https://hive.apache.org/",
-        "pypi_packages": [
-          "pyhive",
-          "pyhive"
-        ],
-        "install_instructions": "pip install \"apache-superset[presto]\"",
-        "connection_string": "hive://hive@{hostname}:{port}/{database}",
-        "default_port": 10000,
-        "parameters": {
-          "hostname": "Presto coordinator hostname",
-          "port": "Presto coordinator port (default 8080)",
-          "database": "Catalog name"
-        },
-        "drivers": [
-          {
-            "name": "PyHive",
-            "pypi_package": "pyhive",
-            "connection_string": "presto://{hostname}:{port}/{database}",
-            "is_recommended": true
-          }
-        ],
+        "description": "Alibaba Cloud Hologres is a real-time interactive analytics service, fully compatible with PostgreSQL 11.",
+        "logo": "hologres.png",
+        "homepage_url": "https://www.alibabacloud.com/product/hologres",
         "categories": [
-          "APACHE_PROJECTS",
-          "QUERY_ENGINES",
-          "OPEN_SOURCE"
-        ]
+          "Cloud Data Warehouses",
+          "Analytical Databases",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "psycopg2"
+        ],
+        "connection_string": "postgresql+psycopg2://{username}:{password}@{host}:{port}/{database}",
+        "parameters": {
+          "username": "AccessKey ID of your Alibaba Cloud account",
+          "password": "AccessKey secret of your Alibaba Cloud account",
+          "host": "Public endpoint of the Hologres instance",
+          "port": "Port number of the Hologres instance",
+          "database": "Name of the Hologres database"
+        },
+        "default_port": 80,
+        "notes": "Uses the PostgreSQL driver. psycopg2 comes bundled with Superset.",
+        "category": "Other Databases"
       },
+      "engine": "hologres",
+      "engine_name": "Hologres",
+      "engine_aliases": [],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "IBM Db2": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -2839,82 +5695,57 @@
         "SIX_HOURS": false,
         "DAY": true,
         "WEEK": true,
-        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_SUNDAY": false,
         "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
         "WEEK_ENDING_SUNDAY": false,
         "MONTH": true,
         "QUARTER": true,
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 140,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.db2",
+      "limit_method": 2,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": true,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": true,
-      "query_cost_estimation": true,
-      "sql_validation": false
-    },
-    "Hologres": {
-      "engine": "hologres",
-      "engine_name": "Hologres",
-      "module": "hologres",
-      "documentation": {
-        "description": "Alibaba Cloud Hologres is a real-time interactive analytics service, fully compatible with PostgreSQL 11.",
-        "logo": "hologres.png",
-        "homepage_url": "https://www.alibabacloud.com/product/hologres",
-        "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "psycopg2"
-        ],
-        "connection_string": "postgresql+psycopg2://{username}:{password}@{host}:{port}/{database}",
-        "parameters": {
-          "username": "AccessKey ID of your Alibaba Cloud account",
-          "password": "AccessKey secret of your Alibaba Cloud account",
-          "host": "Public endpoint of the Hologres instance",
-          "port": "Port number of the Hologres instance",
-          "database": "Name of the Hologres database"
-        },
-        "default_port": 80,
-        "notes": "Uses the PostgreSQL driver. psycopg2 comes bundled with Superset."
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 30,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
       "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "IBM Db2 for i": {
-      "engine": "ibm_db2_for_i",
-      "engine_name": "IBM Db2 for i",
-      "module": "ibmi",
+      "sql_validation": false,
+      "score": 38,
+      "max_score": 201,
       "documentation": {
         "description": "IBM Db2 is a family of data management products for enterprise workloads, available on-premises, in containers, and across cloud platforms.",
         "logo": "ibm-db2.svg",
         "homepage_url": "https://www.ibm.com/db2",
         "categories": [
-          "TRADITIONAL_RDBMS",
-          "PROPRIETARY"
+          "Traditional RDBMS",
+          "Proprietary"
         ],
         "pypi_packages": [
           "ibm_db_sa"
@@ -2934,195 +5765,43 @@
             "notes": "Use for older DB2 versions without LIMIT [n] syntax. Recommended for SQL Lab."
           }
         ],
-        "docs_url": "https://github.com/ibmdb/python-ibmdbsa"
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache Impala": {
-      "engine": "apache_impala",
-      "engine_name": "Apache Impala",
-      "module": "impala",
-      "documentation": {
-        "description": "Apache Impala is an open-source massively parallel processing SQL query engine.",
-        "logo": "apache-impala.png",
-        "homepage_url": "https://impala.apache.org/",
-        "categories": [
-          "APACHE_PROJECTS",
-          "QUERY_ENGINES",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "impyla"
-        ],
-        "connection_string": "impala://{hostname}:{port}/{database}",
-        "default_port": 21050
-      },
-      "time_grains": {
-        "SECOND": false,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": true,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": false,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": false,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 37,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache IoTDB": {
-      "engine": "apache_iotdb",
-      "engine_name": "Apache IoTDB",
-      "module": "iotdb",
-      "documentation": {
-        "description": "Apache IoTDB is a time series database designed for IoT data, with efficient storage and query capabilities for massive time series data.",
-        "logo": "apache-iotdb.svg",
-        "homepage_url": "https://iotdb.apache.org/",
-        "categories": [
-          "APACHE_PROJECTS",
-          "TIME_SERIES",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "apache-iotdb"
-        ],
-        "connection_string": "iotdb://{username}:{password}@{hostname}:{port}",
-        "default_port": 6667,
-        "parameters": {
-          "username": "Database username (default: root)",
-          "password": "Database password (default: root)",
-          "hostname": "IP address or hostname",
-          "port": "Default 6667"
-        },
-        "notes": "The IoTDB SQLAlchemy dialect was written to integrate with Apache Superset. IoTDB uses a hierarchical data model, which is reorganized into a relational model for SQL queries."
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Azure Data Explorer": {
-      "engine": "azure_data_explorer",
-      "engine_name": "Azure Data Explorer",
-      "module": "kusto",
-      "documentation": {
-        "description": "Azure Data Explorer (Kusto) is a fast, fully managed data analytics service from Microsoft Azure. Query data using SQL or native KQL syntax.",
-        "logo": "kusto.png",
-        "homepage_url": "https://azure.microsoft.com/en-us/products/data-explorer/",
-        "categories": [
-          "CLOUD_AZURE",
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "sqlalchemy-kusto"
-        ],
-        "connection_string": "kustosql+https://{cluster}.kusto.windows.net/{database}?msi=False&azure_ad_client_id={client_id}&azure_ad_client_secret={client_secret}&azure_ad_tenant_id={tenant_id}",
-        "parameters": {
-          "cluster": "Azure Data Explorer cluster name",
-          "database": "Database name",
-          "client_id": "Azure AD application (client) ID",
-          "client_secret": "Azure AD application secret",
-          "tenant_id": "Azure AD tenant ID"
-        },
-        "drivers": [
+        "compatible_databases": [
           {
-            "name": "SQL Interface (Recommended)",
-            "pypi_package": "sqlalchemy-kusto",
-            "connection_string": "kustosql+https://{cluster}.kusto.windows.net/{database}?msi=False&azure_ad_client_id={client_id}&azure_ad_client_secret={client_secret}&azure_ad_tenant_id={tenant_id}",
-            "is_recommended": true,
-            "notes": "Use familiar SQL syntax to query Azure Data Explorer."
-          },
-          {
-            "name": "KQL (Kusto Query Language)",
-            "pypi_package": "sqlalchemy-kusto",
-            "connection_string": "kustokql+https://{cluster}.kusto.windows.net/{database}?msi=False&azure_ad_client_id={client_id}&azure_ad_client_secret={client_secret}&azure_ad_tenant_id={tenant_id}",
-            "is_recommended": false,
-            "notes": "Use native Kusto Query Language for advanced analytics."
+            "name": "IBM Db2 for i (AS/400)",
+            "description": "Db2 for i is a fully integrated database engine on IBM i (AS/400) systems. Uses a different SQLAlchemy driver optimized for IBM i.",
+            "logo": "ibm-db2.svg",
+            "homepage_url": "https://www.ibm.com/products/db2-for-i",
+            "pypi_packages": [
+              "sqlalchemy-ibmi"
+            ],
+            "connection_string": "ibmi://{username}:{password}@{host}/{database}",
+            "parameters": {
+              "username": "IBM i username",
+              "password": "IBM i password",
+              "host": "IBM i system host",
+              "database": "Library/schema name"
+            },
+            "docs_url": "https://github.com/IBM/sqlalchemy-ibmi",
+            "categories": [
+              "Proprietary"
+            ]
           }
-        ]
+        ],
+        "docs_url": "https://github.com/ibmdb/python-ibmdbsa",
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
+      "engine": "db2",
+      "engine_name": "IBM Db2",
+      "engine_aliases": [
+        "ibm_db_sa"
+      ],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
-    "Apache Kylin": {
-      "engine": "apache_kylin",
-      "engine_name": "Apache Kylin",
-      "module": "kylin",
-      "documentation": {
-        "description": "Apache Kylin is an open-source OLAP engine for big data.",
-        "logo": "apache-kylin.png",
-        "homepage_url": "https://kylin.apache.org/",
-        "categories": [
-          "APACHE_PROJECTS",
-          "ANALYTICAL_DATABASES",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "kylinpy"
-        ],
-        "connection_string": "kylin://{username}:{password}@{hostname}:{port}/{project}?{param1}={value1}&{param2}={value2}",
-        "default_port": 7070
-      },
+    "IBM Db2 for i": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -3146,80 +5825,187 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 28,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.ibmi",
+      "limit_method": 2,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "MariaDB": {
-      "engine": "mariadb",
-      "engine_name": "MariaDB",
-      "module": "mariadb",
+      "sql_validation": false,
+      "score": 38,
+      "max_score": 201,
       "documentation": {
-        "description": "MariaDB is a community-developed fork of MySQL.",
-        "logo": "mariadb.png",
-        "homepage_url": "https://mariadb.org/",
+        "description": "IBM Db2 is a family of data management products for enterprise workloads, available on-premises, in containers, and across cloud platforms.",
+        "logo": "ibm-db2.svg",
+        "homepage_url": "https://www.ibm.com/db2",
+        "categories": [
+          "Traditional RDBMS",
+          "Proprietary"
+        ],
         "pypi_packages": [
-          "mysqlclient",
-          "mysqlclient"
+          "ibm_db_sa"
         ],
-        "connection_string": "mysql://{username}:{password}@{host}/{database}",
-        "default_port": 3306,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "localhost, 127.0.0.1, IP address, or hostname",
-          "database": "Database name"
-        },
-        "host_examples": [
-          {
-            "platform": "Localhost",
-            "host": "localhost or 127.0.0.1"
-          },
-          {
-            "platform": "Docker on Linux",
-            "host": "172.18.0.1"
-          },
-          {
-            "platform": "Docker on macOS",
-            "host": "docker.for.mac.host.internal"
-          },
-          {
-            "platform": "On-premise",
-            "host": "IP address or hostname"
-          }
-        ],
+        "connection_string": "db2+ibm_db://{username}:{password}@{hostname}:{port}/{database}",
+        "default_port": 50000,
         "drivers": [
           {
-            "name": "mysqlclient",
-            "pypi_package": "mysqlclient",
-            "connection_string": "mysql://{username}:{password}@{host}/{database}",
-            "is_recommended": true,
-            "notes": "Recommended driver. May fail with caching_sha2_password auth."
+            "name": "ibm_db_sa (with LIMIT)",
+            "connection_string": "db2+ibm_db://{username}:{password}@{hostname}:{port}/{database}",
+            "is_recommended": true
           },
           {
-            "name": "mysql-connector-python",
-            "pypi_package": "mysql-connector-python",
-            "connection_string": "mysql+mysqlconnector://{username}:{password}@{host}/{database}",
+            "name": "ibm_db_sa (without LIMIT syntax)",
+            "connection_string": "ibm_db_sa://{username}:{password}@{hostname}:{port}/{database}",
             "is_recommended": false,
-            "notes": "Required for newer MySQL databases using caching_sha2_password authentication."
+            "notes": "Use for older DB2 versions without LIMIT [n] syntax. Recommended for SQL Lab."
           }
         ],
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
+        "compatible_databases": [
+          {
+            "name": "IBM Db2 for i (AS/400)",
+            "description": "Db2 for i is a fully integrated database engine on IBM i (AS/400) systems. Uses a different SQLAlchemy driver optimized for IBM i.",
+            "logo": "ibm-db2.svg",
+            "homepage_url": "https://www.ibm.com/products/db2-for-i",
+            "pypi_packages": [
+              "sqlalchemy-ibmi"
+            ],
+            "connection_string": "ibmi://{username}:{password}@{host}/{database}",
+            "parameters": {
+              "username": "IBM i username",
+              "password": "IBM i password",
+              "host": "IBM i system host",
+              "database": "Library/schema name"
+            },
+            "docs_url": "https://github.com/IBM/sqlalchemy-ibmi",
+            "categories": [
+              "Proprietary"
+            ]
+          }
         ],
-        "notes": "Uses the MySQL driver. Fully compatible with MySQL connector."
+        "docs_url": "https://github.com/ibmdb/python-ibmdbsa",
+        "category": "Other Databases"
       },
+      "engine": "ibmi",
+      "engine_name": "IBM Db2 for i",
+      "engine_aliases": [
+        "ibm_db_sa"
+      ],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "IBM Netezza Performance Server": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.netezza",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
+      "documentation": {
+        "description": "IBM Netezza Performance Server is a data warehouse appliance.",
+        "logo": "netezza.png",
+        "homepage_url": "https://www.ibm.com/products/netezza",
+        "categories": [
+          "Traditional RDBMS",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "nzalchemy"
+        ],
+        "connection_string": "netezza+nzpy://{username}:{password}@{hostname}:{port}/{database}",
+        "default_port": 5480,
+        "category": "Other Databases"
+      },
+      "engine": "netezza",
+      "engine_name": "IBM Netezza Performance Server",
+      "engine_aliases": [],
+      "default_driver": "nzpy",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "MariaDB": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -3243,31 +6029,274 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 59,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.mariadb",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 64,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 59,
+      "max_score": 201,
+      "documentation": {
+        "description": "MariaDB is a community-developed fork of MySQL.",
+        "logo": "mariadb.png",
+        "homepage_url": "https://mariadb.org/",
+        "categories": [
+          "Traditional RDBMS",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "mysqlclient"
+        ],
+        "connection_string": "mysql://{username}:{password}@{host}/{database}",
+        "default_port": 3306,
+        "notes": "Uses the MySQL driver. Fully compatible with MySQL connector.",
+        "category": "Traditional RDBMS"
+      },
+      "engine": "mariadb",
+      "engine_name": "MariaDB",
+      "engine_aliases": [],
+      "default_driver": "mysqldb",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Microsoft SQL Server": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.mssql",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": false,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 44,
+      "max_score": 201,
+      "documentation": {
+        "description": "Microsoft SQL Server is a relational database management system.",
+        "logo": "msql.png",
+        "homepage_url": "https://www.microsoft.com/en-us/sql-server",
+        "categories": [
+          "Traditional RDBMS",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "pymssql"
+        ],
+        "connection_string": "mssql+pymssql://{username}:{password}@{host}:{port}/{database}",
+        "default_port": 1433,
+        "drivers": [
+          {
+            "name": "pymssql",
+            "pypi_package": "pymssql",
+            "connection_string": "mssql+pymssql://{username}:{password}@{host}:{port}/{database}",
+            "is_recommended": true
+          },
+          {
+            "name": "pyodbc",
+            "pypi_package": "pyodbc",
+            "connection_string": "mssql+pyodbc:///?odbc_connect=Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3BServer%3Dtcp%3A%3C{host}%3E%2C1433%3BDatabase%3D{database}%3BUid%3D{username}%3BPwd%3D{password}%3BEncrypt%3Dyes%3BConnection+Timeout%3D30",
+            "is_recommended": false,
+            "notes": "Connection string must be URL-encoded. Special characters like @ need encoding."
+          }
+        ],
+        "docs_url": "https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords",
+        "category": "Cloud - Azure",
+        "custom_errors": [
+          {
+            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
+            "message_template": "Either the username \"%(username)s\", password, or database name \"%(database)s\" is incorrect.",
+            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
+            "category": "Authentication",
+            "description": "Access denied",
+            "issue_codes": [
+              1014,
+              1015
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
+            "message_template": "The hostname \"%(hostname)s\" cannot be resolved.",
+            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
+            "category": "Connection",
+            "description": "Invalid hostname",
+            "issue_codes": [
+              1007
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_PORT_CLOSED_REGEX",
+            "message_template": "Port %(port)s on hostname \"%(hostname)s\" refused the connection.",
+            "error_type": "CONNECTION_PORT_CLOSED_ERROR",
+            "category": "Connection",
+            "description": "Port closed or refused",
+            "issue_codes": [
+              1008
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
+            "message_template": "The host \"%(hostname)s\" might be down, and can't be reached on port %(port)s.",
+            "error_type": "CONNECTION_HOST_DOWN_ERROR",
+            "category": "Connection",
+            "description": "Host unreachable",
+            "issue_codes": [
+              1009
+            ]
+          }
+        ]
+      },
+      "engine": "mssql",
+      "engine_name": "Microsoft SQL Server",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "MonetDB": {
-      "engine": "monetdb",
-      "engine_name": "MonetDB",
-      "module": "monetdb",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": false,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": false,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.monetdb",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 26,
+      "max_score": 201,
       "documentation": {
         "description": "MonetDB is an open-source column-oriented relational database for high-performance analytics.",
         "logo": "monet-db.png",
         "homepage_url": "https://www.monetdb.org/",
         "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
+          "Traditional RDBMS",
+          "Open Source"
         ],
         "pypi_packages": [
           "sqlalchemy-monetdb",
@@ -3282,34 +6311,84 @@
           "port": "Default 50000",
           "database": "Database name"
         },
-        "docs_url": "https://www.monetdb.org/documentation/"
+        "docs_url": "https://www.monetdb.org/documentation/",
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "monetdb",
+      "engine_name": "MonetDB",
+      "engine_aliases": [],
+      "default_driver": "pymonetdb",
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "MongoDB": {
-      "engine": "mongodb",
-      "engine_name": "MongoDB",
-      "module": "mongodb",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.mongodb",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 32,
+      "max_score": 201,
       "documentation": {
         "description": "MongoDB is a document-oriented, operational NoSQL database.",
         "logo": "mongodb.png",
         "homepage_url": "https://www.mongodb.com/",
         "categories": [
-          "SEARCH_NOSQL",
-          "PROPRIETARY"
+          "Search & NoSQL",
+          "Proprietary"
         ],
         "pypi_packages": [
           "pymongosql"
@@ -3339,115 +6418,146 @@
           }
         ],
         "notes": "Uses PartiQL for SQL queries. Requires mode=superset parameter.",
-        "docs_url": "https://github.com/passren/PyMongoSQL"
+        "docs_url": "https://github.com/passren/PyMongoSQL",
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "mongodb",
+      "engine_name": "MongoDB",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
-    "Microsoft SQL Server": {
-      "engine": "microsoft_sql_server",
-      "engine_name": "Microsoft SQL Server",
-      "module": "mssql",
-      "documentation": {
-        "description": "Microsoft SQL Server is a relational database management system.",
-        "logo": "msql.png",
-        "homepage_url": "https://www.microsoft.com/en-us/sql-server",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "pymssql"
-        ],
-        "connection_string": "mssql+pymssql://{username}:{password}@{host}:{port}/{database}",
-        "default_port": 1433,
-        "drivers": [
-          {
-            "name": "pymssql",
-            "pypi_package": "pymssql",
-            "connection_string": "mssql+pymssql://{username}:{password}@{host}:{port}/{database}",
-            "is_recommended": true
-          },
-          {
-            "name": "pyodbc",
-            "pypi_package": "pyodbc",
-            "connection_string": "mssql+pyodbc:///?odbc_connect=Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3BServer%3Dtcp%3A%3C{host}%3E%2C1433%3BDatabase%3D{database}%3BUid%3D{username}%3BPwd%3D{password}%3BEncrypt%3Dyes%3BConnection+Timeout%3D30",
-            "is_recommended": false,
-            "notes": "Connection string must be URL-encoded. Special characters like @ need encoding."
-          }
-        ],
-        "docs_url": "https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords",
-        "custom_errors": [
-          {
-            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
-            "message_template": "Either the username \"%(username)s\", password, or database name \"%(database)s\" is incorrect.",
-            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
-            "category": "Authentication",
-            "description": "Access denied",
-            "issue_codes": [
-              1014,
-              1015
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
-            "message_template": "The hostname \"%(hostname)s\" cannot be resolved.",
-            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
-            "category": "Connection",
-            "description": "Invalid hostname",
-            "issue_codes": [
-              1007
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_PORT_CLOSED_REGEX",
-            "message_template": "Port %(port)s on hostname \"%(hostname)s\" refused the connection.",
-            "error_type": "CONNECTION_PORT_CLOSED_ERROR",
-            "category": "Connection",
-            "description": "Port closed or refused",
-            "issue_codes": [
-              1008
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
-            "message_template": "The host \"%(hostname)s\" might be down, and can't be reached on port %(port)s.",
-            "error_type": "CONNECTION_HOST_DOWN_ERROR",
-            "category": "Connection",
-            "description": "Host unreachable",
-            "issue_codes": [
-              1009
-            ]
-          }
-        ]
-      },
+    "MotherDuck": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
         "THIRTY_SECONDS": false,
         "MINUTE": true,
-        "FIVE_MINUTES": true,
-        "TEN_MINUTES": true,
-        "FIFTEEN_MINUTES": true,
-        "THIRTY_MINUTES": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
         "HALF_HOUR": false,
         "HOUR": true,
         "SIX_HOURS": false,
         "DAY": true,
         "WEEK": true,
-        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.duckdb",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 58,
+      "max_score": 201,
+      "documentation": {
+        "description": "MotherDuck is a serverless cloud analytics platform built on DuckDB. It combines the simplicity of DuckDB with cloud-scale data sharing and collaboration.",
+        "logo": "motherduck.png",
+        "homepage_url": "https://motherduck.com/",
+        "categories": [
+          "Analytical Databases",
+          "Cloud Data Warehouses",
+          "Hosted Open Source"
+        ],
+        "pypi_packages": [
+          "duckdb",
+          "duckdb-engine"
+        ],
+        "connection_string": "duckdb:///md:{database}?motherduck_token={token}",
+        "parameters": {
+          "database": "MotherDuck database name",
+          "token": "Service token from MotherDuck dashboard"
+        },
+        "docs_url": "https://motherduck.com/docs/getting-started/",
+        "drivers": [
+          {
+            "name": "duckdb-engine",
+            "pypi_package": "duckdb-engine",
+            "connection_string": "duckdb:///md:{database}?motherduck_token={token}",
+            "is_recommended": true
+          }
+        ],
+        "category": "Other Databases",
+        "custom_errors": [
+          {
+            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
+            "message_template": "We can't seem to resolve the column \"%(column_name)s\"",
+            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Column not found",
+            "issue_codes": [
+              1003,
+              1004
+            ]
+          }
+        ]
+      },
+      "engine": "motherduck",
+      "engine_name": "MotherDuck",
+      "engine_aliases": [
+        "duckdb"
+      ],
+      "default_driver": "duckdb_engine",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "MySQL": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
         "WEEK_STARTING_MONDAY": true,
         "WEEK_ENDING_SATURDAY": false,
         "WEEK_ENDING_SUNDAY": false,
@@ -3456,125 +6566,48 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 44,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.mysql",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 64,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
-      "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Azure Synapse": {
-      "engine": "azure_synapse",
-      "engine_name": "Azure Synapse",
-      "module": "mssql",
-      "documentation": {
-        "description": "Azure Synapse Analytics is a cloud-based enterprise data warehouse from Microsoft that combines big data and data warehousing.",
-        "logo": "azure.svg",
-        "homepage_url": "https://azure.microsoft.com/en-us/products/synapse-analytics/",
-        "pypi_packages": [
-          "pymssql",
-          "pymssql"
-        ],
-        "connection_string": "mssql+pymssql://{username}@{server}:{password}@{server}.database.windows.net:1433/{database}",
-        "default_port": 1433,
-        "drivers": [
-          {
-            "name": "pymssql",
-            "pypi_package": "pymssql",
-            "connection_string": "mssql+pymssql://{username}:{password}@{host}:{port}/{database}",
-            "is_recommended": true
-          },
-          {
-            "name": "pyodbc",
-            "pypi_package": "pyodbc",
-            "connection_string": "mssql+pyodbc:///?odbc_connect=Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3BServer%3Dtcp%3A%3C{host}%3E%2C1433%3BDatabase%3D{database}%3BUid%3D{username}%3BPwd%3D{password}%3BEncrypt%3Dyes%3BConnection+Timeout%3D30",
-            "is_recommended": false,
-            "notes": "Connection string must be URL-encoded. Special characters like @ need encoding."
-          }
-        ],
-        "docs_url": "https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords",
-        "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
-        ],
-        "custom_errors": [
-          {
-            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
-            "message_template": "Either the username \"%(username)s\", password, or database name \"%(database)s\" is incorrect.",
-            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
-            "category": "Authentication",
-            "description": "Access denied",
-            "issue_codes": [
-              1014,
-              1015
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
-            "message_template": "The hostname \"%(hostname)s\" cannot be resolved.",
-            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
-            "category": "Connection",
-            "description": "Invalid hostname",
-            "issue_codes": [
-              1007
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_PORT_CLOSED_REGEX",
-            "message_template": "Port %(port)s on hostname \"%(hostname)s\" refused the connection.",
-            "error_type": "CONNECTION_PORT_CLOSED_ERROR",
-            "category": "Connection",
-            "description": "Port closed or refused",
-            "issue_codes": [
-              1008
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
-            "message_template": "The host \"%(hostname)s\" might be down, and can't be reached on port %(port)s.",
-            "error_type": "CONNECTION_HOST_DOWN_ERROR",
-            "category": "Connection",
-            "description": "Host unreachable",
-            "issue_codes": [
-              1009
-            ]
-          }
-        ]
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "MySQL": {
-      "engine": "mysql",
-      "engine_name": "MySQL",
-      "module": "mysql",
+      "sql_validation": false,
+      "score": 59,
+      "max_score": 201,
       "documentation": {
         "description": "MySQL is a popular open-source relational database.",
         "logo": "mysql.png",
         "homepage_url": "https://www.mysql.com/",
         "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
+          "Traditional RDBMS",
+          "Open Source"
         ],
         "pypi_packages": [
           "mysqlclient"
@@ -3632,7 +6665,7 @@
             ],
             "connection_string": "mysql://{username}:{password}@{host}:{port}/{database}",
             "categories": [
-              "OPEN_SOURCE"
+              "Open Source"
             ]
           },
           {
@@ -3654,11 +6687,12 @@
             },
             "notes": "Uses the Data API for serverless access. Standard MySQL connections also work with mysqlclient.",
             "categories": [
-              "CLOUD_AWS",
-              "HOSTED_OPEN_SOURCE"
+              "Cloud - AWS",
+              "Hosted Open Source"
             ]
           }
         ],
+        "category": "Traditional RDBMS",
         "custom_errors": [
           {
             "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
@@ -3727,6 +6761,16 @@
           }
         ]
       },
+      "engine": "mysql",
+      "engine_name": "MySQL",
+      "engine_aliases": [],
+      "default_driver": "mysqldb",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "OceanBase": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -3750,111 +6794,54 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 59,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.oceanbase",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "IBM Netezza Performance Server": {
-      "engine": "ibm_netezza_performance_server",
-      "engine_name": "IBM Netezza Performance Server",
-      "module": "netezza",
-      "documentation": {
-        "description": "IBM Netezza Performance Server is a data warehouse appliance.",
-        "logo": "netezza.png",
-        "homepage_url": "https://www.ibm.com/products/netezza",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "nzalchemy"
-        ],
-        "connection_string": "netezza+nzpy://{username}:{password}@{hostname}:{port}/{database}",
-        "default_port": 5480
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "OceanBase": {
-      "engine": "oceanbase",
-      "engine_name": "OceanBase",
-      "module": "oceanbase",
+      "sql_validation": false,
+      "score": 59,
+      "max_score": 201,
       "documentation": {
         "description": "OceanBase is a distributed relational database.",
         "logo": "oceanbase.svg",
         "homepage_url": "https://www.oceanbase.com/",
+        "categories": [
+          "Traditional RDBMS",
+          "Open Source"
+        ],
         "pypi_packages": [
-          "mysqlclient",
           "oceanbase_py"
         ],
         "connection_string": "oceanbase://{username}:{password}@{host}:{port}/{database}",
-        "default_port": 3306,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "localhost, 127.0.0.1, IP address, or hostname",
-          "database": "Database name"
-        },
-        "host_examples": [
-          {
-            "platform": "Localhost",
-            "host": "localhost or 127.0.0.1"
-          },
-          {
-            "platform": "Docker on Linux",
-            "host": "172.18.0.1"
-          },
-          {
-            "platform": "Docker on macOS",
-            "host": "docker.for.mac.host.internal"
-          },
-          {
-            "platform": "On-premise",
-            "host": "IP address or hostname"
-          }
-        ],
-        "drivers": [
-          {
-            "name": "mysqlclient",
-            "pypi_package": "mysqlclient",
-            "connection_string": "mysql://{username}:{password}@{host}/{database}",
-            "is_recommended": true,
-            "notes": "Recommended driver. May fail with caching_sha2_password auth."
-          },
-          {
-            "name": "mysql-connector-python",
-            "pypi_package": "mysql-connector-python",
-            "connection_string": "mysql+mysqlconnector://{username}:{password}@{host}/{database}",
-            "is_recommended": false,
-            "notes": "Required for newer MySQL databases using caching_sha2_password authentication."
-          }
-        ],
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
-        ],
+        "category": "Other Databases",
         "custom_errors": [
           {
             "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
@@ -3923,36 +6910,89 @@
           }
         ]
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
+      "engine": "oceanbase",
+      "engine_name": "OceanBase",
+      "engine_aliases": [
+        "oceanbase",
+        "oceanbase_py"
+      ],
+      "default_driver": "oceanbase",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "Ocient": {
-      "engine": "ocient",
-      "engine_name": "Ocient",
-      "module": "ocient",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": false,
+        "QUARTER_YEAR": true,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.ocient",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": false,
+      "max_column_name": 30,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 38,
+      "max_score": 201,
       "documentation": {
         "description": "Ocient is a hyperscale data analytics database.",
         "categories": [
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
+          "Analytical Databases",
+          "Proprietary"
         ],
         "pypi_packages": [
           "sqlalchemy-ocient"
         ],
         "connection_string": "ocient://{username}:{password}@{host}:{port}/{database}",
         "install_instructions": "pip install sqlalchemy-ocient",
+        "category": "Other Databases",
         "custom_errors": [
           {
             "regex_name": "CONNECTION_INVALID_USERNAME_REGEX",
@@ -4043,6 +7083,16 @@
           }
         ]
       },
+      "engine": "ocient",
+      "engine_name": "Ocient",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "OpenSearch (OpenDistro)": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -4056,50 +7106,66 @@
         "HOUR": true,
         "SIX_HOURS": false,
         "DAY": true,
-        "WEEK": true,
+        "WEEK": false,
         "WEEK_STARTING_SUNDAY": false,
         "WEEK_STARTING_MONDAY": false,
         "WEEK_ENDING_SATURDAY": false,
         "WEEK_ENDING_SUNDAY": false,
         "MONTH": true,
         "QUARTER": false,
-        "QUARTER_YEAR": true,
+        "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 38,
-      "max_score": 201,
-      "joins": true,
+      "module": "superset.db_engine_specs.elasticsearch",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": false,
       "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": true,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": false,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 26,
+      "max_score": 201,
+      "documentation": {
+        "pypi_packages": [],
+        "connection_string": "engine+driver://user:password@host:port/dbname[?key=value&key=value...]",
+        "category": "Other Databases"
+      },
+      "engine": "odelasticsearch",
+      "engine_name": "OpenSearch (OpenDistro)",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "Oracle": {
-      "engine": "oracle",
-      "engine_name": "Oracle",
-      "module": "oracle",
-      "documentation": {
-        "description": "Oracle Database is a multi-model database management system.",
-        "logo": "oraclelogo.png",
-        "homepage_url": "https://www.oracle.com/database/",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "oracledb"
-        ],
-        "connection_string": "oracle://{username}:{password}@{hostname}:{port}",
-        "default_port": 1521,
-        "notes": "Previously used cx_Oracle, now uses oracledb.",
-        "docs_url": "https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html"
-      },
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -4123,29 +7189,131 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 28,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.oracle",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
+      "documentation": {
+        "description": "Oracle Database is a multi-model database management system.",
+        "logo": "oraclelogo.png",
+        "homepage_url": "https://www.oracle.com/database/",
+        "categories": [
+          "Traditional RDBMS",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "oracledb"
+        ],
+        "connection_string": "oracle://{username}:{password}@{hostname}:{port}",
+        "default_port": 1521,
+        "notes": "Previously used cx_Oracle, now uses oracledb.",
+        "docs_url": "https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html",
+        "category": "Other Databases"
+      },
+      "engine": "oracle",
+      "engine_name": "Oracle",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "Parseable": {
-      "engine": "parseable",
-      "engine_name": "Parseable",
-      "module": "parseable",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.parseable",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 28,
+      "max_score": 201,
       "documentation": {
         "description": "Parseable is a distributed log analytics database with SQL-like query interface.",
         "categories": [
-          "SEARCH_NOSQL",
-          "OPEN_SOURCE"
+          "Search & NoSQL",
+          "Open Source"
         ],
         "pypi_packages": [
           "sqlalchemy-parseable"
@@ -4158,121 +7326,23 @@
           }
         ],
         "notes": "Stream name in URI represents the Parseable logstream to query. Supports HTTP (80) and HTTPS (443).",
-        "docs_url": "https://www.parseable.io"
+        "docs_url": "https://www.parseable.io",
+        "category": "Other Databases"
       },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": true,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": false,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": false,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 28,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": false,
+      "engine": "parseable",
+      "engine_name": "Parseable",
+      "engine_aliases": [],
+      "default_driver": null,
       "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache Phoenix": {
-      "engine": "apache_phoenix",
-      "engine_name": "Apache Phoenix",
-      "module": "phoenix",
-      "documentation": {
-        "description": "Apache Phoenix is a relational database layer over Apache HBase, providing low-latency SQL queries over HBase data.",
-        "logo": "apache-phoenix.png",
-        "homepage_url": "https://phoenix.apache.org/",
-        "categories": [
-          "APACHE_PROJECTS",
-          "ANALYTICAL_DATABASES",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "phoenixdb"
-        ],
-        "connection_string": "phoenix://{hostname}:{port}/",
-        "default_port": 8765,
-        "notes": "Phoenix provides a SQL interface to Apache HBase. The phoenixdb driver connects via the Phoenix Query Server and supports a subset of SQLAlchemy."
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
-    "Apache Pinot": {
-      "engine": "apache_pinot",
-      "engine_name": "Apache Pinot",
-      "module": "pinot",
-      "documentation": {
-        "description": "Apache Pinot is a real-time distributed OLAP datastore.",
-        "logo": "apache-pinot.svg",
-        "homepage_url": "https://pinot.apache.org/",
-        "categories": [
-          "APACHE_PROJECTS",
-          "TIME_SERIES",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "pinotdb"
-        ],
-        "connection_string": "pinot+http://{broker_host}:{broker_port}/query?controller=http://{controller_host}:{controller_port}/",
-        "default_port": 8099,
-        "connection_examples": [
-          {
-            "description": "With authentication",
-            "connection_string": "pinot://{username}:{password}@{broker_host}:{broker_port}/query/sql?controller=http://{controller_host}:{controller_port}/verify_ssl=true"
-          }
-        ],
-        "engine_parameters": [
-          {
-            "name": "Multi-stage Query Engine",
-            "description": "Enable for Explore view, joins, window functions",
-            "json": {
-              "connect_args": {
-                "use_multistage_engine": "true"
-              }
-            },
-            "docs_url": "https://docs.pinot.apache.org/reference/multi-stage-engine"
-          }
-        ]
-      },
+    "PostgreSQL": {
       "time_grains": {
         "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
         "MINUTE": true,
         "FIVE_MINUTES": true,
         "TEN_MINUTES": true,
@@ -4292,31 +7362,48 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 32,
-      "max_score": 201,
-      "joins": false,
-      "subqueries": false,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": false,
-      "supports_file_upload": true,
+      "module": "superset.db_engine_specs.postgres",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 63,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
       "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "PostgreSQL": {
-      "engine": "postgresql",
-      "engine_name": "PostgreSQL",
-      "module": "postgres",
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": true,
+      "sql_validation": true,
+      "score": 104,
+      "max_score": 201,
       "documentation": {
         "description": "PostgreSQL is an advanced open-source relational database.",
         "logo": "postgresql.svg",
         "homepage_url": "https://www.postgresql.org/",
         "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
+          "Traditional RDBMS",
+          "Open Source"
         ],
         "pypi_packages": [
           "psycopg2"
@@ -4361,7 +7448,7 @@
               "database": "Name of the Hologres database"
             },
             "categories": [
-              "PROPRIETARY"
+              "Proprietary"
             ]
           },
           {
@@ -4382,7 +7469,7 @@
             "notes": "psycopg2 comes bundled with Superset Docker images.",
             "docs_url": "https://docs.timescale.com/",
             "categories": [
-              "OPEN_SOURCE"
+              "Open Source"
             ]
           },
           {
@@ -4397,7 +7484,7 @@
             "notes": "psycopg2 comes bundled with Superset Docker images.",
             "docs_url": "https://www.yugabyte.com/",
             "categories": [
-              "OPEN_SOURCE"
+              "Open Source"
             ]
           },
           {
@@ -4427,7 +7514,7 @@
             "notes": "Find connection details in your Supabase project dashboard under Settings > Database. Use the connection pooler (port 6543) for better connection management.",
             "docs_url": "https://supabase.com/docs/guides/database/connecting-to-postgres",
             "categories": [
-              "HOSTED_OPEN_SOURCE"
+              "Hosted Open Source"
             ]
           },
           {
@@ -4449,8 +7536,8 @@
             "notes": "For public IP connections, use the AlloyDB Auth Proxy for secure access. Private IP connections can connect directly.",
             "docs_url": "https://cloud.google.com/alloydb/docs",
             "categories": [
-              "CLOUD_GCP",
-              "HOSTED_OPEN_SOURCE"
+              "Cloud - Google",
+              "Hosted Open Source"
             ]
           },
           {
@@ -4471,7 +7558,7 @@
             "notes": "SSL is required for all connections. Find connection details in the Neon console under Connection Details.",
             "docs_url": "https://neon.tech/docs/connect/connect-from-any-app",
             "categories": [
-              "HOSTED_OPEN_SOURCE"
+              "Hosted Open Source"
             ]
           },
           {
@@ -4493,11 +7580,12 @@
             },
             "notes": "Uses the Data API for serverless access. Standard PostgreSQL connections also work with psycopg2.",
             "categories": [
-              "CLOUD_AWS",
-              "HOSTED_OPEN_SOURCE"
+              "Cloud - AWS",
+              "Hosted Open Source"
             ]
           }
         ],
+        "category": "Traditional RDBMS",
         "custom_errors": [
           {
             "regex_name": "CONNECTION_INVALID_USERNAME_REGEX",
@@ -4617,6 +7705,18 @@
           }
         ]
       },
+      "engine": "postgresql",
+      "engine_name": "PostgreSQL",
+      "engine_aliases": [
+        "postgres"
+      ],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "Presto": {
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": true,
@@ -4625,46 +7725,63 @@
         "FIVE_MINUTES": true,
         "TEN_MINUTES": true,
         "FIFTEEN_MINUTES": true,
-        "THIRTY_MINUTES": true,
-        "HALF_HOUR": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": true,
         "HOUR": true,
-        "SIX_HOURS": false,
+        "SIX_HOURS": true,
         "DAY": true,
         "WEEK": true,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
         "MONTH": true,
         "QUARTER": true,
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 104,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.presto",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": true,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": true,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": true,
+      "file_upload": true,
+      "get_extra_table_metadata": true,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
       "ssh_tunneling": true,
       "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": true,
+      "expand_data": true,
       "query_cost_estimation": true,
-      "sql_validation": true
-    },
-    "Presto": {
-      "engine": "presto",
-      "engine_name": "Presto",
-      "module": "presto",
+      "sql_validation": true,
+      "score": 159,
+      "max_score": 201,
       "documentation": {
         "description": "Presto is a distributed SQL query engine for big data.",
         "logo": "presto-og.png",
         "homepage_url": "https://prestodb.io/",
         "categories": [
-          "QUERY_ENGINES",
-          "OPEN_SOURCE"
+          "Query Engines",
+          "Open Source"
         ],
         "pypi_packages": [
           "pyhive"
@@ -4685,6 +7802,7 @@
             "is_recommended": true
           }
         ],
+        "category": "Query Engines",
         "custom_errors": [
           {
             "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
@@ -4772,261 +7890,16 @@
           }
         ]
       },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": true,
-        "THIRTY_SECONDS": true,
-        "MINUTE": true,
-        "FIVE_MINUTES": true,
-        "TEN_MINUTES": true,
-        "FIFTEEN_MINUTES": true,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": true,
-        "HOUR": true,
-        "SIX_HOURS": true,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": true,
-        "WEEK_STARTING_MONDAY": true,
-        "WEEK_ENDING_SATURDAY": true,
-        "WEEK_ENDING_SUNDAY": true,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 159,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
+      "engine": "presto",
+      "engine_name": "Presto",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
       "supports_dynamic_schema": true,
       "supports_catalog": true,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": true,
-      "query_cost_estimation": true,
-      "sql_validation": true
-    },
-    "Amazon Redshift": {
-      "engine": "amazon_redshift",
-      "engine_name": "Amazon Redshift",
-      "module": "redshift",
-      "documentation": {
-        "description": "Amazon Redshift is a fully managed data warehouse service.",
-        "logo": "redshift.png",
-        "homepage_url": "https://aws.amazon.com/redshift/",
-        "categories": [
-          "CLOUD_AWS",
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "sqlalchemy-redshift"
-        ],
-        "connection_string": "redshift+psycopg2://{username}:{password}@{host}:5439/{database}",
-        "default_port": 5439,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "AWS Endpoint",
-          "port": "Default 5439",
-          "database": "Database name"
-        },
-        "drivers": [
-          {
-            "name": "psycopg2",
-            "pypi_package": "psycopg2",
-            "connection_string": "redshift+psycopg2://{username}:{password}@{host}:5439/{database}",
-            "is_recommended": true
-          },
-          {
-            "name": "redshift_connector",
-            "pypi_package": "redshift_connector",
-            "connection_string": "redshift+redshift_connector://{username}:{password}@{host}:5439/{database}",
-            "is_recommended": false,
-            "notes": "Supports IAM-based credentials for clusters and serverless."
-          }
-        ],
-        "authentication_methods": [
-          {
-            "name": "IAM Credentials (Cluster)",
-            "description": "Use IAM-based temporary database credentials for Redshift clusters",
-            "requirements": "IAM role must have redshift:GetClusterCredentials permission",
-            "connection_string": "redshift+redshift_connector://",
-            "engine_parameters": {
-              "connect_args": {
-                "iam": true,
-                "database": "<database>",
-                "cluster_identifier": "<cluster_identifier>",
-                "db_user": "<db_user>"
-              }
-            }
-          },
-          {
-            "name": "IAM Role (Serverless)",
-            "description": "Authenticate using the IAM role attached to the environment (EC2 instance profile, ECS task role, etc.). No credentials needed.",
-            "requirements": "The attached IAM role must have redshift-serverless:GetCredentials and redshift-serverless:GetWorkgroup permissions.",
-            "connection_string": "redshift+redshift_connector://",
-            "engine_parameters": {
-              "connect_args": {
-                "iam": true,
-                "is_serverless": true,
-                "serverless_acct_id": "<aws account number>",
-                "serverless_work_group": "<redshift work group>",
-                "database": "<database>",
-                "user": "IAMR:<superset iam role name>"
-              }
-            }
-          },
-          {
-            "name": "IAM Access Key (Serverless)",
-            "description": "Authenticate using explicit AWS access key and secret. Suitable for local development or CI environments without an attached IAM role.",
-            "requirements": "The IAM user must have redshift-serverless:GetCredentials and redshift-serverless:GetWorkgroup permissions.",
-            "connection_string": "redshift+redshift_connector://",
-            "engine_parameters": {
-              "connect_args": {
-                "iam": true,
-                "is_serverless": true,
-                "serverless_acct_id": "<aws account number>",
-                "serverless_work_group": "<redshift work group>",
-                "database": "<database>",
-                "host": "<endpoint>",
-                "port": 5439,
-                "region": "<aws region>",
-                "access_key_id": "<aws access key id>",
-                "secret_access_key": "<aws secret access key>"
-              }
-            }
-          }
-        ],
-        "custom_errors": [
-          {
-            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
-            "message_template": "Either the username \"%(username)s\" or the password is incorrect.",
-            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
-            "category": "Authentication",
-            "description": "Access denied",
-            "issue_codes": [
-              1014,
-              1015
-            ],
-            "invalid_fields": [
-              "username",
-              "password"
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
-            "message_template": "The hostname \"%(hostname)s\" cannot be resolved.",
-            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
-            "category": "Connection",
-            "description": "Invalid hostname",
-            "issue_codes": [
-              1007
-            ],
-            "invalid_fields": [
-              "host"
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_PORT_CLOSED_REGEX",
-            "message_template": "Port %(port)s on hostname \"%(hostname)s\" refused the connection.",
-            "error_type": "CONNECTION_PORT_CLOSED_ERROR",
-            "category": "Connection",
-            "description": "Port closed or refused",
-            "issue_codes": [
-              1008
-            ],
-            "invalid_fields": [
-              "host",
-              "port"
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
-            "message_template": "The host \"%(hostname)s\" might be down, and can't be reached on port %(port)s.",
-            "error_type": "CONNECTION_HOST_DOWN_ERROR",
-            "category": "Connection",
-            "description": "Host unreachable",
-            "issue_codes": [
-              1009
-            ],
-            "invalid_fields": [
-              "host",
-              "port"
-            ]
-          },
-          {
-            "regex_name": "CONNECTION_UNKNOWN_DATABASE_REGEX",
-            "message_template": "We were unable to connect to your database named \"%(database)s\". Please verify your database name and try again.",
-            "error_type": "CONNECTION_UNKNOWN_DATABASE_ERROR",
-            "category": "Connection",
-            "description": "Unknown database",
-            "issue_codes": [
-              1015
-            ],
-            "invalid_fields": [
-              "database"
-            ]
-          }
-        ]
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": true
     },
     "RisingWave": {
-      "engine": "risingwave",
-      "engine_name": "RisingWave",
-      "module": "risingwave",
-      "documentation": {
-        "description": "RisingWave is a distributed streaming database.",
-        "logo": "risingwave.svg",
-        "homepage_url": "https://risingwave.com/",
-        "pypi_packages": [
-          "psycopg2",
-          "sqlalchemy-risingwave"
-        ],
-        "connection_string": "risingwave://root@{hostname}:{port}/{database}?sslmode=disable",
-        "default_port": 4566,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "For localhost: localhost or 127.0.0.1. For AWS: endpoint URL",
-          "port": "Default 5432",
-          "database": "Database name"
-        },
-        "notes": "The psycopg2 library comes bundled with Superset Docker images.",
-        "connection_examples": [
-          {
-            "description": "Basic connection",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}"
-          },
-          {
-            "description": "With SSL required",
-            "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=require"
-          }
-        ],
-        "docs_url": "https://github.com/risingwavelabs/sqlalchemy-risingwave",
-        "sqlalchemy_docs_url": "https://docs.sqlalchemy.org/en/13/dialects/postgresql.html",
-        "categories": [
-          "ANALYTICAL_DATABASES",
-          "OPEN_SOURCE"
-        ]
-      },
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": true,
@@ -5050,86 +7923,424 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 94,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.risingwave",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": true,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 63,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
       "ssh_tunneling": true,
       "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": true,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 94,
+      "max_score": 201,
+      "documentation": {
+        "description": "RisingWave is a distributed streaming database.",
+        "logo": "risingwave.svg",
+        "homepage_url": "https://risingwave.com/",
+        "categories": [
+          "Analytical Databases",
+          "Open Source"
+        ],
+        "pypi_packages": [
+          "sqlalchemy-risingwave"
+        ],
+        "connection_string": "risingwave://root@{hostname}:{port}/{database}?sslmode=disable",
+        "default_port": 4566,
+        "docs_url": "https://github.com/risingwavelabs/sqlalchemy-risingwave",
+        "category": "Other Databases"
+      },
+      "engine": "risingwave",
+      "engine_name": "RisingWave",
+      "engine_aliases": [
+        "postgres"
+      ],
+      "default_driver": "",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
+    },
+    "SAP HANA": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": false,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.hana",
+      "limit_method": 2,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 30,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 27,
+      "max_score": 201,
+      "documentation": {
+        "description": "SAP HANA is an in-memory relational database and application platform.",
+        "logo": "sap-hana.png",
+        "homepage_url": "https://www.sap.com/products/technology-platform/hana.html",
+        "categories": [
+          "Traditional RDBMS",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "hdbcli",
+          "sqlalchemy-hana"
+        ],
+        "install_instructions": "pip install apache_superset[hana]",
+        "connection_string": "hana://{username}:{password}@{host}:{port}",
+        "default_port": 30015,
+        "docs_url": "https://github.com/SAP/sqlalchemy-hana",
+        "category": "Other Databases"
+      },
+      "engine": "hana",
+      "engine_name": "SAP HANA",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "SAP Sybase": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.sybase",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": false,
+      "max_column_name": 128,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 44,
+      "max_score": 201,
+      "documentation": {
+        "description": "SAP ASE (formerly Sybase) is an enterprise relational database.",
+        "logo": "sybase.png",
+        "homepage_url": "https://www.sap.com/products/technology-platform/sybase-ase.html",
+        "categories": [
+          "Traditional RDBMS",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "sqlalchemy-sybase",
+          "pyodbc"
+        ],
+        "connection_string": "sybase+pyodbc://{username}:{password}@{dsn}",
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "dsn": "ODBC Data Source Name configured for SAP ASE"
+        },
+        "notes": "Requires SAP ASE ODBC driver installed and configured as a DSN.",
+        "docs_url": "https://help.sap.com/docs/SAP_ASE",
+        "category": "Other Databases"
+      },
+      "engine": "sybase",
+      "engine_name": "SAP Sybase",
+      "engine_aliases": [
+        "sybase_sqlany"
+      ],
+      "default_driver": "pyodbc",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "SQLite": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": true,
+        "HOUR": true,
+        "SIX_HOURS": true,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": true,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.sqlite",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": false,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 41,
+      "max_score": 201,
+      "documentation": {
+        "description": "SQLite is a self-contained, serverless SQL database engine.",
+        "logo": "sqlite.png",
+        "homepage_url": "https://www.sqlite.org/",
+        "categories": [
+          "Traditional RDBMS",
+          "Open Source"
+        ],
+        "pypi_packages": [],
+        "connection_string": "sqlite:///path/to/file.db?check_same_thread=false",
+        "notes": "No additional library needed. SQLite is bundled with Python.",
+        "category": "Traditional RDBMS",
+        "custom_errors": [
+          {
+            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
+            "message_template": "We can't seem to resolve the column \"%(column_name)s\"",
+            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Column not found",
+            "issue_codes": [
+              1003,
+              1004
+            ]
+          }
+        ]
+      },
+      "engine": "sqlite",
+      "engine_name": "SQLite",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "Shillelagh": {
-      "engine": "shillelagh",
-      "engine_name": "Shillelagh",
-      "module": "shillelagh",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": true,
+        "HOUR": true,
+        "SIX_HOURS": true,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": true,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.shillelagh",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": false,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 41,
+      "max_score": 201,
       "documentation": {
         "description": "Shillelagh is a Python library that allows querying many data sources using SQL, including Google Sheets, CSV files, and APIs.",
         "logo": "shillelagh.png",
         "homepage_url": "https://shillelagh.readthedocs.io/",
+        "categories": [
+          "Other Databases",
+          "Open Source"
+        ],
         "pypi_packages": [
           "shillelagh[gsheetsapi]"
         ],
         "connection_string": "shillelagh://",
         "notes": "Shillelagh uses virtual tables to query external data sources. Google Sheets requires OAuth credentials configured.",
-        "categories": [
-          "OTHER",
-          "OPEN_SOURCE"
-        ]
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "shillelagh",
+      "engine_name": "Shillelagh",
+      "engine_aliases": [],
+      "default_driver": "apsw",
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "SingleStore": {
-      "engine": "singlestore",
-      "engine_name": "SingleStore",
-      "module": "singlestore",
-      "documentation": {
-        "description": "SingleStore is a distributed SQL database for real-time analytics and transactions.",
-        "logo": "singlestore.png",
-        "homepage_url": "https://www.singlestore.com/",
-        "categories": [
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "singlestoredb"
-        ],
-        "connection_string": "singlestoredb://{username}:{password}@{host}:{port}/{database}",
-        "default_port": 3306,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "SingleStore host",
-          "port": "SingleStore port (default 3306)",
-          "database": "Database name"
-        },
-        "drivers": [
-          {
-            "name": "singlestoredb",
-            "pypi_package": "singlestoredb",
-            "connection_string": "singlestoredb://{username}:{password}@{host}:{port}/{database}",
-            "is_recommended": true
-          }
-        ]
-      },
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -5153,32 +8364,147 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 68,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.singlestore",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 256,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 68,
+      "max_score": 201,
+      "documentation": {
+        "description": "SingleStore is a distributed SQL database for real-time analytics and transactions.",
+        "logo": "singlestore.png",
+        "homepage_url": "https://www.singlestore.com/",
+        "categories": [
+          "Analytical Databases",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "singlestoredb"
+        ],
+        "connection_string": "singlestoredb://{username}:{password}@{host}:{port}/{database}",
+        "default_port": 3306,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "SingleStore host",
+          "port": "SingleStore port (default 3306)",
+          "database": "Database name"
+        },
+        "drivers": [
+          {
+            "name": "singlestoredb",
+            "pypi_package": "singlestoredb",
+            "connection_string": "singlestoredb://{username}:{password}@{host}:{port}/{database}",
+            "is_recommended": true
+          }
+        ],
+        "category": "Other Databases"
+      },
+      "engine": "singlestoredb",
+      "engine_name": "SingleStore",
+      "engine_aliases": [],
+      "default_driver": "singlestoredb",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "Snowflake": {
-      "engine": "snowflake",
-      "engine_name": "Snowflake",
-      "module": "snowflake",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.snowflake",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 256,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 72,
+      "max_score": 201,
       "documentation": {
         "description": "Snowflake is a cloud-native data warehouse.",
         "logo": "snowflake.svg",
         "homepage_url": "https://www.snowflake.com/",
         "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
+          "Cloud Data Warehouses",
+          "Analytical Databases",
+          "Proprietary"
         ],
         "pypi_packages": [
           "snowflake-sqlalchemy"
@@ -5205,6 +8531,7 @@
         ],
         "notes": "Schema is not required in connection string. Ensure user has privileges for all databases/schemas/tables/views/warehouses.",
         "docs_url": "https://docs.snowflake.com/en/user-guide/key-pair-auth.html",
+        "category": "Cloud Data Warehouses",
         "custom_errors": [
           {
             "regex_name": "OBJECT_DOES_NOT_EXIST_REGEX",
@@ -5228,247 +8555,83 @@
           }
         ]
       },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": true,
-        "FIVE_MINUTES": true,
-        "TEN_MINUTES": true,
-        "FIFTEEN_MINUTES": true,
-        "THIRTY_MINUTES": true,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": false,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 72,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
+      "engine": "snowflake",
+      "engine_name": "Snowflake",
+      "engine_aliases": [],
+      "default_driver": "snowflake",
+      "supports_file_upload": true,
       "supports_dynamic_schema": true,
       "supports_catalog": true,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache Solr": {
-      "engine": "apache_solr",
-      "engine_name": "Apache Solr",
-      "module": "solr",
-      "documentation": {
-        "description": "Apache Solr is an open-source enterprise search platform.",
-        "logo": "apache-solr.png",
-        "homepage_url": "https://solr.apache.org/",
-        "categories": [
-          "APACHE_PROJECTS",
-          "SEARCH_NOSQL",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "sqlalchemy-solr"
-        ],
-        "connection_string": "solr://{username}:{password}@{host}:{port}/{server_path}/{collection}[/?use_ssl=true|false]",
-        "default_port": 8983
-      },
-      "time_grains": {
-        "SECOND": false,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": false,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": false,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": false,
-        "HOUR": false,
-        "SIX_HOURS": false,
-        "DAY": false,
-        "WEEK": false,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": false,
-        "QUARTER": false,
-        "QUARTER_YEAR": false,
-        "YEAR": false
-      },
-      "score": 20,
-      "max_score": 201,
-      "joins": false,
-      "subqueries": false,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Apache Spark SQL": {
-      "engine": "apache_spark_sql",
-      "engine_name": "Apache Spark SQL",
-      "module": "spark",
-      "documentation": {
-        "description": "Apache Spark SQL is a module for structured data processing.",
-        "logo": "apache-spark.png",
-        "homepage_url": "https://spark.apache.org/sql/",
-        "pypi_packages": [
-          "pyhive",
-          "pyhive",
-          "pyhive"
-        ],
-        "install_instructions": "pip install \"apache-superset[presto]\"",
-        "connection_string": "hive://hive@{hostname}:{port}/{database}",
-        "default_port": 10000,
-        "parameters": {
-          "hostname": "Presto coordinator hostname",
-          "port": "Presto coordinator port (default 8080)",
-          "database": "Catalog name"
-        },
-        "drivers": [
-          {
-            "name": "PyHive",
-            "pypi_package": "pyhive",
-            "connection_string": "presto://{hostname}:{port}/{database}",
-            "is_recommended": true
-          }
-        ],
-        "categories": [
-          "APACHE_PROJECTS",
-          "QUERY_ENGINES",
-          "OPEN_SOURCE"
-        ]
-      },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": true,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": false,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": false,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": true,
-        "WEEK_STARTING_MONDAY": false,
-        "WEEK_ENDING_SATURDAY": true,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 140,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": true,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": true,
-      "query_cost_estimation": true,
-      "sql_validation": false
-    },
-    "SQLite": {
-      "engine": "sqlite",
-      "engine_name": "SQLite",
-      "module": "sqlite",
-      "documentation": {
-        "description": "SQLite is a self-contained, serverless SQL database engine.",
-        "logo": "sqlite.png",
-        "homepage_url": "https://www.sqlite.org/",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [],
-        "connection_string": "sqlite:///path/to/file.db?check_same_thread=false",
-        "notes": "No additional library needed. SQLite is bundled with Python.",
-        "custom_errors": [
-          {
-            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
-            "message_template": "We can't seem to resolve the column \"%(column_name)s\"",
-            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
-            "category": "Query",
-            "description": "Column not found",
-            "issue_codes": [
-              1003,
-              1004
-            ]
-          }
-        ]
-      },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": true,
-        "THIRTY_SECONDS": true,
-        "MINUTE": true,
-        "FIVE_MINUTES": true,
-        "TEN_MINUTES": true,
-        "FIFTEEN_MINUTES": true,
-        "THIRTY_MINUTES": true,
-        "HALF_HOUR": true,
-        "HOUR": true,
-        "SIX_HOURS": true,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": true,
-        "WEEK_STARTING_MONDAY": true,
-        "WEEK_ENDING_SATURDAY": true,
-        "WEEK_ENDING_SUNDAY": true,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": true,
-        "YEAR": true
-      },
-      "score": 41,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": true
     },
     "StarRocks": {
-      "engine": "starrocks",
-      "engine_name": "StarRocks",
-      "module": "starrocks",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": false,
+        "MINUTE": true,
+        "FIVE_MINUTES": false,
+        "TEN_MINUTES": false,
+        "FIFTEEN_MINUTES": false,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.starrocks",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 64,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": false,
+      "user_impersonation": true,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 89,
+      "max_score": 201,
       "documentation": {
         "description": "StarRocks is a high-performance analytical database for real-time analytics.",
         "logo": "starrocks.png",
         "homepage_url": "https://www.starrocks.io/",
+        "categories": [
+          "Analytical Databases",
+          "Open Source"
+        ],
         "pypi_packages": [
-          "mysqlclient",
           "starrocks"
         ],
         "connection_string": "starrocks://{username}:{password}@{host}:{port}/{catalog}.{database}",
@@ -5477,43 +8640,11 @@
           "username": "Database username",
           "password": "Database password",
           "host": "StarRocks FE host",
-          "database": "Database name",
           "port": "Query port (default 9030)",
-          "catalog": "Catalog name"
+          "catalog": "Catalog name",
+          "database": "Database name"
         },
-        "host_examples": [
-          {
-            "platform": "Localhost",
-            "host": "localhost or 127.0.0.1"
-          },
-          {
-            "platform": "Docker on Linux",
-            "host": "172.18.0.1"
-          },
-          {
-            "platform": "Docker on macOS",
-            "host": "docker.for.mac.host.internal"
-          },
-          {
-            "platform": "On-premise",
-            "host": "IP address or hostname"
-          }
-        ],
         "drivers": [
-          {
-            "name": "mysqlclient",
-            "pypi_package": "mysqlclient",
-            "connection_string": "mysql://{username}:{password}@{host}/{database}",
-            "is_recommended": true,
-            "notes": "Recommended driver. May fail with caching_sha2_password auth."
-          },
-          {
-            "name": "mysql-connector-python",
-            "pypi_package": "mysql-connector-python",
-            "connection_string": "mysql+mysqlconnector://{username}:{password}@{host}/{database}",
-            "is_recommended": false,
-            "notes": "Required for newer MySQL databases using caching_sha2_password authentication."
-          },
           {
             "name": "starrocks",
             "pypi_package": "starrocks",
@@ -5535,10 +8666,6 @@
             "notes": "Pure Python MySQL driver, no compilation required."
           }
         ],
-        "categories": [
-          "ANALYTICAL_DATABASES",
-          "OPEN_SOURCE"
-        ],
         "compatible_databases": [
           {
             "name": "CelerData",
@@ -5546,9 +8673,9 @@
             "logo": "celerdata.png",
             "homepage_url": "https://celerdata.com/",
             "categories": [
-              "ANALYTICAL_DATABASES",
-              "CLOUD_DATA_WAREHOUSES",
-              "HOSTED_OPEN_SOURCE"
+              "Analytical Databases",
+              "Cloud Data Warehouses",
+              "Hosted Open Source"
             ],
             "pypi_packages": [
               "starrocks"
@@ -5565,6 +8692,7 @@
             "docs_url": "https://docs.celerdata.com/"
           }
         ],
+        "category": "Analytical Databases",
         "custom_errors": [
           {
             "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
@@ -5596,158 +8724,96 @@
           }
         ]
       },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": false,
-        "THIRTY_SECONDS": false,
-        "MINUTE": true,
-        "FIVE_MINUTES": false,
-        "TEN_MINUTES": false,
-        "FIFTEEN_MINUTES": false,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": false,
-        "HOUR": true,
-        "SIX_HOURS": false,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": false,
-        "WEEK_STARTING_MONDAY": true,
-        "WEEK_ENDING_SATURDAY": false,
-        "WEEK_ENDING_SUNDAY": false,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 69,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": true,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
+      "engine": "starrocks",
+      "engine_name": "StarRocks",
+      "engine_aliases": [],
+      "default_driver": "starrocks",
       "supports_file_upload": true,
-      "user_impersonation": true,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
     },
     "Superset meta database": {
-      "engine": "superset_meta_database",
-      "engine_name": "Superset meta database",
-      "module": "superset",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": true,
+        "HOUR": true,
+        "SIX_HOURS": true,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": true,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.superset",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": true,
+      "user_impersonation": false,
+      "file_upload": false,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": false,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 31,
+      "max_score": 201,
       "documentation": {
         "description": "Superset meta database is an experimental feature that enables querying across multiple configured databases using a single connection.",
         "logo": "superset.svg",
         "homepage_url": "https://superset.apache.org/",
-        "pypi_packages": [
-          "shillelagh[gsheetsapi]"
+        "categories": [
+          "Other Databases"
         ],
+        "pypi_packages": [],
         "connection_string": "superset://",
         "notes": "This is an internal Superset feature. Enable with ENABLE_SUPERSET_META_DB feature flag. Allows cross-database queries using virtual tables.",
-        "categories": [
-          "OTHER"
-        ]
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "superset",
+      "engine_name": "Superset meta database",
+      "engine_aliases": [],
+      "default_driver": "",
+      "supports_file_upload": false,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "SAP Sybase": {
-      "engine": "sap_sybase",
-      "engine_name": "SAP Sybase",
-      "module": "sybase",
-      "documentation": {
-        "description": "SAP ASE (formerly Sybase) is an enterprise relational database.",
-        "logo": "sybase.png",
-        "homepage_url": "https://www.sap.com/products/technology-platform/sybase-ase.html",
-        "pypi_packages": [
-          "pymssql",
-          "sqlalchemy-sybase",
-          "pyodbc"
-        ],
-        "connection_string": "sybase+pyodbc://{username}:{password}@{dsn}",
-        "default_port": 1433,
-        "drivers": [
-          {
-            "name": "pymssql",
-            "pypi_package": "pymssql",
-            "connection_string": "mssql+pymssql://{username}:{password}@{host}:{port}/{database}",
-            "is_recommended": true
-          },
-          {
-            "name": "pyodbc",
-            "pypi_package": "pyodbc",
-            "connection_string": "mssql+pyodbc:///?odbc_connect=Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3BServer%3Dtcp%3A%3C{host}%3E%2C1433%3BDatabase%3D{database}%3BUid%3D{username}%3BPwd%3D{password}%3BEncrypt%3Dyes%3BConnection+Timeout%3D30",
-            "is_recommended": false,
-            "notes": "Connection string must be URL-encoded. Special characters like @ need encoding."
-          }
-        ],
-        "docs_url": "https://help.sap.com/docs/SAP_ASE",
-        "categories": [
-          "TRADITIONAL_RDBMS",
-          "PROPRIETARY"
-        ],
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "dsn": "ODBC Data Source Name configured for SAP ASE"
-        },
-        "notes": "Requires SAP ASE ODBC driver installed and configured as a DSN."
-      },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "TDengine": {
-      "engine": "tdengine",
-      "engine_name": "TDengine",
-      "module": "tdengine",
-      "documentation": {
-        "description": "TDengine is a high-performance time-series database for IoT.",
-        "logo": "tdengine.png",
-        "homepage_url": "https://tdengine.com/",
-        "categories": [
-          "TIME_SERIES",
-          "OPEN_SOURCE"
-        ],
-        "pypi_packages": [
-          "taospy",
-          "taos-ws-py"
-        ],
-        "connection_string": "taosws://{user}:{password}@{host}:{port}",
-        "default_port": 6041,
-        "connection_examples": [
-          {
-            "description": "Local connection",
-            "connection_string": "taosws://root:taosdata@127.0.0.1:6041"
-          }
-        ],
-        "docs_url": "https://www.tdengine.com"
-      },
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": false,
@@ -5771,54 +8837,74 @@
         "QUARTER_YEAR": false,
         "YEAR": false
       },
-      "score": 25,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.tdengine",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 64,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "Teradata": {
-      "engine": "teradata",
-      "engine_name": "Teradata",
-      "module": "teradata",
+      "sql_validation": false,
+      "score": 25,
+      "max_score": 201,
       "documentation": {
-        "description": "Teradata is an enterprise data warehouse platform.",
-        "logo": "teradata.png",
-        "homepage_url": "https://www.teradata.com/",
+        "description": "TDengine is a high-performance time-series database for IoT.",
+        "logo": "tdengine.png",
+        "homepage_url": "https://tdengine.com/",
         "categories": [
-          "TRADITIONAL_RDBMS",
-          "PROPRIETARY"
+          "Time Series Databases",
+          "Open Source"
         ],
         "pypi_packages": [
-          "teradatasqlalchemy"
+          "taospy",
+          "taos-ws-py"
         ],
-        "connection_string": "teradatasql://{user}:{password}@{host}",
-        "default_port": 1025,
-        "drivers": [
+        "connection_string": "taosws://{user}:{password}@{host}:{port}",
+        "default_port": 6041,
+        "connection_examples": [
           {
-            "name": "teradatasqlalchemy (Recommended)",
-            "pypi_package": "teradatasqlalchemy",
-            "connection_string": "teradatasql://{user}:{password}@{host}",
-            "is_recommended": true,
-            "notes": "No ODBC drivers required."
-          },
-          {
-            "name": "sqlalchemy-teradata (ODBC)",
-            "pypi_package": "sqlalchemy-teradata",
-            "is_recommended": false,
-            "notes": "Requires ODBC driver installation.",
-            "docs_url": "https://downloads.teradata.com/download/connectivity/odbc-driver/linux"
+            "description": "Local connection",
+            "connection_string": "taosws://root:taosdata@127.0.0.1:6041"
           }
-        ]
+        ],
+        "docs_url": "https://www.tdengine.com",
+        "category": "Other Databases"
       },
+      "engine": "taosws",
+      "engine_name": "TDengine",
+      "engine_aliases": [],
+      "default_driver": "taosws",
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "Teradata": {
       "time_grains": {
         "SECOND": false,
         "FIVE_SECONDS": false,
@@ -5842,31 +8928,147 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 27,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.teradata",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": 30,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 27,
+      "max_score": 201,
+      "documentation": {
+        "description": "Teradata is an enterprise data warehouse platform.",
+        "logo": "teradata.png",
+        "homepage_url": "https://www.teradata.com/",
+        "categories": [
+          "Traditional RDBMS",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "teradatasqlalchemy"
+        ],
+        "connection_string": "teradatasql://{user}:{password}@{host}",
+        "default_port": 1025,
+        "drivers": [
+          {
+            "name": "teradatasqlalchemy (Recommended)",
+            "pypi_package": "teradatasqlalchemy",
+            "connection_string": "teradatasql://{user}:{password}@{host}",
+            "is_recommended": true,
+            "notes": "No ODBC drivers required."
+          },
+          {
+            "name": "sqlalchemy-teradata (ODBC)",
+            "pypi_package": "sqlalchemy-teradata",
+            "is_recommended": false,
+            "notes": "Requires ODBC driver installation.",
+            "docs_url": "https://downloads.teradata.com/download/connectivity/odbc-driver/linux"
+          }
+        ],
+        "category": "Other Databases"
+      },
+      "engine": "teradatasql",
+      "engine_name": "Teradata",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "TimescaleDB": {
-      "engine": "timescaledb",
-      "engine_name": "TimescaleDB",
-      "module": "timescaledb",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.timescaledb",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 34,
+      "max_score": 201,
       "documentation": {
         "description": "TimescaleDB is an open-source relational database for time-series and analytics, built on PostgreSQL.",
         "logo": "timescale.png",
         "homepage_url": "https://www.timescale.com/",
         "categories": [
-          "ANALYTICAL_DATABASES",
-          "OPEN_SOURCE"
+          "Analytical Databases",
+          "Open Source"
         ],
         "pypi_packages": [
           "psycopg2"
@@ -5880,34 +9082,84 @@
           }
         ],
         "notes": "Uses the PostgreSQL driver. psycopg2 comes bundled with Superset.",
-        "docs_url": "https://docs.timescale.com/"
+        "docs_url": "https://docs.timescale.com/",
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "timescaledb",
+      "engine_name": "TimescaleDB",
+      "engine_aliases": [],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "supports_dynamic_catalog": false
     },
     "Trino": {
-      "engine": "trino",
-      "engine_name": "Trino",
-      "module": "trino",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": true,
+        "HOUR": true,
+        "SIX_HOURS": true,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.trino",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": true,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
+      "user_impersonation": true,
+      "file_upload": true,
+      "get_extra_table_metadata": true,
+      "dbapi_exception_mapping": true,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": true,
+      "get_metrics": false,
+      "where_latest_partition": true,
+      "expand_data": false,
+      "query_cost_estimation": true,
+      "sql_validation": false,
+      "score": 149,
+      "max_score": 201,
       "documentation": {
         "description": "Trino is a distributed SQL query engine for big data analytics.",
         "logo": "trino.png",
         "homepage_url": "https://trino.io/",
         "categories": [
-          "QUERY_ENGINES",
-          "OPEN_SOURCE"
+          "Query Engines",
+          "Open Source"
         ],
         "pypi_packages": [
           "trino"
@@ -5937,9 +9189,9 @@
             "logo": "starburst.png",
             "homepage_url": "https://www.starburst.io/platform/starburst-galaxy/",
             "categories": [
-              "QUERY_ENGINES",
-              "CLOUD_DATA_WAREHOUSES",
-              "HOSTED_OPEN_SOURCE"
+              "Query Engines",
+              "Cloud Data Warehouses",
+              "Hosted Open Source"
             ],
             "pypi_packages": [
               "trino"
@@ -5960,8 +9212,8 @@
             "logo": "starburst.png",
             "homepage_url": "https://www.starburst.io/platform/starburst-enterprise/",
             "categories": [
-              "QUERY_ENGINES",
-              "HOSTED_OPEN_SOURCE"
+              "Query Engines",
+              "Hosted Open Source"
             ],
             "pypi_packages": [
               "trino"
@@ -5969,72 +9221,19 @@
             "connection_string": "trino://{username}:{password}@{hostname}:{port}/{catalog}",
             "docs_url": "https://docs.starburst.io/"
           }
-        ]
+        ],
+        "category": "Query Engines"
       },
-      "time_grains": {
-        "SECOND": true,
-        "FIVE_SECONDS": true,
-        "THIRTY_SECONDS": true,
-        "MINUTE": true,
-        "FIVE_MINUTES": true,
-        "TEN_MINUTES": true,
-        "FIFTEEN_MINUTES": true,
-        "THIRTY_MINUTES": false,
-        "HALF_HOUR": true,
-        "HOUR": true,
-        "SIX_HOURS": true,
-        "DAY": true,
-        "WEEK": true,
-        "WEEK_STARTING_SUNDAY": true,
-        "WEEK_STARTING_MONDAY": true,
-        "WEEK_ENDING_SATURDAY": true,
-        "WEEK_ENDING_SUNDAY": true,
-        "MONTH": true,
-        "QUARTER": true,
-        "QUARTER_YEAR": false,
-        "YEAR": true
-      },
-      "score": 149,
-      "max_score": 201,
-      "joins": true,
-      "subqueries": true,
+      "engine": "trino",
+      "engine_name": "Trino",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
       "supports_dynamic_schema": true,
       "supports_catalog": true,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": true,
-      "query_cancelation": true,
-      "supports_file_upload": true,
-      "user_impersonation": true,
-      "query_cost_estimation": true,
-      "sql_validation": false
+      "supports_dynamic_catalog": true
     },
     "Vertica": {
-      "engine": "vertica",
-      "engine_name": "Vertica",
-      "module": "vertica",
-      "documentation": {
-        "description": "Vertica is a column-oriented analytics database.",
-        "logo": "vertica.png",
-        "homepage_url": "https://www.vertica.com/",
-        "categories": [
-          "ANALYTICAL_DATABASES",
-          "PROPRIETARY"
-        ],
-        "pypi_packages": [
-          "sqlalchemy-vertica-python"
-        ],
-        "connection_string": "vertica+vertica_python://{username}:{password}@{host}/{database}",
-        "default_port": 5433,
-        "parameters": {
-          "username": "Database username",
-          "password": "Database password",
-          "host": "localhost, IP address, or hostname (cloud or on-prem)",
-          "database": "Database name",
-          "port": "Default 5433"
-        },
-        "notes": "Supports load balancer backup host configuration.",
-        "docs_url": "http://www.vertica.com/"
-      },
       "time_grains": {
         "SECOND": true,
         "FIVE_SECONDS": true,
@@ -6058,31 +9257,140 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 34,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.vertica",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": true,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
+      "sql_validation": false,
+      "score": 34,
+      "max_score": 201,
+      "documentation": {
+        "description": "Vertica is a column-oriented analytics database.",
+        "logo": "vertica.png",
+        "homepage_url": "https://www.vertica.com/",
+        "categories": [
+          "Analytical Databases",
+          "Proprietary"
+        ],
+        "pypi_packages": [
+          "sqlalchemy-vertica-python"
+        ],
+        "connection_string": "vertica+vertica_python://{username}:{password}@{host}/{database}",
+        "default_port": 5433,
+        "parameters": {
+          "username": "Database username",
+          "password": "Database password",
+          "host": "localhost, IP address, or hostname (cloud or on-prem)",
+          "database": "Database name",
+          "port": "Default 5433"
+        },
+        "notes": "Supports load balancer backup host configuration.",
+        "docs_url": "http://www.vertica.com/",
+        "category": "Analytical Databases"
+      },
+      "engine": "vertica",
+      "engine_name": "Vertica",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
     },
     "YDB": {
-      "engine": "ydb",
-      "engine_name": "YDB",
-      "module": "ydb",
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": false,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": true,
+        "HALF_HOUR": false,
+        "HOUR": true,
+        "SIX_HOURS": false,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": false,
+        "WEEK_STARTING_MONDAY": false,
+        "WEEK_ENDING_SATURDAY": false,
+        "WEEK_ENDING_SUNDAY": false,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.ydb",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": false,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
+      "query_cost_estimation": false,
+      "sql_validation": false,
+      "score": 23,
+      "max_score": 201,
       "documentation": {
         "description": "YDB is a distributed SQL database by Yandex.",
         "logo": "ydb.svg",
         "homepage_url": "https://ydb.tech/",
         "categories": [
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
+          "Traditional RDBMS",
+          "Open Source"
         ],
         "pypi_packages": [
           "ydb-sqlalchemy"
@@ -6131,11 +9439,25 @@
               }
             }
           }
-        ]
+        ],
+        "category": "Other Databases"
       },
+      "engine": "yql",
+      "engine_name": "YDB",
+      "engine_aliases": [
+        "yql+ydb",
+        "ydb"
+      ],
+      "default_driver": "ydb",
+      "supports_file_upload": false,
+      "supports_dynamic_schema": false,
+      "supports_catalog": false,
+      "supports_dynamic_catalog": false
+    },
+    "YugabyteDB": {
       "time_grains": {
         "SECOND": true,
-        "FIVE_SECONDS": false,
+        "FIVE_SECONDS": true,
         "THIRTY_SECONDS": true,
         "MINUTE": true,
         "FIVE_MINUTES": true,
@@ -6156,32 +9478,49 @@
         "QUARTER_YEAR": false,
         "YEAR": true
       },
-      "score": 23,
-      "max_score": 201,
+      "module": "superset.db_engine_specs.yugabytedb",
+      "limit_method": 1,
+      "limit_clause": true,
       "joins": true,
       "subqueries": true,
-      "supports_dynamic_schema": false,
-      "supports_catalog": false,
-      "supports_dynamic_catalog": false,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": false,
+      "function_names": false,
+      "user_impersonation": false,
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": false,
+      "catalog": false,
+      "dynamic_catalog": false,
       "ssh_tunneling": true,
       "query_cancelation": false,
-      "supports_file_upload": false,
-      "user_impersonation": false,
+      "get_metrics": false,
+      "where_latest_partition": false,
+      "expand_data": false,
       "query_cost_estimation": false,
-      "sql_validation": false
-    },
-    "YugabyteDB": {
-      "engine": "yugabytedb",
-      "engine_name": "YugabyteDB",
-      "module": "yugabytedb",
+      "sql_validation": false,
+      "score": 34,
+      "max_score": 201,
       "documentation": {
         "description": "YugabyteDB is a distributed SQL database built on top of PostgreSQL.",
         "logo": "yugabyte.png",
         "homepage_url": "https://www.yugabyte.com/",
         "categories": [
-          "CLOUD_DATA_WAREHOUSES",
-          "TRADITIONAL_RDBMS",
-          "OPEN_SOURCE"
+          "Cloud Data Warehouses",
+          "Traditional RDBMS",
+          "Open Source"
         ],
         "pypi_packages": [
           "psycopg2"
@@ -6189,22 +9528,176 @@
         "connection_string": "postgresql://{username}:{password}@{host}:{port}/{database}",
         "default_port": 5433,
         "notes": "Uses the PostgreSQL driver. psycopg2 comes bundled with Superset.",
-        "docs_url": "https://docs.yugabyte.com/"
+        "docs_url": "https://docs.yugabyte.com/",
+        "category": "Other Databases"
       },
-      "time_grains": {},
-      "score": 0,
-      "max_score": 0,
-      "joins": true,
-      "subqueries": true,
+      "engine": "yugabytedb",
+      "engine_name": "YugabyteDB",
+      "engine_aliases": [],
+      "default_driver": "psycopg2",
+      "supports_file_upload": true,
       "supports_dynamic_schema": false,
       "supports_catalog": false,
-      "supports_dynamic_catalog": false,
-      "ssh_tunneling": false,
-      "query_cancelation": false,
-      "supports_file_upload": false,
+      "supports_dynamic_catalog": false
+    },
+    "base": {
+      "time_grains": {
+        "SECOND": true,
+        "FIVE_SECONDS": true,
+        "THIRTY_SECONDS": true,
+        "MINUTE": true,
+        "FIVE_MINUTES": true,
+        "TEN_MINUTES": true,
+        "FIFTEEN_MINUTES": true,
+        "THIRTY_MINUTES": false,
+        "HALF_HOUR": true,
+        "HOUR": true,
+        "SIX_HOURS": true,
+        "DAY": true,
+        "WEEK": true,
+        "WEEK_STARTING_SUNDAY": true,
+        "WEEK_STARTING_MONDAY": true,
+        "WEEK_ENDING_SATURDAY": true,
+        "WEEK_ENDING_SUNDAY": true,
+        "MONTH": true,
+        "QUARTER": true,
+        "QUARTER_YEAR": false,
+        "YEAR": true
+      },
+      "module": "superset.db_engine_specs.presto",
+      "limit_method": 1,
+      "limit_clause": true,
+      "joins": true,
+      "subqueries": true,
+      "alias_in_select": true,
+      "alias_in_orderby": true,
+      "time_groupby_inline": false,
+      "alias_to_source_column": false,
+      "order_by_not_in_select": true,
+      "expressions_in_orderby": false,
+      "cte_in_subquery": true,
+      "max_column_name": null,
+      "sql_comments": true,
+      "escaped_colons": true,
+      "masked_encrypted_extra": false,
+      "column_type_mapping": true,
+      "function_names": true,
       "user_impersonation": false,
-      "query_cost_estimation": false,
-      "sql_validation": false
+      "file_upload": true,
+      "get_extra_table_metadata": false,
+      "dbapi_exception_mapping": false,
+      "custom_errors": false,
+      "dynamic_schema": true,
+      "catalog": true,
+      "dynamic_catalog": true,
+      "ssh_tunneling": true,
+      "query_cancelation": false,
+      "get_metrics": false,
+      "where_latest_partition": true,
+      "expand_data": false,
+      "query_cost_estimation": true,
+      "sql_validation": false,
+      "score": 109,
+      "max_score": 201,
+      "documentation": {
+        "pypi_packages": [],
+        "connection_string": "engine+driver://user:password@host:port/dbname[?key=value&key=value...]",
+        "category": "Other Databases",
+        "custom_errors": [
+          {
+            "regex_name": "COLUMN_DOES_NOT_EXIST_REGEX",
+            "message_template": "We can't seem to resolve the column \"%(column_name)s\" at line %(location)s.",
+            "error_type": "COLUMN_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Column not found",
+            "issue_codes": [
+              1003,
+              1004
+            ]
+          },
+          {
+            "regex_name": "TABLE_DOES_NOT_EXIST_REGEX",
+            "message_template": "The table \"%(table_name)s\" does not exist. A valid table must be used to run this query.",
+            "error_type": "TABLE_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Table not found",
+            "issue_codes": [
+              1003,
+              1005
+            ]
+          },
+          {
+            "regex_name": "SCHEMA_DOES_NOT_EXIST_REGEX",
+            "message_template": "The schema \"%(schema_name)s\" does not exist. A valid schema must be used to run this query.",
+            "error_type": "SCHEMA_DOES_NOT_EXIST_ERROR",
+            "category": "Query",
+            "description": "Schema not found",
+            "issue_codes": [
+              1003,
+              1016
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_ACCESS_DENIED_REGEX",
+            "message_template": "Either the username \"%(username)s\" or the password is incorrect.",
+            "error_type": "CONNECTION_ACCESS_DENIED_ERROR",
+            "category": "Authentication",
+            "description": "Access denied",
+            "issue_codes": [
+              1014,
+              1015
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_INVALID_HOSTNAME_REGEX",
+            "message_template": "The hostname \"%(hostname)s\" cannot be resolved.",
+            "error_type": "CONNECTION_INVALID_HOSTNAME_ERROR",
+            "category": "Connection",
+            "description": "Invalid hostname",
+            "issue_codes": [
+              1007
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_HOST_DOWN_REGEX",
+            "message_template": "The host \"%(hostname)s\" might be down, and can't be reached on port %(port)s.",
+            "error_type": "CONNECTION_HOST_DOWN_ERROR",
+            "category": "Connection",
+            "description": "Host unreachable",
+            "issue_codes": [
+              1009
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_PORT_CLOSED_REGEX",
+            "message_template": "Port %(port)s on hostname \"%(hostname)s\" refused the connection.",
+            "error_type": "CONNECTION_PORT_CLOSED_ERROR",
+            "category": "Connection",
+            "description": "Port closed or refused",
+            "issue_codes": [
+              1008
+            ]
+          },
+          {
+            "regex_name": "CONNECTION_UNKNOWN_DATABASE_ERROR",
+            "message_template": "Unable to connect to catalog named \"%(catalog_name)s\".",
+            "error_type": "CONNECTION_UNKNOWN_DATABASE_ERROR",
+            "category": "Connection",
+            "description": "Unknown database",
+            "issue_codes": [
+              1015
+            ]
+          }
+        ]
+      },
+      "engine": "base",
+      "engine_name": "base",
+      "engine_aliases": [],
+      "default_driver": null,
+      "supports_file_upload": true,
+      "supports_dynamic_schema": true,
+      "supports_catalog": true,
+      "supports_dynamic_catalog": true
     }
   }
 }

--- a/superset/db_engine_specs/lib.py
+++ b/superset/db_engine_specs/lib.py
@@ -753,6 +753,15 @@ def generate_yaml_docs(output_dir: str | None = None) -> dict[str, dict[str, Any
             continue
 
         name = get_name(spec)
+
+        # Skip "base" specs (e.g. PostgresBaseEngineSpec) that share an engine_name
+        # with a real product spec but have no concrete engine value.  When multiple
+        # specs share the same engine_name the one with a non-empty engine string is
+        # the authoritative product spec; letting a base class overwrite it would
+        # produce incorrect capability flags.
+        if not spec.engine and name in all_docs:
+            continue
+
         doc_data = diagnose(spec)
 
         # Get documentation metadata (prefers spec.metadata over DATABASE_DOCS)
@@ -766,6 +775,7 @@ def generate_yaml_docs(output_dir: str | None = None) -> dict[str, dict[str, Any
         doc_data["supports_file_upload"] = spec.supports_file_upload
         doc_data["supports_dynamic_schema"] = spec.supports_dynamic_schema
         doc_data["supports_catalog"] = spec.supports_catalog
+        doc_data["supports_dynamic_catalog"] = spec.supports_dynamic_catalog
 
         all_docs[name] = doc_data
 


### PR DESCRIPTION
### SUMMARY

The database docs generator (`docs/scripts/generate-database-docs.mjs`) previously hardcoded all capability flags to `False` defaults and relied on `mergeWithExistingDiagnostics` to preserve manually-edited values from the committed `databases.json`. This made it impossible to keep capability flags in sync with the Python engine spec source of truth, and caused flags like `supports_catalog`, `supports_dynamic_schema`, `query_cancelation`, etc. to drift silently.

**Changes:**

**`docs/scripts/generate-database-docs.mjs`**
- The embedded Python AST extraction path now reads capability flag class attributes (`supports_dynamic_schema`, `supports_catalog`, `supports_dynamic_catalog`, `disable_ssh_tunneling`, `supports_file_upload`, `allows_joins`, `allows_subqueries`) directly from each engine spec class, with proper inheritance resolution
- Method overrides are tracked to detect capabilities: `cancel_query`/`get_cancel_query_id`/`has_implicit_cancel` → `query_cancelation`; `estimate_statement_cost`/`estimate_query_cost` → `query_cost_estimation`; `impersonate_user`/`update_impersonation_config` → `user_impersonation`
- `mergeWithExistingDiagnostics` now only preserves `score`, `max_score`, and `time_grains` (fields that require Flask context to generate), not capability flags — so regeneration always reflects the current Python source

**`superset/db_engine_specs/lib.py`**
- `generate_yaml_docs()` now includes `supports_dynamic_catalog` in its output (was previously missing)
- Skips "base" specs (no `engine` value) when they would overwrite a real product spec's data for the same `engine_name` (fixes `PostgresBaseEngineSpec` overwriting `PostgresEngineSpec` flags)

**`docs/src/data/databases.json`**
- Regenerated with corrected capability flags for 80 databases based on Python source
- Notable corrections: `supports_catalog`/`supports_dynamic_catalog` now correct for PostgreSQL, StarRocks, Presto, Trino, Hive, Spark SQL, Snowflake, CockroachDB, and others; `query_cancelation` now reflects actual method overrides

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — changes affect database docs capability flag display, not visual UI.

### TESTING INSTRUCTIONS

1. Run `npm run gen-db-docs` from the `docs/` directory
2. Verify the regenerated `docs/src/data/databases.json` matches the checked-in file (flags should be stable across runs)
3. Spot-check a few databases in the docs:
   - StarRocks should show `catalog: true`, `dynamic_catalog: true`
   - Athena should show `catalog: false`, `dynamic_catalog: false`
   - PostgreSQL should show `catalog: true`, `dynamic_catalog: true`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API