### PR TITLE
fix(frontend): prevent LanguagePicker crash when locale is missing from LANGUAGES config

### DIFF
--- a/superset-frontend/src/features/home/LanguagePicker.tsx
+++ b/superset-frontend/src/features/home/LanguagePicker.tsx
@@ -61,9 +61,9 @@ export const useLanguageMenuItems = ({
       key: langKey,
       label: (
         <StyledLabel className="f16">
-          <i className={`flag ${languages[langKey].flag}`} />
-          <Typography.Link href={languages[langKey].url}>
-            {languages[langKey].name}
+          <i className={`flag ${languages[langKey]?.flag ?? ''}`} />
+          <Typography.Link href={languages[langKey]?.url}>
+            {languages[langKey]?.name}
           </Typography.Link>
         </StyledLabel>
       ),
@@ -75,7 +75,7 @@ export const useLanguageMenuItems = ({
       type: 'submenu' as const,
       label: (
         <span className="f16" aria-label={t('Languages')}>
-          <i className={`flag ${languages[locale].flag}`} />
+          <i className={`flag ${languages[locale]?.flag ?? ''}`} />
         </span>
       ),
       icon: <Icons.CaretDownOutlined iconSize="xs" />,

--- a/superset-frontend/src/features/home/LanguagePicker.tsx
+++ b/superset-frontend/src/features/home/LanguagePicker.tsx
@@ -25,9 +25,9 @@ import { Typography } from '@superset-ui/core/components/Typography';
 
 export interface Languages {
   [key: string]: {
-    flag: string;
-    url: string;
-    name: string;
+    flag?: string;
+    url?: string;
+    name?: string;
   };
 }
 

--- a/superset-frontend/src/features/home/LanguagePicker.tsx
+++ b/superset-frontend/src/features/home/LanguagePicker.tsx
@@ -61,7 +61,7 @@ export const useLanguageMenuItems = ({
       key: langKey,
       label: (
         <StyledLabel className="f16">
-          <i className={`flag ${languages[langKey]?.flag ?? ''}`} />
+          <i className={`flag ${languages[langKey]?.flag ?? 'us'}`} />
           <Typography.Link href={languages[langKey]?.url}>
             {languages[langKey]?.name}
           </Typography.Link>
@@ -75,7 +75,7 @@ export const useLanguageMenuItems = ({
       type: 'submenu' as const,
       label: (
         <span className="f16" aria-label={t('Languages')}>
-          <i className={`flag ${languages[locale]?.flag ?? ''}`} />
+          <i className={`flag ${languages[locale]?.flag ?? 'us'}`} />
         </span>
       ),
       icon: <Icons.CaretDownOutlined iconSize="xs" />,


### PR DESCRIPTION
### SUMMARY

When \`BABEL_DEFAULT_LOCALE\` is set to a locale that is not a key in the \`LANGUAGES\` config dict, \`LanguagePicker.tsx\` crashes the entire app with:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'flag')
\`\`\`

**Root cause:** The component accesses \`languages[locale].flag\` and \`languages[langKey].flag\` unconditionally. If the matching entry doesn't exist (user's \`LANGUAGES\` config doesn't include every possible locale, or an entry is missing the \`flag\` property), the app breaks at bundle load.

**Fix:** Add optional chaining (\`?.\`) and a fallback for the \`flag\` className so a missing locale/entry renders harmlessly instead of throwing.

Fixes #39163

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** App fails to load with a blank page. DevTools console shows \`TypeError: Cannot read properties of undefined (reading 'flag')\`.

**After:** App loads normally. If the flag icon can't be resolved for the current locale, the \`<i>\` element simply renders with an empty class — no crash.

### TESTING INSTRUCTIONS

1. In \`superset_config.py\`, set:
   \`\`\`python
   BABEL_DEFAULT_LOCALE = "de"
   LANGUAGES = {
       "en": {"flag": "us", "name": "English"},
       "fr": {"flag": "fr", "name": "French"},
   }
   \`\`\`
2. Start Superset and open it in the browser
3. **Before the fix:** blank page, \`TypeError\` in console
4. **With the fix:** page loads normally, language menu still renders

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #39163
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API