### PR TITLE
fix(table): preserve decimals in totals row when Time Comparison is enabled

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -130,13 +130,12 @@ const processComparisonTotals = (
     Object.keys(totalRecord).forEach(key => {
       if (totalRecord[key] !== undefined && !key.includes(comparisonSuffix)) {
         transformedTotals[`Main ${key}`] =
-          parseInt(transformedTotals[`Main ${key}`]?.toString() || '0', 10) +
-          parseInt(totalRecord[key]?.toString() || '0', 10);
+          Number(transformedTotals[`Main ${key}`]?.toString() || '0') +
+          Number(totalRecord[key]?.toString() || '0');
         transformedTotals[`# ${key}`] =
-          parseInt(transformedTotals[`# ${key}`]?.toString() || '0', 10) +
-          parseInt(
+          Number(transformedTotals[`# ${key}`]?.toString() || '0') +
+          Number(
             totalRecord[`${key}__${comparisonSuffix}`]?.toString() || '0',
-            10,
           );
         const { valueDifference, percentDifferenceNum } = calculateDifferences(
           transformedTotals[`Main ${key}`] as number,

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -479,7 +479,7 @@ const getPageSize = (
     return pageSize || 0;
   }
   if (typeof pageSize === 'string') {
-    return parseFloat(pageSize) || 0;
+    return Number(pageSize) || 0;
   }
   // when pageSize not set, automatically add pagination if too many records
   return numRecords * numColumns > 5000 ? 200 : 0;

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -130,11 +130,11 @@ const processComparisonTotals = (
     Object.keys(totalRecord).forEach(key => {
       if (totalRecord[key] !== undefined && !key.includes(comparisonSuffix)) {
         transformedTotals[`Main ${key}`] =
-          Number(transformedTotals[`Main ${key}`]?.toString() || '0') +
-          Number(totalRecord[key]?.toString() || '0');
+          parseFloat(transformedTotals[`Main ${key}`]?.toString() || '0') +
+          parseFloat(totalRecord[key]?.toString() || '0');
         transformedTotals[`# ${key}`] =
-          Number(transformedTotals[`# ${key}`]?.toString() || '0') +
-          Number(
+          parseFloat(transformedTotals[`# ${key}`]?.toString() || '0') +
+          parseFloat(
             totalRecord[`${key}__${comparisonSuffix}`]?.toString() || '0',
           );
         const { valueDifference, percentDifferenceNum } = calculateDifferences(
@@ -479,7 +479,7 @@ const getPageSize = (
     return pageSize || 0;
   }
   if (typeof pageSize === 'string') {
-    return Number(pageSize) || 0;
+    return parseFloat(pageSize) || 0;
   }
   // when pageSize not set, automatically add pagination if too many records
   return numRecords * numColumns > 5000 ? 200 : 0;


### PR DESCRIPTION
### SUMMARY

`processComparisonTotals` in `superset-frontend/plugins/plugin-chart-table/src/transformProps.ts` was using `parseInt(..., 10)` when accumulating values for the Time-Comparison totals row, which truncated all decimals.

Replaced the `parseInt` calls with `Number(...)` so decimal metric values are preserved.

Fixes #39717

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**

<img width="1600" height="684" alt="image" src="https://github.com/user-attachments/assets/5b481e2e-b4ea-49f7-964d-5c986b1a5258" />

**After:**

<img width="1600" height="743" alt="image" src="https://github.com/user-attachments/assets/7a3272ef-212c-4cbf-b157-245caccd7a1d" />

### TESTING INSTRUCTIONS

1. Open Charts → **+ Chart**
2. Dataset: `birth_names`
3. Chart type: **Table** → **Create new chart**
4. **Data tab:**
   - Query mode: **Aggregate**
   - Dimensions: `gender`
   - Metrics: **+ Add metric** → Custom SQL → `AVG(num)` → Save
5. Filters → drag in `ds` → set a custom range (e.g. `2006-04-29` to `2026-04-29`)
6. **Time shift:** `1 year ago`
7. Toggle **Show summary** = ON
8. Click **Update chart**

**Before the fix:** the Summary row shows truncated integers (e.g. `870` instead of `870.99`).
**With the fix:** the Summary row preserves decimals, matching the rows above.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #39717
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API