### PR TITLE
fix(mcp): warn on invalid chart preview form data key

### DIFF
--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -52,9 +52,10 @@ from superset.utils import json as utils_json
 logger = logging.getLogger(__name__)
 
 INVALID_FORM_DATA_KEY_WARNING = (
-    "Previous cached chart state could not be loaded from form_data_key. "
-    "The preview was generated from the supplied configuration only; the "
-    "previous form_data_key may be invalid or expired."
+    "Previous cached chart state could not be loaded from the previous "
+    "form_data_key. The preview was generated from the supplied "
+    "configuration only; the previous form_data_key may be invalid or "
+    "expired."
 )
 
 

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -51,9 +51,15 @@ from superset.utils import json as utils_json
 
 logger = logging.getLogger(__name__)
 
+INVALID_FORM_DATA_KEY_WARNING = (
+    "Previous cached chart state could not be loaded from form_data_key. "
+    "The preview was generated from the supplied configuration only; the "
+    "previous form_data_key may be invalid or expired."
+)
 
-def _get_old_adhoc_filters(form_data_key: str) -> list[Dict[str, Any]] | None:
-    """Retrieve adhoc_filters from the previously cached form_data."""
+
+def _get_previous_form_data(form_data_key: str) -> dict[str, Any] | None:
+    """Retrieve the previously cached form_data."""
     from superset.commands.exceptions import CommandException
     from superset.commands.explore.form_data.get import GetFormDataCommand
     from superset.commands.explore.form_data.parameters import CommandParameters
@@ -65,11 +71,9 @@ def _get_old_adhoc_filters(form_data_key: str) -> list[Dict[str, Any]] | None:
             if isinstance(cached_data, str):
                 cached_data = utils_json.loads(cached_data)
             if isinstance(cached_data, dict):
-                adhoc_filters = cached_data.get("adhoc_filters")
-                if adhoc_filters:
-                    return adhoc_filters
+                return cached_data
     except (KeyError, ValueError, TypeError, CommandException):
-        logger.debug("Could not retrieve old form_data for filter preservation")
+        logger.debug("Could not retrieve previous form_data from cache")
     return None
 
 
@@ -113,11 +117,18 @@ def update_chart_preview(
                 config, dataset_id=request.dataset_id
             )
             new_form_data.pop("_mcp_warnings", None)
+            warnings: list[str] = []
+            previous_form_data: dict[str, Any] | None = None
+
+            if request.form_data_key:
+                previous_form_data = _get_previous_form_data(request.form_data_key)
+                if previous_form_data is None:
+                    warnings.append(INVALID_FORM_DATA_KEY_WARNING)
 
             # Preserve adhoc filters from the previous cached form_data
             # when the new config doesn't explicitly specify filters
-            if getattr(config, "filters", None) is None and request.form_data_key:
-                old_adhoc_filters = _get_old_adhoc_filters(request.form_data_key)
+            if getattr(config, "filters", None) is None and previous_form_data:
+                old_adhoc_filters = previous_form_data.get("adhoc_filters")
                 if old_adhoc_filters:
                     new_form_data["adhoc_filters"] = old_adhoc_filters
 
@@ -183,6 +194,7 @@ def update_chart_preview(
             "explore_url": explore_url,
             "form_data_key": new_form_data_key,
             "previous_form_data_key": request.form_data_key,  # For reference
+            "warnings": warnings,
             "api_endpoints": {},  # No API endpoints for unsaved charts
             "performance": performance.model_dump() if performance else None,
             "accessibility": accessibility.model_dump() if accessibility else None,

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
@@ -481,6 +481,53 @@ class TestUpdateChartPreview:
         assert request.config.sort_by == ["sales", "profit"]
         assert len(request.config.columns) == 3
 
+    @patch("superset.commands.explore.form_data.get.GetFormDataCommand")
+    def test_get_previous_form_data_parses_json_cache_hit(
+        self,
+        mock_get_form_data_command,
+    ) -> None:
+        """Previous form_data lookup parses JSON strings from the cache."""
+        cached_adhoc_filters = [
+            {
+                "clause": "WHERE",
+                "comparator": "North",
+                "expressionType": "SIMPLE",
+                "operator": "==",
+                "subject": "region",
+            }
+        ]
+        mock_get_form_data_command.return_value.run.return_value = (
+            '{"adhoc_filters": ['
+            '{"clause": "WHERE", "comparator": "North", '
+            '"expressionType": "SIMPLE", "operator": "==", "subject": "region"}'
+            '], "viz_type": "table"}'
+        )
+
+        result = update_chart_preview_module._get_previous_form_data("valid_key_12345")
+
+        assert result == {
+            "adhoc_filters": cached_adhoc_filters,
+            "viz_type": "table",
+        }
+        command_params = mock_get_form_data_command.call_args.args[0]
+        assert command_params.key == "valid_key_12345"
+
+    @patch("superset.commands.explore.form_data.get.GetFormDataCommand")
+    def test_get_previous_form_data_returns_none_for_cache_failure(
+        self,
+        mock_get_form_data_command,
+    ) -> None:
+        """Previous form_data lookup treats command failures as cache misses."""
+        mock_get_form_data_command.return_value.run.side_effect = (
+            update_chart_preview_module.CommandException("cache read failed")
+        )
+
+        result = update_chart_preview_module._get_previous_form_data(
+            "missing_key_12345"
+        )
+
+        assert result is None
+
     @patch.object(update_chart_preview_module, "analyze_chart_semantics")
     @patch.object(update_chart_preview_module, "analyze_chart_capabilities")
     @patch.object(update_chart_preview_module, "generate_explore_link")
@@ -494,7 +541,7 @@ class TestUpdateChartPreview:
         mock_generate_explore_link,
         mock_analyze_chart_capabilities,
         mock_analyze_chart_semantics,
-    ):
+    ) -> None:
         """Invalid previous form_data_key is warning-only for preview updates."""
         mock_user = Mock()
         mock_user.id = 1
@@ -547,7 +594,7 @@ class TestUpdateChartPreview:
         mock_generate_explore_link,
         mock_analyze_chart_capabilities,
         mock_analyze_chart_semantics,
-    ):
+    ) -> None:
         """Valid previous form_data preserves filters without a cache warning."""
         mock_user = Mock()
         mock_user.id = 1

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
@@ -19,6 +19,9 @@
 Unit tests for update_chart_preview MCP tool
 """
 
+import importlib
+from unittest.mock import Mock, patch
+
 import pytest
 
 from superset.mcp_service.chart.schemas import (
@@ -29,6 +32,10 @@ from superset.mcp_service.chart.schemas import (
     TableChartConfig,
     UpdateChartPreviewRequest,
     XYChartConfig,
+)
+
+update_chart_preview_module = importlib.import_module(
+    "superset.mcp_service.chart.tool.update_chart_preview"
 )
 
 
@@ -218,6 +225,7 @@ class TestUpdateChartPreview:
             "explore_url",
             "form_data_key",
             "previous_form_data_key",
+            "warnings",
             "api_endpoints",
             "performance",
             "accessibility",
@@ -472,3 +480,118 @@ class TestUpdateChartPreview:
         )
         assert request.config.sort_by == ["sales", "profit"]
         assert len(request.config.columns) == 3
+
+    @patch.object(update_chart_preview_module, "analyze_chart_semantics")
+    @patch.object(update_chart_preview_module, "analyze_chart_capabilities")
+    @patch.object(update_chart_preview_module, "generate_explore_link")
+    @patch.object(update_chart_preview_module, "_get_previous_form_data")
+    @patch("superset.mcp_service.auth.get_user_from_request")
+    @pytest.mark.asyncio
+    async def test_warns_when_previous_form_data_key_is_missing(
+        self,
+        mock_get_user_from_request,
+        mock_get_previous_form_data,
+        mock_generate_explore_link,
+        mock_analyze_chart_capabilities,
+        mock_analyze_chart_semantics,
+    ):
+        """Invalid previous form_data_key is warning-only for preview updates."""
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_get_user_from_request.return_value = mock_user
+        mock_get_previous_form_data.return_value = None
+        mock_generate_explore_link.return_value = (
+            "http://localhost:8088/explore/?form_data_key=new_preview_key"
+        )
+        mock_analyze_chart_capabilities.return_value = None
+        mock_analyze_chart_semantics.return_value = None
+
+        request = UpdateChartPreviewRequest(
+            form_data_key="nonexistent_key_12345",
+            dataset_id=3,
+            config=TableChartConfig(
+                chart_type="table",
+                columns=[
+                    ColumnRef(name="country", label="Country"),
+                    ColumnRef(name="sales", label="Sales", aggregate="SUM"),
+                ],
+                sort_by=["sales"],
+            ),
+            generate_preview=True,
+            preview_formats=["table"],
+        )
+
+        result = update_chart_preview_module.update_chart_preview(
+            request=request, ctx=Mock()
+        )
+
+        assert result["success"] is True
+        assert result["error"] is None
+        assert result["previous_form_data_key"] == "nonexistent_key_12345"
+        assert result["form_data_key"] == "new_preview_key"
+        assert result["warnings"] == [
+            update_chart_preview_module.INVALID_FORM_DATA_KEY_WARNING
+        ]
+        mock_get_previous_form_data.assert_called_once_with("nonexistent_key_12345")
+
+    @patch.object(update_chart_preview_module, "analyze_chart_semantics")
+    @patch.object(update_chart_preview_module, "analyze_chart_capabilities")
+    @patch.object(update_chart_preview_module, "generate_explore_link")
+    @patch.object(update_chart_preview_module, "_get_previous_form_data")
+    @patch("superset.mcp_service.auth.get_user_from_request")
+    @pytest.mark.asyncio
+    async def test_preserves_previous_adhoc_filters_without_warning(
+        self,
+        mock_get_user_from_request,
+        mock_get_previous_form_data,
+        mock_generate_explore_link,
+        mock_analyze_chart_capabilities,
+        mock_analyze_chart_semantics,
+    ):
+        """Valid previous form_data preserves filters without a cache warning."""
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_get_user_from_request.return_value = mock_user
+        cached_adhoc_filters = [
+            {
+                "clause": "WHERE",
+                "comparator": "North",
+                "expressionType": "SIMPLE",
+                "operator": "==",
+                "subject": "region",
+            }
+        ]
+        mock_get_previous_form_data.return_value = {
+            "adhoc_filters": cached_adhoc_filters
+        }
+        mock_generate_explore_link.return_value = (
+            "http://localhost:8088/explore/?form_data_key=new_preview_key"
+        )
+        mock_analyze_chart_capabilities.return_value = None
+        mock_analyze_chart_semantics.return_value = None
+
+        request = UpdateChartPreviewRequest(
+            form_data_key="valid_key_12345",
+            dataset_id=3,
+            config=TableChartConfig(
+                chart_type="table",
+                columns=[
+                    ColumnRef(name="country", label="Country"),
+                    ColumnRef(name="sales", label="Sales", aggregate="SUM"),
+                ],
+                sort_by=["sales"],
+            ),
+            generate_preview=True,
+            preview_formats=["table"],
+        )
+
+        result = update_chart_preview_module.update_chart_preview(
+            request=request, ctx=Mock()
+        )
+
+        generated_form_data = mock_generate_explore_link.call_args.args[1]
+        assert generated_form_data["adhoc_filters"] == cached_adhoc_filters
+        assert result["success"] is True
+        assert result["error"] is None
+        assert result["warnings"] == []
+        mock_get_previous_form_data.assert_called_once_with("valid_key_12345")


### PR DESCRIPTION
### SUMMARY
- Warn when `update_chart_preview` receives a previous `form_data_key` that cannot be loaded from cached form data.
- Keep preview generation successful for that case, preserving `success: true`, `error: null`, and the returned replacement preview `form_data_key`.
- Reuse the loaded previous form data for existing `adhoc_filters` preservation when the new chart config does not supply filters.
- Add unit coverage for both the invalid-key warning path and the valid-cache filter preservation path.

### BEFORE AND AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable - backend MCP tool response change.

Before this change, a preview update with a fabricated previous `form_data_key` succeeded and returned a new preview key without indicating that previous cached chart state was unavailable.

After this change, the same successful response includes a top-level `warnings` entry explaining that the previous cached chart state could not be loaded and that the preview was generated from the supplied config only.

### TESTING INSTRUCTIONS
- [x] `pytest tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py -q`
- [x] Manual MCP check: call `update_chart_preview` with a fabricated previous `form_data_key`, dataset id `3`, a table config, `generate_preview: true`, and `preview_formats: ["table"]`; confirm the response keeps `success: true`, keeps `error: null`, returns a new preview `form_data_key`, and includes the missing previous cached state warning.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: Not applicable - no public Apache Superset issue
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

<!-- agor:pr-summary:begin -->

### REVIEWER SUMMARY

`update_chart_preview` previously ignored a supplied `form_data_key` when the corresponding cached form data could not be loaded. The preview still succeeded and returned a replacement key, which made it look like the request updated an existing preview even though it was generated from the submitted config alone.

This change performs one explicit previous-form-data cache lookup when a key is provided. On cache hit, the existing `adhoc_filters` preservation path still uses the cached payload. On cache miss, the response stays successful but includes a top-level `warnings` entry explaining that previous cached chart state was unavailable.

Verification:
- Added focused unit coverage for invalid-key warnings and valid-cache filter preservation.
- Reproduced the invalid-key preview call and confirmed the response keeps `success: true`, keeps `error: null`, returns a new preview `form_data_key`, and includes the missing cached state warning.

Risk is low and scoped to the MCP chart preview response path. Rollback is reverting the single PR commit.

<!-- agor:pr-summary:end -->
