### PR TITLE
fix(security): add UserSAMLModelView to USER_MODEL_VIEWS

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -361,6 +361,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "UserOAuthModelView",
         "UserOIDModelView",
         "UserRemoteUserModelView",
+        "UserSAMLModelView",
     }
 
     GAMMA_READ_ONLY_MODEL_VIEWS = {


### PR DESCRIPTION
### SUMMARY

`UserSAMLModelView` was missing from the `USER_MODEL_VIEWS` set in `SupersetSecurityManager`. This is inconsistent with all other `User*ModelView` entries (`UserDBModelView`, `UserOAuthModelView`, `UserOIDModelView`, etc.) which are already included. Adding it ensures SAML user management permissions are handled consistently with other auth providers.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend permission change only.

### TESTING INSTRUCTIONS

1. Configure a Superset instance with SAML authentication
2. Verify that non-admin roles no longer have CRUD permissions on `UserSAMLModelView`
3. Verify Admin users can still manage SAML users normally

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API