### PR TITLE
docs: fix grammar in code comments (wont/dont/doesnt)

### DIFF
--- a/superset/async_events/cache_backend.py
+++ b/superset/async_events/cache_backend.py
@@ -173,7 +173,7 @@ class RedisSentinelCacheBackend(RedisSentinelCache):
         ssl_ca_certs: str | None = None,
         **kwargs: Any,
     ) -> None:
-        # Sentinel dont directly support SSL
+        # Sentinel doesn't directly support SSL
         # Initialize Sentinel without SSL parameters
         self._sentinel = Sentinel(
             sentinels,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1585,7 +1585,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 for metric in metric_names
             }
 
-            # When the original query has limit or offset we wont apply those
+            # When the original query has limit or offset we won't apply those
             # to the subquery so we prevent data inconsistency due to missing records
             # in the dataframes when performing the join
             if query_object.row_limit or query_object.row_offset:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -856,7 +856,7 @@ class Superset(BaseSupersetView):
         if url_params := state.get("urlParams"):
             for param_key, param_val in url_params:
                 if param_key == "native_filters":
-                    # native_filters doesnt need to be encoded here
+                    # native_filters doesn't need to be encoded here
                     url = f"{url}&native_filters={param_val}"
                 else:
                     params = parse.urlencode([(param_key, param_val)])


### PR DESCRIPTION

**Repo:** apache/superset (⭐ 61000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Fixes minor grammatical errors in three inline code comments where contractions
were missing apostrophes: "wont" → "won't" in `superset/models/helpers.py`,
"dont" → "doesn't" in `superset/async_events/cache_backend.py`, and "doesnt" →
"doesn't" in `superset/views/core.py`.

## Why
Comments are part of the codebase's readability. Grammatically correct
contractions make the intent clearer to future readers and align with the
quality bar maintained across the project. Pure comment-only change with no
runtime impact.

## Testing
No behavior changes — comments only. Pre-commit/lint should pass without
modifications. No tests required.

## Risk
Low — comment-only edits, zero runtime impact.
