### PR TITLE
fix(cache-warmup): add missing dashboard context in DashboardTagsStrategy

### DIFF
--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -212,7 +212,7 @@ class DashboardTagsStrategy(Strategy):  # pylint: disable=too-few-public-methods
         )
         for dashboard in tagged_dashboards:
             for chart in dashboard.slices:
-                tasks.append(get_task(chart))
+                tasks.append(get_task(chart, dashboard))
 
         # add charts that are tagged
         tagged_objects = (

--- a/tests/integration_tests/strategy_tests.py
+++ b/tests/integration_tests/strategy_tests.py
@@ -113,14 +113,26 @@ class TestCacheWarmUp(SupersetTestCase):
         # tag dashboard 'births' with `tag1`
         tag1 = get_tag("tag1", db.session, TagType.custom)
         dash = self.get_dash_by_slug("births")
-        tag1_payloads = [{"chart_id": chart.id} for chart in dash.slices]
+        # dashboard-tagged charts must include the dashboard context so the
+        # cache is warmed for the chart as it appears within that dashboard
+        tag1_payloads = [
+            {"chart_id": chart.id, "dashboard_id": dash.id} for chart in dash.slices
+        ]
         tagged_object = TaggedObject(
             tag_id=tag1.id, object_id=dash.id, object_type=ObjectType.dashboard
         )
         db.session.add(tagged_object)
         db.session.commit()
 
-        assert len(strategy.get_tasks()) == len(tag1_payloads)
+        tasks = strategy.get_tasks()
+        assert len(tasks) == len(tag1_payloads)
+        assert sorted(
+            (task["payload"] for task in tasks),
+            key=lambda p: (p["chart_id"], p["dashboard_id"]),
+        ) == sorted(
+            tag1_payloads,
+            key=lambda p: (p["chart_id"], p["dashboard_id"]),
+        )
 
         strategy = DashboardTagsStrategy(["tag2"])
         tag2 = get_tag("tag2", db.session, TagType.custom)
@@ -139,7 +151,9 @@ class TestCacheWarmUp(SupersetTestCase):
         db.session.add(tagged_object)
         db.session.commit()
 
-        assert len(strategy.get_tasks()) == len(tag2_payloads)
+        tasks = strategy.get_tasks()
+        assert len(tasks) == len(tag2_payloads)
+        assert [task["payload"] for task in tasks] == tag2_payloads
 
         strategy = DashboardTagsStrategy(["tag1", "tag2"])
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add missing dashboard context in DashboardTagsStrategy for cache warmup.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
