### PR TITLE
fix(theme): set color-scheme on html to fix dark mode scrollbars

### DIFF
--- a/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
@@ -29,14 +29,20 @@ import '@fontsource/ibm-plex-mono/600.css';
 /* eslint-enable import/extensions */
 
 import { css, useTheme, Global } from '@emotion/react';
+import { useThemeMode } from './utils/themeUtils';
 
 export const GlobalStyles = () => {
   const theme = useTheme();
+  const isDark = useThemeMode();
   return (
     <Global
       key={`global-${theme.colorLink}`}
       styles={css`
         // SPA
+        html {
+          color-scheme: ${isDark ? 'dark' : 'light'};
+        }
+
         html,
         body,
         #app {


### PR DESCRIPTION
### SUMMARY

Browsers render native scroll containers (scrollbars on `overflow: auto/scroll` elements) in light or dark mode based on the CSS `color-scheme` property on `html`. Without it, all native scrollbars stay light regardless of the active dark theme.

This adds `color-scheme: dark | light` to the `html` element in `GlobalStyles`, driven by the existing `useThemeMode()` hook. This fix covers all scroll containers in the app — including SQL Lab's schema browser (react-arborist `FixedSizeList`) and the Ace editor scrollbars — without any per-component overrides.

The dashboard page-level scrollbar was already correct because macOS/Chrome applies the OS dark preference to the viewport scrollbar independently; the issue only manifested in custom scroll containers.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** SQL Lab schema browser and editor scrollbars render with a light background in dark mode.

<img width="1909" height="857" alt="Screenshot 2026-04-27 at 16 29 45" src="https://github.com/user-attachments/assets/22c882e4-a983-4b32-b6c3-cd80dbaa3961" />

**After:** All scrollbars correctly adopt the dark theme.

<img width="1915" height="857" alt="Screenshot 2026-04-27 at 16 46 38" src="https://github.com/user-attachments/assets/39d9b089-f4b5-4c63-9e68-0a493aa71980" />

### TESTING INSTRUCTIONS

1. Enable dark mode in Superset settings
2. Navigate to SQL Lab
3. Verify the schema browser (left panel) scrollbar is dark-themed
4. Verify the SQL editor scrollbar is dark-themed
5. Toggle back to light mode and confirm scrollbars revert to light style

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API