### PR TITLE
fix(CollectionControl): assign stable ids to keyless items

### DIFF
--- a/superset-frontend/src/explore/components/controls/CollectionControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/CollectionControl/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { IconTooltip, List } from '@superset-ui/core/components';
 import { nanoid } from 'nanoid';
 import { t } from '@apache-superset/core/translation';
@@ -185,8 +185,22 @@ function CollectionControl({
     }),
   );
 
+  // Two items can collide when keyAccessor returns falsy and the index
+  // fallback is used — breaking dnd-kit reordering and React reconciliation.
+  // Assign a stable nanoid per item ref when no key is available.
+  const generatedIdsRef = useRef<WeakMap<CollectionItem, string>>(new WeakMap());
   const itemIds = useMemo(
-    () => value.map((item, i) => keyAccessor(item) || String(i)),
+    () =>
+      value.map(item => {
+        const accessed = keyAccessor(item);
+        if (accessed) return accessed;
+        let id = generatedIdsRef.current.get(item);
+        if (!id) {
+          id = nanoid(11);
+          generatedIdsRef.current.set(item, id);
+        }
+        return id;
+      }),
     [value, keyAccessor],
   );
 

--- a/superset-frontend/src/explore/components/controls/CollectionControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/CollectionControl/index.tsx
@@ -211,8 +211,16 @@ function CollectionControl({
 
   const onChangeItem = useCallback(
     (i: number, itemValue: CollectionItem) => {
+      const oldItem = value[i];
+      const newItem = { ...oldItem, ...itemValue };
+      // Replacing the object would orphan the WeakMap-stored id and remount
+      // the row. Carry the generated id over to the new ref.
+      const generatedId = generatedIdsRef.current.get(oldItem);
+      if (generatedId) {
+        generatedIdsRef.current.set(newItem, generatedId);
+      }
       const newValue = [...value];
-      newValue[i] = { ...value[i], ...itemValue };
+      newValue[i] = newItem;
       onChange?.(newValue);
     },
     [value, onChange],


### PR DESCRIPTION
### SUMMARY

Follow-up to #38563. `itemIds` fell back to `String(i)` when `keyAccessor` returned falsy:

```tsx
const itemIds = useMemo(
  () => value.map((item, i) => keyAccessor(item) || String(i)),
  [value, keyAccessor],
);
```

Two items with no `key` field both collapsed to a numeric-string id from their array index. After a drag, `arrayMove` reorders the array and the index→id mapping shifts, but dnd-kit/React keys are still derived from the new index — so the same id can now refer to a different item. This breaks reordering and React's reconciliation.

Maintain a per-instance `WeakMap<item, nanoid>` so keyless items get an id tied to their object reference. Items with a real `key` still use it, so existing callers (which rely on the default `itemGenerator` that already adds a nanoid) are unaffected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — defensive correctness fix; visible only when callers pass keyless items.

### TESTING INSTRUCTIONS

1. Use any chart with a `CollectionControl` (e.g. an explore control list).
2. Drag rows to reorder; confirm rows stay in the order you dropped them and don't visually swap or duplicate.

### ADDITIONAL INFORMATION

- Has associated issue: No
- Required feature flags: None
- Changes UI: No — pure id-derivation change
- Includes DB Migration: No
- Introduces new feature or API: No
- Removes existing feature or API: No