### PR TITLE
fix(mcp): unwrap ToolResult payload before truncation in ResponseSizeGuardMiddleware

### DIFF
--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -954,7 +954,7 @@ class ResponseSizeGuardMiddleware(Middleware):
     @staticmethod
     def _extract_payload_from_tool_result(
         response: Any,
-    ) -> tuple[dict[str, Any], bool] | None:
+    ) -> dict[str, Any] | None:
         """Extract the JSON payload dict from a ToolResult's content[0].text.
 
         FastMCP converts tool return values into ToolResult before middleware
@@ -963,8 +963,8 @@ class ResponseSizeGuardMiddleware(Middleware):
         on that parsed dict — not on the ToolResult wrapper — otherwise
         phases like "truncate charts list" never find the right keys.
 
-        Returns ``(payload_dict, True)`` when extraction succeeds, or
-        ``None`` when the response is not a ToolResult or cannot be parsed.
+        Returns the payload dict when extraction succeeds, or ``None`` when
+        the response is not a ToolResult or cannot be parsed.
         """
         from fastmcp.tools.tool import ToolResult
 
@@ -988,7 +988,7 @@ class ResponseSizeGuardMiddleware(Middleware):
         if not isinstance(payload, dict):
             return None
 
-        return payload, True
+        return payload
 
     @staticmethod
     def _rewrap_as_tool_result(payload: dict[str, Any], original: Any) -> Any:
@@ -1027,9 +1027,13 @@ class ResponseSizeGuardMiddleware(Middleware):
         # Unwrap ToolResult so truncation operates on the real payload
         extracted = self._extract_payload_from_tool_result(response)
         if extracted is not None:
-            payload, _ = extracted
-            truncation_target = payload
+            truncation_target = extracted
         else:
+            logger.debug(
+                "Could not extract dict payload from response for %s; "
+                "falling back to truncating the raw response object",
+                tool_name,
+            )
             truncation_target = response
 
         try:
@@ -1112,7 +1116,7 @@ class ResponseSizeGuardMiddleware(Middleware):
         # payload inside content[0].text rather than on the ToolResult
         # wrapper (which would double-serialize the JSON string).
         extracted = self._extract_payload_from_tool_result(response)
-        estimation_target = extracted[0] if extracted is not None else response
+        estimation_target = extracted if extracted is not None else response
 
         try:
             estimated_tokens = estimate_response_tokens(estimation_target)

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -951,6 +951,59 @@ class ResponseSizeGuardMiddleware(Middleware):
             excluded_tools = [excluded_tools]
         self.excluded_tools = set(excluded_tools or [])
 
+    @staticmethod
+    def _extract_payload_from_tool_result(
+        response: Any,
+    ) -> tuple[dict[str, Any], bool] | None:
+        """Extract the JSON payload dict from a ToolResult's content[0].text.
+
+        FastMCP converts tool return values into ToolResult before middleware
+        sees them.  The actual data (e.g. DashboardInfo dict) is serialized
+        as a JSON string inside ``content[0].text``.  Truncation must operate
+        on that parsed dict — not on the ToolResult wrapper — otherwise
+        phases like "truncate charts list" never find the right keys.
+
+        Returns ``(payload_dict, True)`` when extraction succeeds, or
+        ``None`` when the response is not a ToolResult or cannot be parsed.
+        """
+        from fastmcp.tools.tool import ToolResult
+
+        from superset.utils.json import loads as json_loads
+
+        if not isinstance(response, ToolResult):
+            return None
+
+        if (
+            not response.content
+            or not hasattr(response.content[0], "text")
+            or not response.content[0].text
+        ):
+            return None
+
+        try:
+            payload = json_loads(response.content[0].text)
+        except (ValueError, TypeError):
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+
+        return payload, True
+
+    @staticmethod
+    def _rewrap_as_tool_result(payload: dict[str, Any], original: Any) -> Any:
+        """Re-serialize a truncated payload dict back into a ToolResult."""
+        from fastmcp.tools.tool import ToolResult
+        from mcp.types import TextContent
+
+        from superset.utils.json import dumps as json_dumps
+
+        text = json_dumps(payload)
+        return ToolResult(
+            content=[TextContent(type="text", text=text)],
+            meta=original.meta if isinstance(original, ToolResult) else None,
+        )
+
     def _try_truncate_info_response(
         self,
         tool_name: str,
@@ -960,15 +1013,28 @@ class ResponseSizeGuardMiddleware(Middleware):
         """Attempt to dynamically truncate an info tool response to fit the limit.
 
         Returns the truncated response if successful, None otherwise.
+
+        When the response is a ToolResult (the normal case — FastMCP wraps
+        every tool return value), the actual data lives inside
+        ``content[0].text`` as a JSON string.  We parse that string, run the
+        truncation phases on the resulting dict, then re-wrap the result.
         """
         from superset.mcp_service.utils.token_utils import (
             estimate_response_tokens,
             truncate_oversized_response,
         )
 
+        # Unwrap ToolResult so truncation operates on the real payload
+        extracted = self._extract_payload_from_tool_result(response)
+        if extracted is not None:
+            payload, _ = extracted
+            truncation_target = payload
+        else:
+            truncation_target = response
+
         try:
             truncated, was_truncated, notes = truncate_oversized_response(
-                response, self.token_limit
+                truncation_target, self.token_limit
             )
         except (MemoryError, RecursionError) as trunc_error:
             logger.warning(
@@ -1015,6 +1081,10 @@ class ResponseSizeGuardMiddleware(Middleware):
             truncated["_response_truncated"] = True
             truncated["_truncation_notes"] = notes
 
+        # Re-wrap into ToolResult if we unwrapped one
+        if extracted is not None and isinstance(truncated, dict):
+            return self._rewrap_as_tool_result(truncated, response)
+
         return truncated
 
     async def on_call_tool(
@@ -1038,8 +1108,14 @@ class ResponseSizeGuardMiddleware(Middleware):
             format_size_limit_error,
         )
 
+        # When the response is a ToolResult, estimate tokens on the actual
+        # payload inside content[0].text rather than on the ToolResult
+        # wrapper (which would double-serialize the JSON string).
+        extracted = self._extract_payload_from_tool_result(response)
+        estimation_target = extracted[0] if extracted is not None else response
+
         try:
-            estimated_tokens = estimate_response_tokens(response)
+            estimated_tokens = estimate_response_tokens(estimation_target)
         except MemoryError as me:
             logger.warning(
                 "MemoryError while estimating tokens for %s: %s", tool_name, me

--- a/tests/unit_tests/mcp_service/test_middleware.py
+++ b/tests/unit_tests/mcp_service/test_middleware.py
@@ -403,9 +403,7 @@ class TestExtractPayloadFromToolResult:
         )
 
         assert result is not None
-        extracted_payload, flag = result
-        assert extracted_payload == payload
-        assert flag is True
+        assert result == payload
 
     def test_returns_none_for_plain_dict(self) -> None:
         """Should return None when given a plain dict (not a ToolResult)."""

--- a/tests/unit_tests/mcp_service/test_middleware.py
+++ b/tests/unit_tests/mcp_service/test_middleware.py
@@ -19,6 +19,7 @@
 Unit tests for MCP service middleware.
 """
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -376,6 +377,284 @@ class TestCreateResponseSizeGuardMiddleware:
             middleware = create_response_size_guard_middleware()
 
         assert middleware is None
+
+
+class TestExtractPayloadFromToolResult:
+    """Tests for _extract_payload_from_tool_result static method."""
+
+    def _make_tool_result(self, text: str, meta: dict[str, Any] | None = None) -> Any:
+        from fastmcp.tools.tool import ToolResult
+        from mcp.types import TextContent
+
+        return ToolResult(
+            content=[TextContent(type="text", text=text)],
+            meta=meta,
+        )
+
+    def test_extracts_dict_payload(self) -> None:
+        """Should parse the JSON text inside content[0] and return the dict."""
+        from superset.utils import json
+
+        payload = {"id": 1, "name": "test", "charts": [1, 2, 3]}
+        tool_result = self._make_tool_result(json.dumps(payload))
+
+        result = ResponseSizeGuardMiddleware._extract_payload_from_tool_result(
+            tool_result
+        )
+
+        assert result is not None
+        extracted_payload, flag = result
+        assert extracted_payload == payload
+        assert flag is True
+
+    def test_returns_none_for_plain_dict(self) -> None:
+        """Should return None when given a plain dict (not a ToolResult)."""
+        assert (
+            ResponseSizeGuardMiddleware._extract_payload_from_tool_result(
+                {"key": "val"}
+            )
+            is None
+        )
+
+    def test_returns_none_for_string(self) -> None:
+        """Should return None when given a plain string."""
+        assert (
+            ResponseSizeGuardMiddleware._extract_payload_from_tool_result("string")
+            is None
+        )
+
+    def test_returns_none_for_list(self) -> None:
+        """Should return None when given a plain list."""
+        assert (
+            ResponseSizeGuardMiddleware._extract_payload_from_tool_result([1, 2, 3])
+            is None
+        )
+
+    def test_returns_none_for_none(self) -> None:
+        """Should return None when given None."""
+        assert (
+            ResponseSizeGuardMiddleware._extract_payload_from_tool_result(None) is None
+        )
+
+    def test_returns_none_when_payload_is_list(self) -> None:
+        """Should return None when JSON payload is a list, not a dict."""
+        from superset.utils import json
+
+        tool_result = self._make_tool_result(json.dumps([{"id": 1}, {"id": 2}]))
+
+        result = ResponseSizeGuardMiddleware._extract_payload_from_tool_result(
+            tool_result
+        )
+
+        assert result is None
+
+    def test_returns_none_for_invalid_json(self) -> None:
+        """Should return None when content text is not valid JSON."""
+        tool_result = self._make_tool_result("not valid {{{json")
+
+        result = ResponseSizeGuardMiddleware._extract_payload_from_tool_result(
+            tool_result
+        )
+
+        assert result is None
+
+    def test_returns_none_for_empty_text(self) -> None:
+        """Should return None when content[0].text is empty."""
+        tool_result = self._make_tool_result("")
+
+        result = ResponseSizeGuardMiddleware._extract_payload_from_tool_result(
+            tool_result
+        )
+
+        assert result is None
+
+    def test_returns_none_for_empty_content(self) -> None:
+        """Should return None when ToolResult has no content items."""
+        from fastmcp.tools.tool import ToolResult
+
+        tool_result = ToolResult(content=[], meta=None)
+
+        result = ResponseSizeGuardMiddleware._extract_payload_from_tool_result(
+            tool_result
+        )
+
+        assert result is None
+
+
+class TestRewrapAsToolResult:
+    """Tests for _rewrap_as_tool_result static method."""
+
+    def _make_tool_result(
+        self, payload: dict[str, Any], meta: dict[str, Any] | None = None
+    ) -> Any:
+        from fastmcp.tools.tool import ToolResult
+        from mcp.types import TextContent
+
+        from superset.utils import json
+
+        return ToolResult(
+            content=[TextContent(type="text", text=json.dumps(payload))],
+            meta=meta,
+        )
+
+    def test_returns_tool_result_with_serialized_payload(self) -> None:
+        """Should return a ToolResult whose content[0].text is the JSON payload."""
+        from fastmcp.tools.tool import ToolResult
+
+        from superset.utils import json
+
+        original = self._make_tool_result({"old": "data"})
+        new_payload = {"id": 1, "name": "truncated", "_response_truncated": True}
+
+        result = ResponseSizeGuardMiddleware._rewrap_as_tool_result(
+            new_payload, original
+        )
+
+        assert isinstance(result, ToolResult)
+        assert result.content[0].type == "text"
+        reparsed = json.loads(result.content[0].text)
+        assert reparsed == new_payload
+
+    def test_preserves_meta_from_original_tool_result(self) -> None:
+        """Should copy meta from the original ToolResult."""
+        from fastmcp.tools.tool import ToolResult
+
+        meta = {"request_id": "abc-123", "trace": "xyz"}
+        original = self._make_tool_result({"key": "val"}, meta=meta)
+
+        result = ResponseSizeGuardMiddleware._rewrap_as_tool_result(
+            {"key": "val"}, original
+        )
+
+        assert isinstance(result, ToolResult)
+        assert result.meta == meta
+
+    def test_sets_meta_none_for_non_tool_result_original(self) -> None:
+        """Should set meta=None when original is not a ToolResult."""
+        from fastmcp.tools.tool import ToolResult
+
+        result = ResponseSizeGuardMiddleware._rewrap_as_tool_result(
+            {"key": "val"}, {"not": "a ToolResult"}
+        )
+
+        assert isinstance(result, ToolResult)
+        assert result.meta is None
+
+
+class TestToolResultWrapping:
+    """Integration tests for ToolResult unwrap/truncate/rewrap in on_call_tool."""
+
+    def _make_tool_result(
+        self, payload: dict[str, Any], meta: dict[str, Any] | None = None
+    ) -> Any:
+        from fastmcp.tools.tool import ToolResult
+        from mcp.types import TextContent
+
+        from superset.utils import json
+
+        return ToolResult(
+            content=[TextContent(type="text", text=json.dumps(payload))],
+            meta=meta,
+        )
+
+    @pytest.mark.asyncio
+    async def test_info_tool_result_is_truncated_and_rewrapped(self) -> None:
+        """Truncate a ToolResult-wrapped info response and return a ToolResult."""
+        from fastmcp.tools.tool import ToolResult
+
+        from superset.utils import json
+
+        middleware = ResponseSizeGuardMiddleware(token_limit=500)
+        context = MagicMock()
+        context.message.name = "get_dataset_info"
+        context.message.params = {}
+
+        large_payload = {"id": 1, "table_name": "test", "description": "x" * 50000}
+        tool_result = self._make_tool_result(large_payload)
+        call_next = AsyncMock(return_value=tool_result)
+
+        with (
+            patch("superset.mcp_service.middleware.get_user_id", return_value=1),
+            patch("superset.mcp_service.middleware.event_logger"),
+        ):
+            result = await middleware.on_call_tool(context, call_next)
+
+        # Must return a ToolResult, not a raw dict
+        assert isinstance(result, ToolResult)
+        reparsed = json.loads(result.content[0].text)
+        assert reparsed["id"] == 1
+        assert reparsed["_response_truncated"] is True
+        assert "[truncated" in reparsed["description"]
+
+    @pytest.mark.asyncio
+    async def test_small_tool_result_passes_through_unchanged(self) -> None:
+        """Should return the original ToolResult when within the token limit."""
+
+        middleware = ResponseSizeGuardMiddleware(token_limit=25000)
+        context = MagicMock()
+        context.message.name = "get_chart_info"
+        context.message.params = {}
+
+        small_payload = {"id": 1, "name": "My Chart"}
+        tool_result = self._make_tool_result(small_payload)
+        call_next = AsyncMock(return_value=tool_result)
+
+        with (
+            patch("superset.mcp_service.middleware.get_user_id", return_value=1),
+            patch("superset.mcp_service.middleware.event_logger"),
+        ):
+            result = await middleware.on_call_tool(context, call_next)
+
+        assert result is tool_result
+
+    @pytest.mark.asyncio
+    async def test_large_non_info_tool_result_is_blocked(self) -> None:
+        """Should raise ToolError for a non-info ToolResult that exceeds the limit."""
+        middleware = ResponseSizeGuardMiddleware(token_limit=100)
+        context = MagicMock()
+        context.message.name = "list_charts"
+        context.message.params = {}
+
+        large_payload = {
+            "charts": [{"id": i, "name": f"chart_{i}"} for i in range(500)]
+        }
+        tool_result = self._make_tool_result(large_payload)
+        call_next = AsyncMock(return_value=tool_result)
+
+        with (
+            patch("superset.mcp_service.middleware.get_user_id", return_value=1),
+            patch("superset.mcp_service.middleware.event_logger"),
+            pytest.raises(ToolError),
+        ):
+            await middleware.on_call_tool(context, call_next)
+
+    @pytest.mark.asyncio
+    async def test_meta_preserved_after_truncation(self) -> None:
+        """Should preserve the original ToolResult meta through truncation."""
+        from fastmcp.tools.tool import ToolResult
+
+        from superset.utils import json
+
+        middleware = ResponseSizeGuardMiddleware(token_limit=500)
+        context = MagicMock()
+        context.message.name = "get_dashboard_info"
+        context.message.params = {}
+
+        meta = {"request_id": "abc-123"}
+        large_payload = {"id": 1, "title": "My Dashboard", "description": "x" * 50000}
+        tool_result = self._make_tool_result(large_payload, meta=meta)
+        call_next = AsyncMock(return_value=tool_result)
+
+        with (
+            patch("superset.mcp_service.middleware.get_user_id", return_value=1),
+            patch("superset.mcp_service.middleware.event_logger"),
+        ):
+            result = await middleware.on_call_tool(context, call_next)
+
+        assert isinstance(result, ToolResult)
+        assert result.meta == meta
+        reparsed = json.loads(result.content[0].text)
+        assert reparsed["_response_truncated"] is True
 
 
 class TestMiddlewareIntegration:


### PR DESCRIPTION
## Summary

ResponseSizeGuardMiddleware was truncating the ToolResult wrapper instead of the actual tool payload, causing broken JSON responses for dashboards with many charts.

FastMCP converts tool return values into `ToolResult` objects before middleware runs. The actual data (e.g. `DashboardInfo`) lives inside `content[0].text` as a serialized JSON string. The middleware was:

1. **Double-estimating tokens** — `model_dump()` on `ToolResult` re-serializes the JSON string inside `text`, inflating the estimate
2. **Truncating the wrong object** — the 5-phase truncation looked for fields like `charts`, `description`, `css` at the top level of the `ToolResult` dict, but those fields are buried inside the `content[0].text` JSON string

This caused `get_dashboard_info` to char-truncate `content[0].text` mid-JSON (Phase 1: `_truncate_strings` finds the giant `text` field), producing broken responses like `"Field 'content[0].text' truncated from 109892 chars"`.

### Fix

- Extract the payload from `content[0].text`, parse back to dict
- Run the 5-phase truncation on the actual dashboard/chart/dataset data
- Re-wrap the truncated dict into a new `ToolResult`
- Also fix token estimation to use the extracted payload

## Test plan

- [x] All 36 middleware unit tests pass (16 new tests added by reviewer)
- [x] All 1163 MCP service unit tests pass
- [x] Staging deploy on workspace `bcff9fe0.us1a.app-stg.preset.io`

### Staging test results

**Test 1: `get_dashboard_info(identifier=9)` — 4 charts**
```json
{
  "id": 9,
  "dashboard_title": "Video Game Market Analysis",
  "chart_count": 4,
  "charts": [
    {"id": 80, "slice_name": "Global Sales by Platform - Video Game Sales", "viz_type": "echarts_timeseries_bar"},
    {"id": 81, "slice_name": "Global Sales by Year - Video Game Sales", "viz_type": "echarts_timeseries_line"},
    {"id": 82, "slice_name": "Global Sales by Genre - Video Game Sales", "viz_type": "echarts_timeseries_bar"},
    {"id": 83, "slice_name": "Global Sales by Publisher - Video Game Sales", "viz_type": "echarts_timeseries_bar"}
  ],
  "omitted_fields": {
    "position_json": "Omitted (~3 KB)",
    "json_metadata": "Omitted (~419 B), useful parts extracted"
  }
}
```
Result: Valid JSON, lightweight DashboardChartSummary objects, position_json/json_metadata stripped.

**Test 2: `get_dashboard_info(identifier=7)` — 9 charts, 3 native filters**
```json
{
  "id": 7,
  "dashboard_title": "COVID Vaccine Dashboard",
  "chart_count": 9,
  "native_filters": [
    {"id": "NATIVE_FILTER-8jS1fx4hl", "name": "Country", "filter_type": "filter_select"},
    {"id": "NATIVE_FILTER-3_1wEdKkP", "name": "Vaccine Approach", "filter_type": "filter_select"},
    {"id": "NATIVE_FILTER-EWNH3M70z", "name": "Clinical Stage", "filter_type": "filter_select"}
  ],
  "cross_filters_enabled": true,
  "omitted_fields": {
    "position_json": "Omitted (~5 KB)",
    "json_metadata": "Omitted (~3 KB), useful parts extracted"
  }
}
```
Result: Valid JSON, native filters extracted, cross_filters_enabled extracted.

**Test 3: `get_dashboard_info(identifier=141)` — 94 charts (stress test)**
```
- chart_count: 94
- All 94 charts returned as DashboardChartSummary (id, slice_name, viz_type, datasource_name, url, description)
- position_json: "Omitted (~54 KB)"
- json_metadata: "Omitted (~401 B), useful parts extracted"
- Response: valid JSON, no truncation triggered (under 25K token limit)
```

**Test 4: `get_dashboard_info(identifier=142)` — 167 charts (max stress test)**
```
- chart_count: 167
- All 167 charts returned as DashboardChartSummary
- position_json: "Omitted (~96 KB)"
- json_metadata: "Omitted (~377 B), useful parts extracted"
- Response: valid JSON, no broken mid-JSON truncation
```

**Test 5: `get_dataset_info(identifier=19)` — 141 columns (FCC 2018 Survey)**
```
- 141 columns returned with column_name, verbose_name, type, is_dttm, groupby, filterable, description
- 1 metric (count)
- Response: valid JSON, no truncation needed
```

All responses return properly structured objects with no broken JSON, no `content[0].text` char-truncation.