### PR TITLE
feat(user_info): include Groups in user data payload when include_perms is True and show Groups on user_info page

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -34,6 +34,7 @@ const apiData = {
     lastName: 'last name',
     permissions: {},
     roles: {},
+    groups: [],
   },
 };
 const apiDataWithTabState = {

--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -41,6 +41,7 @@ const ownerUser: UserWithPermissionsAndRoles = {
   username: 'owner',
   permissions: {},
   roles: { Alpha: [['can_write', 'Dashboard']] },
+  groups: [],
 };
 
 const adminUser: UserWithPermissionsAndRoles = {

--- a/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
+++ b/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
@@ -64,6 +64,7 @@ const mockUser: UserWithPermissionsAndRoles = {
   userId: 1,
   username: 'admin',
   isAnonymous: false,
+  groups: [],
 };
 
 const mockUserWithDatasetWrite: UserWithPermissionsAndRoles = {
@@ -77,6 +78,7 @@ const mockUserWithDatasetWrite: UserWithPermissionsAndRoles = {
   userId: 1,
   username: 'admin',
   isAnonymous: false,
+  groups: [],
 };
 const history = createMemoryHistory();
 

--- a/superset-frontend/src/pages/SqlLab/SqlLab.test.tsx
+++ b/superset-frontend/src/pages/SqlLab/SqlLab.test.tsx
@@ -48,6 +48,7 @@ const fakeApiResult = {
       lastName: 'last name',
       permissions: {},
       roles: {},
+      groups: [],
     },
   },
 };

--- a/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
+++ b/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
@@ -108,7 +108,7 @@ describe('UserInfo', () => {
   test('renders "None" when the user has no groups', async () => {
     await renderPage({ ...mockUser, groups: [] });
 
-    expect(await screen.findByText('Group')).toBeInTheDocument();
+    expect(await screen.findByText('Groups')).toBeInTheDocument();
     expect(screen.getByText('None')).toBeInTheDocument();
   });
 

--- a/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
+++ b/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
@@ -51,6 +51,7 @@ const mockUser: UserWithPermissionsAndRoles = {
       ['can_write', 'Chart'],
     ],
   },
+  groups: ['Engineering', 'Analytics'],
   createdOn: new Date().toISOString(),
   isAnonymous: false,
   permissions: {
@@ -61,12 +62,12 @@ const mockUser: UserWithPermissionsAndRoles = {
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UserInfo', () => {
-  const renderPage = async () =>
+  const renderPage = async (user: UserWithPermissionsAndRoles = mockUser) =>
     act(async () => {
       render(
         <MemoryRouter>
           <QueryParamProvider adapter={ReactRouter5Adapter}>
-            <UserInfo user={mockUser} />
+            <UserInfo user={user} />
           </QueryParamProvider>
         </MemoryRouter>,
         { useRedux: true, store },
@@ -97,10 +98,18 @@ describe('UserInfo', () => {
     expect(screen.getByText('johndoe')).toBeInTheDocument();
     expect(screen.getByText('Yes')).toBeInTheDocument();
     expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Engineering, Analytics')).toBeInTheDocument();
     expect(screen.getByText('12')).toBeInTheDocument();
     expect(await screen.findByText('John')).toBeInTheDocument();
     expect(screen.getByText('Doe')).toBeInTheDocument();
     expect(screen.getByText('john@example.com')).toBeInTheDocument();
+  });
+
+  test('renders "None" when the user has no groups', async () => {
+    await renderPage({ ...mockUser, groups: [] });
+
+    expect(await screen.findByText('Group')).toBeInTheDocument();
+    expect(screen.getByText('None')).toBeInTheDocument();
   });
 
   test('calls the /me endpoint on mount', async () => {

--- a/superset-frontend/src/pages/UserInfo/index.tsx
+++ b/superset-frontend/src/pages/UserInfo/index.tsx
@@ -193,6 +193,9 @@ export function UserInfo({ user }: { user: UserWithPermissionsAndRoles }) {
               <Descriptions.Item label={t('Role')}>
                 {user.roles ? Object.keys(user.roles).join(', ') : t('None')}
               </Descriptions.Item>
+              <Descriptions.Item label={t('Group')}>
+                {user.groups.length ? user.groups.join(', ') : t('None')}
+              </Descriptions.Item>
               <Descriptions.Item label={t('Login count')}>
                 {user.loginCount}
               </Descriptions.Item>

--- a/superset-frontend/src/pages/UserInfo/index.tsx
+++ b/superset-frontend/src/pages/UserInfo/index.tsx
@@ -190,10 +190,10 @@ export function UserInfo({ user }: { user: UserWithPermissionsAndRoles }) {
               <Descriptions.Item label={t('Is Active?')}>
                 {user.isActive ? t('Yes') : t('No')}
               </Descriptions.Item>
-              <Descriptions.Item label={t('Role')}>
+              <Descriptions.Item label={t('Roles')}>
                 {user.roles ? Object.keys(user.roles).join(', ') : t('None')}
               </Descriptions.Item>
-              <Descriptions.Item label={t('Group')}>
+              <Descriptions.Item label={t('Groups')}>
                 {user.groups.length ? user.groups.join(', ') : t('None')}
               </Descriptions.Item>
               <Descriptions.Item label={t('Login count')}>

--- a/superset-frontend/src/types/bootstrapTypes.ts
+++ b/superset-frontend/src/types/bootstrapTypes.ts
@@ -55,6 +55,7 @@ export interface PermissionsAndRoles {
     datasource_access?: string[];
   };
   roles: UserRoles;
+  groups: string[];
 }
 
 export type UserWithPermissionsAndRoles = User & PermissionsAndRoles;

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -133,9 +133,7 @@ def bootstrap_user_data(user: User, include_perms: bool = False) -> dict[str, An
         roles, permissions = get_permissions(user)
         payload["roles"] = roles
         payload["permissions"] = permissions
-        payload["groups"] = [
-            group.name for group in getattr(user, "groups", [])
-        ]
+        payload["groups"] = [group.name for group in getattr(user, "groups", [])]
 
     return payload
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -133,6 +133,7 @@ def bootstrap_user_data(user: User, include_perms: bool = False) -> dict[str, An
         roles, permissions = get_permissions(user)
         payload["roles"] = roles
         payload["permissions"] = permissions
+        payload["groups"] = [group.name for group in user.groups or []]
 
     return payload
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -133,7 +133,9 @@ def bootstrap_user_data(user: User, include_perms: bool = False) -> dict[str, An
         roles, permissions = get_permissions(user)
         payload["roles"] = roles
         payload["permissions"] = permissions
-        payload["groups"] = [group.name for group in user.groups or []]
+        payload["groups"] = [
+            group.name for group in getattr(user, "groups", [])
+        ]
 
     return payload
 

--- a/tests/integration_tests/users/api_tests.py
+++ b/tests/integration_tests/users/api_tests.py
@@ -50,6 +50,8 @@ class TestCurrentUserApi(SupersetTestCase):
         response = json.loads(rv.data.decode("utf-8"))
         roles = list(response["result"]["roles"].keys())
         assert "Admin" == roles.pop()
+        assert "groups" in response["result"]
+        assert isinstance(response["result"]["groups"], list)
 
     @patch("superset.security.manager.g")
     def test_get_my_roles_anonymous(self, mock_g):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
feat(user_info): include Groups in user data payload and show Groups on user_info page
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, Group info (which Groups a user belongs to) is missing on the `user_info` page. This change includes Groups in payload when `include_perms` is True and show Groups on `user_info` page.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### Before
<img width="1840" height="1106" alt="image" src="https://github.com/user-attachments/assets/1ff0e317-4284-4a03-8c20-3d53de050dca" />

### After
<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/4e9cb14d-a463-4ba4-b38f-049b899a4a3d" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
