### PR TITLE
fix(mcp): default chart previews to ascii

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -66,7 +66,7 @@ Dataset Management:
 Chart Management:
 - list_charts: List charts with advanced filters (1-based pagination)
 - get_chart_info: Get detailed chart information by ID
-- get_chart_preview: Get a visual preview of a chart with image URL
+- get_chart_preview: Get a visual preview of a chart as formatted content or URL
 - get_chart_data: Get underlying chart data in text-friendly format
 - get_chart_sql: Get the rendered SQL query for a chart (without executing it)
 - generate_chart: Create and save a new chart permanently

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1747,10 +1747,10 @@ class GetChartPreviewRequest(QueryCacheControl):
         return self
 
     format: Literal["url", "ascii", "table", "vega_lite"] = Field(
-        default="url",
+        default="ascii",
         description=(
-            "Preview format: 'url' for explore link (default), "
-            "'ascii' for text art, "
+            "Preview format: 'ascii' for text art (default), "
+            "'url' for explore link, "
             "'table' for data table, "
             "'vega_lite' for interactive JSON specification"
         ),

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1757,11 +1757,11 @@ class GetChartPreviewRequest(QueryCacheControl):
     )
     width: int | None = Field(
         default=800,
-        description="Preview image width in pixels (for url/base64 formats)",
+        description="Preview width in pixels (for url and vega_lite formats)",
     )
     height: int | None = Field(
         default=600,
-        description="Preview image height in pixels (for url/base64 formats)",
+        description="Preview height in pixels (for url and vega_lite formats)",
     )
     ascii_width: int | None = Field(
         default=80, description="ASCII chart width in characters (for ascii format)"
@@ -1773,10 +1773,10 @@ class GetChartPreviewRequest(QueryCacheControl):
 
 # Discriminated union preview formats for type safety
 class URLPreview(BaseModel):
-    """URL-based image preview format."""
+    """URL-based preview format."""
 
     type: Literal["url"] = "url"
-    preview_url: str = Field(..., description="Direct image URL")
+    preview_url: str = Field(..., description="Explore URL for opening the chart")
     width: int = Field(..., description="Image width in pixels")
     height: int = Field(..., description="Image height in pixels")
     supports_interaction: bool = Field(

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -218,7 +218,6 @@ MCP_RESPONSE_SIZE_CONFIG: Dict[str, Any] = {
     "warn_threshold_pct": DEFAULT_WARN_THRESHOLD_PCT,
     "excluded_tools": [  # Tools to skip size checking
         "health_check",  # Always small
-        "get_chart_preview",  # Returns URLs, not data
         "generate_explore_link",  # Returns URLs
         "open_sql_lab_with_context",  # Returns URLs
         "search_tools",  # Returns tool schemas for discovery (intentionally large)

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
@@ -170,7 +170,7 @@ class TestGetChartPreview:
 
         # Default format
         request4 = GetChartPreviewRequest(identifier=789)
-        assert request4.format == "url"  # default
+        assert request4.format == "ascii"  # default
 
     @pytest.mark.asyncio
     async def test_preview_format_types(self):

--- a/tests/unit_tests/mcp_service/test_middleware.py
+++ b/tests/unit_tests/mcp_service/test_middleware.py
@@ -315,7 +315,18 @@ class TestCreateResponseSizeGuardMiddleware:
 
     def test_default_config_checks_chart_preview(self) -> None:
         """Should size-check chart preview responses by default."""
-        assert "get_chart_preview" not in MCP_RESPONSE_SIZE_CONFIG["excluded_tools"]
+        mock_flask_app = MagicMock()
+        mock_flask_app.config.get.return_value = MCP_RESPONSE_SIZE_CONFIG
+
+        with patch(
+            "superset.mcp_service.flask_singleton.get_flask_app",
+            return_value=mock_flask_app,
+        ):
+            middleware = create_response_size_guard_middleware()
+
+        assert middleware is not None
+        assert "get_chart_preview" not in middleware.excluded_tools
+        assert "health_check" in middleware.excluded_tools
 
     def test_creates_middleware_when_enabled(self) -> None:
         """Should create middleware when enabled in config."""

--- a/tests/unit_tests/mcp_service/test_middleware.py
+++ b/tests/unit_tests/mcp_service/test_middleware.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
+from superset.mcp_service.mcp_config import MCP_RESPONSE_SIZE_CONFIG
 from superset.mcp_service.middleware import (
     create_response_size_guard_middleware,
     ResponseSizeGuardMiddleware,
@@ -311,6 +312,10 @@ class TestResponseSizeGuardMiddleware:
 
 class TestCreateResponseSizeGuardMiddleware:
     """Test create_response_size_guard_middleware factory function."""
+
+    def test_default_config_checks_chart_preview(self) -> None:
+        """Should size-check chart preview responses by default."""
+        assert "get_chart_preview" not in MCP_RESPONSE_SIZE_CONFIG["excluded_tools"]
 
     def test_creates_middleware_when_enabled(self) -> None:
         """Should create middleware when enabled in config."""


### PR DESCRIPTION
### SUMMARY

`get_chart_preview` was defaulting to `format=url`, but URL-based screenshot previews are not supported by the tool. As a result, a normal/default call could fail with `UnsupportedFormat` before returning any useful preview.

This PR changes the default preview format to `ascii`, which is already supported, so callers get a text-based visual preview by default instead of an error.

When a user asks the chatbot to show a visual preview of a chart, the LLM may call `get_chart_preview` without explicitly setting a format. Before this change, that default path used `url` and failed with:

```text
URL-based screenshot previews are not supported.
Use the explore_url to view the chart interactively, or try formats: 'ascii', 'table', or 'vega_lite'.
```

The chatbot could recover, but the first tool call still produced an error and the user did not get the preview they asked for.

`get_chart_preview` supports multiple preview formats through format-specific strategies:

- `url` returns an Explore link.
- `ascii` queries the chart data and renders a lightweight text preview.
- `table` queries the chart data and renders a text table.
- `vega_lite` builds a Vega-Lite specification.

The default format matters because callers often omit optional parameters. With the previous default, a normal call selected the URL path, which does not provide screenshot rendering and could fail with `UnsupportedFormat`.

With this change, the default path selects the existing ASCII strategy instead. That strategy uses the saved chart configuration, runs the chart data query, and returns preview content directly in the tool response. The response still includes the Explore URL for opening the full chart interactively.

Changes included:

- Changed `GetChartPreviewRequest.format` default from `url` to `ascii`.
- Updated the schema description so the default behavior is clear to LLM/tool callers.
- Updated the MCP app instructions so `get_chart_preview` is not described as image-URL-only.
- Removed `get_chart_preview` from the response-size guard exclusion list.
  - This matters because `ascii` and `table` previews can contain chart data, so they should be protected by the normal response-size limits.
- Updated tests for the new default.
- Added coverage to ensure chart preview responses are size-checked by default.

This does not implement URL screenshot generation. The `url` format still returns an explore link where supported, but it is no longer the default path.

This also does not guarantee every chart type can produce an ASCII preview. Unsupported chart configurations can still return chart-specific errors. The fix is specifically for the unsupported default `url` format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable. This is an MCP tool behavior change with text-based output.

### TESTING INSTRUCTIONS

Run focused MCP tests:

```bash
PYENV_VERSION=superset pytest \
  tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py \
  tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py::TestGenerateChart::test_preview_formats \
  tests/unit_tests/mcp_service/chart/tool/test_update_chart.py::TestUpdateChart::test_update_chart_preview_formats \
  tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py \
  tests/unit_tests/mcp_service/test_middleware.py::TestCreateResponseSizeGuardMiddleware::test_default_config_checks_chart_preview \
  -q
```

Expected result:

```text
36 passed
```

Manual verification performed through the local chatbot flow:

- Prompt: `Show me a visual preview of chart 11`
- Tool called: `get_chart_preview`
- MCP log showed: `format=ascii`
- Result: chatbot returned a formatted chart preview without `UnsupportedFormat`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
