### PR TITLE
chore(build): remove thread-loader from webpack build

### DIFF
--- a/scripts/oxlint.sh
+++ b/scripts/oxlint.sh
@@ -45,7 +45,17 @@ if [ ${#js_ts_files[@]} -gt 0 ]; then
   # Skip custom OXC build in pre-commit for speed
   export SKIP_CUSTOM_OXC=true
   # Use quiet mode in pre-commit to reduce noise (only show errors)
-  npx oxlint --config oxlint.json --fix --quiet "${js_ts_files[@]}"
+  # Capture output so we can treat "No files found" (all files ignored by
+  # ignorePatterns) as success rather than a false-positive failure.
+  output=$(npx oxlint --config oxlint.json --fix --quiet "${js_ts_files[@]}" 2>&1) || {
+    if echo "$output" | grep -q "No files found"; then
+      echo "No files to lint after applying ignore patterns"
+      exit 0
+    fi
+    echo "$output" >&2
+    exit 1
+  }
+  [ -n "$output" ] && echo "$output"
 else
   echo "No JavaScript/TypeScript files to lint"
 fi

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -280,7 +280,6 @@
         "style-loader": "^4.0.0",
         "swc-loader": "^0.2.7",
         "terser-webpack-plugin": "^5.5.0",
-        "thread-loader": "^4.0.4",
         "ts-jest": "^29.4.9",
         "tscw-config": "^1.1.2",
         "tsx": "^4.21.0",
@@ -46702,29 +46701,6 @@
       },
       "peerDependencies": {
         "tslib": "^2"
-      }
-    },
-    "node_modules/thread-loader": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-4.0.4.tgz",
-      "integrity": "sha512-tXagu6Hivd03wB2tiS1bqvw345sc7mKei32EgpYpq31ZLes9FN0mEK2nKzXLRFgwt3PsBB0E/MZDp159rDoqwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^4.1.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 16.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/throttle-debounce": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -361,7 +361,6 @@
     "style-loader": "^4.0.0",
     "swc-loader": "^0.2.7",
     "terser-webpack-plugin": "^5.5.0",
-    "thread-loader": "^4.0.4",
     "ts-jest": "^29.4.9",
     "tscw-config": "^1.1.2",
     "tsx": "^4.21.0",

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -505,10 +505,7 @@ const config = {
       {
         test: /\.tsx?$/,
         exclude: [/\.test.tsx?$/, /node_modules/],
-        // Skip thread-loader in dev mode - it breaks HMR by running in worker threads
-        use: isDevMode
-          ? [createSwcLoader('typescript', true)]
-          : ['thread-loader', createSwcLoader('typescript', true)],
+        use: [createSwcLoader('typescript', true)],
       },
       {
         test: /\.jsx?$/,


### PR DESCRIPTION
### SUMMARY

Removes `thread-loader` from the webpack TypeScript compilation rule and drops it as a dependency.

`thread-loader` was introduced in #6120 (2018) when TypeScript was first added to the project. At the time, TypeScript compilation was handled by `ts-loader` or `babel-loader` — CPU-bound JavaScript loaders slow enough to meaningfully benefit from being offloaded to a worker thread pool.

The project has since migrated to [swc](https://swc.rs/), a Rust-based compiler that is already an order of magnitude faster than Babel or ts-loader. With swc, the overhead of `thread-loader` — spawning worker processes, serializing and deserializing each module's source over Node.js IPC — is not justified and can exceed the actual compilation cost.

`thread-loader` was already removed from development mode builds in #36433 because it broke HMR. This PR completes the cleanup by removing it from production builds as well, where the same rationale applies.

### TESTING INSTRUCTIONS

1. Run `CI=true npm run build` in `superset-frontend/`
2. Confirm the build completes successfully and produces the expected assets

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
