### PR TITLE
fix(mcp): clarify chart preview URL metadata

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -244,7 +244,7 @@ General usage tips:
 - Use 'filters' parameter for advanced queries with filter columns from get_schema
 - IDs can be integer or UUID format where supported
 - All tools return structured, Pydantic-typed responses
-- Chart previews are served as PNG images via custom screenshot endpoints
+- Chart previews can return ASCII text, Explore URLs, table data, or Vega-Lite specs
 
 Input format:
 - Tool request parameters accept structured objects (dicts/JSON)

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1777,10 +1777,10 @@ class URLPreview(BaseModel):
 
     type: Literal["url"] = "url"
     preview_url: str = Field(..., description="Explore URL for opening the chart")
-    width: int = Field(..., description="Image width in pixels")
-    height: int = Field(..., description="Image height in pixels")
+    width: int = Field(..., description="Requested Explore viewport width in pixels")
+    height: int = Field(..., description="Requested Explore viewport height in pixels")
     supports_interaction: bool = Field(
-        False, description="Static image, no interaction"
+        True, description="Explore URL supports chart interaction"
     )
 
 

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -975,18 +975,16 @@ async def _get_chart_preview_internal(  # noqa: C901
     ctx: Context,
 ) -> ChartPreview | ChartError:
     """
-    Get a visual preview of a chart with URLs for LLM embedding.
+    Get a preview of a chart in the requested format.
 
-    This tool generates or retrieves URLs for chart images that can be
-    displayed directly in LLM clients. The URLs point to Superset's
-    screenshot endpoints for proper image serving.
+    This tool can return text previews for direct LLM responses, Explore URLs
+    for interactive inspection, tabular data, or Vega-Lite specifications.
 
     Supports lookup by:
     - Numeric ID (e.g., 123)
     - UUID string (e.g., "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 
-    Returns a ChartPreview with Superset URLs for the chart image or
-    ChartError on error.
+    Returns a ChartPreview in the requested format or ChartError on error.
     """
     try:
         await ctx.report_progress(1, 3, "Looking up chart")

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
@@ -184,16 +184,15 @@ class TestGetChartPreview:
     async def test_url_preview_structure(self):
         """Test URLPreview response structure."""
         preview = URLPreview(
-            preview_url="http://localhost:5008/screenshot/chart/123.png",
+            preview_url="http://localhost:8088/explore/?slice_id=123",
             width=800,
             height=600,
-            supports_interaction=False,
         )
         assert preview.type == "url"
-        assert preview.preview_url == "http://localhost:5008/screenshot/chart/123.png"
+        assert preview.preview_url == "http://localhost:8088/explore/?slice_id=123"
         assert preview.width == 800
         assert preview.height == 600
-        assert preview.supports_interaction is False
+        assert preview.supports_interaction is True
 
     @pytest.mark.asyncio
     async def test_ascii_preview_structure(self):
@@ -283,10 +282,9 @@ class TestGetChartPreview:
         for width, height in standard_sizes:
             # URL preview with dimensions
             url_preview = URLPreview(
-                preview_url="http://example.com/chart.png",
+                preview_url="http://example.com/explore/?slice_id=123",
                 width=width,
                 height=height,
-                supports_interaction=False,
             )
             assert url_preview.width == width
             assert url_preview.height == height

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
@@ -184,12 +184,12 @@ class TestGetChartPreview:
     async def test_url_preview_structure(self):
         """Test URLPreview response structure."""
         preview = URLPreview(
-            preview_url="http://localhost:8088/explore/?slice_id=123",
+            preview_url="http://example.com/explore/?slice_id=123",
             width=800,
             height=600,
         )
         assert preview.type == "url"
-        assert preview.preview_url == "http://localhost:8088/explore/?slice_id=123"
+        assert preview.preview_url == "http://example.com/explore/?slice_id=123"
         assert preview.width == 800
         assert preview.height == 600
         assert preview.supports_interaction is True


### PR DESCRIPTION
### SUMMARY
Clarifies MCP chart preview metadata and guidance now that URL previews return interactive Explore links rather than static screenshot image URLs.

This follow-up to #39719 updates:
- `URLPreview` width/height descriptions to refer to requested Explore viewport dimensions
- `URLPreview.supports_interaction` to default to `true`
- chart preview tool guidance/docstrings so clients see the supported ASCII, URL, table, and Vega-Lite formats

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable; MCP schema/documentation metadata only.

### TESTING INSTRUCTIONS
```bash
PYENV_VERSION=superset pre-commit run --files superset/mcp_service/app.py superset/mcp_service/chart/schemas.py superset/mcp_service/chart/tool/get_chart_preview.py tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
PYENV_VERSION=superset pytest tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py -q
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
