### PR TITLE
fix(explore): ensure unsaved-changes dialog renders above View SQL modal

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/UnsavedChangesModal/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/UnsavedChangesModal/index.tsx
@@ -20,6 +20,10 @@ import { t } from '@apache-superset/core';
 import { Icons, Modal, Typography, Button } from '@superset-ui/core/components';
 import type { FC, ReactElement } from 'react';
 
+// Ant Design's default modal zIndex is 1000. Using a higher value ensures
+// this dialog always renders above other open modals (e.g. a draggable View SQL modal).
+const UNSAVED_CHANGES_MODAL_Z_INDEX = 1100;
+
 export type UnsavedChangesModalProps = {
   showModal: boolean;
   onHide: () => void;
@@ -27,6 +31,7 @@ export type UnsavedChangesModalProps = {
   onConfirmNavigation: () => void;
   title?: string;
   body?: string;
+  zIndex?: number;
 };
 
 export const UnsavedChangesModal: FC<UnsavedChangesModalProps> = ({
@@ -36,6 +41,7 @@ export const UnsavedChangesModal: FC<UnsavedChangesModalProps> = ({
   onConfirmNavigation,
   title = 'Unsaved Changes',
   body = "If you don't save, changes will be lost.",
+  zIndex = UNSAVED_CHANGES_MODAL_Z_INDEX,
 }: UnsavedChangesModalProps): ReactElement => (
   <Modal
     centered
@@ -43,6 +49,7 @@ export const UnsavedChangesModal: FC<UnsavedChangesModalProps> = ({
     onHide={onHide}
     show={showModal}
     width="444px"
+    zIndex={zIndex}
     title={
       <>
         <Icons.WarningOutlined iconSize="m" style={{ marginRight: 8 }} />


### PR DESCRIPTION
### SUMMARY

In the chart builder (Explore view), when the **View SQL** modal is open and the user tries to navigate away, the **"Save changes to your chart?"** confirmation dialog was rendering _behind_ the View SQL modal — making it inaccessible.

**Root cause:** Both modals use Ant Design's default `zIndex: 1000`. The View SQL modal uses `draggable` + `resizable` props, which wraps its content in `react-draggable`. When dragged, a CSS `transform` is applied to the wrapper, creating a new CSS stacking context. Elements at the same z-index outside that stacking context render behind it, so the `UnsavedChangesModal` ends up hidden.

**Fix:** Give `UnsavedChangesModal` a default `zIndex` of `1100` (overridable via prop) so it always renders above other standard modals. The `Modal` component already accepts and forwards `zIndex` to Ant Design's modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!-- Skip - z-index layering bug; confirmation dialog was hidden behind View SQL modal -->

### TESTING INSTRUCTIONS

1. Open any chart in the Explore view
2. Make a change to the chart configuration (so unsaved changes exist)
3. Open the **⋮ menu → View query** modal
4. While the View SQL modal is open, try to navigate away (e.g. click the Superset logo or a nav link)
5. **Before fix:** the "Save changes to your chart?" dialog does not appear (hidden behind View SQL modal)
6. **After fix:** the dialog appears on top, fully accessible

Also verify:
- UnsavedChangesModal works normally when no other modal is open
- View SQL modal still opens, drags, and resizes correctly
- Dashboard unsaved-changes flow is unaffected

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API