### PR TITLE
feat(logs): add source field to audit logs for MCP and API-key tracking

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -456,16 +456,17 @@ const Select = forwardRef(
       const currentValues = ensureIsArray(selectValue);
       const currentValuesSet = new Set(currentValues.map(getValue));
 
-      const newValues = [...currentValues] as RawValue[];
-      optionsToSelect.forEach(option => {
-        if (
+      const optionsToAdd = optionsToSelect.filter(
+        option =>
           option.value &&
           !option.disabled &&
-          !currentValuesSet.has(option.value)
-        ) {
-          newValues.push(option.value);
-        }
-      });
+          !currentValuesSet.has(option.value),
+      );
+
+      const newValues = [
+        ...currentValues,
+        ...mapValues(optionsToAdd, labelInValue),
+      ] as RawValue[];
 
       setSelectValue(newValues);
       fireOnChange();
@@ -476,6 +477,7 @@ const Select = forwardRef(
       enabledOptions,
       selectValue,
       fireOnChange,
+      labelInValue,
     ]);
 
     const handleDeselectAll = useCallback(() => {

--- a/superset-frontend/src/components/AlteredSliceTag/utils/index.ts
+++ b/superset-frontend/src/components/AlteredSliceTag/utils/index.ts
@@ -52,7 +52,9 @@ export const formatValueHandler = (
           v.comparator && v.comparator.constructor === Array
             ? `[${v.comparator.join(', ')}]`
             : v.comparator;
-        return filterVal ? `${v.subject} ${v.operator} ${filterVal}` : `${v.subject} ${v.operator}`;
+        return filterVal
+          ? `${v.subject} ${v.operator} ${filterVal}`
+          : `${v.subject} ${v.operator}`;
       })
       .join(', ');
   }

--- a/superset-frontend/src/components/ListView/Filters/Select.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Select.tsx
@@ -33,13 +33,49 @@ import { SELECT_WIDTH } from '../utils';
 
 interface SelectFilterProps extends BaseFilter {
   fetchSelects?: Filter['fetchSelects'];
+  mode?: 'single' | 'multiple';
   name?: string;
-  onSelect: (selected: SelectOption | undefined, isClear?: boolean) => void;
+  onSelect: (
+    selected: SelectOption | SelectOption[] | undefined,
+    isClear?: boolean,
+  ) => void;
   optionFilterProps?: string[];
   paginate?: boolean;
   selects: Filter['selects'];
   loading?: boolean;
   dropdownStyle?: React.CSSProperties;
+}
+
+function normalizeMultiSelectValue(
+  initialValue: unknown,
+  selects: SelectOption[],
+): SelectOption[] {
+  if (!Array.isArray(initialValue)) {
+    return [];
+  }
+
+  return initialValue
+    .filter(value => value !== null && value !== undefined)
+    .map(value => {
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        'value' in value &&
+        'label' in value
+      ) {
+        return value as SelectOption;
+      }
+
+      const matchedOption = selects.find(option => option.value === value);
+      if (matchedOption) {
+        return matchedOption;
+      }
+
+      return {
+        label: String(value),
+        value,
+      };
+    });
 }
 
 function SelectFilter(
@@ -48,6 +84,7 @@ function SelectFilter(
     name,
     fetchSelects,
     initialValue,
+    mode = 'single',
     onSelect,
     optionFilterProps,
     selects = [],
@@ -56,7 +93,12 @@ function SelectFilter(
   }: SelectFilterProps,
   ref: RefObject<FilterHandler>,
 ) {
-  const [selectedOption, setSelectedOption] = useState(initialValue);
+  const [selectedOption, setSelectedOption] = useState(
+    mode === 'single' ? initialValue : undefined,
+  );
+  const [selectedOptions, setSelectedOptions] = useState<SelectOption[]>(
+    mode === 'multiple' ? normalizeMultiSelectValue(initialValue, selects) : [],
+  );
 
   const onChange = (selected: SelectOption) => {
     onSelect(
@@ -78,9 +120,24 @@ function SelectFilter(
     setSelectedOption(undefined);
   };
 
+  const onMultiChange = (selected: SelectOption[]) => {
+    const valid = (selected ?? []).filter(Boolean);
+    setSelectedOptions(valid);
+    onSelect(valid.length ? valid : undefined, valid.length === 0);
+  };
+
+  const onMultiClear = () => {
+    setSelectedOptions([]);
+    onSelect(undefined, true);
+  };
+
   useImperativeHandle(ref, () => ({
     clearFilter: () => {
-      onClear();
+      if (mode === 'multiple') {
+        onMultiClear();
+      } else {
+        onClear();
+      }
     },
   }));
 
@@ -123,6 +180,22 @@ function SelectFilter(
           dropdownStyle={dropdownStyle}
           showSearch
           value={selectedOption}
+        />
+      ) : mode === 'multiple' ? (
+        <Select
+          allowClear
+          ariaLabel={typeof Header === 'string' ? Header : name || t('Filter')}
+          data-test="filters-select"
+          labelInValue
+          mode="multiple"
+          onChange={onMultiChange as any}
+          onClear={onMultiClear}
+          options={selects}
+          placeholder={placeholder}
+          dropdownStyle={dropdownStyle}
+          showSearch
+          value={selectedOptions}
+          loading={loading}
         />
       ) : (
         <Select

--- a/superset-frontend/src/components/ListView/Filters/index.test.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.test.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { render, screen } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
 import { ListViewFilterOperator } from '../types';
 import UIFilters from './index';
 
@@ -129,4 +130,65 @@ test('renders multiple search filters with different inputName values', () => {
   expect(inputs).toHaveLength(2);
   expect(inputs[0].name).toBe('filter_name_search');
   expect(inputs[1].name).toBe('description');
+});
+
+test('"Select all" in multiselect filter emits scalar option values, not undefined', async () => {
+  render(
+    <UIFilters
+      filters={[
+        {
+          Header: 'Source',
+          key: 'source',
+          id: 'source',
+          input: 'select',
+          mode: 'multiple' as const,
+          operator: ListViewFilterOperator.In,
+          selects: [
+            { label: 'API', value: 'API' },
+            { label: 'MCP', value: 'MCP' },
+          ],
+        },
+      ]}
+      internalFilters={[]}
+      updateFilterValue={mockUpdateFilterValue}
+    />,
+  );
+
+  await userEvent.click(screen.getByRole('combobox'));
+  await userEvent.click(await screen.findByText('Select all (2)'));
+
+  expect(mockUpdateFilterValue).toHaveBeenCalledWith(0, ['API', 'MCP']);
+});
+
+test('multiselect filters restore scalar query values as selected options', async () => {
+  render(
+    <UIFilters
+      filters={[
+        {
+          Header: 'Source',
+          key: 'source',
+          id: 'source',
+          input: 'select',
+          mode: 'multiple' as const,
+          operator: ListViewFilterOperator.In,
+          selects: [
+            { label: 'API', value: 'API' },
+            { label: 'MCP', value: 'MCP' },
+          ],
+        },
+      ]}
+      internalFilters={[
+        {
+          id: 'source',
+          operator: ListViewFilterOperator.In,
+          value: ['API', 'MCP'],
+        },
+      ]}
+      updateFilterValue={mockUpdateFilterValue}
+    />,
+  );
+
+  await userEvent.click(screen.getByRole('combobox'));
+
+  expect(screen.getAllByRole('option', { selected: true })).toHaveLength(2);
 });

--- a/superset-frontend/src/components/ListView/Filters/index.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.tsx
@@ -30,7 +30,6 @@ import type {
   ListViewFilterValue as FilterValue,
   ListViewFilters as Filters,
   InternalFilter,
-  SelectOption,
 } from '../types';
 import type { FilterHandler } from './types';
 import SearchFilter from './Search';
@@ -72,6 +71,7 @@ function UIFilters(
             key,
             id,
             input,
+            mode,
             optionFilterProps,
             paginate,
             selects,
@@ -96,19 +96,20 @@ function UIFilters(
                 fetchSelects={fetchSelects}
                 initialValue={initialValue}
                 key={key}
+                mode={mode}
                 name={id}
-                onSelect={(
-                  option: SelectOption | undefined,
-                  isClear?: boolean,
-                ) => {
+                onSelect={(option, isClear) => {
                   if (onFilterUpdate) {
                     // Filter change triggers both onChange AND onClear, only want to track onChange
                     if (!isClear) {
                       onFilterUpdate(option);
                     }
                   }
-
-                  updateFilterValue(index, option);
+                  // For multiselect, extract scalar values so the API receives string[]
+                  const filterValue = Array.isArray(option)
+                    ? option.map(o => o.value)
+                    : option;
+                  updateFilterValue(index, filterValue);
                 }}
                 optionFilterProps={optionFilterProps}
                 paginate={paginate}

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -43,6 +43,7 @@ export interface ListViewFilter {
   toolTipDescription?: string;
   urlDisplay?: string;
   operator?: ListViewFilterOperator;
+  mode?: 'single' | 'multiple';
   input?:
     | 'text'
     | 'textarea'
@@ -109,6 +110,7 @@ export enum ListViewFilterOperator {
   EndsWith = 'ew',
   Contains = 'ct',
   Equals = 'eq',
+  In = 'in',
   NotStartsWith = 'nsw',
   NotEndsWith = 'new',
   NotContains = 'nct',

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.test.tsx
@@ -38,7 +38,11 @@ const defaultProps = {
 
 test('renders "is false" operator label without trailing undefined', () => {
   const value: ConditionalFormattingConfig[] = [
-    { column: 'my_col', operator: Comparator.IsFalse, colorScheme: 'colorSuccess' },
+    {
+      column: 'my_col',
+      operator: Comparator.IsFalse,
+      colorScheme: 'colorSuccess',
+    },
   ];
   render(<ConditionalFormattingControl {...defaultProps} value={value} />);
   expect(screen.getByText('my_col is false')).toBeInTheDocument();
@@ -46,7 +50,11 @@ test('renders "is false" operator label without trailing undefined', () => {
 
 test('renders "is true" operator label without trailing undefined', () => {
   const value: ConditionalFormattingConfig[] = [
-    { column: 'my_col', operator: Comparator.IsTrue, colorScheme: 'colorSuccess' },
+    {
+      column: 'my_col',
+      operator: Comparator.IsTrue,
+      colorScheme: 'colorSuccess',
+    },
   ];
   render(<ConditionalFormattingControl {...defaultProps} value={value} />);
   expect(screen.getByText('my_col is true')).toBeInTheDocument();
@@ -54,7 +62,11 @@ test('renders "is true" operator label without trailing undefined', () => {
 
 test('renders "is null" operator label without trailing undefined', () => {
   const value: ConditionalFormattingConfig[] = [
-    { column: 'my_col', operator: Comparator.IsNull, colorScheme: 'colorSuccess' },
+    {
+      column: 'my_col',
+      operator: Comparator.IsNull,
+      colorScheme: 'colorSuccess',
+    },
   ];
   render(<ConditionalFormattingControl {...defaultProps} value={value} />);
   expect(screen.getByText('my_col is null')).toBeInTheDocument();
@@ -62,7 +74,11 @@ test('renders "is null" operator label without trailing undefined', () => {
 
 test('renders "is not null" operator label without trailing undefined', () => {
   const value: ConditionalFormattingConfig[] = [
-    { column: 'my_col', operator: Comparator.IsNotNull, colorScheme: 'colorSuccess' },
+    {
+      column: 'my_col',
+      operator: Comparator.IsNotNull,
+      colorScheme: 'colorSuccess',
+    },
   ];
   render(<ConditionalFormattingControl {...defaultProps} value={value} />);
   expect(screen.getByText('my_col is not null')).toBeInTheDocument();
@@ -70,7 +86,11 @@ test('renders "is not null" operator label without trailing undefined', () => {
 
 test('renders verbose column name when available', () => {
   const value: ConditionalFormattingConfig[] = [
-    { column: 'my_col', operator: Comparator.IsFalse, colorScheme: 'colorSuccess' },
+    {
+      column: 'my_col',
+      operator: Comparator.IsFalse,
+      colorScheme: 'colorSuccess',
+    },
   ];
   render(
     <ConditionalFormattingControl

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1156,7 +1156,13 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
           addDangerToast(t('There was an error retrieving dashboard tabs.'));
         });
     }
-  }, [dashboard, tabsEnabled, filtersEnabled, currentAlert?.extra, addDangerToast]);
+  }, [
+    dashboard,
+    tabsEnabled,
+    filtersEnabled,
+    currentAlert?.extra,
+    addDangerToast,
+  ]);
 
   const databaseLabel = currentAlert?.database && !currentAlert.database.label;
   useEffect(() => {

--- a/superset-frontend/src/pages/ActionLog/index.tsx
+++ b/superset-frontend/src/pages/ActionLog/index.tsx
@@ -38,6 +38,7 @@ export type ActionLogObject = {
   };
 
   action: string;
+  source?: string | null;
   dttm: string | null;
   dashboard_id?: number;
   slice_id?: number;
@@ -106,6 +107,19 @@ function ActionLogList() {
         operator: ListViewFilterOperator.Contains,
       },
       {
+        Header: t('Source'),
+        key: 'source',
+        id: 'source',
+        input: 'select',
+        mode: 'multiple',
+        operator: ListViewFilterOperator.In,
+        unfilteredLabel: t('All'),
+        selects: [
+          { label: 'API', value: 'API' },
+          { label: 'MCP', value: 'MCP' },
+        ],
+      },
+      {
         Header: t('JSON'),
         key: 'json',
         id: 'json',
@@ -148,6 +162,15 @@ function ActionLogList() {
             original: { action },
           },
         }: any) => <span>{action}</span>,
+      },
+      {
+        accessor: 'source',
+        Header: t('Source'),
+        Cell: ({
+          row: {
+            original: { source },
+          },
+        }: any) => <span>{source ?? ''}</span>,
       },
       {
         accessor: 'user',

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -350,8 +350,7 @@ export default function downloadAsImageOptimized(
 
     if (agContainer && agRootWrapper) {
       const api = agContainer._agGridApi;
-      const isFirstDataRendered =
-        agContainer._agGridFirstDataRendered === true;
+      const isFirstDataRendered = agContainer._agGridFirstDataRendered === true;
 
       if (!isFirstDataRendered) {
         addWarningToast(

--- a/superset/advanced_data_type/plugins/internet_address.py
+++ b/superset/advanced_data_type/plugins/internet_address.py
@@ -66,9 +66,9 @@ def cidr_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeResponse:
         else:
             resp["display_value"] = ", ".join(
                 map(  # noqa: C417
-                    lambda x: f"{x['start']} - {x['end']}"
-                    if isinstance(x, dict)
-                    else str(x),
+                    lambda x: (
+                        f"{x['start']} - {x['end']}" if isinstance(x, dict) else str(x)
+                    ),
                     resp["values"],
                 )
             )

--- a/superset/advanced_data_type/plugins/internet_port.py
+++ b/superset/advanced_data_type/plugins/internet_port.py
@@ -95,9 +95,9 @@ def port_translation_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeRespo
         else:
             resp["display_value"] = ", ".join(
                 map(  # noqa: C417
-                    lambda x: f"{x['start']} - {x['end']}"
-                    if isinstance(x, dict)
-                    else str(x),
+                    lambda x: (
+                        f"{x['start']} - {x['end']}" if isinstance(x, dict) else str(x)
+                    ),
                     resp["values"],
                 )
             )

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -574,8 +574,9 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".cache_screenshot",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.cache_screenshot"
+        ),
         log_to_statsd=False,
     )
     def cache_screenshot(self, pk: int, **kwargs: Any) -> WerkzeugResponse:
@@ -876,8 +877,9 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @rison(get_fav_star_ids_schema)
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".favorite_status",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.favorite_status"
+        ),
         log_to_statsd=False,
     )
     def favorite_status(self, **kwargs: Any) -> Response:
@@ -968,8 +970,9 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".remove_favorite",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.remove_favorite"
+        ),
         log_to_statsd=False,
     )
     def remove_favorite(self, pk: int) -> Response:

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -87,8 +87,8 @@ operator_map: Dict[ColumnOperatorEnum, Any] = {
     ColumnOperatorEnum.in_: lambda col, val: col.in_(
         val if isinstance(val, (list, tuple)) else [val]
     ),
-    ColumnOperatorEnum.nin: lambda col, val: ~col.in_(
-        val if isinstance(val, (list, tuple)) else [val]
+    ColumnOperatorEnum.nin: lambda col, val: (
+        ~col.in_(val if isinstance(val, (list, tuple)) else [val])
     ),
     ColumnOperatorEnum.gt: lambda col, val: col > val,
     ColumnOperatorEnum.gte: lambda col, val: col >= val,

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -630,8 +630,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".sync-permissions",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.sync-permissions"
+        ),
         log_to_statsd=False,
     )
     def sync_permissions(self, pk: int, **kwargs: Any) -> FlaskResponse:
@@ -889,8 +890,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".table_metadata_deprecated",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.table_metadata_deprecated"
+        ),
         log_to_statsd=False,
     )
     def table_metadata_deprecated(
@@ -953,8 +955,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @deprecated(deprecated_in="4.0")
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".table_extra_metadata_deprecated",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.table_extra_metadata_deprecated"
+        ),
         log_to_statsd=False,
     )
     def table_extra_metadata_deprecated(
@@ -1016,8 +1019,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".table_metadata",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.table_metadata"
+        ),
         log_to_statsd=False,
     )
     def table_metadata(self, pk: int) -> FlaskResponse:
@@ -1095,8 +1099,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".table_extra_metadata",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.table_extra_metadata"
+        ),
         log_to_statsd=False,
     )
     def table_extra_metadata(self, pk: int) -> FlaskResponse:
@@ -1238,8 +1243,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".test_connection",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.test_connection"
+        ),
         log_to_statsd=False,
     )
     @requires_json
@@ -1288,8 +1294,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".related_objects",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.related_objects"
+        ),
         log_to_statsd=False,
     )
     def related_objects(self, pk: int) -> Response:
@@ -1798,8 +1805,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".function_names",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.function_names"
+        ),
         log_to_statsd=False,
     )
     def function_names(self, pk: int) -> Response:
@@ -1953,8 +1961,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".validate_parameters",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.validate_parameters"
+        ),
         log_to_statsd=False,
     )
     @requires_json
@@ -2010,8 +2019,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".schemas_access_for_file_upload",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.schemas_access_for_file_upload"
+        ),
         log_to_statsd=False,
     )
     def schemas_access_for_file_upload(self, pk: int) -> Response:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -712,8 +712,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        ".detect_datetime_formats",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.detect_datetime_formats"
+        ),
         log_to_statsd=False,
     )
     def detect_datetime_formats(self, pk: int) -> Response:
@@ -794,8 +795,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".related_objects",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.related_objects"
+        ),
         log_to_statsd=False,
     )
     def related_objects(self, id_or_uuid: str) -> Response:
@@ -1051,8 +1053,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".get_or_create_dataset",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.get_or_create_dataset"
+        ),
         log_to_statsd=False,
     )
     def get_or_create_dataset(self) -> Response:
@@ -1272,9 +1275,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.get_drill_info",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.get_drill_info"
+        ),
         log_to_statsd=False,
     )
     def get_drill_info(self, pk: int, **kwargs: Any) -> Response:

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -45,8 +45,9 @@ class DatasourceRestApi(BaseSupersetApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".get_column_values",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.get_column_values"
+        ),
         log_to_statsd=False,
     )
     def get_column_values(
@@ -146,8 +147,9 @@ class DatasourceRestApi(BaseSupersetApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".validate_expression",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.validate_expression"
+        ),
         log_to_statsd=False,
     )
     def validate_expression(

--- a/superset/db_engine_specs/lint_metadata.py
+++ b/superset/db_engine_specs/lint_metadata.py
@@ -454,7 +454,7 @@ def print_report(reports: list[MetadataReport], verbose: bool = False) -> None: 
     print("=" * 60)
 
     all_fields = {**REQUIRED_FIELDS, **RECOMMENDED_FIELDS, **OPTIONAL_FIELDS}
-    field_counts: dict[str, int] = {f: 0 for f in all_fields}
+    field_counts: dict[str, int] = dict.fromkeys(all_fields, 0)
 
     for r in reports:
         for field in r.present_fields:

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -65,7 +65,11 @@ from superset.sql.parse import SQLGLOT_DIALECTS
 from superset.superset_typing import FlaskResponse
 from superset.utils.core import is_test, pessimistic_connection_handling
 from superset.utils.decorators import transaction
-from superset.utils.log import DBEventLogger, get_event_logger_from_cfg_value
+from superset.utils.log import (
+    AuditLogSource,
+    DBEventLogger,
+    get_event_logger_from_cfg_value,
+)
 
 if TYPE_CHECKING:
     from superset.app import SupersetApp
@@ -658,9 +662,20 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         if self.config["SESSION_SERVER_SIDE"]:
             Session(self.superset_app)
 
-    def register_request_handlers(self) -> None:
+    def register_request_handlers(self) -> None:  # noqa: C901
         """Register app-level request handlers"""
-        from flask import request, Response
+        from flask import g, request, Response
+
+        @self.superset_app.before_request
+        def tag_audit_source_from_api_key() -> None:
+            if not current_app.config.get("FAB_API_KEY_ENABLED", False):
+                return
+            sm = self.superset_app.appbuilder.sm
+            if not hasattr(sm, "_extract_api_key_from_request"):
+                return
+            api_key = sm._extract_api_key_from_request()
+            if api_key is not None:
+                g.audit_source = AuditLogSource.API
 
         @self.superset_app.after_request
         def apply_http_headers(response: Response) -> Response:

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -16,9 +16,10 @@
 # under the License.
 
 import logging
+import re
 import time
 from collections import defaultdict
-from typing import Any, Awaitable, Callable, Dict, Protocol, Sequence
+from typing import Any, Awaitable, Callable, Dict, NoReturn, Protocol, Sequence
 
 import mcp.types as mt
 from fastmcp.exceptions import ToolError
@@ -36,12 +37,21 @@ from superset.mcp_service.constants import (
     DEFAULT_WARN_THRESHOLD_PCT,
 )
 from superset.utils.core import get_user_id
+from superset.utils.log import AuditLogSource
 
 logger = logging.getLogger(__name__)
 
 
 def _sanitize_error_for_logging(error: Exception) -> str:
     """Sanitize error messages to prevent information disclosure in logs."""
+    # Short-circuit for well-known error types before any string processing
+    if isinstance(error, (OperationalError, TimeoutError)):
+        return "Database operation failed"
+    if isinstance(error, PermissionError):
+        return "Access denied"
+    if isinstance(error, ValidationError):
+        return "Request validation failed"
+
     error_str = str(error)
 
     # SECURITY FIX: Limit error message length FIRST to prevent ReDoS attacks
@@ -49,8 +59,6 @@ def _sanitize_error_for_logging(error: Exception) -> str:
         error_str = error_str[:500] + "...[truncated]"
 
     # SECURITY FIX: Use bounded patterns to prevent ReDoS
-    import re
-
     # Database connection strings - bounded patterns with word boundaries
     # Use case-insensitive flag to handle both cases
     error_str = re.sub(
@@ -83,14 +91,6 @@ def _sanitize_error_for_logging(error: Exception) -> str:
 
     # IP addresses - already safe pattern, keep as-is
     error_str = re.sub(r"\b(\d+)\.\d+\.\d+\.\d+\b", r"\1.xxx.xxx.xxx", error_str)
-
-    # For certain error types, provide generic messages
-    if isinstance(error, (OperationalError, TimeoutError)):
-        return "Database operation failed"
-    elif isinstance(error, PermissionError):
-        return "Access denied"
-    elif isinstance(error, ValidationError):
-        return "Request validation failed"
 
     return error_str
 
@@ -176,6 +176,16 @@ class LoggingMiddleware(Middleware):
         finally:
             duration_ms = int((time.time() - start_time) * 1000)
             if has_app_context():
+                _payload = {
+                    "tool": tool_name,
+                    "agent_id": agent_id,
+                    "params": _sanitize_params(params),
+                    "method": context.method,
+                    "dashboard_id": dashboard_id,
+                    "slice_id": slice_id,
+                    "dataset_id": dataset_id,
+                    "success": success,
+                }
                 event_logger.log(
                     user_id=user_id,
                     action="mcp_tool_call",
@@ -183,16 +193,9 @@ class LoggingMiddleware(Middleware):
                     duration_ms=duration_ms,
                     slice_id=slice_id,
                     referrer=None,
-                    curated_payload={
-                        "tool": tool_name,
-                        "agent_id": agent_id,
-                        "params": _sanitize_params(params),
-                        "method": context.method,
-                        "dashboard_id": dashboard_id,
-                        "slice_id": slice_id,
-                        "dataset_id": dataset_id,
-                        "success": success,
-                    },
+                    source=AuditLogSource.MCP,
+                    records=[_payload],
+                    curated_payload=_payload,
                 )
             logger.info(
                 "MCP tool call: tool=%s, agent_id=%s, user_id=%s, method=%s, "
@@ -218,15 +221,16 @@ class LoggingMiddleware(Middleware):
         agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
             self._extract_context_info(context)
         )
-        if has_app_context():
-            event_logger.log(
-                user_id=user_id,
-                action="mcp_message",
-                dashboard_id=dashboard_id,
-                duration_ms=None,
-                slice_id=slice_id,
-                referrer=None,
-                curated_payload={
+        start_time = time.time()
+        success = False
+        try:
+            result = await call_next(context)
+            success = True
+            return result
+        finally:
+            duration_ms = int((time.time() - start_time) * 1000)
+            if has_app_context():
+                _payload = {
                     "tool": getattr(context.message, "name", None),
                     "agent_id": agent_id,
                     "params": _sanitize_params(params),
@@ -234,16 +238,26 @@ class LoggingMiddleware(Middleware):
                     "dashboard_id": dashboard_id,
                     "slice_id": slice_id,
                     "dataset_id": dataset_id,
-                },
+                    "success": success,
+                }
+                event_logger.log(
+                    user_id=user_id,
+                    action="mcp_message",
+                    dashboard_id=dashboard_id,
+                    duration_ms=duration_ms,
+                    slice_id=slice_id,
+                    referrer=None,
+                    source=AuditLogSource.MCP,
+                    records=[_payload],
+                    curated_payload=_payload,
+                )
+            logger.info(
+                "MCP message: tool=%s, agent_id=%s, user_id=%s, method=%s",
+                getattr(context.message, "name", None),
+                agent_id,
+                user_id,
+                context.method,
             )
-        logger.info(
-            "MCP message: tool=%s, agent_id=%s, user_id=%s, method=%s",
-            getattr(context.message, "name", None),
-            agent_id,
-            user_id,
-            context.method,
-        )
-        return await call_next(context)
 
 
 class PrivateToolMiddleware(Middleware):
@@ -345,7 +359,7 @@ class GlobalErrorHandlerMiddleware(Middleware):
         context: MiddlewareContext,
         tool_name: str,
         duration_ms: int,
-    ) -> None:
+    ) -> NoReturn:
         """Handle different types of errors with appropriate responses"""
         # Extract user context for logging
         user_id = None
@@ -368,16 +382,22 @@ class GlobalErrorHandlerMiddleware(Middleware):
 
         # Log to Superset's event system
         try:
+            _payload = {
+                "tool": tool_name,
+                "error_type": type(error).__name__,
+                "error_message": sanitized_error,
+                "method": context.method,
+            }
             event_logger.log(
                 user_id=user_id,
                 action="mcp_tool_error",
+                dashboard_id=None,
                 duration_ms=duration_ms,
-                curated_payload={
-                    "tool": tool_name,
-                    "error_type": type(error).__name__,
-                    "error_message": str(error),
-                    "method": context.method,
-                },
+                slice_id=None,
+                referrer=None,
+                source=AuditLogSource.MCP,
+                records=[_payload],
+                curated_payload=_payload,
             )
         except Exception as log_error:
             logger.warning("Failed to log error event: %s", log_error)
@@ -414,7 +434,8 @@ class GlobalErrorHandlerMiddleware(Middleware):
         elif isinstance(error, FileNotFoundError):
             # File/resource not found errors
             raise ToolError(
-                f"Resource not found in {tool_name}: {str(error)}"
+                f"Resource not found in {tool_name}: "
+                "The requested resource does not exist."
             ) from error
         elif isinstance(error, ValueError):
             # Value/parameter errors
@@ -743,15 +764,22 @@ class RateLimitMiddleware(Middleware):
             # Log rate limit event
             try:
                 user_id = get_user_id() if hasattr(context, "session") else None
+                _payload = {
+                    "tool": tool_name,
+                    "rate_limit_key": key,
+                    "limit": limit,
+                    "window_seconds": 60,
+                }
                 event_logger.log(
                     user_id=user_id,
                     action="mcp_rate_limit_exceeded",
-                    curated_payload={
-                        "tool": tool_name,
-                        "rate_limit_key": key,
-                        "limit": limit,
-                        "window_seconds": 60,
-                    },
+                    dashboard_id=None,
+                    duration_ms=None,
+                    slice_id=None,
+                    referrer=None,
+                    source=AuditLogSource.MCP,
+                    records=[_payload],
+                    curated_payload=_payload,
                 )
             except Exception as log_error:
                 logger.warning("Failed to log rate limit event: %s", log_error)
@@ -982,16 +1010,23 @@ class ResponseSizeGuardMiddleware(Middleware):
 
         try:
             user_id = get_user_id()
+            _payload = {
+                "tool": tool_name,
+                "original_tokens": estimated_tokens,
+                "truncated_tokens": truncated_tokens,
+                "token_limit": self.token_limit,
+                "truncation_notes": notes,
+            }
             event_logger.log(
                 user_id=user_id,
                 action="mcp_response_truncated",
-                curated_payload={
-                    "tool": tool_name,
-                    "original_tokens": estimated_tokens,
-                    "truncated_tokens": truncated_tokens,
-                    "token_limit": self.token_limit,
-                    "truncation_notes": notes,
-                },
+                dashboard_id=None,
+                duration_ms=None,
+                slice_id=None,
+                referrer=None,
+                source=AuditLogSource.MCP,
+                records=[_payload],
+                curated_payload=_payload,
             )
         except Exception as log_error:  # noqa: BLE001
             logger.warning("Failed to log truncation event: %s", log_error)
@@ -1073,15 +1108,22 @@ class ResponseSizeGuardMiddleware(Middleware):
             # Log to event logger for monitoring
             try:
                 user_id = get_user_id()
+                _payload = {
+                    "tool": tool_name,
+                    "estimated_tokens": estimated_tokens,
+                    "token_limit": self.token_limit,
+                    "params": _sanitize_params(params),
+                }
                 event_logger.log(
                     user_id=user_id,
                     action="mcp_response_size_exceeded",
-                    curated_payload={
-                        "tool": tool_name,
-                        "estimated_tokens": estimated_tokens,
-                        "token_limit": self.token_limit,
-                        "params": params,
-                    },
+                    dashboard_id=None,
+                    duration_ms=None,
+                    slice_id=None,
+                    referrer=None,
+                    source=AuditLogSource.MCP,
+                    records=[_payload],
+                    curated_payload=_payload,
                 )
             except Exception as log_error:  # noqa: BLE001
                 logger.warning("Failed to log size exceeded event: %s", log_error)

--- a/superset/migrations/versions/2026-04-19_00-00_f3a8b2c91d4e_add_source_to_logs.py
+++ b/superset/migrations/versions/2026-04-19_00-00_f3a8b2c91d4e_add_source_to_logs.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add source to logs
+
+Revision ID: f3a8b2c91d4e
+Revises: ce6bd21901ab
+Create Date: 2026-04-19 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f3a8b2c91d4e"
+down_revision = "ce6bd21901ab"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("logs") as batch_op:
+        batch_op.add_column(sa.Column("source", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("logs") as batch_op:
+        batch_op.drop_column("source")

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1377,6 +1377,7 @@ class Log(Model):  # pylint: disable=too-few-public-methods
     dttm = Column(DateTime, default=datetime.utcnow)
     duration_ms = Column(Integer)
     referrer = Column(String(1024))
+    source = Column(String(32), nullable=True)
 
 
 class FavStarClassName(StrEnum):

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -175,8 +175,9 @@ class QueryRestApi(BaseSupersetModelRestApi):
     @rison(queries_get_updated_since_schema)
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".get_updated_since",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.get_updated_since"
+        ),
         log_to_statsd=False,
     )
     def get_updated_since(self, **kwargs: Any) -> FlaskResponse:

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -533,9 +533,9 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.slack_channels",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.slack_channels"
+        ),
         log_to_statsd=False,
     )
     def slack_channels(self, **kwargs: Any) -> Response:

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -59,7 +59,7 @@ ALLOWED_TAGS = {
     "ul",
 }.union(TABLE_TAGS)
 
-ALLOWED_TABLE_ATTRIBUTES = {tag: TABLE_ATTRIBUTES for tag in TABLE_TAGS}
+ALLOWED_TABLE_ATTRIBUTES = dict.fromkeys(TABLE_TAGS, TABLE_ATTRIBUTES)
 ALLOWED_ATTRIBUTES = {
     "a": {"href", "title"},
     "abbr": {"title"},

--- a/superset/reports/notifications/slack_mixin.py
+++ b/superset/reports/notifications/slack_mixin.py
@@ -94,7 +94,7 @@ class SlackMixin:
         # need to truncate the data
         for i in range(len(df) - 1):
             truncated_df = df[: i + 1].fillna("")
-            truncated_row = pd.Series({k: "..." for k in df.columns})
+            truncated_row = pd.Series(dict.fromkeys(df.columns, "..."))
             truncated_df = pd.concat(
                 [truncated_df, truncated_row.to_frame().T], ignore_index=True
             )
@@ -104,7 +104,7 @@ class SlackMixin:
             if len(message) > MAXIMUM_MESSAGE_SIZE:
                 # Decrement i and build a message that is under the limit
                 truncated_df = df[:i].fillna("")
-                truncated_row = pd.Series({k: "..." for k in df.columns})
+                truncated_row = pd.Series(dict.fromkeys(df.columns, "..."))
                 truncated_df = pd.concat(
                     [truncated_df, truncated_row.to_frame().T], ignore_index=True
                 )

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -149,8 +149,9 @@ class SqlLabRestApi(BaseSupersetApi):
     @statsd_metrics
     @requires_json
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".estimate_query_cost",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.estimate_query_cost"
+        ),
         log_to_statsd=False,
     )
     def estimate_query_cost(self) -> Response:
@@ -331,9 +332,9 @@ class SqlLabRestApi(BaseSupersetApi):
     @permission_name("read")
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.export_streaming_csv",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.export_streaming_csv"
+        ),
         log_to_statsd=False,
     )
     def export_streaming_csv(self) -> Response:

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -600,8 +600,9 @@ class TagRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @rison({"type": "array", "items": {"type": "integer"}})
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".favorite_status",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.favorite_status"
+        ),
         log_to_statsd=False,
     )
     def favorite_status(self, **kwargs: Any) -> Response:
@@ -698,8 +699,9 @@ class TagRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".remove_favorite",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.remove_favorite"
+        ),
         log_to_statsd=False,
     )
     def remove_favorite(self, pk: int) -> Response:

--- a/superset/tasks/api.py
+++ b/superset/tasks/api.py
@@ -380,8 +380,9 @@ class TaskRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        ".related_subscribers",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.related_subscribers"
+        ),
         log_to_statsd=False,
     )
     def related_subscribers(self) -> Response:

--- a/superset/themes/api.py
+++ b/superset/themes/api.py
@@ -559,9 +559,9 @@ class ThemeRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.set_system_default",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.set_system_default"
+        ),
         log_to_statsd=False,
     )
     def set_system_default(self, pk: int) -> Response:
@@ -626,9 +626,9 @@ class ThemeRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.set_system_dark",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.set_system_dark"
+        ),
         log_to_statsd=False,
     )
     def set_system_dark(self, pk: int) -> Response:
@@ -693,9 +693,9 @@ class ThemeRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.unset_system_default",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.unset_system_default"
+        ),
         log_to_statsd=False,
     )
     def unset_system_default(self) -> Response:
@@ -743,9 +743,9 @@ class ThemeRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.unset_system_dark",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.unset_system_dark"
+        ),
         log_to_statsd=False,
     )
     def unset_system_dark(self) -> Response:

--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -70,9 +70,9 @@ def apply_column_types(
                 # if the number is too large, convert it to a string
                 # Excel does not support numbers larger than 10^15
                 df[column] = df[column].apply(
-                    lambda x: str(x)
-                    if isinstance(x, (int, float)) and abs(x) > 10**15
-                    else x
+                    lambda x: (
+                        str(x) if isinstance(x, (int, float)) and abs(x) > 10**15 else x
+                    )
                 )
             except ValueError:
                 df[column] = df[column].astype(str)

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -32,7 +32,17 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from superset.extensions import stats_logger_manager
 from superset.utils import json
+from superset.utils.backports import StrEnum
 from superset.utils.core import get_user_id, LoggerLevel, to_int
+
+
+class AuditLogSource(StrEnum):
+    API = "API"
+    MCP = "MCP"
+    CHATBOT = "Chatbot"
+    PRESET = "Preset"
+    EMBEDDED = "Embedded"
+
 
 logger = logging.getLogger(__name__)
 
@@ -245,6 +255,7 @@ class AbstractEventLogger(ABC):
             referrer=referrer,
             curated_payload=self.curate_payload(payload),
             curated_form_data=self.curate_form_data(form_data),
+            source=g.get("audit_source") if has_request_context() else None,
             **database_params,
         )
 
@@ -399,6 +410,7 @@ class DBEventLogger(AbstractEventLogger):
                 duration_ms=duration_ms,
                 referrer=referrer,
                 user_id=user_id,
+                source=kwargs.get("source"),
             )
             logs.append(log)
         try:

--- a/superset/utils/mock_data.py
+++ b/superset/utils/mock_data.py
@@ -122,8 +122,11 @@ def get_type_generator(  # pylint: disable=too-many-return-statements,too-many-b
             sqlalchemy.sql.sqltypes.DateTime,
         ),
     ):
-        return lambda: datetime.fromordinal(MINIMUM_DATE.toordinal()) + timedelta(
-            seconds=random.randrange(days_range * 86400)  # noqa: S311
+        return lambda: (
+            datetime.fromordinal(MINIMUM_DATE.toordinal())
+            + timedelta(
+                seconds=random.randrange(days_range * 86400)  # noqa: S311
+            )
         )
 
     if isinstance(sqltype, sqlalchemy.sql.sqltypes.Numeric):

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 from flask import current_app as app
 from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.hooks import before_request
-from flask_appbuilder.models.sqla.filters import FilterRelationOneToManyEqual
+from flask_appbuilder.models.sqla.filters import FilterIn, FilterRelationOneToManyEqual
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
 import superset.models.core as models
@@ -51,6 +51,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         "user.username",
         "user_id",
         "action",
+        "source",
         "dttm",
         "json",
         "slice_id",
@@ -62,6 +63,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         "user",
         "user_id",
         "action",
+        "source",
         "dttm",
         "json",
         "slice_id",
@@ -71,6 +73,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
     ]
     search_filters = {
         "user": [FilterRelationOneToManyEqual],
+        "source": [FilterIn],
     }
     show_columns = list_columns
     page_size = 20
@@ -108,8 +111,9 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
     @statsd_metrics
     @rison(get_recent_activity_schema)
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".recent_activity",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.recent_activity"
+        ),
         log_to_statsd=False,
     )
     def recent_activity(self, **kwargs: Any) -> FlaskResponse:

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -217,8 +217,8 @@ class TestDatasource(SupersetTestCase):
     def test_external_metadata_by_name_for_virtual_table_uses_mutator(self):
         self.login(ADMIN_USERNAME)
         with create_and_cleanup_table() as tbl:
-            current_app.config["SQL_QUERY_MUTATOR"] = (
-                lambda sql, **kwargs: "SELECT 456 as intcol, 'def' as mutated_strcol"
+            current_app.config["SQL_QUERY_MUTATOR"] = lambda sql, **kwargs: (
+                "SELECT 456 as intcol, 'def' as mutated_strcol"
             )
 
             params = prison.dumps(
@@ -353,10 +353,12 @@ class TestDatasource(SupersetTestCase):
 
         pytest.raises(
             SupersetGenericDBErrorException,
-            lambda: db.session.query(SqlaTable)
-            .filter_by(id=tbl.id)
-            .one_or_none()
-            .external_metadata(),
+            lambda: (
+                db.session.query(SqlaTable)
+                .filter_by(id=tbl.id)
+                .one_or_none()
+                .external_metadata()
+            ),
         )
 
         resp = self.client.get(url)

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -81,8 +81,8 @@ class TestPrestoDbEngineSpec(SupersetTestCase):
     def verify_presto_column(self, column, expected_results):
         inspector = mock.Mock()
         preparer = inspector.engine.dialect.identifier_preparer
-        preparer.quote_identifier = preparer.quote = preparer.quote_schema = (
-            lambda x: f'"{x}"'
+        preparer.quote_identifier = preparer.quote = preparer.quote_schema = lambda x: (
+            f'"{x}"'
         )
         row = mock.Mock()
         row.Column, row.Type, row.Null = column
@@ -827,8 +827,8 @@ class TestPrestoDbEngineSpec(SupersetTestCase):
     def test_show_columns(self):
         inspector = mock.MagicMock()
         preparer = inspector.engine.dialect.identifier_preparer
-        preparer.quote_identifier = preparer.quote = preparer.quote_schema = (
-            lambda x: f'"{x}"'
+        preparer.quote_identifier = preparer.quote = preparer.quote_schema = lambda x: (
+            f'"{x}"'
         )
         inspector.bind.execute.return_value.fetchall = mock.MagicMock(
             return_value=["a", "b"]
@@ -843,8 +843,8 @@ class TestPrestoDbEngineSpec(SupersetTestCase):
     def test_show_columns_with_schema(self):
         inspector = mock.MagicMock()
         preparer = inspector.engine.dialect.identifier_preparer
-        preparer.quote_identifier = preparer.quote = preparer.quote_schema = (
-            lambda x: f'"{x}"'
+        preparer.quote_identifier = preparer.quote = preparer.quote_schema = lambda x: (
+            f'"{x}"'
         )
         inspector.bind.execute.return_value.fetchall = mock.MagicMock(
             return_value=["a", "b"]

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -47,6 +47,7 @@ EXPECTED_COLUMNS = [
     "json",
     "referrer",
     "slice_id",
+    "source",
     "user",
     "user_id",
 ]
@@ -61,6 +62,7 @@ class TestLogApi(SupersetTestCase):
         slice_id: Optional[int] = 0,
         json: Optional[str] = "",
         duration_ms: Optional[int] = 0,
+        source: Optional[str] = None,
     ):
         log = Log(
             action=action,
@@ -69,6 +71,7 @@ class TestLogApi(SupersetTestCase):
             slice_id=slice_id,
             json=json,
             duration_ms=duration_ms,
+            source=source,
         )
         db.session.add(log)
         db.session.commit()
@@ -100,6 +103,33 @@ class TestLogApi(SupersetTestCase):
         assert response["result"][0]["action"] == "some_action"
         assert response["result"][0]["user"]["username"] == "admin"
         db.session.delete(log)
+        db.session.commit()
+
+    def test_get_list_filtered_by_source(self):
+        """
+        Log API: filtering by source returns only matching entries.
+        """
+        admin_user = self.get_user("admin")
+        self.login(ADMIN_USERNAME)
+
+        mcp_log = self.insert_log("src_filter_marker", admin_user, source="MCP")
+        no_source_log = self.insert_log("src_filter_marker", admin_user)
+
+        arguments = {
+            "filters": [
+                {"col": "action", "opr": "sw", "value": "src_filter_marker"},
+                {"col": "source", "opr": "in", "value": ["MCP"]},
+            ]
+        }
+        uri = f"api/v1/log/?q={prison.dumps(arguments)}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response["count"] == 1
+        assert response["result"][0]["source"] == "MCP"
+
+        db.session.delete(mcp_log)
+        db.session.delete(no_source_log)
         db.session.commit()
 
     def test_get_list_not_allowed(self):

--- a/tests/integration_tests/security/api_tests.py
+++ b/tests/integration_tests/security/api_tests.py
@@ -259,8 +259,9 @@ class TestSecurityGuestTokenApiTokenValidator(SupersetTestCase):
 
     @with_config(
         {
-            "GUEST_TOKEN_VALIDATOR_HOOK": lambda x: len(x["rls"]) == 1
-            and "tenant_id=" in x["rls"][0]["clause"]
+            "GUEST_TOKEN_VALIDATOR_HOOK": lambda x: (
+                len(x["rls"]) == 1 and "tenant_id=" in x["rls"][0]["clause"]
+            )
         }
     )
     def test_guest_validator_hook_real_world_example_positive(self):
@@ -275,8 +276,9 @@ class TestSecurityGuestTokenApiTokenValidator(SupersetTestCase):
 
     @with_config(
         {
-            "GUEST_TOKEN_VALIDATOR_HOOK": lambda x: len(x["rls"]) == 1
-            and "tenant_id=" in x["rls"][0]["clause"]
+            "GUEST_TOKEN_VALIDATOR_HOOK": lambda x: (
+                len(x["rls"]) == 1 and "tenant_id=" in x["rls"][0]["clause"]
+            )
         }
     )
     def test_guest_validator_hook_real_world_example_negative(self):

--- a/tests/unit_tests/commands/export_test.py
+++ b/tests/unit_tests/commands/export_test.py
@@ -38,7 +38,9 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportDatabasesCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: Database\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\ntype: Database\ntimestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),  # noqa: E501
         ),
         ("databases/example.yaml", lambda: "<DATABASE CONTENTS>"),
     ]
@@ -48,7 +50,9 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportDatasetsCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: Dataset\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\ntype: Dataset\ntimestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),  # noqa: E501
         ),
         ("datasets/example/dataset.yaml", lambda: "<DATASET CONTENTS>"),
     ]
@@ -58,7 +62,9 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportChartsCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: Slice\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\ntype: Slice\ntimestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),  # noqa: E501
         ),
         ("charts/pie.yaml", lambda: "<CHART CONTENTS>"),
     ]
@@ -68,7 +74,9 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportDashboardsCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: Dashboard\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\ntype: Dashboard\ntimestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),  # noqa: E501
         ),
         ("dashboards/sales.yaml", lambda: "<DASHBOARD CONTENTS>"),
     ]
@@ -78,7 +86,9 @@ def test_export_assets_command(mocker: MockerFixture) -> None:
     ExportSavedQueriesCommand.return_value.run.return_value = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: SavedQuery\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\ntype: SavedQuery\ntimestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),  # noqa: E501
         ),
         ("queries/example/metric.yaml", lambda: "<SAVED QUERY CONTENTS>"),
     ]

--- a/tests/unit_tests/common/test_query_context_factory.py
+++ b/tests/unit_tests/common/test_query_context_factory.py
@@ -140,8 +140,8 @@ class TestQueryContextFactory:
         existing_columns = {"existing_col"}
 
         with patch.object(self.factory, "_find_column_definition") as mock_find:
-            mock_find.side_effect = (
-                lambda qo, col: f"def_{col}" if col != "tooltip_col2" else None
+            mock_find.side_effect = lambda qo, col: (
+                f"def_{col}" if col != "tooltip_col2" else None
             )
 
             self.factory._append_missing_tooltip_columns(

--- a/tests/unit_tests/datasets/test_datetime_format_detector.py
+++ b/tests/unit_tests/datasets/test_datetime_format_detector.py
@@ -44,8 +44,8 @@ def mock_dataset() -> MagicMock:
     dataset.database.get_sqla_engine.return_value.__exit__.return_value = None
 
     # Mock apply_limit_to_sql to return SQL with LIMIT
-    dataset.database.apply_limit_to_sql = (
-        lambda sql, limit, force: f"{sql} LIMIT {limit}"
+    dataset.database.apply_limit_to_sql = lambda sql, limit, force: (
+        f"{sql} LIMIT {limit}"
     )
 
     return dataset

--- a/tests/unit_tests/db_engine_specs/test_starrocks.py
+++ b/tests/unit_tests/db_engine_specs/test_starrocks.py
@@ -224,8 +224,8 @@ def test_get_catalog_names(mocker: MockerFixture) -> None:
     # StarRocks returns rows with keys: ['Catalog', 'Type', 'Comment']
     mock_row_1 = mocker.MagicMock()
     mock_row_1.keys.return_value = ["Catalog", "Type", "Comment"]
-    mock_row_1.__getitem__ = (
-        lambda self, key: "default_catalog" if key == "Catalog" else None
+    mock_row_1.__getitem__ = lambda self, key: (
+        "default_catalog" if key == "Catalog" else None
     )
 
     mock_row_2 = mocker.MagicMock()

--- a/tests/unit_tests/importexport/api_test.py
+++ b/tests/unit_tests/importexport/api_test.py
@@ -48,7 +48,9 @@ def test_export_assets(
     mocked_export_result = [
         (
             "metadata.yaml",
-            lambda: "version: 1.0.0\ntype: assets\ntimestamp: '2022-01-01T00:00:00+00:00'\n",  # noqa: E501
+            lambda: (
+                "version: 1.0.0\ntype: assets\ntimestamp: '2022-01-01T00:00:00+00:00'\n"
+            ),  # noqa: E501
         ),
         ("databases/example.yaml", lambda: "<DATABASE CONTENTS>"),
     ]

--- a/tests/unit_tests/initialization_test.py
+++ b/tests/unit_tests/initialization_test.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import os
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from sqlalchemy.exc import OperationalError
@@ -188,6 +189,75 @@ class TestSupersetAppInitializer:
             app_initializer._db_uri_cache
             == "postgresql://realuser:realpass@realhost:5432/realdb"
         )
+
+
+class TestAuditSourceHook:
+    """Tests for the tag_audit_source_from_api_key before_request hook."""
+
+    def _make_test_app(self, fab_api_key_enabled: bool, sm_mock: object) -> Any:
+        """Create a minimal Flask app with the audit source hook registered."""
+        from flask import Flask
+
+        from superset.initialization import SupersetAppInitializer
+
+        flask_app = Flask(__name__)
+        flask_app.config["FAB_API_KEY_ENABLED"] = fab_api_key_enabled
+        flask_app.config["SECRET_KEY"] = "test"  # noqa: S105
+
+        # Build a mock SupersetAppInitializer that has the minimal attributes needed
+        initializer = SupersetAppInitializer.__new__(SupersetAppInitializer)
+        initializer.superset_app = flask_app
+        mock_appbuilder = MagicMock()
+        mock_appbuilder.sm = sm_mock
+        flask_app.appbuilder = mock_appbuilder
+
+        initializer.register_request_handlers()
+        return flask_app
+
+    def test_hook_disabled_when_flag_is_false(self) -> None:
+        sm = MagicMock(spec=["_extract_api_key_from_request"])
+        sm._extract_api_key_from_request.return_value = "some-key"
+        app = self._make_test_app(fab_api_key_enabled=False, sm_mock=sm)
+
+        with app.test_request_context("/"):
+            from flask import g
+
+            app.preprocess_request()
+            assert not hasattr(g, "audit_source")
+
+    def test_hook_does_nothing_when_sm_lacks_method(self) -> None:
+        sm = MagicMock(spec=[])  # no _extract_api_key_from_request
+        app = self._make_test_app(fab_api_key_enabled=True, sm_mock=sm)
+
+        with app.test_request_context("/"):
+            from flask import g
+
+            app.preprocess_request()
+            assert not hasattr(g, "audit_source")
+
+    def test_hook_does_not_set_source_when_no_api_key(self) -> None:
+        sm = MagicMock(spec=["_extract_api_key_from_request"])
+        sm._extract_api_key_from_request.return_value = None
+        app = self._make_test_app(fab_api_key_enabled=True, sm_mock=sm)
+
+        with app.test_request_context("/"):
+            from flask import g
+
+            app.preprocess_request()
+            assert not hasattr(g, "audit_source")
+
+    def test_hook_sets_api_source_when_api_key_present(self) -> None:
+        from superset.utils.log import AuditLogSource
+
+        sm = MagicMock(spec=["_extract_api_key_from_request"])
+        sm._extract_api_key_from_request.return_value = "valid-api-key"
+        app = self._make_test_app(fab_api_key_enabled=True, sm_mock=sm)
+
+        with app.test_request_context("/"):
+            from flask import g
+
+            app.preprocess_request()
+            assert g.audit_source == AuditLogSource.API
 
 
 class TestCreateAppRoot:

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -22,14 +22,23 @@ Tests verify that:
 - on_call_tool() captures duration_ms and success status
 - on_message() logs non-tool messages without duration
 - _extract_context_info() extracts entity IDs from params
+- Event logger calls always include required positional args
 """
 
+import contextlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
-from superset.mcp_service.middleware import LoggingMiddleware
+from superset.mcp_service.middleware import (
+    GlobalErrorHandlerMiddleware,
+    LoggingMiddleware,
+    RateLimitMiddleware,
+    ResponseSizeGuardMiddleware,
+)
+from superset.utils.log import AuditLogSource, DBEventLogger
 
 
 def _make_context(
@@ -37,7 +46,7 @@ def _make_context(
     name: str = "list_charts",
     params: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
-):
+) -> MagicMock:
     """Create a mock MiddlewareContext."""
     ctx = MagicMock()
     ctx.method = method
@@ -134,10 +143,10 @@ class TestLoggingMiddlewareOnMessage:
     @patch("superset.mcp_service.middleware.event_logger")
     @patch("superset.mcp_service.middleware.get_user_id", return_value=1)
     @pytest.mark.asyncio
-    async def test_on_message_logs_without_duration(
+    async def test_on_message_logs_with_duration(
         self, mock_get_user_id, mock_event_logger
     ):
-        """on_message logs with action=mcp_message and duration_ms=None."""
+        """on_message logs after call_next with duration_ms and success=True."""
         middleware = LoggingMiddleware()
         ctx = _make_context(method="resources/read", name="instance/metadata")
         call_next = AsyncMock(return_value="resource_data")
@@ -150,9 +159,9 @@ class TestLoggingMiddlewareOnMessage:
         mock_event_logger.log.assert_called_once()
         call_kwargs = mock_event_logger.log.call_args[1]
         assert call_kwargs["action"] == "mcp_message"
-        assert call_kwargs["duration_ms"] is None
-        # on_message should NOT have success field
-        assert "success" not in call_kwargs["curated_payload"]
+        assert isinstance(call_kwargs["duration_ms"], int)
+        assert call_kwargs["duration_ms"] >= 0
+        assert call_kwargs["curated_payload"]["success"] is True
 
 
 class TestExtractContextInfo:
@@ -205,3 +214,230 @@ class TestExtractContextInfo:
         _, _, _, slice_id, _, _ = middleware._extract_context_info(ctx)
 
         assert slice_id == 66
+
+
+class TestLoggingMiddlewareMCPSource:
+    """Tests that LoggingMiddleware passes source=AuditLogSource.MCP."""
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=1)
+    @pytest.mark.asyncio
+    async def test_on_call_tool_passes_mcp_source(
+        self, mock_get_user_id, mock_event_logger
+    ) -> None:
+        middleware = LoggingMiddleware()
+        ctx = _make_context(name="list_charts")
+        call_next = AsyncMock(return_value="result")
+
+        await middleware.on_call_tool(ctx, call_next)
+
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["source"] == AuditLogSource.MCP
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=1)
+    @pytest.mark.asyncio
+    async def test_on_call_tool_failure_still_passes_mcp_source(
+        self, mock_get_user_id, mock_event_logger
+    ) -> None:
+        middleware = LoggingMiddleware()
+        ctx = _make_context(name="execute_sql")
+        call_next = AsyncMock(side_effect=ValueError("fail"))
+
+        with pytest.raises(ValueError, match="fail"):
+            await middleware.on_call_tool(ctx, call_next)
+
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["source"] == AuditLogSource.MCP
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=1)
+    @pytest.mark.asyncio
+    async def test_on_message_passes_mcp_source(
+        self, mock_get_user_id, mock_event_logger
+    ) -> None:
+        middleware = LoggingMiddleware()
+        ctx = _make_context(method="resources/read", name="instance/metadata")
+        call_next = AsyncMock(return_value="data")
+
+        await middleware.on_message(ctx, call_next)
+
+        call_kwargs = mock_event_logger.log.call_args[1]
+        assert call_kwargs["source"] == AuditLogSource.MCP
+
+
+class TestEventLoggerRequiredArgs:
+    """
+    Tests that all event_logger.log() call sites pass the four required
+    positional args (dashboard_id, duration_ms, slice_id, referrer).
+    Without these, DBEventLogger.log() raises TypeError silently swallowed
+    by the surrounding try/except, causing audit events to never be stored.
+    """
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=5)
+    @pytest.mark.asyncio
+    async def test_error_event_includes_required_positional_args(
+        self, mock_get_user_id, mock_event_logger
+    ) -> None:
+        """_handle_error() passes dashboard_id, duration_ms, slice_id, referrer."""
+        middleware = GlobalErrorHandlerMiddleware()
+        ctx = _make_context(name="list_charts")
+        call_next = AsyncMock(side_effect=RuntimeError("db connection failed"))
+
+        with pytest.raises(ToolError):
+            await middleware.on_message(ctx, call_next)
+
+        mock_event_logger.log.assert_called_once()
+        kw = mock_event_logger.log.call_args[1]
+        assert kw["action"] == "mcp_tool_error"
+        assert "dashboard_id" in kw
+        assert "slice_id" in kw
+        assert "referrer" in kw
+        assert "duration_ms" in kw
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=5)
+    @pytest.mark.asyncio
+    async def test_error_event_uses_sanitized_error_message(
+        self, mock_get_user_id, mock_event_logger
+    ) -> None:
+        """_handle_error() writes sanitized_error (not str(error)) to audit payload."""
+        middleware = GlobalErrorHandlerMiddleware()
+        ctx = _make_context(name="list_charts")
+        conn_string = "postgresql://user:p%40ssword@host/db"  # noqa: S105
+        call_next = AsyncMock(side_effect=RuntimeError(conn_string))
+
+        with pytest.raises(ToolError):
+            await middleware.on_message(ctx, call_next)
+
+        mock_event_logger.log.assert_called_once()
+        kw = mock_event_logger.log.call_args[1]
+        payload = kw["curated_payload"]
+        assert conn_string not in payload["error_message"]
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=None)
+    @pytest.mark.asyncio
+    async def test_rate_limit_event_includes_required_positional_args(
+        self, mock_get_user_id, mock_event_logger
+    ) -> None:
+        """RateLimitMiddleware passes dashboard_id, duration_ms, slice_id, referrer."""
+        middleware = RateLimitMiddleware(default_requests_per_minute=1)
+        ctx = _make_context(name="list_charts")
+        call_next = AsyncMock(return_value="ok")
+
+        # First call should succeed; trigger rate limit on second
+        with contextlib.suppress(ToolError):
+            await middleware.on_call_tool(ctx, call_next)
+
+        # Second call hits the rate limit
+        with pytest.raises(ToolError, match="Rate limit exceeded"):
+            await middleware.on_call_tool(ctx, call_next)
+
+        mock_event_logger.log.assert_called()
+        kw = mock_event_logger.log.call_args[1]
+        assert kw["action"] == "mcp_rate_limit_exceeded"
+        assert "dashboard_id" in kw
+        assert "duration_ms" in kw
+        assert "slice_id" in kw
+        assert "referrer" in kw
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=2)
+    @pytest.mark.asyncio
+    async def test_size_exceeded_event_includes_required_positional_args(
+        self, mock_get_user_id, mock_event_logger
+    ) -> None:
+        """ResponseSizeGuardMiddleware size-exceeded log includes all required args."""
+        middleware = ResponseSizeGuardMiddleware(token_limit=100)
+        ctx = _make_context(name="list_charts")
+        call_next = AsyncMock(return_value={"data": "x" * 10000})
+
+        with pytest.raises(ToolError):
+            await middleware.on_call_tool(ctx, call_next)
+
+        mock_event_logger.log.assert_called()
+        kw = mock_event_logger.log.call_args[1]
+        assert kw["action"] == "mcp_response_size_exceeded"
+        assert "dashboard_id" in kw
+        assert "duration_ms" in kw
+        assert "slice_id" in kw
+        assert "referrer" in kw
+
+    @patch("superset.mcp_service.middleware.event_logger")
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=2)
+    @pytest.mark.asyncio
+    async def test_truncation_event_includes_required_positional_args(
+        self, mock_get_user_id, mock_event_logger
+    ) -> None:
+        """ResponseSizeGuardMiddleware truncation log includes all required args."""
+        middleware = ResponseSizeGuardMiddleware(token_limit=500)
+        ctx = _make_context(name="get_dashboard_info")
+        large_response = {"id": 1, "description": "x" * 50000}
+        call_next = AsyncMock(return_value=large_response)
+
+        await middleware.on_call_tool(ctx, call_next)
+
+        mock_event_logger.log.assert_called()
+        kw = mock_event_logger.log.call_args[1]
+        assert kw["action"] == "mcp_response_truncated"
+        assert "dashboard_id" in kw
+        assert "duration_ms" in kw
+        assert "slice_id" in kw
+        assert "referrer" in kw
+
+
+class TestDBEventLoggerBulkSave:
+    """Verify that the records= kwarg actually reaches bulk_save_objects.
+
+    Uses a real DBEventLogger (not mocked) with only db.session patched,
+    confirming that omitting records= produces zero writes while including
+    it produces exactly one.
+    """
+
+    def test_log_with_records_calls_bulk_save_objects(self) -> None:
+        """DBEventLogger.log() with records=[payload] passes a non-empty list
+        to bulk_save_objects."""
+        db_event_logger = DBEventLogger()
+        payload = {"tool": "list_charts", "success": True}
+
+        with patch("superset.db") as mock_db:
+            db_event_logger.log(
+                user_id=1,
+                action="mcp_tool_call",
+                dashboard_id=None,
+                duration_ms=100,
+                slice_id=None,
+                referrer=None,
+                source=AuditLogSource.MCP,
+                records=[payload],
+                curated_payload=payload,
+            )
+
+        mock_db.session.bulk_save_objects.assert_called_once()
+        saved = mock_db.session.bulk_save_objects.call_args[0][0]
+        assert len(saved) == 1
+        assert saved[0].action == "mcp_tool_call"
+
+    def test_log_without_records_writes_nothing(self) -> None:
+        """DBEventLogger.log() without records= kwarg passes an empty list
+        to bulk_save_objects."""
+        db_event_logger = DBEventLogger()
+        payload = {"tool": "list_charts", "success": True}
+
+        with patch("superset.db") as mock_db:
+            db_event_logger.log(
+                user_id=1,
+                action="mcp_tool_call",
+                dashboard_id=None,
+                duration_ms=100,
+                slice_id=None,
+                referrer=None,
+                source=AuditLogSource.MCP,
+                curated_payload=payload,
+            )
+
+        mock_db.session.bulk_save_objects.assert_called_once()
+        saved = mock_db.session.bulk_save_objects.call_args[0][0]
+        assert len(saved) == 0

--- a/tests/unit_tests/migrations/test_add_source_to_logs.py
+++ b/tests/unit_tests/migrations/test_add_source_to_logs.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from importlib import import_module
+
+migration = import_module(
+    "superset.migrations.versions.2026-04-19_00-00_f3a8b2c91d4e_add_source_to_logs",
+)
+
+
+def test_revision_is_non_empty_string() -> None:
+    assert isinstance(migration.revision, str)
+    assert len(migration.revision) > 0
+
+
+def test_down_revision_is_non_empty_string() -> None:
+    assert isinstance(migration.down_revision, str)
+    assert len(migration.down_revision) > 0
+
+
+def test_revision_format() -> None:
+    assert migration.revision == "f3a8b2c91d4e"
+    assert migration.down_revision == "ce6bd21901ab"

--- a/tests/unit_tests/security/guest_rls_test.py
+++ b/tests/unit_tests/security/guest_rls_test.py
@@ -192,8 +192,8 @@ def _make_datasource_with_real_rls(dataset_id: int) -> MagicMock:
     datasource = _make_datasource(dataset_id)
     # Bind real BaseDatasource method so RLS logic executes against mocked
     # security_manager rather than returning MagicMock auto-stub
-    datasource.get_sqla_row_level_filters = (
-        lambda **kwargs: BaseDatasource.get_sqla_row_level_filters(datasource, **kwargs)
+    datasource.get_sqla_row_level_filters = lambda **kwargs: (
+        BaseDatasource.get_sqla_row_level_filters(datasource, **kwargs)
     )
     return datasource
 

--- a/tests/unit_tests/utils/log_tests.py
+++ b/tests/unit_tests/utils/log_tests.py
@@ -16,7 +16,10 @@
 # under the License.
 
 
-from superset.utils.log import get_logger_from_status
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from superset.utils.log import AuditLogSource, DBEventLogger, get_logger_from_status
 
 
 def test_log_from_status_exception() -> None:
@@ -35,3 +38,150 @@ def test_log_from_status_info() -> None:
     (func, log_level) = get_logger_from_status(300)
     assert func.__name__ == "info"
     assert log_level == "info"
+
+
+def test_audit_log_source_values() -> None:
+    assert AuditLogSource.API == "API"
+    assert AuditLogSource.MCP == "MCP"
+    assert AuditLogSource.CHATBOT == "Chatbot"
+    assert AuditLogSource.PRESET == "Preset"
+    assert AuditLogSource.EMBEDDED == "Embedded"
+    assert set(AuditLogSource) == {"API", "MCP", "Chatbot", "Preset", "Embedded"}
+
+
+def test_db_event_logger_log_with_source() -> None:
+    logger = DBEventLogger()
+
+    with (
+        patch("superset.db") as mock_db,
+        patch("superset.models.core.Log") as mock_log,
+    ):
+        mock_db.session.bulk_save_objects = MagicMock()
+        mock_db.session.commit = MagicMock()
+        mock_log.return_value = MagicMock()
+
+        logger.log(
+            user_id=1,
+            action="test_action",
+            dashboard_id=None,
+            duration_ms=100,
+            slice_id=None,
+            referrer=None,
+            records=[{}],
+            source=AuditLogSource.MCP,
+        )
+
+        mock_log.assert_called_once()
+        call_kwargs = mock_log.call_args[1]
+        assert call_kwargs["source"] == AuditLogSource.MCP
+
+
+def test_db_event_logger_log_without_source() -> None:
+    logger = DBEventLogger()
+
+    with (
+        patch("superset.db") as mock_db,
+        patch("superset.models.core.Log") as mock_log,
+    ):
+        mock_db.session.bulk_save_objects = MagicMock()
+        mock_db.session.commit = MagicMock()
+        mock_log.return_value = MagicMock()
+
+        logger.log(
+            user_id=1,
+            action="test_action",
+            dashboard_id=None,
+            duration_ms=100,
+            slice_id=None,
+            referrer=None,
+            records=[{}],
+        )
+
+        call_kwargs = mock_log.call_args[1]
+        assert call_kwargs["source"] is None
+
+
+def test_log_with_context_passes_audit_source() -> None:
+    logger = DBEventLogger()
+    captured: list[Any] = []
+
+    def fake_log(*args: Any, **kwargs: Any) -> None:
+        captured.append(kwargs.get("source"))
+
+    logger.log = fake_log  # type: ignore[method-assign]
+
+    # Pre-create mocks to avoid patch() calling _is_async_obj() on LocalProxies
+    # (Python 3.11 hasattr introspection requires an active request context).
+    mock_g = MagicMock()
+    mock_g.get.return_value = AuditLogSource.API
+    mock_request = MagicMock()
+    mock_request.referrer = None
+    mock_request.form.to_dict.return_value = {}
+    mock_request.args.to_dict.return_value = {}
+    mock_request.is_json = False
+    mock_request.url_rule = "/test"
+    mock_request.path = "/test"
+
+    with (
+        patch("superset.utils.log.has_request_context", return_value=True),
+        patch("superset.utils.log.g", new=mock_g),
+        patch("superset.utils.log.request", new=mock_request),
+        patch("superset.utils.log.get_user_id", return_value=None),
+        patch("superset.utils.log.stats_logger_manager"),
+    ):
+        logger.log_with_context(action="test_action", log_to_statsd=False)
+
+    assert captured == [AuditLogSource.API]
+
+
+def test_log_with_context_no_audit_source() -> None:
+    logger = DBEventLogger()
+    captured: list[Any] = []
+
+    def fake_log(*args: Any, **kwargs: Any) -> None:
+        captured.append(kwargs.get("source"))
+
+    logger.log = fake_log  # type: ignore[method-assign]
+
+    # Pre-create mocks to avoid patch() calling _is_async_obj() on LocalProxies
+    # (Python 3.11 hasattr introspection requires an active request context).
+    mock_g = MagicMock()
+    mock_g.get.return_value = None
+    mock_request = MagicMock()
+    mock_request.referrer = None
+    mock_request.form.to_dict.return_value = {}
+    mock_request.args.to_dict.return_value = {}
+    mock_request.is_json = False
+    mock_request.url_rule = "/test"
+    mock_request.path = "/test"
+
+    with (
+        patch("superset.utils.log.has_request_context", return_value=True),
+        patch("superset.utils.log.g", new=mock_g),
+        patch("superset.utils.log.request", new=mock_request),
+        patch("superset.utils.log.get_user_id", return_value=None),
+        patch("superset.utils.log.stats_logger_manager"),
+    ):
+        logger.log_with_context(action="test_action", log_to_statsd=False)
+
+    assert captured == [None]
+
+
+def test_log_with_context_outside_request() -> None:
+    logger = DBEventLogger()
+    captured: list[Any] = []
+
+    def fake_log(*args: Any, **kwargs: Any) -> None:
+        captured.append(kwargs.get("source"))
+
+    logger.log = fake_log  # type: ignore[method-assign]
+
+    with (
+        patch("superset.utils.log.has_request_context", return_value=False),
+        patch("superset.utils.log.request", None),
+        patch("superset.utils.log.get_user_id", return_value=None),
+        patch("superset.utils.log.stats_logger_manager"),
+    ):
+        logger.log_with_context(action="test_action", log_to_statsd=False)
+
+    assert captured == [None]

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -646,8 +646,9 @@ def test_get_user_agent(mocker: MockerFixture, app_context: None) -> None:
 
 @with_config(
     {
-        "USER_AGENT_FUNC": lambda database,
-        source: f"{database.database_name} {source.name}"
+        "USER_AGENT_FUNC": lambda database, source: (
+            f"{database.database_name} {source.name}"
+        )
     }
 )
 def test_get_user_agent_custom(mocker: MockerFixture, app_context: None) -> None:

--- a/tests/unit_tests/views/log/__init__.py
+++ b/tests/unit_tests/views/log/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/views/log/test_log_api.py
+++ b/tests/unit_tests/views/log/test_log_api.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from flask_appbuilder.models.sqla.filters import FilterIn
+
+from superset.views.log.api import LogRestApi
+
+
+def test_list_columns_contains_source() -> None:
+    assert "source" in LogRestApi.list_columns
+
+
+def test_search_columns_contains_source() -> None:
+    assert "source" in LogRestApi.search_columns
+
+
+def test_source_positioned_after_action_in_list_columns() -> None:
+    cols = LogRestApi.list_columns
+    assert cols.index("source") > cols.index("action")
+
+
+def test_source_positioned_after_action_in_search_columns() -> None:
+    cols = LogRestApi.search_columns
+    assert cols.index("source") > cols.index("action")
+
+
+def test_source_search_filter_uses_filter_in() -> None:
+    assert FilterIn in LogRestApi.search_filters.get("source", [])


### PR DESCRIPTION
### SUMMARY

Adds a nullable `source VARCHAR(32)` column to the `logs` table so administrators can distinguish how each audit log entry was initiated: MCP tool call, API-key-authenticated REST request, or browser session (NULL).

**What ships in this PR (Phase 1 — OSS):**
- `AuditLogSource` StrEnum with 5 values: `API`, `MCP`, `Chatbot`, `Preset`, `Embedded`
- DB migration `f3a8b2c91d4e`: `ALTER TABLE logs ADD COLUMN source VARCHAR(32) NULL` (zero-downtime, `batch_alter_table`)
- `Log.source` column on the SQLAlchemy model
- `DBEventLogger.log()` accepts `source` kwarg → persisted to DB
- `log_with_context()` reads `g.audit_source` when inside a Flask request context
- `before_request` hook: when `FAB_API_KEY_ENABLED=True` and a request carries an API key, stamps `g.audit_source = AuditLogSource.API`
- MCP middleware: all 6 event-logger call sites pass `source=AuditLogSource.MCP`
- `LogRestApi`: `source` added to `list_columns`, `search_columns`, and `search_filters` (multi-value `FilterIn`)
- ActionLog UI: Source column (plain-text render, null → blank) + multi-select Source filter with API/MCP options
- Fixes `handleSelectAll` rison-encode bug when `labelInValue=true` in the ListView Select component

**Phase 2 (separate story):** auto-detection for Chatbot, Preset, and Embedded sources. Enum values are already defined in OSS so Phase 2 requires no schema migration.

**Data flow — MCP tool call:**
```
MCP client → LoggingMiddleware → event_logger.log(source=AuditLogSource.MCP)
           → DBEventLogger → Log(source="MCP") → logs table
```

**Data flow — API-key request:**
```
HTTP request → before_request hook → g.audit_source = AuditLogSource.API
             → @log_this_with_context → log_with_context() reads g.audit_source
             → DBEventLogger → Log(source="API") → logs table
```

Browser sessions leave `source=NULL` — no `before_request` stamp, no MCP middleware.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Source column absent; no Source filter in `/actionlog/list`.

**After:** Source column visible between Action and User; multi-select filter shows API/MCP options; "Select all" applies `?filters=(source:!(API,MCP))` correctly (rison-encoded).

### TESTING INSTRUCTIONS

```bash
# Backend unit tests (39 tests)
pytest tests/unit_tests/utils/log_tests.py -v
pytest tests/unit_tests/initialization_test.py::TestAuditSourceHook -v
pytest tests/unit_tests/mcp_service/test_middleware_logging.py -v
pytest tests/unit_tests/views/log/test_log_api.py -v
pytest tests/unit_tests/migrations/test_add_source_to_logs.py -v

# Integration tests (11 tests)
pytest tests/integration_tests/log_api_tests.py -v

# Frontend tests (6 tests)
npm run test -- src/components/ListView/Filters/index.test.tsx --watchAll=false

# Manual UI verification
# 1. Apply migration: flask db upgrade
# 2. Make an MCP tool call (source should appear as "MCP")
# 3. Make an API-key authenticated request (source should appear as "API")
# 4. Open /actionlog/list — Source column visible between Action and User
# 5. Use Source filter — "API" and "MCP" options appear, multi-select works
# 6. Click "Select all (2)" — URL should show source:!(API,MCP), no runtime error
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: <!-- add upstream issue if exists -->
- [ ] Required feature flags:
- [x] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided — nullable column add, zero-downtime; downgrade drops column (data loss for logged source values)
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

**Pre-commit status:** ruff, mypy, prettier, oxlint all pass on changed files. Full `pre-commit run --all-files` has two pre-existing environment failures (`eslint-docs` — yarn not globally installed; `type-checking-frontend` — unbuilt TS packages) unrelated to this PR.

<!-- agor:pr-summary:begin -->
---

## Compozy Delivery Summary

| | |
|---|---|
| **Slug** | audit-logs-mcp-source |
| **Worktree** | sc-91636-audit-logs-oss |
| **Date** | 2026-04-21 |
| **Confidence** | PASS — 0 critical, 0 high, 0 medium, 1 low |
| **QA** | 40/40 rows pass (pass 4, 2026-04-21T15:50Z) |
| **Review** | Round 9 — Safe to merge |

### Phase 1 Requirements

| Req | Description | Status |
|-----|-------------|--------|
| R-01 | `AuditLogSource` enum (5 values: API, MCP, Chatbot, Preset, Embedded) | ✅ verified |
| R-02 | Nullable `source` column + `batch_alter_table` migration | ✅ verified |
| R-03 | `DBEventLogger.log()` accepts `source` kwarg | ✅ verified |
| R-04 | `log_with_context()` propagates `g.audit_source` | ✅ verified |
| R-05 | `before_request` hook detects API-key requests | ✅ verified |
| R-06 | All 6 MCP middleware call sites pass `source=MCP` | ✅ verified |
| R-07 | `LogRestApi` exposes `source` in list, search, FilterIn | ✅ verified |
| R-08 | `GET /api/v1/log/` returns and filters by source (integration) | ✅ verified |
| R-09 | Source column in ActionLog UI (`/actionlog/list`) | ✅ verified |
| R-10 | Source multi-select filter; F-004 `handleSelectAll` fix | ✅ verified |
| R-11 | Phase 2 sources (Chatbot, Preset, Embedded) | ⏸ deferred-approved |

### Follow-up items

- **r9-001 (LOW):** `LogMixin.label_columns` missing `"source": _("Source")` entry in `superset/views/log/__init__.py:29` — `LogModelView` is not registered in OSS; REST frontend unaffected. Deferred to follow-up PR.
- **Phase 2:** Chatbot, Preset, and Embedded auto-detection hooks (separate Shortcut story). Enum values already defined in OSS so Phase 2 needs no schema migration.
<!-- agor:pr-summary:end -->
