### PR TITLE
feat: Add tab rotator listener and iframe embedding support 

### DIFF
--- a/docker-compose-image-tag.yml
+++ b/docker-compose-image-tag.yml
@@ -30,6 +30,8 @@ x-superset-volumes:
   - ./docker:/app/docker
   - ./superset-core:/app/superset-core
   - superset_home:/app/superset_home
+  # Canias Tab Rotator — postMessage ile tab geçişi ve sayfa yenileme
+  - ./tail_js_custom_extra.html:/app/superset/templates/tail_js_custom_extra.html
 
 services:
   redis:

--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -142,3 +142,14 @@ try:
     )
 except ImportError:
     logger.info("Using default Docker config...")
+
+# ── Canias ERP iframe entegrasyonu ──────────────────────────────────────────
+# X-Frame-Options'ı devre dışı bırak (iframe içinde gösterim için)
+HTTP_HEADERS = {"X-Frame-Options": "ALLOWALL"}
+
+# Talisman (CSP) — iframe embed için gerekli
+TALISMAN_ENABLED = False
+
+# HTML sanitizasyonunu kapat (Markdown chart'larda custom HTML desteği)
+HTML_SANITIZATION = False
+

--- a/tail_js_custom_extra.html
+++ b/tail_js_custom_extra.html
@@ -1,0 +1,14 @@
+<script nonce="{{ macros.get_nonce() }}">
+    window.addEventListener('message', function (event) {
+        if (!event.data) return;
+
+        if (event.data.type === 'SWITCH_TAB') {
+            var tabs = document.querySelectorAll('.ant-tabs-tab-btn');
+            if (tabs && tabs.length > event.data.tabIndex && event.data.tabIndex >= 0) {
+                tabs[event.data.tabIndex].click();
+            }
+        } else if (event.data.type === 'REFRESH') {
+            window.location.reload();
+        }
+    });
+</script>


### PR DESCRIPTION


Add postMessage-based tab rotation and page refresh support for embedding Superset dashboards

Changes:
- Add tail_js_custom_extra.html with SWITCH_TAB and REFRESH message handlers
- Mount the template via shared x-superset-volumes in docker-compose-image-tag.yml
- Configure superset_config.py for iframe embedding:
  - Disable X-Frame-Options (ALLOWALL)
  - Disable Talisman CSP
  - Disable HTML sanitization

This enables  to control dashboard tab switching and page refresh via window.postMessage() without requiring any post-deployment manual steps (e.g. docker cp).

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
