### PR TITLE
fix(docs): Update development setup documentation for port changes

### DIFF
--- a/docs/developer_docs/contributing/development-setup.md
+++ b/docs/developer_docs/contributing/development-setup.md
@@ -71,7 +71,7 @@ Note that:
   [docker-compose.yml](https://github.com/apache/superset/blob/master/docker-compose.yml)
 - The local repository is mounted within the services, meaning updating
   the code on the host will be reflected in the docker images
-- Superset is served at localhost:9000/
+- Superset is served at localhost:8088/
 - You can login with admin/admin
 
 :::note
@@ -348,7 +348,7 @@ curl -f http://localhost:8088/health && echo "✅ Superset ready"
 ```bash
 # Frontend development
 cd superset-frontend
-npm run dev          # Development server on http://localhost:9000
+npm run dev          # Development server on http://localhost:8088
 npm run test         # Run all tests
 npm run test -- filename.test.tsx  # Run single test file
 npm run lint         # Linting and type checking
@@ -577,7 +577,7 @@ sudo sysctl -p
 
 #### Webpack dev server
 
-The dev server by default starts at `http://localhost:9000` and proxies the backend requests to `http://localhost:8088`.
+The dev server by default starts at `http://localhost:8088` and proxies the backend requests to `http://localhost:8088`.
 
 So a typical development workflow is the following:
 
@@ -588,18 +588,18 @@ So a typical development workflow is the following:
    superset run -p 8088 --with-threads --reload --debugger --debug
    ```
 
-2. in parallel, run the Webpack dev server locally on port `9000`,<br/>
+2. in parallel, run the Webpack dev server locally on port `8088`,<br/>
 
    ```bash
    npm run dev-server
    ```
 
-3. access `http://localhost:9000` (the Webpack server, _not_ Flask) in your web browser. This will use the hot-reloading front-end assets from the Webpack development server while redirecting back-end queries to Flask/Superset: your changes on Superset codebase — either front or back-end — will then be reflected live in the browser.
+3. access `http://localhost:8088` (the Webpack server, _not_ Flask) in your web browser. This will use the hot-reloading front-end assets from the Webpack development server while redirecting back-end queries to Flask/Superset: your changes on Superset codebase — either front or back-end — will then be reflected live in the browser.
 
 It's possible to change the Webpack server settings:
 
 ```bash
-# Start the dev server at http://localhost:9000
+# Start the dev server at http://localhost:8088
 npm run dev-server
 
 # Run the dev server on a non-default port


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Hi, first of all thank you for your awesome project!

It seems that the actual basic docker setup defaults to port 8088 first, and only tries 9000 afterward if not available, so I updated the setup docs accordingly. Please let me know if this is incorrect

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
