### PR TITLE
feat(filters): reorder cross-filters to appear after native filters for improved UX

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -77,6 +77,7 @@ import { useChartsVerboseMaps } from '../utils';
 import FilterControl from './FilterControl';
 import FilterDivider from './FilterDivider';
 
+
 function addDataMaskToCustomization(
   customization: ChartCustomization,
   dataMaskSelected: DataMaskStateWithId,
@@ -85,6 +86,7 @@ function addDataMaskToCustomization(
     dataMaskSelected[customization.id] ?? getInitialDataMask(customization.id);
   return { ...customization, dataMask };
 }
+
 
 type FilterControlsProps = {
   dataMaskSelected: DataMaskStateWithId;
@@ -99,9 +101,11 @@ type FilterControlsProps = {
   hideHeader?: boolean;
 };
 
+
 const SectionContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.sizeUnit * 3}px;
 `;
+
 
 const SectionHeader = styled.div`
   display: flex;
@@ -111,6 +115,7 @@ const SectionHeader = styled.div`
   cursor: pointer;
   user-select: none;
 
+
   &:hover {
     background: ${({ theme }) => theme.colorBgTextHover};
     margin: 0 -${({ theme }) => theme.sizeUnit * 2}px;
@@ -119,11 +124,14 @@ const SectionHeader = styled.div`
   }
 `;
 
+
 const { Title } = Typography;
+
 
 const SectionContent = styled.div`
   padding: ${({ theme }) => theme.sizeUnit * 2}px 0;
 `;
+
 
 const StyledDivider = styled.div`
   height: 1px;
@@ -131,17 +139,20 @@ const StyledDivider = styled.div`
   margin: ${({ theme }) => theme.sizeUnit * 2}px 0;
 `;
 
-const StyledIcon = styled(Icons.UpOutlined)<{ isOpen: boolean }>`
+
+const StyledIcon = styled(Icons.UpOutlined) <{ isOpen: boolean }>`
   transform: ${({ isOpen }) => (isOpen ? 'rotate(0deg)' : 'rotate(180deg)')};
   transition: transform 0.2s ease;
   color: ${({ theme }) => theme.colorTextSecondary};
 `;
+
 
 const ChartCustomizationContent = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${({ theme }) => theme.sizeUnit * 2}px;
 `;
+
 
 const FilterControls: FC<FilterControlsProps> = ({
   dataMaskSelected,
@@ -158,10 +169,13 @@ const FilterControls: FC<FilterControlsProps> = ({
     ({ dashboardInfo }) => dashboardInfo.filterBarOrientation,
   );
 
+
   const { outlinedFilterId, lastUpdated } = useFilterOutlined();
+
 
   const [overflowedIds, setOverflowedIds] = useState<string[]>([]);
   const popoverRef = useRef<DropdownContainerRef>(null);
+
 
   const dataMask = useSelector<RootState, DataMaskStateWithId>(
     state => state.dataMask,
@@ -169,6 +183,7 @@ const FilterControls: FC<FilterControlsProps> = ({
   const chartIds = useChartIds();
   const chartLayoutItems = useChartLayoutItems();
   const verboseMaps = useChartsVerboseMaps();
+
 
   const selectedCrossFilters = useMemo(
     () =>
@@ -194,38 +209,47 @@ const FilterControls: FC<FilterControlsProps> = ({
     [filtersWithValues.length],
   );
 
+
   const filterIds = new Set(filtersWithValues.map(item => item.id));
+
 
   const [filtersInScope, filtersOutOfScope] =
     useSelectFiltersInScope(filtersWithValues);
+
 
   const filteredChartCustomizationValues = useMemo(
     () => chartCustomizationValues.filter(item => !item.removed),
     [chartCustomizationValues],
   );
 
+
   const [customizationsInScope, customizationsOutOfScope] =
     useSelectCustomizationsInScope(filteredChartCustomizationValues);
+
 
   const hasRequiredFirst = useMemo(
     () => filtersWithValues.some(filter => filter.requiredFirst),
     [filtersWithValues],
   );
 
+
   const dashboardHasTabs = useDashboardHasTabs();
   const showCollapsePanel = dashboardHasTabs && filtersWithValues.length > 0;
   const showCustomizationCollapsePanel =
     dashboardHasTabs && filteredChartCustomizationValues.length > 0;
+
 
   const [sectionsOpen, setSectionsOpen] = useState({
     filters: true,
     chartCustomization: true,
   });
 
+
   const showFiltersOutOfScope =
     showCollapsePanel &&
     (hideHeader || sectionsOpen.filters) &&
     filtersOutOfScope.length > 0;
+
 
   const toggleSection = useCallback((section: keyof typeof sectionsOpen) => {
     setSectionsOpen(prev => ({
@@ -234,10 +258,12 @@ const FilterControls: FC<FilterControlsProps> = ({
     }));
   }, []);
 
+
   const handleChartCustomizationChange = useCallback(
     (customizationItem: ChartCustomization, dataMask: DataMask) => {
       const columnValue = dataMask.ownState?.column;
       const existingTarget = customizationItem.targets?.[0] || {};
+
 
       dispatch(
         setPendingChartCustomization({
@@ -256,10 +282,12 @@ const FilterControls: FC<FilterControlsProps> = ({
         }),
       );
 
+
       onPendingCustomizationDataMaskChange(customizationItem.id, dataMask);
     },
     [dispatch, onPendingCustomizationDataMaskChange],
   );
+
 
   const renderer = useCallback(
     ({ id }: Filter | Divider, index: number | undefined) => {
@@ -276,6 +304,7 @@ const FilterControls: FC<FilterControlsProps> = ({
     },
     [filtersWithValues, portalNodes],
   );
+
 
   const customizationRenderer = useCallback(
     (item: ChartCustomization | ChartCustomizationDivider, index: number) => {
@@ -308,6 +337,7 @@ const FilterControls: FC<FilterControlsProps> = ({
     },
     [dataMaskSelected, handleChartCustomizationChange],
   );
+
 
   const renderVerticalContent = useCallback(
     () => (
@@ -348,6 +378,7 @@ const FilterControls: FC<FilterControlsProps> = ({
           </SectionContainer>
         )}
 
+
         {showFiltersOutOfScope && (
           <FiltersOutOfScopeCollapsible
             filtersOutOfScope={filtersOutOfScope}
@@ -355,6 +386,7 @@ const FilterControls: FC<FilterControlsProps> = ({
             forceRender={hasRequiredFirst}
           />
         )}
+
 
         {customizationsInScope.length > 0 && (
           <SectionContainer>
@@ -403,6 +435,7 @@ const FilterControls: FC<FilterControlsProps> = ({
           </SectionContainer>
         )}
 
+
         {showCustomizationCollapsePanel &&
           (hideHeader || sectionsOpen.chartCustomization) && (
             <CustomizationsOutOfScopeCollapsible
@@ -432,10 +465,12 @@ const FilterControls: FC<FilterControlsProps> = ({
     ],
   );
 
+
   const overflowedFiltersInScope = useMemo(
     () => filtersInScope.filter(({ id }) => overflowedIds?.includes(id)),
     [filtersInScope, overflowedIds],
   );
+
 
   const overflowedCrossFilters = useMemo(
     () =>
@@ -445,12 +480,14 @@ const FilterControls: FC<FilterControlsProps> = ({
     [overflowedIds, selectedCrossFilters],
   );
 
+
   const activeOverflowedFiltersInScope = useMemo(() => {
     const activeOverflowedFilters = overflowedFiltersInScope.filter(filter =>
       isNativeFilterWithDataMask(filter),
     );
     return [...activeOverflowedFilters, ...overflowedCrossFilters];
   }, [overflowedCrossFilters, overflowedFiltersInScope]);
+
 
   const rendererCrossFilter = useCallback(
     (crossFilter, orientation, last) => (
@@ -460,12 +497,13 @@ const FilterControls: FC<FilterControlsProps> = ({
         last={
           filtersInScope.length > 0 &&
           `${last.name}${last.emitterId}` ===
-            `${crossFilter.name}${crossFilter.emitterId}`
+          `${crossFilter.name}${crossFilter.emitterId}`
         }
       />
     ),
     [filtersInScope.length],
   );
+
 
   const items = useMemo(() => {
     const crossFilters = selectedCrossFilters.map(c => ({
@@ -513,6 +551,7 @@ const FilterControls: FC<FilterControlsProps> = ({
       });
     }
 
+
     const chartCustomizations = customizationsInScope.map(item => {
       if (isChartCustomizationDivider(item)) {
         return {
@@ -556,12 +595,8 @@ const FilterControls: FC<FilterControlsProps> = ({
       };
     });
 
-    return [
-      ...chartCustomizations,
-      ...dividerItems,
-      ...crossFilters,
-      ...nativeFiltersInScope,
-    ];
+
+    return [...nativeFiltersInScope, ...dividerItems, ...chartCustomizations];
   }, [
     filtersInScope,
     renderer,
@@ -574,48 +609,49 @@ const FilterControls: FC<FilterControlsProps> = ({
     chartCustomizationValues.length,
   ]);
 
+
   const renderHorizontalContent = useCallback(
     () => (
-      <div
-        css={(theme: SupersetTheme) => css`
+      <>
+        <div
+          css={(theme: SupersetTheme) => css`
           padding: 0 ${theme.sizeUnit * 4}px;
           min-width: 0;
           flex: 1;
         `}
-      >
-        <DropdownContainer
-          items={items}
-          dropdownTriggerIcon={
-            <Icons.FilterOutlined
-              css={css`
+        >
+          <DropdownContainer
+            items={items}
+            dropdownTriggerIcon={
+              <Icons.FilterOutlined
+                css={css`
                 && {
                   margin-right: -4px;
                   display: flex;
                 }
               `}
-            />
-          }
-          dropdownTriggerText={t('More filters')}
-          dropdownTriggerCount={activeOverflowedFiltersInScope.length}
-          dropdownTriggerTooltip={
-            activeOverflowedFiltersInScope.length === 0
-              ? t('No applied filters')
-              : t(
+              />
+            }
+            dropdownTriggerText={t('More filters')}
+            dropdownTriggerCount={activeOverflowedFiltersInScope.length}
+            dropdownTriggerTooltip={
+              activeOverflowedFiltersInScope.length === 0
+                ? t('No applied filters')
+                : t(
                   'Applied filters: %s',
                   activeOverflowedFiltersInScope
                     .map(filter => filter.name)
                     .join(', '),
                 )
-          }
-          dropdownContent={
-            overflowedFiltersInScope.length ||
-            overflowedCrossFilters.length ||
-            (filtersOutOfScope.length && showCollapsePanel) ||
-            (customizationsOutOfScope.length && showCustomizationCollapsePanel)
-              ? () => (
+            }
+            dropdownContent={
+              overflowedFiltersInScope.length ||
+                (filtersOutOfScope.length && showCollapsePanel) ||
+                (customizationsOutOfScope.length && showCustomizationCollapsePanel)
+                ? () => (
                   <>
                     <FiltersDropdownContent
-                      overflowedCrossFilters={overflowedCrossFilters}
+                      overflowedCrossFilters={[]}
                       filtersInScope={overflowedFiltersInScope}
                       filtersOutOfScope={filtersOutOfScope}
                       renderer={renderer}
@@ -632,23 +668,59 @@ const FilterControls: FC<FilterControlsProps> = ({
                     )}
                   </>
                 )
-              : undefined
-          }
-          forceRender={hasRequiredFirst}
-          ref={popoverRef}
-          onOverflowingStateChange={({ overflowed: nextOverflowedIds }) => {
-            if (
-              nextOverflowedIds.length !== overflowedIds.length ||
-              overflowedIds.reduce(
-                (a, b, i) => a || b !== nextOverflowedIds[i],
-                false,
-              )
-            ) {
-              setOverflowedIds(nextOverflowedIds);
+                : undefined
             }
-          }}
-        />
-      </div>
+            forceRender={hasRequiredFirst}
+            ref={popoverRef}
+            onOverflowingStateChange={({ overflowed: nextOverflowedIds }) => {
+              if (
+                nextOverflowedIds.length !== overflowedIds.length ||
+                overflowedIds.reduce(
+                  (a, b, i) => a || b !== nextOverflowedIds[i],
+                  false,
+                )
+              ) {
+                setOverflowedIds(nextOverflowedIds);
+              }
+            }}
+          />
+        </div>
+        {selectedCrossFilters.length > 0 && (
+          <div
+            css={(theme: SupersetTheme) => css`
+            padding: 0 ${theme.sizeUnit}px;
+            flex-shrink: 0;
+          `}
+          >
+            <DropdownContainer
+              items={[]}
+              dropdownTriggerIcon={
+                <Icons.FilterOutlined
+                  css={css`
+                  && {
+                    margin-right: -4px;
+                    display: flex;
+                  }
+                `}
+                />
+              }
+              dropdownTriggerText={t('Cross filters')}
+              dropdownTriggerCount={selectedCrossFilters.length}
+              dropdownContent={() => (
+                <FiltersDropdownContent
+                  overflowedCrossFilters={selectedCrossFilters}
+                  filtersInScope={[]}
+                  filtersOutOfScope={[]}
+                  renderer={() => null}
+                  rendererCrossFilter={rendererCrossFilter}
+                  showCollapsePanel={false}
+                  forceRenderOutOfScope={false}
+                />
+              )}
+            />
+          </div>
+        )}
+      </>
     ),
     [
       items,
@@ -667,11 +739,13 @@ const FilterControls: FC<FilterControlsProps> = ({
     ],
   );
 
+
   const overflowedByIndex = useMemo(() => {
     const filtersOutOfScopeIds = new Set(filtersOutOfScope.map(({ id }) => id));
     const overflowedFiltersInScopeIds = new Set(
       overflowedFiltersInScope.map(({ id }) => id),
     );
+
 
     return filtersWithValues.map(filter => {
       // Out-of-scope filters in vertical mode are in a Collapse panel, not overflowed
@@ -687,11 +761,13 @@ const FilterControls: FC<FilterControlsProps> = ({
     filterBarOrientation,
   ]);
 
+
   useEffect(() => {
     if (outlinedFilterId && overflowedIds.includes(outlinedFilterId)) {
       popoverRef?.current?.open();
     }
   }, [outlinedFilterId, lastUpdated, popoverRef, overflowedIds]);
+
 
   return (
     <>
@@ -713,5 +789,6 @@ const FilterControls: FC<FilterControlsProps> = ({
     </>
   );
 };
+
 
 export default memo(FilterControls);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+
 /* eslint-disable no-param-reassign */
 import { throttle } from 'lodash';
 import {
@@ -46,14 +47,17 @@ import FilterControls from './FilterControls/FilterControls';
 import CrossFiltersVertical from './CrossFilters/Vertical';
 import crossFiltersSelector from './CrossFilters/selectors';
 
+
 enum SectionType {
   Filters = 'filters',
   ChartCustomization = 'chartCustomization',
   CrossFilters = 'crossFilters',
 }
 
+
 const BarWrapper = styled.div<{ width: number }>`
   width: ${({ theme }) => theme.sizeUnit * 8}px;
+
 
   & .ant-tabs-top > .ant-tabs-nav {
     margin: 0;
@@ -62,6 +66,7 @@ const BarWrapper = styled.div<{ width: number }>`
     width: ${({ width }) => width}px; // arbitrary...
   }
 `;
+
 
 const Bar = styled.div<{ width: number }>`
   ${({ theme, width }) => `
@@ -87,6 +92,7 @@ const Bar = styled.div<{ width: number }>`
   `}
 `;
 
+
 const CollapsedBar = styled.div<{ offset: number }>`
   ${({ theme, offset }) => `
     position: absolute;
@@ -109,9 +115,11 @@ const CollapsedBar = styled.div<{ offset: number }>`
   `}
 `;
 
+
 const FilterBarEmptyStateContainer = styled.div`
   margin-top: ${({ theme }) => theme.sizeUnit * 8}px;
 `;
+
 
 const FilterControlsWrapper = styled.div`
   ${({ theme }) => `
@@ -120,10 +128,17 @@ const FilterControlsWrapper = styled.div`
     gap: ${theme.sizeUnit * 2}px;
     padding: ${theme.sizeUnit * 4}px;
     padding-top: 0; /* Works with other changes in PR https://github.com/apache/superset/pull/38646 to reduces space between filter header and 1st filter */
+  `}
+`;
+
+
+const ScrollableContent = styled.div`
+  ${({ theme }) => `
     // 108px padding to make room for buttons with position: absolute
     padding-bottom: ${theme.sizeUnit * 27}px;
   `}
 `;
+
 
 export const FilterBarScrollContext = createContext(false);
 const VerticalFilterBar: FC<VerticalBarProps> = ({
@@ -147,10 +162,12 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
   const [isScrolling, setIsScrolling] = useState(false);
   const timeout = useRef<any>();
 
+
   const openFiltersBar = useCallback(
     () => toggleFiltersBar(true),
     [toggleFiltersBar],
   );
+
 
   const onScroll = useMemo(
     () =>
@@ -164,6 +181,7 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
     [],
   );
 
+
   useEffect(() => {
     document.onscroll = onScroll;
     return () => {
@@ -171,10 +189,12 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
     };
   }, [onScroll]);
 
+
   const tabPaneStyle = useMemo(
     () => ({ overflow: 'auto', height, overscrollBehavior: 'contain' }),
     [height],
   );
+
 
   const dataMask = useSelector<RootState, DataMaskStateWithId>(
     state => state.dataMask,
@@ -189,21 +209,26 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
     verboseMaps,
   });
 
+
   // Determine available section types
   const availableSectionTypes = useMemo(() => {
     const types: SectionType[] = [];
+
 
     if (filterValues.length > 0) {
       types.push(SectionType.Filters);
     }
 
+
     if (chartCustomizationValues.length > 0) {
       types.push(SectionType.ChartCustomization);
     }
 
+
     if (selectedCrossFilters.length > 0) {
       types.push(SectionType.CrossFilters);
     }
+
 
     return types;
   }, [
@@ -212,11 +237,14 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
     selectedCrossFilters.length,
   ]);
 
+
   const hasOnlyOneSectionType = availableSectionTypes.length === 1;
+
 
   const filterControls = useMemo(() => {
     const hasFiltersOrCustomizations =
       filterValues.length > 0 || chartCustomizationValues.length > 0;
+
 
     return hasFiltersOrCustomizations ? (
       <FilterControlsWrapper>
@@ -254,6 +282,7 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
     chartCustomizationValues,
     hasOnlyOneSectionType,
   ]);
+
 
   return (
     <FilterBarScrollContext.Provider value={isScrolling}>
@@ -300,10 +329,10 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
             </div>
           ) : (
             <div css={tabPaneStyle} onScroll={onScroll}>
-              <>
-                <CrossFiltersVertical hideHeader={hasOnlyOneSectionType} />
+              <ScrollableContent>
                 {filterControls}
-              </>
+                <CrossFiltersVertical hideHeader={hasOnlyOneSectionType} />
+              </ScrollableContent>
             </div>
           )}
           {actions}


### PR DESCRIPTION
Summary:
This PR reorganizes the filter bar layout to prioritize handpicked native filters over dynamically generated cross-filters, improving predictability and user experience for non-technical users.

The Problem:
Currently, when a cross-filter is activated, it renders before the native filters in the horizontal filter bar. This pushes the dashboard creator's curated native filters out of immediate view, which frequently causes confusion for business users navigating the dashboard. Similarly, in the vertical filter bar, cross-filters are placed above native filters, shifting the position of the primary filters.

The Solution:
This PR adjusts the rendering order of the filter components:

Horizontal Filter Bar: Cross-filters are now placed after the native filters in a separate cross filter dropdown. This prevents the handpicked filters from being pushed out of the visible viewport.

Vertical Filter Bar: Cross-filters are moved below the native filters, maintaining a consistent, anchored position for the primary filters.

Impact:
By cleanly separating these filter types and keeping native filters anchored, the interface remains predictable. Dashboard consumers no longer lose track of their primary filters when interacting with cross-filtering elements.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="2822" height="479" alt="superset_filters" src="https://github.com/user-attachments/assets/134acba3-154f-472e-9370-cc906235f822" />



### ADDITIONAL INFORMATION
- [x] This introduces slight reorganization of filters in filter bar
