### PR TITLE
fix(bar-chart): cap bar width so a single data point doesn't stretch across the chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -389,6 +389,9 @@ export function transformSeries(
     ...(colorByPrimaryAxis ? {} : { itemStyle }),
     // @ts-ignore
     type: plotType,
+    // Cap bar width so a single data point doesn't stretch across the
+    // entire chart area. Bars with many categories auto-size below this cap.
+    ...(plotType === 'bar' ? { barMaxWidth: 100 } : {}),
     smooth: seriesType === 'smooth',
     triggerLineEvent: true,
     // @ts-expect-error


### PR DESCRIPTION
### SUMMARY

When a bar chart renders a single data point, the bar stretches to fill the entire chart width, which looks broken and confusing (users often think the chart is misconfigured or that data is duplicated).

**Fix:** Apply ECharts' \`barMaxWidth: 100\` (pixels) on bar series in the shared Timeseries \`transformSeries\` helper. This caps the bar at a sensible maximum width. Charts with many categories auto-scale below this cap, so there's no regression for the common case.

Fixes #33056

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**

<img width="1600" height="778" alt="image" src="https://github.com/user-attachments/assets/dcb860c3-2c4b-41c2-86eb-6723667ba52e" />



**After:**


<img width="1600" height="778" alt="image" src="https://github.com/user-attachments/assets/48953b6a-c9cc-4774-981c-72d240884f50" />

### TESTING INSTRUCTIONS

1. Open Explore → create a **Bar Chart**
2. Dataset: \`birth_names\`
3. X-axis: \`state\`, Metric: \`COUNT(*)\`
4. Filter: \`state = 'CA'\` (to get a single data point)
5. Click **Create chart**

**Before the fix:** the single bar spans the full chart area.
**After the fix:** the bar is capped at ~100px wide.

Also verify charts with many categories still render normally (bars auto-size below the cap).

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #33056
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API