### PR TITLE
fix(trino/presto): use equality for boolean filters to support computed columns

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -165,6 +165,10 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
 
     supports_dynamic_schema = True
     supports_catalog = supports_dynamic_catalog = supports_cross_catalog_queries = True
+    # Presto/Trino don't reliably support IS true/false on computed boolean
+    # expressions (e.g. columns defined as `(expiration = 1) AS expiration`),
+    # which raises a query error. Use = true/false instead.
+    use_equality_for_boolean_filters = True
 
     column_type_mappings = (
         (

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -342,3 +342,33 @@ SELECT * \nFROM my_catalog.my_schema.my_table
  LIMIT :param_1
     """.strip()
     )
+
+
+def test_handle_boolean_filter() -> None:
+    """
+    Test that Presto uses equality operators for boolean filters instead of IS,
+    since `col IS TRUE` can fail on computed boolean expressions like
+    `(expiration = 1) AS expiration`.
+    """
+    from sqlalchemy import Boolean, Column
+
+    from superset.db_engine_specs.presto import PrestoEngineSpec
+    from superset.utils.core import FilterOperator
+
+    bool_col = Column("test_col", Boolean)
+
+    result_true = PrestoEngineSpec.handle_boolean_filter(
+        bool_col, FilterOperator.IS_TRUE, True
+    )
+    assert (
+        str(result_true.compile(compile_kwargs={"literal_binds": True}))
+        == "test_col = true"
+    )
+
+    result_false = PrestoEngineSpec.handle_boolean_filter(
+        bool_col, FilterOperator.IS_FALSE, False
+    )
+    assert (
+        str(result_false.compile(compile_kwargs={"literal_binds": True}))
+        == "test_col = false"
+    )

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -372,3 +372,17 @@ def test_handle_boolean_filter() -> None:
         str(result_false.compile(compile_kwargs={"literal_binds": True}))
         == "test_col = false"
     )
+
+    # Regression: the original bug was on computed boolean columns like
+    # `(expiration = 1) AS expiration`. Verify the equality operator also
+    # compiles correctly when the "column" is a computed expression.
+    from sqlalchemy import literal_column
+
+    computed_col = literal_column("(expiration = 1)")
+    result_computed = PrestoEngineSpec.handle_boolean_filter(
+        computed_col, FilterOperator.IS_TRUE, True
+    )
+    assert (
+        str(result_computed.compile(compile_kwargs={"literal_binds": True}))
+        == "(expiration = 1) = true"
+    )

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -1443,3 +1443,33 @@ def test_handle_cursor_commits_on_progress_text_change(
 
     # There should be commits for progress_text changes
     assert mock_db.session.commit.call_count >= 2
+
+
+def test_handle_boolean_filter() -> None:
+    """
+    Test that Trino uses equality operators for boolean filters instead of IS,
+    since `col IS TRUE` can fail on computed boolean expressions like
+    `(expiration = 1) AS expiration`.
+    """
+    from sqlalchemy import Boolean, Column
+
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+    from superset.utils.core import FilterOperator
+
+    bool_col = Column("test_col", Boolean)
+
+    result_true = TrinoEngineSpec.handle_boolean_filter(
+        bool_col, FilterOperator.IS_TRUE, True
+    )
+    assert (
+        str(result_true.compile(compile_kwargs={"literal_binds": True}))
+        == "test_col = true"
+    )
+
+    result_false = TrinoEngineSpec.handle_boolean_filter(
+        bool_col, FilterOperator.IS_FALSE, False
+    )
+    assert (
+        str(result_false.compile(compile_kwargs={"literal_binds": True}))
+        == "test_col = false"
+    )

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -1473,3 +1473,17 @@ def test_handle_boolean_filter() -> None:
         str(result_false.compile(compile_kwargs={"literal_binds": True}))
         == "test_col = false"
     )
+
+    # Regression: the original bug was on computed boolean columns like
+    # `(expiration = 1) AS expiration`. Verify the equality operator also
+    # compiles correctly when the "column" is a computed expression.
+    from sqlalchemy import literal_column
+
+    computed_col = literal_column("(expiration = 1)")
+    result_computed = TrinoEngineSpec.handle_boolean_filter(
+        computed_col, FilterOperator.IS_TRUE, True
+    )
+    assert (
+        str(result_computed.compile(compile_kwargs={"literal_binds": True}))
+        == "(expiration = 1) = true"
+    )


### PR DESCRIPTION
### SUMMARY

Selecting `IS TRUE` (or `IS FALSE`) on a boolean chart filter raised an error on Trino/Presto when the column was derived from a cast such as `(expiration = 1) AS expiration`. The backend generated `col IS true`, which Trino/Presto reject on these computed boolean expressions.

This PR sets `use_equality_for_boolean_filters = True` on `PrestoBaseEngineSpec`, so both `TrinoEngineSpec` and `PrestoEngineSpec` emit `col = true` / `col = false` instead. This matches the existing Athena behavior introduced in #34598 (Athena is Presto-based and hit the same issue).

Fixes internal ticket sc-97540.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — purely a SQL generation fix.

Before: `SELECT ... WHERE expiration IS true` → query error on Trino/Presto.
After: `SELECT ... WHERE expiration = true` → succeeds.

### TESTING INSTRUCTIONS

1. Connect Superset to a Trino or Presto database.
2. Create a dataset with a computed boolean column, e.g. a virtual dataset selecting `(expiration = 1) AS expiration`.
3. Build a chart against that dataset and add a filter on the `expiration` column with operator `IS TRUE` (or `IS FALSE`).
4. Click **Update Chart** — the query should run successfully and the generated SQL in the query history should use `expiration = true` instead of `expiration IS true`.

Unit tests added:
- `tests/unit_tests/db_engine_specs/test_trino.py::test_handle_boolean_filter`
- `tests/unit_tests/db_engine_specs/test_presto.py::test_handle_boolean_filter`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API