### PR TITLE
fix(query-history): enable sorting by Duration column

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -44,6 +44,7 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.engine.url import URL
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.sql.elements import ColumnElement, literal_column
 from superset_core.queries.models import (
@@ -159,6 +160,20 @@ class Query(
     changed_on = Column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=True
     )
+
+    @hybrid_property
+    def duration(self) -> Optional[float]:
+        start = self.start_running_time or self.start_time
+        if self.end_time is not None and start is not None:
+            return float(self.end_time - start)
+        return None
+
+    @duration.expression  # type: ignore[no-redef]
+    def duration(cls) -> ColumnElement:  # noqa: N805
+        return sqla.func.coalesce(
+            cls.end_time - sqla.func.coalesce(cls.start_running_time, cls.start_time),
+            0,
+        )
 
     database = relationship(
         "Database",

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -142,6 +142,7 @@ class QueryRestApi(BaseSupersetModelRestApi):
     order_columns = [
         "changed_on",
         "database.database_name",
+        "duration",
         "rows",
         "schema",
         "start_time",

--- a/superset/queries/schemas.py
+++ b/superset/queries/schemas.py
@@ -60,6 +60,7 @@ class QuerySchema(Schema):
     schema = fields.String()
     sql = fields.String()
     sql_tables = fields.Method("get_sql_tables")
+    start_running_time = fields.Float(attribute="start_running_time")
     start_time = fields.Float(attribute="start_time")
     status = fields.String()
     tab_name = fields.String()

--- a/tests/integration_tests/queries/api_tests.py
+++ b/tests/integration_tests/queries/api_tests.py
@@ -382,7 +382,7 @@ class TestQueryApi(SupersetTestCase):
             rv = self.client.get(uri)
             assert rv.status_code == 200
 
-    def test_get_list_query_order_duration(self):
+    def test_get_list_query_order_duration(self) -> None:
         """
         Query API: Test that sorting by duration orders by end_time - start_time,
         falling back to start_time when start_running_time is absent, and treating

--- a/tests/integration_tests/queries/api_tests.py
+++ b/tests/integration_tests/queries/api_tests.py
@@ -54,6 +54,9 @@ class TestQueryApi(SupersetTestCase):
         tab_name: str = "",
         status: str = "success",
         changed_on: datetime = datetime(2020, 1, 1),
+        start_time: float | None = None,
+        start_running_time: float | None = None,
+        end_time: float | None = None,
     ) -> Query:
         database = db.session.query(Database).get(database_id)
         user = db.session.query(security_manager.user_model).get(user_id)
@@ -70,6 +73,9 @@ class TestQueryApi(SupersetTestCase):
             tab_name=tab_name,
             status=status,
             changed_on=changed_on,
+            start_time=start_time,
+            start_running_time=start_running_time,
+            end_time=end_time,
         )
         db.session.add(query)
         db.session.commit()
@@ -275,6 +281,7 @@ class TestQueryApi(SupersetTestCase):
             "schema",
             "sql",
             "sql_tables",
+            "start_running_time",
             "start_time",
             "status",
             "tab_name",
@@ -361,6 +368,7 @@ class TestQueryApi(SupersetTestCase):
         order_columns = [
             "changed_on",
             "database.database_name",
+            "duration",
             "rows",
             "schema",
             "sql",
@@ -373,6 +381,81 @@ class TestQueryApi(SupersetTestCase):
             uri = f"api/v1/query/?q={rison.dumps(arguments)}"
             rv = self.client.get(uri)
             assert rv.status_code == 200
+
+    def test_get_list_query_order_duration(self):
+        """
+        Query API: Test that sorting by duration orders by end_time - start_time,
+        falling back to start_time when start_running_time is absent, and treating
+        NULL durations (no end_time) as zero.
+        """
+        admin = self.get_user("admin")
+        example_db = get_example_database()
+        base_time = 1_000_000.0
+
+        # duration = 0.031 (uses start_running_time as start)
+        q_long = self.insert_query(
+            example_db.id,
+            admin.id,
+            self.get_random_string(),
+            start_time=base_time,
+            start_running_time=base_time + 0.005,
+            end_time=base_time + 0.036,
+        )
+        # duration = 0.021
+        q_medium = self.insert_query(
+            example_db.id,
+            admin.id,
+            self.get_random_string(),
+            start_time=base_time,
+            start_running_time=None,
+            end_time=base_time + 0.021,
+        )
+        # duration = 0 (no end_time, NULL treated as 0)
+        q_null = self.insert_query(
+            example_db.id,
+            admin.id,
+            self.get_random_string(),
+            start_time=base_time,
+            start_running_time=None,
+            end_time=None,
+        )
+
+        # Use a unique sql_editor_id to isolate these test queries
+        test_editor_id = self.get_random_string()
+        q_long.sql_editor_id = test_editor_id
+        q_medium.sql_editor_id = test_editor_id
+        q_null.sql_editor_id = test_editor_id
+        db.session.commit()
+
+        self.login(ADMIN_USERNAME)
+        try:
+            arguments = {
+                "order_column": "duration",
+                "order_direction": "asc",
+                "filters": [
+                    {"col": "sql_editor_id", "opr": "eq", "value": test_editor_id}
+                ],
+            }
+            uri = f"api/v1/query/?q={prison.dumps(arguments)}"
+            rv = self.client.get(uri)
+            assert rv.status_code == 200
+            data = rv.get_json()
+            ids = [r["id"] for r in data["result"]]
+            assert ids == [q_null.id, q_medium.id, q_long.id]
+
+            # descending should be the reverse
+            arguments["order_direction"] = "desc"
+            uri = f"api/v1/query/?q={prison.dumps(arguments)}"
+            rv = self.client.get(uri)
+            assert rv.status_code == 200
+            data = rv.get_json()
+            ids = [r["id"] for r in data["result"]]
+            assert ids == [q_long.id, q_medium.id, q_null.id]
+        finally:
+            db.session.delete(q_long)
+            db.session.delete(q_medium)
+            db.session.delete(q_null)
+            db.session.commit()
 
     def test_get_list_query_no_data_access(self):
         """

--- a/tests/integration_tests/queries/api_tests.py
+++ b/tests/integration_tests/queries/api_tests.py
@@ -431,9 +431,7 @@ class TestQueryApi(SupersetTestCase):
         arguments = {
             "order_column": "duration",
             "order_direction": "asc",
-            "filters": [
-                {"col": "sql_editor_id", "opr": "eq", "value": test_editor_id}
-            ],
+            "filters": [{"col": "sql_editor_id", "opr": "eq", "value": test_editor_id}],
         }
         uri = f"api/v1/query/?q={rison.dumps(arguments)}"
         rv = self.client.get(uri)

--- a/tests/integration_tests/queries/api_tests.py
+++ b/tests/integration_tests/queries/api_tests.py
@@ -428,34 +428,33 @@ class TestQueryApi(SupersetTestCase):
         db.session.commit()
 
         self.login(ADMIN_USERNAME)
-        try:
-            arguments = {
-                "order_column": "duration",
-                "order_direction": "asc",
-                "filters": [
-                    {"col": "sql_editor_id", "opr": "eq", "value": test_editor_id}
-                ],
-            }
-            uri = f"api/v1/query/?q={prison.dumps(arguments)}"
-            rv = self.client.get(uri)
-            assert rv.status_code == 200
-            data = rv.get_json()
-            ids = [r["id"] for r in data["result"]]
-            assert ids == [q_null.id, q_medium.id, q_long.id]
+        arguments = {
+            "order_column": "duration",
+            "order_direction": "asc",
+            "filters": [
+                {"col": "sql_editor_id", "opr": "eq", "value": test_editor_id}
+            ],
+        }
+        uri = f"api/v1/query/?q={prison.dumps(arguments)}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        data = rv.get_json()
+        ids = [r["id"] for r in data["result"]]
+        assert ids == [q_null.id, q_medium.id, q_long.id]
 
-            # descending should be the reverse
-            arguments["order_direction"] = "desc"
-            uri = f"api/v1/query/?q={prison.dumps(arguments)}"
-            rv = self.client.get(uri)
-            assert rv.status_code == 200
-            data = rv.get_json()
-            ids = [r["id"] for r in data["result"]]
-            assert ids == [q_long.id, q_medium.id, q_null.id]
-        finally:
-            db.session.delete(q_long)
-            db.session.delete(q_medium)
-            db.session.delete(q_null)
-            db.session.commit()
+        # descending should be the reverse
+        arguments["order_direction"] = "desc"
+        uri = f"api/v1/query/?q={prison.dumps(arguments)}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        data = rv.get_json()
+        ids = [r["id"] for r in data["result"]]
+        assert ids == [q_long.id, q_medium.id, q_null.id]
+
+        db.session.delete(q_long)
+        db.session.delete(q_medium)
+        db.session.delete(q_null)
+        db.session.commit()
 
     def test_get_list_query_no_data_access(self):
         """

--- a/tests/integration_tests/queries/api_tests.py
+++ b/tests/integration_tests/queries/api_tests.py
@@ -382,7 +382,7 @@ class TestQueryApi(SupersetTestCase):
             rv = self.client.get(uri)
             assert rv.status_code == 200
 
-    def test_get_list_query_order_duration(self) -> None:
+    def test_get_list_query_order_duration(self):
         """
         Query API: Test that sorting by duration orders by end_time - start_time,
         falling back to start_time when start_running_time is absent, and treating

--- a/tests/integration_tests/queries/api_tests.py
+++ b/tests/integration_tests/queries/api_tests.py
@@ -435,7 +435,7 @@ class TestQueryApi(SupersetTestCase):
                 {"col": "sql_editor_id", "opr": "eq", "value": test_editor_id}
             ],
         }
-        uri = f"api/v1/query/?q={prison.dumps(arguments)}"
+        uri = f"api/v1/query/?q={rison.dumps(arguments)}"
         rv = self.client.get(uri)
         assert rv.status_code == 200
         data = rv.get_json()
@@ -444,7 +444,7 @@ class TestQueryApi(SupersetTestCase):
 
         # descending should be the reverse
         arguments["order_direction"] = "desc"
-        uri = f"api/v1/query/?q={prison.dumps(arguments)}"
+        uri = f"api/v1/query/?q={rison.dumps(arguments)}"
         rv = self.client.get(uri)
         assert rv.status_code == 200
         data = rv.get_json()


### PR DESCRIPTION
### SUMMARY

Clicking the **Duration** column header in the Query History list page produced:

> An error occurred while fetching Query historys: Invalid order by column: duration

`duration` is a computed value (`end_time - start_running_time` or `end_time - start_time`) with no corresponding DB column, so the API rejected it.

**Changes:**
- Add a `duration` SQLAlchemy `hybrid_property` to the `Query` model. The Python accessor returns the float difference; the SQL expression emits `COALESCE(end_time - COALESCE(start_running_time, start_time), 0)`, matching the frontend cell renderer logic exactly (including the `start_running_time` fallback and treating unfinished queries as zero).
- Add `"duration"` to `QueryRestApi.order_columns` so the API accepts it.
- Add `start_running_time` to `QuerySchema` so the list response includes it — it was already in `list_columns` but was silently dropped by the Marshmallow schema, causing the frontend to always fall back to `start_time` while the backend sort used `start_running_time`. This mismatch caused visible sort inconsistencies.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Clicking Duration header → toast error "Invalid order by column: duration"

**After:** Duration column sorts ascending/descending correctly, with unfinished queries (displayed as `00:00:00.000`) sorting as zero.

### TESTING INSTRUCTIONS

1. Navigate to **SQL Lab → Query History**
2. Click the **Duration** column header — should sort without error
3. Click again to reverse sort direction — order should be consistent with displayed values
4. Queries with no `end_time` (still running or never finished, shown as `00:00:00.000`) should sort first on ascending

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API