### PR TITLE
fix(sqllab): display horizontal scrollbar in data preview modal

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryTable/styles.ts
+++ b/superset-frontend/src/SqlLab/components/QueryTable/styles.ts
@@ -44,5 +44,4 @@ export const ModalResultSetWrapper = styled.div`
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  max-height: 50vh;
 `;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #39631

Also fixed an issue where the SqlLab Data Preview modal doesn't show all results, e.g. at 98 rows instead of 100.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before

https://github.com/user-attachments/assets/926bb248-851e-4e8f-b979-88ec7e7016b2


After

https://github.com/user-attachments/assets/c0347f8b-1b6e-465c-923c-5afc91549f32




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
