### PR TITLE
fix: the mcp service jwt verifier at superset/mcp_se... in...

### DIFF
--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -153,21 +153,22 @@ class DetailedJWTVerifier(JWTVerifier):
             # Step 1: Decode header and check algorithm
             try:
                 header = self._decode_token_header(token)
-            except (ValueError, DecodeError) as e:
+            except (ValueError, DecodeError):
                 reason = "Malformed token header"
                 _jwt_failure_reason.set(reason)
-                logger.debug("Malformed token header: %s", e)
+                logger.debug("Malformed token header")
                 return None
 
             token_alg = header.get("alg")
+            if not token_alg or token_alg.lower() == "none":
+                reason = "Algorithm mismatch"
+                _jwt_failure_reason.set(reason)
+                logger.debug("Rejected token with insecure algorithm")
+                return None
             if self.algorithm and token_alg != self.algorithm:
                 reason = "Algorithm mismatch"
                 _jwt_failure_reason.set(reason)
-                logger.debug(
-                    "Algorithm mismatch: token uses '%s', expected '%s'",
-                    token_alg,
-                    self.algorithm,
-                )
+                logger.debug("Algorithm mismatch")
                 return None
 
             # Step 2: Get verification key (static or JWKS)
@@ -190,10 +191,10 @@ class DetailedJWTVerifier(JWTVerifier):
                 reason = "Token has expired (detected during decode)"
                 _jwt_failure_reason.set(reason)
                 return None
-            except JoseError as e:
+            except JoseError:
                 reason = "Token decode failed"
                 _jwt_failure_reason.set(reason)
-                logger.debug("Token decode failed: %s", e)
+                logger.debug("Token decode failed")
                 return None
 
             # Extract client ID for logging
@@ -206,10 +207,15 @@ class DetailedJWTVerifier(JWTVerifier):
 
             # Step 4: Check expiration
             exp = claims.get("exp")
-            if exp and exp < time.time():
+            if not exp:
+                reason = "Token missing expiration"
+                _jwt_failure_reason.set(reason)
+                logger.debug("Token missing 'exp' claim")
+                return None
+            if exp < time.time():
                 reason = "Token expired"
                 _jwt_failure_reason.set(reason)
-                logger.debug("Token expired for client '%s'", client_id)
+                logger.debug("Token expired")
                 return None
 
             # Step 5: Validate issuer
@@ -223,11 +229,7 @@ class DetailedJWTVerifier(JWTVerifier):
                 if not issuer_valid:
                     reason = "Issuer mismatch"
                     _jwt_failure_reason.set(reason)
-                    logger.debug(
-                        "Issuer mismatch: token has '%s', expected '%s'",
-                        iss,
-                        self.issuer,
-                    )
+                    logger.debug("Issuer mismatch")
                     return None
 
             # Step 6: Validate audience
@@ -250,11 +252,7 @@ class DetailedJWTVerifier(JWTVerifier):
                 if not audience_valid:
                     reason = "Audience mismatch"
                     _jwt_failure_reason.set(reason)
-                    logger.debug(
-                        "Audience mismatch: token has '%s', expected '%s'",
-                        aud,
-                        self.audience,
-                    )
+                    logger.debug("Audience mismatch")
                     return None
 
             # Step 7: Check required scopes
@@ -263,14 +261,9 @@ class DetailedJWTVerifier(JWTVerifier):
                 token_scopes = set(scopes)
                 required = set(self.required_scopes)
                 if not required.issubset(token_scopes):
-                    missing = required - token_scopes
                     reason = "Missing required scopes"
                     _jwt_failure_reason.set(reason)
-                    logger.debug(
-                        "Missing required scopes: %s. Token has: %s",
-                        missing,
-                        token_scopes,
-                    )
+                    logger.debug("Missing required scopes")
                     return None
 
             # All validations passed
@@ -282,10 +275,10 @@ class DetailedJWTVerifier(JWTVerifier):
                 claims=dict(claims),
             )
 
-        except (ValueError, JoseError, KeyError, AttributeError, TypeError) as e:
+        except (ValueError, JoseError, KeyError, AttributeError, TypeError):
             reason = "Token validation failed"
             _jwt_failure_reason.set(reason)
-            logger.debug("Token validation failed: %s", e)
+            logger.debug("Token validation failed")
             return None
 
     def get_middleware(self) -> list[Any]:


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `superset/mcp_service/jwt_verifier.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `superset/mcp_service/jwt_verifier.py:184` |

**Description**: The MCP service JWT verifier at superset/mcp_service/jwt_verifier.py:184 is the authentication gatekeeper for guest token creation at security/api.py:172. If the verifier permits the 'none' algorithm (a known JWT attack vector), fails to validate expiration (exp), audience (aud), or issuer (iss) claims, or accepts tokens with weak signature algorithms (HS256 with guessable secrets), attackers can forge or replay JWT tokens. Guest tokens grant access to embedded dashboards and datasets, making this a high-value authentication bypass target.

## Changes
- `superset/mcp_service/jwt_verifier.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
