### PR TITLE
fix(mcp): Block destructive DDL (DROP, TRUNCATE, ALTER) in execute_sql

### DIFF
--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -131,7 +131,7 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
                     )
 
                 script = SQLScript(sql_to_check, database.db_engine_spec.engine)
-                if script.has_destructive_ddl():
+                if script.has_destructive():
                     await ctx.error(
                         "Destructive DDL blocked: sql_preview=%r" % sql_preview
                     )

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -50,6 +50,7 @@ from superset.mcp_service.utils.oauth2_utils import (
     build_oauth2_redirect_message,
     OAUTH2_CONFIG_ERROR_MESSAGE,
 )
+from superset.sql.parse import SQLScript
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,50 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
                     error_type=SupersetErrorType.DATABASE_SECURITY_ACCESS_ERROR.value,
                 )
 
-        # 2. Build QueryOptions and execute query
+        # 2. Block destructive DDL (DROP, TRUNCATE, ALTER)
+        # Fail-closed: if parsing fails, block the query rather than
+        # allowing potentially destructive SQL to bypass the check.
+        # Render Jinja2 templates first so templated SQL can be parsed.
+        with event_logger.log_context(action="mcp.execute_sql.ddl_check"):
+            try:
+                sql_to_check = request.sql
+                if request.template_params:
+                    from superset.jinja_context import get_template_processor
+
+                    tp = get_template_processor(database=database)
+                    sql_to_check = tp.process_template(
+                        request.sql, **request.template_params
+                    )
+
+                script = SQLScript(sql_to_check, database.db_engine_spec.engine)
+                if script.has_destructive_ddl():
+                    await ctx.error(
+                        "Destructive DDL blocked: sql_preview=%r" % sql_preview
+                    )
+                    return ExecuteSqlResponse(
+                        success=False,
+                        error=(
+                            "Destructive DDL statements (DROP, TRUNCATE, ALTER) "
+                            "are not allowed through MCP. Use the Superset SQL "
+                            "Lab UI for administrative database operations."
+                        ),
+                        error_type=SupersetErrorType.DML_NOT_ALLOWED_ERROR.value,
+                    )
+            except Exception as parse_err:
+                await ctx.error(
+                    "DDL pre-check failed to parse SQL, blocking query: %s"
+                    % str(parse_err)
+                )
+                return ExecuteSqlResponse(
+                    success=False,
+                    error=(
+                        "SQL could not be parsed for security validation. "
+                        "Please check your SQL syntax and try again."
+                    ),
+                    error_type=SupersetErrorType.INVALID_SQL_ERROR.value,
+                )
+
+        # 3. Build QueryOptions and execute query
         cache_opts = CacheOptions(force_refresh=True) if request.force_refresh else None
         options = QueryOptions(
             catalog=request.catalog,
@@ -126,11 +170,11 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
             cache=cache_opts,
         )
 
-        # 3. Execute query
+        # 4. Execute query
         with event_logger.log_context(action="mcp.execute_sql.query_execution"):
             result = database.execute(request.sql, options)
 
-        # 4. Convert to MCP response format
+        # 5. Convert to MCP response format
         with event_logger.log_context(action="mcp.execute_sql.response_conversion"):
             response = _convert_to_response(result)
 

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -748,7 +748,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
 
         # Handle ALTER parsed as Command (Oracle, MS SQL dialects)
         if isinstance(self._parsed, exp.Command) and self._parsed.name == "ALTER":
-            return True
+            return True  # pragma: no cover
 
         return False
 

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -439,6 +439,14 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
+    def is_destructive_ddl(self) -> bool:
+        """
+        Check if the statement is destructive DDL (DROP, TRUNCATE, ALTER).
+
+        :return: True if the statement is destructive DDL.
+        """
+        raise NotImplementedError()
+
     def optimize(self) -> BaseSQLStatement[InternalRepresentation]:
         """
         Return optimized statement.
@@ -716,6 +724,31 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
                 statement=analyzed_sql,
                 engine=self.engine,
             ).is_mutating()
+
+        return False
+
+    def is_destructive_ddl(self) -> bool:
+        """
+        Check if the statement is destructive DDL (DROP, TRUNCATE, ALTER).
+
+        Unlike ``is_mutating()``, this excludes non-destructive DML
+        (INSERT, UPDATE, DELETE, MERGE) and CREATE.
+
+        :return: True if the statement is destructive DDL.
+        """
+        destructive_nodes = (
+            exp.Drop,
+            exp.TruncateTable,
+            exp.Alter,
+        )
+
+        for node_type in destructive_nodes:
+            if self._parsed.find(node_type):
+                return True
+
+        # Handle ALTER parsed as Command (Oracle, MS SQL dialects)
+        if isinstance(self._parsed, exp.Command) and self._parsed.name == "ALTER":
+            return True
 
         return False
 
@@ -1175,6 +1208,18 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         """
         return self._parsed.startswith(".") and not self._parsed.startswith(".show")
 
+    def is_destructive_ddl(self) -> bool:
+        """
+        Check if the statement is destructive DDL.
+
+        Kusto KQL uses dot-commands for management operations. Destructive
+        operations start with ``.drop`` or ``.alter``.
+
+        :return: True if the statement is destructive DDL.
+        """
+        lower = self._parsed.lower()
+        return lower.startswith(".drop") or lower.startswith(".alter")
+
     def optimize(self) -> KustoKQLStatement:
         """
         Return optimized statement.
@@ -1320,6 +1365,14 @@ class SQLScript:
         :return: True if the script contains mutating statements
         """
         return any(statement.is_mutating() for statement in self.statements)
+
+    def has_destructive_ddl(self) -> bool:
+        """
+        Check if the script contains destructive DDL (DROP, TRUNCATE, ALTER).
+
+        :return: True if any statement is destructive DDL.
+        """
+        return any(statement.is_destructive_ddl() for statement in self.statements)
 
     def optimize(self) -> SQLScript:
         """

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -439,7 +439,7 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
-    def is_destructive_ddl(self) -> bool:
+    def is_destructive(self) -> bool:
         """
         Check if the statement is destructive DDL (DROP, TRUNCATE, ALTER).
 
@@ -727,7 +727,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
 
         return False
 
-    def is_destructive_ddl(self) -> bool:
+    def is_destructive(self) -> bool:
         """
         Check if the statement is destructive DDL (DROP, TRUNCATE, ALTER).
 
@@ -1208,7 +1208,7 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         """
         return self._parsed.startswith(".") and not self._parsed.startswith(".show")
 
-    def is_destructive_ddl(self) -> bool:
+    def is_destructive(self) -> bool:
         """
         Check if the statement is destructive DDL.
 
@@ -1366,13 +1366,13 @@ class SQLScript:
         """
         return any(statement.is_mutating() for statement in self.statements)
 
-    def has_destructive_ddl(self) -> bool:
+    def has_destructive(self) -> bool:
         """
         Check if the script contains destructive DDL (DROP, TRUNCATE, ALTER).
 
         :return: True if any statement is destructive DDL.
         """
-        return any(statement.is_destructive_ddl() for statement in self.statements)
+        return any(statement.is_destructive() for statement in self.statements)
 
     def optimize(self) -> SQLScript:
         """

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -1223,164 +1223,119 @@ class TestColumnInfoIsNullable:
 class TestDestructiveDDLBlocking:
     """Tests for destructive DDL blocking in execute_sql."""
 
-    @patch("superset.security_manager")
-    @patch("superset.db")
+    @pytest.fixture
+    def ddl_mocks(self):
+        """Common mock wiring for DDL blocking tests."""
+        with (
+            patch("superset.db") as mock_db,
+            patch("superset.security_manager") as mock_sm,
+        ):
+            mock_database = _mock_database()
+            mock_database.db_engine_spec.engine = "postgresql"
+            query_chain = mock_db.session.query.return_value
+            query_chain.filter_by.return_value.first.return_value = mock_database
+            mock_sm.can_access_database.return_value = True
+            yield mock_database
+
     @pytest.mark.asyncio
-    async def test_drop_table_blocked(self, mock_db, mock_security_manager, mcp_server):
+    async def test_drop_table_blocked(self, ddl_mocks, mcp_server):
         """DROP TABLE is blocked before reaching the executor."""
-        mock_database = _mock_database()
-        mock_database.db_engine_spec.engine = "postgresql"
-        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
-            mock_database
-        )
-        mock_security_manager.can_access_database.return_value = True
-
-        request = {"database_id": 1, "sql": "DROP TABLE birth_names"}
-
         async with Client(mcp_server) as client:
-            result = await client.call_tool("execute_sql", {"request": request})
+            result = await client.call_tool(
+                "execute_sql",
+                {"request": {"database_id": 1, "sql": "DROP TABLE birth_names"}},
+            )
             data = result.structured_content
             assert data["success"] is False
             assert "Destructive DDL" in data["error"]
             assert "DROP" in data["error"]
-            mock_database.execute.assert_not_called()
+            ddl_mocks.execute.assert_not_called()
 
-    @patch("superset.security_manager")
-    @patch("superset.db")
     @pytest.mark.asyncio
-    async def test_truncate_blocked(self, mock_db, mock_security_manager, mcp_server):
+    async def test_truncate_blocked(self, ddl_mocks, mcp_server):
         """TRUNCATE TABLE is blocked before reaching the executor."""
-        mock_database = _mock_database()
-        mock_database.db_engine_spec.engine = "postgresql"
-        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
-            mock_database
-        )
-        mock_security_manager.can_access_database.return_value = True
-
-        request = {"database_id": 1, "sql": "TRUNCATE TABLE birth_names"}
-
         async with Client(mcp_server) as client:
-            result = await client.call_tool("execute_sql", {"request": request})
+            result = await client.call_tool(
+                "execute_sql",
+                {"request": {"database_id": 1, "sql": "TRUNCATE TABLE birth_names"}},
+            )
             data = result.structured_content
             assert data["success"] is False
             assert "Destructive DDL" in data["error"]
-            mock_database.execute.assert_not_called()
+            ddl_mocks.execute.assert_not_called()
 
-    @patch("superset.security_manager")
-    @patch("superset.db")
     @pytest.mark.asyncio
-    async def test_alter_table_blocked(
-        self, mock_db, mock_security_manager, mcp_server
-    ):
+    async def test_alter_table_blocked(self, ddl_mocks, mcp_server):
         """ALTER TABLE is blocked before reaching the executor."""
-        mock_database = _mock_database()
-        mock_database.db_engine_spec.engine = "postgresql"
-        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
-            mock_database
-        )
-        mock_security_manager.can_access_database.return_value = True
-
-        request = {
-            "database_id": 1,
-            "sql": "ALTER TABLE birth_names ADD COLUMN x INT",
-        }
-
         async with Client(mcp_server) as client:
-            result = await client.call_tool("execute_sql", {"request": request})
+            result = await client.call_tool(
+                "execute_sql",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "sql": "ALTER TABLE birth_names ADD COLUMN x INT",
+                    }
+                },
+            )
             data = result.structured_content
             assert data["success"] is False
             assert "Destructive DDL" in data["error"]
-            mock_database.execute.assert_not_called()
+            ddl_mocks.execute.assert_not_called()
 
-    @patch("superset.security_manager")
-    @patch("superset.db")
     @pytest.mark.asyncio
-    async def test_drop_in_multi_statement_blocked(
-        self, mock_db, mock_security_manager, mcp_server
-    ):
+    async def test_drop_in_multi_statement_blocked(self, ddl_mocks, mcp_server):
         """DROP TABLE hidden in a multi-statement query is blocked."""
-        mock_database = _mock_database()
-        mock_database.db_engine_spec.engine = "postgresql"
-        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
-            mock_database
-        )
-        mock_security_manager.can_access_database.return_value = True
-
-        request = {
-            "database_id": 1,
-            "sql": "DROP TABLE birth_names; SELECT 1",
-        }
-
         async with Client(mcp_server) as client:
-            result = await client.call_tool("execute_sql", {"request": request})
+            result = await client.call_tool(
+                "execute_sql",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "sql": "DROP TABLE birth_names; SELECT 1",
+                    }
+                },
+            )
             data = result.structured_content
             assert data["success"] is False
             assert "Destructive DDL" in data["error"]
-            mock_database.execute.assert_not_called()
+            ddl_mocks.execute.assert_not_called()
 
-    @patch("superset.security_manager")
-    @patch("superset.db")
     @pytest.mark.asyncio
-    async def test_select_allowed(self, mock_db, mock_security_manager, mcp_server):
+    async def test_select_allowed(self, ddl_mocks, mcp_server):
         """SELECT queries pass through the DDL check."""
-        mock_database = _mock_database()
-        mock_database.db_engine_spec.engine = "postgresql"
-        mock_database.execute.return_value = _create_select_result(
+        ddl_mocks.execute.return_value = _create_select_result(
             rows=[{"x": 1}], columns=["x"], original_sql="SELECT 1"
         )
-        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
-            mock_database
-        )
-        mock_security_manager.can_access_database.return_value = True
-
-        request = {"database_id": 1, "sql": "SELECT 1"}
 
         async with Client(mcp_server) as client:
-            result = await client.call_tool("execute_sql", {"request": request})
+            result = await client.call_tool(
+                "execute_sql",
+                {"request": {"database_id": 1, "sql": "SELECT 1"}},
+            )
             data = result.structured_content
             assert data["success"] is True
-            mock_database.execute.assert_called_once()
+            ddl_mocks.execute.assert_called_once()
 
-    @patch("superset.security_manager")
-    @patch("superset.db")
     @pytest.mark.asyncio
-    async def test_insert_allowed(self, mock_db, mock_security_manager, mcp_server):
+    async def test_insert_allowed(self, ddl_mocks, mcp_server):
         """INSERT queries pass through the DDL check (DML is allowed)."""
-        mock_database = _mock_database()
-        mock_database.db_engine_spec.engine = "postgresql"
-        mock_database.execute.return_value = _create_dml_result(
+        ddl_mocks.execute.return_value = _create_dml_result(
             affected_rows=1,
             original_sql="INSERT INTO t VALUES (1)",
         )
-        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
-            mock_database
-        )
-        mock_security_manager.can_access_database.return_value = True
-
-        request = {"database_id": 1, "sql": "INSERT INTO t VALUES (1)"}
 
         async with Client(mcp_server) as client:
-            result = await client.call_tool("execute_sql", {"request": request})
+            result = await client.call_tool(
+                "execute_sql",
+                {"request": {"database_id": 1, "sql": "INSERT INTO t VALUES (1)"}},
+            )
             data = result.structured_content
             assert data["success"] is True
-            mock_database.execute.assert_called_once()
+            ddl_mocks.execute.assert_called_once()
 
-    @patch("superset.security_manager")
-    @patch("superset.db")
     @pytest.mark.asyncio
-    async def test_parse_failure_blocks_query(
-        self, mock_db, mock_security_manager, mcp_server
-    ):
+    async def test_parse_failure_blocks_query(self, ddl_mocks, mcp_server):
         """When SQL parsing fails, the query is blocked (fail-closed)."""
-        mock_database = _mock_database()
-        mock_database.db_engine_spec.engine = "postgresql"
-        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
-            mock_database
-        )
-        mock_security_manager.can_access_database.return_value = True
-
-        request = {"database_id": 1, "sql": "DROP TABLE birth_names"}
-
         import sys
 
         execute_sql_mod = sys.modules["superset.mcp_service.sql_lab.tool.execute_sql"]
@@ -1390,31 +1345,26 @@ class TestDestructiveDDLBlocking:
             side_effect=Exception("parse error"),
         ):
             async with Client(mcp_server) as client:
-                result = await client.call_tool("execute_sql", {"request": request})
+                result = await client.call_tool(
+                    "execute_sql",
+                    {"request": {"database_id": 1, "sql": "DROP TABLE birth_names"}},
+                )
                 data = result.structured_content
                 assert data["success"] is False
                 assert "could not be parsed" in data["error"]
-                mock_database.execute.assert_not_called()
+                ddl_mocks.execute.assert_not_called()
 
-    @patch("superset.security_manager")
-    @patch("superset.db")
     @pytest.mark.asyncio
-    async def test_drop_table_blocked_mysql(
-        self, mock_db, mock_security_manager, mcp_server
-    ):
+    async def test_drop_table_blocked_mysql(self, ddl_mocks, mcp_server):
         """DROP TABLE is blocked for non-PostgreSQL dialects too."""
-        mock_database = _mock_database()
-        mock_database.db_engine_spec.engine = "mysql"
-        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
-            mock_database
-        )
-        mock_security_manager.can_access_database.return_value = True
-
-        request = {"database_id": 1, "sql": "DROP TABLE users"}
+        ddl_mocks.db_engine_spec.engine = "mysql"
 
         async with Client(mcp_server) as client:
-            result = await client.call_tool("execute_sql", {"request": request})
+            result = await client.call_tool(
+                "execute_sql",
+                {"request": {"database_id": 1, "sql": "DROP TABLE users"}},
+            )
             data = result.structured_content
             assert data["success"] is False
             assert "Destructive DDL" in data["error"]
-            mock_database.execute.assert_not_called()
+            ddl_mocks.execute.assert_not_called()

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_execute_sql.py
@@ -1218,3 +1218,203 @@ class TestColumnInfoIsNullable:
             {"name": "c", "type": "int", "is_nullable": "UNKNOWN"}
         )
         assert col.is_nullable is None
+
+
+class TestDestructiveDDLBlocking:
+    """Tests for destructive DDL blocking in execute_sql."""
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_drop_table_blocked(self, mock_db, mock_security_manager, mcp_server):
+        """DROP TABLE is blocked before reaching the executor."""
+        mock_database = _mock_database()
+        mock_database.db_engine_spec.engine = "postgresql"
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {"database_id": 1, "sql": "DROP TABLE birth_names"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+            data = result.structured_content
+            assert data["success"] is False
+            assert "Destructive DDL" in data["error"]
+            assert "DROP" in data["error"]
+            mock_database.execute.assert_not_called()
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_truncate_blocked(self, mock_db, mock_security_manager, mcp_server):
+        """TRUNCATE TABLE is blocked before reaching the executor."""
+        mock_database = _mock_database()
+        mock_database.db_engine_spec.engine = "postgresql"
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {"database_id": 1, "sql": "TRUNCATE TABLE birth_names"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+            data = result.structured_content
+            assert data["success"] is False
+            assert "Destructive DDL" in data["error"]
+            mock_database.execute.assert_not_called()
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_alter_table_blocked(
+        self, mock_db, mock_security_manager, mcp_server
+    ):
+        """ALTER TABLE is blocked before reaching the executor."""
+        mock_database = _mock_database()
+        mock_database.db_engine_spec.engine = "postgresql"
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {
+            "database_id": 1,
+            "sql": "ALTER TABLE birth_names ADD COLUMN x INT",
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+            data = result.structured_content
+            assert data["success"] is False
+            assert "Destructive DDL" in data["error"]
+            mock_database.execute.assert_not_called()
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_drop_in_multi_statement_blocked(
+        self, mock_db, mock_security_manager, mcp_server
+    ):
+        """DROP TABLE hidden in a multi-statement query is blocked."""
+        mock_database = _mock_database()
+        mock_database.db_engine_spec.engine = "postgresql"
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {
+            "database_id": 1,
+            "sql": "DROP TABLE birth_names; SELECT 1",
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+            data = result.structured_content
+            assert data["success"] is False
+            assert "Destructive DDL" in data["error"]
+            mock_database.execute.assert_not_called()
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_select_allowed(self, mock_db, mock_security_manager, mcp_server):
+        """SELECT queries pass through the DDL check."""
+        mock_database = _mock_database()
+        mock_database.db_engine_spec.engine = "postgresql"
+        mock_database.execute.return_value = _create_select_result(
+            rows=[{"x": 1}], columns=["x"], original_sql="SELECT 1"
+        )
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {"database_id": 1, "sql": "SELECT 1"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+            data = result.structured_content
+            assert data["success"] is True
+            mock_database.execute.assert_called_once()
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_insert_allowed(self, mock_db, mock_security_manager, mcp_server):
+        """INSERT queries pass through the DDL check (DML is allowed)."""
+        mock_database = _mock_database()
+        mock_database.db_engine_spec.engine = "postgresql"
+        mock_database.execute.return_value = _create_dml_result(
+            affected_rows=1,
+            original_sql="INSERT INTO t VALUES (1)",
+        )
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {"database_id": 1, "sql": "INSERT INTO t VALUES (1)"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+            data = result.structured_content
+            assert data["success"] is True
+            mock_database.execute.assert_called_once()
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_parse_failure_blocks_query(
+        self, mock_db, mock_security_manager, mcp_server
+    ):
+        """When SQL parsing fails, the query is blocked (fail-closed)."""
+        mock_database = _mock_database()
+        mock_database.db_engine_spec.engine = "postgresql"
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {"database_id": 1, "sql": "DROP TABLE birth_names"}
+
+        import sys
+
+        execute_sql_mod = sys.modules["superset.mcp_service.sql_lab.tool.execute_sql"]
+        with patch.object(
+            execute_sql_mod,
+            "SQLScript",
+            side_effect=Exception("parse error"),
+        ):
+            async with Client(mcp_server) as client:
+                result = await client.call_tool("execute_sql", {"request": request})
+                data = result.structured_content
+                assert data["success"] is False
+                assert "could not be parsed" in data["error"]
+                mock_database.execute.assert_not_called()
+
+    @patch("superset.security_manager")
+    @patch("superset.db")
+    @pytest.mark.asyncio
+    async def test_drop_table_blocked_mysql(
+        self, mock_db, mock_security_manager, mcp_server
+    ):
+        """DROP TABLE is blocked for non-PostgreSQL dialects too."""
+        mock_database = _mock_database()
+        mock_database.db_engine_spec.engine = "mysql"
+        mock_db.session.query.return_value.filter_by.return_value.first.return_value = (
+            mock_database
+        )
+        mock_security_manager.can_access_database.return_value = True
+
+        request = {"database_id": 1, "sql": "DROP TABLE users"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("execute_sql", {"request": request})
+            data = result.structured_content
+            assert data["success"] is False
+            assert "Destructive DDL" in data["error"]
+            mock_database.execute.assert_not_called()

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1343,6 +1343,24 @@ def test_has_destructive_ddl(sql: str, expected: bool) -> None:
     assert SQLScript(sql, "postgresql").has_destructive_ddl() == expected
 
 
+@pytest.mark.parametrize(
+    "kql, expected",
+    [
+        (".drop table T", True),
+        (".alter table T (col:string)", True),
+        (".show tables", False),
+        ("T | count", False),
+    ],
+)
+def test_kusto_is_destructive_ddl(kql: str, expected: bool) -> None:
+    """
+    Test ``is_destructive_ddl`` on KustoKQLStatement.
+    """
+    from superset.sql.parse import KustoKQLStatement
+
+    assert KustoKQLStatement(kql, "kustokql").is_destructive_ddl() == expected
+
+
 def test_optimize() -> None:
     """
     Test that the `optimize` method works as expected.

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1318,12 +1318,12 @@ def test_is_mutating_anonymous_block(sql: str, expected: bool) -> None:
         ("ALTER TABLE t DROP COLUMN x", True),
     ],
 )
-def test_is_destructive_ddl(sql: str, expected: bool) -> None:
+def test_is_destructive(sql: str, expected: bool) -> None:
     """
-    Test that ``is_destructive_ddl`` detects DROP, TRUNCATE, and ALTER
+    Test that ``is_destructive`` detects DROP, TRUNCATE, and ALTER
     but not SELECT, INSERT, UPDATE, DELETE, MERGE, or CREATE.
     """
-    assert SQLStatement(sql, "postgresql").is_destructive_ddl() == expected
+    assert SQLStatement(sql, "postgresql").is_destructive() == expected
 
 
 @pytest.mark.parametrize(
@@ -1335,12 +1335,12 @@ def test_is_destructive_ddl(sql: str, expected: bool) -> None:
         ("CREATE TABLE t (id INT); ALTER TABLE t ADD COLUMN x INT", True),
     ],
 )
-def test_has_destructive_ddl(sql: str, expected: bool) -> None:
+def test_has_destructive(sql: str, expected: bool) -> None:
     """
-    Test that ``has_destructive_ddl`` on SQLScript detects destructive DDL
+    Test that ``has_destructive`` on SQLScript detects destructive DDL
     across multiple statements.
     """
-    assert SQLScript(sql, "postgresql").has_destructive_ddl() == expected
+    assert SQLScript(sql, "postgresql").has_destructive() == expected
 
 
 @pytest.mark.parametrize(
@@ -1352,13 +1352,13 @@ def test_has_destructive_ddl(sql: str, expected: bool) -> None:
         ("T | count", False),
     ],
 )
-def test_kusto_is_destructive_ddl(kql: str, expected: bool) -> None:
+def test_kusto_is_destructive(kql: str, expected: bool) -> None:
     """
-    Test ``is_destructive_ddl`` on KustoKQLStatement.
+    Test ``is_destructive`` on KustoKQLStatement.
     """
     from superset.sql.parse import KustoKQLStatement
 
-    assert KustoKQLStatement(kql, "kustokql").is_destructive_ddl() == expected
+    assert KustoKQLStatement(kql, "kustokql").is_destructive() == expected
 
 
 def test_optimize() -> None:

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1301,6 +1301,48 @@ def test_is_mutating_anonymous_block(sql: str, expected: bool) -> None:
     assert SQLStatement(sql, "postgresql").is_mutating() == expected
 
 
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ("SELECT 1", False),
+        ("INSERT INTO t VALUES (1)", False),
+        ("UPDATE t SET x = 1", False),
+        ("DELETE FROM t", False),
+        ("MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE", False),
+        ("CREATE TABLE t (id INT)", False),
+        ("DROP TABLE t", True),
+        ("DROP TABLE IF EXISTS t", True),
+        ("DROP VIEW v", True),
+        ("TRUNCATE TABLE t", True),
+        ("ALTER TABLE t ADD COLUMN x INT", True),
+        ("ALTER TABLE t DROP COLUMN x", True),
+    ],
+)
+def test_is_destructive_ddl(sql: str, expected: bool) -> None:
+    """
+    Test that ``is_destructive_ddl`` detects DROP, TRUNCATE, and ALTER
+    but not SELECT, INSERT, UPDATE, DELETE, MERGE, or CREATE.
+    """
+    assert SQLStatement(sql, "postgresql").is_destructive_ddl() == expected
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ("SELECT 1; INSERT INTO t VALUES (1)", False),
+        ("SELECT 1; DROP TABLE t", True),
+        ("SELECT 1; TRUNCATE TABLE t", True),
+        ("CREATE TABLE t (id INT); ALTER TABLE t ADD COLUMN x INT", True),
+    ],
+)
+def test_has_destructive_ddl(sql: str, expected: bool) -> None:
+    """
+    Test that ``has_destructive_ddl`` on SQLScript detects destructive DDL
+    across multiple statements.
+    """
+    assert SQLScript(sql, "postgresql").has_destructive_ddl() == expected
+
+
 def test_optimize() -> None:
     """
     Test that the `optimize` method works as expected.


### PR DESCRIPTION
### SUMMARY

**Root cause:**
The MCP `execute_sql` tool delegated all SQL validation to the executor's `_check_security()`, which only blocks mutations when `database.allow_dml=False`. When `allow_dml=True`, destructive DDL (DROP TABLE, TRUNCATE, ALTER) passed through unchecked — the only protection was database-level permissions. If a user had DDL privileges on the database, MCP would happily execute `DROP TABLE birth_names`.

**Solution:**
Added a fail-closed DDL pre-check in the MCP tool layer (not the executor, since SQL Lab admins may legitimately need DDL). Before the query reaches the executor:

1. Render Jinja2 templates (if any) so templated SQL is properly validated
2. Parse the SQL with `SQLScript` and check for destructive DDL nodes (`exp.Drop`, `exp.TruncateTable`, `exp.Alter`)
3. If destructive DDL is found, return an error directing users to SQL Lab UI
4. If parsing fails, block the query (fail-closed) rather than allowing potentially destructive SQL to bypass the check

New methods `is_destructive_ddl()` / `has_destructive_ddl()` on `SQLStatement` / `SQLScript` distinguish destructive DDL from safe DML (INSERT/UPDATE/DELETE), which `is_mutating()` groups together.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
