### PR TITLE
fix(sqllab): Disable duration sorting in query history

### DIFF
--- a/superset-frontend/src/pages/QueryHistoryList/index.tsx
+++ b/superset-frontend/src/pages/QueryHistoryList/index.tsx
@@ -273,6 +273,7 @@ function QueryList({ addDangerToast }: QueryListProps) {
           );
         },
         id: 'duration',
+        disableSortBy: true,
       },
       {
         accessor: QueryObjectColumns.TabName,


### PR DESCRIPTION
### SUMMARY
The duration column was not sortable. This setting was accidentally omitted during the migration from the Flask view to the CRUD view, which was causing the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

In 5.1:

<img width="1243" height="185" alt="Screenshot 2026-04-24 at 11 43 46 AM" src="https://github.com/user-attachments/assets/a9f02382-0de4-4189-a75a-5c09f0c9ad08" />

Before:

<img width="916" height="172" alt="Screenshot 2026-04-24 at 11 37 49 AM" src="https://github.com/user-attachments/assets/927807ef-e411-4448-9ac3-1539ce8ac6e8" />

After:

<img width="581" height="82" alt="Screenshot 2026-04-24 at 11 45 57 AM" src="https://github.com/user-attachments/assets/d953d32c-3e9f-4c44-8ffa-3df9ec726cea" />



### TESTING INSTRUCTIONS

Go to Query History
Duration column sorting should be disabled

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
