### PR TITLE
fix(mcp): point get_dataset_info url to explore view instead of legacy tablemodelview edit

### DIFF
--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -135,7 +135,7 @@ class DatasetInfo(BaseModel):
     database_id: int | None = Field(None, description="Database ID")
     uuid: str | None = Field(None, description="Dataset UUID")
     schema_perm: str | None = Field(None, description="Schema permission string")
-    url: str | None = Field(None, description="Dataset URL")
+    url: str | None = Field(None, description="Explore view URL for this dataset")
     sql: str | None = Field(None, description="SQL for virtual datasets")
     main_dttm_col: str | None = Field(None, description="Main datetime column")
     offset: int | None = Field(None, description="Offset")
@@ -707,8 +707,8 @@ def serialize_dataset_object(dataset: Any) -> DatasetInfo | None:
             else None,
             schema_perm=getattr(dataset, "schema_perm", None),
             url=(
-                f"{get_superset_base_url()}/tablemodelview/edit/"
-                f"{getattr(dataset, 'id', None)}"
+                f"{get_superset_base_url()}/explore/"
+                f"?datasource_type=table&datasource_id={getattr(dataset, 'id', None)}"
                 if getattr(dataset, "id", None)
                 else None
             ),

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -970,9 +970,13 @@ async def test_list_datasets_simple_api_error(mock_list, mcp_server):
         assert "API request failed" in str(excinfo.value)
 
 
+@patch(
+    "superset.mcp_service.utils.url_utils.get_superset_base_url",
+    return_value="http://test-superset",
+)
 @patch("superset.daos.dataset.DatasetDAO.find_by_id")
 @pytest.mark.asyncio
-async def test_get_dataset_info_success(mock_info, mcp_server):
+async def test_get_dataset_info_success(mock_info, mock_base_url, mcp_server):
     dataset = MagicMock()
     dataset.id = 1
     dataset.table_name = "Test DatasetInfo"
@@ -1030,6 +1034,10 @@ async def test_get_dataset_info_success(mock_info, mcp_server):
         assert data["id"] == 1
         assert data["table_name"] == "Test DatasetInfo"
         assert data["database_name"] == "examples"
+        assert (
+            data["url"]
+            == "http://test-superset/explore/?datasource_type=table&datasource_id=1"
+        )
         # Check that columns and metrics are included
         assert len(data["columns"]) == 1
         assert len(data["metrics"]) == 1

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -84,7 +84,7 @@ def create_mock_dataset(
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = f"[{database_name}].[{schema}]"
-    dataset.url = f"/tablemodelview/edit/{dataset_id}"
+    dataset.url = f"/explore/?datasource_type=table&datasource_id={dataset_id}"
     dataset.database = MagicMock()
     dataset.database.database_name = database_name
     dataset.sql = None
@@ -228,7 +228,7 @@ async def test_list_datasets_basic(mock_list, mcp_server):
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/1"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=1"
     dataset.database = MagicMock()
     dataset.database.database_name = "examples"
     dataset.sql = None
@@ -336,7 +336,7 @@ async def test_list_datasets_custom_uuid_columns(mock_list, mcp_server):
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[public]"
-    dataset.url = "/tablemodelview/edit/1"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=1"
     dataset.database = MagicMock()
     dataset.database.database_name = "test_db"
     dataset.sql = None
@@ -416,7 +416,7 @@ async def test_list_datasets_with_filters(mock_list, mcp_server):
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/2"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=2"
     dataset.database = MagicMock()
     dataset.database.database_name = "examples"
     dataset.sql = None
@@ -519,7 +519,7 @@ async def test_list_datasets_with_string_filters(mock_list, mcp_server):
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/3"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=3"
     dataset.database = MagicMock()
     dataset.database.database_name = "examples"
     dataset.sql = None
@@ -782,7 +782,7 @@ async def test_list_datasets_simple_basic(mock_list, mcp_server):
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/1"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=1"
     dataset.database = MagicMock()
     dataset.database.database_name = "examples"
     dataset.sql = None
@@ -879,7 +879,7 @@ async def test_list_datasets_simple_with_filters(mock_list, mcp_server):
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/2"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=2"
     dataset.database = MagicMock()
     dataset.database.database_name = "examples"
     dataset.sql = None
@@ -991,7 +991,7 @@ async def test_get_dataset_info_success(mock_info, mcp_server):
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/1"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=1"
     dataset.database = MagicMock()
     dataset.database.database_name = "examples"
     dataset.sql = None
@@ -1130,7 +1130,7 @@ async def test_get_dataset_info_includes_columns_and_metrics(mock_info, mcp_serv
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/10"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=10"
     dataset.sql = None
     dataset.main_dttm_col = None
     dataset.offset = 0
@@ -1222,7 +1222,7 @@ async def test_list_datasets_includes_columns_and_metrics(mock_list, mcp_server)
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/11"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=11"
     dataset.sql = None
     dataset.main_dttm_col = None
     dataset.offset = 0
@@ -1298,7 +1298,7 @@ async def test_get_dataset_info_by_uuid(mock_find_object, mcp_server):
     dataset.is_virtual = False
     dataset.database_id = 1
     dataset.schema_perm = "[examples].[main]"
-    dataset.url = "/tablemodelview/edit/1"
+    dataset.url = "/explore/?datasource_type=table&datasource_id=1"
     dataset.database = MagicMock()
     dataset.database.database_name = "examples"
     dataset.sql = None


### PR DESCRIPTION
### SUMMARY

The `get_dataset_info` MCP tool was returning a `url` field pointing to `/tablemodelview/edit/{id}` — the legacy Flask-AppBuilder admin edit endpoint. This is not a useful user-facing URL.

The URL now points to the Explore view: `/explore/?datasource_type=table&datasource_id={id}`, which is the standard user-facing entry point for interacting with a dataset. This matches the pattern used by the chart info tool (`/explore/?slice_id={id}`) and the explore link generation utilities in the MCP service.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — URL string change only.

### TESTING INSTRUCTIONS

1. Start Superset with the MCP service enabled.
2. Call `get_dataset_info` with a valid dataset ID via the MCP client.
3. Verify the returned `url` field contains `/explore/?datasource_type=table&datasource_id={id}` rather than `/tablemodelview/edit/{id}`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API