### PR TITLE
fix(mcp): exclude self-referencing filter columns from get_schema output

### DIFF
--- a/superset/mcp_service/system/tool/get_schema.py
+++ b/superset/mcp_service/system/tool/get_schema.py
@@ -56,6 +56,7 @@ from superset.mcp_service.mcp_core import ModelGetSchemaCore
 from superset.mcp_service.privacy import (
     PrivacyError,
     remove_chart_data_model_columns,
+    SELF_REFERENCING_FILTER_COLUMNS,
     user_can_view_data_model_metadata,
 )
 
@@ -77,6 +78,7 @@ def _get_chart_schema_core() -> ModelGetSchemaCore[ModelSchemaInfo]:
         search_columns=CHART_SEARCH_COLUMNS,
         default_sort="changed_on",
         default_sort_direction="desc",
+        exclude_filter_columns=set(SELF_REFERENCING_FILTER_COLUMNS),
         logger=logger,
     )
 
@@ -96,6 +98,7 @@ def _get_dataset_schema_core() -> ModelGetSchemaCore[ModelSchemaInfo]:
         search_columns=DATASET_SEARCH_COLUMNS,
         default_sort="changed_on",
         default_sort_direction="desc",
+        exclude_filter_columns=set(SELF_REFERENCING_FILTER_COLUMNS),
         logger=logger,
     )
 
@@ -115,6 +118,7 @@ def _get_dashboard_schema_core() -> ModelGetSchemaCore[ModelSchemaInfo]:
         search_columns=DASHBOARD_SEARCH_COLUMNS,
         default_sort="changed_on",
         default_sort_direction="desc",
+        exclude_filter_columns=set(SELF_REFERENCING_FILTER_COLUMNS),
         logger=logger,
     )
 

--- a/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
@@ -369,6 +369,7 @@ class TestGetSchemaToolViaClient:
             "slice_name": ["eq", "ilike"],
             "created_by_fk": ["eq"],
             "owner": ["eq", "in"],
+            "created_by_fk_or_owner": ["eq"],
         }
 
         async with Client(mcp_server) as client:
@@ -397,6 +398,7 @@ class TestGetSchemaToolViaClient:
             "table_name": ["eq", "ilike"],
             "created_by_fk": ["eq"],
             "owner": ["eq", "in"],
+            "created_by_fk_or_owner": ["eq"],
         }
 
         async with Client(mcp_server) as client:
@@ -408,6 +410,35 @@ class TestGetSchemaToolViaClient:
         info = data["schema_info"]
 
         assert "table_name" in info["filter_columns"]
+        for field in ("created_by_fk", "owner", "created_by_fk_or_owner"):
+            assert field not in info["filter_columns"]
+
+    @patch("superset.daos.dashboard.DashboardDAO.get_filterable_columns_and_operators")
+    @pytest.mark.asyncio
+    async def test_get_schema_dashboard_omits_self_referencing_filter_columns(
+        self, mock_filters, mcp_server
+    ):
+        """Test dashboard schema omits self-referencing filter columns.
+
+        Even if the DAO returns created_by_fk or owner, they must be excluded
+        so LLMs cannot discover and use them to enumerate user IDs.
+        """
+        mock_filters.return_value = {
+            "dashboard_title": ["eq", "ilike"],
+            "created_by_fk": ["eq"],
+            "owner": ["eq", "in"],
+            "created_by_fk_or_owner": ["eq"],
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_schema", {"request": {"model_type": "dashboard"}}
+            )
+
+        data = json.loads(result.content[0].text)
+        info = data["schema_info"]
+
+        assert "dashboard_title" in info["filter_columns"]
         for field in ("created_by_fk", "owner", "created_by_fk_or_owner"):
             assert field not in info["filter_columns"]
 

--- a/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_get_schema.py
@@ -355,6 +355,62 @@ class TestGetSchemaToolViaClient:
             assert field not in info["filter_columns"]
             assert field not in info["sortable_columns"]
 
+    @patch("superset.daos.chart.ChartDAO.get_filterable_columns_and_operators")
+    @pytest.mark.asyncio
+    async def test_get_schema_chart_omits_self_referencing_filter_columns(
+        self, mock_filters, mcp_server
+    ):
+        """Test that chart schema does not advertise self-referencing filter columns.
+
+        Even if the DAO returns created_by_fk or owner, they must be excluded so
+        LLMs cannot discover and use them to enumerate user IDs.
+        """
+        mock_filters.return_value = {
+            "slice_name": ["eq", "ilike"],
+            "created_by_fk": ["eq"],
+            "owner": ["eq", "in"],
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_schema", {"request": {"model_type": "chart"}}
+            )
+
+        data = json.loads(result.content[0].text)
+        info = data["schema_info"]
+
+        assert "slice_name" in info["filter_columns"]
+        for field in ("created_by_fk", "owner", "created_by_fk_or_owner"):
+            assert field not in info["filter_columns"]
+
+    @patch("superset.daos.dataset.DatasetDAO.get_filterable_columns_and_operators")
+    @pytest.mark.asyncio
+    async def test_get_schema_dataset_omits_self_referencing_filter_columns(
+        self, mock_filters, mcp_server
+    ):
+        """Test that dataset schema does not advertise self-referencing filter columns.
+
+        Even if the DAO returns created_by_fk or owner, they must be excluded so
+        LLMs cannot discover and use them to enumerate user IDs.
+        """
+        mock_filters.return_value = {
+            "table_name": ["eq", "ilike"],
+            "created_by_fk": ["eq"],
+            "owner": ["eq", "in"],
+        }
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_schema", {"request": {"model_type": "dataset"}}
+            )
+
+        data = json.loads(result.content[0].text)
+        info = data["schema_info"]
+
+        assert "table_name" in info["filter_columns"]
+        for field in ("created_by_fk", "owner", "created_by_fk_or_owner"):
+            assert field not in info["filter_columns"]
+
 
 class TestGetSchemaEdgeCases:
     """Test edge cases for get_schema tool."""


### PR DESCRIPTION
### SUMMARY

Regression from #39638: `get_schema(model_type='chart|dataset|dashboard')` still advertised `created_by_fk` and `owner` in `filter_columns` because the chart, dataset, and dashboard `ModelGetSchemaCore` instances had no `exclude_filter_columns` set.

The LLM workflow that triggered the bug:
1. LLM calls `get_schema(model_type='chart')` to discover available filter columns
2. Response includes `created_by_fk` in `filter_columns`
3. LLM calls `get_instance_info` to get `current_user.id`
4. LLM calls `list_charts(request={"filters": [{"col": "created_by_fk", "opr": "eq", "value": 13}]})`

This bypasses the `created_by_me`/`owned_by_me` server-side injection added in #39638, re-exposing user IDs in tool calls.

**Fix**: pass `SELF_REFERENCING_FILTER_COLUMNS` as `exclude_filter_columns` to the chart, dataset, and dashboard `ModelGetSchemaCore` instances. The database schema core already had its user-directory columns excluded via `DATABASE_EXCLUDE_COLUMNS`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/mcp_service/system/tool/test_get_schema.py -q
```

Manually verify `get_schema` no longer advertises `created_by_fk` or `owner`:
```python
result = await client.call_tool("get_schema", {"request": {"model_type": "chart"}})
# filter_columns should NOT contain "created_by_fk" or "owner"
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [x] Removes existing feature or API

Fixes regression introduced by #39638.