### PR TITLE
fix: remove debug console.log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,6 +202,7 @@ RUN mkdir -p /app/data && chown -R superset:superset /app/data
 
 # Copy compiled things from previous stages
 COPY --from=superset-node /app/superset/static/assets superset/static/assets
+COPY --from=superset-node /app/superset/static/service-worker.js superset/static/service-worker.js
 
 # TODO, when the next version comes out, use --exclude superset/translations
 COPY superset superset

--- a/superset-frontend/src/explore/components/controls/ZoomConfigControl/ZoomConfigControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ZoomConfigControl/ZoomConfigControl.tsx
@@ -66,7 +66,6 @@ export const ZoomConfigControl: FC<ZoomConfigsControlProps> = ({
   };
 
   const onBaseWidthChange = (width: number) => {
-    console.log('now in onbasewidthcahnge');
     setBaseWidth(width);
     if (!value) {
       return;


### PR DESCRIPTION
## Summary

Two small fixes for the Superset frontend build:

### fix: Remove leftover debug console.log in ZoomConfigControl

Removes a debug `console.log` statement accidentally left in the `onBaseWidthChange` handler. This pollutes the browser console on every Base Width slider drag. Fixes #39622.

### fix: Add service-worker.js to Dockerfile lean stage

The webpack build outputs `service-worker.js` one directory above `assets/`, but only `assets/` was being copied in the lean Docker image stage. This causes a 404 when the browser tries to register the service worker in subdirectory deployments. Fixes #39431.