### PR TITLE
chore: simplify Trino's OAuth detection

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -66,16 +66,6 @@ except ImportError:
     HttpError = Exception
 
 
-class CustomTrinoAuthErrorMeta(type):
-    def __instancecheck__(cls, instance: object) -> bool:
-        logger.info("is this being called?")
-        return isinstance(instance, HttpError) and "error 401" in str(instance)
-
-
-class TrinoAuthError(HttpError, metaclass=CustomTrinoAuthErrorMeta):
-    pass
-
-
 class TrinoEngineSpec(PrestoBaseEngineSpec):
     engine = "trino"
     engine_name = "Trino"
@@ -160,8 +150,21 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
 
     # OAuth 2.0
     supports_oauth2 = True
-    oauth2_exception = TrinoAuthError
     oauth2_token_request_type = "data"  # noqa: S105
+
+    @classmethod
+    def needs_oauth2(cls, ex: Exception) -> bool:
+        """
+        Check if the exception indicates that OAuth2 authentication is required.
+
+        Trino returns an HTTP 401 error when the access token is missing or expired.
+        """
+        return (
+            bool(g)
+            and hasattr(g, "user")
+            and isinstance(ex, HttpError)
+            and "error 401" in str(ex)
+        )
 
     @classmethod
     def get_extra_table_metadata(

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -859,6 +859,64 @@ def test_get_oauth2_token(
     )
 
 
+def test_needs_oauth2_with_401_error(mocker: MockerFixture) -> None:
+    """
+    Test that needs_oauth2 returns True when Trino raises an HTTP 401 error.
+    """
+    from trino.exceptions import HttpError
+
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    g = mocker.patch("superset.db_engine_specs.trino.g")
+    g.user = mocker.MagicMock()
+
+    ex = HttpError("error 401: Unauthorized")
+    assert TrinoEngineSpec.needs_oauth2(ex) is True
+
+
+def test_needs_oauth2_without_401_error(mocker: MockerFixture) -> None:
+    """
+    Test that needs_oauth2 returns False when the error is not a 401.
+    """
+    from trino.exceptions import HttpError
+
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    g = mocker.patch("superset.db_engine_specs.trino.g")
+    g.user = mocker.MagicMock()
+
+    ex = HttpError("error 500: Internal Server Error")
+    assert TrinoEngineSpec.needs_oauth2(ex) is False
+
+
+def test_needs_oauth2_with_non_http_error(mocker: MockerFixture) -> None:
+    """
+    Test that needs_oauth2 returns False for non-HttpError exceptions.
+    """
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    g = mocker.patch("superset.db_engine_specs.trino.g")
+    g.user = mocker.MagicMock()
+
+    ex = RuntimeError("error 401: something else")
+    assert TrinoEngineSpec.needs_oauth2(ex) is False
+
+
+def test_needs_oauth2_without_user(mocker: MockerFixture) -> None:
+    """
+    Test that needs_oauth2 returns False when there is no authenticated user.
+    """
+    from trino.exceptions import HttpError
+
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    g = mocker.patch("superset.db_engine_specs.trino.g")
+    del g.user
+
+    ex = HttpError("error 401: Unauthorized")
+    assert TrinoEngineSpec.needs_oauth2(ex) is False
+
+
 @pytest.mark.parametrize(
     "time_grain,expected_result",
     [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The logic to start OAuth in Trino is a bit convoluted, since it's based on the only example available at the time GSheets. GSheets has a custom exception that indicates OAuth is needed, but only because I added it. :D Trino follows the same pattern, but via a metaclass that implements `__instancecheck__`, which is way more complicated than it should be.

This PR changes the Trino DB engine spec to use `needs_oauth2` instead, which is the right approach in this case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
