### PR TITLE
feat(audit-log): add source column to action logs

### DIFF
--- a/superset-frontend/src/pages/ActionLog/index.tsx
+++ b/superset-frontend/src/pages/ActionLog/index.tsx
@@ -38,6 +38,7 @@ export type ActionLogObject = {
   };
 
   action: string;
+  source?: string;
   dttm: string | null;
   dashboard_id?: number;
   slice_id?: number;
@@ -106,6 +107,21 @@ function ActionLogList() {
         operator: ListViewFilterOperator.Contains,
       },
       {
+        Header: t('Source'),
+        key: 'source',
+        id: 'source',
+        input: 'select',
+        operator: ListViewFilterOperator.Equals,
+        unfilteredLabel: t('All'),
+        selects: [
+          { label: t('API'), value: 'API' },
+          { label: t('MCP'), value: 'MCP' },
+          { label: t('Chatbot'), value: 'Chatbot' },
+          { label: t('Preset'), value: 'Preset' },
+          { label: t('Embedded'), value: 'Embedded' },
+        ],
+      },
+      {
         Header: t('JSON'),
         key: 'json',
         id: 'json',
@@ -148,6 +164,15 @@ function ActionLogList() {
             original: { action },
           },
         }: any) => <span>{action}</span>,
+      },
+      {
+        accessor: 'source',
+        Header: t('Source'),
+        Cell: ({
+          row: {
+            original: { source },
+          },
+        }: any) => <span>{source}</span>,
       },
       {
         accessor: 'user',

--- a/superset/migrations/versions/2026-04-19_00-00_5c9c775d72de_add_source_to_logs.py
+++ b/superset/migrations/versions/2026-04-19_00-00_5c9c775d72de_add_source_to_logs.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add source column to logs table
+
+Revision ID: 5c9c775d72de
+Revises: ce6bd21901ab
+Create Date: 2026-04-19 00:00:00.000000
+
+"""
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+from superset.migrations.shared.utils import get_table_column
+
+logger = logging.getLogger("alembic.env")
+
+# revision identifiers, used by Alembic.
+revision = "5c9c775d72de"
+down_revision = "ce6bd21901ab"
+
+
+def upgrade() -> None:
+    column_info = get_table_column("logs", "source")
+    if column_info is not None:
+        logger.info("Column logs.source already exists. Skipping migration.")
+        return
+
+    with op.batch_alter_table("logs") as batch_op:
+        batch_op.add_column(sa.Column("source", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    column_info = get_table_column("logs", "source")
+    if column_info is None:
+        logger.info("Column logs.source does not exist. Skipping downgrade.")
+        return
+
+    with op.batch_alter_table("logs") as batch_op:
+        batch_op.drop_column("source")

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1377,6 +1377,7 @@ class Log(Model):  # pylint: disable=too-few-public-methods
     dttm = Column(DateTime, default=datetime.utcnow)
     duration_ms = Column(Integer)
     referrer = Column(String(1024))
+    source = Column(String(32), nullable=True)
 
 
 class FavStarClassName(StrEnum):

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -32,9 +32,18 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from superset.extensions import stats_logger_manager
 from superset.utils import json
+from superset.utils.backports import StrEnum
 from superset.utils.core import get_user_id, LoggerLevel, to_int
 
 logger = logging.getLogger(__name__)
+
+
+class AuditLogSource(StrEnum):
+    API = "API"
+    MCP = "MCP"
+    CHATBOT = "Chatbot"
+    PRESET = "Preset"
+    EMBEDDED = "Embedded"
 
 
 def collect_request_payload() -> dict[str, Any]:
@@ -399,6 +408,7 @@ class DBEventLogger(AbstractEventLogger):
                 duration_ms=duration_ms,
                 referrer=referrer,
                 user_id=user_id,
+                source=kwargs.get("source"),
             )
             logs.append(log)
         try:

--- a/superset/views/log/__init__.py
+++ b/superset/views/log/__init__.py
@@ -29,6 +29,7 @@ class LogMixin:  # pylint: disable=too-few-public-methods
     label_columns = {
         "user": _("User"),
         "action": _("Action"),
+        "source": _("Source"),
         "dttm": _("dttm"),
         "json": _("JSON"),
     }

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -51,6 +51,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         "user.username",
         "user_id",
         "action",
+        "source",
         "dttm",
         "json",
         "slice_id",
@@ -62,6 +63,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         "user",
         "user_id",
         "action",
+        "source",
         "dttm",
         "json",
         "slice_id",
@@ -108,8 +110,9 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
     @statsd_metrics
     @rison(get_recent_activity_schema)
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".recent_activity",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.recent_activity"
+        ),
         log_to_statsd=False,
     )
     def recent_activity(self, **kwargs: Any) -> FlaskResponse:

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -47,6 +47,7 @@ EXPECTED_COLUMNS = [
     "json",
     "referrer",
     "slice_id",
+    "source",
     "user",
     "user_id",
 ]

--- a/tests/unit_tests/utils/log_tests.py
+++ b/tests/unit_tests/utils/log_tests.py
@@ -16,7 +16,7 @@
 # under the License.
 
 
-from superset.utils.log import get_logger_from_status
+from superset.utils.log import AuditLogSource, get_logger_from_status
 
 
 def test_log_from_status_exception() -> None:
@@ -35,3 +35,11 @@ def test_log_from_status_info() -> None:
     (func, log_level) = get_logger_from_status(300)
     assert func.__name__ == "info"
     assert log_level == "info"
+
+
+def test_audit_log_source_values() -> None:
+    assert AuditLogSource.API == "API"
+    assert AuditLogSource.MCP == "MCP"
+    assert AuditLogSource.CHATBOT == "Chatbot"
+    assert AuditLogSource.PRESET == "Preset"
+    assert AuditLogSource.EMBEDDED == "Embedded"


### PR DESCRIPTION
### SUMMARY

Adds a `source` column to the `logs` table to allow consumers to distinguish how an action was triggered. This enables operators to filter audit logs by the originating source.

**Changes:**
- `AuditLogSource` enum in `superset/utils/log.py` with values: `API`, `MCP`, `Chatbot`, `Preset`, `Embedded`
- `source` column (`String(32)`, nullable) added to the `Log` SQLAlchemy model
- DB migration `5c9c775d72de` to add `logs.source`
- `DBEventLogger.log()` reads `source` from `**kwargs` and stores it
- `LogRestApi` exposes `source` in `list_columns` and `search_columns`
- `LogMixin` adds `source` label
- Frontend `ActionLogList` shows a Source column (after Action) and a Source dropdown filter

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: Action log list has no Source column or filter.

After: Action log list shows a Source column after Action, and a Source dropdown filter with options: API, MCP, Chatbot, Preset, Embedded.

### TESTING INSTRUCTIONS

1. Run the DB migration: `superset db upgrade`
2. Navigate to **Settings > Action Log**
3. Verify the **Source** column appears after the **Action** column
4. Verify the **Source** dropdown filter is present with the correct options
5. Create a log entry via the API and verify `source` is stored and displayed
6. Run unit tests: `pytest tests/unit_tests/utils/log_tests.py -v`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API