### PR TITLE
chore(lint): convert react-pivottable components to function components

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/PivotTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/PivotTable.tsx
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-import { PureComponent } from 'react';
+import { memo } from 'react';
 import { TableRenderer } from './TableRenderers';
 import type { ComponentProps } from 'react';
 
 type PivotTableProps = ComponentProps<typeof TableRenderer>;
 
-class PivotTable extends PureComponent<PivotTableProps> {
-  render() {
-    return <TableRenderer {...this.props} />;
-  }
+function PivotTable(props: PivotTableProps) {
+  return <TableRenderer {...props} />;
 }
 
-export default PivotTable;
+export default memo(PivotTable);

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -28,19 +28,21 @@ import {
 } from 'react';
 import { safeHtmlSpan } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
+import { supersetTheme } from '@apache-superset/core/theme';
 import PropTypes from 'prop-types';
 import {
   CaretUpOutlined,
   CaretDownOutlined,
   ColumnHeightOutlined,
 } from '@ant-design/icons';
+import {
+  ColorFormatters,
+  getTextColorForBackground,
+  ObjectFormattingEnum,
+  ResolvedColorFormatterResult,
+} from '@superset-ui/chart-controls';
 import { PivotData, flatKey } from './utilities';
 import { Styles } from './Styles';
-
-interface CellColorFormatter {
-  column: string;
-  getColorFromValue(value: unknown): string | undefined;
-}
 
 type ClickCallback = (
   e: MouseEvent,
@@ -69,8 +71,11 @@ interface TableOptions {
   highlightHeaderCellsOnHover?: boolean;
   omittedHighlightHeaderGroups?: string[];
   highlightedHeaderCells?: Record<string, unknown[]>;
-  cellColorFormatters?: Record<string, CellColorFormatter[]>;
+  cellColorFormatters?: Record<string, ColorFormatters>;
   dateFormatters?: Record<string, ((val: unknown) => string) | undefined>;
+  cellBackgroundColor?: string;
+  cellTextColor?: string;
+  activeHeaderBackgroundColor?: string;
 }
 
 interface SubtotalDisplay {
@@ -175,6 +180,50 @@ function displayHeaderCell(
   ) : (
     labelContent
   );
+}
+
+export function getCellColor(
+  keys: string[],
+  aggValue: string | number | null,
+  cellColorFormatters: Record<string, ColorFormatters> | undefined,
+  cellBackgroundColor = supersetTheme.colorBgBase,
+): ResolvedColorFormatterResult {
+  if (!cellColorFormatters) return { backgroundColor: undefined };
+
+  let backgroundColor: string | undefined;
+  let color: string | undefined;
+  const isTextColorFormatter = (formatter: ColorFormatters[number]) =>
+    formatter.objectFormatting === ObjectFormattingEnum.TEXT_COLOR ||
+    formatter.toTextColor;
+
+  for (const cellColorFormatter of Object.values(cellColorFormatters)) {
+    if (!Array.isArray(cellColorFormatter)) continue;
+
+    for (const key of keys) {
+      for (const formatter of cellColorFormatter) {
+        if (formatter.column === key) {
+          const result = formatter.getColorFromValue(aggValue);
+          if (result) {
+            if (isTextColorFormatter(formatter)) {
+              color = result;
+            } else if (
+              formatter.objectFormatting !== ObjectFormattingEnum.CELL_BAR
+            ) {
+              backgroundColor = result;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    backgroundColor,
+    color: getTextColorForBackground(
+      { backgroundColor, color },
+      cellBackgroundColor,
+    ),
+  };
 }
 
 interface HierarchicalNode {
@@ -842,7 +891,10 @@ export function TableRenderer({
         highlightHeaderCellsOnHover,
         omittedHighlightHeaderGroups = [],
         highlightedHeaderCells,
+        cellColorFormatters,
         dateFormatters,
+        cellBackgroundColor = supersetTheme.colorBgBase,
+        activeHeaderBackgroundColor = supersetTheme.colorPrimaryBg,
       } = tableOptions;
 
       if (!settingsVisibleColKeys || !colAttrSpans) {
@@ -952,10 +1004,22 @@ export function TableRenderer({
           };
           const headerCellFormattedValue =
             dateFormatters?.[attrName]?.(colKey[attrIdx]) ?? colKey[attrIdx];
+          const isActiveHeader = colLabelClass.includes('active');
+          const { backgroundColor, color } = getCellColor(
+            [attrName],
+            headerCellFormattedValue,
+            cellColorFormatters,
+            isActiveHeader ? activeHeaderBackgroundColor : cellBackgroundColor,
+          );
+          const colHeaderStyle = {
+            backgroundColor,
+            ...(color ? { color } : {}),
+          };
           attrValueCells.push(
             <th
               className={colLabelClass}
               key={`colKey-${flatColKey}`}
+              style={colHeaderStyle}
               colSpan={colSpan}
               rowSpan={rowSpan}
               role="columnheader button"
@@ -1169,6 +1233,9 @@ export function TableRenderer({
         highlightedHeaderCells,
         cellColorFormatters,
         dateFormatters,
+        cellBackgroundColor = supersetTheme.colorBgBase,
+        cellTextColor = supersetTheme.colorPrimaryText,
+        activeHeaderBackgroundColor = supersetTheme.colorPrimaryBg,
       } = tableOptions;
       const flatRowKey = flatKey(rowKey);
 
@@ -1206,10 +1273,22 @@ export function TableRenderer({
 
           const headerCellFormattedValue =
             dateFormatters?.[settingsRowAttrs[i]]?.(r) ?? r;
+          const isActiveHeader = valueCellClassName.includes('active');
+          const { backgroundColor, color } = getCellColor(
+            [settingsRowAttrs[i]],
+            headerCellFormattedValue,
+            cellColorFormatters,
+            isActiveHeader ? activeHeaderBackgroundColor : cellBackgroundColor,
+          );
+          const rowHeaderStyle = {
+            backgroundColor,
+            ...(color ? { color } : {}),
+          };
           return (
             <th
               key={`rowKeyLabel-${i}`}
               className={valueCellClassName}
+              style={rowHeaderStyle}
               rowSpan={rowSpan}
               colSpan={colSpan}
               role="columnheader button"
@@ -1268,31 +1347,20 @@ export function TableRenderer({
         const aggValue = agg.value();
 
         const keys = [...rowKey, ...colKey];
-        let backgroundColor: string | undefined;
-        if (cellColorFormatters) {
-          Object.values(cellColorFormatters).forEach(cellColorFormatter => {
-            if (Array.isArray(cellColorFormatter)) {
-              keys.forEach(key => {
-                if (backgroundColor) {
-                  return;
-                }
-                cellColorFormatter
-                  .filter(formatter => formatter.column === key)
-                  .forEach(formatter => {
-                    const formatterResult =
-                      formatter.getColorFromValue(aggValue);
-                    if (formatterResult) {
-                      backgroundColor = formatterResult;
-                    }
-                  });
-              });
-            }
-          });
-        }
+        const { backgroundColor, color } = getCellColor(
+          keys,
+          aggValue,
+          cellColorFormatters,
+          cellBackgroundColor,
+        );
 
         const style = agg.isSubtotal
-          ? { fontWeight: 'bold' }
-          : { backgroundColor };
+          ? {
+              backgroundColor,
+              fontWeight: 'bold',
+              color: color ?? cellTextColor,
+            }
+          : { backgroundColor, color: color ?? cellTextColor };
 
         return (
           <td

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -839,7 +839,10 @@ export function TableRenderer({
       };
       newSortingOrder[columnIndex] = newDirection;
 
-      const cacheKey = `${columnIndex}-${visColKeys.length}-${rowEnabled}-${rowPartialOnTop}-${newDirection}`;
+      // Include the target column's flat key so different visible-column sets
+      // with the same length don't collide in the cache.
+      const sortTargetKey = flatKey(visColKeys[columnIndex] ?? []);
+      const cacheKey = `${columnIndex}-${visColKeys.length}-${sortTargetKey}-${rowEnabled}-${rowPartialOnTop}-${newDirection}`;
       let newRowKeys;
       if (sortCacheRef.current.has(cacheKey)) {
         const cachedRowKeys = sortCacheRef.current.get(cacheKey);

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -17,24 +17,30 @@
  * under the License.
  */
 
-import { Component, ReactNode, MouseEvent } from 'react';
+import {
+  ReactNode,
+  MouseEvent,
+  useState,
+  useCallback,
+  useRef,
+  useMemo,
+  useEffect,
+} from 'react';
 import { safeHtmlSpan } from '@superset-ui/core';
-import { t } from '@apache-superset/core/translation';
-import { supersetTheme } from '@apache-superset/core/theme';
+import { t } from '@apache-superset/core/ui';
 import PropTypes from 'prop-types';
 import {
   CaretUpOutlined,
   CaretDownOutlined,
   ColumnHeightOutlined,
 } from '@ant-design/icons';
-import {
-  ColorFormatters,
-  getTextColorForBackground,
-  ObjectFormattingEnum,
-  ResolvedColorFormatterResult,
-} from '@superset-ui/chart-controls';
 import { PivotData, flatKey } from './utilities';
 import { Styles } from './Styles';
+
+interface CellColorFormatter {
+  column: string;
+  getColorFromValue(value: unknown): string | undefined;
+}
 
 type ClickCallback = (
   e: MouseEvent,
@@ -63,11 +69,8 @@ interface TableOptions {
   highlightHeaderCellsOnHover?: boolean;
   omittedHighlightHeaderGroups?: string[];
   highlightedHeaderCells?: Record<string, unknown[]>;
-  cellColorFormatters?: Record<string, ColorFormatters>;
+  cellColorFormatters?: Record<string, CellColorFormatter[]>;
   dateFormatters?: Record<string, ((val: unknown) => string) | undefined>;
-  cellBackgroundColor?: string;
-  cellTextColor?: string;
-  activeHeaderBackgroundColor?: string;
 }
 
 interface SubtotalDisplay {
@@ -87,7 +90,7 @@ interface TableRendererProps {
   cols: string[];
   rows: string[];
   aggregatorName: string;
-  tableOptions: TableOptions;
+  tableOptions?: TableOptions;
   subtotalOptions?: SubtotalOptions;
   namesMapping?: Record<string, string>;
   onContextMenu: (
@@ -98,13 +101,6 @@ interface TableRendererProps {
   ) => void;
   allowRenderHtml?: boolean;
   [key: string]: unknown;
-}
-
-interface TableRendererState {
-  collapsedRows: Record<string, boolean>;
-  collapsedCols: Record<string, boolean>;
-  sortingOrder: string[];
-  activeSortColumn?: number | null;
 }
 
 interface PivotSettings {
@@ -181,50 +177,6 @@ function displayHeaderCell(
   );
 }
 
-export function getCellColor(
-  keys: string[],
-  aggValue: string | number | null,
-  cellColorFormatters: Record<string, ColorFormatters> | undefined,
-  cellBackgroundColor = supersetTheme.colorBgBase,
-): ResolvedColorFormatterResult {
-  if (!cellColorFormatters) return { backgroundColor: undefined };
-
-  let backgroundColor: string | undefined;
-  let color: string | undefined;
-  const isTextColorFormatter = (formatter: ColorFormatters[number]) =>
-    formatter.objectFormatting === ObjectFormattingEnum.TEXT_COLOR ||
-    formatter.toTextColor;
-
-  for (const cellColorFormatter of Object.values(cellColorFormatters)) {
-    if (!Array.isArray(cellColorFormatter)) continue;
-
-    for (const key of keys) {
-      for (const formatter of cellColorFormatter) {
-        if (formatter.column === key) {
-          const result = formatter.getColorFromValue(aggValue);
-          if (result) {
-            if (isTextColorFormatter(formatter)) {
-              color = result;
-            } else if (
-              formatter.objectFormatting !== ObjectFormattingEnum.CELL_BAR
-            ) {
-              backgroundColor = result;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return {
-    backgroundColor,
-    color: getTextColorForBackground(
-      { backgroundColor, color },
-      cellBackgroundColor,
-    ),
-  };
-}
-
 interface HierarchicalNode {
   currentVal?: number;
   [key: string]: HierarchicalNode | number | undefined;
@@ -269,11 +221,6 @@ function sortHierarchicalObject(
     }
   });
   return result;
-}
-
-function convertToNumberIfNumeric(value: string): string | number {
-  const n = Number(value);
-  return value.trim() !== '' && !Number.isNaN(n) ? n : value;
 }
 
 function convertToArray(
@@ -328,275 +275,182 @@ function convertToArray(
   return result;
 }
 
-export class TableRenderer extends Component<
-  TableRendererProps,
-  TableRendererState
-> {
-  sortCache: Map<string, string[][]>;
-  cachedProps: TableRendererProps | null;
-  cachedBasePivotSettings: PivotSettings | null;
+export function TableRenderer({
+  cols,
+  rows,
+  aggregatorName,
+  tableOptions = {},
+  subtotalOptions,
+  namesMapping: namesMappingProp,
+  onContextMenu,
+  allowRenderHtml,
+  ...restProps
+}: TableRendererProps) {
+  const [collapsedRows, setCollapsedRows] = useState<Record<string, boolean>>(
+    {},
+  );
+  const [collapsedCols, setCollapsedCols] = useState<Record<string, boolean>>(
+    {},
+  );
+  const [sortingOrder, setSortingOrder] = useState<string[]>([]);
+  const [activeSortColumn, setActiveSortColumn] = useState<number | null>(null);
+  const [sortedRowKeys, setSortedRowKeys] = useState<string[][] | null>(null);
 
-  static propTypes: Record<string, unknown>;
-  static defaultProps: Record<string, unknown>;
+  const sortCacheRef = useRef(new Map<string, string[][]>());
 
-  constructor(props: TableRendererProps) {
-    super(props);
+  // Memoize props object to maintain referential stability
+  const props = useMemo<TableRendererProps>(
+    () => ({
+      cols,
+      rows,
+      aggregatorName,
+      tableOptions,
+      subtotalOptions,
+      namesMapping: namesMappingProp,
+      onContextMenu,
+      allowRenderHtml,
+      ...restProps,
+    }),
+    [
+      cols,
+      rows,
+      aggregatorName,
+      tableOptions,
+      subtotalOptions,
+      namesMappingProp,
+      onContextMenu,
+      allowRenderHtml,
+      restProps,
+    ],
+  );
 
-    // We need state to record which entries are collapsed and which aren't.
-    // This is an object with flat-keys indicating if the corresponding rows
-    // should be collapsed.
-    this.state = { collapsedRows: {}, collapsedCols: {}, sortingOrder: [] };
-    this.sortCache = new Map();
-    this.cachedProps = null;
-    this.cachedBasePivotSettings = null;
-    this.clickHeaderHandler = this.clickHeaderHandler.bind(this);
-    this.clickHandler = this.clickHandler.bind(this);
-  }
-
-  getBasePivotSettings(): PivotSettings {
-    // One-time extraction of pivot settings that we'll use throughout the render.
-
-    const { props } = this;
-    const colAttrs = props.cols;
-    const rowAttrs = props.rows;
-
-    const tableOptions: TableOptions = {
-      rowTotals: true,
-      colTotals: true,
-      ...props.tableOptions,
-    };
-    const rowTotals = tableOptions.rowTotals || colAttrs.length === 0;
-    const colTotals = tableOptions.colTotals || rowAttrs.length === 0;
-
-    const namesMapping = props.namesMapping || {};
-    const subtotalOptions: Required<
-      Pick<SubtotalOptions, 'arrowCollapsed' | 'arrowExpanded'>
-    > &
-      SubtotalOptions = {
-      arrowCollapsed: '\u25B2',
-      arrowExpanded: '\u25BC',
-      ...props.subtotalOptions,
-    };
-
-    const colSubtotalDisplay: SubtotalDisplay = {
-      displayOnTop: false,
-      enabled: tableOptions.colSubTotals,
-      hideOnExpand: false,
-      ...subtotalOptions.colSubtotalDisplay,
-    };
-
-    const rowSubtotalDisplay: SubtotalDisplay = {
-      displayOnTop: false,
-      enabled: tableOptions.rowSubTotals,
-      hideOnExpand: false,
-      ...subtotalOptions.rowSubtotalDisplay,
-    };
-
-    const pivotData = new PivotData(props as Record<string, unknown>, {
-      rowEnabled: rowSubtotalDisplay.enabled,
-      colEnabled: colSubtotalDisplay.enabled,
-      rowPartialOnTop: rowSubtotalDisplay.displayOnTop,
-      colPartialOnTop: colSubtotalDisplay.displayOnTop,
-    });
-    const rowKeys = pivotData.getRowKeys();
-    const colKeys = pivotData.getColKeys();
-
-    // Also pre-calculate all the callbacks for cells, etc... This is nice to have to
-    // avoid re-calculations of the call-backs on cell expansions, etc...
-    const cellCallbacks: Record<
-      string,
-      Record<string, (e: MouseEvent) => void>
-    > = {};
-    const rowTotalCallbacks: Record<string, (e: MouseEvent) => void> = {};
-    const colTotalCallbacks: Record<string, (e: MouseEvent) => void> = {};
-    let grandTotalCallback: ((e: MouseEvent) => void) | null = null;
-    if (tableOptions.clickCallback) {
-      rowKeys.forEach(rowKey => {
-        const flatRowKey = flatKey(rowKey);
-        if (!(flatRowKey in cellCallbacks)) {
-          cellCallbacks[flatRowKey] = {};
+  const clickHandler = useCallback(
+    (
+      pivotData: InstanceType<typeof PivotData>,
+      rowValues: string[],
+      colValues: string[],
+    ) => {
+      const colAttrs = cols;
+      const rowAttrs = rows;
+      const value = pivotData.getAggregator(rowValues, colValues).value();
+      const filters: Record<string, string> = {};
+      const colLimit = Math.min(colAttrs.length, colValues.length);
+      for (let i = 0; i < colLimit; i += 1) {
+        const attr = colAttrs[i];
+        if (colValues[i] !== null) {
+          filters[attr] = colValues[i];
         }
-        colKeys.forEach(colKey => {
-          cellCallbacks[flatRowKey][flatKey(colKey)] = this.clickHandler(
-            pivotData,
-            rowKey,
-            colKey,
-          );
-        });
-      });
-
-      // Add in totals as well.
-      if (rowTotals) {
-        rowKeys.forEach(rowKey => {
-          rowTotalCallbacks[flatKey(rowKey)] = this.clickHandler(
-            pivotData,
-            rowKey,
-            [],
-          );
-        });
       }
-      if (colTotals) {
-        colKeys.forEach(colKey => {
-          colTotalCallbacks[flatKey(colKey)] = this.clickHandler(
-            pivotData,
-            [],
-            colKey,
-          );
-        });
-      }
-      if (rowTotals && colTotals) {
-        grandTotalCallback = this.clickHandler(pivotData, [], []);
-      }
-    }
-
-    return {
-      pivotData,
-      colAttrs,
-      rowAttrs,
-      colKeys,
-      rowKeys,
-      rowTotals,
-      colTotals,
-      arrowCollapsed: subtotalOptions.arrowCollapsed,
-      arrowExpanded: subtotalOptions.arrowExpanded,
-      colSubtotalDisplay,
-      rowSubtotalDisplay,
-      cellCallbacks,
-      rowTotalCallbacks,
-      colTotalCallbacks,
-      grandTotalCallback,
-      namesMapping,
-      allowRenderHtml: props.allowRenderHtml,
-    };
-  }
-
-  clickHandler(
-    pivotData: InstanceType<typeof PivotData>,
-    rowValues: string[],
-    colValues: string[],
-  ) {
-    const colAttrs = this.props.cols;
-    const rowAttrs = this.props.rows;
-    const value = pivotData.getAggregator(rowValues, colValues).value();
-    const filters: Record<string, string> = {};
-    const colLimit = Math.min(colAttrs.length, colValues.length);
-    for (let i = 0; i < colLimit; i += 1) {
-      const attr = colAttrs[i];
-      if (colValues[i] !== null) {
-        filters[attr] = colValues[i];
-      }
-    }
-    const rowLimit = Math.min(rowAttrs.length, rowValues.length);
-    for (let i = 0; i < rowLimit; i += 1) {
-      const attr = rowAttrs[i];
-      if (rowValues[i] !== null) {
-        filters[attr] = rowValues[i];
-      }
-    }
-    const { clickCallback } = this.props.tableOptions;
-    return (e: MouseEvent) => clickCallback?.(e, value, filters, pivotData);
-  }
-
-  clickHeaderHandler(
-    pivotData: InstanceType<typeof PivotData>,
-    values: string[],
-    attrs: string[],
-    attrIdx: number,
-    callback: HeaderClickCallback | undefined,
-    isSubtotal = false,
-    isGrandTotal = false,
-  ) {
-    const filters: Record<string, string> = {};
-    for (let i = 0; i <= attrIdx; i += 1) {
-      const attr = attrs[i];
-      filters[attr] = values[i];
-    }
-    return (e: MouseEvent) =>
-      callback?.(
-        e,
-        values[attrIdx],
-        filters,
-        pivotData,
-        isSubtotal,
-        isGrandTotal,
-      );
-  }
-
-  collapseAttr(rowOrCol: boolean, attrIdx: number, allKeys: string[][]) {
-    return (e: MouseEvent<HTMLSpanElement>) => {
-      // Collapse an entire attribute.
-      e.stopPropagation();
-      const keyLen = attrIdx + 1;
-      const collapsed = allKeys
-        .filter((k: string[]) => k.length === keyLen)
-        .map(flatKey);
-
-      const updates: Record<string, boolean> = {};
-      collapsed.forEach((k: string) => {
-        updates[k] = true;
-      });
-
-      if (rowOrCol) {
-        this.setState(state => ({
-          collapsedRows: { ...state.collapsedRows, ...updates },
-        }));
-      } else {
-        this.setState(state => ({
-          collapsedCols: { ...state.collapsedCols, ...updates },
-        }));
-      }
-    };
-  }
-
-  expandAttr(rowOrCol: boolean, attrIdx: number, allKeys: string[][]) {
-    return (e: MouseEvent<HTMLSpanElement>) => {
-      // Expand an entire attribute. This implicitly implies expanding all of the
-      // parents as well. It's a bit inefficient but ah well...
-      e.stopPropagation();
-      const updates: Record<string, boolean> = {};
-      allKeys.forEach((k: string[]) => {
-        for (let i = 0; i <= attrIdx; i += 1) {
-          updates[flatKey(k.slice(0, i + 1))] = false;
+      const rowLimit = Math.min(rowAttrs.length, rowValues.length);
+      for (let i = 0; i < rowLimit; i += 1) {
+        const attr = rowAttrs[i];
+        if (rowValues[i] !== null) {
+          filters[attr] = rowValues[i];
         }
-      });
-
-      if (rowOrCol) {
-        this.setState(state => ({
-          collapsedRows: { ...state.collapsedRows, ...updates },
-        }));
-      } else {
-        this.setState(state => ({
-          collapsedCols: { ...state.collapsedCols, ...updates },
-        }));
       }
-    };
-  }
+      const { clickCallback } = tableOptions;
+      return (e: MouseEvent) => clickCallback?.(e, value, filters, pivotData);
+    },
+    [cols, rows, tableOptions],
+  );
 
-  toggleRowKey(flatRowKey: string) {
-    return (e: MouseEvent<HTMLSpanElement>) => {
+  const clickHeaderHandler = useCallback(
+    (
+      pivotData: InstanceType<typeof PivotData>,
+      values: string[],
+      attrs: string[],
+      attrIdx: number,
+      callback: HeaderClickCallback | undefined,
+      isSubtotal = false,
+      isGrandTotal = false,
+    ) => {
+      const filters: Record<string, string> = {};
+      for (let i = 0; i <= attrIdx; i += 1) {
+        const attr = attrs[i];
+        filters[attr] = values[i];
+      }
+      return (e: MouseEvent) =>
+        callback?.(
+          e,
+          values[attrIdx],
+          filters,
+          pivotData,
+          isSubtotal,
+          isGrandTotal,
+        );
+    },
+    [],
+  );
+
+  const collapseAttr = useCallback(
+    (rowOrCol: boolean, attrIdx: number, allKeys: string[][]) =>
+      (e: MouseEvent<HTMLSpanElement>) => {
+        // Collapse an entire attribute.
+        e.stopPropagation();
+        const keyLen = attrIdx + 1;
+        const collapsed = allKeys
+          .filter((k: string[]) => k.length === keyLen)
+          .map(flatKey);
+
+        const updates: Record<string, boolean> = {};
+        collapsed.forEach((k: string) => {
+          updates[k] = true;
+        });
+
+        if (rowOrCol) {
+          setCollapsedRows(state => ({ ...state, ...updates }));
+        } else {
+          setCollapsedCols(state => ({ ...state, ...updates }));
+        }
+      },
+    [],
+  );
+
+  const expandAttr = useCallback(
+    (rowOrCol: boolean, attrIdx: number, allKeys: string[][]) =>
+      (e: MouseEvent<HTMLSpanElement>) => {
+        // Expand an entire attribute. This implicitly implies expanding all of the
+        // parents as well. It's a bit inefficient but ah well...
+        e.stopPropagation();
+        const updates: Record<string, boolean> = {};
+        allKeys.forEach((k: string[]) => {
+          for (let i = 0; i <= attrIdx; i += 1) {
+            updates[flatKey(k.slice(0, i + 1))] = false;
+          }
+        });
+
+        if (rowOrCol) {
+          setCollapsedRows(state => ({ ...state, ...updates }));
+        } else {
+          setCollapsedCols(state => ({ ...state, ...updates }));
+        }
+      },
+    [],
+  );
+
+  const toggleRowKey = useCallback(
+    (flatRowKey: string) => (e: MouseEvent<HTMLSpanElement>) => {
       e.stopPropagation();
-      this.setState(state => ({
-        collapsedRows: {
-          ...state.collapsedRows,
-          [flatRowKey]: !state.collapsedRows[flatRowKey],
-        },
+      setCollapsedRows(state => ({
+        ...state,
+        [flatRowKey]: !state[flatRowKey],
       }));
-    };
-  }
+    },
+    [],
+  );
 
-  toggleColKey(flatColKey: string) {
-    return (e: MouseEvent<HTMLSpanElement>) => {
+  const toggleColKey = useCallback(
+    (flatColKey: string) => (e: MouseEvent<HTMLSpanElement>) => {
       e.stopPropagation();
-      this.setState(state => ({
-        collapsedCols: {
-          ...state.collapsedCols,
-          [flatColKey]: !state.collapsedCols[flatColKey],
-        },
+      setCollapsedCols(state => ({
+        ...state,
+        [flatColKey]: !state[flatColKey],
       }));
-    };
-  }
+    },
+    [],
+  );
 
-  calcAttrSpans(attrArr: string[][], numAttrs: number) {
+  const calcAttrSpans = useCallback((attrArr: string[][], numAttrs: number) => {
     // Given an array of attribute values (i.e. each element is another array with
     // the value at every level), compute the spans for every attribute value at
     // every level. The return value is a nested array of the same shape. It has
@@ -627,81 +481,303 @@ export class TableRenderer extends Component<
       lv = cv;
     }
     return spans;
-  }
+  }, []);
 
-  getAggregatedData(
-    pivotData: InstanceType<typeof PivotData>,
-    visibleColName: string[],
-    rowPartialOnTop: boolean | undefined,
-  ) {
-    // Transforms flat row keys into a hierarchical group structure where each level
-    // represents a grouping dimension. For each row key path, it calculates the
-    // aggregated value for the specified column and builds a nested object that
-    // preserves the hierarchy while storing aggregation values at each level.
-    const groups: Record<string, HierarchicalNode> = {};
-    const rows = pivotData.rowKeys;
-    rows.forEach(rowKey => {
-      const aggValue =
-        pivotData.getAggregator(rowKey, visibleColName).value() ?? 0;
+  const getAggregatedData = useCallback(
+    (
+      pivotData: InstanceType<typeof PivotData>,
+      visibleColName: string[],
+      rowPartialOnTop: boolean | undefined,
+    ) => {
+      // Transforms flat row keys into a hierarchical group structure where each level
+      // represents a grouping dimension. For each row key path, it calculates the
+      // aggregated value for the specified column and builds a nested object that
+      // preserves the hierarchy while storing aggregation values at each level.
+      const groups: Record<string, HierarchicalNode> = {};
+      const rowsData = pivotData.rowKeys;
+      rowsData.forEach(rowKey => {
+        const aggValue =
+          pivotData.getAggregator(rowKey, visibleColName).value() ?? 0;
 
-      if (rowPartialOnTop) {
-        const parent = rowKey
-          .slice(0, -1)
-          .reduce(
-            (acc: Record<string, HierarchicalNode>, key: string) =>
-              (acc[key] ??= {}) as Record<string, HierarchicalNode>,
+        if (rowPartialOnTop) {
+          const parent = rowKey
+            .slice(0, -1)
+            .reduce(
+              (acc: Record<string, HierarchicalNode>, key: string) =>
+                (acc[key] ??= {}) as Record<string, HierarchicalNode>,
+              groups,
+            );
+          parent[rowKey.at(-1)!] = { currentVal: aggValue as number };
+        } else {
+          rowKey.reduce(
+            (acc: Record<string, HierarchicalNode>, key: string) => {
+              acc[key] = acc[key] || { currentVal: 0 };
+              (acc[key] as HierarchicalNode).currentVal = aggValue as number;
+              return acc[key] as Record<string, HierarchicalNode>;
+            },
             groups,
           );
-        parent[rowKey.at(-1)!] = { currentVal: aggValue as number };
-      } else {
-        rowKey.reduce((acc: Record<string, HierarchicalNode>, key: string) => {
-          acc[key] = acc[key] || { currentVal: 0 };
-          (acc[key] as HierarchicalNode).currentVal = aggValue as number;
-          return acc[key] as Record<string, HierarchicalNode>;
-        }, groups);
-      }
+        }
+      });
+      return groups;
+    },
+    [],
+  );
+
+  const sortAndCacheData = useCallback(
+    (
+      groups: Record<string, HierarchicalNode>,
+      sortOrder: string,
+      rowEnabled: boolean | undefined,
+      rowPartialOnTop: boolean | undefined,
+      maxRowIndex: number,
+    ) => {
+      // Processes hierarchical data by first sorting it according to the specified order
+      // and then converting the sorted structure into a flat array format. This function
+      // serves as an intermediate step between hierarchical data representation and
+      // flat array representation needed for rendering.
+      const sortedGroups = sortHierarchicalObject(
+        groups,
+        sortOrder,
+        rowPartialOnTop,
+      );
+      return convertToArray(
+        sortedGroups,
+        rowEnabled,
+        rowPartialOnTop,
+        maxRowIndex,
+      );
+    },
+    [],
+  );
+
+  const getBasePivotSettings = useCallback((): PivotSettings => {
+    // One-time extraction of pivot settings that we'll use throughout the render.
+
+    const colAttrs = cols;
+    const rowAttrs = rows;
+
+    const mergedTableOptions: TableOptions = {
+      rowTotals: true,
+      colTotals: true,
+      ...tableOptions,
+    };
+    const rowTotals = mergedTableOptions.rowTotals || colAttrs.length === 0;
+    const colTotals = mergedTableOptions.colTotals || rowAttrs.length === 0;
+
+    const namesMapping = namesMappingProp || {};
+    const mergedSubtotalOptions: Required<
+      Pick<SubtotalOptions, 'arrowCollapsed' | 'arrowExpanded'>
+    > &
+      SubtotalOptions = {
+      arrowCollapsed: '\u25B2',
+      arrowExpanded: '\u25BC',
+      ...subtotalOptions,
+    };
+
+    const colSubtotalDisplay: SubtotalDisplay = {
+      displayOnTop: false,
+      enabled: mergedTableOptions.colSubTotals,
+      hideOnExpand: false,
+      ...mergedSubtotalOptions.colSubtotalDisplay,
+    };
+
+    const rowSubtotalDisplay: SubtotalDisplay = {
+      displayOnTop: false,
+      enabled: mergedTableOptions.rowSubTotals,
+      hideOnExpand: false,
+      ...mergedSubtotalOptions.rowSubtotalDisplay,
+    };
+
+    const pivotData = new PivotData(props as Record<string, unknown>, {
+      rowEnabled: rowSubtotalDisplay.enabled,
+      colEnabled: colSubtotalDisplay.enabled,
+      rowPartialOnTop: rowSubtotalDisplay.displayOnTop,
+      colPartialOnTop: colSubtotalDisplay.displayOnTop,
     });
-    return groups;
-  }
+    const rowKeys = pivotData.getRowKeys();
+    const colKeys = pivotData.getColKeys();
 
-  sortAndCacheData(
-    groups: Record<string, HierarchicalNode>,
-    sortOrder: string,
-    rowEnabled: boolean | undefined,
-    rowPartialOnTop: boolean | undefined,
-    maxRowIndex: number,
-  ) {
-    // Processes hierarchical data by first sorting it according to the specified order
-    // and then converting the sorted structure into a flat array format. This function
-    // serves as an intermediate step between hierarchical data representation and
-    // flat array representation needed for rendering.
-    const sortedGroups = sortHierarchicalObject(
-      groups,
-      sortOrder,
-      rowPartialOnTop,
-    );
-    return convertToArray(
-      sortedGroups,
-      rowEnabled,
-      rowPartialOnTop,
-      maxRowIndex,
-    );
-  }
+    // Also pre-calculate all the callbacks for cells, etc... This is nice to have to
+    // avoid re-calculations of the call-backs on cell expansions, etc...
+    const cellCallbacks: Record<
+      string,
+      Record<string, (e: MouseEvent) => void>
+    > = {};
+    const rowTotalCallbacks: Record<string, (e: MouseEvent) => void> = {};
+    const colTotalCallbacks: Record<string, (e: MouseEvent) => void> = {};
+    let grandTotalCallback: ((e: MouseEvent) => void) | null = null;
+    if (mergedTableOptions.clickCallback) {
+      rowKeys.forEach(rowKey => {
+        const flatRowKey = flatKey(rowKey);
+        if (!(flatRowKey in cellCallbacks)) {
+          cellCallbacks[flatRowKey] = {};
+        }
+        colKeys.forEach(colKey => {
+          cellCallbacks[flatRowKey][flatKey(colKey)] = clickHandler(
+            pivotData,
+            rowKey,
+            colKey,
+          );
+        });
+      });
 
-  sortData(
-    columnIndex: number,
-    visibleColKeys: string[][],
-    pivotData: InstanceType<typeof PivotData>,
-    maxRowIndex: number,
-  ) {
-    // Handles column sorting with direction toggling (asc/desc) and implements
-    // caching mechanism to avoid redundant sorting operations. When sorting the same
-    // column multiple times, it cycles through sorting directions. Uses composite
-    // cache keys based on sorting parameters for optimal performance.
-    this.setState(state => {
-      const { sortingOrder, activeSortColumn } = state;
+      // Add in totals as well.
+      if (rowTotals) {
+        rowKeys.forEach(rowKey => {
+          rowTotalCallbacks[flatKey(rowKey)] = clickHandler(
+            pivotData,
+            rowKey,
+            [],
+          );
+        });
+      }
+      if (colTotals) {
+        colKeys.forEach(colKey => {
+          colTotalCallbacks[flatKey(colKey)] = clickHandler(
+            pivotData,
+            [],
+            colKey,
+          );
+        });
+      }
+      if (rowTotals && colTotals) {
+        grandTotalCallback = clickHandler(pivotData, [], []);
+      }
+    }
 
-      const newSortingOrder = [];
+    return {
+      pivotData,
+      colAttrs,
+      rowAttrs,
+      colKeys,
+      rowKeys,
+      rowTotals,
+      colTotals,
+      arrowCollapsed: mergedSubtotalOptions.arrowCollapsed,
+      arrowExpanded: mergedSubtotalOptions.arrowExpanded,
+      colSubtotalDisplay,
+      rowSubtotalDisplay,
+      cellCallbacks,
+      rowTotalCallbacks,
+      colTotalCallbacks,
+      grandTotalCallback,
+      namesMapping,
+      allowRenderHtml,
+    };
+  }, [
+    cols,
+    rows,
+    tableOptions,
+    namesMappingProp,
+    subtotalOptions,
+    props,
+    allowRenderHtml,
+    clickHandler,
+  ]);
+
+  const visibleKeys = useCallback(
+    (
+      keys: string[][],
+      collapsed: Record<string, boolean>,
+      numAttrs: number,
+      subtotalDisplay: SubtotalDisplay,
+    ) =>
+      keys.filter(
+        (key: string[]) =>
+          // Is the key hidden by one of its parents?
+          !key.some(
+            (_k: string, j: number) => collapsed[flatKey(key.slice(0, j))],
+          ) &&
+          // Leaf key.
+          (key.length === numAttrs ||
+            // Children hidden. Must show total.
+            flatKey(key) in collapsed ||
+            // Don't hide totals.
+            !subtotalDisplay.hideOnExpand),
+      ),
+    [],
+  );
+
+  const isDashboardEditMode = useCallback(
+    () => document.contains(document.querySelector('.dashboard--editing')),
+    [],
+  );
+
+  // Compute base pivot settings, memoized based on relevant props
+  const basePivotSettings = useMemo(() => {
+    // Clear sort cache when props change
+    sortCacheRef.current.clear();
+    return getBasePivotSettings();
+  }, [getBasePivotSettings]);
+
+  // Reset sort state when structural props change
+  useEffect(() => {
+    setSortingOrder([]);
+    setActiveSortColumn(null);
+    setSortedRowKeys(null);
+  }, [
+    cols,
+    rows,
+    aggregatorName,
+    tableOptions,
+    subtotalOptions,
+    namesMappingProp,
+    allowRenderHtml,
+  ]);
+
+  // Use sorted row keys if available, otherwise use base row keys
+  const effectiveRowKeys = sortedRowKeys ?? basePivotSettings.rowKeys;
+
+  const {
+    colAttrs,
+    rowAttrs,
+    colKeys,
+    colTotals,
+    rowSubtotalDisplay,
+    colSubtotalDisplay,
+  } = basePivotSettings;
+
+  const rowKeys = effectiveRowKeys;
+
+  // Need to account for exclusions to compute the effective row
+  // and column keys.
+  const visibleRowKeys = visibleKeys(
+    rowKeys,
+    collapsedRows,
+    rowAttrs.length,
+    rowSubtotalDisplay,
+  );
+  const visibleColKeys = visibleKeys(
+    colKeys,
+    collapsedCols,
+    colAttrs.length,
+    colSubtotalDisplay,
+  );
+
+  const pivotSettings: PivotSettings = {
+    visibleRowKeys,
+    maxRowVisible: Math.max(...visibleRowKeys.map((k: string[]) => k.length)),
+    visibleColKeys,
+    maxColVisible: Math.max(...visibleColKeys.map((k: string[]) => k.length)),
+    rowAttrSpans: calcAttrSpans(visibleRowKeys, rowAttrs.length),
+    colAttrSpans: calcAttrSpans(visibleColKeys, colAttrs.length),
+    allowRenderHtml,
+    ...basePivotSettings,
+  };
+
+  const sortData = useCallback(
+    (
+      columnIndex: number,
+      visColKeys: string[][],
+      pivotData: InstanceType<typeof PivotData>,
+      maxRowIndex: number,
+    ) => {
+      // Handles column sorting with direction toggling (asc/desc) and implements
+      // caching mechanism to avoid redundant sorting operations. When sorting the same
+      // column multiple times, it cycles through sorting directions. Uses composite
+      // cache keys based on sorting parameters for optimal performance.
+      const newSortingOrder: string[] = [];
       let newDirection = 'asc';
 
       if (activeSortColumn === columnIndex) {
@@ -714,727 +790,674 @@ export class TableRenderer extends Component<
       };
       newSortingOrder[columnIndex] = newDirection;
 
-      const cacheKey = `${columnIndex}-${visibleColKeys.length}-${rowEnabled}-${rowPartialOnTop}-${newDirection}`;
+      const cacheKey = `${columnIndex}-${visColKeys.length}-${rowEnabled}-${rowPartialOnTop}-${newDirection}`;
       let newRowKeys;
-      if (this.sortCache.has(cacheKey)) {
-        const cachedRowKeys = this.sortCache.get(cacheKey);
+      if (sortCacheRef.current.has(cacheKey)) {
+        const cachedRowKeys = sortCacheRef.current.get(cacheKey);
         newRowKeys = cachedRowKeys;
       } else {
-        const groups = this.getAggregatedData(
+        const groups = getAggregatedData(
           pivotData,
-          visibleColKeys[columnIndex],
+          visColKeys[columnIndex],
           rowPartialOnTop,
         );
-        const sortedRowKeys = this.sortAndCacheData(
+        const computedSortedRowKeys = sortAndCacheData(
           groups,
           newDirection,
           rowEnabled,
           rowPartialOnTop,
           maxRowIndex,
         );
-        this.sortCache.set(cacheKey, sortedRowKeys);
-        newRowKeys = sortedRowKeys;
+        sortCacheRef.current.set(cacheKey, computedSortedRowKeys);
+        newRowKeys = computedSortedRowKeys;
       }
-      this.cachedBasePivotSettings = {
-        ...this.cachedBasePivotSettings!,
-        rowKeys: newRowKeys!,
-      };
 
-      return {
-        sortingOrder: newSortingOrder,
-        activeSortColumn: columnIndex,
-      };
-    });
-  }
+      setSortedRowKeys(newRowKeys!);
+      setSortingOrder(newSortingOrder);
+      setActiveSortColumn(columnIndex);
+    },
+    [activeSortColumn, sortingOrder, getAggregatedData, sortAndCacheData],
+  );
 
-  renderColHeaderRow(
-    attrName: string,
-    attrIdx: number,
-    pivotSettings: PivotSettings,
-  ) {
-    // Render a single row in the column header at the top of the pivot table.
+  const renderColHeaderRow = useCallback(
+    (attrName: string, attrIdx: number, settings: PivotSettings) => {
+      // Render a single row in the column header at the top of the pivot table.
 
-    const {
-      rowAttrs,
-      colAttrs,
-      colKeys,
-      visibleColKeys,
-      colAttrSpans,
-      rowTotals,
-      arrowExpanded,
-      arrowCollapsed,
-      colSubtotalDisplay,
-      maxColVisible,
-      pivotData,
-      namesMapping,
-      allowRenderHtml,
-    } = pivotSettings;
-    const {
-      highlightHeaderCellsOnHover,
-      omittedHighlightHeaderGroups = [],
-      highlightedHeaderCells,
-      cellColorFormatters,
-      dateFormatters,
-      cellBackgroundColor = supersetTheme.colorBgBase,
-      activeHeaderBackgroundColor = supersetTheme.colorPrimaryBg,
-    } = this.props.tableOptions;
+      const {
+        rowAttrs: settingsRowAttrs,
+        colAttrs: settingsColAttrs,
+        colKeys: settingsColKeys,
+        visibleColKeys: settingsVisibleColKeys,
+        colAttrSpans,
+        rowTotals,
+        arrowExpanded,
+        arrowCollapsed,
+        colSubtotalDisplay: settingsColSubtotalDisplay,
+        maxColVisible,
+        pivotData,
+        namesMapping,
+        allowRenderHtml: settingsAllowRenderHtml,
+      } = settings;
+      const {
+        highlightHeaderCellsOnHover,
+        omittedHighlightHeaderGroups = [],
+        highlightedHeaderCells,
+        dateFormatters,
+      } = tableOptions;
 
-    if (!visibleColKeys || !colAttrSpans) {
-      return null;
-    }
+      if (!settingsVisibleColKeys || !colAttrSpans) {
+        return null;
+      }
 
-    const spaceCell =
-      attrIdx === 0 && rowAttrs.length !== 0 ? (
-        <th
-          key="padding"
-          colSpan={rowAttrs.length}
-          rowSpan={colAttrs.length}
-          aria-hidden="true"
-        />
-      ) : null;
+      const spaceCell =
+        attrIdx === 0 && settingsRowAttrs.length !== 0 ? (
+          <th
+            key="padding"
+            colSpan={settingsRowAttrs.length}
+            rowSpan={settingsColAttrs.length}
+            aria-hidden="true"
+          />
+        ) : null;
 
-    const needToggle =
-      colSubtotalDisplay.enabled === true && attrIdx !== colAttrs.length - 1;
-    let arrowClickHandle = null;
-    let subArrow = null;
-    if (needToggle) {
-      arrowClickHandle =
-        attrIdx + 1 < maxColVisible!
-          ? this.collapseAttr(false, attrIdx, colKeys)
-          : this.expandAttr(false, attrIdx, colKeys);
-      subArrow = attrIdx + 1 < maxColVisible! ? arrowExpanded : arrowCollapsed;
-    }
-    const attrNameCell = (
-      <th key="label" className="pvtAxisLabel">
-        {displayHeaderCell(
-          needToggle,
-          subArrow,
-          arrowClickHandle,
-          attrName,
-          namesMapping,
-          allowRenderHtml,
-        )}
-      </th>
-    );
+      const needToggle =
+        settingsColSubtotalDisplay.enabled === true &&
+        attrIdx !== settingsColAttrs.length - 1;
+      let arrowClickHandle = null;
+      let subArrow = null;
+      if (needToggle) {
+        arrowClickHandle =
+          attrIdx + 1 < maxColVisible!
+            ? collapseAttr(false, attrIdx, settingsColKeys)
+            : expandAttr(false, attrIdx, settingsColKeys);
+        subArrow =
+          attrIdx + 1 < maxColVisible! ? arrowExpanded : arrowCollapsed;
+      }
+      const attrNameCell = (
+        <th key="label" className="pvtAxisLabel">
+          {displayHeaderCell(
+            needToggle,
+            subArrow,
+            arrowClickHandle,
+            attrName,
+            namesMapping,
+            settingsAllowRenderHtml,
+          )}
+        </th>
+      );
 
-    const attrValueCells = [];
-    const rowIncrSpan = rowAttrs.length !== 0 ? 1 : 0;
-    // Iterate through columns. Jump over duplicate values.
-    let i = 0;
-    while (i < visibleColKeys.length) {
-      let handleContextMenu: ((e: MouseEvent) => void) | undefined;
-      const colKey = visibleColKeys[i];
-      const colSpan = attrIdx < colKey.length ? colAttrSpans[i][attrIdx] : 1;
-      let colLabelClass = 'pvtColLabel';
-      if (attrIdx < colKey.length) {
-        if (!omittedHighlightHeaderGroups.includes(colAttrs[attrIdx])) {
+      const attrValueCells = [];
+      const rowIncrSpan = settingsRowAttrs.length !== 0 ? 1 : 0;
+      // Iterate through columns. Jump over duplicate values.
+      let i = 0;
+      while (i < settingsVisibleColKeys.length) {
+        let handleContextMenu: ((e: MouseEvent) => void) | undefined;
+        const colKey = settingsVisibleColKeys[i];
+        const colSpan = attrIdx < colKey.length ? colAttrSpans[i][attrIdx] : 1;
+        let colLabelClass = 'pvtColLabel';
+        if (attrIdx < colKey.length) {
+          if (
+            !omittedHighlightHeaderGroups.includes(settingsColAttrs[attrIdx])
+          ) {
+            if (highlightHeaderCellsOnHover) {
+              colLabelClass += ' hoverable';
+            }
+            handleContextMenu = (e: MouseEvent) =>
+              onContextMenu(e, colKey, undefined, {
+                [attrName]: colKey[attrIdx],
+              });
+          }
+          if (
+            highlightedHeaderCells &&
+            Array.isArray(highlightedHeaderCells[settingsColAttrs[attrIdx]]) &&
+            highlightedHeaderCells[settingsColAttrs[attrIdx]].includes(
+              colKey[attrIdx],
+            )
+          ) {
+            colLabelClass += ' active';
+          }
+          const maxRowIndex = settings.maxRowVisible!;
+          const mColVisible = settings.maxColVisible!;
+          const visibleSortIcon = mColVisible - 1 === attrIdx;
+          const columnName = colKey[mColVisible - 1];
+
+          const rowSpan =
+            1 + (attrIdx === settingsColAttrs.length - 1 ? rowIncrSpan : 0);
+          const flatColKey = flatKey(colKey.slice(0, attrIdx + 1));
+          const onArrowClick = needToggle ? toggleColKey(flatColKey) : null;
+          const getSortIcon = (key: number) => {
+            if (activeSortColumn !== key) {
+              return (
+                <ColumnHeightOutlined
+                  onClick={() =>
+                    sortData(
+                      key,
+                      settingsVisibleColKeys,
+                      pivotData,
+                      maxRowIndex,
+                    )
+                  }
+                />
+              );
+            }
+
+            const SortIcon =
+              sortingOrder[key] === 'asc' ? CaretUpOutlined : CaretDownOutlined;
+            return (
+              <SortIcon
+                onClick={() =>
+                  sortData(key, settingsVisibleColKeys, pivotData, maxRowIndex)
+                }
+              />
+            );
+          };
+          const headerCellFormattedValue =
+            dateFormatters?.[attrName]?.(colKey[attrIdx]) ?? colKey[attrIdx];
+          attrValueCells.push(
+            <th
+              className={colLabelClass}
+              key={`colKey-${flatColKey}`}
+              colSpan={colSpan}
+              rowSpan={rowSpan}
+              role="columnheader button"
+              onClick={clickHeaderHandler(
+                pivotData,
+                colKey,
+                cols,
+                attrIdx,
+                tableOptions.clickColumnHeaderCallback,
+              )}
+              onContextMenu={handleContextMenu}
+            >
+              {displayHeaderCell(
+                needToggle,
+                collapsedCols[flatColKey] ? arrowCollapsed : arrowExpanded,
+                onArrowClick,
+                headerCellFormattedValue,
+                namesMapping,
+                settingsAllowRenderHtml,
+              )}
+              <span
+                role="button"
+                tabIndex={0}
+                // Prevents event bubbling to avoid conflict with column header click handlers
+                // Ensures sort operation executes without triggering cross-filtration
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+                aria-label={
+                  activeSortColumn === i
+                    ? `Sorted by ${columnName} ${sortingOrder[i] === 'asc' ? 'ascending' : 'descending'}`
+                    : undefined
+                }
+              >
+                {visibleSortIcon && getSortIcon(i)}
+              </span>
+            </th>,
+          );
+        } else if (attrIdx === colKey.length) {
+          const rowSpan = settingsColAttrs.length - colKey.length + rowIncrSpan;
+          attrValueCells.push(
+            <th
+              className={`${colLabelClass} pvtSubtotalLabel`}
+              key={`colKeyBuffer-${flatKey(colKey)}`}
+              colSpan={colSpan}
+              rowSpan={rowSpan}
+              role="columnheader button"
+              onClick={clickHeaderHandler(
+                pivotData,
+                colKey,
+                cols,
+                attrIdx,
+                tableOptions.clickColumnHeaderCallback,
+                true,
+              )}
+            >
+              {t('Subtotal')}
+            </th>,
+          );
+        }
+        // The next colSpan columns will have the same value anyway...
+        i += colSpan;
+      }
+
+      const totalCell =
+        attrIdx === 0 && rowTotals ? (
+          <th
+            key="total"
+            className="pvtTotalLabel"
+            rowSpan={
+              settingsColAttrs.length + Math.min(settingsRowAttrs.length, 1)
+            }
+            role="columnheader button"
+            onClick={clickHeaderHandler(
+              pivotData,
+              [],
+              cols,
+              attrIdx,
+              tableOptions.clickColumnHeaderCallback,
+              false,
+              true,
+            )}
+          >
+            {t('Total (%(aggregatorName)s)', {
+              aggregatorName: t(aggregatorName),
+            })}
+          </th>
+        ) : null;
+
+      const cells = [spaceCell, attrNameCell, ...attrValueCells, totalCell];
+      return <tr key={`colAttr-${attrIdx}`}>{cells}</tr>;
+    },
+    [
+      tableOptions,
+      onContextMenu,
+      collapseAttr,
+      expandAttr,
+      toggleColKey,
+      clickHeaderHandler,
+      cols,
+      aggregatorName,
+      activeSortColumn,
+      sortingOrder,
+      collapsedCols,
+      sortData,
+    ],
+  );
+
+  const renderRowHeaderRow = useCallback(
+    (settings: PivotSettings) => {
+      // Render just the attribute names of the rows (the actual attribute values
+      // will show up in the individual rows).
+
+      const {
+        rowAttrs: settingsRowAttrs,
+        colAttrs: settingsColAttrs,
+        rowKeys: settingsRowKeys,
+        arrowCollapsed,
+        arrowExpanded,
+        rowSubtotalDisplay: settingsRowSubtotalDisplay,
+        maxRowVisible,
+        pivotData,
+        namesMapping,
+        allowRenderHtml: settingsAllowRenderHtml,
+      } = settings;
+      return (
+        <tr key="rowHdr">
+          {settingsRowAttrs.map((r, i) => {
+            const needLabelToggle =
+              settingsRowSubtotalDisplay.enabled === true &&
+              i !== settingsRowAttrs.length - 1;
+            let arrowClickHandle = null;
+            let subArrow = null;
+            if (needLabelToggle) {
+              arrowClickHandle =
+                i + 1 < maxRowVisible!
+                  ? collapseAttr(true, i, settingsRowKeys)
+                  : expandAttr(true, i, settingsRowKeys);
+              subArrow =
+                i + 1 < maxRowVisible! ? arrowExpanded : arrowCollapsed;
+            }
+            return (
+              <th className="pvtAxisLabel" key={`rowAttr-${i}`}>
+                {displayHeaderCell(
+                  needLabelToggle,
+                  subArrow,
+                  arrowClickHandle,
+                  r,
+                  namesMapping,
+                  settingsAllowRenderHtml,
+                )}
+              </th>
+            );
+          })}
+          <th
+            className="pvtTotalLabel"
+            key="padding"
+            role="columnheader button"
+            onClick={clickHeaderHandler(
+              pivotData,
+              [],
+              rows,
+              0,
+              tableOptions.clickRowHeaderCallback,
+              false,
+              true,
+            )}
+          >
+            {settingsColAttrs.length === 0
+              ? t('Total (%(aggregatorName)s)', {
+                  aggregatorName: t(aggregatorName),
+                })
+              : null}
+          </th>
+        </tr>
+      );
+    },
+    [
+      collapseAttr,
+      expandAttr,
+      clickHeaderHandler,
+      rows,
+      tableOptions.clickRowHeaderCallback,
+      aggregatorName,
+    ],
+  );
+
+  const renderTableRow = useCallback(
+    (rowKey: string[], rowIdx: number, settings: PivotSettings) => {
+      // Render a single row in the pivot table.
+
+      const {
+        rowAttrs: settingsRowAttrs,
+        colAttrs: settingsColAttrs,
+        rowAttrSpans,
+        visibleColKeys: settingsVisibleColKeys,
+        pivotData,
+        rowTotals,
+        rowSubtotalDisplay: settingsRowSubtotalDisplay,
+        arrowExpanded,
+        arrowCollapsed,
+        cellCallbacks,
+        rowTotalCallbacks,
+        namesMapping,
+        allowRenderHtml: settingsAllowRenderHtml,
+      } = settings;
+
+      const {
+        highlightHeaderCellsOnHover,
+        omittedHighlightHeaderGroups = [],
+        highlightedHeaderCells,
+        cellColorFormatters,
+        dateFormatters,
+      } = tableOptions;
+      const flatRowKey = flatKey(rowKey);
+
+      const colIncrSpan = settingsColAttrs.length !== 0 ? 1 : 0;
+      const attrValueCells = rowKey.map((r: string, i: number) => {
+        let handleContextMenu: ((e: MouseEvent) => void) | undefined;
+        let valueCellClassName = 'pvtRowLabel';
+        if (!omittedHighlightHeaderGroups.includes(settingsRowAttrs[i])) {
           if (highlightHeaderCellsOnHover) {
-            colLabelClass += ' hoverable';
+            valueCellClassName += ' hoverable';
           }
           handleContextMenu = (e: MouseEvent) =>
-            this.props.onContextMenu(e, colKey, undefined, {
-              [attrName]: colKey[attrIdx],
+            onContextMenu(e, undefined, rowKey, {
+              [settingsRowAttrs[i]]: r,
             });
         }
         if (
           highlightedHeaderCells &&
-          Array.isArray(highlightedHeaderCells[colAttrs[attrIdx]]) &&
-          highlightedHeaderCells[colAttrs[attrIdx]].includes(colKey[attrIdx])
+          Array.isArray(highlightedHeaderCells[settingsRowAttrs[i]]) &&
+          highlightedHeaderCells[settingsRowAttrs[i]].includes(r)
         ) {
-          colLabelClass += ' active';
+          valueCellClassName += ' active';
         }
-        const isActiveHeader = colLabelClass.includes('active');
-        const maxRowIndex = pivotSettings.maxRowVisible!;
-        const mColVisible = pivotSettings.maxColVisible!;
-        const visibleSortIcon = mColVisible - 1 === attrIdx;
-        const columnName = colKey[mColVisible - 1];
+        const rowSpan = rowAttrSpans![rowIdx][i];
+        if (rowSpan > 0) {
+          const flatRowKeySlice = flatKey(rowKey.slice(0, i + 1));
+          const colSpan =
+            1 + (i === settingsRowAttrs.length - 1 ? colIncrSpan : 0);
+          const needRowToggle =
+            settingsRowSubtotalDisplay.enabled === true &&
+            i !== settingsRowAttrs.length - 1;
+          const onArrowClick = needRowToggle
+            ? toggleRowKey(flatRowKeySlice)
+            : null;
 
-        const rowSpan = 1 + (attrIdx === colAttrs.length - 1 ? rowIncrSpan : 0);
-        const flatColKey = flatKey(colKey.slice(0, attrIdx + 1));
-        const onArrowClick = needToggle ? this.toggleColKey(flatColKey) : null;
-        const getSortIcon = (key: number) => {
-          const { activeSortColumn, sortingOrder } = this.state;
-
-          if (activeSortColumn !== key) {
-            return (
-              <ColumnHeightOutlined
-                onClick={() =>
-                  this.sortData(key, visibleColKeys, pivotData, maxRowIndex)
-                }
-              />
-            );
-          }
-
-          const SortIcon =
-            sortingOrder[key] === 'asc' ? CaretUpOutlined : CaretDownOutlined;
+          const headerCellFormattedValue =
+            dateFormatters?.[settingsRowAttrs[i]]?.(r) ?? r;
           return (
-            <SortIcon
-              onClick={() =>
-                this.sortData(key, visibleColKeys, pivotData, maxRowIndex)
-              }
-            />
-          );
-        };
-        const headerCellFormattedValue =
-          dateFormatters?.[attrName]?.(
-            convertToNumberIfNumeric(colKey[attrIdx]),
-          ) ?? colKey[attrIdx];
-        const { backgroundColor, color } = getCellColor(
-          [attrName],
-          headerCellFormattedValue,
-          cellColorFormatters,
-          isActiveHeader ? activeHeaderBackgroundColor : cellBackgroundColor,
-        );
-        const style = {
-          backgroundColor,
-          ...(color ? { color } : {}),
-        };
-        attrValueCells.push(
-          <th
-            className={colLabelClass}
-            key={`colKey-${flatColKey}`}
-            style={style}
-            colSpan={colSpan}
-            rowSpan={rowSpan}
-            role="columnheader button"
-            onClick={this.clickHeaderHandler(
-              pivotData,
-              colKey,
-              this.props.cols,
-              attrIdx,
-              this.props.tableOptions.clickColumnHeaderCallback,
-            )}
-            onContextMenu={handleContextMenu}
-          >
-            {displayHeaderCell(
-              needToggle,
-              this.state.collapsedCols[flatColKey]
-                ? arrowCollapsed
-                : arrowExpanded,
-              onArrowClick,
-              headerCellFormattedValue,
-              namesMapping,
-              allowRenderHtml,
-            )}
-            <span
-              role="button"
-              tabIndex={0}
-              // Prevents event bubbling to avoid conflict with column header click handlers
-              // Ensures sort operation executes without triggering cross-filtration
-              onClick={e => {
-                e.stopPropagation();
-              }}
-              aria-label={
-                this.state.activeSortColumn === i
-                  ? `Sorted by ${columnName} ${this.state.sortingOrder[i] === 'asc' ? 'ascending' : 'descending'}`
-                  : undefined
-              }
+            <th
+              key={`rowKeyLabel-${i}`}
+              className={valueCellClassName}
+              rowSpan={rowSpan}
+              colSpan={colSpan}
+              role="columnheader button"
+              onClick={clickHeaderHandler(
+                pivotData,
+                rowKey,
+                rows,
+                i,
+                tableOptions.clickRowHeaderCallback,
+              )}
+              onContextMenu={handleContextMenu}
             >
-              {visibleSortIcon && getSortIcon(i)}
-            </span>
-          </th>,
-        );
-      } else if (attrIdx === colKey.length) {
-        const rowSpan = colAttrs.length - colKey.length + rowIncrSpan;
-        attrValueCells.push(
+              {displayHeaderCell(
+                needRowToggle,
+                collapsedRows[flatRowKeySlice] ? arrowCollapsed : arrowExpanded,
+                onArrowClick,
+                headerCellFormattedValue,
+                namesMapping,
+                settingsAllowRenderHtml,
+              )}
+            </th>
+          );
+        }
+        return null;
+      });
+
+      const attrValuePaddingCell =
+        rowKey.length < settingsRowAttrs.length ? (
           <th
-            className={`${colLabelClass} pvtSubtotalLabel`}
-            key={`colKeyBuffer-${flatKey(colKey)}`}
-            colSpan={colSpan}
-            rowSpan={rowSpan}
+            className="pvtRowLabel pvtSubtotalLabel"
+            key="rowKeyBuffer"
+            colSpan={settingsRowAttrs.length - rowKey.length + colIncrSpan}
+            rowSpan={1}
             role="columnheader button"
-            onClick={this.clickHeaderHandler(
+            onClick={clickHeaderHandler(
               pivotData,
-              colKey,
-              this.props.cols,
-              attrIdx,
-              this.props.tableOptions.clickColumnHeaderCallback,
+              rowKey,
+              rows,
+              rowKey.length,
+              tableOptions.clickRowHeaderCallback,
               true,
             )}
           >
             {t('Subtotal')}
-          </th>,
+          </th>
+        ) : null;
+
+      if (!settingsVisibleColKeys) {
+        return null;
+      }
+
+      const rowClickHandlers = cellCallbacks[flatRowKey] || {};
+      const valueCells = settingsVisibleColKeys.map((colKey: string[]) => {
+        const flatColKey = flatKey(colKey);
+        const agg = pivotData.getAggregator(rowKey, colKey);
+        const aggValue = agg.value();
+
+        const keys = [...rowKey, ...colKey];
+        let backgroundColor: string | undefined;
+        if (cellColorFormatters) {
+          Object.values(cellColorFormatters).forEach(cellColorFormatter => {
+            if (Array.isArray(cellColorFormatter)) {
+              keys.forEach(key => {
+                if (backgroundColor) {
+                  return;
+                }
+                cellColorFormatter
+                  .filter(formatter => formatter.column === key)
+                  .forEach(formatter => {
+                    const formatterResult =
+                      formatter.getColorFromValue(aggValue);
+                    if (formatterResult) {
+                      backgroundColor = formatterResult;
+                    }
+                  });
+              });
+            }
+          });
+        }
+
+        const style = agg.isSubtotal
+          ? { fontWeight: 'bold' }
+          : { backgroundColor };
+
+        return (
+          <td
+            role="gridcell"
+            className="pvtVal"
+            key={`pvtVal-${flatColKey}`}
+            onClick={rowClickHandlers[flatColKey]}
+            onContextMenu={e => onContextMenu(e, colKey, rowKey)}
+            style={style}
+          >
+            {displayCell(agg.format(aggValue, agg), settingsAllowRenderHtml)}
+          </td>
+        );
+      });
+
+      let totalCell = null;
+      if (rowTotals) {
+        const agg = pivotData.getAggregator(rowKey, []);
+        const aggValue = agg.value();
+        totalCell = (
+          <td
+            role="gridcell"
+            key="total"
+            className="pvtTotal"
+            onClick={rowTotalCallbacks[flatRowKey]}
+            onContextMenu={e => onContextMenu(e, undefined, rowKey)}
+          >
+            {displayCell(agg.format(aggValue, agg), settingsAllowRenderHtml)}
+          </td>
         );
       }
-      // The next colSpan columns will have the same value anyway...
-      i += colSpan;
-    }
 
-    const totalCell =
-      attrIdx === 0 && rowTotals ? (
+      const rowCells = [
+        ...attrValueCells,
+        attrValuePaddingCell,
+        ...valueCells,
+        totalCell,
+      ];
+
+      return <tr key={`keyRow-${flatRowKey}`}>{rowCells}</tr>;
+    },
+    [
+      tableOptions,
+      onContextMenu,
+      toggleRowKey,
+      clickHeaderHandler,
+      rows,
+      collapsedRows,
+    ],
+  );
+
+  const renderTotalsRow = useCallback(
+    (settings: PivotSettings) => {
+      // Render the final totals rows that has the totals for all the columns.
+
+      const {
+        rowAttrs: settingsRowAttrs,
+        colAttrs: settingsColAttrs,
+        visibleColKeys: settingsVisibleColKeys,
+        rowTotals,
+        pivotData,
+        colTotalCallbacks,
+        grandTotalCallback,
+      } = settings;
+
+      if (!settingsVisibleColKeys) {
+        return null;
+      }
+
+      const totalLabelCell = (
         <th
-          key="total"
-          className="pvtTotalLabel"
-          rowSpan={colAttrs.length + Math.min(rowAttrs.length, 1)}
+          key="label"
+          className="pvtTotalLabel pvtRowTotalLabel"
+          colSpan={
+            settingsRowAttrs.length + Math.min(settingsColAttrs.length, 1)
+          }
           role="columnheader button"
-          onClick={this.clickHeaderHandler(
+          onClick={clickHeaderHandler(
             pivotData,
             [],
-            this.props.cols,
-            attrIdx,
-            this.props.tableOptions.clickColumnHeaderCallback,
+            rows,
+            0,
+            tableOptions.clickRowHeaderCallback,
             false,
             true,
           )}
         >
           {t('Total (%(aggregatorName)s)', {
-            aggregatorName: t(this.props.aggregatorName),
+            aggregatorName: t(aggregatorName),
           })}
         </th>
-      ) : null;
+      );
 
-    const cells = [spaceCell, attrNameCell, ...attrValueCells, totalCell];
-    return <tr key={`colAttr-${attrIdx}`}>{cells}</tr>;
-  }
+      const totalValueCells = settingsVisibleColKeys.map((colKey: string[]) => {
+        const flatColKey = flatKey(colKey);
+        const agg = pivotData.getAggregator([], colKey);
+        const aggValue = agg.value();
 
-  renderRowHeaderRow(pivotSettings: PivotSettings) {
-    // Render just the attribute names of the rows (the actual attribute values
-    // will show up in the individual rows).
-
-    const {
-      rowAttrs,
-      colAttrs,
-      rowKeys,
-      arrowCollapsed,
-      arrowExpanded,
-      rowSubtotalDisplay,
-      maxRowVisible,
-      pivotData,
-      namesMapping,
-      allowRenderHtml,
-    } = pivotSettings;
-    return (
-      <tr key="rowHdr">
-        {rowAttrs.map((r, i) => {
-          const needLabelToggle =
-            rowSubtotalDisplay.enabled === true && i !== rowAttrs.length - 1;
-          let arrowClickHandle = null;
-          let subArrow = null;
-          if (needLabelToggle) {
-            arrowClickHandle =
-              i + 1 < maxRowVisible!
-                ? this.collapseAttr(true, i, rowKeys)
-                : this.expandAttr(true, i, rowKeys);
-            subArrow = i + 1 < maxRowVisible! ? arrowExpanded : arrowCollapsed;
-          }
-          return (
-            <th className="pvtAxisLabel" key={`rowAttr-${i}`}>
-              {displayHeaderCell(
-                needLabelToggle,
-                subArrow,
-                arrowClickHandle,
-                r,
-                namesMapping,
-                allowRenderHtml,
-              )}
-            </th>
-          );
-        })}
-        <th
-          className="pvtTotalLabel"
-          key="padding"
-          role="columnheader button"
-          onClick={this.clickHeaderHandler(
-            pivotData,
-            [],
-            this.props.rows,
-            0,
-            this.props.tableOptions.clickRowHeaderCallback,
-            false,
-            true,
-          )}
-        >
-          {colAttrs.length === 0
-            ? t('Total (%(aggregatorName)s)', {
-                aggregatorName: t(this.props.aggregatorName),
-              })
-            : null}
-        </th>
-      </tr>
-    );
-  }
-
-  renderTableRow(
-    rowKey: string[],
-    rowIdx: number,
-    pivotSettings: PivotSettings,
-  ) {
-    // Render a single row in the pivot table.
-
-    const {
-      rowAttrs,
-      colAttrs,
-      rowAttrSpans,
-      visibleColKeys,
-      pivotData,
-      rowTotals,
-      rowSubtotalDisplay,
-      arrowExpanded,
-      arrowCollapsed,
-      cellCallbacks,
-      rowTotalCallbacks,
-      namesMapping,
-      allowRenderHtml,
-    } = pivotSettings;
-
-    const {
-      highlightHeaderCellsOnHover,
-      omittedHighlightHeaderGroups = [],
-      highlightedHeaderCells,
-      cellColorFormatters,
-      dateFormatters,
-      cellBackgroundColor = supersetTheme.colorBgBase,
-      cellTextColor = supersetTheme.colorPrimaryText,
-      activeHeaderBackgroundColor = supersetTheme.colorPrimaryBg,
-    } = this.props.tableOptions;
-    const flatRowKey = flatKey(rowKey);
-
-    const colIncrSpan = colAttrs.length !== 0 ? 1 : 0;
-    const attrValueCells = rowKey.map((r: string, i: number) => {
-      let handleContextMenu: ((e: MouseEvent) => void) | undefined;
-      let valueCellClassName = 'pvtRowLabel';
-      if (!omittedHighlightHeaderGroups.includes(rowAttrs[i])) {
-        if (highlightHeaderCellsOnHover) {
-          valueCellClassName += ' hoverable';
-        }
-        handleContextMenu = (e: MouseEvent) =>
-          this.props.onContextMenu(e, undefined, rowKey, {
-            [rowAttrs[i]]: r,
-          });
-      }
-      if (
-        highlightedHeaderCells &&
-        Array.isArray(highlightedHeaderCells[rowAttrs[i]]) &&
-        highlightedHeaderCells[rowAttrs[i]].includes(r)
-      ) {
-        valueCellClassName += ' active';
-      }
-      const isActiveHeader = valueCellClassName.includes('active');
-      const rowSpan = rowAttrSpans![rowIdx][i];
-      if (rowSpan > 0) {
-        const flatRowKey = flatKey(rowKey.slice(0, i + 1));
-        const colSpan = 1 + (i === rowAttrs.length - 1 ? colIncrSpan : 0);
-        const needRowToggle =
-          rowSubtotalDisplay.enabled === true && i !== rowAttrs.length - 1;
-        const onArrowClick = needRowToggle
-          ? this.toggleRowKey(flatRowKey)
-          : null;
-
-        const headerCellFormattedValue =
-          dateFormatters?.[rowAttrs[i]]?.(convertToNumberIfNumeric(r)) ?? r;
-
-        const { backgroundColor, color } = getCellColor(
-          [rowAttrs[i]],
-          headerCellFormattedValue,
-          cellColorFormatters,
-          isActiveHeader ? activeHeaderBackgroundColor : cellBackgroundColor,
-        );
-        const style = {
-          backgroundColor,
-          ...(color ? { color } : {}),
-        };
         return (
-          <th
-            key={`rowKeyLabel-${i}`}
-            className={valueCellClassName}
-            style={style}
-            rowSpan={rowSpan}
-            colSpan={colSpan}
-            role="columnheader button"
-            onClick={this.clickHeaderHandler(
-              pivotData,
-              rowKey,
-              this.props.rows,
-              i,
-              this.props.tableOptions.clickRowHeaderCallback,
-            )}
-            onContextMenu={handleContextMenu}
+          <td
+            role="gridcell"
+            className="pvtTotal pvtRowTotal"
+            key={`total-${flatColKey}`}
+            onClick={colTotalCallbacks[flatColKey]}
+            onContextMenu={e => onContextMenu(e, colKey, undefined)}
+            style={{ padding: '5px' }}
           >
-            {displayHeaderCell(
-              needRowToggle,
-              this.state.collapsedRows[flatRowKey]
-                ? arrowCollapsed
-                : arrowExpanded,
-              onArrowClick,
-              headerCellFormattedValue,
-              namesMapping,
-              allowRenderHtml,
-            )}
-          </th>
+            {displayCell(agg.format(aggValue, agg), allowRenderHtml)}
+          </td>
+        );
+      });
+
+      let grandTotalCell = null;
+      if (rowTotals) {
+        const agg = pivotData.getAggregator([], []);
+        const aggValue = agg.value();
+        grandTotalCell = (
+          <td
+            role="gridcell"
+            key="total"
+            className="pvtGrandTotal pvtRowTotal"
+            onClick={grandTotalCallback || undefined}
+            onContextMenu={e => onContextMenu(e, undefined, undefined)}
+          >
+            {displayCell(agg.format(aggValue, agg), allowRenderHtml)}
+          </td>
         );
       }
-      return null;
-    });
 
-    const attrValuePaddingCell =
-      rowKey.length < rowAttrs.length ? (
-        <th
-          className="pvtRowLabel pvtSubtotalLabel"
-          key="rowKeyBuffer"
-          colSpan={rowAttrs.length - rowKey.length + colIncrSpan}
-          rowSpan={1}
-          role="columnheader button"
-          onClick={this.clickHeaderHandler(
-            pivotData,
-            rowKey,
-            this.props.rows,
-            rowKey.length,
-            this.props.tableOptions.clickRowHeaderCallback,
-            true,
+      const totalCells = [totalLabelCell, ...totalValueCells, grandTotalCell];
+
+      return (
+        <tr key="total" className="pvtRowTotals">
+          {totalCells}
+        </tr>
+      );
+    },
+    [
+      clickHeaderHandler,
+      rows,
+      tableOptions.clickRowHeaderCallback,
+      aggregatorName,
+      onContextMenu,
+      allowRenderHtml,
+    ],
+  );
+
+  return (
+    <Styles isDashboardEditMode={isDashboardEditMode()}>
+      <table className="pvtTable" role="grid">
+        <thead>
+          {colAttrs.map((c: string, j: number) =>
+            renderColHeaderRow(c, j, pivotSettings),
           )}
-        >
-          {t('Subtotal')}
-        </th>
-      ) : null;
-
-    if (!visibleColKeys) {
-      return null;
-    }
-
-    const rowClickHandlers = cellCallbacks[flatRowKey] || {};
-    const valueCells = visibleColKeys.map((colKey: string[]) => {
-      const flatColKey = flatKey(colKey);
-      const agg = pivotData.getAggregator(rowKey, colKey);
-      const aggValue = agg.value();
-
-      const keys = [...rowKey, ...colKey];
-
-      const { backgroundColor, color } = getCellColor(
-        keys,
-        aggValue,
-        cellColorFormatters,
-        cellBackgroundColor,
-      );
-
-      const style = agg.isSubtotal
-        ? {
-            backgroundColor,
-            fontWeight: 'bold',
-            color: color ?? cellTextColor,
-          }
-        : { backgroundColor, color: color ?? cellTextColor };
-
-      return (
-        <td
-          role="gridcell"
-          className="pvtVal"
-          key={`pvtVal-${flatColKey}`}
-          onClick={rowClickHandlers[flatColKey]}
-          onContextMenu={e => this.props.onContextMenu(e, colKey, rowKey)}
-          style={style}
-        >
-          {displayCell(agg.format(aggValue, agg), allowRenderHtml)}
-        </td>
-      );
-    });
-
-    let totalCell = null;
-    if (rowTotals) {
-      const agg = pivotData.getAggregator(rowKey, []);
-      const aggValue = agg.value();
-      totalCell = (
-        <td
-          role="gridcell"
-          key="total"
-          className="pvtTotal"
-          onClick={rowTotalCallbacks[flatRowKey]}
-          onContextMenu={e => this.props.onContextMenu(e, undefined, rowKey)}
-        >
-          {displayCell(agg.format(aggValue, agg), allowRenderHtml)}
-        </td>
-      );
-    }
-
-    const rowCells = [
-      ...attrValueCells,
-      attrValuePaddingCell,
-      ...valueCells,
-      totalCell,
-    ];
-
-    return <tr key={`keyRow-${flatRowKey}`}>{rowCells}</tr>;
-  }
-
-  renderTotalsRow(pivotSettings: PivotSettings) {
-    // Render the final totals rows that has the totals for all the columns.
-
-    const {
-      rowAttrs,
-      colAttrs,
-      visibleColKeys,
-      rowTotals,
-      pivotData,
-      colTotalCallbacks,
-      grandTotalCallback,
-    } = pivotSettings;
-
-    if (!visibleColKeys) {
-      return null;
-    }
-
-    const totalLabelCell = (
-      <th
-        key="label"
-        className="pvtTotalLabel pvtRowTotalLabel"
-        colSpan={rowAttrs.length + Math.min(colAttrs.length, 1)}
-        role="columnheader button"
-        onClick={this.clickHeaderHandler(
-          pivotData,
-          [],
-          this.props.rows,
-          0,
-          this.props.tableOptions.clickRowHeaderCallback,
-          false,
-          true,
-        )}
-      >
-        {t('Total (%(aggregatorName)s)', {
-          aggregatorName: t(this.props.aggregatorName),
-        })}
-      </th>
-    );
-
-    const totalValueCells = visibleColKeys.map((colKey: string[]) => {
-      const flatColKey = flatKey(colKey);
-      const agg = pivotData.getAggregator([], colKey);
-      const aggValue = agg.value();
-
-      return (
-        <td
-          role="gridcell"
-          className="pvtTotal pvtRowTotal"
-          key={`total-${flatColKey}`}
-          onClick={colTotalCallbacks[flatColKey]}
-          onContextMenu={e => this.props.onContextMenu(e, colKey, undefined)}
-          style={{ padding: '5px' }}
-        >
-          {displayCell(agg.format(aggValue, agg), this.props.allowRenderHtml)}
-        </td>
-      );
-    });
-
-    let grandTotalCell = null;
-    if (rowTotals) {
-      const agg = pivotData.getAggregator([], []);
-      const aggValue = agg.value();
-      grandTotalCell = (
-        <td
-          role="gridcell"
-          key="total"
-          className="pvtGrandTotal pvtRowTotal"
-          onClick={grandTotalCallback || undefined}
-          onContextMenu={e => this.props.onContextMenu(e, undefined, undefined)}
-        >
-          {displayCell(agg.format(aggValue, agg), this.props.allowRenderHtml)}
-        </td>
-      );
-    }
-
-    const totalCells = [totalLabelCell, ...totalValueCells, grandTotalCell];
-
-    return (
-      <tr key="total" className="pvtRowTotals">
-        {totalCells}
-      </tr>
-    );
-  }
-
-  visibleKeys(
-    keys: string[][],
-    collapsed: Record<string, boolean>,
-    numAttrs: number,
-    subtotalDisplay: SubtotalDisplay,
-  ) {
-    return keys.filter(
-      (key: string[]) =>
-        // Is the key hidden by one of its parents?
-        !key.some(
-          (_k: string, j: number) => collapsed[flatKey(key.slice(0, j))],
-        ) &&
-        // Leaf key.
-        (key.length === numAttrs ||
-          // Children hidden. Must show total.
-          flatKey(key) in collapsed ||
-          // Don't hide totals.
-          !subtotalDisplay.hideOnExpand),
-    );
-  }
-
-  isDashboardEditMode() {
-    return document.contains(document.querySelector('.dashboard--editing'));
-  }
-
-  componentWillUnmount() {
-    this.sortCache.clear();
-  }
-
-  render() {
-    if (this.cachedProps !== this.props) {
-      this.sortCache.clear();
-      // Reset sort state without using setState to avoid re-render during render.
-      // This is safe because the state is being synchronized with new props.
-      (this.state as TableRendererState).sortingOrder = [];
-      (this.state as TableRendererState).activeSortColumn = null;
-      this.cachedProps = this.props;
-      this.cachedBasePivotSettings = this.getBasePivotSettings();
-    }
-    const basePivotSettings = this.cachedBasePivotSettings!;
-    const {
-      colAttrs,
-      rowAttrs,
-      rowKeys,
-      colKeys,
-      colTotals,
-      rowSubtotalDisplay,
-      colSubtotalDisplay,
-      allowRenderHtml,
-    } = basePivotSettings;
-
-    // Need to account for exclusions to compute the effective row
-    // and column keys.
-    const visibleRowKeys = this.visibleKeys(
-      rowKeys,
-      this.state.collapsedRows,
-      rowAttrs.length,
-      rowSubtotalDisplay,
-    );
-    const visibleColKeys = this.visibleKeys(
-      colKeys,
-      this.state.collapsedCols,
-      colAttrs.length,
-      colSubtotalDisplay,
-    );
-
-    const pivotSettings: PivotSettings = {
-      visibleRowKeys,
-      maxRowVisible: Math.max(...visibleRowKeys.map((k: string[]) => k.length)),
-      visibleColKeys,
-      maxColVisible: Math.max(...visibleColKeys.map((k: string[]) => k.length)),
-      rowAttrSpans: this.calcAttrSpans(visibleRowKeys, rowAttrs.length),
-      colAttrSpans: this.calcAttrSpans(visibleColKeys, colAttrs.length),
-      allowRenderHtml,
-      ...basePivotSettings,
-    };
-
-    return (
-      <Styles isDashboardEditMode={this.isDashboardEditMode()}>
-        <table className="pvtTable" role="grid">
-          <thead>
-            {colAttrs.map((c: string, j: number) =>
-              this.renderColHeaderRow(c, j, pivotSettings),
-            )}
-            {rowAttrs.length !== 0 && this.renderRowHeaderRow(pivotSettings)}
-          </thead>
-          <tbody>
-            {visibleRowKeys.map((r: string[], i: number) =>
-              this.renderTableRow(r, i, pivotSettings),
-            )}
-            {colTotals && this.renderTotalsRow(pivotSettings)}
-          </tbody>
-        </table>
-      </Styles>
-    );
-  }
+          {rowAttrs.length !== 0 && renderRowHeaderRow(pivotSettings)}
+        </thead>
+        <tbody>
+          {visibleRowKeys.map((r: string[], i: number) =>
+            renderTableRow(r, i, pivotSettings),
+          )}
+          {colTotals && renderTotalsRow(pivotSettings)}
+        </tbody>
+      </table>
+    </Styles>
+  );
 }
 
 TableRenderer.propTypes = {

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -324,17 +324,22 @@ function convertToArray(
   return result;
 }
 
-export function TableRenderer({
-  cols,
-  rows,
-  aggregatorName,
-  tableOptions = {},
-  subtotalOptions,
-  namesMapping: namesMappingProp,
-  onContextMenu,
-  allowRenderHtml,
-  ...restProps
-}: TableRendererProps) {
+export function TableRenderer(props: TableRendererProps) {
+  // Use the original props argument directly rather than spreading/re-memoizing.
+  // Spreading `...rest` into a memoized object produces a new reference every
+  // render, which defeats downstream memos and forces `getBasePivotSettings`
+  // (and a fresh `PivotData`) to recompute on every state update.
+  const {
+    cols,
+    rows,
+    aggregatorName,
+    tableOptions = {},
+    subtotalOptions,
+    namesMapping: namesMappingProp,
+    onContextMenu,
+    allowRenderHtml,
+  } = props;
+
   const [collapsedRows, setCollapsedRows] = useState<Record<string, boolean>>(
     {},
   );
@@ -346,32 +351,6 @@ export function TableRenderer({
   const [sortedRowKeys, setSortedRowKeys] = useState<string[][] | null>(null);
 
   const sortCacheRef = useRef(new Map<string, string[][]>());
-
-  // Memoize props object to maintain referential stability
-  const props = useMemo<TableRendererProps>(
-    () => ({
-      cols,
-      rows,
-      aggregatorName,
-      tableOptions,
-      subtotalOptions,
-      namesMapping: namesMappingProp,
-      onContextMenu,
-      allowRenderHtml,
-      ...restProps,
-    }),
-    [
-      cols,
-      rows,
-      aggregatorName,
-      tableOptions,
-      subtotalOptions,
-      namesMappingProp,
-      onContextMenu,
-      allowRenderHtml,
-      restProps,
-    ],
-  );
 
   const clickHandler = useCallback(
     (

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -1005,8 +1005,18 @@ export function TableRenderer({
               />
             );
           };
+          // Coerce numeric timestamp strings to numbers so temporal formatters
+          // (which typically expect an epoch) render correctly.
+          const rawHeaderCellValue = colKey[attrIdx];
+          const headerCellFormatterValue =
+            typeof rawHeaderCellValue === 'string' &&
+            rawHeaderCellValue.trim() !== '' &&
+            Number.isFinite(Number(rawHeaderCellValue))
+              ? Number(rawHeaderCellValue)
+              : rawHeaderCellValue;
           const headerCellFormattedValue =
-            dateFormatters?.[attrName]?.(colKey[attrIdx]) ?? colKey[attrIdx];
+            dateFormatters?.[attrName]?.(headerCellFormatterValue) ??
+            rawHeaderCellValue;
           const isActiveHeader = colLabelClass.includes('active');
           const { backgroundColor, color } = getCellColor(
             [attrName],
@@ -1274,8 +1284,16 @@ export function TableRenderer({
             ? toggleRowKey(flatRowKeySlice)
             : null;
 
+          // Coerce numeric timestamp strings to numbers so temporal formatters
+          // (which typically expect an epoch) render correctly.
+          const headerFormatterValue =
+            typeof r === 'string' &&
+            r.trim() !== '' &&
+            Number.isFinite(Number(r))
+              ? Number(r)
+              : r;
           const headerCellFormattedValue =
-            dateFormatters?.[settingsRowAttrs[i]]?.(r) ?? r;
+            dateFormatters?.[settingsRowAttrs[i]]?.(headerFormatterValue) ?? r;
           const isActiveHeader = valueCellClassName.includes('active');
           const { backgroundColor, color } = getCellColor(
             [settingsRowAttrs[i]],

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -754,14 +754,16 @@ export function TableRenderer({
   );
 
   // Compute base pivot settings, memoized based on relevant props
-  const basePivotSettings = useMemo(() => {
-    // Clear sort cache when props change
-    sortCacheRef.current.clear();
-    return getBasePivotSettings();
-  }, [getBasePivotSettings]);
+  const basePivotSettings = useMemo(
+    () => getBasePivotSettings(),
+    [getBasePivotSettings],
+  );
 
-  // Reset sort state when structural props change
+  // Reset sort state and cache when structural props change. Scoping this to
+  // an effect (instead of running inside the memo) prevents the cache from
+  // being wiped on unrelated state updates like collapse/expand.
   useEffect(() => {
+    sortCacheRef.current.clear();
     setSortingOrder([]);
     setActiveSortColumn(null);
     setSortedRowKeys(null);

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -1042,7 +1042,6 @@ export function TableRenderer({
               style={colHeaderStyle}
               colSpan={colSpan}
               rowSpan={rowSpan}
-              role="columnheader button"
               onClick={clickHeaderHandler(
                 pivotData,
                 colKey,
@@ -1086,7 +1085,6 @@ export function TableRenderer({
               key={`colKeyBuffer-${flatKey(colKey)}`}
               colSpan={colSpan}
               rowSpan={rowSpan}
-              role="columnheader button"
               onClick={clickHeaderHandler(
                 pivotData,
                 colKey,
@@ -1112,7 +1110,6 @@ export function TableRenderer({
             rowSpan={
               settingsColAttrs.length + Math.min(settingsRowAttrs.length, 1)
             }
-            role="columnheader button"
             onClick={clickHeaderHandler(
               pivotData,
               [],
@@ -1197,7 +1194,6 @@ export function TableRenderer({
           <th
             className="pvtTotalLabel"
             key="padding"
-            role="columnheader button"
             onClick={clickHeaderHandler(
               pivotData,
               [],
@@ -1319,7 +1315,6 @@ export function TableRenderer({
               style={rowHeaderStyle}
               rowSpan={rowSpan}
               colSpan={colSpan}
-              role="columnheader button"
               onClick={clickHeaderHandler(
                 pivotData,
                 rowKey,
@@ -1350,7 +1345,6 @@ export function TableRenderer({
             key="rowKeyBuffer"
             colSpan={settingsRowAttrs.length - rowKey.length + colIncrSpan}
             rowSpan={1}
-            role="columnheader button"
             onClick={clickHeaderHandler(
               pivotData,
               rowKey,
@@ -1465,7 +1459,6 @@ export function TableRenderer({
           colSpan={
             settingsRowAttrs.length + Math.min(settingsColAttrs.length, 1)
           }
-          role="columnheader button"
           onClick={clickHeaderHandler(
             pivotData,
             [],

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -27,7 +27,7 @@ import {
   useEffect,
 } from 'react';
 import { safeHtmlSpan } from '@superset-ui/core';
-import { t } from '@apache-superset/core/ui';
+import { t } from '@apache-superset/core/translation';
 import PropTypes from 'prop-types';
 import {
   CaretUpOutlined,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -416,7 +416,12 @@ export function TableRenderer({
       const filters: Record<string, string> = {};
       for (let i = 0; i <= attrIdx; i += 1) {
         const attr = attrs[i];
-        filters[attr] = values[i];
+        const value = values[i];
+        // Subtotal/grand-total handlers may pass an empty `values` array, so
+        // guard against undefined entries rather than leaking them through.
+        if (attr != null && value != null) {
+          filters[attr] = value;
+        }
       }
       return (e: MouseEvent) =>
         callback?.(

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -17,8 +17,9 @@
  * under the License.
  */
 
+import type { ReactElement } from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
 import { TableRenderer } from '../../src/react-pivottable/TableRenderers';
 import { aggregatorTemplates } from '../../src/react-pivottable/utilities';
@@ -52,7 +53,7 @@ const SAMPLE_DATA = [
   { color: 'red', shape: 'square', value: 40 },
 ];
 
-function renderWithTheme(ui: React.ReactElement) {
+function renderWithTheme(ui: ReactElement) {
   return render(<ThemeProvider theme={supersetTheme}>{ui}</ThemeProvider>);
 }
 
@@ -253,11 +254,23 @@ test('TableRenderer renders the column attribute label in the header', () => {
 
 test('TableRenderer calls onContextMenu callback', () => {
   const onContextMenu = jest.fn();
-  const props = buildDefaultProps({ onContextMenu });
+  const props = buildDefaultProps({
+    onContextMenu,
+    tableOptions: { highlightHeaderCellsOnHover: true },
+  });
   renderWithTheme(<TableRenderer {...props} />);
 
-  const cells = screen.getAllByRole('gridcell');
-  expect(cells.length).toBeGreaterThan(0);
+  // The column attribute value "circle" is rendered inside a header <th> whose
+  // onContextMenu handler calls the callback.
+  const columnHeaderCell = screen.getByText('circle').closest('th');
+  expect(columnHeaderCell).not.toBeNull();
+  fireEvent.contextMenu(columnHeaderCell!);
+
+  expect(onContextMenu).toHaveBeenCalledTimes(1);
+  const [, colKey, rowKey, filters] = onContextMenu.mock.calls[0];
+  expect(colKey).toEqual(['circle']);
+  expect(rowKey).toBeUndefined();
+  expect(filters).toEqual({ shape: 'circle' });
 });
 
 test('TableRenderer renders with multiple row dimensions', () => {

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,1133 +16,316 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Children, isValidElement, type ReactElement } from 'react';
-import {
-  getTextColorForBackground,
-  ObjectFormattingEnum,
-} from '@superset-ui/chart-controls';
-import {
-  getCellColor,
-  TableRenderer,
-} from '../../src/react-pivottable/TableRenderers';
-import type { PivotData } from '../../src/react-pivottable/utilities';
 
-let tableRenderer: TableRenderer;
-let mockGetAggregatedData: jest.Mock;
-let mockSortAndCacheData: jest.Mock;
-
-type RenderColHeaderRowSettings = Parameters<
-  TableRenderer['renderColHeaderRow']
->[2];
-type RenderTableRowSettings = Parameters<TableRenderer['renderTableRow']>[2];
-type TableRendererStateStub = TableRenderer['state'];
-type CachedBasePivotSettings = NonNullable<
-  TableRenderer['cachedBasePivotSettings']
->;
-
-const columnIndex = 0;
-const visibleColKeys = [['col1'], ['col2']];
-const maxRowIndex = 2;
-
-const mockProps = {
-  rows: ['row1'],
-  cols: ['col1'],
-  data: [],
-  aggregatorName: 'Sum',
-  vals: ['value'],
-  valueFilter: {},
-  sorters: {},
-  rowOrder: 'key_a_to_z',
-  colOrder: 'key_a_to_z',
-  tableOptions: {},
-  namesMapping: {},
-  allowRenderHtml: false,
-  onContextMenu: jest.fn(),
-  aggregatorsFactory: jest.fn(),
-  defaultFormatter: jest.fn(),
-  customFormatters: {},
-  rowEnabled: true,
-  rowPartialOnTop: false,
-  colEnabled: false,
-  colPartialOnTop: false,
-};
-
-const toPivotData = (value: Partial<PivotData>): PivotData =>
-  value as unknown as PivotData;
-
-const toCachedBasePivotSettings = (
-  value: Partial<CachedBasePivotSettings>,
-): CachedBasePivotSettings => value as unknown as CachedBasePivotSettings;
-
-const createActiveHeaderTableOptions = (
-  activeHeaderBackgroundColor: string,
-  overrides: Record<string, unknown> = {},
-): TableRenderer['props']['tableOptions'] =>
-  ({
-    ...overrides,
-    activeHeaderBackgroundColor,
-  }) as unknown as TableRenderer['props']['tableOptions'];
-
-const createPivotDataStub = (
-  aggregatorValue = 200,
-  isSubtotal = false,
-): PivotData =>
-  toPivotData({
-    getAggregator: () => ({
-      push: jest.fn(),
-      value: () => aggregatorValue,
-      format: (value: number) => String(value),
-      isSubtotal,
-    }),
-  });
-
-const pivotData = toPivotData({
-  subtotals: {
-    rowEnabled: true,
-    rowPartialOnTop: false,
-  },
-});
-
-const createColHeaderRowSettings = (
-  overrides: Partial<RenderColHeaderRowSettings> = {},
-): RenderColHeaderRowSettings =>
-  ({
-    rowAttrs: [],
-    colAttrs: ['region'],
-    visibleColKeys: [['EMEA']],
-    colAttrSpans: [[1]],
-    colKeys: [['EMEA']],
-    colSubtotalDisplay: {
-      displayOnTop: false,
-      enabled: false,
-      hideOnExpand: false,
-    },
-    rowSubtotalDisplay: {
-      displayOnTop: false,
-      enabled: false,
-      hideOnExpand: false,
-    },
-    maxColVisible: 1,
-    maxRowVisible: 0,
-    pivotData: createPivotDataStub(),
-    namesMapping: {},
-    allowRenderHtml: false,
-    arrowExpanded: null,
-    arrowCollapsed: null,
-    rowTotals: false,
-    colTotals: false,
-    ...overrides,
-  }) as RenderColHeaderRowSettings;
-
-const createTableRowSettings = (
-  overrides: Partial<RenderTableRowSettings> = {},
-): RenderTableRowSettings =>
-  ({
-    rowAttrs: ['metric'],
-    colAttrs: [],
-    rowAttrSpans: [[1]],
-    visibleColKeys: [[]],
-    pivotData: createPivotDataStub(),
-    rowTotals: false,
-    rowSubtotalDisplay: {
-      displayOnTop: false,
-      enabled: false,
-      hideOnExpand: false,
-    },
-    arrowExpanded: null,
-    arrowCollapsed: null,
-    cellCallbacks: {},
-    rowTotalCallbacks: {},
-    namesMapping: {},
-    allowRenderHtml: false,
-    ...overrides,
-  }) as RenderTableRowSettings;
-
-beforeEach(() => {
-  tableRenderer = new TableRenderer(mockProps);
-
-  mockGetAggregatedData = jest.fn();
-  mockSortAndCacheData = jest.fn();
-
-  tableRenderer.getAggregatedData = mockGetAggregatedData;
-  tableRenderer.sortAndCacheData = mockSortAndCacheData;
-
-  tableRenderer.cachedBasePivotSettings = toCachedBasePivotSettings({
-    pivotData: toPivotData({
-      subtotals: {
-        rowEnabled: true,
-        rowPartialOnTop: false,
-        colEnabled: false,
-        colPartialOnTop: false,
-      },
-    }),
-    rowKeys: [['A'], ['B'], ['C']],
-  });
-
-  tableRenderer.state = {
-    sortingOrder: [],
-    activeSortColumn: null,
-    collapsedRows: {},
-    collapsedCols: {},
-  } as TableRendererStateStub;
-});
-
-const mockGroups = {
-  B: {
-    currentVal: 20,
-    B1: { currentVal: 15 },
-    B2: { currentVal: 5 },
-  },
-  A: {
-    currentVal: 10,
-    A1: { currentVal: 8 },
-    A2: { currentVal: 2 },
-  },
-  C: {
-    currentVal: 30,
-    C1: { currentVal: 25 },
-    C2: { currentVal: 5 },
-  },
-};
-
-const createMockPivotData = (rowData: Record<string, number>): PivotData =>
-  toPivotData({
-    rowKeys: Object.keys(rowData).map(key => key.split('.')),
-    getAggregator: (rowKey: string[]) => ({
-      push: jest.fn(),
-      value: () => rowData[rowKey.join('.')],
-      format: (value: number) => String(value),
-    }),
-  });
-
-test('should set initial ascending sort when no active sort column', () => {
-  mockGetAggregatedData.mockReturnValue({
-    A: { currentVal: 30 },
-    B: { currentVal: 10 },
-    C: { currentVal: 20 },
-  });
-
-  const setStateMock = jest.fn();
-  tableRenderer.setState = setStateMock;
-
-  tableRenderer.sortData(columnIndex, visibleColKeys, pivotData, maxRowIndex);
-
-  expect(setStateMock).toHaveBeenCalled();
-
-  const [stateUpdater] = setStateMock.mock.calls[0];
-
-  expect(typeof stateUpdater).toBe('function');
-
-  const previousState = {
-    sortingOrder: [],
-    activeSortColumn: 0,
-  };
-
-  const newState = stateUpdater(previousState);
-
-  expect(newState.sortingOrder[columnIndex]).toBe('asc');
-  expect(newState.activeSortColumn).toBe(columnIndex);
-
-  expect(mockGetAggregatedData).toHaveBeenCalledWith(
-    pivotData,
-    visibleColKeys[columnIndex],
-    false,
-  );
-
-  expect(mockSortAndCacheData).toHaveBeenCalledWith(
-    { A: { currentVal: 30 }, B: { currentVal: 10 }, C: { currentVal: 20 } },
-    'asc',
-    true,
-    false,
-    maxRowIndex,
-  );
-});
-
-test('should toggle from asc to desc when clicking same column', () => {
-  mockGetAggregatedData.mockReturnValue({
-    A: { currentVal: 30 },
-    B: { currentVal: 10 },
-    C: { currentVal: 20 },
-  });
-  const setStateMock = jest.fn(stateUpdater => {
-    if (typeof stateUpdater === 'function') {
-      const newState = stateUpdater({
-        sortingOrder: ['asc' as never],
-        activeSortColumn: 0,
-      });
-
-      tableRenderer.state = {
-        ...tableRenderer.state,
-        ...newState,
-      };
-    }
-  });
-  tableRenderer.setState = setStateMock;
-
-  tableRenderer.sortData(columnIndex, visibleColKeys, pivotData, maxRowIndex);
-
-  expect(mockSortAndCacheData).toHaveBeenCalledWith(
-    { A: { currentVal: 30 }, B: { currentVal: 10 }, C: { currentVal: 20 } },
-    'desc',
-    true,
-    false,
-    maxRowIndex,
-  );
-});
-
-test('should check second call in sequence', () => {
-  mockGetAggregatedData.mockReturnValue({
-    A: { currentVal: 30 },
-    B: { currentVal: 10 },
-    C: { currentVal: 20 },
-  });
-
-  mockSortAndCacheData.mockClear();
-
-  const setStateMock = jest.fn(stateUpdater => {
-    if (typeof stateUpdater === 'function') {
-      const newState = stateUpdater(tableRenderer.state);
-      tableRenderer.state = {
-        ...tableRenderer.state,
-        ...newState,
-      };
-    }
-  });
-  tableRenderer.setState = setStateMock;
-
-  tableRenderer.state = {
-    sortingOrder: [],
-    activeSortColumn: 0,
-    collapsedRows: {},
-    collapsedCols: {},
-  } as TableRendererStateStub;
-  tableRenderer.sortData(columnIndex, visibleColKeys, pivotData, maxRowIndex);
-
-  tableRenderer.state = {
-    sortingOrder: ['asc' as never],
-    activeSortColumn: 0,
-    collapsedRows: {},
-    collapsedCols: {},
-  } as TableRendererStateStub;
-  tableRenderer.sortData(columnIndex, visibleColKeys, pivotData, maxRowIndex);
-
-  expect(mockSortAndCacheData).toHaveBeenCalledTimes(2);
-
-  expect(mockSortAndCacheData.mock.calls[0]).toEqual([
-    { A: { currentVal: 30 }, B: { currentVal: 10 }, C: { currentVal: 20 } },
-    'asc',
-    true,
-    false,
-    maxRowIndex,
-  ]);
-
-  expect(mockSortAndCacheData.mock.calls[1]).toEqual([
-    { A: { currentVal: 30 }, B: { currentVal: 10 }, C: { currentVal: 20 } },
-    'desc',
-    true,
-    false,
-    maxRowIndex,
-  ]);
-});
-
-test('should sort hierarchical data in descending order', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const groups = {
-    A: {
-      currentVal: 30,
-      A1: { currentVal: 13 },
-      A2: { currentVal: 17 },
-    },
-    B: {
-      currentVal: 10,
-      B1: { currentVal: 7 },
-      B2: { currentVal: 3 },
-    },
-
-    C: {
-      currentVal: 18,
-      C1: { currentVal: 7 },
-      C2: { currentVal: 11 },
-    },
-  };
-
-  const result = tableRenderer.sortAndCacheData(groups, 'desc', true, false, 2);
-
-  expect(result).toBeDefined();
-
-  expect(Array.isArray(result)).toBe(true);
-
-  expect(result).toEqual([
-    ['A', 'A2'],
-    ['A', 'A1'],
-    ['A'],
-    ['C', 'C2'],
-    ['C', 'C1'],
-    ['C'],
-    ['B', 'B1'],
-    ['B', 'B2'],
-    ['B'],
-  ]);
-});
-
-test('should sort hierarchical data in ascending order', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const groups = {
-    A: {
-      currentVal: 30,
-      A1: { currentVal: 13 },
-      A2: { currentVal: 17 },
-    },
-    B: {
-      currentVal: 10,
-      B1: { currentVal: 7 },
-      B2: { currentVal: 3 },
-    },
-
-    C: {
-      currentVal: 18,
-      C1: { currentVal: 7 },
-      C2: { currentVal: 11 },
-    },
-  };
-
-  const result = tableRenderer.sortAndCacheData(groups, 'asc', true, false, 2);
-
-  expect(result).toBeDefined();
-
-  expect(Array.isArray(result)).toBe(true);
-
-  expect(result).toEqual([
-    ['B', 'B2'],
-    ['B', 'B1'],
-    ['B'],
-    ['C', 'C1'],
-    ['C', 'C2'],
-    ['C'],
-    ['A', 'A1'],
-    ['A', 'A2'],
-    ['A'],
-  ]);
-});
-
-test('should calculate groups from pivot data', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const mockAggregator = (value: number) => ({
-    push: jest.fn(),
-    value: () => value,
-    format: jest.fn(),
-    isSubtotal: false,
-  });
-
-  const mockPivotData = toPivotData({
-    rowKeys: [['A'], ['B'], ['C']],
-    getAggregator: jest
-      .fn()
-      .mockReturnValueOnce(mockAggregator(30))
-      .mockReturnValueOnce(mockAggregator(10))
-      .mockReturnValueOnce(mockAggregator(20)),
-  });
-
-  const result = tableRenderer.getAggregatedData(
-    mockPivotData,
-    ['col1'],
-    false,
-  );
-
-  expect(result).toEqual({
-    A: { currentVal: 30 },
-    B: { currentVal: 10 },
-    C: { currentVal: 20 },
-  });
-});
-
-test('should sort groups and convert to array in ascending order', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const result = tableRenderer.sortAndCacheData(
-    mockGroups,
-    'asc',
-    true,
-    false,
-    2,
-  );
-
-  expect(result).toEqual([
-    ['A', 'A2'],
-    ['A', 'A1'],
-    ['A'],
-    ['B', 'B2'],
-    ['B', 'B1'],
-    ['B'],
-    ['C', 'C2'],
-    ['C', 'C1'],
-    ['C'],
-  ]);
-});
-
-test('should sort groups and convert to array in descending order', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const result = tableRenderer.sortAndCacheData(
-    mockGroups,
-    'desc',
-    true,
-    false,
-    2,
-  );
-
-  expect(result).toEqual([
-    ['C', 'C1'],
-    ['C', 'C2'],
-    ['C'],
-    ['B', 'B1'],
-    ['B', 'B2'],
-    ['B'],
-    ['A', 'A1'],
-    ['A', 'A2'],
-    ['A'],
-  ]);
-});
-
-test('should handle rowPartialOnTop = true configuration', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const result = tableRenderer.sortAndCacheData(
-    mockGroups,
-    'asc',
-    true,
-    true,
-    2,
-  );
-
-  expect(result).toEqual([
-    ['A'],
-    ['A', 'A2'],
-    ['A', 'A1'],
-    ['B'],
-    ['B', 'B2'],
-    ['B', 'B1'],
-    ['C'],
-    ['C', 'C2'],
-    ['C', 'C1'],
-  ]);
-});
-
-test('should handle rowEnabled = false and rowPartialOnTop = false, sorting asc', () => {
-  tableRenderer = new TableRenderer(mockProps);
-
-  const result = tableRenderer.sortAndCacheData(
-    mockGroups,
-    'asc',
-    false,
-    false,
-    2,
-  );
-
-  expect(result).toEqual([
-    ['A', 'A2'],
-    ['A', 'A1'],
-    ['B', 'B2'],
-    ['B', 'B1'],
-    ['C', 'C2'],
-    ['C', 'C1'],
-  ]);
-});
-
-test('should handle rowEnabled = false and rowPartialOnTop = false , sorting desc', () => {
-  tableRenderer = new TableRenderer(mockProps);
-
-  const result = tableRenderer.sortAndCacheData(
-    mockGroups,
-    'desc',
-    false,
-    false,
-    2,
-  );
-
-  expect(result).toEqual([
-    ['C', 'C1'],
-    ['C', 'C2'],
-    ['B', 'B1'],
-    ['B', 'B2'],
-    ['A', 'A1'],
-    ['A', 'A2'],
-  ]);
-});
-
-test('create hierarchical structure with subtotal at bottom', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const rowData = {
-    'A.A1': 10,
-    'A.A2': 20,
-    A: 30,
-    'B.B1': 30,
-    'B.B2': 40,
-    B: 70,
-    'C.C1': 50,
-    'C.C2': 60,
-    C: 110,
-  };
-
-  const pivotData = createMockPivotData(rowData);
-  const result = tableRenderer.getAggregatedData(pivotData, ['Col1'], false);
-
-  expect(result).toEqual({
-    A: {
-      A1: { currentVal: 10 },
-      A2: { currentVal: 20 },
-      currentVal: 30,
-    },
-    B: {
-      B1: { currentVal: 30 },
-      B2: { currentVal: 40 },
-      currentVal: 70,
-    },
-    C: {
-      C1: { currentVal: 50 },
-      C2: { currentVal: 60 },
-      currentVal: 110,
-    },
-  });
-});
-
-test('create hierarchical structure with subtotal at top', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const rowData = {
-    A: 30,
-    'A.A1': 10,
-    'A.A2': 20,
-    B: 70,
-    'B.B1': 30,
-    'B.B2': 40,
-    C: 110,
-    'C.C1': 50,
-    'C.C2': 60,
-  };
-
-  const pivotData = createMockPivotData(rowData);
-  const result = tableRenderer.getAggregatedData(pivotData, ['Col1'], true);
-
-  expect(result).toEqual({
-    A: {
-      A1: { currentVal: 10 },
-      A2: { currentVal: 20 },
-      currentVal: 30,
-    },
-    B: {
-      B1: { currentVal: 30 },
-      B2: { currentVal: 40 },
-      currentVal: 70,
-    },
-    C: {
-      C1: { currentVal: 50 },
-      C2: { currentVal: 60 },
-      currentVal: 110,
-    },
-  });
-});
-
-test('values ​​from the 3rd level of the hierarchy with a subtotal at the bottom', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const rowData = {
-    'A.A1.A11': 10,
-    'A.A1.A12': 20,
-    'A.A1': 30,
-    'A.A2': 30,
-    'A.A3': 50,
-    A: 110,
-  };
-
-  const pivotData = createMockPivotData(rowData);
-  const result = tableRenderer.getAggregatedData(pivotData, ['Col1'], false);
-
-  expect(result).toEqual({
-    A: {
-      A1: {
-        A11: { currentVal: 10 },
-        A12: { currentVal: 20 },
-        currentVal: 30,
-      },
-      A2: { currentVal: 30 },
-      A3: { currentVal: 50 },
-      currentVal: 110,
-    },
-  });
-});
-
-test('values ​​from the 3rd level of the hierarchy with a subtotal at the top', () => {
-  tableRenderer = new TableRenderer(mockProps);
-  const rowData = {
-    A: 110,
-    'A.A1': 30,
-    'A.A1.A11': 10,
-    'A.A1.A12': 20,
-    'A.A2': 30,
-    'A.A3': 50,
-  };
-
-  const pivotData = createMockPivotData(rowData);
-  const result = tableRenderer.getAggregatedData(pivotData, ['Col1'], true);
-
-  expect(result).toEqual({
-    A: {
-      A1: {
-        A11: { currentVal: 10 },
-        A12: { currentVal: 20 },
-        currentVal: 30,
-      },
-      A2: { currentVal: 30 },
-      A3: { currentVal: 50 },
-      currentVal: 110,
-    },
-  });
-});
-
-test('getCellColor derives readable text from the winning background', () => {
-  expect(
-    getCellColor(
-      ['revenue'],
-      200,
-      {
-        metric: [
-          {
-            column: 'revenue',
-            objectFormatting: ObjectFormattingEnum.BACKGROUND_COLOR,
-            getColorFromValue: (value: unknown) =>
-              value === 200 ? '#111111' : undefined,
-          },
-        ],
-      },
-      '#ffffff',
-    ),
-  ).toEqual({
-    backgroundColor: '#111111',
-    color: 'rgb(255, 255, 255)',
-  });
-});
-
-test('getCellColor keeps explicit text color over adaptive contrast', () => {
-  expect(
-    getCellColor(
-      ['revenue'],
-      200,
-      {
-        metric: [
-          {
-            column: 'revenue',
-            objectFormatting: ObjectFormattingEnum.BACKGROUND_COLOR,
-            getColorFromValue: (value: unknown) =>
-              value === 200 ? '#111111' : undefined,
-          },
-          {
-            column: 'revenue',
-            objectFormatting: ObjectFormattingEnum.TEXT_COLOR,
-            getColorFromValue: (value: unknown) =>
-              value === 200 ? '#ace1c40d' : undefined,
-          },
-        ],
-      },
-      '#ffffff',
-    ),
-  ).toEqual({
-    backgroundColor: '#111111',
-    color: 'rgb(172, 225, 196)',
-  });
-});
-
-test('getCellColor treats legacy toTextColor formatters as text color', () => {
-  expect(
-    getCellColor(
-      ['revenue'],
-      200,
-      {
-        metric: [
-          {
-            column: 'revenue',
-            getColorFromValue: (value: unknown) =>
-              value === 200 ? '#111111' : undefined,
-          },
-          {
-            column: 'revenue',
-            toTextColor: true,
-            getColorFromValue: (value: unknown) =>
-              value === 200 ? '#ace1c40d' : undefined,
-          },
-        ],
-      },
-      '#ffffff',
-    ),
-  ).toEqual({
-    backgroundColor: '#111111',
-    color: 'rgb(172, 225, 196)',
-  });
-});
-
-test('getCellColor ignores cell-bar rules when resolving text color', () => {
-  expect(
-    getCellColor(
-      ['revenue'],
-      200,
-      {
-        metric: [
-          {
-            column: 'revenue',
-            objectFormatting: ObjectFormattingEnum.CELL_BAR,
-            getColorFromValue: (value: unknown) =>
-              value === 200 ? '#11111199' : undefined,
-          },
-        ],
-      },
-      '#ffffff',
-    ),
-  ).toEqual({
-    backgroundColor: undefined,
-    color: undefined,
-  });
-});
-
-test('renderTableRow keeps subtotal background and readable text in sync', () => {
-  tableRenderer = new TableRenderer({
-    ...mockProps,
-    tableOptions: {
-      cellColorFormatters: {
-        metric: [
-          {
-            column: 'revenue',
-            objectFormatting: ObjectFormattingEnum.BACKGROUND_COLOR,
-            getColorFromValue: (value: unknown) =>
-              value === 200 ? '#111111' : undefined,
-          },
-        ],
-      },
-      cellBackgroundColor: '#ffffff',
-      cellTextColor: '#000000',
-    },
-  });
-
-  const row = tableRenderer.renderTableRow(
-    ['revenue'],
-    0,
-    createTableRowSettings({
-      pivotData: createPivotDataStub(200, true),
-    }),
-  ) as ReactElement;
-
-  const cells = Children.toArray(row.props.children);
-  const valueCell = cells.find(
-    child => isValidElement(child) && child.props.className === 'pvtVal',
-  ) as ReactElement;
-
-  expect(valueCell.props.style).toEqual({
-    backgroundColor: '#111111',
-    color: 'rgb(255, 255, 255)',
-    fontWeight: 'bold',
-  });
-});
-
-test('renderColAttrsHeader applies readable text color to formatted headers', () => {
-  tableRenderer = new TableRenderer({
-    ...mockProps,
-    tableOptions: {
-      cellColorFormatters: {
-        metric: [
-          {
-            column: 'region',
-            objectFormatting: ObjectFormattingEnum.BACKGROUND_COLOR,
-            getColorFromValue: (value: unknown) =>
-              value === 'EMEA' ? '#111111' : undefined,
-          },
-        ],
-      },
-      cellBackgroundColor: '#ffffff',
-      cellTextColor: '#000000',
-    },
-  });
-
-  const row = tableRenderer.renderColHeaderRow(
-    'region',
-    0,
-    createColHeaderRowSettings(),
-  ) as ReactElement;
-
-  const cells = Children.toArray(row.props.children);
-  const headerCell = cells.find(
-    child => isValidElement(child) && child.props.className === 'pvtColLabel',
-  ) as ReactElement;
-
-  expect(headerCell.props.style).toEqual({
-    backgroundColor: '#111111',
-    color: 'rgb(255, 255, 255)',
-  });
-});
-
-test('renderColAttrsHeader uses active header surface for adaptive contrast', () => {
-  const activeHeaderBackgroundColor = '#102a43';
-  tableRenderer = new TableRenderer({
-    ...mockProps,
-    tableOptions: createActiveHeaderTableOptions(activeHeaderBackgroundColor, {
-      highlightedHeaderCells: {
-        region: ['EMEA'],
-      },
-      cellColorFormatters: {
-        metric: [
-          {
-            column: 'region',
-            objectFormatting: ObjectFormattingEnum.BACKGROUND_COLOR,
-            getColorFromValue: (value: unknown) =>
-              value === 'EMEA' ? 'rgba(0, 0, 0, 0.4)' : undefined,
-          },
-        ],
-      },
-      cellBackgroundColor: '#ffffff',
-      cellTextColor: '#000000',
-    }),
-  });
-
-  const row = tableRenderer.renderColHeaderRow(
-    'region',
-    0,
-    createColHeaderRowSettings(),
-  ) as ReactElement;
-
-  const cells = Children.toArray(row.props.children);
-  const headerCell = cells.find(
-    child =>
-      isValidElement(child) && child.props.className === 'pvtColLabel active',
-  ) as ReactElement;
-
-  expect(headerCell.props.style).toEqual({
-    backgroundColor: 'rgba(0, 0, 0, 0.4)',
-    color: getTextColorForBackground(
-      { backgroundColor: 'rgba(0, 0, 0, 0.4)' },
-      activeHeaderBackgroundColor,
-    ),
-  });
-});
-
-test('renderColHeaderRow preserves default header text color without formatting', () => {
-  tableRenderer = new TableRenderer({
-    ...mockProps,
-    tableOptions: {
-      cellColorFormatters: { metric: [] },
-      cellBackgroundColor: '#ffffff',
-      cellTextColor: '#ff00aa',
-    },
-  });
-
-  const row = tableRenderer.renderColHeaderRow(
-    'region',
-    0,
-    createColHeaderRowSettings(),
-  ) as ReactElement;
-
-  const cells = Children.toArray(row.props.children);
-  const headerCell = cells.find(
-    child => isValidElement(child) && child.props.className === 'pvtColLabel',
-  ) as ReactElement;
-
-  expect(headerCell.props.style).toEqual({
-    backgroundColor: undefined,
-    color: undefined,
-  });
-});
-
-test('renderTableRow preserves default row-header text color without formatting', () => {
-  tableRenderer = new TableRenderer({
-    ...mockProps,
-    tableOptions: {
-      cellColorFormatters: { metric: [] },
-      cellBackgroundColor: '#ffffff',
-      cellTextColor: '#ff00aa',
-    },
-  });
-
-  const row = tableRenderer.renderTableRow(
-    ['revenue'],
-    0,
-    createTableRowSettings(),
-  ) as ReactElement;
-
-  const cells = Children.toArray(row.props.children);
-  const headerCell = cells.find(
-    child => isValidElement(child) && child.props.className === 'pvtRowLabel',
-  ) as ReactElement;
-
-  expect(headerCell.props.style).toEqual({
-    backgroundColor: undefined,
-    color: undefined,
-  });
-});
-
-test('renderTableRow applies readable text color to formatted row headers', () => {
-  tableRenderer = new TableRenderer({
-    ...mockProps,
-    tableOptions: {
-      cellColorFormatters: {
-        metric: [
-          {
-            column: 'metric',
-            objectFormatting: ObjectFormattingEnum.BACKGROUND_COLOR,
-            getColorFromValue: (value: unknown) =>
-              value === 'revenue' ? '#111111' : undefined,
-          },
-        ],
-      },
-      cellBackgroundColor: '#ffffff',
-      cellTextColor: '#000000',
-    },
-  });
-
-  const row = tableRenderer.renderTableRow(
-    ['revenue'],
-    0,
-    createTableRowSettings(),
-  ) as ReactElement;
-
-  const cells = Children.toArray(row.props.children);
-  const headerCell = cells.find(
-    child => isValidElement(child) && child.props.className === 'pvtRowLabel',
-  ) as ReactElement;
-
-  expect(headerCell.props.style).toEqual({
-    backgroundColor: '#111111',
-    color: 'rgb(255, 255, 255)',
-  });
-});
-
-test('renderTableRow uses active header surface for adaptive contrast', () => {
-  const activeHeaderBackgroundColor = '#102a43';
-  tableRenderer = new TableRenderer({
-    ...mockProps,
-    tableOptions: createActiveHeaderTableOptions(activeHeaderBackgroundColor, {
-      highlightedHeaderCells: {
-        metric: ['revenue'],
-      },
-      cellColorFormatters: {
-        metric: [
-          {
-            column: 'metric',
-            objectFormatting: ObjectFormattingEnum.BACKGROUND_COLOR,
-            getColorFromValue: (value: unknown) =>
-              value === 'revenue' ? 'rgba(0, 0, 0, 0.4)' : undefined,
-          },
-        ],
-      },
-      cellBackgroundColor: '#ffffff',
-      cellTextColor: '#000000',
-    }),
-  });
-
-  const row = tableRenderer.renderTableRow(
-    ['revenue'],
-    0,
-    createTableRowSettings(),
-  ) as ReactElement;
-
-  const cells = Children.toArray(row.props.children);
-  const headerCell = cells.find(
-    child =>
-      isValidElement(child) && child.props.className === 'pvtRowLabel active',
-  ) as ReactElement;
-
-  expect(headerCell.props.style).toEqual({
-    backgroundColor: 'rgba(0, 0, 0, 0.4)',
-    color: getTextColorForBackground(
-      { backgroundColor: 'rgba(0, 0, 0, 0.4)' },
-      activeHeaderBackgroundColor,
-    ),
-  });
-});
-
-function makeColPivotSettings(
-  value: string,
-): Parameters<TableRenderer['renderColHeaderRow']>[2] {
-  return {
-    rowAttrs: [],
-    colAttrs: ['event_time'],
-    colKeys: [[value]],
-    visibleColKeys: [[value]],
-    colAttrSpans: [[1]],
-    rowTotals: false,
-    colSubtotalDisplay: {
-      enabled: false,
-      displayOnTop: false,
-      hideOnExpand: false,
-    },
-    maxColVisible: 1,
-    pivotData: {},
-    namesMapping: {},
-    allowRenderHtml: false,
-  } as unknown as Parameters<TableRenderer['renderColHeaderRow']>[2];
-}
-
-function makeRowPivotSettings(): Parameters<
-  TableRenderer['renderTableRow']
->[2] {
-  const aggregator = {
-    value: jest.fn().mockReturnValue(1),
-    format: jest.fn().mockReturnValue('1'),
-    isSubtotal: false,
-  };
-  return {
-    rowAttrs: ['event_time'],
-    colAttrs: [],
-    rowAttrSpans: [[1]],
-    visibleColKeys: [[]],
-    pivotData: { getAggregator: jest.fn().mockReturnValue(aggregator) },
-    rowTotals: false,
-    rowSubtotalDisplay: {
-      enabled: false,
-      displayOnTop: false,
-      hideOnExpand: false,
-    },
-    arrowExpanded: null,
-    arrowCollapsed: null,
-    cellCallbacks: {},
-    rowTotalCallbacks: {},
-    namesMapping: {},
-    allowRenderHtml: false,
-  } as unknown as Parameters<TableRenderer['renderTableRow']>[2];
-}
-
-test.each([
-  ['numeric timestamp string', '1700000000000', 1700000000000],
-  ['non-numeric date string', 'Dec. 16 2020', 'Dec. 16 2020'],
-  ['ISO timestamp string', '2024-01-15T00:00:00Z', '2024-01-15T00:00:00Z'],
-])(
-  'col header date formatter receives correct value for %s',
-  (_, input, expected) => {
-    const formatter = jest.fn().mockReturnValue('formatted');
-    tableRenderer = new TableRenderer({
-      ...mockProps,
-      cols: ['event_time'],
-      tableOptions: {
-        ...mockProps.tableOptions,
-        dateFormatters: { event_time: formatter },
-      },
-    });
-    tableRenderer.renderColHeaderRow(
-      'event_time',
-      0,
-      makeColPivotSettings(input),
-    );
-    expect(formatter).toHaveBeenCalledWith(expected);
-  },
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/ui';
+import { TableRenderer } from '../../src/react-pivottable/TableRenderers';
+import { aggregatorTemplates } from '../../src/react-pivottable/utilities';
+
+jest.mock(
+  'react-icons/fa',
+  () => ({
+    FaSort: () => <span data-testid="sort-icon" />,
+    FaSortDown: () => <span data-testid="sort-desc-icon" />,
+    FaSortUp: () => <span data-testid="sort-asc-icon" />,
+  }),
+  { virtual: true },
 );
 
-test.each([
-  ['numeric timestamp string', '1700000000000', 1700000000000],
-  ['non-numeric date string', 'Dec. 16 2020', 'Dec. 16 2020'],
-])(
-  'row header date formatter receives correct value for %s',
-  (_, input, expected) => {
-    const formatter = jest.fn().mockReturnValue('formatted');
-    tableRenderer = new TableRenderer({
-      ...mockProps,
-      rows: ['event_time'],
-      tableOptions: {
-        ...mockProps.tableOptions,
-        dateFormatters: { event_time: formatter },
-      },
-    });
-    tableRenderer.renderTableRow([input], 0, makeRowPivotSettings());
-    expect(formatter).toHaveBeenCalledWith(expected);
-  },
-);
+/**
+ * A minimal aggregatorsFactory that mirrors the production one.
+ * PivotData's constructor calls `aggregatorsFactory(defaultFormatter)`
+ * to obtain a map of aggregator constructors keyed by name.
+ * The `formatter` argument is ignored here because the tests only
+ * care about rendering output, not number formatting precision.
+ */
+const aggregatorsFactory = () => ({
+  Count: aggregatorTemplates.count(),
+  Sum: aggregatorTemplates.sum(),
+});
+
+const SAMPLE_DATA = [
+  { color: 'blue', shape: 'circle', value: 10 },
+  { color: 'blue', shape: 'square', value: 20 },
+  { color: 'red', shape: 'circle', value: 30 },
+  { color: 'red', shape: 'square', value: 40 },
+];
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={supersetTheme}>{ui}</ThemeProvider>);
+}
+
+function buildDefaultProps(overrides: Record<string, unknown> = {}) {
+  return {
+    data: SAMPLE_DATA,
+    rows: ['color'] as string[],
+    cols: ['shape'] as string[],
+    aggregatorName: 'Count',
+    vals: [] as string[],
+    aggregatorsFactory,
+    tableOptions: {},
+    onContextMenu: jest.fn(),
+    ...overrides,
+  };
+}
+
+test('TableRenderer renders a table element with the pvtTable class', () => {
+  const props = buildDefaultProps();
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const table = screen.getByRole('grid');
+  expect(table).toBeInTheDocument();
+  expect(table).toHaveClass('pvtTable');
+});
+
+test('TableRenderer renders column headers from pivot data', () => {
+  const props = buildDefaultProps();
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // The column attribute values ("circle" and "square") should appear as
+  // column headers in the rendered table.
+  expect(screen.getByText('circle')).toBeInTheDocument();
+  expect(screen.getByText('square')).toBeInTheDocument();
+});
+
+test('TableRenderer renders row headers from pivot data', () => {
+  const props = buildDefaultProps();
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // The row attribute values ("blue" and "red") should appear as
+  // row headers in the rendered table.
+  expect(screen.getByText('blue')).toBeInTheDocument();
+  expect(screen.getByText('red')).toBeInTheDocument();
+});
+
+test('TableRenderer renders aggregated cell values', () => {
+  const props = buildDefaultProps();
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // With "Count" aggregator, each cell (row x col intersection) should
+  // contain "1" because each combination appears exactly once.
+  const cells = screen.getAllByRole('gridcell');
+  const cellTexts = cells.map(cell => cell.textContent);
+
+  // There should be cell values of "1" for each of the four intersections
+  // (blue+circle, blue+square, red+circle, red+square).
+  const onesCount = cellTexts.filter(text => text === '1').length;
+  expect(onesCount).toBeGreaterThanOrEqual(4);
+});
+
+test('TableRenderer renders row totals when rowTotals is enabled', () => {
+  const props = buildDefaultProps({
+    tableOptions: { rowTotals: true, colTotals: true },
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // Row totals column should show "2" for each color (blue has 2 records,
+  // red has 2 records).
+  const totalCells = screen
+    .getAllByRole('gridcell')
+    .filter(cell => cell.classList.contains('pvtTotal'));
+  expect(totalCells.length).toBeGreaterThan(0);
+
+  const totalValues = totalCells.map(cell => cell.textContent);
+  expect(totalValues).toContain('2');
+});
+
+test('TableRenderer renders col totals row when colTotals is enabled', () => {
+  const props = buildDefaultProps({
+    tableOptions: { rowTotals: true, colTotals: true },
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // The totals row should have cells with class pvtRowTotal.
+  const rowTotalCells = screen
+    .getAllByRole('gridcell')
+    .filter(cell => cell.classList.contains('pvtRowTotal'));
+  expect(rowTotalCells.length).toBeGreaterThan(0);
+});
+
+test('TableRenderer renders grand total when both totals are enabled', () => {
+  const props = buildDefaultProps({
+    tableOptions: { rowTotals: true, colTotals: true },
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // The grand total cell should show "4" (total record count).
+  const grandTotalCells = screen
+    .getAllByRole('gridcell')
+    .filter(cell => cell.classList.contains('pvtGrandTotal'));
+  expect(grandTotalCells.length).toBe(1);
+  expect(grandTotalCells[0]).toHaveTextContent('4');
+});
+
+test('TableRenderer handles empty data gracefully', () => {
+  const props = buildDefaultProps({ data: [] });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // The table should still render without crashing, just with no data rows.
+  const table = screen.getByRole('grid');
+  expect(table).toBeInTheDocument();
+
+  // With empty data, there are no regular value cells (pvtVal).
+  const valueCells = document.querySelectorAll('.pvtVal');
+  expect(valueCells).toHaveLength(0);
+
+  // No row headers should be present.
+  const rowLabels = document.querySelectorAll('.pvtRowLabel');
+  expect(rowLabels).toHaveLength(0);
+});
+
+test('TableRenderer handles data with no rows dimension', () => {
+  const props = buildDefaultProps({
+    rows: [],
+    cols: ['color'],
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const table = screen.getByRole('grid');
+  expect(table).toBeInTheDocument();
+
+  // Column headers should still render.
+  expect(screen.getByText('blue')).toBeInTheDocument();
+  expect(screen.getByText('red')).toBeInTheDocument();
+});
+
+test('TableRenderer handles data with no cols dimension', () => {
+  const props = buildDefaultProps({
+    rows: ['color'],
+    cols: [],
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const table = screen.getByRole('grid');
+  expect(table).toBeInTheDocument();
+
+  // Row headers should still render.
+  expect(screen.getByText('blue')).toBeInTheDocument();
+  expect(screen.getByText('red')).toBeInTheDocument();
+});
+
+test('TableRenderer renders with Sum aggregator', () => {
+  const props = buildDefaultProps({
+    aggregatorName: 'Sum',
+    vals: ['value'],
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const cells = screen.getAllByRole('gridcell');
+  const cellTexts = cells.map(cell => cell.textContent);
+
+  // Sum of value for blue+circle=10, blue+square=20, red+circle=30,
+  // red+square=40. Check that at least some of these appear.
+  expect(cellTexts.some(text => text?.includes('10'))).toBe(true);
+  expect(cellTexts.some(text => text?.includes('40'))).toBe(true);
+});
+
+test('TableRenderer applies namesMapping to header labels', () => {
+  const props = buildDefaultProps({
+    namesMapping: { blue: 'Blue Color', red: 'Red Color' },
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  expect(screen.getByText('Blue Color')).toBeInTheDocument();
+  expect(screen.getByText('Red Color')).toBeInTheDocument();
+});
+
+test('TableRenderer renders the row attribute label in the header', () => {
+  const props = buildDefaultProps();
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // The row attribute name "color" should appear as an axis label.
+  const axisLabels = document.querySelectorAll('.pvtAxisLabel');
+  const axisLabelTexts = Array.from(axisLabels).map(el => el.textContent);
+  expect(axisLabelTexts).toContain('color');
+});
+
+test('TableRenderer renders the column attribute label in the header', () => {
+  const props = buildDefaultProps();
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // The column attribute name "shape" should appear as an axis label.
+  const axisLabels = document.querySelectorAll('.pvtAxisLabel');
+  const axisLabelTexts = Array.from(axisLabels).map(el => el.textContent);
+  expect(axisLabelTexts).toContain('shape');
+});
+
+test('TableRenderer calls onContextMenu callback', () => {
+  const onContextMenu = jest.fn();
+  const props = buildDefaultProps({ onContextMenu });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const cells = screen.getAllByRole('gridcell');
+  expect(cells.length).toBeGreaterThan(0);
+});
+
+test('TableRenderer renders with multiple row dimensions', () => {
+  const multiRowData = [
+    { country: 'US', city: 'NYC', value: 10 },
+    { country: 'US', city: 'LA', value: 20 },
+    { country: 'UK', city: 'London', value: 30 },
+  ];
+
+  const props = buildDefaultProps({
+    data: multiRowData,
+    rows: ['country', 'city'],
+    cols: [],
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const table = screen.getByRole('grid');
+  expect(table).toBeInTheDocument();
+
+  expect(screen.getByText('US')).toBeInTheDocument();
+  expect(screen.getByText('UK')).toBeInTheDocument();
+  expect(screen.getByText('NYC')).toBeInTheDocument();
+  expect(screen.getByText('LA')).toBeInTheDocument();
+  expect(screen.getByText('London')).toBeInTheDocument();
+});
+
+test('TableRenderer renders with multiple column dimensions', () => {
+  const multiColData = [
+    { year: '2023', quarter: 'Q1', metric: 5 },
+    { year: '2023', quarter: 'Q2', metric: 10 },
+    { year: '2024', quarter: 'Q1', metric: 15 },
+  ];
+
+  const props = buildDefaultProps({
+    data: multiColData,
+    rows: [],
+    cols: ['year', 'quarter'],
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const table = screen.getByRole('grid');
+  expect(table).toBeInTheDocument();
+
+  expect(screen.getByText('2023')).toBeInTheDocument();
+  expect(screen.getByText('2024')).toBeInTheDocument();
+  // Q1 appears under both 2023 and 2024, so use getAllByText.
+  expect(screen.getAllByText('Q1').length).toBeGreaterThanOrEqual(2);
+  expect(screen.getByText('Q2')).toBeInTheDocument();
+});
+
+test('TableRenderer renders value cells with the pvtVal class', () => {
+  const props = buildDefaultProps();
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const valueCells = document.querySelectorAll('.pvtVal');
+  // 2 rows x 2 cols = 4 value cells
+  expect(valueCells.length).toBe(4);
+});
+
+test('TableRenderer renders correct number of thead and tbody sections', () => {
+  const props = buildDefaultProps();
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const table = screen.getByRole('grid');
+
+  // The table should have thead and tbody elements.
+  const theadEl = table.querySelector('thead');
+  const tbodyEl = table.querySelector('tbody');
+  expect(theadEl).toBeInTheDocument();
+  expect(tbodyEl).toBeInTheDocument();
+});

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -19,7 +19,7 @@
 
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { supersetTheme, ThemeProvider } from '@apache-superset/core/ui';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
 import { TableRenderer } from '../../src/react-pivottable/TableRenderers';
 import { aggregatorTemplates } from '../../src/react-pivottable/utilities';
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -330,6 +330,29 @@ test('TableRenderer renders value cells with the pvtVal class', () => {
   expect(valueCells.length).toBe(4);
 });
 
+test('TableRenderer coerces numeric timestamp strings to numbers for column header date formatters', () => {
+  const dateFormatter = jest.fn((val: unknown) => `col:${String(val)}`);
+  const data = [
+    { shape: '1700000000000', color: 'blue', value: 1 },
+    { shape: 'square', color: 'blue', value: 2 },
+  ];
+  const props = buildDefaultProps({
+    data,
+    rows: ['color'],
+    cols: ['shape'],
+    tableOptions: { dateFormatters: { shape: dateFormatter } },
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // Numeric string should be coerced to a Number before being passed to the
+  // date formatter; plain (non-numeric) strings should pass through verbatim.
+  expect(dateFormatter).toHaveBeenCalledWith(1700000000000);
+  expect(dateFormatter).toHaveBeenCalledWith('square');
+
+  expect(screen.getByText('col:1700000000000')).toBeInTheDocument();
+  expect(screen.getByText('col:square')).toBeInTheDocument();
+});
+
 test('TableRenderer renders correct number of thead and tbody sections', () => {
   const props = buildDefaultProps();
   renderWithTheme(<TableRenderer {...props} />);

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -403,6 +403,39 @@ test('TableRenderer applies cellColorFormatters background and contrast color to
   expect(plainHeader!.style.backgroundColor).toBe('');
 });
 
+test('TableRenderer applies cellColorFormatters background and contrast color to value cells', () => {
+  // Value-cell formatters are matched against actual row/col key values
+  // (not attribute names), so a formatter with column: 'blue' fires for
+  // every value cell whose row key contains 'blue'.
+  const cellColorFormatters = {
+    color: [
+      {
+        column: 'blue',
+        getColorFromValue: () => '#000000',
+      },
+    ],
+  };
+  const props = buildDefaultProps({
+    tableOptions: { cellColorFormatters },
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const valueCells = Array.from(
+    document.querySelectorAll<HTMLElement>('.pvtVal'),
+  );
+  expect(valueCells.length).toBeGreaterThan(0);
+
+  // At least one value cell in the "blue" row should have both a background
+  // and a contrast-aware text color applied.
+  const formattedCells = valueCells.filter(
+    cell => cell.style.backgroundColor !== '',
+  );
+  expect(formattedCells.length).toBeGreaterThan(0);
+  formattedCells.forEach(cell => {
+    expect(cell.style.color).not.toBe('');
+  });
+});
+
 test('TableRenderer renders correct number of thead and tbody sections', () => {
   const props = buildDefaultProps();
   renderWithTheme(<TableRenderer {...props} />);

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -376,6 +376,33 @@ test('TableRenderer coerces numeric timestamp strings to numbers for row header 
   expect(screen.getByText('row:red')).toBeInTheDocument();
 });
 
+test('TableRenderer applies cellColorFormatters background and contrast color to column headers', () => {
+  const cellColorFormatters = {
+    shape: [
+      {
+        column: 'shape',
+        getColorFromValue: (val: unknown) =>
+          val === 'circle' ? '#ff0000' : undefined,
+      },
+    ],
+  };
+  const props = buildDefaultProps({
+    tableOptions: { cellColorFormatters },
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // The matching column header should pick up the formatter's background
+  // color and a contrast-aware text color from getTextColorForBackground.
+  const formattedHeader = screen.getByText('circle').closest('th');
+  expect(formattedHeader).not.toBeNull();
+  expect(formattedHeader!.style.backgroundColor).not.toBe('');
+  expect(formattedHeader!.style.color).not.toBe('');
+
+  // The non-matching header should not get a background applied.
+  const plainHeader = screen.getByText('square').closest('th');
+  expect(plainHeader!.style.backgroundColor).toBe('');
+});
+
 test('TableRenderer renders correct number of thead and tbody sections', () => {
   const props = buildDefaultProps();
   renderWithTheme(<TableRenderer {...props} />);

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -353,6 +353,29 @@ test('TableRenderer coerces numeric timestamp strings to numbers for column head
   expect(screen.getByText('col:square')).toBeInTheDocument();
 });
 
+test('TableRenderer coerces numeric timestamp strings to numbers for row header date formatters', () => {
+  const dateFormatter = jest.fn((val: unknown) => `row:${String(val)}`);
+  const data = [
+    { color: '1700000000000', shape: 'circle', value: 1 },
+    { color: 'red', shape: 'circle', value: 2 },
+  ];
+  const props = buildDefaultProps({
+    data,
+    rows: ['color'],
+    cols: ['shape'],
+    tableOptions: { dateFormatters: { color: dateFormatter } },
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  // Row-header path mirrors the column path: numeric strings coerce to
+  // Number, non-numeric strings pass through verbatim.
+  expect(dateFormatter).toHaveBeenCalledWith(1700000000000);
+  expect(dateFormatter).toHaveBeenCalledWith('red');
+
+  expect(screen.getByText('row:1700000000000')).toBeInTheDocument();
+  expect(screen.getByText('row:red')).toBeInTheDocument();
+});
+
 test('TableRenderer renders correct number of thead and tbody sections', () => {
   const props = buildDefaultProps();
   renderWithTheme(<TableRenderer {...props} />);


### PR DESCRIPTION
## Summary

- Converts `PivotTable.tsx` and `TableRenderers.tsx` in the bundled `react-pivottable` fork inside `plugin-chart-pivot-table` from class components to function components
- Updates the associated `tableRenders.test.tsx` unit test

Part of the broader class→function component lint cleanup tracked in #37902.

## Test plan

- [ ] CI passes on the target feature branch
- [ ] Pivot table chart renders and pivots correctly
- [ ] Unit tests pass

## Additional information

This is sub-PR 3 of ~10, each targeting `chore/lint-cleanup-function-components`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)