### PR TITLE
fix(sql-lab): show table expand/collapse arrow only on hover

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
@@ -388,6 +388,7 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
                 />
                 <ActionButton
                   label={`toggle-${schema}-${tableName}`}
+                  tooltip={isManuallyOpen ? t('Collapse') : t('Expand')}
                   icon={
                     isManuallyOpen ? (
                       <Icons.UpOutlined iconSize="m" />

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
@@ -386,18 +386,18 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
                       : handlePinTable(tableName, schema, catalog ?? null)
                   }
                 />
+                <ActionButton
+                  label={`toggle-${schema}-${tableName}`}
+                  icon={
+                    isManuallyOpen ? (
+                      <Icons.UpOutlined iconSize="m" />
+                    ) : (
+                      <Icons.DownOutlined iconSize="m" />
+                    )
+                  }
+                  onClick={() => node.toggle()}
+                />
               </div>
-              <ActionButton
-                label={`toggle-${schema}-${tableName}`}
-                icon={
-                  isManuallyOpen ? (
-                    <Icons.UpOutlined iconSize="m" />
-                  ) : (
-                    <Icons.DownOutlined iconSize="m" />
-                  )
-                }
-                onClick={() => node.toggle()}
-              />
             </div>
           );
         })()}


### PR DESCRIPTION
### SUMMARY
The expand/collapse arrow on table nodes in SQL Lab's schema browser was always visible. This was because the toggle `ActionButton` was placed outside the `.action-hover` container, unlike the other table actions (sort, refresh, pin) which are correctly hidden until hover. This PR moves the toggle button inside `.action-hover` so it follows the same behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1896" height="859" alt="Screenshot 2026-04-24 at 10 02 15" src="https://github.com/user-attachments/assets/f42acef7-010a-4c8e-8abd-5f76122872cc" />
<br>
<img width="1895" height="860" alt="Screenshot 2026-04-24 at 09 59 16" src="https://github.com/user-attachments/assets/87821d8e-81bd-4967-b893-d43404dfe6a4" />

### TESTING INSTRUCTIONS
1. Open SQL Lab
2. Select a database and schema with tables
3. Verify the expand/collapse arrow is not visible on table rows by default
4. Hover over a table row and verify the expand/collapse arrow appears alongside the other action buttons (sort, refresh, pin)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)