### PR TITLE
fix(deps): regenerate pinned requirements for psycopg2-binary 2.9.12

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -707,7 +707,7 @@ protobuf==4.25.8
     #   proto-plus
 psutil==6.1.0
     # via apache-superset
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.12
     # via apache-superset
 py-key-value-aio==0.4.4
     # via fastmcp


### PR DESCRIPTION
### SUMMARY

Regenerates pinned requirements files via `./scripts/uv-pip-compile.sh` to update `psycopg2-binary` from `2.9.9` to `2.9.12` in `requirements/development.txt`.

The `check-python-deps` CI job was failing because the pinned version (`2.9.9`) no longer matched what `uv` resolves (`2.9.12`). See failing CI run: https://github.com/apache/superset/actions/runs/25173478956/job/73799078378

Only one line changed — the `psycopg2-binary` version bump.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — dependency pin update only.

### TESTING INSTRUCTIONS

1. Verify the `check-python-deps` CI job passes on this PR.
2. Optionally run locally:
   ```bash
   ./scripts/uv-pip-compile.sh
   git diff requirements/
   ```
   Expected: only `psycopg2-binary==2.9.9` → `psycopg2-binary==2.9.12` in `requirements/development.txt`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API