### PR TITLE
feat(mcp): add typed Pydantic response schemas to generate_explore_link tool

### DIFF
--- a/superset/mcp_service/explore/schemas.py
+++ b/superset/mcp_service/explore/schemas.py
@@ -25,6 +25,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from superset.mcp_service.common.error_schemas import ChartGenerationError
+
 
 class GenerateExploreLinkResponse(BaseModel):
     """
@@ -33,11 +35,10 @@ class GenerateExploreLinkResponse(BaseModel):
     On success, ``url`` is a fully-qualified Superset Explore URL that the
     user can open immediately, and ``form_data_key`` can be used to
     reconstruct or share the same configuration. On failure, ``url`` is
-    empty and ``error`` is a ``ChartGenerationError`` serialized as a dict;
-    its ``error_type`` distinguishes ``dataset_not_found``,
-    ``permission_denied``, ``validation_error``, and ``generation_failed``
-    so callers can branch on failure mode without parsing free-text
-    messages.
+    empty and ``error`` is a ``ChartGenerationError``; its ``error_type``
+    distinguishes ``dataset_not_found``, ``permission_denied``,
+    ``validation_error``, and ``generation_failed`` so callers can branch
+    on failure mode without parsing free-text messages.
     """
 
     url: str = Field(
@@ -76,11 +77,11 @@ class GenerateExploreLinkResponse(BaseModel):
             "Null on failure or when the viz_type has no specific label."
         ),
     )
-    error: dict[str, Any] | None = Field(
+    error: ChartGenerationError | None = Field(
         None,
         description=(
             "Structured ChartGenerationError when generation fails, else "
-            "null. Branch on error['error_type'] to handle specific failure "
+            "null. Branch on error.error_type to handle specific failure "
             "modes (dataset_not_found, permission_denied, validation_error, "
             "generation_failed)."
         ),

--- a/superset/mcp_service/explore/schemas.py
+++ b/superset/mcp_service/explore/schemas.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Pydantic schemas for explore-related MCP tool outputs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class GenerateExploreLinkResponse(BaseModel):
+    """
+    Output schema for the generate_explore_link tool.
+
+    On success, ``url`` is a fully-qualified Superset Explore URL that the
+    user can open immediately, and ``form_data_key`` can be used to
+    reconstruct or share the same configuration. On failure, ``url`` is
+    empty and ``error`` is a ``ChartGenerationError`` serialized as a dict;
+    its ``error_type`` distinguishes ``dataset_not_found``,
+    ``permission_denied``, ``validation_error``, and ``generation_failed``
+    so callers can branch on failure mode without parsing free-text
+    messages.
+    """
+
+    url: str = Field(
+        ...,
+        description=(
+            "Explore URL — open in a browser to view the interactive chart. "
+            "Empty string on failure."
+        ),
+    )
+    form_data: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw Superset form_data dict that was encoded into the URL.",
+    )
+    permalink_key: str | None = Field(
+        None,
+        description=(
+            "Durable permalink key for the generated Explore URL, when one "
+            "was created. Prefer this over ``form_data_key`` for sharing; it "
+            "survives cache eviction. Null on failure or when only an "
+            "ephemeral form_data key is available."
+        ),
+    )
+    form_data_key: str | None = Field(
+        None,
+        description=(
+            "Short, ephemeral cache key that represents this form_data "
+            "configuration. Populated only when no ``permalink_key`` is "
+            "available. Can be passed to the Explore UI as ?form_data_key=<key>."
+        ),
+    )
+    chart_type_label: str | None = Field(
+        None,
+        description=(
+            "Human-readable label for the resulting chart type "
+            "(e.g. 'table chart', 'interactive table chart'). "
+            "Null on failure or when the viz_type has no specific label."
+        ),
+    )
+    error: dict[str, Any] | None = Field(
+        None,
+        description=(
+            "Structured ChartGenerationError when generation fails, else "
+            "null. Branch on error['error_type'] to handle specific failure "
+            "modes (dataset_not_found, permission_denied, validation_error, "
+            "generation_failed)."
+        ),
+    )
+    success: bool = Field(
+        True,
+        description="True when a valid URL was produced, False on any error.",
+    )

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -27,6 +27,7 @@ import logging
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
+from superset.daos.dataset import DatasetDAO
 from superset.extensions import event_logger
 from superset.mcp_service.auth import has_dataset_access
 from superset.mcp_service.chart.chart_helpers import extract_form_data_key_from_url
@@ -39,10 +40,12 @@ from superset.mcp_service.chart.compile import validate_and_compile
 from superset.mcp_service.chart.schemas import (
     GenerateExploreLinkRequest,
 )
+from superset.mcp_service.chart.validation.dataset_validator import DatasetValidator
 from superset.mcp_service.common.error_schemas import ChartGenerationError
 from superset.mcp_service.explore.schemas import GenerateExploreLinkResponse
 from superset.mcp_service.utils.url_utils import (
     extract_permalink_key_from_url,
+    get_superset_base_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -117,8 +120,6 @@ async def generate_explore_link(
     try:
         await ctx.report_progress(1, 4, "Validating dataset exists")
         with event_logger.log_context(action="mcp.generate_explore_link.dataset_check"):
-            from superset.daos.dataset import DatasetDAO
-
             dataset = None
             if isinstance(request.dataset_id, int) or (
                 isinstance(request.dataset_id, str) and request.dataset_id.isdigit()
@@ -144,6 +145,7 @@ async def generate_explore_link(
                     chart_type_label=None,
                     error=ChartGenerationError(
                         error_type="dataset_not_found",
+                        error_code="MCP_EXPLORE_DATASET_NOT_FOUND",
                         message=f"Dataset not found: {request.dataset_id}.",
                         details=(
                             f"No dataset found with identifier "
@@ -154,7 +156,7 @@ async def generate_explore_link(
                             "Verify the dataset ID or UUID is correct",
                             "Use the list_datasets tool to find available datasets",
                         ],
-                    ).model_dump(),
+                    ),
                     success=False,
                 )
 
@@ -176,6 +178,11 @@ async def generate_explore_link(
                     chart_type_label=None,
                     error=ChartGenerationError(
                         error_type="permission_denied",
+                        # Same code as the not-found path: the user-visible
+                        # message is intentionally indistinguishable so
+                        # access policy isn't disclosed; ``error_type`` is
+                        # the programmatic distinguisher.
+                        error_code="MCP_EXPLORE_DATASET_NOT_FOUND",
                         message=f"Dataset not found: {request.dataset_id}.",
                         details=(
                             f"No dataset found with identifier "
@@ -186,7 +193,7 @@ async def generate_explore_link(
                             "Check that you have access to this dataset",
                             "Use the list_datasets tool to find available datasets",
                         ],
-                    ).model_dump(),
+                    ),
                     success=False,
                 )
 
@@ -194,8 +201,6 @@ async def generate_explore_link(
         # the dataset in Superset without a preconfigured chart.
         if request.config is None:
             await ctx.report_progress(4, 4, "URL generation complete")
-            from superset.mcp_service.utils.url_utils import get_superset_base_url
-
             base_url = get_superset_base_url()
             default_url = (
                 f"{base_url}/explore/?datasource_type=table&datasource_id={dataset.id}"
@@ -221,14 +226,28 @@ async def generate_explore_link(
             # Normalize column names to match canonical dataset column names
             # This fixes case sensitivity issues (e.g., 'order_date' vs 'OrderDate')
             try:
-                from superset.mcp_service.chart.validation.dataset_validator import (
-                    DatasetValidator,
-                )
-
                 normalized_config = DatasetValidator.normalize_column_names(
                     config, request.dataset_id
                 )
-            except (ImportError, AttributeError, KeyError, ValueError, TypeError):
+            except (
+                ImportError,
+                AttributeError,
+                KeyError,
+                ValueError,
+                TypeError,
+            ) as norm_err:
+                logger.warning(
+                    "Column normalization failed for dataset_id=%s; falling back "
+                    "to caller-supplied config. %s: %s",
+                    request.dataset_id,
+                    type(norm_err).__name__,
+                    norm_err,
+                )
+                await ctx.warning(
+                    "Column normalization failed for dataset_id=%s; using config "
+                    "as-supplied. Chart may behave unexpectedly if column names "
+                    "differ in case." % (request.dataset_id,)
+                )
                 normalized_config = config
 
             # Map config to form_data using shared utilities
@@ -265,14 +284,14 @@ async def generate_explore_link(
                 "Explore link validation failed: error=%s" % (compile_result.error,)
             )
             if compile_result.error_obj is not None:
-                error_payload = compile_result.error_obj.model_dump()
+                error_payload = compile_result.error_obj
             else:
                 error_payload = ChartGenerationError(
                     error_type="validation_error",
                     message="Explore link validation failed",
                     details=compile_result.error or "",
                     error_code=compile_result.error_code,
-                ).model_dump()
+                )
             return GenerateExploreLinkResponse(
                 url="",
                 form_data=form_data,
@@ -325,6 +344,10 @@ async def generate_explore_link(
                 str(e),
             )
         )
+        # ``details`` intentionally omits ``str(e)`` so internal info
+        # (file paths, schema names) isn't echoed to the MCP response.
+        # The raw exception is already captured in the server-side log
+        # above via ``ctx.error``.
         return GenerateExploreLinkResponse(
             url="",
             form_data={},
@@ -333,8 +356,11 @@ async def generate_explore_link(
             chart_type_label=None,
             error=ChartGenerationError(
                 error_type="generation_failed",
+                error_code="MCP_EXPLORE_GENERATION_FAILED",
                 message="Failed to generate explore link",
-                details=str(e),
-            ).model_dump(),
+                details=(
+                    "An unexpected error occurred; check server logs for details."
+                ),
+            ),
             success=False,
         )

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -23,16 +23,13 @@ chart configuration.
 """
 
 import logging
-from typing import Any, Dict
 
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.auth import has_dataset_access
-from superset.mcp_service.chart.chart_helpers import (
-    extract_form_data_key_from_url,
-)
+from superset.mcp_service.chart.chart_helpers import extract_form_data_key_from_url
 from superset.mcp_service.chart.chart_utils import (
     generate_explore_link as generate_url,
     get_table_chart_type_label,
@@ -42,6 +39,8 @@ from superset.mcp_service.chart.compile import validate_and_compile
 from superset.mcp_service.chart.schemas import (
     GenerateExploreLinkRequest,
 )
+from superset.mcp_service.common.error_schemas import ChartGenerationError
+from superset.mcp_service.explore.schemas import GenerateExploreLinkResponse
 from superset.mcp_service.utils.url_utils import (
     extract_permalink_key_from_url,
 )
@@ -60,7 +59,7 @@ logger = logging.getLogger(__name__)
 )
 async def generate_explore_link(
     request: GenerateExploreLinkRequest, ctx: Context
-) -> Dict[str, Any]:
+) -> GenerateExploreLinkResponse:
     """Generate explore URL for interactive visualization.
 
     PREFERRED TOOL for most visualization requests.
@@ -137,17 +136,27 @@ async def generate_explore_link(
                 await ctx.warning(
                     "Dataset not found: dataset_id=%s" % (request.dataset_id,)
                 )
-                return {
-                    "url": "",
-                    "form_data": {},
-                    "permalink_key": None,
-                    "form_data_key": None,
-                    "chart_type_label": None,
-                    "error": (
-                        f"Dataset not found: {request.dataset_id}. "
-                        "Use list_datasets to find valid dataset IDs."
-                    ),
-                }
+                return GenerateExploreLinkResponse(
+                    url="",
+                    form_data={},
+                    permalink_key=None,
+                    form_data_key=None,
+                    chart_type_label=None,
+                    error=ChartGenerationError(
+                        error_type="dataset_not_found",
+                        message=f"Dataset not found: {request.dataset_id}.",
+                        details=(
+                            f"No dataset found with identifier "
+                            f"'{request.dataset_id}'. Use list_datasets to "
+                            "find valid dataset IDs."
+                        ),
+                        suggestions=[
+                            "Verify the dataset ID or UUID is correct",
+                            "Use the list_datasets tool to find available datasets",
+                        ],
+                    ).model_dump(),
+                    success=False,
+                )
 
             if not has_dataset_access(dataset):
                 logger.warning(
@@ -157,17 +166,29 @@ async def generate_explore_link(
                 await ctx.warning(
                     "Dataset access denied: dataset_id=%s" % (request.dataset_id,)
                 )
-                return {
-                    "url": "",
-                    "form_data": {},
-                    "permalink_key": None,
-                    "form_data_key": None,
-                    "chart_type_label": None,
-                    "error": (
-                        f"Dataset not found: {request.dataset_id}. "
-                        "Use list_datasets to find valid dataset IDs."
-                    ),
-                }
+                # User-facing message stays generic to avoid leaking dataset
+                # existence; error_type lets programmatic callers distinguish.
+                return GenerateExploreLinkResponse(
+                    url="",
+                    form_data={},
+                    permalink_key=None,
+                    form_data_key=None,
+                    chart_type_label=None,
+                    error=ChartGenerationError(
+                        error_type="permission_denied",
+                        message=f"Dataset not found: {request.dataset_id}.",
+                        details=(
+                            f"No dataset found with identifier "
+                            f"'{request.dataset_id}'. Use list_datasets to "
+                            "find valid dataset IDs."
+                        ),
+                        suggestions=[
+                            "Check that you have access to this dataset",
+                            "Use the list_datasets tool to find available datasets",
+                        ],
+                    ).model_dump(),
+                    success=False,
+                )
 
         # When no config is provided, return a default explore URL that opens
         # the dataset in Superset without a preconfigured chart.
@@ -182,14 +203,15 @@ async def generate_explore_link(
             await ctx.info(
                 "Default explore link generated: dataset_id=%s" % (request.dataset_id,)
             )
-            return {
-                "url": default_url,
-                "form_data": {},
-                "permalink_key": None,
-                "form_data_key": None,
-                "chart_type_label": None,
-                "error": None,
-            }
+            return GenerateExploreLinkResponse(
+                url=default_url,
+                form_data={},
+                permalink_key=None,
+                form_data_key=None,
+                chart_type_label=None,
+                error=None,
+                success=True,
+            )
 
         await ctx.report_progress(2, 4, "Converting configuration to form data")
         with event_logger.log_context(action="mcp.generate_explore_link.form_data"):
@@ -242,25 +264,24 @@ async def generate_explore_link(
             await ctx.warning(
                 "Explore link validation failed: error=%s" % (compile_result.error,)
             )
-            error_payload: Dict[str, Any]
             if compile_result.error_obj is not None:
                 error_payload = compile_result.error_obj.model_dump()
             else:
-                error_payload = {
-                    "error_type": "validation_error",
-                    "message": "Explore link validation failed",
-                    "details": compile_result.error or "",
-                    "error_code": compile_result.error_code,
-                    "suggestions": [],
-                }
-            return {
-                "url": "",
-                "form_data": form_data,
-                "permalink_key": None,
-                "form_data_key": None,
-                "chart_type_label": None,
-                "error": error_payload,
-            }
+                error_payload = ChartGenerationError(
+                    error_type="validation_error",
+                    message="Explore link validation failed",
+                    details=compile_result.error or "",
+                    error_code=compile_result.error_code,
+                ).model_dump()
+            return GenerateExploreLinkResponse(
+                url="",
+                form_data=form_data,
+                permalink_key=None,
+                form_data_key=None,
+                chart_type_label=None,
+                error=error_payload,
+                success=False,
+            )
 
         await ctx.report_progress(3, 4, "Generating explore URL")
         with event_logger.log_context(
@@ -284,14 +305,15 @@ async def generate_explore_link(
             % (len(explore_url or ""), request.dataset_id, permalink_key, form_data_key)
         )
 
-        return {
-            "url": explore_url,
-            "form_data": form_data,
-            "permalink_key": permalink_key,
-            "form_data_key": form_data_key,
-            "chart_type_label": get_table_chart_type_label(form_data.get("viz_type")),
-            "error": None,
-        }
+        return GenerateExploreLinkResponse(
+            url=explore_url,
+            form_data=form_data,
+            permalink_key=permalink_key,
+            form_data_key=form_data_key,
+            chart_type_label=get_table_chart_type_label(form_data.get("viz_type")),
+            error=None,
+            success=True,
+        )
 
     except Exception as e:
         await ctx.error(
@@ -303,11 +325,16 @@ async def generate_explore_link(
                 str(e),
             )
         )
-        return {
-            "url": "",
-            "form_data": {},
-            "permalink_key": None,
-            "form_data_key": None,
-            "chart_type_label": None,
-            "error": f"Failed to generate explore link: {str(e)}",
-        }
+        return GenerateExploreLinkResponse(
+            url="",
+            form_data={},
+            permalink_key=None,
+            form_data_key=None,
+            chart_type_label=None,
+            error=ChartGenerationError(
+                error_type="generation_failed",
+                message="Failed to generate explore link",
+                details=str(e),
+            ).model_dump(),
+            success=False,
+        )

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -74,6 +74,14 @@ def mock_auth():
 
 
 @pytest.fixture(autouse=True)
+def mock_event_logger():
+    """Skip event-logger DB writes so a bad logs FK doesn't poison the
+    session for FastMCP's response serialization on the success path."""
+    with patch("superset.utils.log.DBEventLogger.log", return_value=None):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def mock_dataset_access_granted():
     """Grant dataset access by default; tests that need a denial override this."""
     with patch.object(
@@ -167,14 +175,14 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
-            assert result.data["permalink_key"] == "test_permalink_key"
-            assert result.data["form_data_key"] is None
-            assert result.data["chart_type_label"] == "table chart"
+            assert result.structured_content["permalink_key"] == "test_permalink_key"
+            assert result.structured_content["form_data_key"] is None
+            assert result.structured_content["chart_type_label"] == "table chart"
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -204,14 +212,14 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
-            assert result.data["permalink_key"] == "test_permalink_key"
-            assert result.data["form_data_key"] is None
-            assert result.data["chart_type_label"] == "table chart"
+            assert result.structured_content["permalink_key"] == "test_permalink_key"
+            assert result.structured_content["form_data_key"] is None
+            assert result.structured_content["chart_type_label"] == "table chart"
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -233,8 +241,8 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
-            assert result.data["chart_type_label"] == "interactive table chart"
+            assert result.structured_content["error"] is None
+            assert result.structured_content["chart_type_label"] == "interactive table chart"
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -264,12 +272,12 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
-            assert result.data["chart_type_label"] is None
+            assert result.structured_content["chart_type_label"] is None
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -292,9 +300,9 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
 
@@ -324,9 +332,9 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
 
@@ -354,9 +362,9 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
 
@@ -392,13 +400,13 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/?form_data_key=fallback_form_data_key"
             )
-            assert result.data["form_data_key"] == "fallback_form_data_key"
-            assert result.data["permalink_key"] is None
+            assert result.structured_content["form_data_key"] == "fallback_form_data_key"
+            assert result.structured_content["permalink_key"] is None
             mock_create_form_data.assert_called_once()
 
     @patch(_PERMALINK_PATCH)
@@ -434,9 +442,9 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/?datasource_type=table&datasource_id=1"
             )
 
@@ -473,9 +481,9 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/?form_data_key=lock_fallback_key"
             )
 
@@ -505,9 +513,9 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
 
@@ -543,9 +551,9 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
 
@@ -595,10 +603,10 @@ class TestGenerateExploreLink:
 
                 # All URLs should follow the same permalink format
                 assert (
-                    result.data["url"]
+                    result.structured_content["url"]
                     == "http://localhost:9001/explore/p/test_permalink_key/"
                 )
-                assert result.data["error"] is None
+                assert result.structured_content["error"] is None
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -621,9 +629,9 @@ class TestGenerateExploreLink:
                 result = await client.call_tool(
                     "generate_explore_link", {"request": request.model_dump()}
                 )
-                assert result.data["error"] is None
+                assert result.structured_content["error"] is None
                 assert (
-                    result.data["url"]
+                    result.structured_content["url"]
                     == "http://localhost:9001/explore/p/test_permalink_key/"
                 )
 
@@ -661,9 +669,9 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
             )
 
@@ -708,8 +716,8 @@ class TestGenerateExploreLink:
                     f"http://localhost:9001/explore/?datasource_type=table"
                     f"&datasource_id={dataset_id}"
                 )
-                assert result.data["error"] is None
-                assert result.data["url"] == expected_url
+                assert result.structured_content["error"] is None
+                assert result.structured_content["url"] == expected_url
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -744,12 +752,14 @@ class TestGenerateExploreLink:
                 )
 
                 # Should return error response with empty URL
-                assert result.data["url"] == ""
-                assert result.data["form_data"] == {}
-                assert result.data["form_data_key"] is None
-                assert result.data["permalink_key"] is None
-                assert result.data["chart_type_label"] is None
-                assert "Invalid config structure" in result.data["error"]
+                assert result.structured_content["url"] == ""
+                assert result.structured_content["form_data"] == {}
+                assert result.structured_content["form_data_key"] is None
+                assert result.structured_content["permalink_key"] is None
+                assert result.structured_content["chart_type_label"] is None
+                error = result.structured_content["error"]
+                assert error["error_type"] == "generation_failed"
+                assert "Invalid config structure" in error["details"]
         finally:
             # Restore original function
             explore_module.map_config_to_form_data = original_func
@@ -774,11 +784,11 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
-            assert result.data["permalink_key"] == "extracted_permalink_xyz"
-            assert result.data["form_data_key"] is None
-            assert "extracted_permalink_xyz" in result.data["url"]
-            assert result.data["url"] == (
+            assert result.structured_content["error"] is None
+            assert result.structured_content["permalink_key"] == "extracted_permalink_xyz"
+            assert result.structured_content["form_data_key"] is None
+            assert "extracted_permalink_xyz" in result.structured_content["url"]
+            assert result.structured_content["url"] == (
                 "http://localhost:9001/explore/p/extracted_permalink_xyz/"
             )
 
@@ -803,13 +813,13 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
-            assert "form_data" in result.data
-            assert isinstance(result.data["form_data"], dict)
-            assert result.data["form_data"].get("viz_type") == "echarts_timeseries_line"
-            assert result.data["form_data"].get("x_axis") == "date"
+            assert result.structured_content["error"] is None
+            assert "form_data" in result.structured_content
+            assert isinstance(result.structured_content["form_data"], dict)
+            assert result.structured_content["form_data"].get("viz_type") == "echarts_timeseries_line"
+            assert result.structured_content["form_data"].get("x_axis") == "date"
             # Verify datasource field format: "{dataset_id}__table"
-            assert result.data["form_data"].get("datasource") == "1__table"
+            assert result.structured_content["form_data"].get("datasource") == "1__table"
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -829,13 +839,15 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["url"] == ""
-            assert result.data["form_data"] == {}
-            assert result.data["form_data_key"] is None
-            assert result.data["permalink_key"] is None
-            assert result.data["chart_type_label"] is None
-            assert "Dataset not found: 99999" in result.data["error"]
-            assert "list_datasets" in result.data["error"]
+            assert result.structured_content["url"] == ""
+            assert result.structured_content["form_data"] == {}
+            assert result.structured_content["form_data_key"] is None
+            assert result.structured_content["permalink_key"] is None
+            assert result.structured_content["chart_type_label"] is None
+            error = result.structured_content["error"]
+            assert error["error_type"] == "dataset_not_found"
+            assert "Dataset not found: 99999" in error["message"]
+            assert "list_datasets" in error["details"]
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -852,16 +864,16 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             assert (
-                result.data["url"]
+                result.structured_content["url"]
                 == "http://localhost:9001/explore/?datasource_type=table"
                 "&datasource_id=42"
             )
-            assert result.data["form_data"] == {}
-            assert result.data["form_data_key"] is None
-            assert result.data["permalink_key"] is None
-            assert result.data["chart_type_label"] is None
+            assert result.structured_content["form_data"] == {}
+            assert result.structured_content["form_data_key"] is None
+            assert result.structured_content["permalink_key"] is None
+            assert result.structured_content["chart_type_label"] is None
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -878,12 +890,14 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["url"] == ""
-            assert result.data["form_data"] == {}
-            assert result.data["form_data_key"] is None
-            assert result.data["permalink_key"] is None
-            assert result.data["chart_type_label"] is None
-            assert "Dataset not found: 99999" in result.data["error"]
+            assert result.structured_content["url"] == ""
+            assert result.structured_content["form_data"] == {}
+            assert result.structured_content["form_data_key"] is None
+            assert result.structured_content["permalink_key"] is None
+            assert result.structured_content["chart_type_label"] is None
+            error = result.structured_content["error"]
+            assert error["error_type"] == "dataset_not_found"
+            assert "Dataset not found: 99999" in error["message"]
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -905,12 +919,14 @@ class TestGenerateExploreLink:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["url"] == ""
-            assert result.data["form_data"] == {}
-            assert result.data["form_data_key"] is None
-            assert result.data["permalink_key"] is None
-            assert result.data["chart_type_label"] is None
-            assert "Dataset not found" in result.data["error"]
+            assert result.structured_content["url"] == ""
+            assert result.structured_content["form_data"] == {}
+            assert result.structured_content["form_data_key"] is None
+            assert result.structured_content["permalink_key"] is None
+            assert result.structured_content["chart_type_label"] is None
+            error = result.structured_content["error"]
+            assert error["error_type"] == "dataset_not_found"
+            assert "Dataset not found" in error["message"]
 
 
 class TestGenerateExploreLinkColumnNormalization:
@@ -959,9 +975,9 @@ class TestGenerateExploreLinkColumnNormalization:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             # x-axis should be normalized from 'orderdate' to 'OrderDate'
-            assert result.data["form_data"]["x_axis"] == "OrderDate"
+            assert result.structured_content["form_data"]["x_axis"] == "OrderDate"
 
     @patch(
         "superset.mcp_service.chart.validation.dataset_validator.DatasetValidator._get_dataset_context"
@@ -1004,8 +1020,8 @@ class TestGenerateExploreLinkColumnNormalization:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
-            form_data = result.data["form_data"]
+            assert result.structured_content["error"] is None
+            form_data = result.structured_content["form_data"]
             # x-axis normalized
             assert form_data["x_axis"] == "OrderDate"
             # filter subject normalized to match x-axis
@@ -1045,9 +1061,9 @@ class TestGenerateExploreLinkColumnNormalization:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["error"] is None
+            assert result.structured_content["error"] is None
             # original names should pass through unchanged
-            assert result.data["form_data"]["x_axis"] == "orderdate"
+            assert result.structured_content["form_data"]["x_axis"] == "orderdate"
 
 
 class TestGenerateExploreLinkValidation:
@@ -1105,11 +1121,11 @@ class TestGenerateExploreLinkValidation:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["url"] == ""
-            assert result.data["form_data_key"] is None
-            assert result.data["permalink_key"] is None
-            assert result.data["chart_type_label"] is None
-            error = result.data["error"]
+            assert result.structured_content["url"] == ""
+            assert result.structured_content["form_data_key"] is None
+            assert result.structured_content["permalink_key"] is None
+            assert result.structured_content["chart_type_label"] is None
+            error = result.structured_content["error"]
             assert isinstance(error, dict)
             assert error["error_code"] == "CHART_VALIDATION_FAILED"
             assert "sum_boys" in error["suggestions"]
@@ -1141,8 +1157,11 @@ class TestGenerateExploreLinkValidation:
                 "generate_explore_link", {"request": request.model_dump()}
             )
 
-            assert result.data["url"] == ""
-            assert result.data["chart_type_label"] is None
-            # Surface as "not found" rather than leaking that the dataset exists.
-            assert "Dataset not found" in result.data["error"]
+            assert result.structured_content["url"] == ""
+            assert result.structured_content["chart_type_label"] is None
+            error = result.structured_content["error"]
+            # error_type lets programmatic callers distinguish, while the
+            # user-facing message still avoids leaking dataset existence.
+            assert error["error_type"] == "permission_denied"
+            assert "Dataset not found" in error["message"]
             mock_create_permalink.assert_not_called()

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -176,6 +176,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -213,6 +215,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -242,7 +246,12 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
-            assert result.structured_content["chart_type_label"] == "interactive table chart"
+
+            assert result.structured_content["success"] is True
+            assert (
+                result.structured_content["chart_type_label"]
+                == "interactive table chart"
+            )
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -273,6 +282,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -301,6 +312,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -333,6 +346,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -363,6 +378,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -405,7 +422,9 @@ class TestGenerateExploreLink:
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/?form_data_key=fallback_form_data_key"
             )
-            assert result.structured_content["form_data_key"] == "fallback_form_data_key"
+            assert (
+                result.structured_content["form_data_key"] == "fallback_form_data_key"
+            )
             assert result.structured_content["permalink_key"] is None
             mock_create_form_data.assert_called_once()
 
@@ -443,6 +462,7 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/?datasource_type=table&datasource_id=1"
@@ -482,6 +502,7 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/?form_data_key=lock_fallback_key"
@@ -514,6 +535,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -552,6 +575,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -607,6 +632,7 @@ class TestGenerateExploreLink:
                     == "http://localhost:9001/explore/p/test_permalink_key/"
                 )
                 assert result.structured_content["error"] is None
+                assert result.structured_content["success"] is True
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -630,6 +656,7 @@ class TestGenerateExploreLink:
                     "generate_explore_link", {"request": request.model_dump()}
                 )
                 assert result.structured_content["error"] is None
+                assert result.structured_content["success"] is True
                 assert (
                     result.structured_content["url"]
                     == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -670,6 +697,8 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/p/test_permalink_key/"
@@ -717,6 +746,7 @@ class TestGenerateExploreLink:
                     f"&datasource_id={dataset_id}"
                 )
                 assert result.structured_content["error"] is None
+                assert result.structured_content["success"] is True
                 assert result.structured_content["url"] == expected_url
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
@@ -757,9 +787,14 @@ class TestGenerateExploreLink:
                 assert result.structured_content["form_data_key"] is None
                 assert result.structured_content["permalink_key"] is None
                 assert result.structured_content["chart_type_label"] is None
+                assert result.structured_content["success"] is False
                 error = result.structured_content["error"]
                 assert error["error_type"] == "generation_failed"
-                assert "Invalid config structure" in error["details"]
+                # ``details`` is the static, sanitized message; the raw
+                # exception text ("Invalid config structure") is kept
+                # only in the server-side log, not echoed to the client.
+                assert "check server logs" in error["details"]
+                assert "Invalid config structure" not in error["details"]
         finally:
             # Restore original function
             explore_module.map_config_to_form_data = original_func
@@ -785,7 +820,10 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
-            assert result.structured_content["permalink_key"] == "extracted_permalink_xyz"
+            assert result.structured_content["success"] is True
+            assert (
+                result.structured_content["permalink_key"] == "extracted_permalink_xyz"
+            )
             assert result.structured_content["form_data_key"] is None
             assert "extracted_permalink_xyz" in result.structured_content["url"]
             assert result.structured_content["url"] == (
@@ -814,12 +852,19 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             assert "form_data" in result.structured_content
             assert isinstance(result.structured_content["form_data"], dict)
-            assert result.structured_content["form_data"].get("viz_type") == "echarts_timeseries_line"
+            assert (
+                result.structured_content["form_data"].get("viz_type")
+                == "echarts_timeseries_line"
+            )
             assert result.structured_content["form_data"].get("x_axis") == "date"
             # Verify datasource field format: "{dataset_id}__table"
-            assert result.structured_content["form_data"].get("datasource") == "1__table"
+            assert (
+                result.structured_content["form_data"].get("datasource") == "1__table"
+            )
 
     @patch("superset.daos.dataset.DatasetDAO.find_by_id")
     @pytest.mark.asyncio
@@ -844,6 +889,7 @@ class TestGenerateExploreLink:
             assert result.structured_content["form_data_key"] is None
             assert result.structured_content["permalink_key"] is None
             assert result.structured_content["chart_type_label"] is None
+            assert result.structured_content["success"] is False
             error = result.structured_content["error"]
             assert error["error_type"] == "dataset_not_found"
             assert "Dataset not found: 99999" in error["message"]
@@ -854,7 +900,10 @@ class TestGenerateExploreLink:
     async def test_generate_explore_link_without_config(
         self, mock_find_dataset, mcp_server
     ):
-        """Omitting config returns a default dataset explore URL."""
+        """Omitting config returns a default dataset explore URL through
+        the same typed ``GenerateExploreLinkResponse`` shape as every
+        other code path. ``success=True`` and ``error=None`` so callers
+        cannot mistake a no-config response for a failure."""
         mock_find_dataset.return_value = _mock_dataset(id=42)
 
         request = GenerateExploreLinkRequest(dataset_id="42")
@@ -865,6 +914,7 @@ class TestGenerateExploreLink:
             )
 
             assert result.structured_content["error"] is None
+            assert result.structured_content["success"] is True
             assert (
                 result.structured_content["url"]
                 == "http://localhost:9001/explore/?datasource_type=table"
@@ -880,7 +930,9 @@ class TestGenerateExploreLink:
     async def test_generate_explore_link_without_config_missing_dataset(
         self, mock_find_dataset, mcp_server
     ):
-        """Omitting config still surfaces a dataset-not-found error."""
+        """Omitting config still surfaces a dataset-not-found error
+        through the structured error object — not as a substring on a
+        dict, which is the bug this test originally hid."""
         mock_find_dataset.return_value = None
 
         request = GenerateExploreLinkRequest(dataset_id="99999")
@@ -895,6 +947,7 @@ class TestGenerateExploreLink:
             assert result.structured_content["form_data_key"] is None
             assert result.structured_content["permalink_key"] is None
             assert result.structured_content["chart_type_label"] is None
+            assert result.structured_content["success"] is False
             error = result.structured_content["error"]
             assert error["error_type"] == "dataset_not_found"
             assert "Dataset not found: 99999" in error["message"]
@@ -924,6 +977,7 @@ class TestGenerateExploreLink:
             assert result.structured_content["form_data_key"] is None
             assert result.structured_content["permalink_key"] is None
             assert result.structured_content["chart_type_label"] is None
+            assert result.structured_content["success"] is False
             error = result.structured_content["error"]
             assert error["error_type"] == "dataset_not_found"
             assert "Dataset not found" in error["message"]
@@ -976,6 +1030,8 @@ class TestGenerateExploreLinkColumnNormalization:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             # x-axis should be normalized from 'orderdate' to 'OrderDate'
             assert result.structured_content["form_data"]["x_axis"] == "OrderDate"
 
@@ -1021,6 +1077,8 @@ class TestGenerateExploreLinkColumnNormalization:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             form_data = result.structured_content["form_data"]
             # x-axis normalized
             assert form_data["x_axis"] == "OrderDate"
@@ -1062,6 +1120,8 @@ class TestGenerateExploreLinkColumnNormalization:
             )
 
             assert result.structured_content["error"] is None
+
+            assert result.structured_content["success"] is True
             # original names should pass through unchanged
             assert result.structured_content["form_data"]["x_axis"] == "orderdate"
 
@@ -1125,6 +1185,7 @@ class TestGenerateExploreLinkValidation:
             assert result.structured_content["form_data_key"] is None
             assert result.structured_content["permalink_key"] is None
             assert result.structured_content["chart_type_label"] is None
+            assert result.structured_content["success"] is False
             error = result.structured_content["error"]
             assert isinstance(error, dict)
             assert error["error_code"] == "CHART_VALIDATION_FAILED"
@@ -1159,6 +1220,7 @@ class TestGenerateExploreLinkValidation:
 
             assert result.structured_content["url"] == ""
             assert result.structured_content["chart_type_label"] is None
+            assert result.structured_content["success"] is False
             error = result.structured_content["error"]
             # error_type lets programmatic callers distinguish, while the
             # user-facing message still avoids leaking dataset existence.


### PR DESCRIPTION
### SUMMARY
Types the `generate_explore_link` MCP tool's response with a new `GenerateExploreLinkResponse` Pydantic model (in `superset/mcp_service/explore/schemas.py`) and switches all four failure paths to return the existing `ChartGenerationError` schema (from `superset/mcp_service/common/error_schemas.py`), serialized via `.model_dump()`.

Before this PR, the tool returned `Dict[str, Any]` with **inconsistent error shapes**: three failure paths returned a free-text `error` string while the validation path returned a structured dict. Callers had to detect the shape before reading it.

After this PR:

- One consistent return type (`GenerateExploreLinkResponse`)
- `error` is either `null` (success) or a `ChartGenerationError` dict on every failure
- A machine-readable `error_type` discriminant on every error path, so LLM/programmatic callers can branch on failure mode without parsing free-text messages:
  - `dataset_not_found` — dataset ID does not resolve
  - `permission_denied` — dataset exists but the user lacks access (user-facing message stays generic to avoid leaking dataset existence; the discriminant lets callers handle this case distinctly)
  - `validation_error` — Tier-1 schema validation fails (pre-existing path, now wrapped in the typed response)
  - `generation_failed` — generic exception fallback
- An explicit `success: bool` field so callers don't have to infer success from the absence of an error

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend/MCP-only change, no UI surface.

### TESTING INSTRUCTIONS
1. Run the unit tests for the tool:
   ```
   pytest tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py -v
   ```
2. Manually invoke the MCP `generate_explore_link` tool against a valid dataset and confirm the response is a structured object with `success: true`, a populated `url`, and `error: null`.
3. Invoke against an invalid dataset id and confirm the response includes `success: false` and an `error` object with `error_type: "dataset_not_found"`.
4. Invoke against a dataset the user lacks access to and confirm `error.error_type == "permission_denied"` while the user-facing `error.message` stays generic.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API