### PR TITLE
fix(sqllab): keep saved-query list working when Jinja `dataset(id)` references a deleted dataset

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -52,7 +52,11 @@ from superset_core.queries.models import (
 )
 
 from superset import security_manager
-from superset.exceptions import SupersetParseError, SupersetSecurityException
+from superset.exceptions import (
+    SupersetException,
+    SupersetParseError,
+    SupersetSecurityException,
+)
 from superset.explorables.base import TimeGrainDict
 from superset.jinja_context import BaseTemplateProcessor, get_template_processor
 from superset.models.helpers import (
@@ -97,6 +101,14 @@ class SqlTablesMixin:  # pylint: disable=too-few-public-methods
                 ).tables
             )
         except (SupersetSecurityException, SupersetParseError, TemplateError):
+            return []
+        except SupersetException as ex:
+            # Jinja macros such as ``{{ dataset(id) }}`` or ``{{ metric(...) }}``
+            # may reference resources that no longer exist (e.g. a deleted
+            # dataset). Surfacing the failure here would break list endpoints
+            # that include ``sql_tables`` in their payload, hiding every saved
+            # query from the user. Treat it as a parse failure instead.
+            logger.warning("Unable to extract tables from SQL via Jinja: %s", ex)
             return []
 
 

--- a/tests/unit_tests/models/sql_lab_test.py
+++ b/tests/unit_tests/models/sql_lab_test.py
@@ -21,8 +21,13 @@ from flask_appbuilder import Model
 from jinja2.exceptions import TemplateError
 from pytest_mock import MockerFixture
 
+from superset.commands.dataset.exceptions import DatasetNotFoundError
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetParseError, SupersetSecurityException
+from superset.exceptions import (
+    SupersetParseError,
+    SupersetSecurityException,
+    SupersetTemplateException,
+)
 from superset.models.sql_lab import Query, SavedQuery
 
 
@@ -48,6 +53,11 @@ from superset.models.sql_lab import Query, SavedQuery
             message="Invalid SQL syntax",
         ),
         TemplateError,
+        # ``{{ dataset(id) }}`` referencing a deleted dataset previously
+        # bubbled up through ``sql_tables`` and broke saved-query list
+        # endpoints (see issue #32771).
+        DatasetNotFoundError("Dataset 1 not found!"),
+        SupersetTemplateException("Template rendering failed"),
     ],
 )
 def test_sql_tables_mixin_sql_tables_exception(

--- a/tests/unit_tests/models/sql_lab_test.py
+++ b/tests/unit_tests/models/sql_lab_test.py
@@ -28,6 +28,7 @@ from superset.exceptions import (
     SupersetSecurityException,
     SupersetTemplateException,
 )
+from superset.models import sql_lab as sql_lab_module
 from superset.models.sql_lab import Query, SavedQuery
 
 
@@ -39,38 +40,60 @@ from superset.models.sql_lab import Query, SavedQuery
     ],
 )
 @pytest.mark.parametrize(
-    "exception",
+    ("exception", "should_warn"),
     [
-        SupersetSecurityException(
-            SupersetError(
-                error_type=SupersetErrorType.QUERY_SECURITY_ACCESS_ERROR,
-                message="",
-                level=ErrorLevel.ERROR,
-            )
+        # Original silent handler — security/parse/template errors are
+        # expected during list rendering and produce no log noise.
+        (
+            SupersetSecurityException(
+                SupersetError(
+                    error_type=SupersetErrorType.QUERY_SECURITY_ACCESS_ERROR,
+                    message="",
+                    level=ErrorLevel.ERROR,
+                )
+            ),
+            False,
         ),
-        SupersetParseError(
-            sql="INVALID SQL",
-            message="Invalid SQL syntax",
+        (
+            SupersetParseError(
+                sql="INVALID SQL",
+                message="Invalid SQL syntax",
+            ),
+            False,
         ),
-        TemplateError,
+        (TemplateError, False),
         # ``{{ dataset(id) }}`` referencing a deleted dataset previously
         # bubbled up through ``sql_tables`` and broke saved-query list
-        # endpoints (see issue #32771).
-        DatasetNotFoundError("Dataset 1 not found!"),
-        SupersetTemplateException("Template rendering failed"),
+        # endpoints (see issue #32771). The new handler swallows it but
+        # logs a warning so the underlying breakage is still observable —
+        # pinned here so a future refactor that collapses the case into
+        # the silent handler fails this test.
+        (DatasetNotFoundError("Dataset 1 not found!"), True),
+        (SupersetTemplateException("Template rendering failed"), True),
     ],
 )
 def test_sql_tables_mixin_sql_tables_exception(
     klass: type[Model],
     exception: Exception,
+    should_warn: bool,
     mocker: MockerFixture,
 ) -> None:
     mocker.patch(
         "superset.models.sql_lab.process_jinja_sql",
         side_effect=exception,
     )
+    warning_spy = mocker.spy(sql_lab_module.logger, "warning")
 
     assert klass(sql="SELECT 1", database=MagicMock()).sql_tables == []
+
+    if should_warn:
+        assert warning_spy.call_count == 1, (
+            f"{type(exception).__name__} should hit the warning-logging "
+            "handler; if this fails, the case was likely collapsed into "
+            "the silent first-handler clause."
+        )
+    else:
+        warning_spy.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY

Fixes #32771.

When a saved query contains a Jinja macro such as `{{ dataset(id) }}` and the referenced dataset is subsequently deleted, the saved-query list endpoint blows up with `Dataset ID not found!`, causing the entire saved-queries UI to render empty. Users have no way to clean up the broken saved query because they can't see *any* saved queries to delete.

The root cause: `SqlTablesMixin.sql_tables` (in `superset/models/sql_lab.py`) calls `process_jinja_sql`, which actually renders the Jinja template to extract table references. The `dataset()` macro raises `DatasetNotFoundError` when the dataset is missing, and `sql_tables` only caught `SupersetSecurityException`, `SupersetParseError`, and `TemplateError` — so the exception escaped, broke list serialization, and tanked the whole endpoint.

This PR widens the safety net to also catch `SupersetException` (the parent of `DatasetNotFoundError` and `SupersetTemplateException`). On failure, we log a warning and return an empty list, matching the existing fallback behavior for the other expected errors. Saved queries with broken Jinja still appear in the list — they just don't contribute table metadata — so users can edit/delete them as expected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend fix; UI behavior change is "list now renders" instead of "list is empty with error toast".

### TESTING INSTRUCTIONS

1. Add a dataset.
2. Create a saved query whose SQL uses `{{ dataset(<id>) }}` (e.g. `SELECT * FROM {{ dataset(1) }}`).
3. Confirm the query appears at `/savedqueryview/list/`.
4. Delete the dataset from step 1.
5. Reload `/savedqueryview/list/` — **before this fix** the list is empty and a toast shows "An error occurred while fetching Saved queriess: Dataset ID not found!"; **after this fix** the list renders normally and the broken saved query is editable/deletable.
6. Visit `/superset/welcome/` — the recent saved queries section no longer fails with `[object Response]`.

A unit test covering both `DatasetNotFoundError` and `SupersetTemplateException` was added to `tests/unit_tests/models/sql_lab_test.py` (extends the existing parametrized `sql_tables` exception test).

### ADDITIONAL INFORMATION

- [x] Has associated issue: #32771
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)