### PR TITLE
fix(embedded): respect show_filters param in standalone report mode

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -271,7 +271,10 @@ function sortHierarchicalObject(
   return result;
 }
 
-function convertToNumberIfNumeric(value: string): string | number {
+function convertToNumberIfNumeric(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
   const n = Number(value);
   return value.trim() !== '' && !Number.isNaN(n) ? n : value;
 }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -1052,7 +1052,7 @@ test('renderTableRow uses active header surface for adaptive contrast', () => {
 });
 
 function makeColPivotSettings(
-  value: string,
+  value: unknown,
 ): Parameters<TableRenderer['renderColHeaderRow']>[2] {
   return {
     rowAttrs: [],
@@ -1146,3 +1146,45 @@ test.each([
     expect(formatter).toHaveBeenCalledWith(expected);
   },
 );
+
+test('col header date formatter does not throw when value is a Date object', () => {
+  const dateValue = new Date(1700000000000);
+  const formatter = jest.fn().mockReturnValue('formatted');
+  tableRenderer = new TableRenderer({
+    ...mockProps,
+    cols: ['event_time'],
+    tableOptions: {
+      ...mockProps.tableOptions,
+      dateFormatters: { event_time: formatter },
+    },
+  });
+  expect(() =>
+    tableRenderer.renderColHeaderRow(
+      'event_time',
+      0,
+      makeColPivotSettings(dateValue),
+    ),
+  ).not.toThrow();
+  expect(formatter).toHaveBeenCalledWith(dateValue);
+});
+
+test('row header date formatter does not throw when value is a Date object', () => {
+  const dateValue = new Date(1700000000000);
+  const formatter = jest.fn().mockReturnValue('formatted');
+  tableRenderer = new TableRenderer({
+    ...mockProps,
+    rows: ['event_time'],
+    tableOptions: {
+      ...mockProps.tableOptions,
+      dateFormatters: { event_time: formatter },
+    },
+  });
+  expect(() =>
+    tableRenderer.renderTableRow(
+      [dateValue as unknown as string],
+      0,
+      makeRowPivotSettings(),
+    ),
+  ).not.toThrow();
+  expect(formatter).toHaveBeenCalledWith(dateValue);
+});

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/// <reference types="@emotion/jest" />
 import fetchMock from 'fetch-mock';
 import {
   fireEvent,
@@ -42,6 +43,7 @@ import {
 import { storeWithState } from 'spec/fixtures/mockStore';
 import mockState from 'spec/fixtures/mockState';
 import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
+import * as urlUtils from 'src/utils/urlUtils';
 import * as useNativeFiltersModule from './state';
 
 fetchMock.get('glob:*/csstemplateasyncmodelview/api/read', {});
@@ -455,6 +457,116 @@ describe('DashboardBuilder', () => {
     });
 
     expect(queryByTestId('dashboard-filters-panel')).not.toBeInTheDocument();
+  });
+
+  test('should hide filter panel in standalone=3 report mode', () => {
+    const urlParamSpy = (
+      jest.spyOn(urlUtils, 'getUrlParam') as jest.SpyInstance
+    ).mockImplementation((param: { name: string }) => {
+      if (param.name === 'standalone') return 3;
+      return null;
+    });
+    const nativeFiltersSpy = jest
+      .spyOn(useNativeFiltersModule, 'useNativeFilters')
+      .mockReturnValue({
+        showDashboard: true,
+        missingInitialFilters: [],
+        dashboardFiltersOpen: true,
+        toggleDashboardFiltersOpen: jest.fn(),
+        nativeFiltersEnabled: true,
+      });
+    try {
+      const { getByTestId } = setup();
+      const filterPanel = getByTestId('dashboard-filters-panel');
+      expect(filterPanel).toHaveStyleRule('display', 'none');
+    } finally {
+      urlParamSpy.mockRestore();
+      nativeFiltersSpy.mockRestore();
+    }
+  });
+
+  test('should show filter panel in standalone=3 when show_filters=true', () => {
+    const urlParamSpy = (
+      jest.spyOn(urlUtils, 'getUrlParam') as jest.SpyInstance
+    ).mockImplementation((param: { name: string }) => {
+      if (param.name === 'standalone') return 3;
+      if (param.name === 'show_filters') return true;
+      return null;
+    });
+    const nativeFiltersSpy = jest
+      .spyOn(useNativeFiltersModule, 'useNativeFilters')
+      .mockReturnValue({
+        showDashboard: true,
+        missingInitialFilters: [],
+        dashboardFiltersOpen: true,
+        toggleDashboardFiltersOpen: jest.fn(),
+        nativeFiltersEnabled: true,
+      });
+    try {
+      const { getByTestId } = setup();
+      const filterPanel = getByTestId('dashboard-filters-panel');
+      expect(filterPanel).not.toHaveStyleRule('display', 'none');
+    } finally {
+      urlParamSpy.mockRestore();
+      nativeFiltersSpy.mockRestore();
+    }
+  });
+
+  test('should hide filter panel in standalone=3 when show_filters=false', () => {
+    const urlParamSpy = (
+      jest.spyOn(urlUtils, 'getUrlParam') as jest.SpyInstance
+    ).mockImplementation((param: { name: string }) => {
+      if (param.name === 'standalone') return 3;
+      if (param.name === 'show_filters') return false;
+      return null;
+    });
+    const nativeFiltersSpy = jest
+      .spyOn(useNativeFiltersModule, 'useNativeFilters')
+      .mockReturnValue({
+        showDashboard: true,
+        missingInitialFilters: [],
+        dashboardFiltersOpen: true,
+        toggleDashboardFiltersOpen: jest.fn(),
+        nativeFiltersEnabled: true,
+      });
+    try {
+      const { getByTestId } = setup();
+      const filterPanel = getByTestId('dashboard-filters-panel');
+      expect(filterPanel).toHaveStyleRule('display', 'none');
+    } finally {
+      urlParamSpy.mockRestore();
+      nativeFiltersSpy.mockRestore();
+    }
+  });
+
+  test('should show filters but hide tab navigation in report mode with show_filters=true on tabbed dashboard', () => {
+    const urlParamSpy = (
+      jest.spyOn(urlUtils, 'getUrlParam') as jest.SpyInstance
+    ).mockImplementation((param: { name: string }) => {
+      if (param.name === 'standalone') return 3;
+      if (param.name === 'show_filters') return true;
+      return null;
+    });
+    const nativeFiltersSpy = jest
+      .spyOn(useNativeFiltersModule, 'useNativeFilters')
+      .mockReturnValue({
+        showDashboard: true,
+        missingInitialFilters: [],
+        dashboardFiltersOpen: true,
+        toggleDashboardFiltersOpen: jest.fn(),
+        nativeFiltersEnabled: true,
+      });
+    try {
+      const { getByTestId, queryByRole } = setup({
+        dashboardLayout: undoableDashboardLayoutWithTabs,
+      });
+      const filterPanel = getByTestId('dashboard-filters-panel');
+      expect(filterPanel).not.toHaveStyleRule('display', 'none');
+      expect(queryByRole('tablist')).not.toBeInTheDocument();
+    } finally {
+      urlParamSpy.mockRestore();
+      nativeFiltersSpy.mockRestore();
+    }
   });
 });
 

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -414,6 +414,8 @@ const DashboardBuilder = () => {
       : undefined;
   const standaloneMode = getUrlParam(URL_PARAMS.standalone);
   const isReport = standaloneMode === DashboardStandaloneMode.Report;
+  const showFiltersUrlParam = getUrlParam(URL_PARAMS.showFilters);
+  const hideFilterBar = isReport && showFiltersUrlParam !== true;
   const hideDashboardHeader =
     uiConfig.hideTitle ||
     standaloneMode === DashboardStandaloneMode.HideNavAndTitle ||
@@ -511,12 +513,12 @@ const DashboardBuilder = () => {
           filterBarOrientation === FilterBarOrientation.Horizontal && (
             <FilterBar
               orientation={FilterBarOrientation.Horizontal}
-              hidden={isReport}
+              hidden={hideFilterBar}
             />
           )}
       </>
     ),
-    [hideDashboardHeader, showFilterBar, filterBarOrientation, isReport],
+    [hideDashboardHeader, showFilterBar, filterBarOrientation, hideFilterBar],
   );
 
   const renderDraggableContent = useCallback(
@@ -578,7 +580,7 @@ const DashboardBuilder = () => {
       return (
         <FiltersPanel
           width={filterBarWidth}
-          hidden={isReport}
+          hidden={hideFilterBar}
           data-test="dashboard-filters-panel"
         >
           <StickyPanel ref={containerRef} width={filterBarWidth}>
@@ -603,7 +605,7 @@ const DashboardBuilder = () => {
       toggleDashboardFiltersOpen,
       filterBarHeight,
       filterBarOffset,
-      isReport,
+      hideFilterBar,
     ],
   );
 


### PR DESCRIPTION
### SUMMARY
In standalone report mode (`standalone=3`), the filter bar is unconditionally hidden via `hidden={isReport}` on both the horizontal `FilterBar` and vertical `FiltersPanel` components. This was introduced in #23543 and #23811 to hide filters for scheduled reports, but it also affects embedded dashboard users who adopted `standalone=3` to hide titles/tabs/nav while still wanting filters visible via `dashboardUIConfig.filters.visible = true` (which maps to `show_filters=true` URL param).

This fix introduces `hideFilterBar = isReport && showFiltersUrlParam !== true` so that:
- Report mode still hides filters by default (backward compatible)
- `show_filters=true` explicitly overrides the hiding
- Tab navigation remains hidden in report mode regardless of filter visibility

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - CSS `display: none` toggle, behavior verified via unit tests.

### TESTING INSTRUCTIONS
1. Load an embedded dashboard with `standalone=3&show_filters=true`
2. Verify the filter bar is visible (both horizontal and vertical orientations)
3. Load with `standalone=3` (no `show_filters`) — filter bar should still be hidden
4. Load with `standalone=3&show_filters=false` — filter bar should be hidden

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #30630
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API