### PR TITLE
fix(docs): fix embedding page frontmatter and title capitalization

### DIFF
--- a/docs/docs/using-superset/embedding.mdx
+++ b/docs/docs/using-superset/embedding.mdx
@@ -1,3 +1,8 @@
+---
+title: Embedding Superset
+sidebar_position: 6
+---
+
 {/*
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@ specific language governing permissions and limitations
 under the License.
 */}
 
----
-title: Embedding Superset
-sidebar_position: 6
----
 
 # Embedding Superset
 


### PR DESCRIPTION
Fixes #39762

The frontmatter block was placed after the license comment, 
causing it to render as visible text on the docs page instead 
of being parsed silently. Moved frontmatter to the top of the 
file so it is correctly parsed by Docusaurus.

This also fixes the lowercase "embedding" title issue since 
the title field in frontmatter is now properly read.