### PR TITLE
fix(mysql): fallback to pymysql when MySQLdb is not installed in get_datatype()

### DIFF
--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -402,7 +402,10 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
         if not cls.type_code_map:
             # only import and store if needed at least once
             # pylint: disable=import-outside-toplevel
-            import MySQLdb
+            try:
+                import MySQLdb
+            except ImportError:
+                import pymysql as MySQLdb
 
             ft = MySQLdb.constants.FIELD_TYPE
             cls.type_code_map = {

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -405,7 +405,7 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
             try:
                 import MySQLdb
             except ImportError:
-                import pymysql as MySQLdb
+                import pymysql as MySQLdb  # noqa: N812
 
             ft = MySQLdb.constants.FIELD_TYPE
             cls.type_code_map = {

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -405,7 +405,7 @@ class MySQLEngineSpec(BasicParametersMixin, BaseEngineSpec):
             try:
                 import MySQLdb
             except ImportError:
-                import pymysql as MySQLdb  # noqa: N812
+                import pymysql as MySQLdb  # type: ignore[import-untyped] # noqa: N812
 
             ft = MySQLdb.constants.FIELD_TYPE
             cls.type_code_map = {

--- a/tests/unit_tests/db_engine_specs/test_mysql.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql.py
@@ -18,6 +18,8 @@
 from datetime import datetime
 from decimal import Decimal
 from typing import Any, Optional
+import builtins
+from types import ModuleType
 from unittest.mock import Mock, patch
 
 import pytest
@@ -262,3 +264,42 @@ def test_column_type_mutator(
     mock_cursor.description = description
 
     assert spec.fetch_data(mock_cursor) == expected_result
+
+
+def test_get_datatype_pymysql_fallback():
+    """get_datatype() falls back to pymysql when MySQLdb is not installed."""
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    # Reset cached type_code_map so the import path is exercised
+    original_type_code_map = MySQLEngineSpec.type_code_map
+    MySQLEngineSpec.type_code_map = {}
+
+    try:
+        # Build a fake pymysql module with constants.FIELD_TYPE
+        fake_field_type = ModuleType("pymysql.constants.FIELD_TYPE")
+        fake_field_type.TINY = 1  # type: ignore
+        fake_field_type.VARCHAR = 15  # type: ignore
+
+        fake_constants = ModuleType("pymysql.constants")
+        fake_constants.FIELD_TYPE = fake_field_type  # type: ignore
+
+        fake_pymysql = ModuleType("pymysql")
+        fake_pymysql.constants = fake_constants  # type: ignore
+
+        original_import = builtins.__import__
+
+        def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "MySQLdb":
+                raise ImportError("No module named 'MySQLdb'")
+            if name == "pymysql":
+                return fake_pymysql
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            assert MySQLEngineSpec.get_datatype(1) == "TINY"
+            assert MySQLEngineSpec.get_datatype(15) == "VARCHAR"
+            assert MySQLEngineSpec.get_datatype("BIGINT") == "BIGINT"
+            assert MySQLEngineSpec.get_datatype(999) is None
+    finally:
+        # Restore original state
+        MySQLEngineSpec.type_code_map = original_type_code_map

--- a/tests/unit_tests/db_engine_specs/test_mysql.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import builtins
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Optional
-import builtins
 from types import ModuleType
+from typing import Any, Optional
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/unit_tests/db_engine_specs/test_mysql.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql.py
@@ -277,14 +277,14 @@ def test_get_datatype_pymysql_fallback():
     try:
         # Build a fake pymysql module with constants.FIELD_TYPE
         fake_field_type = ModuleType("pymysql.constants.FIELD_TYPE")
-        fake_field_type.TINY = 1  # type: ignore
-        fake_field_type.VARCHAR = 15  # type: ignore
+        fake_field_type.TINY = 1
+        fake_field_type.VARCHAR = 15
 
         fake_constants = ModuleType("pymysql.constants")
-        fake_constants.FIELD_TYPE = fake_field_type  # type: ignore
+        fake_constants.FIELD_TYPE = fake_field_type
 
         fake_pymysql = ModuleType("pymysql")
-        fake_pymysql.constants = fake_constants  # type: ignore
+        fake_pymysql.constants = fake_constants
 
         original_import = builtins.__import__
 


### PR DESCRIPTION
### SUMMARY
`MySQLEngineSpec.get_datatype()` hardcodes `import MySQLdb` to resolve column type codes from SQL Lab query results. This fails with `No module named 'MySQLdb'` in environments that use the `pymysql` driver (e.g., Alpine-based images without the `mysqlclient` C library).

This PR adds a `try/except ImportError` fallback to import `pymysql` when `MySQLdb` is unavailable. Both libraries expose compatible `constants.FIELD_TYPE` mappings. A unit test verifies the fallback path using mocked imports (no `pymysql` dependency required).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - backend-only fix, no UI changes.

### TESTING INSTRUCTIONS
1. In an environment with only `pymysql` installed (no `mysqlclient`):
   - Configure a MySQL connection using `mysql+pymysql://` URI
   - Run any SQL query in SQL Lab
   - Verify results are returned without `No module named 'MySQLdb'` error
2. Run the new unit test: `pytest tests/unit_tests/db_engine_specs/test_mysql.py::test_get_datatype_pymysql_fallback -xvs`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)