### PR TITLE
fix(i18n): correct Ukrainian locale flag code and language name typo

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -436,7 +436,7 @@ LANGUAGES = {
     "sk": {"flag": "sk", "name": "Slovak"},
     "sl": {"flag": "si", "name": "Slovenian"},
     "nl": {"flag": "nl", "name": "Dutch"},
-    "uk": {"flag": "uk", "name": "Ukranian"},
+    "uk": {"flag": "ua", "name": "Ukrainian"},
     "mi": {"flag": "nz", "name": "Māori"},
 }
 # Turning off i18n by default as translation in most languages are


### PR DESCRIPTION
- Fix flag code from "uk" (United Kingdom 🇬🇧) to "ua" (Ukraine 🇺🇦)
- Fix typo in language name: "Ukranian" → "Ukrainian"

### SUMMARY
The Ukrainian locale had two bugs:
- Flag code was set to "uk" which maps to United Kingdom 🇬🇧 instead of "ua" for Ukraine 🇺🇦
- Language name had a typo: "Ukranian" instead of "Ukrainian"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable — config-only change, no visual diff available.

### TESTING INSTRUCTIONS
1. Add "uk" to LANGUAGES in superset_config.py
2. Switch language to Ukrainian in Settings → Language
3. Verify the Ukrainian flag 🇺🇦 appears in the language selector instead of 🇬🇧

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API