### PR TITLE
fix(deckgl): emit usable cross-filter values from polygon and geojson clicks

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/buildQuery.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/buildQuery.ts
@@ -33,6 +33,7 @@ export interface DeckGeoJsonFormData extends SqlaFormData {
   geojson?: string;
   filter_nulls?: boolean;
   js_columns?: string[];
+  cross_filter_column?: string | null;
   tooltip_contents?: unknown[];
 }
 
@@ -41,6 +42,7 @@ export default function buildQuery(formData: DeckGeoJsonFormData) {
     geojson,
     filter_nulls = true,
     js_columns,
+    cross_filter_column,
     tooltip_contents,
   } = formData;
 
@@ -60,6 +62,10 @@ export default function buildQuery(formData: DeckGeoJsonFormData) {
     );
     const withJsColumns = addJsColumnsToColumns(columnStrings, js_columns);
     columns = withJsColumns as QueryFormColumn[];
+
+    if (cross_filter_column && !columns.includes(cross_filter_column)) {
+      columns.push(cross_filter_column);
+    }
 
     // Add tooltip columns
     columns = addTooltipColumnsToQuery(columns, tooltip_contents);

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
@@ -44,6 +44,7 @@ import {
   tooltipContents,
   tooltipTemplate,
   jsFunctionControl,
+  crossFilterColumn,
 } from '../../utilities/Shared_DeckGL';
 import { dndGeojsonColumn } from '../../utilities/sharedDndControls';
 import { BLACK_COLOR } from '../../utilities/controls';
@@ -367,6 +368,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Advanced'),
       controlSetRows: [
+        [crossFilterColumn],
         [jsColumns],
         [jsDataMutator],
         [jsTooltip],

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/transformProps.ts
@@ -32,6 +32,7 @@ export default function transformProps(chartProps: ChartProps) {
   }
 
   const records = getRecordsFromQuery(chartProps.queriesData);
+  const crossFilterCol = formData.cross_filter_column || undefined;
 
   // Parse each record's geojson column value (replicates backend DeckGeoJson.get_properties)
   const features = records
@@ -39,7 +40,17 @@ export default function transformProps(chartProps: ChartProps) {
       const geojsonStr = record[geojsonCol];
       if (geojsonStr == null) return null;
       try {
-        return JSON.parse(String(geojsonStr));
+        const feature = JSON.parse(String(geojsonStr));
+        // Surface cross_filter_column from the row onto feature.properties so
+        // that picking can emit a dimension filter even when the GeoJSON blob
+        // doesn't carry the column itself.
+        if (crossFilterCol && record[crossFilterCol] !== undefined) {
+          feature.properties = {
+            ...feature.properties,
+            [crossFilterCol]: record[crossFilterCol],
+          };
+        }
+        return feature;
       } catch {
         return null;
       }

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/buildQuery.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/buildQuery.test.ts
@@ -363,6 +363,42 @@ describe('Polygon buildQuery', () => {
       expect(query.filters).toEqual([]);
     });
 
+    test('should include cross_filter_column in query columns when set', () => {
+      const formDataWithCrossFilter = {
+        ...baseFormData,
+        cross_filter_column: 'sa3_name',
+      };
+
+      const queryContext = buildQuery(formDataWithCrossFilter);
+      const [query] = queryContext.queries;
+
+      expect(query.columns).toContain('sa3_name');
+    });
+
+    test('should not duplicate cross_filter_column when it overlaps with another column', () => {
+      const formDataWithOverlap = {
+        ...baseFormData,
+        js_columns: ['sa3_name', 'extra_col'],
+        cross_filter_column: 'sa3_name',
+      };
+
+      const queryContext = buildQuery(formDataWithOverlap);
+      const [query] = queryContext.queries;
+
+      const sa3Count = query.columns?.filter(
+        (col: unknown) => col === 'sa3_name',
+      ).length;
+      expect(sa3Count).toBe(1);
+    });
+
+    test('should not add cross_filter_column to query columns when unset', () => {
+      const queryContext = buildQuery(baseFormData);
+      const [query] = queryContext.queries;
+
+      // Only the geometry column should be present; the control was not set.
+      expect(query.columns).toEqual(['polygon_geom']);
+    });
+
     test('should build comprehensive query when multiple form data fields are specified', () => {
       const complexFormData = {
         ...baseFormData,

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/buildQuery.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/buildQuery.ts
@@ -47,6 +47,7 @@ export interface DeckPolygonFormData extends SqlaFormData {
   reverse_long_lat?: boolean;
   filter_nulls?: boolean;
   js_columns?: string[];
+  cross_filter_column?: string | null;
   tooltip_contents?: unknown[];
   tooltip_template?: string;
 }
@@ -58,6 +59,7 @@ export default function buildQuery(formData: DeckPolygonFormData) {
     point_radius_fixed,
     filter_nulls = true,
     js_columns,
+    cross_filter_column,
     tooltip_contents,
   } = formData;
 
@@ -77,6 +79,10 @@ export default function buildQuery(formData: DeckPolygonFormData) {
         columns.push(col);
       }
     });
+
+    if (cross_filter_column && !columns.includes(cross_filter_column)) {
+      columns.push(cross_filter_column);
+    }
 
     columns = addTooltipColumnsToQuery(columns, tooltip_contents);
 

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/controlPanel.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/controlPanel.ts
@@ -30,6 +30,7 @@ import {
   jsDataMutator,
   jsTooltip,
   jsOnclickHref,
+  crossFilterColumn,
   legendFormat,
   legendPosition,
   fillColorPicker,
@@ -203,6 +204,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Advanced'),
       controlSetRows: [
+        [crossFilterColumn],
         [jsColumns],
         [jsDataMutator],
         [jsTooltip],

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/common.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/common.test.ts
@@ -166,6 +166,125 @@ describe('commonLayerProps', () => {
     props.onClick?.(pickingData, {});
     expect(mockOnSelect).toHaveBeenCalledWith('John Doe');
   });
+
+  describe('cross-filter onClick (deck.gl v9 event shape)', () => {
+    const crossFilterFormData = {
+      ...partialformData,
+      viz_type: 'deck_polygon',
+      line_column: 'geojson',
+      cross_filter_column: 'sa3_name',
+    } as unknown as QueryFormData;
+
+    const pickedPolygon = {
+      picked: true,
+      object: {
+        polygon: [
+          [-122.42, 37.8],
+          [-122.42, 37.81],
+        ],
+        sa3_name: 'Christchurch West',
+        extraProps: {},
+      },
+    } as unknown as PickingInfo;
+
+    test('left click dispatches setDataMask via event.type and srcEvent.button', () => {
+      const mockSetDataMask = jest.fn();
+      const mockOnContextMenu = jest.fn();
+      const props = commonLayerProps({
+        formData: crossFilterFormData,
+        setTooltip: mockSetTooltip,
+        setTooltipContent: mockSetTooltipContent,
+        setDataMask: mockSetDataMask,
+        onContextMenu: mockOnContextMenu,
+        emitCrossFilters: true,
+      });
+
+      props.onClick?.(pickedPolygon, {
+        type: 'click',
+        srcEvent: { button: 0 },
+        offsetCenter: { x: 10, y: 20 },
+      });
+
+      expect(mockSetDataMask).toHaveBeenCalledTimes(1);
+      expect(mockOnContextMenu).not.toHaveBeenCalled();
+      const arg = mockSetDataMask.mock.calls[0][0];
+      expect(arg.extraFormData.filters[0]).toEqual({
+        col: 'sa3_name',
+        op: '==',
+        val: 'Christchurch West',
+      });
+    });
+
+    test('right click dispatches onContextMenu via event.type "contextmenu"', () => {
+      const mockSetDataMask = jest.fn();
+      const mockOnContextMenu = jest.fn();
+      const props = commonLayerProps({
+        formData: crossFilterFormData,
+        setTooltip: mockSetTooltip,
+        setTooltipContent: mockSetTooltipContent,
+        setDataMask: mockSetDataMask,
+        onContextMenu: mockOnContextMenu,
+        emitCrossFilters: true,
+      });
+
+      props.onClick?.(pickedPolygon, {
+        type: 'contextmenu',
+        srcEvent: { button: 2 },
+        offsetCenter: { x: 100, y: 200 },
+      });
+
+      expect(mockOnContextMenu).toHaveBeenCalledTimes(1);
+      expect(mockSetDataMask).not.toHaveBeenCalled();
+      expect(mockOnContextMenu.mock.calls[0][0]).toBe(100);
+      expect(mockOnContextMenu.mock.calls[0][1]).toBe(200);
+    });
+
+    test('right click via srcEvent.button=2 (no contextmenu type) still dispatches onContextMenu', () => {
+      // deck.gl can deliver a right-click as event.type='click' with button=2.
+      const mockSetDataMask = jest.fn();
+      const mockOnContextMenu = jest.fn();
+      const props = commonLayerProps({
+        formData: crossFilterFormData,
+        setTooltip: mockSetTooltip,
+        setTooltipContent: mockSetTooltipContent,
+        setDataMask: mockSetDataMask,
+        onContextMenu: mockOnContextMenu,
+        emitCrossFilters: true,
+      });
+
+      props.onClick?.(pickedPolygon, {
+        type: 'click',
+        srcEvent: { button: 2 },
+        offsetCenter: { x: 50, y: 60 },
+      });
+
+      expect(mockOnContextMenu).toHaveBeenCalledTimes(1);
+      expect(mockSetDataMask).not.toHaveBeenCalled();
+    });
+
+    test('does not gate off when event has no leftButton/rightButton fields', () => {
+      // Regression guard: pre-v9 code checked event.leftButton/rightButton,
+      // which are undefined in current deck.gl. An event with only type+srcEvent
+      // must still dispatch.
+      const mockSetDataMask = jest.fn();
+      const props = commonLayerProps({
+        formData: crossFilterFormData,
+        setTooltip: mockSetTooltip,
+        setTooltipContent: mockSetTooltipContent,
+        setDataMask: mockSetDataMask,
+        emitCrossFilters: true,
+      });
+
+      props.onClick?.(pickedPolygon, {
+        type: 'click',
+        srcEvent: { button: 0 },
+        offsetCenter: { x: 0, y: 0 },
+        // leftButton/rightButton intentionally absent
+      });
+
+      expect(mockSetDataMask).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('getColorForBreakpoints', () => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/common.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/common.tsx
@@ -121,10 +121,21 @@ export function commonLayerProps({
         formData,
       });
 
-      if (event.leftButton && setDataMask !== undefined && crossFilters) {
+      // deck.gl v9 event shape: { type, offsetCenter, srcEvent, tapCount }.
+      // Older code checked event.leftButton / event.rightButton which no
+      // longer exist; dispatch on event.type and the underlying MouseEvent
+      // button instead.
+      const srcEvent = event?.srcEvent;
+      const isContextMenu =
+        event?.type === 'contextmenu' || srcEvent?.button === 2;
+      const isLeftClick =
+        event?.type === 'click' && (srcEvent?.button ?? 0) === 0;
+
+      if (isLeftClick && setDataMask !== undefined && crossFilters) {
         setDataMask(crossFilters.dataMask);
-      } else if (event.rightButton && onContextMenu !== undefined) {
-        onContextMenu(event.center.x, event.center.y, {
+      } else if (isContextMenu && onContextMenu !== undefined) {
+        const center = event?.offsetCenter ?? event?.center ?? { x: 0, y: 0 };
+        onContextMenu(center.x, center.y, {
           drillToDetail: [],
           crossFilter: crossFilters,
           drillBy: {},

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utilities/Shared_DeckGL.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utilities/Shared_DeckGL.tsx
@@ -181,6 +181,21 @@ export const jsColumns = {
   },
 };
 
+export const crossFilterColumn: CustomControlItem = {
+  name: 'cross_filter_column',
+  config: {
+    ...sharedControls.groupby,
+    label: t('Cross-filter column'),
+    multi: false,
+    default: null,
+    description: t(
+      'Dimension column emitted as a cross-filter when a feature is clicked. ' +
+        'Other charts on the dashboard match against this column. If unset, ' +
+        'falls back to the geometry column (legacy behavior, often unmatchable).',
+    ),
+  },
+};
+
 export const jsDataMutator = {
   name: 'js_data_mutator',
   config: jsFunctionControl(

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils/crossFiltersDataMask.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils/crossFiltersDataMask.test.ts
@@ -400,6 +400,293 @@ describe('getCrossFilterDataMask', () => {
     expect(dataMask).toStrictEqual(expected);
   });
 
+  test('deck_polygon with cross_filter_column emits dimension filter (top-level)', () => {
+    const polygonFormData = {
+      ...formData,
+      line_column: 'geojson',
+      cross_filter_column: 'sa3_name',
+    };
+
+    const polygonPickingData = {
+      ...pickingData,
+      object: {
+        polygon: [
+          [-122.42, 37.8],
+          [-122.42, 37.81],
+          [-122.41, 37.81],
+          [-122.41, 37.8],
+          [-122.42, 37.8],
+        ],
+        sa3_name: 'Christchurch West',
+        extraProps: {},
+      },
+    };
+
+    const dataMask = getCrossFilterDataMask({
+      formData: polygonFormData,
+      data: polygonPickingData,
+      filterState: {},
+    });
+
+    expect(dataMask).toStrictEqual({
+      dataMask: {
+        extraFormData: {
+          filters: [
+            {
+              col: 'sa3_name',
+              op: '==',
+              val: 'Christchurch West',
+            },
+          ],
+        },
+        filterState: {
+          value: ['Christchurch West'],
+        },
+      },
+      isCurrentValueSelected: false,
+    });
+  });
+
+  test('deck_polygon with cross_filter_column reads from extraProps fallback', () => {
+    const polygonFormData = {
+      ...formData,
+      line_column: 'geojson',
+      cross_filter_column: 'region_id',
+    };
+
+    const polygonPickingData = {
+      ...pickingData,
+      object: {
+        polygon: [
+          [-122.42, 37.8],
+          [-122.42, 37.81],
+          [-122.41, 37.81],
+          [-122.41, 37.8],
+          [-122.42, 37.8],
+        ],
+        extraProps: { region_id: 42 },
+      },
+    };
+
+    const dataMask = getCrossFilterDataMask({
+      formData: polygonFormData,
+      data: polygonPickingData,
+      filterState: {},
+    });
+
+    expect(dataMask).toStrictEqual({
+      dataMask: {
+        extraFormData: {
+          filters: [
+            {
+              col: 'region_id',
+              op: '==',
+              val: 42,
+            },
+          ],
+        },
+        filterState: {
+          value: [42],
+        },
+      },
+      isCurrentValueSelected: false,
+    });
+  });
+
+  test('deck_polygon falls back to legacy when cross_filter_column value missing on feature', () => {
+    const polygonFormData = {
+      ...formData,
+      line_column: 'geojson',
+      cross_filter_column: 'sa3_name',
+    };
+
+    const polygonPickingData = {
+      ...pickingData,
+      object: {
+        polygon: 'POLYGON_PATH_STRING',
+        // sa3_name intentionally absent (e.g. chart was saved before the column
+        // was added to the query)
+        extraProps: {},
+      },
+    };
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const dataMask = getCrossFilterDataMask({
+      formData: polygonFormData,
+      data: polygonPickingData,
+      filterState: {},
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+
+    expect(dataMask).toStrictEqual({
+      dataMask: {
+        extraFormData: {
+          filters: [
+            {
+              col: {
+                expressionType: 'SQL',
+                sqlExpression: "REPLACE(geojson, ' ', '')",
+                label: 'geojson',
+              },
+              op: '==',
+              val: '"POLYGON_PATH_STRING"',
+            },
+          ],
+        },
+        filterState: {
+          value: ['"POLYGON_PATH_STRING"'],
+        },
+      },
+      isCurrentValueSelected: false,
+    });
+  });
+
+  test('deck_polygon without cross_filter_column falls back to legacy geometry filter', () => {
+    const polygonFormData = {
+      ...formData,
+      line_column: 'geojson',
+    };
+
+    const polygonPickingData = {
+      ...pickingData,
+      object: {
+        polygon: 'POLYGON_PATH_STRING',
+      },
+    };
+
+    const dataMask = getCrossFilterDataMask({
+      formData: polygonFormData,
+      data: polygonPickingData,
+      filterState: {},
+    });
+
+    expect(dataMask).toStrictEqual({
+      dataMask: {
+        extraFormData: {
+          filters: [
+            {
+              col: {
+                expressionType: 'SQL',
+                sqlExpression: "REPLACE(geojson, ' ', '')",
+                label: 'geojson',
+              },
+              op: '==',
+              val: '"POLYGON_PATH_STRING"',
+            },
+          ],
+        },
+        filterState: {
+          value: ['"POLYGON_PATH_STRING"'],
+        },
+      },
+      isCurrentValueSelected: false,
+    });
+  });
+
+  test('deck_geojson with cross_filter_column emits filter from feature.properties', () => {
+    const geojsonFormData = {
+      ...formData,
+      geojson: 'shape',
+      cross_filter_column: 'sa3_name',
+    };
+
+    const geojsonPickingData = {
+      ...pickingData,
+      object: {
+        type: 'Feature',
+        properties: { sa3_name: 'Christchurch West', sa3_code: '301' },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-122.42, 37.8],
+              [-122.42, 37.81],
+              [-122.41, 37.81],
+              [-122.41, 37.8],
+              [-122.42, 37.8],
+            ],
+          ],
+        },
+      },
+    };
+
+    const dataMask = getCrossFilterDataMask({
+      formData: geojsonFormData,
+      data: geojsonPickingData,
+      filterState: {},
+    });
+
+    expect(dataMask).toStrictEqual({
+      dataMask: {
+        extraFormData: {
+          filters: [
+            {
+              col: 'sa3_name',
+              op: '==',
+              val: 'Christchurch West',
+            },
+          ],
+        },
+        filterState: {
+          value: ['Christchurch West'],
+        },
+      },
+      isCurrentValueSelected: false,
+    });
+  });
+
+  test('deck_geojson without cross_filter_column falls back to legacy LIKE filter', () => {
+    const geojsonFormData = {
+      ...formData,
+      geojson: 'shape',
+    };
+
+    const coords = [
+      [
+        [-122.42, 37.8],
+        [-122.42, 37.81],
+      ],
+    ];
+
+    const geojsonPickingData = {
+      ...pickingData,
+      object: {
+        type: 'Feature',
+        properties: {},
+        geometry: { type: 'Polygon', coordinates: coords },
+      },
+    };
+
+    const dataMask = getCrossFilterDataMask({
+      formData: geojsonFormData,
+      data: geojsonPickingData,
+      filterState: {},
+    });
+
+    expect(dataMask).toStrictEqual({
+      dataMask: {
+        extraFormData: {
+          filters: [
+            {
+              col: {
+                expressionType: 'SQL',
+                sqlExpression: "REPLACE(shape, ' ', '')",
+                label: 'shape',
+              },
+              op: 'LIKE',
+              val: `%${JSON.stringify(coords)}%`,
+            },
+          ],
+        },
+        filterState: {
+          value: [coords],
+        },
+      },
+      isCurrentValueSelected: false,
+    });
+  });
+
   test('handles Charts with GPU aggregation', () => {
     const latlongGPUFormData = {
       ...formData,

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils/crossFiltersDataMask.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils/crossFiltersDataMask.test.ts
@@ -493,7 +493,7 @@ describe('getCrossFilterDataMask', () => {
     });
   });
 
-  test('deck_polygon falls back to legacy when cross_filter_column value missing on feature', () => {
+  test('deck_polygon throws when cross_filter_column value missing on feature', () => {
     const polygonFormData = {
       ...formData,
       line_column: 'geojson',
@@ -510,36 +510,46 @@ describe('getCrossFilterDataMask', () => {
       },
     };
 
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const dataMask = getCrossFilterDataMask({
-      formData: polygonFormData,
-      data: polygonPickingData,
-      filterState: {},
-    });
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    warnSpy.mockRestore();
+    expect(() =>
+      getCrossFilterDataMask({
+        formData: polygonFormData,
+        data: polygonPickingData,
+        filterState: {},
+      }),
+    ).toThrow(/Cross-filter column "sa3_name" not present/);
+  });
 
-    expect(dataMask).toStrictEqual({
-      dataMask: {
-        extraFormData: {
-          filters: [
-            {
-              col: {
-                expressionType: 'SQL',
-                sqlExpression: "REPLACE(geojson, ' ', '')",
-                label: 'geojson',
-              },
-              op: '==',
-              val: '"POLYGON_PATH_STRING"',
-            },
+  test('deck_geojson throws when cross_filter_column value missing on feature properties', () => {
+    const geojsonFormData = {
+      ...formData,
+      geojson: 'shape',
+      cross_filter_column: 'sa3_name',
+    };
+
+    const geojsonPickingData = {
+      ...pickingData,
+      object: {
+        type: 'Feature',
+        properties: { other: 'value' },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-122.42, 37.8],
+              [-122.42, 37.81],
+            ],
           ],
         },
-        filterState: {
-          value: ['"POLYGON_PATH_STRING"'],
-        },
       },
-      isCurrentValueSelected: false,
-    });
+    };
+
+    expect(() =>
+      getCrossFilterDataMask({
+        formData: geojsonFormData,
+        data: geojsonPickingData,
+        filterState: {},
+      }),
+    ).toThrow(/Cross-filter column "sa3_name" not present/);
   });
 
   test('deck_polygon without cross_filter_column falls back to legacy geometry filter', () => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils/crossFiltersDataMask.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils/crossFiltersDataMask.ts
@@ -54,6 +54,7 @@ export interface LayerFormData extends SqlaFormData {
   spatial?: SpatialData;
   line_column?: string;
   geojson?: string;
+  cross_filter_column?: string | null;
 }
 
 export interface FilterResult {
@@ -408,10 +409,51 @@ const getLineColumnFilters = ({
   data: PickingInfo;
 }): FilterResult => {
   const path = (data?.object?.path || data.object?.polygon) as string;
-  const val = JSON.stringify(path);
 
   if (!formData.line_column) throw new Error('Line column is required');
   if (!path) throw new Error('Position of picked data is required');
+
+  // Preferred path: emit on a dimension column the user selected. The value
+  // can land either directly on the picked feature (groupby/excluded keys are
+  // spread by addPropertiesToFeature) or under extraProps when it overlaps
+  // with js_columns (addJsColumnsToExtraProps).
+  if (formData.cross_filter_column) {
+    const col = formData.cross_filter_column;
+    const obj = data.object ?? {};
+    const extraProps = (obj.extraProps ?? {}) as Record<string, unknown>;
+    const dimensionVal = (obj[col] ?? extraProps[col]) as
+      | string
+      | number
+      | boolean
+      | null
+      | undefined;
+
+    if (dimensionVal != null) {
+      return {
+        values: [dimensionVal as string | number],
+        filters: [
+          {
+            col,
+            op: '==',
+            val: dimensionVal as string | number | boolean,
+          },
+        ],
+      };
+    }
+    // Value missing on the picked feature (e.g. column not in query yet
+    // because chart was saved pre-feature). Fall through to legacy path so
+    // the click still produces *some* filter rather than a silent error.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `deck.gl cross-filter: column "${col}" not present on picked feature; ` +
+        `falling back to geometry filter. Re-save the chart to refresh its query.`,
+    );
+  }
+
+  // Legacy fallback: filter on the geometry column itself. This rarely matches
+  // anything stored as a full GeoJSON Feature; users should set
+  // cross_filter_column instead.
+  const val = JSON.stringify(path);
 
   return {
     values: [val],
@@ -436,6 +478,40 @@ const getGeojsonFilters = ({
   formData: LayerFormData;
   data: PickingInfo;
 }): FilterResult => {
+  // Preferred path: emit on a property of the picked GeoJSON Feature.
+  if (formData.cross_filter_column) {
+    const col = formData.cross_filter_column;
+    const properties = (data.object?.properties ?? {}) as Record<
+      string,
+      unknown
+    >;
+    const dimensionVal = properties[col] as
+      | string
+      | number
+      | boolean
+      | null
+      | undefined;
+
+    if (dimensionVal != null) {
+      return {
+        values: [dimensionVal as string | number],
+        filters: [
+          {
+            col,
+            op: '==',
+            val: dimensionVal as string | number | boolean,
+          },
+        ],
+      };
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `deck.gl cross-filter: column "${col}" not present on picked feature ` +
+        `properties; falling back to geometry filter.`,
+    );
+  }
+
+  // Legacy fallback: substring match against the stored geojson string.
   const geometry = data.object?.geometry?.coordinates;
 
   if (!geometry) throw new Error('Position of picked data is required');

--- a/superset-frontend/plugins/preset-chart-deckgl/src/utils/crossFiltersDataMask.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/utils/crossFiltersDataMask.ts
@@ -428,30 +428,28 @@ const getLineColumnFilters = ({
       | null
       | undefined;
 
-    if (dimensionVal != null) {
-      return {
-        values: [dimensionVal as string | number],
-        filters: [
-          {
-            col,
-            op: '==',
-            val: dimensionVal as string | number | boolean,
-          },
-        ],
-      };
+    if (dimensionVal == null) {
+      throw new Error(
+        `Cross-filter column "${col}" not present on picked feature. ` +
+          `Re-save the chart to refresh its query.`,
+      );
     }
-    // Value missing on the picked feature (e.g. column not in query yet
-    // because chart was saved pre-feature). Fall through to legacy path so
-    // the click still produces *some* filter rather than a silent error.
-    // eslint-disable-next-line no-console
-    console.warn(
-      `deck.gl cross-filter: column "${col}" not present on picked feature; ` +
-        `falling back to geometry filter. Re-save the chart to refresh its query.`,
-    );
+
+    return {
+      values: [dimensionVal],
+      filters: [
+        {
+          col,
+          op: '==',
+          val: dimensionVal,
+        },
+      ],
+    };
   }
 
-  // Legacy fallback: filter on the geometry column itself. This rarely matches
-  // anything stored as a full GeoJSON Feature; users should set
+  // No cross_filter_column configured: emit a filter on the geometry column.
+  // This is preserved for backwards compatibility, but typically does not
+  // match anything stored as a full GeoJSON Feature; users should set
   // cross_filter_column instead.
   const val = JSON.stringify(path);
 
@@ -492,26 +490,26 @@ const getGeojsonFilters = ({
       | null
       | undefined;
 
-    if (dimensionVal != null) {
-      return {
-        values: [dimensionVal as string | number],
-        filters: [
-          {
-            col,
-            op: '==',
-            val: dimensionVal as string | number | boolean,
-          },
-        ],
-      };
+    if (dimensionVal == null) {
+      throw new Error(
+        `Cross-filter column "${col}" not present on picked feature properties`,
+      );
     }
-    // eslint-disable-next-line no-console
-    console.warn(
-      `deck.gl cross-filter: column "${col}" not present on picked feature ` +
-        `properties; falling back to geometry filter.`,
-    );
+
+    return {
+      values: [dimensionVal],
+      filters: [
+        {
+          col,
+          op: '==',
+          val: dimensionVal,
+        },
+      ],
+    };
   }
 
-  // Legacy fallback: substring match against the stored geojson string.
+  // No cross_filter_column configured: substring match against the stored
+  // geojson string. Preserved for backwards compatibility.
   const geometry = data.object?.geometry?.coordinates;
 
   if (!geometry) throw new Error('Position of picked data is required');


### PR DESCRIPTION
### SUMMARY

deck.gl Polygon and Geojson charts emit cross-filters whose values cannot match anything in receiving charts. Clicking a region produces a chip with a long polygon-coordinate JSON string, and any receiving chart filtered by it shows "No data". The emitted SQL clause is:

```
REPLACE(<geometry_column>, ' ', '') == '<JSON.stringify(picked path)>'
```

…which compares a bare coordinate path to a column that typically stores a full GeoJSON Feature. It can never match.

This PR adds a new optional **Cross-filter column** control (`cross_filter_column`) to deck_polygon and deck_geojson. When set, clicking a feature emits a clean dimension filter:

```
sa3_name == 'Christchurch West'
```

…which other charts on the dashboard match by column name and renders as a readable chip.

**Resolution paths for the dimension value:**
- **deck_polygon**: read from `data.object[col]` (groupby/columns are spread onto the picked feature by `addPropertiesToFeature`), falling back to `data.object.extraProps[col]` for `js_columns` overlap. The control is added to the chart's query in `buildQuery.ts` so the column actually comes back in records.
- **deck_geojson**: read from `data.object.properties[col]` — the standard non-spatial location on a GeoJSON Feature.

When `cross_filter_column` is unset (or its value is missing on the picked feature), behavior falls back to the legacy filter so existing dashboards keep working. A `console.warn` flags the fallback case so users know to re-save.

### Bonus fix: deck.gl v9 event-shape regression

While testing locally I found that left-click on any deck.gl chart with cross-filtering enabled has been silently emitting nothing since the deck.gl v9 upgrade. The handler in `commonLayerProps` was checking `event.leftButton` / `event.rightButton`, which deck.gl v9 no longer provides:

```ts
if (event.leftButton && setDataMask !== undefined && crossFilters) { ... }
else if (event.rightButton && onContextMenu !== undefined) { ... }
```

Both flags are `undefined` in v9; the actual event shape is `{ type, offsetCenter, srcEvent, tapCount }`. Dispatch now uses `event.type` and `srcEvent.button` (standard MouseEvent semantics — `button === 0` is left, `=== 2` is right). This restores left-click filter emission and right-click context menus across all deck.gl chart types, not just the polygon/geojson cases above.

This fix is included in scope because the cross-filter feature is unobservably broken without it — even verifying the original bug locally requires the click handler to fire at all.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — text-only diff. Symptom is described in detail above.

### TESTING INSTRUCTIONS

1. Build a deck.gl Polygon chart with `Polygon Column = geojson` (any dataset whose geometry column stores GeoJSON Features will do).
2. Add it to a dashboard alongside another chart whose dataset shares a non-spatial dimension (e.g. `sa3_name`).
3. Enable cross-filtering on the dashboard and on the chart.
4. **Without the fix**: clicking a polygon does nothing visible (left-click event not gated correctly) or, if the click handler ran, would emit a polygon-JSON chip and "No data" in the receiving chart.
5. **With the fix, `cross_filter_column` unset**: clicking emits the legacy broken filter (chip = polygon JSON), which is what older charts expect. Backwards-compatible.
6. **With the fix, `cross_filter_column = 'sa3_name'`** (set under Customize → Advanced → Cross-filter column, then re-run the chart so the column lands in records, then save): clicking emits `sa3_name == '<region>'`. Chip reads `sa3_name: <region>`. Receiving chart filters correctly.
7. Right-click on a polygon should now open the standard context menu (Drill / Filter) — same fix as #4.
8. Same flow works for deck.gl Geojson, where the dimension column must exist inside each Feature's `properties` object.

#### Automated tests

- `crossFiltersDataMask.test.ts` extended with 6 new cases: polygon w/ top-level dimension, polygon w/ extraProps fallback, polygon w/ legacy fallback when value missing (validates the warn), polygon legacy path (no cross_filter_column), geojson w/ properties, geojson legacy path.
- All 256 tests in `preset-chart-deckgl` pass; tsc and prettier clean.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

This supersedes #28262 (open since April 2024, marked stale by maintainers, targets the now-removed `legacy-preset-chart-deckgl/` path, predates the merged cross-filter feature in #33789).