### PR TITLE
chore(codeowners): notify @sfirke on translation changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,10 @@
 **/*.geojson @villebro @rusackas
 /superset-frontend/plugins/legacy-plugin-chart-country-map/ @villebro @rusackas
 
+# Notify translation maintainers of changes to translations
+
+/superset/translations/ @sfirke
+
 # Notify PMC members of changes to extension-related files
 
 /docs/developer_portal/extensions/ @michael-s-molina @villebro @rusackas


### PR DESCRIPTION
### SUMMARY
Adds @sfirke as a code owner for `/superset/translations/` so he gets pinged on PRs touching translation files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
N/A — CODEOWNERS-only change. GitHub will validate the entry once merged.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)