### PR TITLE
fix(home): refresh Recent activity immediately after Dashboard or Chart delete

### DIFF
--- a/superset-frontend/src/features/charts/ChartCard.tsx
+++ b/superset-frontend/src/features/charts/ChartCard.tsx
@@ -50,6 +50,7 @@ interface ChartCardProps {
   userId?: string | number;
   showThumbnails?: boolean;
   handleBulkChartExport: (chartsToExport: Chart[]) => void;
+  onDeleteSuccess?: () => void;
 }
 
 export default function ChartCard({
@@ -67,6 +68,7 @@ export default function ChartCard({
   chartFilter,
   userId,
   handleBulkChartExport,
+  onDeleteSuccess,
 }: ChartCardProps) {
   const history = useHistory();
   const canEdit = hasPerm('can_write');
@@ -136,6 +138,7 @@ export default function ChartCard({
               refreshData,
               chartFilter,
               userId,
+              onDeleteSuccess,
             )
           }
         >

--- a/superset-frontend/src/features/home/ChartTable.tsx
+++ b/superset-frontend/src/features/home/ChartTable.tsx
@@ -59,6 +59,7 @@ interface ChartTableProps {
   otherTabData?: Array<object>;
   otherTabFilters: Filter[];
   otherTabTitle: string;
+  onDeleteSuccess?: () => void;
 }
 
 function ChartTable({
@@ -70,6 +71,7 @@ function ChartTable({
   otherTabData,
   otherTabFilters,
   otherTabTitle,
+  onDeleteSuccess,
 }: ChartTableProps) {
   const history = useHistory();
   const initialTab = getItem(
@@ -234,6 +236,7 @@ function ChartTable({
               refreshData={refreshData}
               addDangerToast={addDangerToast}
               addSuccessToast={addSuccessToast}
+              onDeleteSuccess={onDeleteSuccess}
               favoriteStatus={favoriteStatus[e.id]}
               saveFavoriteStatus={saveFavoriteStatus}
               handleBulkChartExport={handleBulkChartExport}

--- a/superset-frontend/src/features/home/DashboardTable.test.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.test.tsx
@@ -493,6 +493,7 @@ test('passes correct parameters to handleDashboardDelete for Other tab', async (
     'Other',
     mockUser.userId,
     expect.any(Function),
+    undefined,
   );
 
   const lastCall = mockHandleDashboardDelete.mock.calls[0];

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -55,6 +55,7 @@ function DashboardTable({
   otherTabData,
   otherTabFilters,
   otherTabTitle,
+  onDeleteSuccess,
 }: DashboardTableProps) {
   const history = useHistory();
   const defaultTab = getItem(
@@ -246,6 +247,7 @@ function DashboardTable({
               activeTab,
               user?.userId,
               getData,
+              onDeleteSuccess,
             );
             setDashboardToDelete(null);
           }}

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -208,6 +208,30 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     ];
   }, []);
 
+  const fetchRecentActivity = () => {
+    getRecentActivityObjs(user.userId!, recent, addDangerToast, otherTabFilters)
+      .then(res => {
+        const data: ActivityData = {};
+        data[TableTab.Other] = res.other;
+        if (res.viewed) {
+          const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
+          data[TableTab.Viewed] = filtered;
+        }
+        setActivityData(prev => ({ ...prev, ...data }));
+      })
+      .catch(
+        createErrorHandler((errMsg: unknown) => {
+          setActivityData(prev => ({
+            ...prev,
+            [TableTab.Viewed]: [],
+          }));
+          addDangerToast(
+            t('There was an issue fetching your recent activity: %s', errMsg),
+          );
+        }),
+      );
+  };
+
   useEffect(() => {
     if (!otherTabFilters || WelcomeMainExtension) {
       return;
@@ -394,6 +418,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
                         otherTabData={activityData?.[TableTab.Other]}
                         otherTabFilters={otherTabFilters}
                         otherTabTitle={otherTabTitle}
+                        onDeleteSuccess={fetchRecentActivity}
                       />
                     ),
                 },
@@ -411,6 +436,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
                         otherTabData={activityData?.[TableTab.Other]}
                         otherTabFilters={otherTabFilters}
                         otherTabTitle={otherTabTitle}
+                        onDeleteSuccess={fetchRecentActivity}
                       />
                     ),
                 },

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -49,6 +49,7 @@ export interface DashboardTableProps {
   otherTabData?: Array<Dashboard>;
   otherTabFilters: Filter[];
   otherTabTitle: string;
+  onDeleteSuccess?: () => void;
 }
 
 export interface Dashboard {

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -327,6 +327,7 @@ export function handleChartDelete(
   refreshData: (arg0?: FetchDataConfig | null) => void,
   chartFilter?: string,
   userId?: string | number,
+  onActivityRefresh?: () => void,
 ) {
   const filters = {
     pageIndex: 0,
@@ -351,6 +352,7 @@ export function handleChartDelete(
     () => {
       if (chartFilter === 'Mine') refreshData(filters);
       else refreshData();
+      onActivityRefresh?.();
       addSuccessToast(t('Deleted: %s', sliceName));
     },
     () => {
@@ -367,6 +369,7 @@ export function handleDashboardDelete(
   dashboardFilter?: string,
   userId?: string | number,
   getData?: (tab: TableTab) => void,
+  onActivityRefresh?: () => void,
 ) {
   return SupersetClient.delete({
     endpoint: `/api/v1/dashboard/${id}`,
@@ -393,6 +396,7 @@ export function handleDashboardDelete(
       else if (dashboardFilter === 'Other' && getData)
         getData(dashboardFilter as TableTab);
       else refreshData();
+      onActivityRefresh?.();
       addSuccessToast(t('Deleted: %s', dashboardTitle));
     },
     createErrorHandler(errMsg =>


### PR DESCRIPTION
### SUMMARY

Deleting a Dashboard or Chart from the Home page removes it from the Dashboards/Charts section immediately, but the **Recent activity** section (Viewed tab) retained the deleted item until the page was manually reloaded. This PR fixes the inconsistency.

**Root cause:** `handleDashboardDelete` and `handleChartDelete` in `src/views/CRUD/utils.tsx` called `refreshData()` on success, which only refreshes the Dashboard/Chart list. The `activityData` state in Home (which drives Recent activity) was fetched once at page load via `getRecentActivityObjs()` with no hook wired to delete actions.

**Fix:** Added an optional `onActivityRefresh?: () => void` callback as a trailing argument to both `handleDashboardDelete` and `handleChartDelete`. When provided, it is called after a successful delete. Home passes `fetchRecentActivity` as `onDeleteSuccess` to both `DashboardTable` and `ChartTable`, which re-fetches from `/api/v1/log/recent_activity/` and merges the refreshed Viewed/Other tabs into state without resetting the active tab. All existing callers outside Home remain unaffected (the parameter is optional).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before** — "Video Game Sales" stays in Recents/Viewed after delete until page reload:

![Before — stale entry in Recents after delete](.agor/bugfix/gh-39435-home-recent-delete-refresh/evidence/before-04-bug-reproduced-stale-recent.png)

> Note: evidence paths reference local QA files. Key observation: Dashboards section shows item removed; Recents still shows item.

**After** — Recents/Viewed immediately shows "No results" after delete (no reload):

The Recents section clears the deleted item at the same time as the "Deleted: ..." toast appears, with no page reload required.

### TESTING INSTRUCTIONS

1. Log in to Superset; navigate to the Home page.
2. Click any Dashboard to create a "Viewed" entry in the Recent activity section.
3. Return to Home. Confirm the Dashboard appears in **both** Recent activity (Viewed tab) and the Dashboards section.
4. Click ⋮ on the Dashboard card → Delete → type `DELETE` → confirm.
5. **Expected (after fix):** Recent activity immediately shows the item removed — no page reload needed.
6. **Expected (before fix / regression check):** Reloading would clear it, but without reload it stays.

Repeat with a Chart to verify the Chart delete path.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #39435
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Regression risk:** Low. `onActivityRefresh` is optional — passing `undefined` (all non-Home callers) is a no-op via optional chaining (`?.`). One extra GET to `/api/v1/log/recent_activity/` fires per delete from Home, which is acceptable.