### PR TITLE
fix(mcp): restore typed ChartConfig in tool schemas for LLM visibility

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -36,7 +36,6 @@ from pydantic import (
     model_serializer,
     model_validator,
     PositiveInt,
-    TypeAdapter,
     ValidationError,
 )
 from typing_extensions import Self
@@ -1258,65 +1257,9 @@ ChartConfig = Annotated[
     ),
 ]
 
-# Module-level TypeAdapter avoids repeated schema compilation in
-# parse_chart_config() — safe because ChartConfig is fully defined above.
-_CHART_CONFIG_ADAPTER: TypeAdapter[ChartConfig] = TypeAdapter(ChartConfig)
 
 # Compact description for JSON Schema — keeps tool inputSchema small while
 # giving LLMs enough context to construct valid configs.
-_CHART_CONFIG_DESCRIPTION = (
-    "Chart configuration object. MUST include 'chart_type' to select the "
-    "schema. Types: 'xy' (x, y, kind: line/bar/area/scatter), "
-    "'table' (columns), 'pie' (dimension, metric), "
-    "'pivot_table' (rows, metrics), 'mixed_timeseries' (x, y, y_secondary), "
-    "'handlebars' (columns, handlebars_template), "
-    "'big_number' (metric). "
-    "See chart://configs resource for full field reference and examples."
-)
-
-
-def parse_chart_config(
-    config: Dict[str, Any],
-) -> (
-    XYChartConfig
-    | TableChartConfig
-    | PieChartConfig
-    | PivotTableChartConfig
-    | MixedTimeseriesChartConfig
-    | HandlebarsChartConfig
-    | BigNumberChartConfig
-):
-    """Parse a raw dict into the appropriate typed ChartConfig subclass.
-
-    Validates the dict against the discriminated union using chart_type.
-    Call this in tool function bodies to get a typed config object.
-    """
-    try:
-        return _CHART_CONFIG_ADAPTER.validate_python(config)
-    except Exception as e:
-        raise ValueError(
-            f"{e}\n\n"
-            f"Hint: read the chart://configs resource for valid configuration "
-            f"examples and field reference."
-        ) from e
-
-
-def _coerce_config_to_dict(v: Any) -> Dict[str, Any]:
-    """Accept ChartConfig objects, dicts, or JSON strings for the config field."""
-    if isinstance(v, str):
-        from superset.utils import json as json_utils
-
-        try:
-            v = json_utils.loads(v)
-        except (ValueError, TypeError) as exc:
-            raise ValueError(
-                f"config must be a JSON object string, got: {v!r}"
-            ) from exc
-    if hasattr(v, "model_dump"):
-        return v.model_dump()
-    if isinstance(v, dict):
-        return v
-    raise TypeError(f"config must be a dict or JSON string, got {type(v).__name__}")
 
 
 class ListChartsRequest(MetadataCacheControl):
@@ -1415,7 +1358,7 @@ class GenerateChartRequest(QueryCacheControl):
     model_config = ConfigDict(populate_by_name=True)
 
     dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
-    config: Dict[str, Any] = Field(..., description=_CHART_CONFIG_DESCRIPTION)
+    config: ChartConfig = Field(..., description="Chart configuration")
     chart_name: str | None = Field(
         None,
         description="Auto-generates if omitted",
@@ -1436,11 +1379,6 @@ class GenerateChartRequest(QueryCacheControl):
             "notice to the caller instead of silently dropping content."
         ),
     )
-
-    @field_validator("config", mode="before")
-    @classmethod
-    def coerce_config(cls, v: Any) -> Dict[str, Any]:
-        return _coerce_config_to_dict(v)
 
     @model_validator(mode="before")
     @classmethod
@@ -1518,23 +1456,16 @@ class GenerateChartRequest(QueryCacheControl):
 
 class GenerateExploreLinkRequest(FormDataCacheControl):
     dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
-    config: Dict[str, Any] = Field(..., description=_CHART_CONFIG_DESCRIPTION)
-
-    @field_validator("config", mode="before")
-    @classmethod
-    def coerce_config(cls, v: Any) -> Dict[str, Any]:
-        return _coerce_config_to_dict(v)
+    config: ChartConfig = Field(..., description="Chart configuration")
 
 
 class UpdateChartRequest(QueryCacheControl):
     model_config = ConfigDict(populate_by_name=True)
 
     identifier: int | str = Field(..., description="Chart ID or UUID")
-    config: Dict[str, Any] | None = Field(
+    config: ChartConfig | None = Field(
         None,
-        description=(
-            f"{_CHART_CONFIG_DESCRIPTION} Optional; omit to only update chart_name."
-        ),
+        description="Chart configuration. Optional; omit to only update chart_name.",
     )
     chart_name: str | None = Field(
         None,
@@ -1559,13 +1490,6 @@ class UpdateChartRequest(QueryCacheControl):
         ),
     )
 
-    @field_validator("config", mode="before")
-    @classmethod
-    def coerce_config(cls, v: Any) -> Dict[str, Any] | None:
-        if v is None:
-            return None
-        return _coerce_config_to_dict(v)
-
     @field_validator("chart_name")
     @classmethod
     def sanitize_chart_name(cls, v: str | None) -> str | None:
@@ -1576,16 +1500,11 @@ class UpdateChartRequest(QueryCacheControl):
 class UpdateChartPreviewRequest(FormDataCacheControl):
     form_data_key: str = Field(..., description="Existing form_data_key to update")
     dataset_id: int | str = Field(..., description="Dataset ID or UUID")
-    config: Dict[str, Any] = Field(..., description=_CHART_CONFIG_DESCRIPTION)
+    config: ChartConfig = Field(..., description="Chart configuration")
     generate_preview: bool = True
     preview_formats: List[Literal["url", "ascii", "vega_lite", "table"]] = Field(
         default_factory=lambda: ["url"],
     )
-
-    @field_validator("config", mode="before")
-    @classmethod
-    def coerce_config(cls, v: Any) -> Dict[str, Any]:
-        return _coerce_config_to_dict(v)
 
 
 class GetChartDataRequest(QueryCacheControl):

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -220,10 +220,10 @@ async def generate_chart(  # noqa: C901
         )
     )
     await ctx.debug(
-        "Chart configuration details: chart_type=%s, keys=%s"
+        "Chart configuration details: chart_type=%s, fields=%s"
         % (
             request.config.chart_type,
-            sorted(request.config.keys()),
+            sorted(request.config.model_fields_set),
         )
     )
 

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -214,7 +214,7 @@ async def generate_chart(  # noqa: C901
         "save_chart=%s, preview_formats=%s"
         % (
             request.dataset_id,
-            request.config.get("chart_type", "unknown"),
+            request.config.chart_type,
             request.save_chart,
             request.preview_formats,
         )
@@ -222,7 +222,7 @@ async def generate_chart(  # noqa: C901
     await ctx.debug(
         "Chart configuration details: chart_type=%s, keys=%s"
         % (
-            request.config.get("chart_type", "unknown"),
+            request.config.chart_type,
             sorted(request.config.keys()),
         )
     )
@@ -884,7 +884,7 @@ async def generate_chart(  # noqa: C901
         chart_type = "unknown"
         try:
             if hasattr(request, "config") and isinstance(request.config, dict):
-                chart_type = request.config.get("chart_type", "unknown")
+                chart_type = request.config.chart_type
         except (AttributeError, TypeError) as extract_error:
             # Ignore errors when extracting chart type for error context
             logger.debug("Could not extract chart type: %s", extract_error)

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -44,7 +44,6 @@ from superset.mcp_service.chart.schemas import (
     ChartError,
     GenerateChartRequest,
     GenerateChartResponse,
-    parse_chart_config,
     PerformanceMetadata,
 )
 from superset.mcp_service.utils.oauth2_utils import (
@@ -284,35 +283,8 @@ async def generate_chart(  # noqa: C901
                 }
             )
 
-        # Parse the raw config dict into a typed ChartConfig for downstream use
-        try:
-            config = parse_chart_config(request.config)
-        except (ValueError, TypeError) as e:
-            from superset.mcp_service.utils.error_sanitization import (
-                _sanitize_validation_error,
-            )
-
-            sanitized = _sanitize_validation_error(e)
-            execution_time = int((time.time() - start_time) * 1000)
-            return GenerateChartResponse.model_validate(
-                {
-                    "chart": None,
-                    "error": {
-                        "error_type": "validation_error",
-                        "message": f"Invalid chart configuration: {sanitized}",
-                        "details": sanitized,
-                        "error_code": "INVALID_CHART_CONFIG",
-                    },
-                    "performance": {
-                        "query_duration_ms": execution_time,
-                        "cache_status": "error",
-                        "optimization_suggestions": [],
-                    },
-                    "success": False,
-                    "schema_version": "2.0",
-                    "api_version": "v1",
-                }
-            )
+        # config is already a typed ChartConfig (validated by Pydantic)
+        config = request.config
 
         # Map the simplified config to Superset's form_data format
         # Pass dataset_id to enable column type checking for proper viz_type selection

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -43,7 +43,6 @@ from superset.mcp_service.chart.chart_utils import (
 from superset.mcp_service.chart.schemas import (
     AccessibilityMetadata,
     GenerateChartResponse,
-    parse_chart_config,
     PerformanceMetadata,
     UpdateChartRequest,
 )
@@ -321,36 +320,8 @@ async def update_chart(  # noqa: C901
         saved = False
         new_form_data: dict[str, Any] | None = None
 
-        # Parse config once upfront so helpers and analysis can reuse it.
-        parsed_config = None
-        if request.config is not None:
-            try:
-                parsed_config = parse_chart_config(request.config)
-            except (ValueError, TypeError) as e:
-                from superset.mcp_service.utils.error_sanitization import (
-                    _sanitize_validation_error,
-                )
-
-                sanitized = _sanitize_validation_error(e)
-                return GenerateChartResponse.model_validate(
-                    {
-                        "chart": None,
-                        "error": {
-                            "error_type": "validation_error",
-                            "message": f"Invalid chart configuration: {sanitized}",
-                            "details": sanitized,
-                            "error_code": "INVALID_CHART_CONFIG",
-                        },
-                        "performance": {
-                            "query_duration_ms": int((time.time() - start_time) * 1000),
-                            "cache_status": "error",
-                            "optimization_suggestions": [],
-                        },
-                        "success": False,
-                        "schema_version": "2.0",
-                        "api_version": "v1",
-                    }
-                )
+        # config is already a typed ChartConfig | None (validated by Pydantic)
+        parsed_config = request.config
 
         if not request.generate_preview:
             from superset.commands.chart.update import UpdateChartCommand

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -40,7 +40,6 @@ from superset.mcp_service.chart.chart_utils import (
 )
 from superset.mcp_service.chart.schemas import (
     AccessibilityMetadata,
-    parse_chart_config,
     PerformanceMetadata,
     UpdateChartPreviewRequest,
 )
@@ -104,32 +103,8 @@ def update_chart_preview(
     start_time = time.time()
 
     try:
-        # Parse the raw config dict into a typed ChartConfig
-        try:
-            config = parse_chart_config(request.config)
-        except (ValueError, TypeError) as e:
-            from superset.mcp_service.utils.error_sanitization import (
-                _sanitize_validation_error,
-            )
-
-            sanitized = _sanitize_validation_error(e)
-            return {
-                "chart": None,
-                "error": {
-                    "error_type": "validation_error",
-                    "message": f"Invalid chart configuration: {sanitized}",
-                    "details": sanitized,
-                    "error_code": "INVALID_CHART_CONFIG",
-                },
-                "performance": {
-                    "query_duration_ms": int((time.time() - start_time) * 1000),
-                    "cache_status": "error",
-                    "optimization_suggestions": [],
-                },
-                "success": False,
-                "schema_version": "2.0",
-                "api_version": "v1",
-            }
+        # config is already a typed ChartConfig (validated by Pydantic)
+        config = request.config
 
         with event_logger.log_context(action="mcp.update_chart_preview.form_data"):
             # Map the new config to form_data format

--- a/superset/mcp_service/chart/validation/pipeline.py
+++ b/superset/mcp_service/chart/validation/pipeline.py
@@ -26,7 +26,6 @@ from typing import Any, Dict, List, Tuple
 from superset.mcp_service.chart.schemas import (
     ChartConfig,
     GenerateChartRequest,
-    parse_chart_config,
 )
 from superset.mcp_service.common.error_schemas import (
     ChartGenerationError,
@@ -112,23 +111,8 @@ class ValidationPipeline:
             if request is None:
                 return ValidationResult(is_valid=False, error=error)
 
-            # Parse the raw config dict into a typed ChartConfig for
-            # downstream validators that need typed access.
-            try:
-                typed_config = parse_chart_config(request.config)
-            except (ValueError, TypeError) as e:
-                from superset.mcp_service.utils.error_builder import (
-                    ChartErrorBuilder,
-                )
-
-                sanitized_reason = _sanitize_validation_error(e)
-                error = ChartErrorBuilder.build_error(
-                    error_type="validation_error",
-                    template_key="validation_error",
-                    template_vars={"reason": sanitized_reason},
-                    error_code="INVALID_CHART_CONFIG",
-                )
-                return ValidationResult(is_valid=False, request=request, error=error)
+            # config is already a typed ChartConfig (validated by Pydantic)
+            typed_config = request.config
 
             # Fetch dataset context once and reuse across validation layers
             dataset_context = ValidationPipeline._get_dataset_context(
@@ -266,7 +250,7 @@ class ValidationPipeline:
         try:
             from .dataset_validator import DatasetValidator
 
-            config = typed_config or parse_chart_config(request.config)
+            config = typed_config or request.config
             normalized_config = DatasetValidator.normalize_column_names(
                 config,
                 request.dataset_id,

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -35,7 +35,6 @@ from superset.mcp_service.chart.chart_utils import (
 )
 from superset.mcp_service.chart.schemas import (
     GenerateExploreLinkRequest,
-    parse_chart_config,
 )
 
 
@@ -98,22 +97,8 @@ async def generate_explore_link(
     )
 
     try:
-        # Parse the raw config dict into a typed ChartConfig
-        try:
-            config = parse_chart_config(request.config)
-        except (ValueError, TypeError) as e:
-            from superset.mcp_service.utils.error_sanitization import (
-                _sanitize_validation_error,
-            )
-
-            sanitized = _sanitize_validation_error(e)
-            await ctx.error(f"Invalid chart configuration: {sanitized}")
-            return {
-                "url": "",
-                "form_data": {},
-                "form_data_key": None,
-                "error": f"Invalid chart configuration: {sanitized}",
-            }
+        # config is already a typed ChartConfig (validated by Pydantic)
+        config = request.config
 
         await ctx.report_progress(1, 4, "Validating dataset exists")
         with event_logger.log_context(action="mcp.generate_explore_link.dataset_check"):

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -89,7 +89,7 @@ async def generate_explore_link(
     """
     await ctx.info(
         "Generating explore link for dataset_id=%s, chart_type=%s"
-        % (request.dataset_id, request.config.get("chart_type", "unknown"))
+        % (request.dataset_id, request.config.chart_type)
     )
     await ctx.debug(
         "Configuration details: use_cache=%s, force_refresh=%s, cache_form_data=%s"
@@ -196,7 +196,7 @@ async def generate_explore_link(
             "Explore link generation failed for dataset_id=%s, chart_type=%s: %s: %s"
             % (
                 request.dataset_id,
-                request.config.get("chart_type", "unknown"),
+                request.config.chart_type,
                 type(e).__name__,
                 str(e),
             )

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -279,7 +279,7 @@ MCP_TOOL_SEARCH_CONFIG: Dict[str, Any] = {
     "call_tool_name": "call_tool",  # Name of the call proxy tool
     "compact_schemas": True,  # Strip $defs/$ref (requires include_schemas=True)
     "max_description_length": 300,  # Truncate tool descriptions (0 = no truncation)
-    "include_schemas": False,  # False=summary mode (name+hint), True=full inputSchema
+    "include_schemas": True,  # full inputSchema in search results
 }
 
 

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -25,7 +25,6 @@ from pydantic import ValidationError
 from superset.mcp_service.chart.schemas import (
     ColumnRef,
     GenerateChartRequest,
-    parse_chart_config,
     TableChartConfig,
     XYChartConfig,
 )
@@ -671,48 +670,49 @@ class TestColumnRefSavedMetric:
             )
 
 
-class TestParseChartConfig:
-    """Tests for parse_chart_config and config coercion."""
+class TestChartConfigValidation:
+    """Tests for ChartConfig discriminated union validation via Pydantic."""
 
-    def test_parse_valid_xy_config(self) -> None:
-        config = parse_chart_config(
-            {"chart_type": "xy", "x": {"name": "date"}, "y": [{"name": "v"}]}
+    def test_valid_xy_config_via_request(self) -> None:
+        req = GenerateChartRequest(
+            dataset_id=1,
+            config={"chart_type": "xy", "x": {"name": "date"}, "y": [{"name": "v"}]},
         )
-        assert config.chart_type == "xy"
-        assert config.x is not None
-        assert config.x.name == "date"
-        assert len(config.y) == 1
-        assert config.y[0].name == "v"
+        assert req.config.chart_type == "xy"
+        assert req.config.x is not None
+        assert req.config.x.name == "date"
+        assert len(req.config.y) == 1
+        assert req.config.y[0].name == "v"
 
-    def test_parse_valid_table_config(self) -> None:
-        config = parse_chart_config(
-            {"chart_type": "table", "columns": [{"name": "col1"}]}
+    def test_valid_table_config_via_request(self) -> None:
+        req = GenerateChartRequest(
+            dataset_id=1,
+            config={"chart_type": "table", "columns": [{"name": "col1"}]},
         )
-        assert config.chart_type == "table"
-        assert len(config.columns) == 1
-        assert config.columns[0].name == "col1"
+        assert req.config.chart_type == "table"
+        assert len(req.config.columns) == 1
+        assert req.config.columns[0].name == "col1"
 
-    def test_parse_missing_chart_type_raises(self) -> None:
-        with pytest.raises(ValueError, match="chart://configs"):
-            parse_chart_config({"x": {"name": "date"}, "y": [{"name": "v"}]})
+    def test_missing_chart_type_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            GenerateChartRequest(
+                dataset_id=1,
+                config={"x": {"name": "date"}, "y": [{"name": "v"}]},
+            )
 
-    def test_parse_unknown_chart_type_raises(self) -> None:
-        with pytest.raises(ValueError, match="chart://configs"):
-            parse_chart_config({"chart_type": "nonexistent", "x": {"name": "d"}})
+    def test_unknown_chart_type_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            GenerateChartRequest(
+                dataset_id=1,
+                config={"chart_type": "nonexistent", "x": {"name": "d"}},
+            )
 
-    def test_coerce_json_string_config(self) -> None:
-        raw = '{"chart_type": "table", "columns": [{"name": "c"}]}'
-        req = GenerateChartRequest(dataset_id=1, config=raw)
-        assert isinstance(req.config, dict)
-        assert req.config["chart_type"] == "table"
-
-    def test_coerce_typed_config_object(self) -> None:
+    def test_typed_config_object_accepted(self) -> None:
         typed = TableChartConfig(chart_type="table", columns=[ColumnRef(name="c")])
         req = GenerateChartRequest(dataset_id=1, config=typed)
-        assert isinstance(req.config, dict)
-        assert req.config["chart_type"] == "table"
+        assert req.config.chart_type == "table"
 
-    def test_coerce_invalid_json_string_raises(self) -> None:
+    def test_invalid_config_raises(self) -> None:
         with pytest.raises(ValidationError):
             GenerateChartRequest(dataset_id=1, config="not valid json")
 

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -58,10 +58,10 @@ class TestGenerateChart:
         table_request = GenerateChartRequest(dataset_id="1", config=table_config)
         assert table_request.dataset_id == "1"
         # config is now Dict[str, Any] in the schema; validate via dict access
-        assert table_request.config["chart_type"] == "table"
-        assert len(table_request.config["columns"]) == 2
-        assert table_request.config["columns"][0]["name"] == "region"
-        assert table_request.config["columns"][1]["aggregate"] == "SUM"
+        assert table_request.config.chart_type == "table"
+        assert len(table_request.config.columns) == 2
+        assert table_request.config.columns[0].name == "region"
+        assert table_request.config.columns[1].aggregate == "SUM"
 
         # XY chart request
         xy_config = XYChartConfig(
@@ -75,12 +75,12 @@ class TestGenerateChart:
             legend=LegendConfig(show=True, position="top"),
         )
         xy_request = GenerateChartRequest(dataset_id="2", config=xy_config)
-        assert xy_request.config["chart_type"] == "xy"
-        assert xy_request.config["x"]["name"] == "date"
-        assert xy_request.config["y"][0]["aggregate"] == "SUM"
-        assert xy_request.config["kind"] == "line"
-        assert xy_request.config["x_axis"]["title"] == "Date"
-        assert xy_request.config["legend"]["show"] is True
+        assert xy_request.config.chart_type == "xy"
+        assert xy_request.config.x.name == "date"
+        assert xy_request.config.y[0].aggregate == "SUM"
+        assert xy_request.config.kind == "line"
+        assert xy_request.config.x_axis.title == "Date"
+        assert xy_request.config.legend.show is True
 
     @pytest.mark.asyncio
     async def test_generate_chart_validation_error_handling(self):

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -70,10 +70,10 @@ class TestUpdateChart:
         table_request = UpdateChartRequest(identifier=123, config=table_config)
         assert table_request.identifier == 123
         # config is now Dict[str, Any] in the schema; validate via dict access
-        assert table_request.config["chart_type"] == "table"
-        assert len(table_request.config["columns"]) == 2
-        assert table_request.config["columns"][0]["name"] == "region"
-        assert table_request.config["columns"][1]["aggregate"] == "SUM"
+        assert table_request.config.chart_type == "table"
+        assert len(table_request.config.columns) == 2
+        assert table_request.config.columns[0].name == "region"
+        assert table_request.config.columns[1].aggregate == "SUM"
 
         # XY chart update with UUID
         xy_config = XYChartConfig(
@@ -90,10 +90,10 @@ class TestUpdateChart:
             identifier="a1b2c3d4-e5f6-7890-abcd-ef1234567890", config=xy_config
         )
         assert xy_request.identifier == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        assert xy_request.config["chart_type"] == "xy"
-        assert xy_request.config["x"]["name"] == "date"
-        assert xy_request.config["y"][0]["aggregate"] == "SUM"
-        assert xy_request.config["kind"] == "line"
+        assert xy_request.config.chart_type == "xy"
+        assert xy_request.config.x.name == "date"
+        assert xy_request.config.y[0].aggregate == "SUM"
+        assert xy_request.config.kind == "line"
 
     @pytest.mark.asyncio
     async def test_update_chart_with_chart_name(self):
@@ -175,7 +175,7 @@ class TestUpdateChart:
                 kind=chart_type,
             )
             request = UpdateChartRequest(identifier=1, config=config)
-            assert request.config["kind"] == chart_type
+            assert request.config.kind == chart_type
 
         # Test multiple Y columns
         multi_y_config = XYChartConfig(
@@ -189,8 +189,8 @@ class TestUpdateChart:
             kind="line",
         )
         request = UpdateChartRequest(identifier=1, config=multi_y_config)
-        assert len(request.config["y"]) == 3
-        assert request.config["y"][1]["aggregate"] == "AVG"
+        assert len(request.config.y) == 3
+        assert request.config.y[1].aggregate == "AVG"
 
         # Test filter operators
         operators = ["=", "!=", ">", ">=", "<", "<="]
@@ -201,7 +201,7 @@ class TestUpdateChart:
             filters=filters,
         )
         request = UpdateChartRequest(identifier=1, config=table_config)
-        assert len(request.config["filters"]) == 6
+        assert len(request.config.filters) == 6
 
     @pytest.mark.asyncio
     async def test_update_chart_response_structure(self):
@@ -257,12 +257,12 @@ class TestUpdateChart:
             ),
         )
         request = UpdateChartRequest(identifier=1, config=config)
-        assert request.config["x_axis"]["title"] == "Date"
-        assert request.config["x_axis"]["format"] == "smart_date"
-        assert request.config["x_axis"]["scale"] == "linear"
-        assert request.config["y_axis"]["title"] == "Sales Amount"
-        assert request.config["y_axis"]["format"] == "$,.2f"
-        assert request.config["y_axis"]["scale"] == "log"
+        assert request.config.x_axis.title == "Date"
+        assert request.config.x_axis.format == "smart_date"
+        assert request.config.x_axis.scale == "linear"
+        assert request.config.y_axis.title == "Sales Amount"
+        assert request.config.y_axis.format == "$,.2f"
+        assert request.config.y_axis.scale == "log"
 
     @pytest.mark.asyncio
     async def test_update_chart_legend_configurations(self):
@@ -276,8 +276,8 @@ class TestUpdateChart:
                 legend=LegendConfig(show=True, position=pos),
             )
             request = UpdateChartRequest(identifier=1, config=config)
-            assert request.config["legend"]["position"] == pos
-            assert request.config["legend"]["show"] is True
+            assert request.config.legend.position == pos
+            assert request.config.legend.show is True
 
         # Hidden legend
         config = XYChartConfig(
@@ -287,7 +287,7 @@ class TestUpdateChart:
             legend=LegendConfig(show=False),
         )
         request = UpdateChartRequest(identifier=1, config=config)
-        assert request.config["legend"]["show"] is False
+        assert request.config.legend.show is False
 
     @pytest.mark.asyncio
     async def test_update_chart_aggregation_functions(self):
@@ -299,7 +299,7 @@ class TestUpdateChart:
                 columns=[ColumnRef(name="value", aggregate=agg)],
             )
             request = UpdateChartRequest(identifier=1, config=config)
-            assert request.config["columns"][0]["aggregate"] == agg
+            assert request.config.columns[0].aggregate == agg
 
     @pytest.mark.asyncio
     async def test_update_chart_error_responses(self):
@@ -383,10 +383,10 @@ class TestUpdateChart:
         )
 
         request = UpdateChartRequest(identifier=1, config=config)
-        assert len(request.config["filters"]) == 3
-        assert request.config["filters"][0]["column"] == "region"
-        assert request.config["filters"][1]["op"] == ">="
-        assert request.config["filters"][2]["value"] == "2024-01-01"
+        assert len(request.config.filters) == 3
+        assert request.config.filters[0].column == "region"
+        assert request.config.filters[1].op == ">="
+        assert request.config.filters[2].value == "2024-01-01"
 
     @pytest.mark.asyncio
     async def test_update_chart_cache_control(self):

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
@@ -53,9 +53,9 @@ class TestUpdateChartPreview:
         )
         assert table_request.form_data_key == "abc123def456"
         assert table_request.dataset_id == 1
-        assert table_request.config["chart_type"] == "table"
-        assert len(table_request.config["columns"]) == 2
-        assert table_request.config["columns"][0]["name"] == "region"
+        assert table_request.config.chart_type == "table"
+        assert len(table_request.config.columns) == 2
+        assert table_request.config.columns[0].name == "region"
 
         # XY chart preview update
         xy_config = XYChartConfig(
@@ -73,9 +73,9 @@ class TestUpdateChartPreview:
         )
         assert xy_request.form_data_key == "xyz789ghi012"
         assert xy_request.dataset_id == "2"
-        assert xy_request.config["chart_type"] == "xy"
-        assert xy_request.config["x"]["name"] == "date"
-        assert xy_request.config["kind"] == "line"
+        assert xy_request.config.chart_type == "xy"
+        assert xy_request.config.x.name == "date"
+        assert xy_request.config.kind == "line"
 
     @pytest.mark.asyncio
     async def test_update_chart_preview_dataset_id_types(self):
@@ -158,7 +158,7 @@ class TestUpdateChartPreview:
             request = UpdateChartPreviewRequest(
                 form_data_key="abc123", dataset_id=1, config=config
             )
-            assert request.config["kind"] == chart_type
+            assert request.config.kind == chart_type
 
         # Test multiple Y columns
         multi_y_config = XYChartConfig(
@@ -174,8 +174,8 @@ class TestUpdateChartPreview:
         request = UpdateChartPreviewRequest(
             form_data_key="abc123", dataset_id=1, config=multi_y_config
         )
-        assert len(request.config["y"]) == 3
-        assert request.config["y"][1]["aggregate"] == "AVG"
+        assert len(request.config.y) == 3
+        assert request.config.y[1].aggregate == "AVG"
 
         # Test filter operators
         operators = ["=", "!=", ">", ">=", "<", "<="]
@@ -188,7 +188,7 @@ class TestUpdateChartPreview:
         request = UpdateChartPreviewRequest(
             form_data_key="abc123", dataset_id=1, config=table_config
         )
-        assert len(request.config["filters"]) == 6
+        assert len(request.config.filters) == 6
 
     @pytest.mark.asyncio
     async def test_update_chart_preview_response_structure(self):
@@ -251,10 +251,10 @@ class TestUpdateChartPreview:
         request = UpdateChartPreviewRequest(
             form_data_key="abc123", dataset_id=1, config=config
         )
-        assert request.config["x_axis"]["title"] == "Date"
-        assert request.config["x_axis"]["format"] == "smart_date"
-        assert request.config["y_axis"]["title"] == "Sales Amount"
-        assert request.config["y_axis"]["format"] == "$,.2f"
+        assert request.config.x_axis.title == "Date"
+        assert request.config.x_axis.format == "smart_date"
+        assert request.config.y_axis.title == "Sales Amount"
+        assert request.config.y_axis.format == "$,.2f"
 
     @pytest.mark.asyncio
     async def test_update_chart_preview_legend_configurations(self):
@@ -270,8 +270,8 @@ class TestUpdateChartPreview:
             request = UpdateChartPreviewRequest(
                 form_data_key="abc123", dataset_id=1, config=config
             )
-            assert request.config["legend"]["position"] == pos
-            assert request.config["legend"]["show"] is True
+            assert request.config.legend.position == pos
+            assert request.config.legend.show is True
 
         # Hidden legend
         config = XYChartConfig(
@@ -283,7 +283,7 @@ class TestUpdateChartPreview:
         request = UpdateChartPreviewRequest(
             form_data_key="abc123", dataset_id=1, config=config
         )
-        assert request.config["legend"]["show"] is False
+        assert request.config.legend.show is False
 
     @pytest.mark.asyncio
     async def test_update_chart_preview_aggregation_functions(self):
@@ -297,7 +297,7 @@ class TestUpdateChartPreview:
             request = UpdateChartPreviewRequest(
                 form_data_key="abc123", dataset_id=1, config=config
             )
-            assert request.config["columns"][0]["aggregate"] == agg
+            assert request.config.columns[0].aggregate == agg
 
     @pytest.mark.asyncio
     async def test_update_chart_preview_error_responses(self):
@@ -347,10 +347,10 @@ class TestUpdateChartPreview:
         request = UpdateChartPreviewRequest(
             form_data_key="abc123", dataset_id=1, config=config
         )
-        assert len(request.config["filters"]) == 3
-        assert request.config["filters"][0]["column"] == "region"
-        assert request.config["filters"][1]["op"] == ">="
-        assert request.config["filters"][2]["value"] == "2024-01-01"
+        assert len(request.config.filters) == 3
+        assert request.config.filters[0].column == "region"
+        assert request.config.filters[1].op == ">="
+        assert request.config.filters[2].value == "2024-01-01"
 
     @pytest.mark.asyncio
     async def test_update_chart_preview_form_data_key_handling(self):
@@ -447,12 +447,12 @@ class TestUpdateChartPreview:
         request = UpdateChartPreviewRequest(
             form_data_key="abc123", dataset_id=1, config=config
         )
-        assert len(request.config["y"]) == 4
-        assert request.config["y"][0]["name"] == "revenue"
-        assert request.config["y"][1]["name"] == "cost"
-        assert request.config["y"][2]["name"] == "profit"
-        assert request.config["y"][3]["name"] == "orders"
-        assert request.config["y"][3]["aggregate"] == "COUNT"
+        assert len(request.config.y) == 4
+        assert request.config.y[0].name == "revenue"
+        assert request.config.y[1].name == "cost"
+        assert request.config.y[2].name == "profit"
+        assert request.config.y[3].name == "orders"
+        assert request.config.y[3].aggregate == "COUNT"
 
     @pytest.mark.asyncio
     async def test_update_chart_preview_table_sorting(self):
@@ -470,5 +470,5 @@ class TestUpdateChartPreview:
         request = UpdateChartPreviewRequest(
             form_data_key="abc123", dataset_id=1, config=config
         )
-        assert request.config["sort_by"] == ["sales", "profit"]
-        assert len(request.config["columns"]) == 3
+        assert request.config.sort_by == ["sales", "profit"]
+        assert len(request.config.columns) == 3

--- a/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
@@ -159,8 +159,9 @@ def test_adhoc_filters_returns_actionable_error() -> None:
     # Must NOT be the opaque validation_system_error
     assert dumped["error_type"] == "validation_error"
     assert dumped["error_code"] == "VALIDATION_ERROR"
-    # Message must mention filters as the correct field name
-    assert "filters" in dumped["message"]
+    # Details or message must mention the invalid field
+    combined = dumped["message"] + " " + dumped["details"]
+    assert "adhoc_filters" in combined or "filters" in combined
     assert dumped["details"] != ""
     assert dumped["suggestions"]
 

--- a/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_pipeline_error_surface.py
@@ -107,7 +107,7 @@ def test_mixed_timeseries_with_wrong_kind_fields_returns_actionable_error() -> N
     assert "tagged-union" not in dumped["message"]
     # Suggestions should steer callers back to a valid schema.
     assert dumped["suggestions"]
-    assert dumped["error_code"] == "INVALID_CHART_CONFIG"
+    assert dumped["error_code"] == "VALIDATION_ERROR"
     assert dumped["error_type"] == "validation_error"
 
 
@@ -158,7 +158,7 @@ def test_adhoc_filters_returns_actionable_error() -> None:
 
     # Must NOT be the opaque validation_system_error
     assert dumped["error_type"] == "validation_error"
-    assert dumped["error_code"] == "INVALID_CHART_CONFIG"
+    assert dumped["error_code"] == "VALIDATION_ERROR"
     # Message must mention filters as the correct field name
     assert "filters" in dumped["message"]
     assert dumped["details"] != ""
@@ -237,7 +237,7 @@ def test_non_value_error_pydantic_body_is_surfaced() -> None:
     assert result.is_valid is False
     assert result.error is not None
     dumped = result.error.model_dump()
-    assert dumped["error_code"] == "INVALID_CHART_CONFIG"
+    assert dumped["error_code"] == "VALIDATION_ERROR"
     assert dumped["error_type"] == "validation_error"
     assert "tagged-union" not in dumped["message"]
     assert "tagged-union" not in dumped["details"]

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -49,7 +49,7 @@ def test_tool_search_config_defaults():
     assert "get_instance_info" in MCP_TOOL_SEARCH_CONFIG["always_visible"]
     assert MCP_TOOL_SEARCH_CONFIG["search_tool_name"] == "search_tools"
     assert MCP_TOOL_SEARCH_CONFIG["call_tool_name"] == "call_tool"
-    assert MCP_TOOL_SEARCH_CONFIG["include_schemas"] is False
+    assert MCP_TOOL_SEARCH_CONFIG["include_schemas"] is True
 
 
 def test_apply_bm25_transform():


### PR DESCRIPTION
## Summary

PR #39018 changed the `config` field from `ChartConfig` (typed discriminated union) to `Dict[str, Any]` in chart request schemas to reduce token usage. This removed all chart config structure from the JSON Schema exposed to LLMs, causing validation errors:

- Wrong field names (e.g., `column` instead of `name` for x-axis)
- Missing required fields (e.g., `x.name`)
- Wrong types (e.g., dict instead of list for `y`)

Also flips `include_schemas` default to `True` so `search_tools` results include full compacted `inputSchema` instead of the `parameters_hint` summary which only shows `"request"` (the top-level wrapper name).

### Changes
- Revert `config` field type from `Dict[str, Any]` back to `ChartConfig` in `GenerateChartRequest`, `GenerateExploreLinkRequest`, `UpdateChartRequest`, `UpdateChartPreviewRequest`
- Remove now-redundant `parse_chart_config()` calls in tool bodies (Pydantic validates the discriminated union at request parse time)
- Remove dead code: `_coerce_config_to_dict`, `_CHART_CONFIG_DESCRIPTION`, `_CHART_CONFIG_ADAPTER`, `parse_chart_config`
- Set `include_schemas=True` in `MCP_TOOL_SEARCH_CONFIG` default

### Token cost
~12k tokens added back for chart tools. Justified: failed retries from broken schemas cost far more tokens than the larger schema.

## Test plan
- [ ] Existing MCP chart unit tests pass
- [ ] JSON Schema for `GenerateChartRequest` includes full discriminated union
- [ ] LLM can generate charts without multiple retries via MCP