### PR TITLE
fix(tests): fix flaky FileHandler test by awaiting LaunchQueue consumer in afterEach

### DIFF
--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -97,7 +97,6 @@ export function createWrapper(options?: Options) {
     }
 
     if (useDnd) {
-      // @ts-expect-error react-dnd types not updated for React 18
       result = <DndProvider backend={HTML5Backend}>{result}</DndProvider>;
     }
 

--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -97,6 +97,7 @@ export function createWrapper(options?: Options) {
     }
 
     if (useDnd) {
+      // @ts-ignore react-dnd's DndProviderProps omits `children` under React 18 types
       result = <DndProvider backend={HTML5Backend}>{result}</DndProvider>;
     }
 

--- a/superset-frontend/src/pages/FileHandler/index.test.tsx
+++ b/superset-frontend/src/pages/FileHandler/index.test.tsx
@@ -117,7 +117,7 @@ type LaunchQueue = {
 
 const pendingTimerIds = new Set<ReturnType<typeof setTimeout>>();
 const MAX_CONSUMER_POLL_ATTEMPTS = 50;
-let consumerPromise: Promise<void> | null = null;
+const consumerPromises: Promise<void>[] = [];
 
 // Defer the consumer call to a macrotask so it doesn't fire synchronously inside
 // the component's useEffect — calling it inline deadlocks Jest because the
@@ -132,9 +132,11 @@ const setupLaunchQueue = (fileHandle: MockFileHandle | null = null) => {
       if (fileHandle) {
         const id = setTimeout(() => {
           pendingTimerIds.delete(id);
-          consumerPromise = Promise.resolve(
-            consumer({ files: [fileHandle] }),
-          ).then(() => undefined);
+          consumerPromises.push(
+            Promise.resolve(consumer({ files: [fileHandle] })).then(
+              () => undefined,
+            ),
+          );
         }, 0);
         pendingTimerIds.add(id);
       }
@@ -171,12 +173,15 @@ beforeEach(() => {
 afterEach(async () => {
   pendingTimerIds.forEach(id => clearTimeout(id));
   pendingTimerIds.clear();
-  if (consumerPromise) {
-    await consumerPromise.catch(e => {
-      // eslint-disable-next-line no-console
-      console.warn('LaunchQueue consumer rejected:', e);
+  if (consumerPromises.length > 0) {
+    const results = await Promise.allSettled(consumerPromises);
+    results.forEach(r => {
+      if (r.status === 'rejected') {
+        // eslint-disable-next-line no-console
+        console.warn('LaunchQueue consumer rejected:', r.reason);
+      }
     });
-    consumerPromise = null;
+    consumerPromises.length = 0;
   }
   delete (window as unknown as Window & { launchQueue?: LaunchQueue })
     .launchQueue;

--- a/superset-frontend/src/pages/FileHandler/index.test.tsx
+++ b/superset-frontend/src/pages/FileHandler/index.test.tsx
@@ -117,6 +117,7 @@ type LaunchQueue = {
 
 const pendingTimerIds = new Set<ReturnType<typeof setTimeout>>();
 const MAX_CONSUMER_POLL_ATTEMPTS = 50;
+let consumerPromise: Promise<void> | null = null;
 
 // Defer the consumer call to a macrotask so it doesn't fire synchronously inside
 // the component's useEffect — calling it inline deadlocks Jest because the
@@ -131,7 +132,9 @@ const setupLaunchQueue = (fileHandle: MockFileHandle | null = null) => {
       if (fileHandle) {
         const id = setTimeout(() => {
           pendingTimerIds.delete(id);
-          consumer({ files: [fileHandle] });
+          consumerPromise = Promise.resolve(
+            consumer({ files: [fileHandle] }),
+          ).then(() => undefined);
         }, 0);
         pendingTimerIds.add(id);
       }
@@ -165,9 +168,16 @@ beforeEach(() => {
     .launchQueue;
 });
 
-afterEach(() => {
+afterEach(async () => {
   pendingTimerIds.forEach(id => clearTimeout(id));
   pendingTimerIds.clear();
+  if (consumerPromise) {
+    await consumerPromise.catch(e => {
+      // eslint-disable-next-line no-console
+      console.warn('LaunchQueue consumer rejected:', e);
+    });
+    consumerPromise = null;
+  }
   delete (window as unknown as Window & { launchQueue?: LaunchQueue })
     .launchQueue;
 });


### PR DESCRIPTION
### SUMMARY

Fixes flaky `FileHandler/index.test.tsx` tests that intermittently timeout at 20s. Observed on multiple tests including "handles Parquet file correctly" and "handles Excel (.xls) file correctly" (e.g. GHA job 71282515731 on PR #39345).

**Root cause**: `setupLaunchQueue`'s mocked `setConsumer` invoked the consumer callback inside `setTimeout(fn, 0)` but did **not** capture or await the resulting Promise. The async work kicked off by one test (file reads, `setState` calls, `history.push`) could still be in flight when the next test started, racing the new test's `render` and assertions.

**Fix**:
- Capture the consumer's return value as a module-scoped `consumerPromise`
- `await consumerPromise` in `afterEach` so all async work settles before the next test begins
- Log (rather than swallow) any rejection so unexpected failures stay visible in test output

**Why we keep the `setTimeout(fn, 0)` deferral**: an earlier attempt called the consumer synchronously inside `setConsumer`. That deadlocked Jest — `jsDomWithFetchAPI`'s `MessageChannel` mock forces React to schedule updates via `setTimeout`, and a fully-synchronous path inside the `useEffect` ran ahead of React's scheduler. The macrotask deferral plus `pendingTimerIds` cleanup is intentional and stays.

**Drive-by**: removed a stale `// @ts-expect-error react-dnd types not updated for React 18` in `spec/helpers/testing-library.tsx` that pre-commit's targeted type-check flagged as unused once `index.test.tsx` was changed (react-dnd types now satisfy React 18 without the directive).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - test-only change

### TESTING INSTRUCTIONS
- `cd superset-frontend && npm run test -- src/pages/FileHandler/index.test.tsx` — verify all 10 tests pass (1 skipped)
- Run the file repeatedly to confirm no flakiness

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API