### PR TITLE
fix(embedded): prevent duplicate React root on rehandshake

### DIFF
--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -152,7 +152,6 @@ if (!window.parent || window.parent === window) {
 let displayedUnauthorizedToast = false;
 let root: Root | null = null;
 let started = false;
-let startInFlight = false;
 
 /**
  * If there is a problem with the guest token, we will start getting
@@ -178,8 +177,8 @@ function guestUnauthorizedHandler() {
 }
 
 function start() {
-  if (started || startInFlight) return undefined;
-  startInFlight = true;
+  if (started) return undefined;
+  started = true;
   const getMeWithRole = makeApi<void, { result: UserWithPermissionsAndRoles }>({
     method: 'GET',
     endpoint: '/api/v1/me/roles/',
@@ -198,19 +197,17 @@ function start() {
         root = createRoot(appMountPoint);
       }
       root.render(<EmbeddedApp />);
-      started = true;
-      startInFlight = false;
     },
     err => {
-      // something is most likely wrong with the guest token; leave started
-      // false so a rehandshake with a valid token can retry.
+      // something is most likely wrong with the guest token; reset the guard
+      // so a rehandshake with a valid token can retry.
       logging.error(err);
       showFailureMessage(
         t(
           'Something went wrong with embedded authentication. Check the dev console for details.',
         ),
       );
-      startInFlight = false;
+      started = false;
     },
   );
 }

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -152,6 +152,7 @@ if (!window.parent || window.parent === window) {
 let displayedUnauthorizedToast = false;
 let root: Root | null = null;
 let started = false;
+let startInFlight = false;
 
 /**
  * If there is a problem with the guest token, we will start getting
@@ -177,6 +178,8 @@ function guestUnauthorizedHandler() {
 }
 
 function start() {
+  if (started || startInFlight) return undefined;
+  startInFlight = true;
   const getMeWithRole = makeApi<void, { result: UserWithPermissionsAndRoles }>({
     method: 'GET',
     endpoint: '/api/v1/me/roles/',
@@ -195,15 +198,19 @@ function start() {
         root = createRoot(appMountPoint);
       }
       root.render(<EmbeddedApp />);
+      started = true;
+      startInFlight = false;
     },
     err => {
-      // something is most likely wrong with the guest token
+      // something is most likely wrong with the guest token; leave started
+      // false so a rehandshake with a valid token can retry.
       logging.error(err);
       showFailureMessage(
         t(
           'Something went wrong with embedded authentication. Check the dev console for details.',
         ),
       );
+      startInFlight = false;
     },
   );
 }
@@ -252,10 +259,7 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
       'guestToken',
       ({ guestToken }: { guestToken: string }) => {
         setupGuestClient(guestToken);
-        if (!started) {
-          start();
-          started = true;
-        }
+        start();
       },
     );
 

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -19,7 +19,7 @@
 import 'src/public-path';
 
 import { lazy, Suspense } from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Global } from '@emotion/react';
 import { t } from '@apache-superset/core/translation';
@@ -150,6 +150,8 @@ if (!window.parent || window.parent === window) {
 // }
 
 let displayedUnauthorizedToast = false;
+let root: Root | null = null;
+let started = false;
 
 /**
  * If there is a problem with the guest token, we will start getting
@@ -189,7 +191,10 @@ function start() {
         type: USER_LOADED,
         user: result,
       });
-      createRoot(appMountPoint).render(<EmbeddedApp />);
+      if (!root) {
+        root = createRoot(appMountPoint);
+      }
+      root.render(<EmbeddedApp />);
     },
     err => {
       // something is most likely wrong with the guest token
@@ -242,8 +247,6 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
       name: 'superset',
       debug: debugMode,
     });
-
-    let started = false;
 
     Switchboard.defineMethod(
       'guestToken',
@@ -322,7 +325,7 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
   }
 });
 
-// Clean up theme controller on page unload
+// Clean up theme controller and unmount React root on page unload
 window.addEventListener('beforeunload', () => {
   try {
     const controller = getThemeController();
@@ -332,6 +335,10 @@ window.addEventListener('beforeunload', () => {
     }
   } catch (error) {
     logging.warn('Failed to destroy theme controller:', error);
+  }
+  if (root) {
+    root.unmount();
+    root = null;
   }
 });
 


### PR DESCRIPTION
### SUMMARY

Follow-up to #38563. The `started` flag and the inline `createRoot(appMountPoint).render(...)` call both lived inside the message handler closure, so each `'port transfer'` MessageEvent reset `started=false` and could call `createRoot` a second time on the same DOM node. React 18 logs *"You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before"* and behavior is undefined.

Hoist `started` and a lazily-created `root` to module scope, render via the existing root on rehandshake, and unmount it in the existing `beforeunload` handler. The root is created lazily so the no-iframe failure path can still write to `appMountPoint.innerHTML` without conflicting with React.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no UI change; defensive fix for a console warning + undefined behavior on rehandshake.

### TESTING INSTRUCTIONS

1. Embed a Superset dashboard in an iframe, set up Switchboard.
2. Trigger a second `'port transfer'` handshake from the parent (e.g. recreate the iframe channel).
3. Confirm no `createRoot()` warning in console; the embedded app continues to render correctly.

### ADDITIONAL INFORMATION

- Has associated issue: No
- Required feature flags: None
- Changes UI: No — defensive fix in module bootstrap
- Includes DB Migration: No
- Introduces new feature or API: No
- Removes existing feature or API: No