### PR TITLE
fix(sql-lab): add overflow-x auto to TablePreview wrapper for horizontal scroll

### DIFF
--- a/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
@@ -326,6 +326,7 @@ const TablePreview: FC<Props> = ({ dbId, catalog, schema, tableName }) => {
           <div
             css={css`
               flex: 1 1 auto;
+              overflow-x: auto;
             `}
           >
             <AutoSizer disableWidth>


### PR DESCRIPTION
Body:
Fixes #39631

The wrapper div in TablePreview used flex: 1 1 auto but had no
overflow-x rule. Wide tables were silently clipped with no horizontal
scroll bar. Added overflow-x: auto — one line, zero logic risk.

base repository: apache/superset      base: master
head repository: iskanderknani2005-oss/superset