### PR TITLE
fix(sunburst): remove label text outline in dark theme

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -285,8 +285,6 @@ export default function transformProps(
   }
   const labelProps = {
     color: theme.colorText,
-    textBorderColor: theme.colorBgBase,
-    textBorderWidth: 1,
   };
   const traverse = (
     treeNodes: TreeNode[],

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Sunburst/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Sunburst/transformProps.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ChartProps } from '@superset-ui/core';
+import { supersetTheme } from '@apache-superset/core/theme';
+import { EchartsSunburstChartProps } from '../../src/Sunburst/types';
+import transformProps from '../../src/Sunburst/transformProps';
+
+const formData = {
+  colorScheme: 'bnbColors',
+  datasource: '3__table',
+  groupby: ['category'],
+  metric: 'sum__value',
+};
+
+const chartProps = new ChartProps({
+  formData,
+  width: 800,
+  height: 600,
+  queriesData: [
+    {
+      data: [
+        { category: 'A', sum__value: 10 },
+        { category: 'B', sum__value: 20 },
+      ],
+    },
+  ],
+  theme: supersetTheme,
+});
+
+test('series label has no textBorderColor or textBorderWidth', () => {
+  const { echartOptions } = transformProps(
+    chartProps as EchartsSunburstChartProps,
+  );
+  const series = (echartOptions as any).series[0];
+  expect(series.label).not.toHaveProperty('textBorderColor');
+  expect(series.label).not.toHaveProperty('textBorderWidth');
+});


### PR DESCRIPTION
### SUMMARY

Sunburst segment labels were rendered with a black 1px text border (`textBorderColor` + `textBorderWidth: 1`), making them difficult to read — especially in dark theme where the white text + black outline creates a noisy appearance.

The fix is to remove the outline entirely. `theme.colorText` already provides the correct contrast color for both light and dark themes via Ant Design theme tokens, so no conditional logic is needed.

The center "Total" text label is untouched — it was already using `theme.colorText` correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!-- Upload before/after screenshots to the PR via drag-drop. Don't commit image files. -->

### TESTING INSTRUCTIONS

1. Open a Superset instance with a Sunburst chart.
2. Switch to dark theme. Confirm segment labels render as clean solid text with no black outline.
3. Switch to light theme. Confirm labels remain readable (no regression).
4. Verify the center "Total" text is unchanged.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #37905
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
