### PR TITLE
feat(frontend): enable React StrictMode at root

### DIFF
--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -18,7 +18,7 @@
  */
 import 'src/public-path';
 
-import { lazy, Suspense } from 'react';
+import { lazy, StrictMode, Suspense } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Global } from '@emotion/react';
@@ -196,7 +196,11 @@ function start() {
       if (!root) {
         root = createRoot(appMountPoint);
       }
-      root.render(<EmbeddedApp />);
+      root.render(
+        <StrictMode>
+          <EmbeddedApp />
+        </StrictMode>,
+      );
     },
     err => {
       // something is most likely wrong with the guest token; reset the guard

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -66,7 +66,7 @@ const LazyDashboardPage = lazy(
     ),
 );
 
-const EmbededLazyDashboardPage = () => {
+const EmbeddedLazyDashboardPage = () => {
   const uiConfig = useUiConfig();
   const emitDataMasks = uiConfig?.emitDataMasks;
 
@@ -108,7 +108,7 @@ const EmbeddedRoute = () => (
     />
     <Suspense fallback={<Loading />}>
       <ErrorBoundary>
-        <EmbededLazyDashboardPage />
+        <EmbeddedLazyDashboardPage />
       </ErrorBoundary>
       <ToastContainer position="top" />
     </Suspense>

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -18,7 +18,7 @@
  */
 import 'src/public-path';
 
-import { lazy, StrictMode, Suspense } from 'react';
+import { lazy, StrictMode, Suspense, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Global } from '@emotion/react';
@@ -68,18 +68,19 @@ const LazyDashboardPage = lazy(
 
 const EmbededLazyDashboardPage = () => {
   const uiConfig = useUiConfig();
+  const emitDataMasks = uiConfig?.emitDataMasks;
 
-  // Emit data mask changes to the parent window
-  if (uiConfig?.emitDataMasks) {
+  // Emit data mask changes to the parent window. Subscribing inside an effect
+  // (rather than during render) ensures the unsubscribe runs on unmount,
+  // including StrictMode's dev-mode double-mount cycle.
+  useEffect(() => {
+    if (!emitDataMasks) return undefined;
     log('setting up Switchboard event emitter');
 
     let previousDataMask = store.getState().dataMask;
 
-    store.subscribe(() => {
-      const currentState = store.getState();
-      const currentDataMask = currentState.dataMask;
-
-      // Only emit if the dataMask has changed
+    return store.subscribe(() => {
+      const currentDataMask = store.getState().dataMask;
       if (previousDataMask !== currentDataMask) {
         Switchboard.emit('observeDataMask', {
           ...currentDataMask,
@@ -88,7 +89,7 @@ const EmbededLazyDashboardPage = () => {
         previousDataMask = currentDataMask;
       }
     });
-  }
+  }, [emitDataMasks]);
 
   return <LazyDashboardPage idOrSlug={bootstrapData.embedded!.dashboard_id} />;
 };

--- a/superset-frontend/src/views/index.tsx
+++ b/superset-frontend/src/views/index.tsx
@@ -18,6 +18,7 @@
  */
 import 'src/public-path';
 
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { logging } from '@apache-superset/core/utils';
 import initPreamble from 'src/preamble';
@@ -31,7 +32,11 @@ if (appMountPoint) {
       await initPreamble();
     } finally {
       const { default: App } = await import(/* webpackMode: "eager" */ './App');
-      root.render(<App />);
+      root.render(
+        <StrictMode>
+          <App />
+        </StrictMode>,
+      );
     }
   })().catch(err => {
     logging.error('Unhandled error during app initialization', err);

--- a/superset-frontend/src/views/menu.tsx
+++ b/superset-frontend/src/views/menu.tsx
@@ -20,6 +20,7 @@ import 'src/public-path';
 
 // Menu App. Used in views that do not already include the Menu component in the layout.
 // eg, backend rendered views
+import { StrictMode } from 'react';
 import { Provider } from 'react-redux';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
@@ -45,24 +46,26 @@ const emotionCache = createCache({
 });
 
 const app = (
-  <CacheProvider value={emotionCache}>
-    <ThemeProvider theme={theme}>
-      <Provider store={store}>
-        <BrowserRouter>
-          <QueryParamProvider
-            adapter={ReactRouter5Adapter}
-            options={{
-              searchStringToObject: querystring.parse,
-              objectToSearchString: (object: Record<string, any>) =>
-                querystring.stringify(object, { encode: false }),
-            }}
-          >
-            <Menu data={menu} />
-          </QueryParamProvider>
-        </BrowserRouter>
-      </Provider>
-    </ThemeProvider>
-  </CacheProvider>
+  <StrictMode>
+    <CacheProvider value={emotionCache}>
+      <ThemeProvider theme={theme}>
+        <Provider store={store}>
+          <BrowserRouter>
+            <QueryParamProvider
+              adapter={ReactRouter5Adapter}
+              options={{
+                searchStringToObject: querystring.parse,
+                objectToSearchString: (object: Record<string, any>) =>
+                  querystring.stringify(object, { encode: false }),
+              }}
+            >
+              <Menu data={menu} />
+            </QueryParamProvider>
+          </BrowserRouter>
+        </Provider>
+      </ThemeProvider>
+    </CacheProvider>
+  </StrictMode>
 );
 
 const menuMountPoint = document.getElementById('app-menu');


### PR DESCRIPTION
### SUMMARY

First foundational step for #39890 (React 18 concurrent-feature adoption).

Wraps the three React 18 root mounts in `<StrictMode>`:

- `superset-frontend/src/views/index.tsx` (main app)
- `superset-frontend/src/views/menu.tsx` (backend-rendered views' menu)
- `superset-frontend/src/embedded/index.tsx` (embedded SDK)

### Why

Per the React 18 docs, StrictMode's dev-mode double-invocation surfaces effect-cleanup and non-idempotent-render bugs that concurrent rendering will eventually expose at runtime. Turning it on now lets us catch those deliberately during local dev rather than have them appear later as "weird remount" or stale-state regressions.

### Scope notes

- **Dev-only**. StrictMode is a no-op in production React builds; this PR has zero production impact.
- **Test suite unaffected**. The custom RTL render wrapper at `spec/helpers/testing-library.tsx` does not enable StrictMode, so existing tests behave identically.
- **No effect-cleanup audit in this PR.** The tracking issue's own guidance is "Expect a follow-up wave of small fixes once it's on. Plan for a cleanup pass; don't merge alongside other work." Any double-mount issues that surface during local dev should be triaged as discrete follow-ups against #39890.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no UI change. Dev-mode console may now show second-invocation warnings for components with cleanup bugs; those are pre-existing latent issues to be fixed in follow-ups.

### TESTING INSTRUCTIONS

1. `npm run dev` from `superset-frontend/`.
2. Load any page (dashboard, explore, SQL Lab, embedded) — verify the app renders normally.
3. Open the browser console; existing functionality should work. Expect possible new warnings from React about effects/refs in components that aren't yet idempotent — these are not regressions from this PR but are pre-existing issues StrictMode is now surfacing.
4. Run `npm run build` to confirm production builds still succeed (StrictMode is stripped in prod).

### ADDITIONAL INFORMATION

- [x] Has associated issue: #39890
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API