### PR TITLE
fix(result_set): preserve unicode characters in stringified nested va…

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -60,7 +60,7 @@ def dedup(l: list[str], suffix: str = "__", case_sensitive: bool = True) -> list
 
 
 def stringify(obj: Any) -> str:
-    return json.dumps(obj, default=json.json_iso_dttm_ser)
+    return json.dumps(obj, default=json.json_iso_dttm_ser, ensure_ascii=False)
 
 
 def stringify_values(array: NDArray[Any]) -> NDArray[Any]:

--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -194,6 +194,7 @@ def dumps(  # pylint: disable=too-many-arguments
     separators: Union[tuple[str, str], None] = None,
     cls: Union[type[simplejson.JSONEncoder], None] = None,
     encoding: Optional[str] = "utf-8",
+    ensure_ascii: bool = True,
 ) -> str:
     """
     Dumps object to compatible JSON format
@@ -219,6 +220,7 @@ def dumps(  # pylint: disable=too-many-arguments
         "separators": separators,
         "cls": cls,
         "encoding": encoding,
+        "ensure_ascii": ensure_ascii,
     }
     try:
         results_string = simplejson.dumps(obj, **dumps_kwargs)

--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -207,6 +207,8 @@ def dumps(  # pylint: disable=too-many-arguments
     :param indent: when set elements and object members will be pretty-printed
     :param separators: when specified dumps will use (item_separator, key_separator)
     :param cls: custom `JSONEncoder` subclass
+    :param encoding: character encoding used to interpret byte strings
+    :param ensure_ascii: when set to False non-ASCII characters are emitted as-is
     :returns: String object in the JSON compatible form
     """
 

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -21,12 +21,13 @@ from datetime import datetime, timezone
 
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.core.multiarray import array
 from pytest_mock import MockerFixture
 
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.result_set import stringify_values, SupersetResultSet
-from superset.superset_typing import DbapiResult
+from superset.superset_typing import DbapiDescription, DbapiResult
 
 
 def test_column_names_as_bytes() -> None:
@@ -144,6 +145,49 @@ def test_stringify_with_null_timestamps():
     )
 
     assert np.array_equal(result_set, expected)
+
+
+@pytest.mark.parametrize(
+    ("nested_value", "expected"),
+    [
+        pytest.param(
+            ["ASCII", "plain text"],
+            '["ASCII", "plain text"]',
+            id="ascii",
+        ),
+        pytest.param(
+            ["日本語", "ひらがな"],
+            '["日本語", "ひらがな"]',
+            id="japanese",
+        ),
+        pytest.param(
+            ["móre", "áccent"],
+            '["móre", "áccent"]',
+            id="accented-latin",
+        ),
+        pytest.param(
+            ["emoji", "😁"],
+            '["emoji", "😁"]',
+            id="emoji",
+        ),
+    ],
+)
+def test_stringify_nested_values_preserves_unicode(
+    nested_value: list[str], expected: str
+) -> None:
+    """
+    Nested values should be stringified without escaping Unicode characters.
+    """
+
+    data = [(nested_value,)]
+    description: DbapiDescription = [
+        ("tags", "ARRAY<STRING>", None, None, None, None, False)
+    ]
+
+    result_set = SupersetResultSet(data, description, BaseEngineSpec)
+    df = result_set.to_pandas_df()
+
+    assert df["tags"].iloc[0] == expected
 
 
 def test_timezone_series(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -28,6 +28,7 @@ from pytest_mock import MockerFixture
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.result_set import stringify_values, SupersetResultSet
 from superset.superset_typing import DbapiDescription, DbapiResult
+from superset.utils import json
 
 
 def test_column_names_as_bytes() -> None:
@@ -148,33 +149,27 @@ def test_stringify_with_null_timestamps():
 
 
 @pytest.mark.parametrize(
-    ("nested_value", "expected"),
+    "nested_value",
     [
         pytest.param(
             ["ASCII", "plain text"],
-            '["ASCII", "plain text"]',
             id="ascii",
         ),
         pytest.param(
             ["日本語", "ひらがな"],
-            '["日本語", "ひらがな"]',
             id="japanese",
         ),
         pytest.param(
             ["móre", "áccent"],
-            '["móre", "áccent"]',
             id="accented-latin",
         ),
         pytest.param(
             ["emoji", "😁"],
-            '["emoji", "😁"]',
             id="emoji",
         ),
     ],
 )
-def test_stringify_nested_values_preserves_unicode(
-    nested_value: list[str], expected: str
-) -> None:
+def test_stringify_nested_values_preserves_unicode(nested_value: list[str]) -> None:
     """
     Nested values should be stringified without escaping Unicode characters.
     """
@@ -186,8 +181,12 @@ def test_stringify_nested_values_preserves_unicode(
 
     result_set = SupersetResultSet(data, description, BaseEngineSpec)
     df = result_set.to_pandas_df()
+    serialized_value = df["tags"].iloc[0]
 
-    assert df["tags"].iloc[0] == expected
+    assert json.loads(serialized_value) == nested_value
+    assert "\\u" not in serialized_value
+    for value in nested_value:
+        assert value in serialized_value
 
 
 def test_timezone_series(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/utils/json_tests.py
+++ b/tests/unit_tests/utils/json_tests.py
@@ -90,6 +90,16 @@ def test_json_dumps():
     assert reloaded_data["bool"] is True
 
 
+def test_json_dumps_ensure_ascii_disabled() -> None:
+    data = {"text": "日本語 😁"}
+
+    json_str = json.dumps(data, ensure_ascii=False)
+
+    assert json.loads(json_str) == data
+    assert "\\u" not in json_str
+    assert data["text"] in json_str
+
+
 def test_json_dumps_encoding():
     data = {
         "utf8": b"Hello World",


### PR DESCRIPTION
### SUMMARY

When nested column values (e.g. `ARRAY<STRING>`) are serialised via
`stringify()`, the JSON encoder was called with `ensure_ascii=True`
(the default). This caused all non-ASCII characters — CJK, accented
Latin, emoji, etc. — to be escaped to `\uXXXX` sequences, making the
values unreadable in query results.

The fix threads an `ensure_ascii` parameter through `superset.utils.json.dumps`
(defaulting to `True` for backwards compatibility) and passes
`ensure_ascii=False` from `result_set.stringify()` so that Unicode
characters are preserved as-is.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change, no UI impact.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/result_set_test.py -v
```

New parametrized test `test_stringify_nested_values_preserves_unicode`
covers ASCII, Japanese (CJK), accented-Latin, and emoji values.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API