### PR TITLE
fix(ci): switch Dependabot Python ecosystem from uv to pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,15 +59,13 @@ updates:
     versioning-strategy: increase
 
 
-  # NOTE: `uv` support is in beta, more details here:
-  # https://github.com/dependabot/dependabot-core/pull/10040#issuecomment-2696978430
-  - package-ecosystem: "uv"
-    directory: "requirements/"
+  - package-ecosystem: "pip"
+    directory: "/"
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
     labels:
-      - uv
+      - pip
       - dependabot
 
   - package-ecosystem: "npm"


### PR DESCRIPTION
### SUMMARY
The `uv` package ecosystem support in Dependabot is [still in beta](https://github.com/dependabot/dependabot-core/pull/10040#issuecomment-2696978430) and has been unreliable — Dependabot alerts for Python dependencies hang indefinitely when attempting to open PRs (e.g. https://github.com/apache/superset/security/dependabot/1150).

This switches the Python dependency section from `uv` to `pip`, which natively understands `requirements/*.txt` files. The `uv` ecosystem primarily targets projects with a `uv.lock` file, which this project doesn't use (we use `uv pip compile` to generate `.txt` files).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
- After merge, verify that Dependabot can successfully create PRs for Python dependency updates
- Check the Dependabot security tab for any previously stuck Python alerts

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API