### PR TITLE
refactor(docs): replace barrel regex parser with @babel/parser AST walk

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.1",
+    "@babel/parser": "^7.28.6",
     "@docusaurus/core": "^3.10.0",
     "@docusaurus/faster": "^3.10.0",
     "@docusaurus/plugin-client-redirects": "^3.10.0",

--- a/docs/scripts/generate-superset-components.mjs
+++ b/docs/scripts/generate-superset-components.mjs
@@ -203,6 +203,48 @@ function resolveRelativeModule(fromFile, specifier) {
 }
 
 /**
+ * Collect every `Identifier` bound by a destructuring (or simple) pattern
+ * into `out`. Handles object/array destructuring, rest elements, defaults,
+ * and TS-specific assignment patterns. Used so that `export const { Foo } = X`
+ * contributes `Foo` to the public export set.
+ */
+function collectPatternIdentifiers(node, out) {
+  if (!node) return;
+  switch (node.type) {
+    case 'Identifier':
+      out.add(node.name);
+      return;
+    case 'ObjectPattern':
+      for (const prop of node.properties) {
+        if (prop.type === 'RestElement') {
+          collectPatternIdentifiers(prop.argument, out);
+        } else {
+          // ObjectProperty: bound name is the value side
+          // (`{ foo: bar }` binds `bar`, `{ foo }` binds `foo` via shorthand).
+          collectPatternIdentifiers(prop.value, out);
+        }
+      }
+      return;
+    case 'ArrayPattern':
+      for (const el of node.elements) {
+        if (el) collectPatternIdentifiers(el, out);
+      }
+      return;
+    case 'RestElement':
+      collectPatternIdentifiers(node.argument, out);
+      return;
+    case 'AssignmentPattern':
+      collectPatternIdentifiers(node.left, out);
+      return;
+    default:
+      // TypeScript wraps patterns in TSParameterProperty / TSAsExpression /
+      // TSTypeAssertion etc. Probe common holders.
+      if (node.parameter) collectPatternIdentifiers(node.parameter, out);
+      if (node.expression) collectPatternIdentifiers(node.expression, out);
+  }
+}
+
+/**
  * Collect the set of value names exported from a barrel file, following
  * `export * from './X'` re-exports recursively. Used to verify that a
  * component the docs claim is importable is actually re-exported from the
@@ -231,11 +273,12 @@ function collectBarrelExports(barrelPath, visited = new Set()) {
       if (node.exportKind === 'type') continue;
 
       if (node.declaration) {
-        // `export const Foo = ...`, `export function Foo() {}`, `export class Foo {}`
+        // `export const Foo = ...`, `export function Foo() {}`, `export class Foo {}`,
+        // `export const { Foo, Bar: Baz } = ...`, `export const [a, b] = ...`
         const decl = node.declaration;
         if (decl.type === 'VariableDeclaration') {
           for (const d of decl.declarations) {
-            if (d.id?.type === 'Identifier') exports.add(d.id.name);
+            collectPatternIdentifiers(d.id, exports);
           }
         } else if (decl.id?.type === 'Identifier') {
           exports.add(decl.id.name);

--- a/docs/scripts/generate-superset-components.mjs
+++ b/docs/scripts/generate-superset-components.mjs
@@ -53,6 +53,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { parse as parseModule } from '@babel/parser';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -186,8 +187,24 @@ const SKIP_STORIES = [
 
 
 /**
+ * Resolve a relative TS module specifier to an on-disk file path, trying the
+ * usual TS extension and `/index` permutations.
+ */
+function resolveRelativeModule(fromFile, specifier) {
+  if (!specifier.startsWith('.')) return null;
+  const baseDir = path.dirname(fromFile);
+  const candidates = [
+    path.resolve(baseDir, `${specifier}.ts`),
+    path.resolve(baseDir, `${specifier}.tsx`),
+    path.resolve(baseDir, specifier, 'index.ts'),
+    path.resolve(baseDir, specifier, 'index.tsx'),
+  ];
+  return candidates.find(p => fs.existsSync(p)) || null;
+}
+
+/**
  * Collect the set of value names exported from a barrel file, following
- * `export * from './X'` re-exports one level deep. Used to verify that a
+ * `export * from './X'` re-exports recursively. Used to verify that a
  * component the docs claim is importable is actually re-exported from the
  * public package entry point.
  */
@@ -196,42 +213,52 @@ function collectBarrelExports(barrelPath, visited = new Set()) {
   if (!fs.existsSync(barrelPath) || visited.has(barrelPath)) return exports;
   visited.add(barrelPath);
 
-  const content = fs.readFileSync(barrelPath, 'utf8');
+  const source = fs.readFileSync(barrelPath, 'utf8');
+  let ast;
+  try {
+    ast = parseModule(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    });
+  } catch (err) {
+    console.warn(`  ! Failed to parse ${barrelPath}: ${err.message}`);
+    return exports;
+  }
 
-  for (const m of content.matchAll(/export\s+\{([\s\S]*?)\}(?:\s+from\s+['"][^'"]+['"])?/g)) {
-    for (const part of m[1].split(',')) {
-      const cleaned = part.trim().replace(/^type\s+/, '');
-      if (!cleaned) continue;
-      const asMatch = cleaned.match(/(?:^|\s)as\s+([A-Za-z_]\w*)\s*$/);
-      if (asMatch) {
-        exports.add(asMatch[1]);
-      } else {
-        const plain = cleaned.match(/^([A-Za-z_]\w*)\s*$/);
-        if (plain) exports.add(plain[1]);
+  for (const node of ast.program.body) {
+    if (node.type === 'ExportNamedDeclaration') {
+      // Skip type-only re-exports: `export type { Foo } from '...'`
+      if (node.exportKind === 'type') continue;
+
+      if (node.declaration) {
+        // `export const Foo = ...`, `export function Foo() {}`, `export class Foo {}`
+        const decl = node.declaration;
+        if (decl.type === 'VariableDeclaration') {
+          for (const d of decl.declarations) {
+            if (d.id?.type === 'Identifier') exports.add(d.id.name);
+          }
+        } else if (decl.id?.type === 'Identifier') {
+          exports.add(decl.id.name);
+        }
       }
-    }
-  }
 
-  for (const m of content.matchAll(
-    /export\s+(?:const|let|var|function|class)\s+([A-Za-z_]\w*)/g
-  )) {
-    exports.add(m[1]);
-  }
-
-  for (const m of content.matchAll(/export\s+\*\s+from\s+['"]([^'"]+)['"]/g)) {
-    const target = m[1];
-    if (!target.startsWith('.')) continue;
-    const baseDir = path.dirname(barrelPath);
-    const candidates = [
-      path.resolve(baseDir, `${target}.ts`),
-      path.resolve(baseDir, `${target}.tsx`),
-      path.resolve(baseDir, target, 'index.ts'),
-      path.resolve(baseDir, target, 'index.tsx'),
-    ];
-    const resolved = candidates.find(p => fs.existsSync(p));
-    if (resolved) {
-      for (const name of collectBarrelExports(resolved, visited)) {
-        exports.add(name);
+      for (const spec of node.specifiers || []) {
+        // Skip individual type specifiers: `export { type Foo }`
+        if (spec.exportKind === 'type') continue;
+        const exported = spec.exported;
+        if (exported?.type === 'Identifier') {
+          exports.add(exported.name);
+        } else if (exported?.type === 'StringLiteral') {
+          exports.add(exported.value);
+        }
+      }
+    } else if (node.type === 'ExportAllDeclaration') {
+      if (node.exportKind === 'type') continue;
+      const resolved = resolveRelativeModule(barrelPath, node.source.value);
+      if (resolved) {
+        for (const name of collectBarrelExports(resolved, visited)) {
+          exports.add(name);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Targets #38486 — follow-up to the regex-driven barrel parser merged in #39649.

The previous barrel-export collector relied on a stack of multiline regexes that were both hard to read and fragile (a separate pass for `export const Foo`, brittle handling of `export type {}`). hainenber called this out in the #39649 review thread as "almost a Perl script in disguise", and they were right.

This swaps the parser for a `@babel/parser` AST walk:

- `ExportNamedDeclaration` → collect specifier names and identifier from the `declaration` (handles `const`, `let`, `var`, `function`, `class`).
- `ExportAllDeclaration` → resolve the relative module specifier and recurse.
- TS type-only exports (`export type {}`, `export { type Foo }`) are skipped via the `exportKind` field — no more regex carve-outs.
- Falls back gracefully if a barrel fails to parse.

## Notes

- `@babel/parser` was already a transitive dep via Docusaurus; declaring it as a direct dep adds no new install footprint and the lockfile is unchanged.
- Regenerating with the new parser produces zero diffs in the existing component MDX files — same exports detected, same Import block omitted for `TableCollection`.

## Test plan

- [x] `node docs/scripts/generate-superset-components.mjs` produces no MDX changes from the merged state of #39649.
- [ ] Netlify preview renders component pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)