### PR TITLE
fix(mcp): clear stale thread-local DB session in sync tool wrapper

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -633,16 +633,18 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             with _get_app_context_manager():
                 # Clear any stale thread-local SQLAlchemy session before user lookup.
-                # Thread pool workers reuse threads across requests; db.session is
-                # scoped by thread (not ContextVar), so a prior request's session may
-                # still be bound to a different tenant's DB engine. Removing it here
-                # ensures the next DB access creates a fresh session bound to the
-                # correct engine for the current request. The per-request context is
+                # Only needed in the request-context path (HTTP transport): thread pool
+                # workers reuse threads across requests, and db.session is scoped by
+                # thread (not ContextVar), so a prior request's session may still be
+                # bound to a different tenant's DB engine. The per-request context is
                 # correctly propagated via ContextVar — only the thread-local session
-                # binding is stale.
-                from superset.extensions import db
+                # binding is stale. In the no-request-context path,
+                # _get_app_context_manager() already pushes a fresh app context so the
+                # session is clean by construction.
+                if has_request_context():
+                    from superset.extensions import db
 
-                db.session.remove()
+                    db.session.remove()
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -637,10 +637,9 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                 # scoped by thread (not ContextVar), so a prior request's session may
                 # still be bound to a different tenant's DB engine. Removing it here
                 # ensures the next DB access creates a fresh session bound to the
-                # correct engine for the current request's workspace context.
-                # The workspace context itself (g.__CURRENT_WORKSPACE_NAME__) is
-                # correctly propagated from the request via ContextVar — only the
-                # thread-local session binding is stale.
+                # correct engine for the current request. The per-request context is
+                # correctly propagated via ContextVar — only the thread-local session
+                # binding is stale.
                 from superset.extensions import db
 
                 db.session.remove()

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -632,6 +632,18 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
         @functools.wraps(tool_func)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             with _get_app_context_manager():
+                # Clear any stale thread-local SQLAlchemy session before user lookup.
+                # Thread pool workers reuse threads across requests; db.session is
+                # scoped by thread (not ContextVar), so a prior request's session may
+                # still be bound to a different tenant's DB engine. Removing it here
+                # ensures the next DB access creates a fresh session bound to the
+                # correct engine for the current request's workspace context.
+                # The workspace context itself (g.__CURRENT_WORKSPACE_NAME__) is
+                # correctly propagated from the request via ContextVar — only the
+                # thread-local session binding is stale.
+                from superset.extensions import db
+
+                db.session.remove()
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -633,18 +633,14 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
             with _get_app_context_manager():
                 # Clear any stale thread-local SQLAlchemy session before user lookup.
-                # Only needed in the request-context path (HTTP transport): thread pool
-                # workers reuse threads across requests, and db.session is scoped by
-                # thread (not ContextVar), so a prior request's session may still be
-                # bound to a different tenant's DB engine. The per-request context is
-                # correctly propagated via ContextVar — only the thread-local session
-                # binding is stale. In the no-request-context path,
-                # _get_app_context_manager() already pushes a fresh app context so the
-                # session is clean by construction.
-                if has_request_context():
-                    from superset.extensions import db
+                # Thread pool workers reuse threads across requests; db.session is
+                # scoped by thread (not ContextVar), so a prior request's session may
+                # still be bound to a different tenant's DB engine. Removing it here
+                # ensures the next DB access creates a fresh session bound to the
+                # correct engine for the current request.
+                from superset.extensions import db
 
-                    db.session.remove()
+                db.session.remove()
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -372,6 +372,37 @@ def test_mcp_auth_hook_preserves_g_user_in_request_context(app) -> None:
     assert result == "middleware_user"
 
 
+def test_mcp_auth_hook_removes_stale_db_session_in_sync_wrapper(app) -> None:
+    """sync_wrapper calls db.session.remove() before user setup.
+
+    Thread pool workers reuse threads across requests; db.session is
+    thread-local and may be bound to a different tenant's DB engine from a
+    prior request. Removing it before user lookup ensures a fresh session is
+    created for the current request's workspace context.
+    """
+    fresh_user = _make_mock_user("fresh")
+
+    def dummy_tool():
+        """Dummy tool."""
+        return g.user.username
+
+    wrapped = mcp_auth_hook(dummy_tool)
+
+    with app.test_request_context():
+        g.user = fresh_user
+        with (
+            patch(
+                "superset.mcp_service.auth.get_user_from_request",
+                return_value=fresh_user,
+            ),
+            patch("superset.extensions.db") as mock_db,
+        ):
+            result = wrapped()
+            mock_db.session.remove.assert_called_once()
+
+    assert result == "fresh"
+
+
 # -- default_user_resolver --
 
 

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -373,12 +373,15 @@ def test_mcp_auth_hook_preserves_g_user_in_request_context(app) -> None:
 
 
 def test_mcp_auth_hook_removes_stale_db_session_in_sync_wrapper(app) -> None:
-    """sync_wrapper calls db.session.remove() before user setup.
+    """sync_wrapper calls db.session.remove() BEFORE get_user_from_request().
 
     Thread pool workers reuse threads across requests; db.session is
     thread-local and may be bound to a different tenant's DB engine from a
     prior request. Removing it before user lookup ensures a fresh session is
-    created for the current request's workspace context.
+    created for the current request.
+
+    The ordering is critical: if remove() were called after user lookup,
+    the stale session binding would already have caused a mismatch error.
     """
     fresh_user = _make_mock_user("fresh")
 
@@ -390,15 +393,18 @@ def test_mcp_auth_hook_removes_stale_db_session_in_sync_wrapper(app) -> None:
 
     with app.test_request_context():
         g.user = fresh_user
-        with (
-            patch(
+        with patch("superset.extensions.db") as mock_db:
+
+            def _assert_remove_already_called() -> MagicMock:
+                """Verify remove() was called before user resolution runs."""
+                mock_db.session.remove.assert_called_once_with()
+                return fresh_user
+
+            with patch(
                 "superset.mcp_service.auth.get_user_from_request",
-                return_value=fresh_user,
-            ),
-            patch("superset.extensions.db") as mock_db,
-        ):
-            result = wrapped()
-            mock_db.session.remove.assert_called_once()
+                side_effect=_assert_remove_already_called,
+            ):
+                result = wrapped()
 
     assert result == "fresh"
 


### PR DESCRIPTION
### SUMMARY

MCP sync tools run in a thread pool (\`anyio.to_thread.run_sync\`). SQLAlchemy's \`ScopedSession\` is scoped by **thread** (not \`ContextVar\`), so a prior request's session may still be bound to a different tenant's DB engine when a new tool call lands on the same worker thread.

The per-request context is correctly propagated from the HTTP request via \`ContextVar\` — but the thread-local session binding is stale, causing a DB session mismatch when \`load_user_with_relationships\` queries the DB during user authentication.

**Fix:** call \`db.session.remove()\` at the top of \`sync_wrapper\` before \`_setup_user_context()\`, so the next DB access creates a fresh session bound to the correct engine for the current request. \`async_wrapper\` is unaffected (runs in the event loop thread, no thread-local stale state).

The pattern mirrors the existing \`_cleanup_session_on_error()\` which already calls \`db.session.remove()\` in the retry path.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — server-side auth fix.

### TESTING INSTRUCTIONS

1. Deploy with multiple tenants and a thread-pooled MCP server.
2. Send MCP tool calls from two different tenants in rapid succession (to hit the same thread pool worker).
3. Before: DB session mismatch error on the second request during user authentication.
4. After: both requests resolve the correct user and succeed.

Unit test added: \`test_mcp_auth_hook_removes_stale_db_session_in_sync_wrapper\` — asserts \`db.session.remove()\` is called once per sync tool invocation.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API