### PR TITLE
docs: fix duplicate front matter in embedding.mdx

### DIFF
--- a/docs/docs/using-superset/embedding.mdx
+++ b/docs/docs/using-superset/embedding.mdx
@@ -1,3 +1,8 @@
+---
+title: Embedding Superset
+sidebar_position: 6
+---
+
 {/*
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -16,11 +21,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 */}
-
----
-title: Embedding Superset
-sidebar_position: 6
----
 
 # Embedding Superset
 


### PR DESCRIPTION
Removed duplicate front matter from embedding.mdx.
fixes : #39762 

### SUMMARY

the comment before `---` caused the title and sidebar_position to render as visible text on the page, and the sidebar label showed "embedding" (lowercase) instead of "Embedding Superset", Now the JSX license comment to after the frontmatter block so that Docusaurus can correctly parse the frontmatter

