### PR TITLE
chore(deps): bump pillow from 12.1.1 to 12.2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -281,7 +281,7 @@ parsedatetime==2.6
     # via apache-superset (pyproject.toml)
 pgsanity==0.2.9
     # via apache-superset (pyproject.toml)
-pillow==12.1.1
+pillow==12.2.0
     # via apache-superset (pyproject.toml)
 platformdirs==4.3.8
     # via requests-cache

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -655,7 +655,7 @@ pgsanity==0.2.9
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset


### PR DESCRIPTION
### SUMMARY

Bumps [Pillow](https://github.com/python-pillow/Pillow) from 12.1.1 to 12.2.0.

This addresses [CVE-2026-40192](https://nvd.nist.gov/vuln/detail/CVE-2026-40192) (CVSS 7.5 HIGH) — Pillow versions 10.3.0 through 12.1.1 did not limit the amount of GZIP-compressed data read when decoding a FITS image, making it vulnerable to decompression bomb attacks that could cause denial-of-service through memory exhaustion.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — dependency update only.

### TESTING INSTRUCTIONS

No functional changes. Verify CI passes and Pillow imports correctly.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API