### PR TITLE
fix(import): import tags during CLI native asset import

### DIFF
--- a/superset/commands/importers/v1/assets.py
+++ b/superset/commands/importers/v1/assets.py
@@ -35,6 +35,7 @@ from superset.commands.dataset.importers.v1.utils import import_dataset
 from superset.commands.exceptions import CommandInvalidError, ImportFailedError
 from superset.commands.importers.v1.utils import (
     get_resource_mappings_batched,
+    import_tag,
     load_configs,
     load_metadata,
     validate_metadata_type,
@@ -45,6 +46,7 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.dashboards.schemas import ImportV1DashboardSchema
 from superset.databases.schemas import ImportV1DatabaseSchema
 from superset.datasets.schemas import ImportV1DatasetSchema
+from superset.extensions import feature_flag_manager
 from superset.migrations.shared.native_filters import migrate_dashboard
 from superset.models.core import Database
 from superset.models.dashboard import dashboard_slices
@@ -90,7 +92,12 @@ class ImportAssetsCommand(BaseCommand):
 
     # pylint: disable=too-many-locals
     @staticmethod
-    def _import(configs: dict[str, Any], sparse: bool = False) -> None:  # noqa: C901
+    def _import(  # noqa: C901
+        configs: dict[str, Any],
+        sparse: bool = False,
+        contents: Optional[dict[str, Any]] = None,
+    ) -> None:
+        contents = {} if contents is None else contents
         # import databases first
         database_ids: dict[str, int] = {}
         dataset_info: dict[str, dict[str, Any]] = {}
@@ -139,6 +146,13 @@ class ImportAssetsCommand(BaseCommand):
                 charts.append(chart)
                 chart_ids[str(chart.uuid)] = chart.id
 
+                # Handle tags using import_tag function
+                if feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
+                    if "tags" in config:
+                        import_tag(
+                            config["tags"], contents, chart.id, "chart", db.session
+                        )
+
         # import dashboards
         for file_name, config in configs.items():
             if file_name.startswith("dashboards/"):
@@ -164,6 +178,17 @@ class ImportAssetsCommand(BaseCommand):
                 )
                 db.session.execute(insert(dashboard_slices).values(dashboard_chart_ids))
 
+                # Handle tags using import_tag function
+                if feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
+                    if "tags" in config:
+                        import_tag(
+                            config["tags"],
+                            contents,
+                            dashboard.id,
+                            "dashboard",
+                            db.session,
+                        )
+
                 # Migrate any filter-box charts to native dashboard filters.
                 migrate_dashboard(dashboard)
 
@@ -181,7 +206,7 @@ class ImportAssetsCommand(BaseCommand):
     )
     def run(self) -> None:
         self.validate()
-        self._import(self._configs, self.sparse)
+        self._import(self._configs, self.sparse, self.contents)
 
     def validate(self) -> None:
         exceptions: list[ValidationError] = []

--- a/tests/unit_tests/commands/importers/v1/assets_test.py
+++ b/tests/unit_tests/commands/importers/v1/assets_test.py
@@ -17,6 +17,7 @@
 
 import copy
 
+import yaml
 from pytest_mock import MockerFixture
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import select
@@ -100,6 +101,119 @@ def test_import_adds_dashboard_charts(mocker: MockerFixture, session: Session) -
 
     assert len(chart_ids) == expected_number_of_charts
     assert len(dashboard_ids) == expected_number_of_dashboards
+
+
+def test_import_assets_imports_tags(mocker: MockerFixture, session: Session) -> None:
+    """
+    Test that tags on charts and dashboards are imported when importing assets
+    via ``ImportAssetsCommand`` (the code path used by the CLI ``sync native``
+    command). Previously tags were silently dropped for the CLI path.
+    """
+    from superset import db, security_manager
+    from superset.commands.importers.v1.assets import ImportAssetsCommand
+    from superset.extensions import feature_flag_manager
+    from superset.models.dashboard import Dashboard
+    from superset.models.slice import Slice
+    from superset.tags.models import Tag, TaggedObject
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+    mocker.patch.object(feature_flag_manager, "is_feature_enabled", return_value=True)
+
+    engine = db.session.get_bind()
+    Slice.metadata.create_all(engine)  # pylint: disable=no-member
+    Tag.metadata.create_all(engine)  # pylint: disable=no-member
+
+    charts_with_tags = copy.deepcopy(charts_config_1)
+    for chart_config in charts_with_tags.values():
+        chart_config["tags"] = ["chart_tag"]
+
+    dashboards_with_tags = copy.deepcopy(dashboards_config_1)
+    for dashboard_config in dashboards_with_tags.values():
+        dashboard_config["tags"] = ["dashboard_tag"]
+
+    configs = {
+        **copy.deepcopy(databases_config),
+        **copy.deepcopy(datasets_config),
+        **charts_with_tags,
+        **dashboards_with_tags,
+    }
+    contents = {
+        "tags.yaml": yaml.dump(
+            {
+                "tags": [
+                    {"tag_name": "chart_tag", "description": "Tag for charts"},
+                    {
+                        "tag_name": "dashboard_tag",
+                        "description": "Tag for dashboards",
+                    },
+                ]
+            }
+        )
+    }
+
+    ImportAssetsCommand._import(configs, contents=contents)
+
+    chart_uuids = {config["uuid"] for config in charts_with_tags.values()}
+    imported_charts = db.session.query(Slice).filter(Slice.uuid.in_(chart_uuids)).all()
+    assert len(imported_charts) == len(chart_uuids)
+    for chart in imported_charts:
+        assocs = (
+            db.session.query(TaggedObject)
+            .filter_by(object_id=chart.id, object_type="chart")
+            .all()
+        )
+        assert len(assocs) == 1
+        assert assocs[0].tag.name == "chart_tag"
+
+    dashboard_uuids = {config["uuid"] for config in dashboards_with_tags.values()}
+    imported_dashboards = (
+        db.session.query(Dashboard).filter(Dashboard.uuid.in_(dashboard_uuids)).all()
+    )
+    assert len(imported_dashboards) == len(dashboard_uuids)
+    for dashboard in imported_dashboards:
+        assocs = (
+            db.session.query(TaggedObject)
+            .filter_by(object_id=dashboard.id, object_type="dashboard")
+            .all()
+        )
+        assert len(assocs) == 1
+        assert assocs[0].tag.name == "dashboard_tag"
+
+
+def test_import_assets_skips_tags_when_feature_disabled(
+    mocker: MockerFixture, session: Session
+) -> None:
+    """
+    Test that tag import is skipped when the ``TAGGING_SYSTEM`` feature flag
+    is disabled, even when the configs include tags.
+    """
+    from superset import db, security_manager
+    from superset.commands.importers.v1.assets import ImportAssetsCommand
+    from superset.extensions import feature_flag_manager
+    from superset.models.slice import Slice
+    from superset.tags.models import Tag, TaggedObject
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+    mocker.patch.object(feature_flag_manager, "is_feature_enabled", return_value=False)
+
+    engine = db.session.get_bind()
+    Slice.metadata.create_all(engine)  # pylint: disable=no-member
+    Tag.metadata.create_all(engine)  # pylint: disable=no-member
+
+    charts_with_tags = copy.deepcopy(charts_config_1)
+    for chart_config in charts_with_tags.values():
+        chart_config["tags"] = ["chart_tag"]
+
+    configs = {
+        **copy.deepcopy(databases_config),
+        **copy.deepcopy(datasets_config),
+        **charts_with_tags,
+        **copy.deepcopy(dashboards_config_1),
+    }
+
+    ImportAssetsCommand._import(configs)
+
+    assert db.session.query(TaggedObject).count() == 0
 
 
 def test_import_removes_dashboard_charts(


### PR DESCRIPTION
### SUMMARY

The CLI asset import path (`ImportAssetsCommand`, invoked by `superset sync native`) did not call `import_tag` for charts or dashboards, so tags present in exported YAML were silently dropped. The UI import path (`ImportChartsCommand` / `ImportDashboardsCommand`) already handles tags correctly.

This PR aligns the CLI path with the UI path by:

- Adding `import_tag` + `feature_flag_manager` imports to `superset/commands/importers/v1/assets.py`
- Extending `ImportAssetsCommand._import` to accept `contents` so it can read optional `tags.yaml` metadata (tag descriptions)
- Calling `import_tag(...)` for each imported chart and dashboard under the `TAGGING_SYSTEM` feature flag
- Passing `self.contents` into `_import` from `run()`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (CLI-only change)

### TESTING INSTRUCTIONS

1. Enable the `TAGGING_SYSTEM` feature flag.
2. Add a tag to a dashboard and/or chart in the UI.
3. Export the asset via the UI or CLI (produces a ZIP with YAML files, including `tags.yaml`).
4. Delete the asset.
5. Import the ZIP using `superset import-directory` (or the `superset sync native` wrapper that ultimately calls `ImportAssetsCommand`).
6. Verify that the imported asset has the expected tag associations.

Automated coverage:

```
pytest tests/unit_tests/commands/importers/v1/assets_test.py
```

Two new tests cover the fix:
- `test_import_assets_imports_tags` — asserts `TaggedObject` rows exist for imported charts and dashboards when `TAGGING_SYSTEM` is enabled.
- `test_import_assets_skips_tags_when_feature_disabled` — asserts no tags are created when the feature flag is disabled.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `TAGGING_SYSTEM` (existing; behavior is gated on this flag)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API