### PR TITLE
fix(dataset-editor): drop null warning_markdown from extra JSON serialisation

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
@@ -29,7 +29,7 @@ import fetchMock from 'fetch-mock';
 import { SupersetClient } from '@superset-ui/core';
 import mockDatasource from 'spec/fixtures/mockDatasource';
 import React from 'react';
-import DatasourceModalComponent from '.';
+import DatasourceModalComponent, { buildExtraJsonObject } from '.';
 
 // Cast to accept partial mock props in tests
 const DatasourceModal = DatasourceModalComponent as unknown as React.FC<
@@ -314,5 +314,37 @@ describe('DatasourceModal', () => {
         'override_columns=false',
       );
     });
+  });
+});
+
+describe('buildExtraJsonObject', () => {
+  test('returns "{}" for an item with no warning and no certification', () => {
+    expect(buildExtraJsonObject({} as any)).toBe('{}');
+  });
+
+  test('drops warning_markdown when its value is null', () => {
+    expect(buildExtraJsonObject({ warning_markdown: null } as any)).toBe('{}');
+  });
+
+  test('drops warning_markdown when its value is an empty string', () => {
+    expect(buildExtraJsonObject({ warning_markdown: '' } as any)).toBe('{}');
+  });
+
+  test('preserves a non-empty warning_markdown verbatim', () => {
+    expect(buildExtraJsonObject({ warning_markdown: '⚠ caveat' } as any)).toBe(
+      '{"warning_markdown":"⚠ caveat"}',
+    );
+  });
+
+  test('preserves certification and drops null warning_markdown', () => {
+    expect(
+      buildExtraJsonObject({
+        certified_by: 'data-team',
+        certification_details: 'verified',
+        warning_markdown: null,
+      } as any),
+    ).toBe(
+      '{"certification":{"certified_by":"data-team","details":"verified"}}',
+    );
   });
 });

--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -71,7 +71,7 @@ const StyledDatasourceModal = styled(Modal)`
   }
 `;
 
-function buildExtraJsonObject(
+export function buildExtraJsonObject(
   item: DatasetObject['metrics'][0] | DatasetObject['columns'][0],
 ) {
   const certification =
@@ -83,7 +83,7 @@ function buildExtraJsonObject(
       : undefined;
   return JSON.stringify({
     certification,
-    warning_markdown: item?.warning_markdown,
+    warning_markdown: item?.warning_markdown || undefined,
   });
 }
 


### PR DESCRIPTION
### SUMMARY

Every Dataset Editor save silently rewrote every column's and metric's `extra` JSON-string field from `\"{}\"` to `'{\"warning_markdown\":null}'`, even when no one touched any warning-related setting. The two forms are functionally equivalent for downstream consumers, so the bug has been latent in production for a long time. It became visible during the entity-versioning work, where the diff engine surfaced **N+1 spurious change records per save** — one per existing column whose `extra` got rewritten, plus the actual user-intended change.

#### Root cause

1. `TableColumn.data` (`superset/connectors/sqla/models.py:1075-1094`) serialises every column with `warning_markdown` exposed at the top level, derived from `CertificationMixin.warning_markdown`. That property parses `extra` JSON and returns Python `None` when the key is absent — which serialises to JSON `null`.
2. The API response delivers `column.warning_markdown: null` to the frontend.
3. `buildExtraJsonObject` (in `DatasourceModal/index.tsx`) re-serialises that null back into `extra` via `JSON.stringify({ ..., warning_markdown: item?.warning_markdown })`. `JSON.stringify` keeps explicit `null`; only `undefined` is dropped.
4. Save POSTs the rewritten `extra`; the backend stores it; the next load round-trips identically. The rewrite is permanent.

#### Fix

One expression change in `buildExtraJsonObject`: coerce empty/null `warning_markdown` to `undefined` before serialisation.

```diff
-    warning_markdown: item?.warning_markdown,
+    warning_markdown: item?.warning_markdown || undefined,
```

`JSON.stringify` then drops the key entirely when the value is empty/null. Matches the existing UI semantic where `warning_markdown && <WarningIconWithTooltip />` already treats empty/null as absent. The fix applies uniformly to columns and metrics — both flow through the same helper.

The helper is also now exported (was module-local) so the new unit tests can call it directly.

### BEFORE/AFTER

Pre-fix on the [entity-versioning branch](https://github.com/apache/superset/pull/39603), adding **one** calculated column to a dataset with 8 existing columns produces **9 records** in `version_changes`:

```
8 records: kind=column, path=[\"columns\",<name>], extra: \"{}\" → '{\"warning_markdown\":null}'
1 record:  kind=column, path=[\"columns\",\"num_new_york\"], from_value: null, to_value: <new column>
```

After this fix on the same branch, the same edit produces exactly **1 record** — only the actual added column.

### TESTING INSTRUCTIONS

1. Open the Dataset Editor on any dataset with several columns (e.g., \`birth_names\`).
2. Settings tab → edit Description → Save.
3. Query Postgres directly:

   ```sql
   SELECT column_name, extra FROM table_columns
   WHERE table_id = (SELECT id FROM tables WHERE table_name = 'birth_names');
   ```

   Expected: every column's \`extra\` is unchanged from before the save (still \`'{}'\` for columns that started that way). Pre-fix, every column's \`extra\` would have been rewritten to \`'{\"warning_markdown\":null}'\`.

4. **Regression check — warning roundtrip**: Metrics tab → expand a metric → set \"⚠ test\" in the **Warning** field → Save → reopen → confirm warning icon appears. Then expand the metric → clear the field → Save → reopen → confirm warning icon is gone.

5. Run the unit tests:

   ```
   cd superset-frontend && npm run test -- DatasourceModal
   # Test Suites: 3 passed, 3 total   Tests: 22 passed, 22 total (17 existing + 5 new)
   ```

### Existing data healing

Rows whose \`extra\` is currently \`'{\"warning_markdown\":null}'\` (pre-fix noise from previous saves) heal naturally on their next save — the helper serialises them to \`'{}'\`. No data migration needed.

### Out of scope

- Backend serialisation cleanup (\`TableColumn.data\` exposing \`warning_markdown: null\` instead of omitting absent keys). The frontend fix is necessary regardless and sufficient on its own; backend change has bigger API-contract implications.
- Lifting \`warning_markdown\` and \`certification\` fields out of \`extra\` JSON into proper columns. That's a schema-evolution project on its own.

### ADDITIONAL INFORMATION

- [x] Has associated issue: internal ticket sc-104972
- [ ] Required feature flags:
- [x] Changes UI (behaviourally — the saved \`extra\` JSON differs by one omitted key when no warning is set)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)