### PR TITLE
fix(models): make naive datetime object timezone-aware before converting to unix timestamp

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -27,7 +27,7 @@ import re
 import uuid
 from collections.abc import Hashable, Iterator
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import (
     Any,
     Callable,
@@ -2765,7 +2765,15 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
         if tf:
             if tf in {"epoch_ms", "epoch_s"}:
-                seconds_since_epoch = int(dttm.timestamp())
+                # In general, Superset works with timezone-naive datetime objects
+                # internally. However, timestamp() applies local timezone to
+                # timezone-naive datetime objects. Therefore, we have to be explicit
+                # about UTC before calling timestamp().
+                dttm_tz_aware = dttm
+                if dttm_tz_aware.tzinfo is None:
+                    dttm_tz_aware = dttm_tz_aware.replace(tzinfo=timezone.utc)
+
+                seconds_since_epoch = int(dttm_tz_aware.timestamp())
                 if tf == "epoch_s":
                     return str(seconds_since_epoch)
                 return str(seconds_since_epoch * 1000)

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -16,7 +16,7 @@
 # under the License.
 
 # pylint: disable=import-outside-toplevel
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flask import current_app
@@ -201,13 +201,13 @@ def test_get_db_engine_spec(mocker: MockerFixture) -> None:
     "dttm,col,database,result",
     [
         (
-            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            datetime(2023, 1, 1, 1, 23, 45, 600000, timezone.utc),
             TableColumn(python_date_format="epoch_s"),
             Database(),
             "1672536225",
         ),
         (
-            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            datetime(2023, 1, 1, 1, 23, 45, 600000, timezone.utc),
             TableColumn(python_date_format="epoch_ms"),
             Database(),
             "1672536225000",

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -202,6 +202,11 @@ def test_get_db_engine_spec(mocker: MockerFixture) -> None:
 
 @pytest.mark.parametrize(
     "dttm,col,database,result",
+    # Make sure that dttm and result share the same timezone awareness.
+    # Either dttm and result are both timezone-naive.
+    # Or dttm and result are both timezone-aware, e.g. dttm is a datetime object with
+    # non-null tzinfo and result is a UNIX timestamp with epoch (sub-)seconds since
+    # 1970-01-01 00:00:00 UTC.
     [
         (
             datetime(2023, 1, 1, 1, 23, 45, 600000, timezone.utc),

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -16,7 +16,7 @@
 # under the License.
 
 # pylint: disable=import-outside-toplevel
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 import numpy
@@ -204,13 +204,13 @@ def test_get_db_engine_spec(mocker: MockerFixture) -> None:
     "dttm,col,database,result",
     [
         (
-            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            datetime(2023, 1, 1, 1, 23, 45, 600000, timezone.utc),
             TableColumn(python_date_format="epoch_s"),
             Database(),
             "1672536225",
         ),
         (
-            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            datetime(2023, 1, 1, 1, 23, 45, 600000, timezone.utc),
             TableColumn(python_date_format="epoch_ms"),
             Database(),
             "1672536225000",

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -16,7 +16,7 @@
 # under the License.
 
 # pylint: disable=import-outside-toplevel
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Callable
 
 import numpy
@@ -202,20 +202,15 @@ def test_get_db_engine_spec(mocker: MockerFixture) -> None:
 
 @pytest.mark.parametrize(
     "dttm,col,database,result",
-    # Make sure that dttm and result share the same timezone awareness.
-    # Either dttm and result are both timezone-naive.
-    # Or dttm and result are both timezone-aware, e.g. dttm is a datetime object with
-    # non-null tzinfo and result is a UNIX timestamp with epoch (sub-)seconds since
-    # 1970-01-01 00:00:00 UTC.
     [
         (
-            datetime(2023, 1, 1, 1, 23, 45, 600000, timezone.utc),
+            datetime(2023, 1, 1, 1, 23, 45, 600000),
             TableColumn(python_date_format="epoch_s"),
             Database(),
             "1672536225",
         ),
         (
-            datetime(2023, 1, 1, 1, 23, 45, 600000, timezone.utc),
+            datetime(2023, 1, 1, 1, 23, 45, 600000),
             TableColumn(python_date_format="epoch_ms"),
             Database(),
             "1672536225000",


### PR DESCRIPTION
Fixes #39781 .

### SUMMARY

Currently, two testcases rely on the environment to have UTC timezone in order to pass.
The problem is that given timestamp is timezone-native, and that the solution timestamp is a UNIX timestamp, and thus timezone-aware.
Fix the timezone for those timestamps.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

This test passes here but not on the main branch:

```
env TZ='US/Eastern' python3 -m pytest tests/unit_tests/models/core_test.py -k test_dttm_sql_literal
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #39781 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
