### PR TITLE
fix(view query): Update style for code viewer container

### DIFF
--- a/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
@@ -47,6 +47,13 @@ const Title = styled.h4`
   font-weight: ${({ theme }) => theme.fontWeightStrong};
 `;
 
+const StyledTabs = styled(Tabs)`
+  margin-top: ${({ theme }) => theme.sizeUnit * -8}px;
+  .ant-tabs-nav {
+    margin-bottom: ${({ theme }) => theme.sizeUnit * 4}px;
+  }
+`;
+
 const shrinkSql = (sql: string, maxLines: number, maxWidth: number) => {
   const ssql = sql || '';
   let lines = ssql.split('\n');
@@ -94,7 +101,7 @@ function HighlightSqlModal({ rawSql, sql }: HighlightedSqlModalTypes) {
   }
 
   return (
-    <Tabs
+    <StyledTabs
       defaultActiveKey="executed"
       items={[
         {

--- a/superset-frontend/src/explore/components/controls/ViewQuery.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.tsx
@@ -62,6 +62,8 @@ const StyledSyntaxContainer = styled.div`
 
 const StyledThemedSyntaxHighlighter = styled(CodeSyntaxHighlighter)`
   flex: 1;
+  height: ${({ theme }) => theme.sizeUnit * 26}px;
+  margin-top: 0;
 `;
 
 const StyledFooter = styled.div`
@@ -163,7 +165,12 @@ const ViewQuery: FC<ViewQueryProps> = props => {
         ) : (
           <StyledThemedSyntaxHighlighter
             language={language}
-            customStyle={{ flex: 1, marginBottom: theme.sizeUnit * 3 }}
+            customStyle={{
+              flex: 1,
+              marginBottom: theme.sizeUnit * 3,
+              fontSize: theme.fontSize * 0.75,
+              padding: 0,
+            }}
           >
             {currentSQL}
           </StyledThemedSyntaxHighlighter>


### PR DESCRIPTION
### SUMMARY
Following up #39075, this commit updates additional styling for sql code viewers
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

|before|after|
|--|--|
|<img width="1077" height="736" alt="Screenshot_2026-04-24_at_12_20_36 PM" src="https://github.com/user-attachments/assets/bf7e4f8a-568b-4183-92e6-a11a0b3476a5" />|<img width="949" height="843" alt="Screenshot_2026-04-24_at_12_29_24 PM" src="https://github.com/user-attachments/assets/301fa3ca-5d0d-4053-a53d-cac5cb499a0b" />|
|<img width="929" height="303" alt="Screenshot_2026-04-24_at_12_33_47 PM" src="https://github.com/user-attachments/assets/0f2b1f07-7da7-4050-a298-3ea1d824f78f" />|<img width="930" height="287" alt="Screenshot_2026-04-24_at_12_33_29 PM" src="https://github.com/user-attachments/assets/f3c33584-85b0-47a3-a6f0-18c594326f39" />|

### TESTING INSTRUCTIONS
Check stying for view query modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
