### PR TITLE
fix(clickhouse): prevent expensive table scan

### DIFF
--- a/superset/datasets/datetime_format_detector.py
+++ b/superset/datasets/datetime_format_detector.py
@@ -110,12 +110,13 @@ class DatetimeFormatDetector:
                 else:
                     full_table = table_name_quoted
 
-                # Build SQL query string with quoted identifiers
+                # Build SQL query string with quoted identifiers.
+                # The WHERE IS NOT NULL filter is intentionally omitted:
+                # detect_datetime_format() already calls dropna(), and the
+                # predicate forces engines like ClickHouse to scan the entire
+                # table even with LIMIT, triggering max_rows_to_read errors.
                 # S608: false positive - using dialect's identifier preparer
-                sql = (  # noqa: S608
-                    f"SELECT {column_name_quoted} FROM {full_table} "  # noqa: S608
-                    f"WHERE {column_name_quoted} IS NOT NULL"  # noqa: S608
-                )
+                sql = f"SELECT {column_name_quoted} FROM {full_table}"  # noqa: S608
 
             # Apply database-specific LIMIT using apply_limit_to_sql
             # This handles different SQL dialects (LIMIT, TOP, FETCH FIRST, etc.)

--- a/tests/unit_tests/datasets/test_datetime_format_detector.py
+++ b/tests/unit_tests/datasets/test_datetime_format_detector.py
@@ -223,3 +223,36 @@ def test_detect_column_format_expression_column(
 
     assert detected_format is None
     mock_dataset.database.get_df.assert_not_called()
+
+
+def test_detect_column_format_query_has_no_is_not_null(
+    mock_dataset: MagicMock, mock_column: MagicMock
+) -> None:
+    """The sampling query must not include a WHERE IS NOT NULL predicate.
+
+    detect_datetime_format() already calls dropna(), so filtering NULLs
+    in SQL is redundant. Worse, on engines like ClickHouse the predicate
+    forces a full table scan even with LIMIT, triggering max_rows_to_read
+    errors on large tables.
+    """
+    sample_data = pd.DataFrame(
+        {"date_column": ["2023-01-01", "2023-01-02", "2023-01-03"]}
+    )
+    mock_dataset.database.get_df.return_value = sample_data
+
+    captured_sql: list[str] = []
+    original_get_df = mock_dataset.database.get_df
+
+    def capture_sql(sql: str, schema: str) -> pd.DataFrame:
+        captured_sql.append(sql)
+        return original_get_df.return_value
+
+    mock_dataset.database.get_df.side_effect = capture_sql
+
+    detector = DatetimeFormatDetector(sample_size=100)
+    detector.detect_column_format(mock_dataset, mock_column)
+
+    assert len(captured_sql) == 1
+    assert "IS NOT NULL" not in captured_sql[0], (
+        f"Query should not contain IS NOT NULL predicate, got: {captured_sql[0]}"
+    )

--- a/tests/unit_tests/datasets/test_datetime_format_detector.py
+++ b/tests/unit_tests/datasets/test_datetime_format_detector.py
@@ -256,3 +256,27 @@ def test_detect_column_format_query_has_no_is_not_null(
     assert "IS NOT NULL" not in captured_sql[0], (
         f"Query should not contain IS NOT NULL predicate, got: {captured_sql[0]}"
     )
+
+
+def test_detect_column_format_with_leading_null_samples(
+    mock_dataset: MagicMock, mock_column: MagicMock
+) -> None:
+    """Leading NULL values are ignored during format detection."""
+    sample_data = pd.DataFrame(
+        {
+            "date_column": [
+                None,
+                None,
+                "2023-01-01",
+                "2023-01-02",
+                "2023-01-03",
+            ]
+        }
+    )
+    mock_dataset.database.get_df.return_value = sample_data
+
+    detector = DatetimeFormatDetector(sample_size=5)
+    detected_format = detector.detect_column_format(mock_dataset, mock_column)
+
+    assert detected_format == "%Y-%m-%d"
+    mock_dataset.database.get_df.assert_called_once()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, `DatetimeFormatDetector.detect_column_format()` builds a sampling query with a `WHERE col IS NOT NULL` predicate:

```sql
SELECT
  "col"
FROM "table"
WHERE
  "col" IS NOT NULL
LIMIT 1000
```

On ClickHouse, the `IS NOT NULL` predicate forces a **full table scan** even with `LIMIT`, because ClickHouse can't short-circuit predicate evaluation across granules. On large tables this triggers `Code 158 TOO_MANY_ROWS` (e.g., 4.62B rows exceeding the 4B max_rows_to_read limit).

This PR fixes the issue by removing `WHERE col IS NOT NULL` from the query. The `NULL` filtering is redundant, since `detect_datetime_format()` in `superset/utils/pandas.py` already calls `series.dropna()` on the result. The simplified query lets ClickHouse read a single granule (~8K rows) instead of scanning the entire table (~65K+ rows before hitting the limit).

Trade-off: A mostly-`NULL` column may yield fewer non-null samples without the SQL filter. But there's no way to guarantee `N` non-null rows without scanning an unbounded number of rows, which is exactly what causes
  the error. A column that's all-`NULL` in its first 1000 rows returns `None`, which is already handled gracefully.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
