### PR TITLE
fix(oauth2): silence lock acquisition errors on token refresh

### DIFF
--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -82,6 +82,8 @@ def generate_code_challenge(code_verifier: str) -> str:
     factor=10,
     base=2,
     max_tries=5,
+    raise_on_giveup=False,
+    giveup_log_level=logging.DEBUG,
 )
 def get_oauth2_access_token(
     config: OAuth2ClientConfig,

--- a/tests/unit_tests/utils/oauth2_tests.py
+++ b/tests/unit_tests/utils/oauth2_tests.py
@@ -338,6 +338,45 @@ def test_encode_decode_oauth2_state(
     assert decoded["user_id"] == 2
 
 
+def test_get_oauth2_access_token_lock_not_acquired_no_error_log(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test that when a distributed lock can't be acquired, no error is logged and
+    the function returns None instead of raising.
+
+    This scenario occurs when a dashboard with multiple charts from the same
+    OAuth2-enabled DB has an expired token: simultaneous requests compete for
+    the lock, and only the first one wins. The rest should silently return None.
+    """
+    import logging
+
+    from superset.exceptions import AcquireDistributedLockFailedException
+
+    mocker.patch("time.sleep")  # avoid backoff delays in tests
+
+    db = mocker.patch("superset.utils.oauth2.db")
+    db_engine_spec = mocker.MagicMock()
+    token = mocker.MagicMock()
+    token.access_token = "access-token"  # noqa: S105
+    token.access_token_expiration = datetime(2024, 1, 1)
+    token.refresh_token = "refresh-token"  # noqa: S105
+    db.session.query().filter_by().one_or_none.return_value = token
+
+    mocker.patch(
+        "superset.utils.oauth2.refresh_oauth2_token",
+        side_effect=AcquireDistributedLockFailedException("Lock not available"),
+    )
+
+    with freeze_time("2024-01-02"):
+        with caplog.at_level(logging.DEBUG):
+            result = get_oauth2_access_token({}, 1, 1, db_engine_spec)
+
+    assert result is None
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
 def test_get_oauth2_redirect_uri_from_config(mocker: MockerFixture) -> None:
     """
     Test that get_oauth2_redirect_uri returns the configured value when set.


### PR DESCRIPTION
## Summary

When a dashboard contains multiple charts from the same OAuth2-enabled DB with an expired token, simultaneous requests all try to refresh the token at once. Only the first process acquires a distributed lock; the rest raise `AcquireDistributedLockFailedException`. This is expected behavior — the first request does the refresh and subsequent ones should just retry and find a valid token — but backoff was logging it at `ERROR` level and re-raising after all retries, which was both noisy and incorrect.

- Add `raise_on_giveup=False` to silently return `None` instead of re-raising when all retries are exhausted
- Add `giveup_log_level=logging.DEBUG` to downgrade the giveup log from `ERROR` to `DEBUG`
- Add unit test `test_get_oauth2_access_token_lock_not_acquired_no_error_log` covering this scenario

## Test plan
- [ ] `pytest tests/unit_tests/utils/oauth2_tests.py::test_get_oauth2_access_token_lock_not_acquired_no_error_log -xvs`
- [ ] Load a dashboard with multiple charts from the same OAuth2-enabled DB with an expired token and verify no error logs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)