### PR TITLE
fix(mcp): sanitize chart config errors and accept field name aliases

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1460,7 +1460,12 @@ class GenerateChartRequest(QueryCacheControl):
         if not isinstance(data, dict):
             return data
         data["sanitization_warnings"] = []
-        raw = data.get("chart_name")
+        raw = (
+            data.get("chart_name")
+            or data.get("name")
+            or data.get("title")
+            or data.get("slice_name")
+        )
         if not isinstance(raw, str) or not raw.strip():
             return data
         sanitized, was_modified = sanitize_user_input_with_changes(

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1527,6 +1527,8 @@ class GenerateExploreLinkRequest(FormDataCacheControl):
 
 
 class UpdateChartRequest(QueryCacheControl):
+    model_config = ConfigDict(populate_by_name=True)
+
     identifier: int | str = Field(..., description="Chart ID or UUID")
     config: Dict[str, Any] | None = Field(
         None,
@@ -1535,7 +1537,10 @@ class UpdateChartRequest(QueryCacheControl):
         ),
     )
     chart_name: str | None = Field(
-        None, description="Auto-generates if omitted", max_length=255
+        None,
+        description="Auto-generates if omitted",
+        max_length=255,
+        validation_alias=AliasChoices("chart_name", "name", "title", "slice_name"),
     )
     generate_preview: bool = Field(
         default=True,

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1412,10 +1412,15 @@ class ListChartsRequest(MetadataCacheControl):
 
 # The tool input models
 class GenerateChartRequest(QueryCacheControl):
+    model_config = ConfigDict(populate_by_name=True)
+
     dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
     config: Dict[str, Any] = Field(..., description=_CHART_CONFIG_DESCRIPTION)
     chart_name: str | None = Field(
-        None, description="Auto-generates if omitted", max_length=255
+        None,
+        description="Auto-generates if omitted",
+        max_length=255,
+        validation_alias=AliasChoices("chart_name", "name", "title", "slice_name"),
     )
     save_chart: bool = Field(default=False, description="Save permanently in Superset")
     generate_preview: bool = True

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1460,12 +1460,12 @@ class GenerateChartRequest(QueryCacheControl):
         if not isinstance(data, dict):
             return data
         data["sanitization_warnings"] = []
-        raw = (
-            data.get("chart_name")
-            or data.get("name")
-            or data.get("title")
-            or data.get("slice_name")
-        )
+        for key in ("chart_name", "name", "title", "slice_name"):
+            if key in data:
+                raw = data[key]
+                break
+        else:
+            raw = None
         if not isinstance(raw, str) or not raw.strip():
             return data
         sanitized, was_modified = sanitize_user_input_with_changes(

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -285,7 +285,34 @@ async def generate_chart(  # noqa: C901
             )
 
         # Parse the raw config dict into a typed ChartConfig for downstream use
-        config = parse_chart_config(request.config)
+        try:
+            config = parse_chart_config(request.config)
+        except (ValueError, TypeError) as e:
+            from superset.mcp_service.chart.validation.pipeline import (
+                _sanitize_validation_error,
+            )
+
+            sanitized = _sanitize_validation_error(e)
+            execution_time = int((time.time() - start_time) * 1000)
+            return GenerateChartResponse.model_validate(
+                {
+                    "chart": None,
+                    "error": {
+                        "error_type": "validation_error",
+                        "message": f"Invalid chart configuration: {sanitized}",
+                        "details": sanitized,
+                        "error_code": "INVALID_CHART_CONFIG",
+                    },
+                    "performance": {
+                        "query_duration_ms": execution_time,
+                        "cache_status": "error",
+                        "optimization_suggestions": [],
+                    },
+                    "success": False,
+                    "schema_version": "2.0",
+                    "api_version": "v1",
+                }
+            )
 
         # Map the simplified config to Superset's form_data format
         # Pass dataset_id to enable column type checking for proper viz_type selection

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -288,7 +288,7 @@ async def generate_chart(  # noqa: C901
         try:
             config = parse_chart_config(request.config)
         except (ValueError, TypeError) as e:
-            from superset.mcp_service.chart.validation.pipeline import (
+            from superset.mcp_service.utils.error_sanitization import (
                 _sanitize_validation_error,
             )
 

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -86,43 +86,23 @@ def _missing_config_or_name_error() -> GenerateChartResponse:
 def _build_update_payload(
     request: UpdateChartRequest,
     chart: Any,
+    parsed_config: Any = None,
 ) -> dict[str, Any] | GenerateChartResponse:
     """Build the update payload for a chart update.
 
     Returns a dict payload on success, or a GenerateChartResponse error
     when neither config nor chart_name is provided.
+    ``parsed_config`` is the pre-parsed chart config from the caller.
     """
-    if request.config is not None:
-        try:
-            config = parse_chart_config(request.config)
-        except (ValueError, TypeError) as e:
-            from superset.mcp_service.chart.validation.pipeline import (
-                _sanitize_validation_error,
-            )
-
-            sanitized = _sanitize_validation_error(e)
-            return GenerateChartResponse.model_validate(
-                {
-                    "chart": None,
-                    "error": {
-                        "error_type": "validation_error",
-                        "message": f"Invalid chart configuration: {sanitized}",
-                        "details": sanitized,
-                        "error_code": "INVALID_CHART_CONFIG",
-                    },
-                    "success": False,
-                    "schema_version": "2.0",
-                    "api_version": "v1",
-                }
-            )
+    if parsed_config is not None:
         dataset_id = chart.datasource_id if chart.datasource_id else None
-        new_form_data = map_config_to_form_data(config, dataset_id=dataset_id)
+        new_form_data = map_config_to_form_data(parsed_config, dataset_id=dataset_id)
         new_form_data.pop("_mcp_warnings", None)
 
         chart_name = (
             request.chart_name
             if request.chart_name
-            else chart.slice_name or generate_chart_name(config)
+            else chart.slice_name or generate_chart_name(parsed_config)
         )
 
         return {
@@ -142,12 +122,14 @@ def _build_update_payload(
 def _build_preview_form_data(
     request: UpdateChartRequest,
     chart: Any,
+    parsed_config: Any = None,
 ) -> dict[str, Any] | GenerateChartResponse:
     """Merge the existing chart's form_data with the requested changes.
 
     Used by the preview-first flow so the user can review edits in Explore
     before clicking Save. Returns the merged form_data dict on success, or a
     GenerateChartResponse error when neither config nor chart_name is given.
+    ``parsed_config`` is the pre-parsed chart config from the caller.
     """
     existing_form_data: dict[str, Any] = {}
     if getattr(chart, "params", None):
@@ -159,31 +141,9 @@ def _build_preview_form_data(
             )
             existing_form_data = {}
 
-    if request.config is not None:
-        try:
-            config = parse_chart_config(request.config)
-        except (ValueError, TypeError) as e:
-            from superset.mcp_service.chart.validation.pipeline import (
-                _sanitize_validation_error,
-            )
-
-            sanitized = _sanitize_validation_error(e)
-            return GenerateChartResponse.model_validate(
-                {
-                    "chart": None,
-                    "error": {
-                        "error_type": "validation_error",
-                        "message": f"Invalid chart configuration: {sanitized}",
-                        "details": sanitized,
-                        "error_code": "INVALID_CHART_CONFIG",
-                    },
-                    "success": False,
-                    "schema_version": "2.0",
-                    "api_version": "v1",
-                }
-            )
+    if parsed_config is not None:
         dataset_id = chart.datasource_id if chart.datasource_id else None
-        new_form_data = map_config_to_form_data(config, dataset_id=dataset_id)
+        new_form_data = map_config_to_form_data(parsed_config, dataset_id=dataset_id)
         new_form_data.pop("_mcp_warnings", None)
         merged = {**existing_form_data, **new_form_data}
     else:
@@ -361,10 +321,36 @@ async def update_chart(  # noqa: C901
         saved = False
         new_form_data: dict[str, Any] | None = None
 
+        # Parse config once upfront so helpers and analysis can reuse it.
+        parsed_config = None
+        if request.config is not None:
+            try:
+                parsed_config = parse_chart_config(request.config)
+            except (ValueError, TypeError) as e:
+                from superset.mcp_service.chart.validation.pipeline import (
+                    _sanitize_validation_error,
+                )
+
+                sanitized = _sanitize_validation_error(e)
+                return GenerateChartResponse.model_validate(
+                    {
+                        "chart": None,
+                        "error": {
+                            "error_type": "validation_error",
+                            "message": f"Invalid chart configuration: {sanitized}",
+                            "details": sanitized,
+                            "error_code": "INVALID_CHART_CONFIG",
+                        },
+                        "success": False,
+                        "schema_version": "2.0",
+                        "api_version": "v1",
+                    }
+                )
+
         if not request.generate_preview:
             from superset.commands.chart.update import UpdateChartCommand
 
-            payload_or_error = _build_update_payload(request, chart)
+            payload_or_error = _build_update_payload(request, chart, parsed_config)
             if isinstance(payload_or_error, GenerateChartResponse):
                 return payload_or_error
 
@@ -380,7 +366,7 @@ async def update_chart(  # noqa: C901
                 f"{get_superset_base_url()}/explore/?slice_id={updated_chart.id}"
             )
         else:
-            preview_or_error = _build_preview_form_data(request, chart)
+            preview_or_error = _build_preview_form_data(request, chart, parsed_config)
             if isinstance(preview_or_error, GenerateChartResponse):
                 return preview_or_error
 
@@ -389,15 +375,9 @@ async def update_chart(  # noqa: C901
                     chart, preview_or_error
                 )
 
-        # Parse config for analysis (may be None for name-only updates)
-        try:
-            config = parse_chart_config(request.config) if request.config else None
-        except (ValueError, TypeError):
-            config = None
-
         chart_for_analysis = updated_chart if saved else chart
-        capabilities = analyze_chart_capabilities(chart_for_analysis, config)
-        semantics = analyze_chart_semantics(chart_for_analysis, config)
+        capabilities = analyze_chart_capabilities(chart_for_analysis, parsed_config)
+        semantics = analyze_chart_semantics(chart_for_analysis, parsed_config)
 
         execution_time = int((time.time() - start_time) * 1000)
         performance = PerformanceMetadata(

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -93,7 +93,28 @@ def _build_update_payload(
     when neither config nor chart_name is provided.
     """
     if request.config is not None:
-        config = parse_chart_config(request.config)
+        try:
+            config = parse_chart_config(request.config)
+        except (ValueError, TypeError) as e:
+            from superset.mcp_service.chart.validation.pipeline import (
+                _sanitize_validation_error,
+            )
+
+            sanitized = _sanitize_validation_error(e)
+            return GenerateChartResponse.model_validate(
+                {
+                    "chart": None,
+                    "error": {
+                        "error_type": "validation_error",
+                        "message": f"Invalid chart configuration: {sanitized}",
+                        "details": sanitized,
+                        "error_code": "INVALID_CHART_CONFIG",
+                    },
+                    "success": False,
+                    "schema_version": "2.0",
+                    "api_version": "v1",
+                }
+            )
         dataset_id = chart.datasource_id if chart.datasource_id else None
         new_form_data = map_config_to_form_data(config, dataset_id=dataset_id)
         new_form_data.pop("_mcp_warnings", None)
@@ -139,7 +160,28 @@ def _build_preview_form_data(
             existing_form_data = {}
 
     if request.config is not None:
-        config = parse_chart_config(request.config)
+        try:
+            config = parse_chart_config(request.config)
+        except (ValueError, TypeError) as e:
+            from superset.mcp_service.chart.validation.pipeline import (
+                _sanitize_validation_error,
+            )
+
+            sanitized = _sanitize_validation_error(e)
+            return GenerateChartResponse.model_validate(
+                {
+                    "chart": None,
+                    "error": {
+                        "error_type": "validation_error",
+                        "message": f"Invalid chart configuration: {sanitized}",
+                        "details": sanitized,
+                        "error_code": "INVALID_CHART_CONFIG",
+                    },
+                    "success": False,
+                    "schema_version": "2.0",
+                    "api_version": "v1",
+                }
+            )
         dataset_id = chart.datasource_id if chart.datasource_id else None
         new_form_data = map_config_to_form_data(config, dataset_id=dataset_id)
         new_form_data.pop("_mcp_warnings", None)
@@ -348,7 +390,10 @@ async def update_chart(  # noqa: C901
                 )
 
         # Parse config for analysis (may be None for name-only updates)
-        config = parse_chart_config(request.config) if request.config else None
+        try:
+            config = parse_chart_config(request.config) if request.config else None
+        except (ValueError, TypeError):
+            config = None
 
         chart_for_analysis = updated_chart if saved else chart
         capabilities = analyze_chart_capabilities(chart_for_analysis, config)

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -392,7 +392,11 @@ async def update_chart(  # noqa: C901
             else (
                 request.chart_name
                 or (chart.slice_name if hasattr(chart, "slice_name") else None)
-                or (generate_chart_name(config) if config else "Updated chart")
+                or (
+                    generate_chart_name(parsed_config)
+                    if parsed_config
+                    else "Updated chart"
+                )
             )
         )
         accessibility = AccessibilityMetadata(

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -327,7 +327,7 @@ async def update_chart(  # noqa: C901
             try:
                 parsed_config = parse_chart_config(request.config)
             except (ValueError, TypeError) as e:
-                from superset.mcp_service.chart.validation.pipeline import (
+                from superset.mcp_service.utils.error_sanitization import (
                     _sanitize_validation_error,
                 )
 
@@ -340,6 +340,11 @@ async def update_chart(  # noqa: C901
                             "message": f"Invalid chart configuration: {sanitized}",
                             "details": sanitized,
                             "error_code": "INVALID_CHART_CONFIG",
+                        },
+                        "performance": {
+                            "query_duration_ms": int((time.time() - start_time) * 1000),
+                            "cache_status": "error",
+                            "optimization_suggestions": [],
                         },
                         "success": False,
                         "schema_version": "2.0",

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -105,7 +105,26 @@ def update_chart_preview(
 
     try:
         # Parse the raw config dict into a typed ChartConfig
-        config = parse_chart_config(request.config)
+        try:
+            config = parse_chart_config(request.config)
+        except (ValueError, TypeError) as e:
+            from superset.mcp_service.chart.validation.pipeline import (
+                _sanitize_validation_error,
+            )
+
+            sanitized = _sanitize_validation_error(e)
+            return {
+                "chart": None,
+                "error": f"Invalid chart configuration: {sanitized}",
+                "performance": {
+                    "query_duration_ms": int((time.time() - start_time) * 1000),
+                    "cache_status": "error",
+                    "optimization_suggestions": [],
+                },
+                "success": False,
+                "schema_version": "2.0",
+                "api_version": "v1",
+            }
 
         with event_logger.log_context(action="mcp.update_chart_preview.form_data"):
             # Map the new config to form_data format

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -108,14 +108,19 @@ def update_chart_preview(
         try:
             config = parse_chart_config(request.config)
         except (ValueError, TypeError) as e:
-            from superset.mcp_service.chart.validation.pipeline import (
+            from superset.mcp_service.utils.error_sanitization import (
                 _sanitize_validation_error,
             )
 
             sanitized = _sanitize_validation_error(e)
             return {
                 "chart": None,
-                "error": f"Invalid chart configuration: {sanitized}",
+                "error": {
+                    "error_type": "validation_error",
+                    "message": f"Invalid chart configuration: {sanitized}",
+                    "details": sanitized,
+                    "error_code": "INVALID_CHART_CONFIG",
+                },
                 "performance": {
                     "query_duration_ms": int((time.time() - start_time) * 1000),
                     "cache_status": "error",

--- a/superset/mcp_service/chart/validation/pipeline.py
+++ b/superset/mcp_service/chart/validation/pipeline.py
@@ -21,7 +21,6 @@ Orchestrates schema, dataset, and runtime validations.
 """
 
 import logging
-import re
 from typing import Any, Dict, List, Tuple
 
 from superset.mcp_service.chart.schemas import (
@@ -36,88 +35,14 @@ from superset.mcp_service.common.error_schemas import (
 
 logger = logging.getLogger(__name__)
 
-
-def _redact_sql_select(error_str: str, error_str_upper: str) -> str:
-    """Redact SELECT...FROM clause content to prevent data disclosure."""
-    if "SELECT" in error_str_upper and "FROM" in error_str_upper:
-        select_idx = error_str_upper.find("SELECT")
-        from_idx = error_str_upper.find("FROM", select_idx)
-        if select_idx != -1 and from_idx != -1:
-            return error_str[: select_idx + 7] + " [REDACTED] " + error_str[from_idx:]
-    return error_str
-
-
-def _redact_sql_where(error_str: str, error_str_upper: str) -> str:
-    """Redact WHERE clause content to prevent data disclosure."""
-    if "WHERE" not in error_str_upper:
-        return error_str
-
-    where_idx = error_str_upper.find("WHERE")
-    terminators = ["ORDER", "GROUP", "LIMIT", "UNION", "EXCEPT", "INTERSECT"]
-    term_idx = len(error_str)
-    for term in terminators:
-        idx = error_str_upper.find(term, where_idx)
-        if idx != -1 and idx < term_idx:
-            term_idx = idx
-    return error_str[: where_idx + 6] + " [REDACTED]" + error_str[term_idx:]
-
-
-def _get_generic_error_message(error_str: str) -> str | None:
-    """Return generic message for common error types, or None."""
-    error_lower = error_str.lower()
-    if "permission" in error_lower or "access" in error_lower:
-        return "Validation failed due to access restrictions"
-    if "database" in error_lower or "connection" in error_lower:
-        return "Validation failed due to database connectivity"
-    if "timeout" in error_lower:
-        return "Validation timed out"
-    return None
-
-
-def _sanitize_validation_error(error: Exception) -> str:
-    """SECURITY FIX: Sanitize validation errors to prevent disclosure."""
-    error_str = str(error)
-
-    # Pydantic tagged-union errors prefix the message with a long
-    # ``1 validation error for tagged-union[...]`` header before the
-    # per-field body (e.g. ``Value error, ...``, ``Field required``,
-    # ``Input should be ...``). The body always lives on a line indented
-    # by exactly two spaces — pull it out so the 200-char truncation
-    # below doesn't swallow the actionable part. The pydantic footer
-    # ``\n    For further information ...`` uses four-space indent and
-    # is dropped here.
-    if "tagged-union[" in error_str:
-        body_match = re.search(r"\n  (?! )", error_str)
-        if body_match:
-            idx = body_match.end()
-            footer_idx = error_str.find("\n    For further information", idx)
-            end = footer_idx if footer_idx != -1 else len(error_str)
-            error_str = error_str[idx:end].strip()
-
-    # SECURITY FIX: Limit length FIRST to prevent ReDoS attacks
-    if len(error_str) > 200:
-        error_str = error_str[:200] + "...[truncated]"
-
-    # Remove potentially sensitive schema information
-    sensitive_patterns = [
-        (r'\btable\s+[\'"`]?(\w+)[\'"`]?', "table [REDACTED]"),
-        (r'\bcolumn\s+[\'"`]?(\w+)[\'"`]?', "column [REDACTED]"),
-        (r'\bdatabase\s+[\'"`]?(\w+)[\'"`]?', "database [REDACTED]"),
-        (r'\bschema\s+[\'"`]?(\w+)[\'"`]?', "schema [REDACTED]"),
-    ]
-    for pattern, replacement in sensitive_patterns:
-        error_str = re.sub(pattern, replacement, error_str, flags=re.IGNORECASE)
-
-    # SECURITY FIX: SQL sanitization without ReDoS-vulnerable patterns
-    error_str_upper = error_str.upper()
-    error_str = _redact_sql_select(error_str, error_str_upper)
-    error_str = _redact_sql_where(error_str, error_str_upper)
-
-    # Return generic message for common error types
-    if generic := _get_generic_error_message(error_str):
-        return generic
-
-    return error_str
+# Re-export from shared utility so existing ``from pipeline import ...``
+# callers continue to work without changes.
+from superset.mcp_service.utils.error_sanitization import (  # noqa: E402, F401
+    _get_generic_error_message,
+    _redact_sql_select,
+    _redact_sql_where,
+    _sanitize_validation_error,
+)
 
 
 class ValidationResult:

--- a/superset/mcp_service/chart/validation/pipeline.py
+++ b/superset/mcp_service/chart/validation/pipeline.py
@@ -189,7 +189,21 @@ class ValidationPipeline:
 
             # Parse the raw config dict into a typed ChartConfig for
             # downstream validators that need typed access.
-            typed_config = parse_chart_config(request.config)
+            try:
+                typed_config = parse_chart_config(request.config)
+            except (ValueError, TypeError) as e:
+                from superset.mcp_service.utils.error_builder import (
+                    ChartErrorBuilder,
+                )
+
+                sanitized_reason = _sanitize_validation_error(e)
+                error = ChartErrorBuilder.build_error(
+                    error_type="validation_error",
+                    template_key="validation_error",
+                    template_vars={"reason": sanitized_reason},
+                    error_code="INVALID_CHART_CONFIG",
+                )
+                return ValidationResult(is_valid=False, request=request, error=error)
 
             # Fetch dataset context once and reuse across validation layers
             dataset_context = ValidationPipeline._get_dataset_context(

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -540,7 +540,12 @@ class GenerateDashboardRequest(BaseModel):
         if not isinstance(data, dict):
             return data
         data["sanitization_warnings"] = []
-        raw = data.get("dashboard_title") or data.get("title") or data.get("name")
+        for key in ("dashboard_title", "title", "name"):
+            if key in data:
+                raw = data[key]
+                break
+        else:
+            raw = None
         if not isinstance(raw, str) or not raw.strip():
             return data
         sanitized, was_modified = sanitize_user_input_with_changes(

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -71,6 +71,7 @@ from typing import Annotated, Any, Dict, List, Literal, TYPE_CHECKING
 
 import humanize
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -493,6 +494,8 @@ class AddChartToDashboardResponse(BaseModel):
 class GenerateDashboardRequest(BaseModel):
     """Request schema for generating a dashboard."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     chart_ids: List[int] = Field(
         ..., description="List of chart IDs to include in the dashboard", min_length=1
     )
@@ -502,6 +505,7 @@ class GenerateDashboardRequest(BaseModel):
             "Title for the new dashboard. When omitted a descriptive title "
             "is generated from the included chart names."
         ),
+        validation_alias=AliasChoices("dashboard_title", "title", "name"),
     )
     description: str | None = Field(None, description="Description for the dashboard")
     published: bool = Field(

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -540,7 +540,7 @@ class GenerateDashboardRequest(BaseModel):
         if not isinstance(data, dict):
             return data
         data["sanitization_warnings"] = []
-        raw = data.get("dashboard_title")
+        raw = data.get("dashboard_title") or data.get("title") or data.get("name")
         if not isinstance(raw, str) or not raw.strip():
             return data
         sanitized, was_modified = sanitize_user_input_with_changes(

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -99,7 +99,21 @@ async def generate_explore_link(
 
     try:
         # Parse the raw config dict into a typed ChartConfig
-        config = parse_chart_config(request.config)
+        try:
+            config = parse_chart_config(request.config)
+        except (ValueError, TypeError) as e:
+            from superset.mcp_service.chart.validation.pipeline import (
+                _sanitize_validation_error,
+            )
+
+            sanitized = _sanitize_validation_error(e)
+            await ctx.error("Invalid chart config: %s" % sanitized)
+            return {
+                "url": "",
+                "form_data": {},
+                "form_data_key": None,
+                "error": f"Invalid chart configuration: {sanitized}",
+            }
 
         await ctx.report_progress(1, 4, "Validating dataset exists")
         with event_logger.log_context(action="mcp.generate_explore_link.dataset_check"):

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -107,7 +107,7 @@ async def generate_explore_link(
             )
 
             sanitized = _sanitize_validation_error(e)
-            await ctx.error("Invalid chart configuration: %s" % sanitized)
+            await ctx.error(f"Invalid chart configuration: {sanitized}")
             return {
                 "url": "",
                 "form_data": {},

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -102,12 +102,12 @@ async def generate_explore_link(
         try:
             config = parse_chart_config(request.config)
         except (ValueError, TypeError) as e:
-            from superset.mcp_service.chart.validation.pipeline import (
+            from superset.mcp_service.utils.error_sanitization import (
                 _sanitize_validation_error,
             )
 
             sanitized = _sanitize_validation_error(e)
-            await ctx.error("Invalid chart config: %s" % sanitized)
+            await ctx.error("Invalid chart configuration: %s" % sanitized)
             return {
                 "url": "",
                 "form_data": {},

--- a/superset/mcp_service/utils/error_sanitization.py
+++ b/superset/mcp_service/utils/error_sanitization.py
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Shared error sanitization utilities for MCP service.
+
+SECURITY: These functions sanitize validation errors to prevent information
+disclosure (e.g., SQL fragments, schema names, table names) while preserving
+actionable error messages for LLM callers.
+"""
+
+import re
+
+
+def _redact_sql_select(error_str: str, error_str_upper: str) -> str:
+    """Redact SELECT...FROM clause content to prevent data disclosure."""
+    if "SELECT" in error_str_upper and "FROM" in error_str_upper:
+        select_idx = error_str_upper.find("SELECT")
+        from_idx = error_str_upper.find("FROM", select_idx)
+        if select_idx != -1 and from_idx != -1:
+            return error_str[: select_idx + 7] + " [REDACTED] " + error_str[from_idx:]
+    return error_str
+
+
+def _redact_sql_where(error_str: str, error_str_upper: str) -> str:
+    """Redact WHERE clause content to prevent data disclosure."""
+    if "WHERE" not in error_str_upper:
+        return error_str
+
+    where_idx = error_str_upper.find("WHERE")
+    terminators = ["ORDER", "GROUP", "LIMIT", "UNION", "EXCEPT", "INTERSECT"]
+    term_idx = len(error_str)
+    for term in terminators:
+        idx = error_str_upper.find(term, where_idx)
+        if idx != -1 and idx < term_idx:
+            term_idx = idx
+    return error_str[: where_idx + 6] + " [REDACTED]" + error_str[term_idx:]
+
+
+def _get_generic_error_message(error_str: str) -> str | None:
+    """Return generic message for common error types, or None."""
+    error_lower = error_str.lower()
+    if "permission" in error_lower or "access" in error_lower:
+        return "Validation failed due to access restrictions"
+    if "database" in error_lower or "connection" in error_lower:
+        return "Validation failed due to database connectivity"
+    if "timeout" in error_lower:
+        return "Validation timed out"
+    return None
+
+
+def _sanitize_validation_error(error: Exception) -> str:
+    """SECURITY FIX: Sanitize validation errors to prevent disclosure."""
+    error_str = str(error)
+
+    # Pydantic tagged-union errors prefix the message with a long
+    # ``1 validation error for tagged-union[...]`` header before the
+    # per-field body (e.g. ``Value error, ...``, ``Field required``,
+    # ``Input should be ...``). The body always lives on a line indented
+    # by exactly two spaces — pull it out so the 200-char truncation
+    # below doesn't swallow the actionable part. The pydantic footer
+    # ``\n    For further information ...`` uses four-space indent and
+    # is dropped here.
+    if "tagged-union[" in error_str:
+        body_match = re.search(r"\n  (?! )", error_str)
+        if body_match:
+            idx = body_match.end()
+            footer_idx = error_str.find("\n    For further information", idx)
+            end = footer_idx if footer_idx != -1 else len(error_str)
+            error_str = error_str[idx:end].strip()
+
+    # SECURITY FIX: Limit length FIRST to prevent ReDoS attacks
+    if len(error_str) > 200:
+        error_str = error_str[:200] + "...[truncated]"
+
+    # Remove potentially sensitive schema information
+    sensitive_patterns = [
+        (r'\btable\s+[\'"`]?(\w+)[\'"`]?', "table [REDACTED]"),
+        (r'\bcolumn\s+[\'"`]?(\w+)[\'"`]?', "column [REDACTED]"),
+        (r'\bdatabase\s+[\'"`]?(\w+)[\'"`]?', "database [REDACTED]"),
+        (r'\bschema\s+[\'"`]?(\w+)[\'"`]?', "schema [REDACTED]"),
+    ]
+    for pattern, replacement in sensitive_patterns:
+        error_str = re.sub(pattern, replacement, error_str, flags=re.IGNORECASE)
+
+    # SECURITY FIX: SQL sanitization without ReDoS-vulnerable patterns
+    error_str_upper = error_str.upper()
+    error_str = _redact_sql_select(error_str, error_str_upper)
+    error_str = _redact_sql_where(error_str, error_str_upper)
+
+    # Return generic message for common error types
+    if generic := _get_generic_error_message(error_str):
+        return generic
+
+    return error_str

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -609,7 +609,7 @@ class TestBuildUpdatePayload:
         chart = Mock()
         chart.datasource_id = None  # Avoid dataset lookup
 
-        result = _build_update_payload(request, chart)
+        result = _build_update_payload(request, chart, parsed_config=config)
 
         assert isinstance(result, dict)
         assert result["slice_name"] == "My Custom Name"
@@ -629,7 +629,7 @@ class TestBuildUpdatePayload:
         chart.datasource_id = None
         chart.slice_name = "Existing Name"
 
-        result = _build_update_payload(request, chart)
+        result = _build_update_payload(request, chart, parsed_config=config)
 
         assert isinstance(result, dict)
         assert result["slice_name"] == "Existing Name"
@@ -867,7 +867,7 @@ class TestBuildPreviewFormData:
         chart.slice_name = "Existing"
         chart.params = '{"viz_type": "line", "custom_flag": true}'
 
-        result = _build_preview_form_data(request, chart)
+        result = _build_preview_form_data(request, chart, parsed_config=config)
 
         assert isinstance(result, dict)
         # Existing keys not touched by the new config are preserved
@@ -924,7 +924,7 @@ class TestBuildPreviewFormData:
         chart.slice_name = "Broken"
         chart.params = "not-json"
 
-        result = _build_preview_form_data(request, chart)
+        result = _build_preview_form_data(request, chart, parsed_config=config)
 
         assert isinstance(result, dict)
         assert result["slice_id"] == 9

--- a/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
@@ -103,7 +103,62 @@ def test_mixed_timeseries_with_wrong_kind_fields_returns_actionable_error() -> N
     assert "tagged-union" not in dumped["message"]
     # Suggestions should steer callers back to a valid schema.
     assert dumped["suggestions"]
-    assert dumped["error_code"] == "VALIDATION_PIPELINE_ERROR"
+    assert dumped["error_code"] == "INVALID_CHART_CONFIG"
+    assert dumped["error_type"] == "validation_error"
+
+
+def test_adhoc_filters_returns_actionable_error() -> None:
+    """Regression: adhoc_filters is not a valid field — generate_chart should
+    return a clear validation_error pointing to 'filters' instead of an opaque
+    validation_system_error.
+
+    See: https://app.shortcut.com/preset/story/103356
+    """
+    request_data = {
+        "dataset_id": 1,
+        "config": {
+            "chart_type": "xy",
+            "x": {"name": "year"},
+            "y": [{"name": "sales", "aggregate": "SUM"}],
+            "adhoc_filters": [
+                {
+                    "clause": "WHERE",
+                    "comparator": "Role-Playing",
+                    "expressionType": "SIMPLE",
+                    "operator": "==",
+                    "subject": "genre",
+                }
+            ],
+        },
+    }
+
+    with (
+        patch.object(ValidationPipeline, "_get_dataset_context", return_value=None),
+        patch.object(
+            ValidationPipeline, "_validate_dataset", return_value=(True, None)
+        ),
+        patch.object(
+            ValidationPipeline, "_validate_runtime", return_value=(True, None)
+        ),
+        patch.object(
+            ValidationPipeline,
+            "_normalize_column_names",
+            side_effect=_passthrough_normalize,
+        ),
+    ):
+        result = ValidationPipeline.validate_request_with_warnings(request_data)
+
+    assert result.is_valid is False
+    assert result.error is not None
+    dumped = result.error.model_dump()
+
+    # Must NOT be the opaque validation_system_error
+    assert dumped["error_type"] == "validation_error"
+    assert dumped["error_code"] == "INVALID_CHART_CONFIG"
+    # Message must mention filters as the correct field name
+    assert "filters" in dumped["message"]
+    assert dumped["details"] != ""
+    assert dumped["suggestions"]
 
 
 def test_valid_mixed_timeseries_config_passes() -> None:
@@ -178,7 +233,8 @@ def test_non_value_error_pydantic_body_is_surfaced() -> None:
     assert result.is_valid is False
     assert result.error is not None
     dumped = result.error.model_dump()
-    assert dumped["error_code"] == "VALIDATION_PIPELINE_ERROR"
+    assert dumped["error_code"] == "INVALID_CHART_CONFIG"
+    assert dumped["error_type"] == "validation_error"
     assert "tagged-union" not in dumped["message"]
     assert "tagged-union" not in dumped["details"]
     # The actionable body must survive the 200-char truncation.

--- a/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
@@ -32,7 +32,11 @@ fields ``primary_kind`` / ``secondary_kind``.
 
 from unittest.mock import patch
 
+import pytest
+
+from superset.mcp_service.chart.schemas import GenerateChartRequest
 from superset.mcp_service.chart.validation.pipeline import ValidationPipeline
+from superset.mcp_service.dashboard.schemas import GenerateDashboardRequest
 from superset.mcp_service.utils.error_builder import ChartErrorBuilder
 
 
@@ -249,3 +253,55 @@ def test_validation_error_template_suggestions_are_chart_type_agnostic() -> None
     assert "mixed_timeseries" not in joined
     assert "primary_kind" not in joined
     assert "secondary_kind" not in joined
+
+
+# --- Alias field tests ---
+
+
+def test_title_alias_populates_dashboard_title() -> None:
+    """Sending ``title`` instead of ``dashboard_title`` should populate the field."""
+    req = GenerateDashboardRequest(
+        chart_ids=[1],
+        title="My Dashboard",  # type: ignore[call-arg]
+    )
+    assert req.dashboard_title == "My Dashboard"
+
+
+def test_name_alias_populates_chart_name() -> None:
+    """Sending ``name`` instead of ``chart_name`` should populate the field."""
+    req = GenerateChartRequest(
+        dataset_id=1,
+        config={
+            "chart_type": "xy",
+            "x": {"name": "col"},
+            "y": [{"name": "val", "aggregate": "SUM"}],
+        },
+        name="My Chart",  # type: ignore[call-arg]
+    )
+    assert req.chart_name == "My Chart"
+
+
+def test_xss_via_alias_title_is_rejected() -> None:
+    """XSS payload via alias field ``title`` should be rejected by sanitization."""
+    with pytest.raises(ValueError, match="sanitization"):
+        GenerateDashboardRequest(
+            chart_ids=[1],
+            title="<script>alert(1)</script>",  # type: ignore[call-arg]
+        )
+
+
+def test_chart_name_and_name_simultaneously_first_alias_wins() -> None:
+    """When both ``chart_name`` and ``name`` are provided, ``chart_name``
+    takes precedence because it appears first in the alias list."""
+    req = GenerateChartRequest(
+        dataset_id=1,
+        config={
+            "chart_type": "xy",
+            "x": {"name": "col"},
+            "y": [{"name": "val", "aggregate": "SUM"}],
+        },
+        chart_name="Primary Name",
+        name="Secondary Name",  # type: ignore[call-arg]
+    )
+    # chart_name is the canonical field and takes precedence via AliasChoices
+    assert req.chart_name == "Primary Name"

--- a/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
@@ -262,7 +262,7 @@ def test_title_alias_populates_dashboard_title() -> None:
     """Sending ``title`` instead of ``dashboard_title`` should populate the field."""
     req = GenerateDashboardRequest(
         chart_ids=[1],
-        title="My Dashboard",  # type: ignore[call-arg]
+        title="My Dashboard",
     )
     assert req.dashboard_title == "My Dashboard"
 
@@ -276,7 +276,7 @@ def test_name_alias_populates_chart_name() -> None:
             "x": {"name": "col"},
             "y": [{"name": "val", "aggregate": "SUM"}],
         },
-        name="My Chart",  # type: ignore[call-arg]
+        name="My Chart",
     )
     assert req.chart_name == "My Chart"
 
@@ -286,7 +286,7 @@ def test_xss_via_alias_title_is_rejected() -> None:
     with pytest.raises(ValueError, match="sanitization"):
         GenerateDashboardRequest(
             chart_ids=[1],
-            title="<script>alert(1)</script>",  # type: ignore[call-arg]
+            title="<script>alert(1)</script>",
         )
 
 
@@ -301,7 +301,7 @@ def test_chart_name_and_name_simultaneously_first_alias_wins() -> None:
             "y": [{"name": "val", "aggregate": "SUM"}],
         },
         chart_name="Primary Name",
-        name="Secondary Name",  # type: ignore[call-arg]
+        name="Secondary Name",
     )
     # chart_name is the canonical field and takes precedence via AliasChoices
     assert req.chart_name == "Primary Name"


### PR DESCRIPTION
### SUMMARY

Fixes two families of bugs where MCP tools return opaque errors or silently drop LLM-provided field names.

**Fix 1: Sanitize `parse_chart_config` errors across all chart tools**

When MCP chart tools receive unknown config fields like `adhoc_filters`, `viz_type`, `time_range`, or `echarts_timeseries_bar`, `parse_chart_config` raises a `ValueError` with a raw Pydantic tagged-union prefix that leaks to the client. This caused:
- Opaque "1 validation error for tagged-union[...]" messages
- Chatbot retrying with different params (slow responses)
- Cascading "unexpected errors" in the chatbot UI

**Affected tools and fixes:**
| Tool | Before | After |
|------|--------|-------|
| `generate_chart` (pipeline) | `validation_system_error` / `VALIDATION_PIPELINE_ERROR` | `validation_error` / `INVALID_CHART_CONFIG` |
| `generate_chart` (post-validation) | Unhandled `ValueError` | Structured error response |
| `generate_explore_link` | Raw tagged-union in error string | Sanitized error message |
| `update_chart` (3 call sites) | Unhandled `ValueError` to middleware | Structured `GenerateChartResponse` |
| `update_chart_preview` | Raw `str(e)` with tagged-union | Sanitized error message |

All errors now go through `_sanitize_validation_error()` which strips the tagged-union prefix, redacts sensitive schema info, and preserves actionable "did you mean?" suggestions.

**Fix 2: Accept common field name aliases to prevent silent drops**

| Schema | Field | Aliases Added |
|--------|-------|---------------|
| `GenerateDashboardRequest` | `dashboard_title` | `title`, `name` |
| `GenerateChartRequest` | `chart_name` | `name`, `title`, `slice_name` |

The `_detect_dashboard_title_sanitization` before-validator now checks all alias keys so XSS content sent via `title` or `name` is also properly rejected/warned.

### BEFORE/AFTER SCREENSHOTS OR COVERAGE

N/A (API-only changes)

### TESTING INSTRUCTIONS

1. Call `generate_explore_link` with `viz_type` or `adhoc_filters` in config — clean error, no tagged-union
2. Call `generate_chart` with `adhoc_filters` — `validation_error` with `INVALID_CHART_CONFIG`
3. Call `generate_dashboard` with `title` instead of `dashboard_title` — title applied correctly
4. Call `generate_dashboard` with `title: "<script>alert(1)</script>"` — XSS rejected with clear error
5. All 1337 MCP unit tests pass

### ADDITIONAL INFORMATION

- Error sanitization reuses `_sanitize_validation_error()` from the validation pipeline
- Dashboard/chart aliases use Pydantic `AliasChoices` with `populate_by_name=True`
- Broader alias audit for remaining 13 request classes tracked in follow-up story