### PR TITLE
chore(ci): require PMC review for CI-executed scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,11 @@
 
 /.github/ @villebro @geido @eschutho @rusackas @betodealmeida @nytai @mistercrunch @craig-rueda @kgabryje @dpgaspar @sadpandajoe @hainenber
 
+# Notify PMC members of changes to CI-executed scripts (supply-chain risk:
+# scripts/ files run directly in CI workflows and can execute arbitrary code)
+
+/scripts/ @villebro @geido @eschutho @rusackas @betodealmeida @nytai @mistercrunch @craig-rueda @kgabryje @dpgaspar @sadpandajoe @hainenber
+
 # Notify PMC members of changes to required GitHub Actions
 
 /.asf.yaml @villebro @geido @eschutho @rusackas @betodealmeida @nytai @mistercrunch @craig-rueda @kgabryje @dpgaspar @Antonio-RiveroMartnez

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,6 +17,11 @@
   - any-glob-to-any-file:
     - 'superset/migrations/**'
 
+"risk:ci-script":
+- changed-files:
+  - any-glob-to-any-file:
+    - 'scripts/**'
+
 ############################################
 # Dependencies
 ############################################


### PR DESCRIPTION
### SUMMARY

Scripts under `scripts/` are executed directly inside GitHub Actions CI workflows (e.g. `babel_update.sh`, `python_tests.sh`, `check_license.sh`, `change_detector.py`, and others). A PR that modifies one of these files can run arbitrary code on the CI runner — the same supply-chain risk that already motivates PMC review for `.github/` changes.

This PR closes that gap with two changes:

1. **CODEOWNERS** — adds a `/scripts/` entry using the same PMC owner list as `/.github/`, so any PR touching a CI script requires approval from a PMC member before it can be merged.

2. **labeler.yml** — adds a `risk:ci-script` label (orange, consistent with other `risk:` labels) that is automatically applied to any PR touching `scripts/**`, making the risk visible at a glance in the PR list.

The `risk:ci-script` label has been created in GitHub.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

- Open a PR that modifies any file under `scripts/` and verify:
  - The `risk:ci-script` label is automatically applied by the labeler action
  - The CODEOWNERS rule requests review from PMC members

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)