### PR TITLE
test(table): add regression tests for column number format in summary row

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -1983,6 +1983,161 @@ describe('plugin-chart-table', () => {
         });
       });
 
+      test('applies column number format to summary row for metric column', () => {
+        const props = transformProps({
+          ...testData.basic,
+          rawFormData: {
+            ...testData.basic.rawFormData,
+            query_mode: QueryMode.Aggregate,
+            show_totals: true,
+            metrics: ['sum__num'],
+            column_config: {
+              sum__num: { d3NumberFormat: '.0%' },
+            },
+          },
+          queriesData: [
+            testData.basic.queriesData[0],
+            {
+              annotation_data: null,
+              cache_key: null,
+              cached_dttm: null,
+              cache_timeout: null,
+              queried_dttm: null,
+              data: [{ sum__num: 0.27 }],
+              colnames: ['sum__num'],
+              coltypes: [GenericDataType.Numeric],
+              error: null,
+              is_cached: false,
+              query: 'SELECT ...',
+              rowcount: 1,
+              sql_rowcount: 1,
+              stacktrace: null,
+              status: 'success',
+              from_dttm: null,
+              to_dttm: null,
+            },
+          ],
+        });
+
+        render(
+          <ProviderWrapper>
+            <TableChart {...props} sticky={false} />
+          </ProviderWrapper>,
+        );
+
+        const table = screen.getByRole('table');
+        expect(within(table).getByText('27%')).toBeInTheDocument();
+      });
+
+      test('applies column number format to summary row for non-metric numeric column', () => {
+        // non-metric columns with explicit d3NumberFormat should format the totals row
+        const props = transformProps({
+          ...testData.basic,
+          rawFormData: {
+            ...testData.basic.rawFormData,
+            query_mode: QueryMode.Aggregate,
+            show_totals: true,
+            metrics: [],
+            column_config: {
+              sum__num: { d3NumberFormat: '.0%' },
+            },
+          },
+          queriesData: [
+            testData.basic.queriesData[0],
+            {
+              annotation_data: null,
+              cache_key: null,
+              cached_dttm: null,
+              cache_timeout: null,
+              queried_dttm: null,
+              data: [{ sum__num: 0.27 }],
+              colnames: ['sum__num'],
+              coltypes: [GenericDataType.Numeric],
+              error: null,
+              is_cached: false,
+              query: 'SELECT ...',
+              rowcount: 1,
+              sql_rowcount: 1,
+              stacktrace: null,
+              status: 'success',
+              from_dttm: null,
+              to_dttm: null,
+            },
+          ],
+        });
+
+        render(
+          <ProviderWrapper>
+            <TableChart {...props} sticky={false} />
+          </ProviderWrapper>,
+        );
+
+        const table = screen.getByRole('table');
+        expect(within(table).getByText('27%')).toBeInTheDocument();
+      });
+
+      test('applies column number format to summary row after search filter', async () => {
+        // summary row should keep formatting when search is applied
+        const props = transformProps({
+          ...testData.basic,
+          rawFormData: {
+            ...testData.basic.rawFormData,
+            query_mode: QueryMode.Aggregate,
+            show_totals: true,
+            include_search: true,
+            server_pagination: false,
+            metrics: ['sum__num'],
+            column_config: {
+              sum__num: { d3NumberFormat: '.0%' },
+            },
+          },
+          queriesData: [
+            testData.basic.queriesData[0],
+            {
+              annotation_data: null,
+              cache_key: null,
+              cached_dttm: null,
+              cache_timeout: null,
+              queried_dttm: null,
+              data: [{ sum__num: 0.27 }],
+              colnames: ['sum__num'],
+              coltypes: [GenericDataType.Numeric],
+              error: null,
+              is_cached: false,
+              query: 'SELECT ...',
+              rowcount: 1,
+              sql_rowcount: 1,
+              stacktrace: null,
+              status: 'success',
+              from_dttm: null,
+              to_dttm: null,
+            },
+          ],
+        });
+        props.includeSearch = true;
+
+        render(
+          <ProviderWrapper>
+            <TableChart {...props} sticky={false} />
+          </ProviderWrapper>,
+        );
+
+        const table = screen.getByRole('table');
+        // Before search: summary should show formatted value
+        expect(within(table).getByText('27%')).toBeInTheDocument();
+
+        // After filtering: summary should still show formatted value
+        const searchInput = screen.getByRole('textbox');
+        fireEvent.change(searchInput, { target: { value: 'Michael' } });
+
+        await waitFor(() => {
+          const rows = within(table).getAllByRole('row');
+          // The summary row value should still be formatted
+          const footerRow = rows[rows.length - 1];
+          expect(footerRow.textContent).toContain('%');
+        });
+      });
+
       test('preserves client-side search text across temporal table rerenders', async () => {
         const formDataWithSearch = {
           ...testData.basic.formData,


### PR DESCRIPTION
### SUMMARY

Add regression tests that verify the per-column number formatter (`d3NumberFormat`) is applied correctly to the Table chart's summary/totals row when "Show totals" is enabled.

The tests cover:
1. **Metric column with `d3NumberFormat: '.0%'`** — confirms `0.27` renders as `"27%"` in the summary row
2. **Non-metric numeric column with `d3NumberFormat: '.0%'`** — same expectation for non-aggregate numeric columns
3. **After client-side search filter** — confirms the formatted value is preserved when a search filter recomputes the displayed totals from visible rows

Investigation showed the fix was already present in the current code via `formatColumnValue(column, displayedTotals[key])` in the `Footer` cell renderer. These tests lock in that behavior.

Fixes #39587

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — test-only change.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
NODE_ENV=test NODE_OPTIONS="--max-old-space-size=8192" \
  ./node_modules/.bin/jest "plugins/plugin-chart-table" --watchAll=false
```

All 107 tests should pass.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #39587
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API