### PR TITLE
fix(sqllab): include template_params when overwriting a dataset

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -391,10 +391,19 @@ describe('SaveDatasetModal', () => {
     await setupOverwriteFlow();
 
     await waitFor(() => {
-      expect(putSpy).toHaveBeenCalled();
+      expect(
+        putSpy.mock.calls.some(([req]) =>
+          req.endpoint?.includes('api/v1/dataset/'),
+        ),
+      ).toBe(true);
     });
 
-    const body = JSON.parse(putSpy.mock.calls[0][0].body as string);
+    const datasetPutCall = putSpy.mock.calls.find(([req]) =>
+      req.endpoint?.includes('api/v1/dataset/'),
+    )!;
+    const [req] = datasetPutCall;
+    expect(req.endpoint).toContain('override_columns=true');
+    const body = JSON.parse(req.body as string);
     // _filters should be stripped, but my_param should be preserved
     expect(body.template_params).toEqual(JSON.stringify({ my_param: 12 }));
 
@@ -430,10 +439,18 @@ describe('SaveDatasetModal', () => {
     await setupOverwriteFlow();
 
     await waitFor(() => {
-      expect(putSpy).toHaveBeenCalled();
+      expect(
+        putSpy.mock.calls.some(([req]) =>
+          req.endpoint?.includes('api/v1/dataset/'),
+        ),
+      ).toBe(true);
     });
 
-    const body = JSON.parse(putSpy.mock.calls[0][0].body as string);
+    const datasetPutCall = putSpy.mock.calls.find(([req]) =>
+      req.endpoint?.includes('api/v1/dataset/'),
+    )!;
+    const [req] = datasetPutCall;
+    const body = JSON.parse(req.body as string);
     expect(body.template_params).toBeUndefined();
 
     putSpy.mockRestore();

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -29,7 +29,7 @@ import fetchMock from 'fetch-mock';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
 import { createDatasource } from 'src/SqlLab/actions/sqlLab';
 import { user, testQuery, mockdatasets } from 'src/SqlLab/fixtures';
-import { FeatureFlag } from '@superset-ui/core';
+import { FeatureFlag, SupersetClient } from '@superset-ui/core';
 
 const mockedProps = {
   visible: true,
@@ -339,6 +339,104 @@ describe('SaveDatasetModal', () => {
       sql: 'SELECT *',
       templateParams: undefined,
     });
+  });
+
+  const setupOverwriteFlow = async () => {
+    // Select the "Overwrite existing" radio
+    userEvent.click(screen.getByRole('radio', { name: /overwrite existing/i }));
+    // Open the select and pick an existing dataset
+    userEvent.click(
+      screen.getByRole('combobox', { name: /existing dataset/i }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText('Loading...')).not.toBeVisible(),
+    );
+    userEvent.click(screen.getAllByText('coolest table 0')[1]);
+    // First overwrite click → confirmation screen
+    userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
+    // Wait for the confirmation screen to render
+    await screen.findByText(/are you sure you want to overwrite this dataset/i);
+    // Second overwrite click → triggers the PUT
+    userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
+  };
+
+  test('sends template_params when overwriting a dataset with include template parameters checked', async () => {
+    // @ts-expect-error
+    global.featureFlags = {
+      [FeatureFlag.EnableTemplateProcessing]: true,
+    };
+
+    const putSpy = jest
+      .spyOn(SupersetClient, 'put')
+      .mockResolvedValue({ json: { result: { id: 0 } } } as any);
+
+    const dummyDispatch = jest.fn().mockResolvedValue({});
+    useDispatchMock.mockReturnValue(dummyDispatch);
+    useSelectorMock.mockReturnValue({ ...user });
+
+    const propsWithTemplateParam = {
+      ...mockedProps,
+      datasource: {
+        ...testQuery,
+        templateParams: JSON.stringify({ my_param: 12, _filters: 'foo' }),
+      },
+    };
+    render(<SaveDatasetModal {...propsWithTemplateParam} />, {
+      useRedux: true,
+    });
+
+    // Check the "Include Template Parameters" checkbox
+    userEvent.click(screen.getByRole('checkbox'));
+
+    await setupOverwriteFlow();
+
+    await waitFor(() => {
+      expect(putSpy).toHaveBeenCalled();
+    });
+
+    const body = JSON.parse(putSpy.mock.calls[0][0].body as string);
+    // _filters should be stripped, but my_param should be preserved
+    expect(body.template_params).toEqual(JSON.stringify({ my_param: 12 }));
+
+    putSpy.mockRestore();
+  });
+
+  test('does not send template_params when overwriting a dataset with include template parameters unchecked', async () => {
+    // @ts-expect-error
+    global.featureFlags = {
+      [FeatureFlag.EnableTemplateProcessing]: true,
+    };
+
+    const putSpy = jest
+      .spyOn(SupersetClient, 'put')
+      .mockResolvedValue({ json: { result: { id: 0 } } } as any);
+
+    const dummyDispatch = jest.fn().mockResolvedValue({});
+    useDispatchMock.mockReturnValue(dummyDispatch);
+    useSelectorMock.mockReturnValue({ ...user });
+
+    const propsWithTemplateParam = {
+      ...mockedProps,
+      datasource: {
+        ...testQuery,
+        templateParams: JSON.stringify({ my_param: 12 }),
+      },
+    };
+    render(<SaveDatasetModal {...propsWithTemplateParam} />, {
+      useRedux: true,
+    });
+
+    // Do NOT check the "Include Template Parameters" checkbox
+    await setupOverwriteFlow();
+
+    await waitFor(() => {
+      expect(putSpy).toHaveBeenCalled();
+    });
+
+    const body = JSON.parse(putSpy.mock.calls[0][0].body as string);
+    expect(body.template_params).toBeUndefined();
+
+    putSpy.mockRestore();
   });
 
   test('clears dataset cache when creating new dataset', async () => {

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -149,15 +149,25 @@ const Styles = styled.div`
     }
   `}
 `;
-const updateDataset = async (
-  dbId: number,
-  datasetId: number,
-  sql: string,
-  columns: Array<Record<string, any>>,
-  owners: [number],
-  overrideColumns: boolean,
-  templateParams?: string,
-) => {
+type UpdateDatasetPayload = {
+  dbId: number;
+  datasetId: number;
+  sql: string;
+  columns: Array<Record<string, any>>;
+  owners: number[];
+  overrideColumns: boolean;
+  templateParams?: string;
+};
+
+const updateDataset = async ({
+  dbId,
+  datasetId,
+  sql,
+  columns,
+  owners,
+  overrideColumns,
+  templateParams,
+}: UpdateDatasetPayload) => {
   const endpoint = `api/v1/dataset/${datasetId}?override_columns=${overrideColumns}`;
   const headers = { 'Content-Type': 'application/json' };
   const body = JSON.stringify({
@@ -191,13 +201,10 @@ const sanitizeTemplateParams = (
     return undefined;
   }
   try {
-    const p = JSON.parse(templateParams);
-    /* eslint-disable-next-line no-underscore-dangle */
-    if (p._filters) {
-      /* eslint-disable-next-line no-underscore-dangle */
-      delete p._filters;
-    }
-    return JSON.stringify(p);
+    const parsed = JSON.parse(templateParams) as Record<string, unknown>;
+    // Remove the special _filters entry — it is only used to test jinja templates.
+    const { _filters: _ignored, ...clean } = parsed;
+    return JSON.stringify(clean);
   } catch (e) {
     // malformed templateParams, do not include it
     return undefined;
@@ -263,21 +270,21 @@ export const SaveDatasetModal = ({
 
     try {
       const [, key] = await Promise.all([
-        updateDataset(
-          datasource?.dbId,
-          datasetToOverwrite?.datasetid,
-          datasource?.sql,
-          datasource?.columns?.map(
+        updateDataset({
+          dbId: datasource?.dbId,
+          datasetId: datasetToOverwrite?.datasetid,
+          sql: datasource?.sql,
+          columns: datasource?.columns?.map(
             (d: { column_name: string; type: string; is_dttm: boolean }) => ({
               column_name: d.column_name,
               type: d.type,
               is_dttm: d.is_dttm,
             }),
           ),
-          datasetToOverwrite?.owners?.map((o: DatasetOwner) => o.id),
-          true,
+          owners: datasetToOverwrite?.owners?.map((o: DatasetOwner) => o.id),
+          overrideColumns: true,
           templateParams,
-        ),
+        }),
         postFormData(datasetToOverwrite.datasetid, 'table', {
           ...formDataWithDefaults,
           datasource: `${datasetToOverwrite.datasetid}__table`,

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -156,6 +156,7 @@ const updateDataset = async (
   columns: Array<Record<string, any>>,
   owners: [number],
   overrideColumns: boolean,
+  templateParams?: string,
 ) => {
   const endpoint = `api/v1/dataset/${datasetId}?override_columns=${overrideColumns}`;
   const headers = { 'Content-Type': 'application/json' };
@@ -164,6 +165,7 @@ const updateDataset = async (
     columns,
     owners,
     database_id: dbId,
+    ...(templateParams !== undefined && { template_params: templateParams }),
   });
 
   const data: JsonResponse = await SupersetClient.put({
@@ -178,6 +180,29 @@ const updateDataset = async (
 };
 
 const UNTITLED = t('Untitled Dataset');
+
+// The filters param is only used to test jinja templates.
+// Remove the special filters entry from the templateParams
+// before saving the dataset.
+const sanitizeTemplateParams = (
+  templateParams: string | object | null | undefined,
+): string | undefined => {
+  if (typeof templateParams !== 'string') {
+    return undefined;
+  }
+  try {
+    const p = JSON.parse(templateParams);
+    /* eslint-disable-next-line no-underscore-dangle */
+    if (p._filters) {
+      /* eslint-disable-next-line no-underscore-dangle */
+      delete p._filters;
+    }
+    return JSON.stringify(p);
+  } catch (e) {
+    // malformed templateParams, do not include it
+    return undefined;
+  }
+};
 
 export const SaveDatasetModal = ({
   visible,
@@ -232,6 +257,10 @@ export const SaveDatasetModal = ({
     }
     setLoading(true);
 
+    const templateParams = includeTemplateParameters
+      ? sanitizeTemplateParams(datasource?.templateParams)
+      : undefined;
+
     try {
       const [, key] = await Promise.all([
         updateDataset(
@@ -247,6 +276,7 @@ export const SaveDatasetModal = ({
           ),
           datasetToOverwrite?.owners?.map((o: DatasetOwner) => o.id),
           true,
+          templateParams,
         ),
         postFormData(datasetToOverwrite.datasetid, 'table', {
           ...formDataWithDefaults,
@@ -319,27 +349,9 @@ export const SaveDatasetModal = ({
     setLoading(true);
     const selectedColumns = datasource?.columns ?? [];
 
-    // The filters param is only used to test jinja templates.
-    // Remove the special filters entry from the templateParams
-    // before saving the dataset.
-    let templateParams;
-    if (
-      typeof datasource?.templateParams === 'string' &&
-      includeTemplateParameters
-    ) {
-      try {
-        const p = JSON.parse(datasource.templateParams);
-        /* eslint-disable-next-line no-underscore-dangle */
-        if (p._filters) {
-          /* eslint-disable-next-line no-underscore-dangle */
-          delete p._filters;
-        }
-        templateParams = JSON.stringify(p);
-      } catch (e) {
-        // malformed templateParams, do not include it
-        templateParams = undefined;
-      }
-    }
+    const templateParams = includeTemplateParameters
+      ? sanitizeTemplateParams(datasource?.templateParams)
+      : undefined;
 
     dispatch(
       createDatasource({


### PR DESCRIPTION
### SUMMARY

The SQL Lab **Save Dataset** modal silently dropped the `template_params` field when overwriting an existing dataset, even with the **Include Template Parameters** checkbox checked. It worked correctly for new dataset creation but was never forwarded on overwrite.

Root cause: `updateDataset()` (the PUT helper used by the overwrite path) did not accept or send `template_params`, while `createDatasource` (the create path) did. The sanitization logic that strips the special `_filters` entry was also only inlined in the create handler.

This PR:
- Extracts the sanitize-template-params logic into a shared `sanitizeTemplateParams` helper.
- Threads `template_params` through `updateDataset` → the PUT payload, conditionally (only when defined) so existing overwrites without the checkbox behave identically.
- Refactors the create handler to use the shared helper so both paths stay in sync.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no UI changes, only request payload behavior.

### TESTING INSTRUCTIONS

1. Enable `ENABLE_TEMPLATE_PROCESSING` feature flag.
2. In SQL Lab, run a query that uses Jinja templates, e.g. ``SELECT {{ my_param }} AS val`` and set Template Parameters to `{"my_param": 12}`.
3. Save the result as a new virtual dataset — verify `template_params` is persisted on the dataset.
4. Re-run a different query and, from the Save Dataset modal, choose **Overwrite existing**, select the dataset from step 3, tick **Include Template Parameters**, and confirm overwrite.
5. Inspect the dataset (via the UI or `GET /api/v1/dataset/<id>`): `template_params` should now reflect the latest value (with the internal `_filters` key stripped).
6. Repeat step 4 without ticking the checkbox — `template_params` should not be sent (existing stored value is preserved via server-side behavior).

Automated coverage added in `SaveDatasetModal.test.tsx`:
- `sends template_params when overwriting a dataset with include template parameters checked`
- `does not send template_params when overwriting a dataset with include template parameters unchecked`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `ENABLE_TEMPLATE_PROCESSING`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API