### PR TITLE
fix(mcp): resolve $ref by inlining definitions in compact schema

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -215,7 +215,7 @@ def _resolve_ref(
     ref_name = ref_path.rsplit("/", 1)[-1] if "/" in ref_path else ""
     definition = defs.get(ref_name) if ref_name else None
 
-    if definition and ref_name not in resolving:
+    if definition is not None and ref_name not in resolving:
         inlined = _compact_schema(
             definition,
             _defs=defs,

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -201,7 +201,43 @@ def _simplify_optional_union(result: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
-def _compact_schema(obj: Any) -> Any:
+def _resolve_ref(
+    obj: dict[str, Any],
+    defs: dict[str, Any],
+    resolving: frozenset[str],
+) -> Any:
+    """Resolve a ``$ref`` pointer by inlining its definition from *defs*.
+
+    Falls back to ``{"type": "object"}`` when the definition is missing
+    or would cause a circular reference.
+    """
+    ref_path: str = obj["$ref"]
+    ref_name = ref_path.rsplit("/", 1)[-1] if "/" in ref_path else ""
+    definition = defs.get(ref_name) if ref_name else None
+
+    if definition and ref_name not in resolving:
+        inlined = _compact_schema(
+            definition,
+            _defs=defs,
+            _resolving=resolving | {ref_name},
+        )
+        if isinstance(inlined, dict):
+            if desc := obj.get("description"):
+                inlined.setdefault("description", desc)
+        return inlined
+
+    replacement: dict[str, Any] = {"type": "object"}
+    if desc := obj.get("description"):
+        replacement["description"] = desc
+    return replacement
+
+
+def _compact_schema(
+    obj: Any,
+    *,
+    _defs: dict[str, Any] | None = None,
+    _resolving: frozenset[str] | None = None,
+) -> Any:
     """Collapse ``$defs`` and ``$ref`` pointers in a JSON Schema.
 
     Search results only need enough schema detail for the LLM to identify
@@ -212,28 +248,35 @@ def _compact_schema(obj: Any) -> Any:
     Transformations applied:
 
     * ``$defs`` sections are removed entirely.
-    * ``{"$ref": "..."}`` is replaced with ``{"type": "object"}``.
+    * ``{"$ref": "..."}`` is resolved by inlining the referenced
+      definition from ``$defs``.  If the definition cannot be found
+      (or would cause a circular reference), the ref is replaced with
+      ``{"type": "object"}``.
     * ``anyOf``/``oneOf`` lists containing only a ``$ref`` and
       ``{"type": "null"}`` (Pydantic's Optional encoding) are collapsed
       to the simplified non-null variant.
     """
     if isinstance(obj, list):
-        return [_compact_schema(item) for item in obj]
+        return [
+            _compact_schema(item, _defs=_defs, _resolving=_resolving) for item in obj
+        ]
     if not isinstance(obj, dict):
         return obj
 
-    # Direct $ref → generic object type
+    # On the first (top-level) call, extract $defs for later resolution.
+    if _defs is None:
+        _defs = obj.get("$defs", {})
+    if _resolving is None:
+        _resolving = frozenset()
+
     if "$ref" in obj:
-        replacement: dict[str, Any] = {"type": "object"}
-        if desc := obj.get("description"):
-            replacement["description"] = desc
-        return replacement
+        return _resolve_ref(obj, _defs, _resolving)
 
     result: dict[str, Any] = {}
     for key, value in obj.items():
         if key == "$defs":
             continue
-        result[key] = _compact_schema(value)
+        result[key] = _compact_schema(value, _defs=_defs, _resolving=_resolving)
 
     return _simplify_optional_union(result)
 

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -311,7 +311,7 @@ def test_normalize_ignores_keys_not_in_schema():
 
 
 def test_compact_schema_removes_defs():
-    """$defs section is stripped from the schema."""
+    """$defs section is stripped and refs are inlined from definitions."""
     schema = {
         "type": "object",
         "properties": {
@@ -328,7 +328,11 @@ def test_compact_schema_removes_defs():
     result = _compact_schema(schema)
 
     assert "$defs" not in result
-    assert result["properties"]["filters"]["items"] == {"type": "object"}
+    # $ref is resolved by inlining the definition from $defs
+    assert result["properties"]["filters"]["items"] == {
+        "type": "object",
+        "properties": {"col": {"type": "string"}},
+    }
 
 
 def test_compact_schema_replaces_ref_with_object():
@@ -399,7 +403,7 @@ def test_compact_schema_preserves_multi_variant_anyof():
 
 
 def test_compact_schema_nested_in_items():
-    """$ref nested inside items/properties is also replaced."""
+    """$ref nested inside items/properties falls back to object when no $defs."""
     schema = {
         "type": "object",
         "properties": {
@@ -413,6 +417,7 @@ def test_compact_schema_nested_in_items():
 
     result = _compact_schema(schema)
 
+    # No $defs in schema → falls back to {"type": "object"}
     assert result["properties"]["filters"]["items"] == {"type": "object"}
     assert result["properties"]["name"] == {"type": "string"}
 
@@ -438,6 +443,162 @@ def test_compact_schema_handles_non_dict():
     assert _compact_schema(42) == 42
     assert _compact_schema(None) is None
     assert _compact_schema([1, 2]) == [1, 2]
+
+
+def test_compact_schema_inlines_columnref_like_model():
+    """$ref to a model with fields is inlined, preserving field structure."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "metrics": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/ColumnRef"},
+            },
+        },
+        "$defs": {
+            "ColumnRef": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Column name"},
+                    "aggregate": {"type": "string", "description": "SQL aggregate"},
+                    "saved_metric": {"type": "boolean", "default": False},
+                },
+                "required": ["name"],
+            }
+        },
+    }
+
+    result = _compact_schema(schema)
+
+    assert "$defs" not in result
+    inlined = result["properties"]["metrics"]["items"]
+    assert inlined["type"] == "object"
+    assert "name" in inlined["properties"]
+    assert "aggregate" in inlined["properties"]
+    assert "saved_metric" in inlined["properties"]
+    assert inlined["required"] == ["name"]
+
+
+def test_compact_schema_inlines_nested_refs():
+    """Nested $ref chains are resolved transitively."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "config": {"$ref": "#/$defs/ChartConfig"},
+        },
+        "$defs": {
+            "ChartConfig": {
+                "type": "object",
+                "properties": {
+                    "metrics": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/ColumnRef"},
+                    },
+                },
+            },
+            "ColumnRef": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                },
+                "required": ["name"],
+            },
+        },
+    }
+
+    result = _compact_schema(schema)
+
+    assert "$defs" not in result
+    config = result["properties"]["config"]
+    assert config["type"] == "object"
+    col_ref = config["properties"]["metrics"]["items"]
+    assert col_ref["type"] == "object"
+    assert "name" in col_ref["properties"]
+
+
+def test_compact_schema_circular_ref_fallback():
+    """Circular $ref falls back to {"type": "object"} to avoid infinite recursion."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "node": {"$ref": "#/$defs/TreeNode"},
+        },
+        "$defs": {
+            "TreeNode": {
+                "type": "object",
+                "properties": {
+                    "children": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/TreeNode"},
+                    },
+                },
+            }
+        },
+    }
+
+    result = _compact_schema(schema)
+
+    assert "$defs" not in result
+    node = result["properties"]["node"]
+    assert node["type"] == "object"
+    # The self-reference falls back to {"type": "object"}
+    assert node["properties"]["children"]["items"] == {"type": "object"}
+
+
+def test_compact_schema_inline_with_sibling_description():
+    """Inlined $ref preserves sibling description via setdefault."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "col": {
+                "$ref": "#/$defs/ColumnRef",
+                "description": "The column to use",
+            },
+        },
+        "$defs": {
+            "ColumnRef": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }
+        },
+    }
+
+    result = _compact_schema(schema)
+
+    col = result["properties"]["col"]
+    assert col["type"] == "object"
+    assert "name" in col["properties"]
+    assert col["description"] == "The column to use"
+
+
+def test_compact_schema_inline_optional_ref():
+    """anyOf with $ref and null inlines the definition, not just {"type": "object"}."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "col": {
+                "anyOf": [
+                    {"$ref": "#/$defs/ColumnRef"},
+                    {"type": "null"},
+                ],
+                "description": "Optional column",
+            },
+        },
+        "$defs": {
+            "ColumnRef": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }
+        },
+    }
+
+    result = _compact_schema(schema)
+
+    col = result["properties"]["col"]
+    assert "anyOf" not in col
+    assert col["type"] == "object"
+    assert "name" in col["properties"]
+    assert col["description"] == "Optional column"
 
 
 # -- _truncate_description tests --
@@ -524,7 +685,11 @@ def test_create_serializer_compacts_schemas():
     assert len(result) == 1
     schema = result[0]["inputSchema"]
     assert "$defs" not in schema
-    assert schema["properties"]["filters"]["items"] == {"type": "object"}
+    # $ref is inlined from $defs, preserving field structure
+    assert schema["properties"]["filters"]["items"] == {
+        "type": "object",
+        "properties": {"col": {"type": "string"}},
+    }
 
 
 def test_create_serializer_truncates_descriptions():

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -601,6 +601,25 @@ def test_compact_schema_inline_optional_ref():
     assert col["description"] == "Optional column"
 
 
+def test_compact_schema_inlines_empty_def():
+    """Empty $defs entry ({}) is inlined as-is, not downgraded to {"type": "object"}."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "anything": {"$ref": "#/$defs/Anything"},
+        },
+        "$defs": {
+            "Anything": {},
+        },
+    }
+
+    result = _compact_schema(schema)
+
+    assert "$defs" not in result
+    # Empty dict is a valid schema — should be inlined as {}, not {"type": "object"}
+    assert result["properties"]["anything"] == {}
+
+
 # -- _truncate_description tests --
 
 

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -445,7 +445,7 @@ def test_compact_schema_handles_non_dict():
     assert _compact_schema([1, 2]) == [1, 2]
 
 
-def test_compact_schema_inlines_columnref_like_model():
+def test_compact_schema_inlines_columnref_like_model() -> None:
     """$ref to a model with fields is inlined, preserving field structure."""
     schema = {
         "type": "object",
@@ -479,7 +479,7 @@ def test_compact_schema_inlines_columnref_like_model():
     assert inlined["required"] == ["name"]
 
 
-def test_compact_schema_inlines_nested_refs():
+def test_compact_schema_inlines_nested_refs() -> None:
     """Nested $ref chains are resolved transitively."""
     schema = {
         "type": "object",
@@ -516,7 +516,7 @@ def test_compact_schema_inlines_nested_refs():
     assert "name" in col_ref["properties"]
 
 
-def test_compact_schema_circular_ref_fallback():
+def test_compact_schema_circular_ref_fallback() -> None:
     """Circular $ref falls back to {"type": "object"} to avoid infinite recursion."""
     schema = {
         "type": "object",
@@ -545,7 +545,7 @@ def test_compact_schema_circular_ref_fallback():
     assert node["properties"]["children"]["items"] == {"type": "object"}
 
 
-def test_compact_schema_inline_with_sibling_description():
+def test_compact_schema_inline_with_sibling_description() -> None:
     """Inlined $ref preserves sibling description via setdefault."""
     schema = {
         "type": "object",
@@ -571,7 +571,7 @@ def test_compact_schema_inline_with_sibling_description():
     assert col["description"] == "The column to use"
 
 
-def test_compact_schema_inline_optional_ref():
+def test_compact_schema_inline_optional_ref() -> None:
     """anyOf with $ref and null inlines the definition, not just {"type": "object"}."""
     schema = {
         "type": "object",
@@ -601,7 +601,7 @@ def test_compact_schema_inline_optional_ref():
     assert col["description"] == "Optional column"
 
 
-def test_compact_schema_inlines_empty_def():
+def test_compact_schema_inlines_empty_def() -> None:
     """Empty $defs entry ({}) is inlined as-is, not downgraded to {"type": "object"}."""
     schema = {
         "type": "object",


### PR DESCRIPTION
### SUMMARY

When `compact_schemas` is enabled for `search_tools`, `_compact_schema()` replaced all `$ref` pointers with `{"type": "object"}`, discarding referenced model field structure. This caused LLMs to lose `ColumnRef` fields (`name`, `label`, `aggregate`, `saved_metric`) and send malformed parameters to chart generation tools.

**Fix:** Resolve `$ref` pointers by inlining the actual definition from `$defs`. Circular references are detected and fall back to `{"type": "object"}`. Extracted `_resolve_ref()` helper to keep complexity under limits.

### TESTING INSTRUCTIONS

1. `pytest tests/unit_tests/mcp_service/test_tool_search_transform.py -v` — 54 tests pass (7 new)
2. New tests cover: ColumnRef inlining, nested ref chains, circular ref fallback, empty def inlining, optional ref inlining
3. E2E: `search_tools` → `generate_explore_link` with ColumnRef params succeeds

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API