### PR TITLE
fix(home): refresh Recent Activity after dashboard or chart deletion

### DIFF
--- a/superset-frontend/src/features/home/ChartTable.tsx
+++ b/superset-frontend/src/features/home/ChartTable.tsx
@@ -59,6 +59,7 @@ interface ChartTableProps {
   otherTabData?: Array<object>;
   otherTabFilters: Filter[];
   otherTabTitle: string;
+  refreshActivityData?: () => void;
 }
 
 function ChartTable({
@@ -70,6 +71,7 @@ function ChartTable({
   otherTabData,
   otherTabFilters,
   otherTabTitle,
+  refreshActivityData,
 }: ChartTableProps) {
   const history = useHistory();
   const initialTab = getItem(
@@ -231,7 +233,10 @@ function ChartTable({
               hasPerm={hasPerm}
               showThumbnails={showThumbnails}
               bulkSelectEnabled={bulkSelectEnabled}
-              refreshData={refreshData}
+              refreshData={() => {
+                refreshData();
+                refreshActivityData?.();
+              }}
               addDangerToast={addDangerToast}
               addSuccessToast={addSuccessToast}
               favoriteStatus={favoriteStatus[e.id]}

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -55,6 +55,7 @@ function DashboardTable({
   otherTabData,
   otherTabFilters,
   otherTabTitle,
+  refreshActivityData,
 }: DashboardTableProps) {
   const history = useHistory();
   const defaultTab = getItem(
@@ -240,7 +241,10 @@ function DashboardTable({
           onConfirm={() => {
             handleDashboardDelete(
               dashboardToDelete,
-              refreshData,
+              () => {
+                refreshData();
+                refreshActivityData?.();
+              },
               addSuccessToast,
               addDangerToast,
               activeTab,

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import {
   isFeatureEnabled,
@@ -208,12 +208,11 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     ];
   }, []);
 
-  useEffect(() => {
+  const refreshActivityData = useCallback(() => {
     if (!otherTabFilters || WelcomeMainExtension) {
       return;
     }
     const activeTab = getItem(LocalStorageKeys.HomepageActivityFilter, null);
-    setActiveState(collapseState.length > 0 ? collapseState : DEFAULT_TAB_ARR);
     getRecentActivityObjs(user.userId!, recent, addDangerToast, otherTabFilters)
       .then(res => {
         const data: ActivityData | null = {};
@@ -241,6 +240,14 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
           );
         }),
       );
+  }, [otherTabFilters, WelcomeMainExtension, user.userId, recent, addDangerToast]);
+
+  useEffect(() => {
+    if (!otherTabFilters || WelcomeMainExtension) {
+      return;
+    }
+    setActiveState(collapseState.length > 0 ? collapseState : DEFAULT_TAB_ARR);
+    refreshActivityData();
 
     // Sets other activity data in parallel with recents api call
     const ownSavedQueryFilters = [
@@ -394,6 +401,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
                         otherTabData={activityData?.[TableTab.Other]}
                         otherTabFilters={otherTabFilters}
                         otherTabTitle={otherTabTitle}
+                        refreshActivityData={refreshActivityData}
                       />
                     ),
                 },
@@ -411,6 +419,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
                         otherTabData={activityData?.[TableTab.Other]}
                         otherTabFilters={otherTabFilters}
                         otherTabTitle={otherTabTitle}
+                        refreshActivityData={refreshActivityData}
                       />
                     ),
                 },

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -49,6 +49,7 @@ export interface DashboardTableProps {
   otherTabData?: Array<Dashboard>;
   otherTabFilters: Filter[];
   otherTabTitle: string;
+  refreshActivityData?: () => void;
 }
 
 export interface Dashboard {


### PR DESCRIPTION
### SUMMARY

When a dashboard or chart is deleted from the Home page, the **Recent Activity** section was never re-fetched, leaving stale entries visible until the user manually reloaded the page.

**Root cause:** `activityData` was fetched once on mount inside a `useEffect` in `pages/Home/index.tsx`. `DashboardTable` and `ChartTable` each called their own `refreshData()` on deletion (which only refreshed their own section), but had no way to trigger a refresh of the activity feed.

**Fix:**
- Extracted the `getRecentActivityObjs` call from the one-shot `useEffect` into a stable `useCallback` (`refreshActivityData`) in `Home/index.tsx`.
- Passed `refreshActivityData` as an optional prop to both `<DashboardTable>` and `<ChartTable>`.
- In `DashboardTable`, the delete confirmation wraps `refreshData` so it also calls `refreshActivityData?.()` — `handleDashboardDelete` only invokes this on success, so no spurious refresh occurs.
- In `ChartTable`, the `refreshData` prop forwarded to `ChartCard` is wrapped identically.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (the bug is in async state management — stale React state vs. fresh API fetch).

### TESTING INSTRUCTIONS

1. Start Superset locally.
2. On the Home page, open the **Recents** section and note a dashboard (or chart) that appears under **Viewed**.
3. Scroll to the **Dashboards** (or **Charts**) section and delete that item.
4. **Before this fix:** the item remains in Recent Activity. **After this fix:** the Recent Activity section re-fetches and the deleted item disappears immediately.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #39435
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API