### PR TITLE
fix(drill-to-detail): drill to detail by correctly filtering by metric

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3027,6 +3027,14 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 col_obj = columns_by_name.get(cast(str, flt_col))
                 # If not found in columns, check if it's a metric
                 # This supports filtering on metric columns for any chart type
+                if col_obj is None:
+                    # Fall back to verbose_name so filters produced by
+                    # right-click "Drill to detail by" (which can pass a
+                    # column's verbose label) still resolve to a real column.
+                    col_obj = next(
+                        (c for c in self.columns if c.verbose_name == flt_col),
+                        None,
+                    )
                 if (
                     col_obj is None
                     and isinstance(flt_col, str)

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -2256,3 +2256,49 @@ def test_numeric_adhoc_filter_value_is_unquoted_in_where_clause(
     # The numeric value should be emitted without quotes.
     assert "IN (3)" in sql, f"Expected numeric IN-list, got SQL: {sql}"
     assert "IN ('3')" not in sql, f"Value should not be quoted, got SQL: {sql}"
+
+
+def test_filter_by_verbose_name_resolves_to_column(
+    database: Database,
+) -> None:
+    """
+    A filter whose "col" value matches a column's verbose_name
+    (e.g. the label emitted by "Drill to detail by") must resolve to that
+    column and produce a WHERE clause on the underlying column_name.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[
+            TableColumn(
+                column_name="country_code",
+                verbose_name="Country",
+                type="TEXT",
+            ),
+            TableColumn(column_name="b", type="TEXT"),
+        ],
+    )
+
+    sqla_query = table.get_sqla_query(
+        columns=["b"],
+        # Filter uses the verbose label, as "Drill to detail by" does.
+        filter=[{"col": "Country", "op": "==", "val": "US"}],
+        is_timeseries=False,
+        row_limit=10,
+    )
+
+    with database.get_sqla_engine() as engine:
+        sql = str(
+            sqla_query.sqla_query.compile(
+                dialect=engine.dialect,
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    # The filter should be translated to a WHERE clause on the real column.
+    assert "WHERE" in sql, f"Expected WHERE clause, got SQL: {sql}"
+    assert "country_code" in sql, f"Expected filter on 'country_code', got SQL: {sql}"
+    assert "'US'" in sql, f"Expected filter value 'US', got SQL: {sql}"


### PR DESCRIPTION
### SUMMARY

When a chart has a column whose `verbose_name` differs from its physical `column_name` (e.g. column `case_owner` displayed as `Case Owner`), right-clicking a bar and selecting **Drill to detail by Case Owner** sends a filter `{col: "Case Owner", op: "==", val: "..."}` in the samples request.

`get_sqla_query` builds `columns_by_name` keyed exclusively by physical `column_name`, so the lookup `columns_by_name.get("Case Owner")` returns `None`. With neither `col_obj` nor `sqla_col` set, the filter is silently skipped — no WHERE clause is generated and the drill returns the full unfiltered dataset.

#### Root cause

`get_sqla_query` (`superset/models/helpers.py`) resolves filter columns only by physical name. There is no fallback for the case where a chart plugin sends the column's `verbose_name` as the filter column — which is what the echarts context-menu handler does when `groupby` contains a column whose displayed label is the verbose name.

#### Fix

After the physical-name lookup fails, fall back to matching `verbose_name` across `self.columns` before continuing to the metric-filter path. The resolution order becomes: physical `column_name` → `verbose_name` → metric name.



### TESTING INSTRUCTIONS

1. Create or open a dataset that has a column with a `verbose_name` set (e.g. column `case_owner`, verbose name `Case Owner`).
2. Build a bar chart using that column as the **groupby** dimension with at least one metric.
3. On a dashboard, right-click a bar and choose **Drill to detail by \<verbose label\>**.
4. Confirm the modal opens with the filter tag showing and the rows are correctly filtered to only that dimension value.
5. Confirm **Drill to detail** (no filter) still returns the full unfiltered dataset.
6. Confirm **Drill to detail by all** (multiple filters) still works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with x -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API