### PR TITLE
fix(plugin-chart-ag-grid-table): use display text for filter and sort on HTML cells

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.test.ts
@@ -72,3 +72,12 @@ test('htmlTextComparator handles nulls and numbers', () => {
   expect(htmlTextComparator(1, 2)).toBeLessThan(0);
   expect(htmlTextComparator(2, 1)).toBeGreaterThan(0);
 });
+
+test('htmlTextComparator preserves default codepoint ordering for plain strings', () => {
+  // AG Grid's default string comparator orders by codepoint, so 'Z' (90)
+  // sorts before 'a' (97). A locale-aware comparator would flip this —
+  // verify we match the default so plain string columns are unaffected.
+  expect(htmlTextComparator('Z', 'a')).toBeLessThan(0);
+  expect(htmlTextComparator('a', 'Z')).toBeGreaterThan(0);
+  expect(htmlTextComparator('apple', 'banana')).toBeLessThan(0);
+});

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ValueGetterParams } from '@superset-ui/core/components/ThemedAgGridReact';
+import htmlTextFilterValueGetter, {
+  htmlTextComparator,
+} from './htmlTextFilterValueGetter';
+
+const makeParams = (value: unknown): ValueGetterParams =>
+  ({
+    data: { foo: value },
+    colDef: { field: 'foo' },
+  }) as unknown as ValueGetterParams;
+
+test('htmlTextFilterValueGetter extracts visible text from HTML anchor', () => {
+  expect(
+    htmlTextFilterValueGetter(
+      makeParams(
+        '<a href="https://jira.example.com/123/S18_3232">S18_3232</a>',
+      ),
+    ),
+  ).toBe('S18_3232');
+});
+
+test('htmlTextFilterValueGetter strips nested HTML markup', () => {
+  expect(
+    htmlTextFilterValueGetter(
+      makeParams('<div><strong>Hello</strong> <em>World</em></div>'),
+    ),
+  ).toBe('Hello World');
+});
+
+test('htmlTextFilterValueGetter passes plain strings through', () => {
+  expect(htmlTextFilterValueGetter(makeParams('plain value'))).toBe(
+    'plain value',
+  );
+});
+
+test('htmlTextFilterValueGetter passes non-string values through', () => {
+  expect(htmlTextFilterValueGetter(makeParams(42))).toBe(42);
+  expect(htmlTextFilterValueGetter(makeParams(null))).toBeNull();
+  expect(htmlTextFilterValueGetter(makeParams(undefined))).toBeUndefined();
+});
+
+test('htmlTextComparator orders by visible text, not raw HTML', () => {
+  // URL prefixes (zzz vs bbb) would flip the order under raw-HTML sort,
+  // but the visible labels (S700_4002 vs S72_3212) sort the other way.
+  const left = '<a href="https://jira.example.com/zzz/S700_4002">S700_4002</a>';
+  const right = '<a href="https://jira.example.com/bbb/S72_3212">S72_3212</a>';
+  expect(htmlTextComparator(left, right)).toBeLessThan(0);
+});
+
+test('htmlTextComparator handles nulls and numbers', () => {
+  expect(htmlTextComparator(null, null)).toBe(0);
+  expect(htmlTextComparator(null, 'x')).toBeLessThan(0);
+  expect(htmlTextComparator('x', null)).toBeGreaterThan(0);
+  expect(htmlTextComparator(1, 2)).toBeLessThan(0);
+  expect(htmlTextComparator(2, 1)).toBeGreaterThan(0);
+});

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.ts
@@ -37,6 +37,13 @@ const htmlTextFilterValueGetter = (params: ValueGetterParams) => {
   return raw;
 };
 
+/**
+ * Comparator that mirrors AG Grid's default string comparator (codepoint
+ * order, nulls first), but extracts visible text from HTML values first
+ * so HTML cells sort by their displayed label. Plain (non-HTML) values
+ * pass through unchanged, preserving default ordering — e.g. 'Z' still
+ * sorts before 'a' as it does under the default comparator.
+ */
 export const htmlTextComparator = (a: unknown, b: unknown): number => {
   const toText = (v: unknown) =>
     typeof v === 'string' && isProbablyHTML(v) ? stripHtmlToText(v) : v;
@@ -46,7 +53,8 @@ export const htmlTextComparator = (a: unknown, b: unknown): number => {
   if (aT == null) return -1;
   if (bT == null) return 1;
   if (typeof aT === 'number' && typeof bT === 'number') return aT - bT;
-  return String(aT).localeCompare(String(bT));
+  if (aT === bT) return 0;
+  return aT < bT ? -1 : 1;
 };
 
 export default htmlTextFilterValueGetter;

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.ts
@@ -19,9 +19,19 @@
 import { isProbablyHTML, sanitizeHtml } from '@superset-ui/core';
 import { ValueGetterParams } from '@superset-ui/core/components/ThemedAgGridReact';
 
+// Cache extracted text by raw HTML string. Sort comparators run O(n log n)
+// times against the same set of cell values, so reparsing on every call is
+// a measurable cost on large tables. Bounded by the number of unique HTML
+// values in the dataset.
+const htmlTextCache = new Map<string, string>();
+
 const stripHtmlToText = (html: string): string => {
+  const cached = htmlTextCache.get(html);
+  if (cached !== undefined) return cached;
   const doc = new DOMParser().parseFromString(sanitizeHtml(html), 'text/html');
-  return (doc.body.textContent || '').trim();
+  const text = (doc.body.textContent || '').trim();
+  htmlTextCache.set(html, text);
+  return text;
 };
 
 /**

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.ts
@@ -19,19 +19,26 @@
 import { isProbablyHTML, sanitizeHtml } from '@superset-ui/core';
 import { ValueGetterParams } from '@superset-ui/core/components/ThemedAgGridReact';
 
-// Cache extracted text by raw HTML string. Sort comparators run O(n log n)
-// times against the same set of cell values, so reparsing on every call is
-// a measurable cost on large tables. Bounded by the number of unique HTML
-// values in the dataset.
-const htmlTextCache = new Map<string, string>();
-
 const stripHtmlToText = (html: string): string => {
-  const cached = htmlTextCache.get(html);
-  if (cached !== undefined) return cached;
   const doc = new DOMParser().parseFromString(sanitizeHtml(html), 'text/html');
-  const text = (doc.body.textContent || '').trim();
-  htmlTextCache.set(html, text);
-  return text;
+  return (doc.body.textContent || '').trim();
+};
+
+// Cache the comparator-ready form per raw string. Both the HTML-detection
+// step (`isProbablyHTML`, which itself invokes DOMParser for HTML-looking
+// values) and the extraction step (`stripHtmlToText`, also DOMParser) are
+// expensive; sort runs `O(n log n)` comparator calls against the same set
+// of cell values. Memoizing the combined detection + extraction means each
+// unique cell value pays the cost once per session. Module-level scope;
+// bounded by the count of unique string cell values seen.
+const comparableTextCache = new Map<string, string>();
+
+const toComparableText = (raw: string): string => {
+  const cached = comparableTextCache.get(raw);
+  if (cached !== undefined) return cached;
+  const normalized = isProbablyHTML(raw) ? stripHtmlToText(raw) : raw;
+  comparableTextCache.set(raw, normalized);
+  return normalized;
 };
 
 /**
@@ -41,10 +48,7 @@ const stripHtmlToText = (html: string): string => {
  */
 const htmlTextFilterValueGetter = (params: ValueGetterParams) => {
   const raw = params.data?.[params.colDef.field as string];
-  if (typeof raw === 'string' && isProbablyHTML(raw)) {
-    return stripHtmlToText(raw);
-  }
-  return raw;
+  return typeof raw === 'string' ? toComparableText(raw) : raw;
 };
 
 /**
@@ -56,7 +60,7 @@ const htmlTextFilterValueGetter = (params: ValueGetterParams) => {
  */
 export const htmlTextComparator = (a: unknown, b: unknown): number => {
   const toText = (v: unknown) =>
-    typeof v === 'string' && isProbablyHTML(v) ? stripHtmlToText(v) : v;
+    typeof v === 'string' ? toComparableText(v) : v;
   const aT = toText(a);
   const bT = toText(b);
   if (aT == null && bT == null) return 0;

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/htmlTextFilterValueGetter.ts
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { isProbablyHTML, sanitizeHtml } from '@superset-ui/core';
+import { ValueGetterParams } from '@superset-ui/core/components/ThemedAgGridReact';
+
+const stripHtmlToText = (html: string): string => {
+  const doc = new DOMParser().parseFromString(sanitizeHtml(html), 'text/html');
+  return (doc.body.textContent || '').trim();
+};
+
+/**
+ * Returns the visible-text representation of an HTML cell value so AG Grid
+ * filters and sort operate on what the user sees, not the underlying markup.
+ * Pass-through for non-HTML values.
+ */
+const htmlTextFilterValueGetter = (params: ValueGetterParams) => {
+  const raw = params.data?.[params.colDef.field as string];
+  if (typeof raw === 'string' && isProbablyHTML(raw)) {
+    return stripHtmlToText(raw);
+  }
+  return raw;
+};
+
+export const htmlTextComparator = (a: unknown, b: unknown): number => {
+  const toText = (v: unknown) =>
+    typeof v === 'string' && isProbablyHTML(v) ? stripHtmlToText(v) : v;
+  const aT = toText(a);
+  const bT = toText(b);
+  if (aT == null && bT == null) return 0;
+  if (aT == null) return -1;
+  if (bT == null) return 1;
+  if (typeof aT === 'number' && typeof bT === 'number') return aT - bT;
+  return String(aT).localeCompare(String(bT));
+};
+
+export default htmlTextFilterValueGetter;

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
@@ -32,6 +32,9 @@ import {
 } from '../types';
 import getCellClass from './getCellClass';
 import filterValueGetter from './filterValueGetter';
+import htmlTextFilterValueGetter, {
+  htmlTextComparator,
+} from './htmlTextFilterValueGetter';
 import dateFilterComparator from './dateFilterComparator';
 import DateWithFormatter from './DateWithFormatter';
 import { getAggFunc } from './getAggFunc';
@@ -316,6 +319,13 @@ export const useColDefs = ({
         filter,
         ...(isPercentMetric && {
           filterValueGetter,
+        }),
+        ...(dataType === GenericDataType.String && {
+          // HTML cells (e.g. anchor markup) are rendered by TextCellRenderer
+          // via dangerouslySetInnerHTML; without these the set-filter dropdown
+          // shows raw markup and sort orders by raw HTML lexically.
+          filterValueGetter: htmlTextFilterValueGetter,
+          comparator: htmlTextComparator,
         }),
         ...(dataType === GenericDataType.Temporal && {
           // Use dateFilterValueGetter so AG Grid correctly identifies null dates for blank filter

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
@@ -320,20 +320,24 @@ export const useColDefs = ({
         ...(isPercentMetric && {
           filterValueGetter,
         }),
-        ...(dataType === GenericDataType.String && {
-          // HTML cells (e.g. anchor markup) are rendered by TextCellRenderer
-          // via dangerouslySetInnerHTML; without these the filter and sort
-          // operate on raw HTML so the URL inside the markup dictates order
-          // and the "Contains" filter matches against the raw HTML string.
-          //
-          // Scope: client-side only. When `serverPagination` is enabled, a
-          // later spread overrides `comparator` with `() => 0` so sorting is
-          // delegated to the server; the database does not know to extract
-          // visible text from HTML, so server-paginated tables with HTML
-          // columns are out of scope for this fix.
-          filterValueGetter: htmlTextFilterValueGetter,
-          comparator: htmlTextComparator,
-        }),
+        ...(dataType === GenericDataType.String &&
+          !serverPagination && {
+            // HTML cells (e.g. anchor markup) are rendered by TextCellRenderer
+            // via dangerouslySetInnerHTML; without these the filter and sort
+            // operate on raw HTML so the URL inside the markup dictates order
+            // and the "Contains" filter matches against the raw HTML string.
+            //
+            // Gated on !serverPagination: in server-pagination mode sort and
+            // filter are both delegated to the backend (which sees raw HTML
+            // in the database), so applying the visible-text getter only on
+            // the client would create a mismatch where the typed filter
+            // value is stripped client-side but the server query still
+            // operates on the raw HTML. Server-paginated tables with HTML
+            // columns are out of scope for this fix and would require
+            // server-side handling.
+            filterValueGetter: htmlTextFilterValueGetter,
+            comparator: htmlTextComparator,
+          }),
         ...(dataType === GenericDataType.Temporal && {
           // Use dateFilterValueGetter so AG Grid correctly identifies null dates for blank filter
           filterValueGetter: dateFilterValueGetter,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
@@ -322,8 +322,15 @@ export const useColDefs = ({
         }),
         ...(dataType === GenericDataType.String && {
           // HTML cells (e.g. anchor markup) are rendered by TextCellRenderer
-          // via dangerouslySetInnerHTML; without these the set-filter dropdown
-          // shows raw markup and sort orders by raw HTML lexically.
+          // via dangerouslySetInnerHTML; without these the filter and sort
+          // operate on raw HTML so the URL inside the markup dictates order
+          // and the "Contains" filter matches against the raw HTML string.
+          //
+          // Scope: client-side only. When `serverPagination` is enabled, a
+          // later spread overrides `comparator` with `() => 0` so sorting is
+          // delegated to the server; the database does not know to extract
+          // visible text from HTML, so server-paginated tables with HTML
+          // columns are out of scope for this fix.
           filterValueGetter: htmlTextFilterValueGetter,
           comparator: htmlTextComparator,
         }),


### PR DESCRIPTION
### SUMMARY

The Table V2 chart's `TextCellRenderer` renders cells containing HTML markup (e.g. anchor tags) via `dangerouslySetInnerHTML`, but the column definition's `filterValueGetter` and `comparator` are not configured for string columns. Both filter and sort therefore operate on the raw HTML string instead of the visible text:

- **Sort:** Rows are ordered by raw HTML lexically. The URL inside the markup dictates ordering instead of the visible label — e.g. all rows whose anchor `href` starts with `https://aaa/...` sort before rows with `https://bbb/...` regardless of what label is shown to the user.
- **"Contains" filter:** Matches against the raw HTML string. Typing a fragment of the visible label may miss; typing a URL substring (e.g. `https`) matches every HTML row.

This change adds a small `htmlTextFilterValueGetter` utility (with a matching `htmlTextComparator`) that extracts the visible text from HTML values via `DOMParser` + `sanitizeHtml`, and wires it into the colDef for string columns. Pass-through for non-HTML values, so plain string columns are unaffected — the comparator deliberately matches AG Grid's default codepoint ordering (`'Z'` before `'a'`) so plain string columns behave identically to before.

**Scope:** Client-side sort and filter only. When `serverPagination` is enabled, the existing `comparator: () => 0` override delegates sorting to the backend; the database does not know to extract visible text from HTML, so server-paginated tables with HTML columns would need server-side handling and are out of scope for this PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — the bug is observable via sort order rather than a visually distinct rendering.

### TESTING INSTRUCTIONS

1. Enable the `AG_GRID_TABLE_ENABLED` feature flag.
2. Create a Table V2 chart against a dataset where one string column contains HTML, e.g. via a calculated column: `'<a href="https://example.com/' || id || '">label_' || id || '</a>'`
3. **Before this fix:** clicking the column header sorts by URL prefix, not the visible label. Typing the label text into the column's "Contains" filter may not match.
4. **After this fix:** sort matches the visible label order; the "Contains" filter matches the visible label.

Unit tests added in `htmlTextFilterValueGetter.test.ts` cover HTML extraction (anchor and nested markup), pass-through for plain strings, nulls, and numbers, plus the comparator's ordering, null handling, and preservation of AG Grid's default codepoint ordering for plain strings.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `AG_GRID_TABLE_ENABLED`
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API