### PR TITLE
chore(deps): drop stale legacy-plugin-chart-map-box lockfile entry

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -52666,25 +52666,6 @@
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
       "license": "ISC"
     },
-    "plugins/legacy-plugin-chart-map-box": {
-      "name": "@superset-ui/legacy-plugin-chart-map-box",
-      "version": "0.20.3",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@math.gl/web-mercator": "^4.1.0",
-        "prop-types": "^15.8.1",
-        "react-map-gl": "^6.1.19",
-        "supercluster": "^8.0.1"
-      },
-      "peerDependencies": {
-        "@apache-superset/core": "*",
-        "@superset-ui/chart-controls": "*",
-        "@superset-ui/core": "*",
-        "mapbox-gl": "*",
-        "react": "^17.0.2"
-      }
-    },
     "plugins/legacy-plugin-chart-paired-t-test": {
       "name": "@superset-ui/legacy-plugin-chart-paired-t-test",
       "version": "0.20.3",


### PR DESCRIPTION
### SUMMARY

`plugins/legacy-plugin-chart-map-box` was removed in #38035 (the deck.gl/MapLibre/Mapbox dual-renderer modernization), but its entry remained in `superset-frontend/package-lock.json` flagged as `"extraneous": true`. The dead entry caused `npm install` to surface several deprecation warnings via the now-orphaned transitive dependencies (notably `react-map-gl@6` → `viewport-mercator-project`, plus `@types/mapbox__point-geometry`, `inflight`, `@babel/polyfill`, and `glob@9.x`).

This PR removes the 19-line stale entry. No `package.json` files change. After this lands, a fresh `npm install` will no longer pull `react-map-gl@6.x` / `viewport-mercator-project` into `node_modules`, and the corresponding deprecation warnings stop firing.

Verified via `npm install --package-lock-only`: the lockfile is self-consistent after the deletion (no other lines change).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
rm -rf node_modules
npm install
```

The following deprecation warnings should no longer appear:
- `@types/mapbox__point-geometry@1.0.87`
- `viewport-mercator-project@7.0.4`
- `inflight@1.0.6`
- `@babel/polyfill@7.12.1`
- `glob@9.3.5`

CI should pass unchanged — no runtime dependencies of any current workspace are affected.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API