### PR TITLE
fix(roles): resolve HTTP 429 and 414 errors on role management page

### DIFF
--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -233,16 +233,19 @@ describe('RoleListEditModal', () => {
   test('preserves missing IDs as numeric fallbacks on partial hydration', async () => {
     const mockGet = SupersetClient.get as jest.Mock;
     mockGet.mockImplementation(({ endpoint }) => {
-      if (endpoint?.includes('/api/v1/security/permissions-resources/')) {
+      if (
+        endpoint?.includes(
+          `/api/v1/security/roles/${mockRole.id}/permissions/`,
+        )
+      ) {
         // Only return permission id=10, not id=20
         return Promise.resolve({
           json: {
-            count: 1,
             result: [
               {
                 id: 10,
-                permission: { name: 'can_read' },
-                view_menu: { name: 'Dashboard' },
+                permission_name: 'can_read',
+                view_menu_name: 'Dashboard',
               },
             ],
           },
@@ -276,7 +279,11 @@ describe('RoleListEditModal', () => {
     mockToasts.addDangerToast.mockClear();
     const mockGet = SupersetClient.get as jest.Mock;
     mockGet.mockImplementation(({ endpoint }) => {
-      if (endpoint?.includes('/api/v1/security/permissions-resources/')) {
+      if (
+        endpoint?.includes(
+          `/api/v1/security/roles/${mockRole.id}/permissions/`,
+        )
+      ) {
         return Promise.reject(new Error('network error'));
       }
       if (endpoint?.includes('/api/v1/security/groups/')) {
@@ -346,24 +353,26 @@ describe('RoleListEditModal', () => {
     };
 
     mockGet.mockImplementation(({ endpoint }) => {
-      if (endpoint?.includes('/api/v1/security/permissions-resources/')) {
-        const query = rison.decode(endpoint.split('?q=')[1]) as Record<
-          string,
-          unknown
-        >;
-        const filters = query.filters as Array<{
-          col: string;
-          opr: string;
-          value: number[];
-        }>;
-        const ids = filters?.[0]?.value || [];
-        const result = ids.map((id: number) => ({
-          id,
-          permission: { name: `perm_${id}` },
-          view_menu: { name: `view_${id}` },
-        }));
+      if (endpoint?.includes(`/api/v1/security/roles/${roleA.id}/permissions/`)) {
         return Promise.resolve({
-          json: { count: result.length, result },
+          json: {
+            result: roleA.permission_ids.map(pid => ({
+              id: pid,
+              permission_name: `perm_${pid}`,
+              view_menu_name: `view_${pid}`,
+            })),
+          },
+        });
+      }
+      if (endpoint?.includes(`/api/v1/security/roles/${roleB.id}/permissions/`)) {
+        return Promise.resolve({
+          json: {
+            result: roleB.permission_ids.map(pid => ({
+              id: pid,
+              permission_name: `perm_${pid}`,
+              view_menu_name: `view_${pid}`,
+            })),
+          },
         });
       }
       return Promise.resolve({ json: { count: 0, result: [] } });
@@ -380,7 +389,7 @@ describe('RoleListEditModal', () => {
 
     await waitFor(() => {
       const permCall = mockGet.mock.calls.find(([c]) =>
-        c.endpoint.includes('/api/v1/security/permissions-resources/'),
+        c.endpoint.includes(`/api/v1/security/roles/${roleA.id}/permissions/`),
       );
       expect(permCall).toBeTruthy();
     });
@@ -400,26 +409,16 @@ describe('RoleListEditModal', () => {
 
     await waitFor(() => {
       const permCalls = mockGet.mock.calls.filter(([c]) =>
-        c.endpoint.includes('/api/v1/security/permissions-resources/'),
+        c.endpoint.includes(`/api/v1/security/roles/${roleB.id}/permissions/`),
       );
       expect(permCalls.length).toBeGreaterThan(0);
-      // Should request role B's IDs, not role A's
-      const query = rison.decode(
-        permCalls[0][0].endpoint.split('?q=')[1],
-      ) as Record<string, unknown>;
-      const filters = query.filters as Array<{
-        col: string;
-        opr: string;
-        value: number[];
-      }>;
-      expect(filters[0].value).toEqual(roleB.permission_ids);
     });
 
     unmount();
     mockGet.mockReset();
   });
 
-  test('fetches permissions and groups by id for hydration', async () => {
+  test('fetches permissions via role endpoint and groups by id for hydration', async () => {
     const mockGet = SupersetClient.get as jest.Mock;
     mockGet.mockResolvedValue({
       json: {
@@ -434,8 +433,11 @@ describe('RoleListEditModal', () => {
       expect(mockGet).toHaveBeenCalled();
     });
 
+    // Permissions should be fetched via the role's permissions endpoint (no ID list in URL)
     const permissionCall = mockGet.mock.calls.find(([call]) =>
-      call.endpoint.includes('/api/v1/security/permissions-resources/'),
+      call.endpoint.includes(
+        `/api/v1/security/roles/${mockRole.id}/permissions/`,
+      ),
     )?.[0];
     const groupsCall = mockGet.mock.calls.find(([call]) =>
       call.endpoint.includes('/api/v1/security/groups/'),
@@ -447,26 +449,17 @@ describe('RoleListEditModal', () => {
       throw new Error('Expected hydration calls to be defined');
     }
 
-    const permissionQuery = permissionCall.endpoint.match(/\?q=(.+)/);
+    // Permission endpoint has no query params (role ID is in the path)
+    expect(permissionCall.endpoint).toBe(
+      `/api/v1/security/roles/${mockRole.id}/permissions/`,
+    );
+
+    // Groups still use the id-in filter
     const groupsQuery = groupsCall.endpoint.match(/\?q=(.+)/);
-    expect(permissionQuery).toBeTruthy();
     expect(groupsQuery).toBeTruthy();
-    if (!permissionQuery || !groupsQuery) {
-      throw new Error('Expected query params to be present');
+    if (!groupsQuery) {
+      throw new Error('Expected groups query params to be present');
     }
-
-    expect(rison.decode(permissionQuery[1])).toEqual({
-      page_size: 100,
-      page: 0,
-      filters: [
-        {
-          col: 'id',
-          opr: 'in',
-          value: mockRole.permission_ids,
-        },
-      ],
-    });
-
     expect(rison.decode(groupsQuery[1])).toEqual({
       page_size: 100,
       page: 0,

--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -63,6 +63,16 @@ jest.mock('@superset-ui/core', () => {
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RoleListEditModal', () => {
+  beforeEach(() => {
+    (SupersetClient.get as jest.Mock).mockResolvedValue({
+      json: { count: 0, result: [] },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const mockRole = {
     id: 1,
     name: 'Admin',

--- a/superset-frontend/src/features/roles/RoleListEditModal.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.tsx
@@ -155,14 +155,13 @@ function RoleListEditModal({
     })
       .then(response => {
         permissionFetchSucceeded.current = true;
+        const result: Array<{
+          id: number;
+          permission_name: string;
+          view_menu_name: string;
+        }> = response.json?.result ?? [];
         setRolePermissions(
-          (
-            response.json?.result as Array<{
-              id: number;
-              permission_name: string;
-              view_menu_name: string;
-            }>
-          ).map(p => ({
+          result.map(p => ({
             value: p.id,
             label: formatPermissionLabel(p.permission_name, p.view_menu_name),
           })),

--- a/superset-frontend/src/features/roles/RoleListEditModal.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.tsx
@@ -33,6 +33,7 @@ import {
   SelectOption,
 } from 'src/features/roles/types';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
+import { SupersetClient } from '@superset-ui/core';
 import { fetchPaginatedData } from 'src/utils/fetchOptions';
 import { type UserObject } from 'src/pages/UsersList/types';
 import { ModalTitleWithIcon } from 'src/components/ModalTitleWithIcon';
@@ -146,41 +147,34 @@ function RoleListEditModal({
   }, [addDangerToast, id]);
 
   useEffect(() => {
-    if (!stablePermissionIds.length) {
-      setRolePermissions([]);
-      setLoadingRolePermissions(false);
-      return;
-    }
-
     setLoadingRolePermissions(true);
     permissionFetchSucceeded.current = false;
-    const filters = [{ col: 'id', opr: 'in', value: stablePermissionIds }];
 
-    fetchPaginatedData({
-      endpoint: `/api/v1/security/permissions-resources/`,
-      pageSize: 100,
-      setData: (data: SelectOption[]) => {
+    SupersetClient.get({
+      endpoint: `/api/v1/security/roles/${id}/permissions/`,
+    })
+      .then(response => {
         permissionFetchSucceeded.current = true;
-        setRolePermissions(data);
-      },
-      filters,
-      setLoadingState: (loading: boolean) => setLoadingRolePermissions(loading),
-      loadingKey: 'rolePermissions',
-      addDangerToast,
-      errorMessage: t('There was an error loading permissions.'),
-      mapResult: (permission: {
-        id: number;
-        permission: { name: string };
-        view_menu: { name: string };
-      }) => ({
-        value: permission.id,
-        label: formatPermissionLabel(
-          permission.permission.name,
-          permission.view_menu.name,
-        ),
-      }),
-    });
-  }, [addDangerToast, id, stablePermissionIds]);
+        setRolePermissions(
+          (
+            response.json?.result as Array<{
+              id: number;
+              permission_name: string;
+              view_menu_name: string;
+            }>
+          ).map(p => ({
+            value: p.id,
+            label: formatPermissionLabel(p.permission_name, p.view_menu_name),
+          })),
+        );
+      })
+      .catch(() => {
+        addDangerToast(t('There was an error loading permissions.'));
+      })
+      .finally(() => {
+        setLoadingRolePermissions(false);
+      });
+  }, [addDangerToast, id]);
 
   useEffect(() => {
     if (!stableGroupIds.length) {

--- a/superset-frontend/src/features/roles/RoleListEditModal.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.tsx
@@ -148,6 +148,12 @@ function RoleListEditModal({
   }, [addDangerToast, id]);
 
   useEffect(() => {
+    if (!stablePermissionIds.length) {
+      setRolePermissions([]);
+      setLoadingRolePermissions(false);
+      return;
+    }
+
     let cancelled = false;
     setLoadingRolePermissions(true);
     permissionFetchSucceeded.current = false;
@@ -180,7 +186,7 @@ function RoleListEditModal({
     return () => {
       cancelled = true;
     };
-  }, [addDangerToast, id]);
+  }, [addDangerToast, id, stablePermissionIds]);
 
   useEffect(() => {
     if (!stableGroupIds.length) {

--- a/superset-frontend/src/features/roles/RoleListEditModal.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.tsx
@@ -30,6 +30,7 @@ import {
 import {
   BaseModalProps,
   RoleForm,
+  RolePermissions,
   SelectOption,
 } from 'src/features/roles/types';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
@@ -147,6 +148,7 @@ function RoleListEditModal({
   }, [addDangerToast, id]);
 
   useEffect(() => {
+    let cancelled = false;
     setLoadingRolePermissions(true);
     permissionFetchSucceeded.current = false;
 
@@ -154,12 +156,9 @@ function RoleListEditModal({
       endpoint: `/api/v1/security/roles/${id}/permissions/`,
     })
       .then(response => {
+        if (cancelled) return;
         permissionFetchSucceeded.current = true;
-        const result: Array<{
-          id: number;
-          permission_name: string;
-          view_menu_name: string;
-        }> = response.json?.result ?? [];
+        const result: RolePermissions[] = response.json.result ?? [];
         setRolePermissions(
           result.map(p => ({
             value: p.id,
@@ -168,11 +167,19 @@ function RoleListEditModal({
         );
       })
       .catch(() => {
-        addDangerToast(t('There was an error loading permissions.'));
+        if (!cancelled) {
+          addDangerToast(t('There was an error loading permissions.'));
+        }
       })
       .finally(() => {
-        setLoadingRolePermissions(false);
+        if (!cancelled) {
+          setLoadingRolePermissions(false);
+        }
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [addDangerToast, id]);
 
   useEffect(() => {

--- a/superset-frontend/src/utils/fetchOptions.ts
+++ b/superset-frontend/src/utils/fetchOptions.ts
@@ -88,16 +88,21 @@ export const fetchPaginatedData = async ({
     }
 
     const totalPages = Math.ceil(totalItems / pageSize);
+    const concurrencyLimit = 5;
+    const allResults = [...firstPageResults];
 
-    const requests = Array.from({ length: totalPages - 1 }, (_, i) =>
-      fetchPage(i + 1),
-    );
-    const remainingResults = await Promise.all(requests);
+    for (let batch = 1; batch < totalPages; batch += concurrencyLimit) {
+      const batchEnd = Math.min(batch + concurrencyLimit, totalPages);
+      // eslint-disable-next-line no-await-in-loop
+      const batchResults = await Promise.all(
+        Array.from({ length: batchEnd - batch }, (_, i) =>
+          fetchPage(batch + i),
+        ),
+      );
+      allResults.push(...batchResults.flatMap(res => res.results));
+    }
 
-    setData([
-      ...firstPageResults,
-      ...remainingResults.flatMap(res => res.results),
-    ]);
+    setData(allResults);
   } catch (err) {
     addDangerToast(t(errorMessage));
   } finally {


### PR DESCRIPTION
### SUMMARY

Fixes two related errors on the Role management page when roles have many permissions:

**HTTP 414 (URI Too Long)** — When loading a role's permissions in the edit modal, the old code built a filter `id in [all_permission_ids]` and rison-encoded the entire ID list into the GET query string. For roles with hundreds or thousands of permissions this exceeds URL length limits.

**Fix:** Use the existing FAB endpoint `GET /api/v1/security/roles/{id}/permissions/` instead. The role ID goes in the path, so URL length is constant regardless of permission count. One request replaces N paginated requests.

**HTTP 429 (Too Many Requests)** — `fetchPaginatedData` fetched the first page to get the total count, then fired **all** remaining pages simultaneously via `Promise.all()`. With 226 pages that meant 225 concurrent requests at once.

**Fix:** Process pages in sequential batches of 5 (matching the pattern already used in `fetchAllPermissionPages` in `utils.ts`).

Note: apache/superset#37235 (already merged) fixed the same 414 pattern for the **users** fetch. This PR applies the same class of fix to **permissions**.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — fixes network errors, no visual change when working correctly.

### TESTING INSTRUCTIONS

1. Create or find a role with a large number of permissions (hundreds+)
2. Navigate to **Settings → Security → List Roles**
3. Click the edit (pencil) icon on that role
4. Verify the edit modal opens without HTTP 429 or 414 errors in the network tab
5. Verify permissions load correctly with their labels

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API