### PR TITLE
fix(dashboard): apply full transitive ancestor chain for dependent filters

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -61,7 +61,7 @@ import { RESPONSIVE_WIDTH } from 'src/filters/components/common';
 import { dispatchHoverAction, dispatchFocusAction } from './utils';
 import { FilterControlProps } from './types';
 import { getFormData } from '../../utils';
-import { useFilterDependencies } from './state';
+import { useFilterDependencies, useTransitiveParentIds } from './state';
 import { useFilterOutlined } from '../useFilterOutlined';
 
 const HEIGHT = 32;
@@ -119,6 +119,7 @@ const FilterValue: FC<FilterValueProps> = ({
   const granularitySqla = isCustomization ? undefined : filter.granularity_sqla;
   const metadata = getChartMetadataRegistry().get(filterType);
   const dependencies = useFilterDependencies(id, dataMaskSelected);
+  const transitiveParentIds = useTransitiveParentIds(id);
   const shouldRefresh = useShouldFilterRefresh();
 
   const behaviors = useMemo(
@@ -187,12 +188,15 @@ const FilterValue: FC<FilterValueProps> = ({
       dashboardId,
     });
     const filterOwnState = filter.dataMask?.ownState || {};
-    if ((filter.cascadeParentIds ?? []).length) {
-      // Prevent unnecessary backend requests by validating parent filter selections first
+    if (transitiveParentIds.length) {
+      // Prevent unnecessary backend requests by validating ancestor filter
+      // selections first. We walk the full transitive ancestor chain (not just
+      // direct parents) so the counts line up with `dependencies`, which is
+      // itself built from the transitive chain by `useFilterDependencies`.
 
       let selectedParentFilterValueCounts = 0;
       let isTimeRangeSelected = false;
-      (filter.cascadeParentIds ?? []).forEach(pId => {
+      transitiveParentIds.forEach(pId => {
         const extraFormData = dataMaskSelected?.[pId]?.extraFormData;
         if (extraFormData?.filters?.length) {
           selectedParentFilterValueCounts += extraFormData.filters.length;
@@ -202,7 +206,7 @@ const FilterValue: FC<FilterValueProps> = ({
         }
       });
 
-      // check if all parent filters with defaults have a value selected
+      // check if all ancestor filters with defaults have a value selected
 
       const depsCount = dependencies.filters?.length ?? 0;
       const hasTimeRangeDeps = Boolean(dependencies?.time_range);
@@ -212,7 +216,7 @@ const FilterValue: FC<FilterValueProps> = ({
         (hasTimeRangeDeps && !isTimeRangeSelected)
       ) {
         // child filter should not request backend until it
-        // has all the required information from parent filters
+        // has all the required information from ancestor filters
         return;
       }
       setHasDepsFilterValue(false);
@@ -291,6 +295,7 @@ const FilterValue: FC<FilterValueProps> = ({
     shouldRefresh,
     dataMaskSelected,
     setHasDepsFilterValue,
+    transitiveParentIds,
   ]);
 
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts
@@ -21,15 +21,16 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { createElement } from 'react';
 import type { ReactNode } from 'react';
+import type { DataMaskStateWithId } from '@superset-ui/core';
 import {
+  FilterConfigMap,
   resolveTransitiveParentIds,
-  useFilterDependencies,
-  useTransitiveParentIds,
-} from './state';
+} from '../../dependencyGraph';
+import { useFilterDependencies, useTransitiveParentIds } from './state';
 
 const mockStore = configureStore([]);
 
-const buildWrapper = (filters: Record<string, any>) => {
+const buildWrapper = (filters: FilterConfigMap) => {
   const store = mockStore({ nativeFilters: { filters } });
   return ({ children }: { children: ReactNode }) =>
     createElement(Provider, { store }, children);
@@ -113,7 +114,7 @@ test('useFilterDependencies merges extraFormData across the full chain', () => {
     C: { cascadeParentIds: ['B'] },
     D: { cascadeParentIds: ['C'] },
   });
-  const dataMaskSelected = {
+  const dataMaskSelected: DataMaskStateWithId = {
     A: {
       id: 'A',
       extraFormData: { filters: [{ col: 'country', op: 'IN', val: ['US'] }] },
@@ -128,13 +129,40 @@ test('useFilterDependencies merges extraFormData across the full chain', () => {
     },
   };
   const { result } = renderHook(
-    () => useFilterDependencies('D', dataMaskSelected as any),
+    () => useFilterDependencies('D', dataMaskSelected),
     { wrapper },
   );
   const cols = (result.current.filters ?? []).map(f => f.col);
   // All three ancestor clauses must be present.
   expect(cols).toEqual(expect.arrayContaining(['country', 'region', 'state']));
   expect(result.current.filters ?? []).toHaveLength(3);
+});
+
+test('useFilterDependencies lets the closest ancestor override scalar fields', () => {
+  // `mergeExtraFormData` appends filter arrays but overrides scalar fields
+  // like `time_range`. Topological order must put the closest parent last so
+  // its scalar overrides win over further ancestors.
+  const wrapper = buildWrapper({
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['B'] },
+  });
+  const dataMaskSelected: DataMaskStateWithId = {
+    A: {
+      id: 'A',
+      extraFormData: { time_range: 'Last year' },
+    },
+    B: {
+      id: 'B',
+      extraFormData: { time_range: 'Last month' },
+    },
+  };
+  const { result } = renderHook(
+    () => useFilterDependencies('C', dataMaskSelected),
+    { wrapper },
+  );
+  // B is C's closest ancestor with a time_range, so it should win over A.
+  expect(result.current.time_range).toBe('Last month');
 });
 
 test('useFilterDependencies returns empty object when parent state is missing', () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import {
+  resolveTransitiveParentIds,
+  useFilterDependencies,
+  useTransitiveParentIds,
+} from './state';
+
+const mockStore = configureStore([]);
+
+const buildWrapper = (filters: Record<string, any>) => {
+  const store = mockStore({ nativeFilters: { filters } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(Provider, { store }, children);
+};
+
+test('resolveTransitiveParentIds returns empty for a filter with no parents', () => {
+  expect(
+    resolveTransitiveParentIds('A', {
+      A: { cascadeParentIds: [] },
+    }),
+  ).toEqual([]);
+});
+
+test('resolveTransitiveParentIds walks a linear chain A -> B -> C -> D', () => {
+  // D depends on C, C on B, B on A; each level only lists its direct parent.
+  const result = resolveTransitiveParentIds('D', {
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['B'] },
+    D: { cascadeParentIds: ['C'] },
+  });
+  // Furthest ancestor first, closest parent last.
+  expect(result).toEqual(['A', 'B', 'C']);
+});
+
+test('resolveTransitiveParentIds deduplicates shared ancestors in a diamond', () => {
+  //      A
+  //    /  \
+  //   B    C
+  //    \  /
+  //     D
+  const result = resolveTransitiveParentIds('D', {
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['A'] },
+    D: { cascadeParentIds: ['B', 'C'] },
+  });
+  expect(result).toContain('A');
+  expect(result).toContain('B');
+  expect(result).toContain('C');
+  // A should only appear once even though reachable via B and C.
+  expect(result.filter(id => id === 'A')).toHaveLength(1);
+});
+
+test('resolveTransitiveParentIds defends against cyclic configuration', () => {
+  // Filter config modal enforces acyclicity, but malformed saved state
+  // should not spin forever here.
+  const result = resolveTransitiveParentIds('A', {
+    A: { cascadeParentIds: ['B'] },
+    B: { cascadeParentIds: ['A'] },
+  });
+  expect(result).toEqual(['B']);
+});
+
+test('resolveTransitiveParentIds tolerates missing filter entries', () => {
+  // Unknown parent id referenced in cascadeParentIds should not crash.
+  expect(
+    resolveTransitiveParentIds('X', {
+      X: { cascadeParentIds: ['Y'] },
+    }),
+  ).toEqual(['Y']);
+});
+
+test('useTransitiveParentIds reads filter config from redux', () => {
+  const wrapper = buildWrapper({
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['B'] },
+  });
+  const { result } = renderHook(() => useTransitiveParentIds('C'), { wrapper });
+  expect(result.current).toEqual(['A', 'B']);
+});
+
+test('useFilterDependencies merges extraFormData across the full chain', () => {
+  // Regression test for sc-102912: a chain A -> B -> C -> D where each level
+  // only lists its direct parent must still produce extra_form_data that
+  // includes clauses from every ancestor, not just the closest parent.
+  const wrapper = buildWrapper({
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['B'] },
+    D: { cascadeParentIds: ['C'] },
+  });
+  const dataMaskSelected = {
+    A: {
+      id: 'A',
+      extraFormData: { filters: [{ col: 'country', op: 'IN', val: ['US'] }] },
+    },
+    B: {
+      id: 'B',
+      extraFormData: { filters: [{ col: 'region', op: 'IN', val: ['West'] }] },
+    },
+    C: {
+      id: 'C',
+      extraFormData: { filters: [{ col: 'state', op: 'IN', val: ['CA'] }] },
+    },
+  };
+  const { result } = renderHook(
+    () => useFilterDependencies('D', dataMaskSelected as any),
+    { wrapper },
+  );
+  const cols = (result.current.filters ?? []).map(f => f.col);
+  // All three ancestor clauses must be present.
+  expect(cols).toEqual(expect.arrayContaining(['country', 'region', 'state']));
+  expect(result.current.filters ?? []).toHaveLength(3);
+});
+
+test('useFilterDependencies returns empty object when parent state is missing', () => {
+  const wrapper = buildWrapper({
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+  });
+  const { result } = renderHook(() => useFilterDependencies('B', {}), {
+    wrapper,
+  });
+  expect(result.current).toEqual({});
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.ts
@@ -22,21 +22,81 @@ import {
   DataMaskStateWithId,
   ensureIsArray,
   ExtraFormData,
+  Filter,
 } from '@superset-ui/core';
 import { mergeExtraFormData } from '../../utils';
 
-// eslint-disable-next-line import/prefer-default-export
+type FilterConfigMap = Record<string, Pick<Filter, 'cascadeParentIds'>>;
+
+/**
+ * Resolve the full set of transitive ancestor filter ids for the given filter,
+ * in topological order (furthest ancestor first, closest parent last).
+ *
+ * Dependent filters only list their *direct* parents in `cascadeParentIds`, but
+ * the child filter's options and applied extra-form-data must reflect the full
+ * chain of upstream filters. A chain A -> B -> C -> D where each level lists
+ * only its direct parent used to compute C's options from B alone and D's
+ * options from C alone; this meant the child filter's generated
+ * `extra_form_data` did not include A's clause even though A is an effective
+ * ancestor. That mismatch caused only a subset of filter values to land on
+ * charts until the user pressed Apply a second time.
+ *
+ * Cycles are silently skipped; the filter-config modal enforces acyclicity at
+ * save time, but we still defend against malformed config so that a bad entry
+ * can never produce an infinite loop here.
+ */
+export function resolveTransitiveParentIds(
+  id: string,
+  filterConfig: FilterConfigMap,
+): string[] {
+  const ordered: string[] = [];
+  const visited = new Set<string>([id]);
+
+  const visit = (currentId: string) => {
+    const parents = ensureIsArray(
+      filterConfig[currentId]?.cascadeParentIds,
+    ) as string[];
+    parents.forEach(parentId => {
+      if (visited.has(parentId)) return;
+      visited.add(parentId);
+      // Depth-first so the furthest ancestors are appended before the
+      // closer parents, giving a stable topological order.
+      visit(parentId);
+      ordered.push(parentId);
+    });
+  };
+
+  visit(id);
+  return ordered;
+}
+
+/**
+ * Resolve the transitive ancestor ids for a given filter from the live
+ * native-filter configuration in Redux. Shared between
+ * `useFilterDependencies` and the readiness guard in `FilterValue` so they
+ * always agree on which parents count.
+ */
+export function useTransitiveParentIds(id: string): string[] {
+  const filterConfig = useSelector<any, FilterConfigMap | undefined>(
+    state => state.nativeFilters?.filters,
+    shallowEqual,
+  );
+
+  return useMemo(
+    () => resolveTransitiveParentIds(id, filterConfig ?? {}),
+    [id, filterConfig],
+  );
+}
+
 export function useFilterDependencies(
   id: string,
   dataMaskSelected?: DataMaskStateWithId,
 ): ExtraFormData {
-  const dependencyIds = useSelector<any, string[] | undefined>(
-    state => state.nativeFilters.filters[id]?.cascadeParentIds,
-    shallowEqual,
-  );
+  const dependencyIds = useTransitiveParentIds(id);
+
   return useMemo(() => {
-    let dependencies = {};
-    ensureIsArray(dependencyIds).forEach(parentId => {
+    let dependencies: ExtraFormData = {};
+    dependencyIds.forEach(parentId => {
       const parentState = dataMaskSelected?.[parentId];
       dependencies = mergeExtraFormData(
         dependencies,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.ts
@@ -18,57 +18,13 @@
  */
 import { useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
-import {
-  DataMaskStateWithId,
-  ensureIsArray,
-  ExtraFormData,
-  Filter,
-} from '@superset-ui/core';
+import { DataMaskStateWithId, ExtraFormData } from '@superset-ui/core';
+import { RootState } from 'src/dashboard/types';
 import { mergeExtraFormData } from '../../utils';
-
-type FilterConfigMap = Record<string, Pick<Filter, 'cascadeParentIds'>>;
-
-/**
- * Resolve the full set of transitive ancestor filter ids for the given filter,
- * in topological order (furthest ancestor first, closest parent last).
- *
- * Dependent filters only list their *direct* parents in `cascadeParentIds`, but
- * the child filter's options and applied extra-form-data must reflect the full
- * chain of upstream filters. A chain A -> B -> C -> D where each level lists
- * only its direct parent used to compute C's options from B alone and D's
- * options from C alone; this meant the child filter's generated
- * `extra_form_data` did not include A's clause even though A is an effective
- * ancestor. That mismatch caused only a subset of filter values to land on
- * charts until the user pressed Apply a second time.
- *
- * Cycles are silently skipped; the filter-config modal enforces acyclicity at
- * save time, but we still defend against malformed config so that a bad entry
- * can never produce an infinite loop here.
- */
-export function resolveTransitiveParentIds(
-  id: string,
-  filterConfig: FilterConfigMap,
-): string[] {
-  const ordered: string[] = [];
-  const visited = new Set<string>([id]);
-
-  const visit = (currentId: string) => {
-    const parents = ensureIsArray(
-      filterConfig[currentId]?.cascadeParentIds,
-    ) as string[];
-    parents.forEach(parentId => {
-      if (visited.has(parentId)) return;
-      visited.add(parentId);
-      // Depth-first so the furthest ancestors are appended before the
-      // closer parents, giving a stable topological order.
-      visit(parentId);
-      ordered.push(parentId);
-    });
-  };
-
-  visit(id);
-  return ordered;
-}
+import {
+  FilterConfigMap,
+  resolveTransitiveParentIds,
+} from '../../dependencyGraph';
 
 /**
  * Resolve the transitive ancestor ids for a given filter from the live
@@ -77,7 +33,7 @@ export function resolveTransitiveParentIds(
  * always agree on which parents count.
  */
 export function useTransitiveParentIds(id: string): string[] {
-  const filterConfig = useSelector<any, FilterConfigMap | undefined>(
+  const filterConfig = useSelector<RootState, FilterConfigMap | undefined>(
     state => state.nativeFilters?.filters,
     shallowEqual,
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/dependencyGraph.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/dependencyGraph.ts
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ensureIsArray } from '@superset-ui/core';
+
+/**
+ * Shared graph primitives for the native-filter dependency graph.
+ *
+ * A dependent filter stores only its *direct* parents in `cascadeParentIds`,
+ * but most consumers (options queries, `extra_form_data` emitted to charts,
+ * readiness checks) need the full transitive ancestor set. Keeping the graph
+ * primitives here lets the hook layer and any non-React callers (e.g. form
+ * validation, batch checks) share one traversal implementation.
+ */
+
+/**
+ * Minimal shape we need from the native-filter config map. Kept intentionally
+ * narrow so dividers / chart customizations (which may omit `cascadeParentIds`)
+ * are also assignable.
+ */
+export type FilterConfigMap = Record<string, { cascadeParentIds?: string[] }>;
+
+/**
+ * Resolve the full set of transitive ancestor filter ids for the given filter,
+ * in topological order (furthest ancestor first, closest parent last).
+ *
+ * The ordering is significant: `mergeExtraFormData` appends filter arrays but
+ * *overrides* scalar fields like `time_range`, so iterating ancestors from
+ * furthest to closest makes the closest parent's scalar overrides win. A chain
+ * A -> B -> C -> D where each level lists only its direct parent therefore
+ * produces `[A, B, C]` for D, which matches the intended precedence.
+ *
+ * Cycles are silently skipped. The filter-config modal enforces acyclicity at
+ * save time (see `hasCircularDependency`), but defensive traversal here keeps
+ * a malformed saved config from spinning forever.
+ */
+export function resolveTransitiveParentIds(
+  id: string,
+  filterConfig: FilterConfigMap,
+): string[] {
+  const ordered: string[] = [];
+  const visited = new Set<string>([id]);
+
+  const visit = (currentId: string) => {
+    const parents = ensureIsArray(
+      filterConfig[currentId]?.cascadeParentIds,
+    ) as string[];
+    parents.forEach(parentId => {
+      if (visited.has(parentId)) return;
+      visited.add(parentId);
+      // Depth-first so the furthest ancestors are appended before the
+      // closer parents, giving a stable topological order.
+      visit(parentId);
+      ordered.push(parentId);
+    });
+  };
+
+  visit(id);
+  return ordered;
+}


### PR DESCRIPTION
### SUMMARY

Dashboard filters configured as a dependency chain (e.g. `A -> B -> C -> D`, where each level lists only its direct parent in `cascadeParentIds`) were applying only a partial filter set to charts on the first Apply. The user had to click Apply a second time to get the correct result.

**Root cause:** `useFilterDependencies` in `FilterBar/FilterControls/state.ts` only iterated a filter's *direct* `cascadeParentIds`. For a chain `A -> B -> C -> D`, D's emitted `extra_form_data` reflected only C's state, not A's and B's, so downstream charts received a partial filter set until the cascade had fully re-settled on a second Apply. The readiness guard in `FilterValue.tsx` suffered from the same single-hop assumption, so its value-count check could disagree with the merged dependencies.

**Fix:**
- New `resolveTransitiveParentIds` function walks the full ancestor graph depth-first, with a `visited` set for cycle protection.
- `useFilterDependencies` now merges `extraFormData` across the *entire* transitive chain in topological order.
- Extracted `useTransitiveParentIds` hook, used by both `useFilterDependencies` and the readiness guard in `FilterValue`, so the two views always agree on which parents count.

Shortcut: sc-102912

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — behavior-only fix, no UI change.

### TESTING INSTRUCTIONS

1. Create a dashboard with four native filters A, B, C, D where:
   - B depends on A
   - C depends on B
   - D depends on C
2. Add at least one chart that uses all four filters.
3. Set values for A, then B, then C, then D in order.
4. Click Apply once.
5. **Before this fix:** the chart is filtered by only a subset of the selected values; a second Apply is needed.
6. **After this fix:** the chart correctly reflects all four filter selections on the first Apply.

Automated coverage: `superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts` covers linear chains, diamond-shaped shared ancestors, cycle protection, missing filter entries, and end-to-end `extra_form_data` merging. All 8 tests pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API