### PR TITLE
fix(dashboard): match auto-refresh paused-dot outline to icon color

### DIFF
--- a/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.test.tsx
+++ b/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.test.tsx
@@ -17,7 +17,8 @@
  * under the License.
  */
 import { render, screen, act } from 'spec/helpers/testing-library';
-import { StatusIndicatorDot } from './StatusIndicatorDot';
+import { supersetTheme } from '@apache-superset/core/theme';
+import { getStatusConfig, StatusIndicatorDot } from './StatusIndicatorDot';
 import { AutoRefreshStatus } from '../../types/autoRefresh';
 
 afterEach(() => {
@@ -60,6 +61,15 @@ test('renders with paused status', () => {
   render(<StatusIndicatorDot status={AutoRefreshStatus.Paused} />);
   const dot = screen.getByTestId('status-indicator-dot');
   expect(dot).toHaveAttribute('data-status', AutoRefreshStatus.Paused);
+});
+
+test('uses the icon color for the paused status outline', () => {
+  expect(
+    getStatusConfig(supersetTheme, AutoRefreshStatus.Paused),
+  ).toMatchObject({
+    needsBorder: true,
+    outlineColor: 'currentColor',
+  });
 });
 
 test('has correct accessibility attributes', () => {

--- a/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.tsx
+++ b/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.tsx
@@ -39,9 +39,10 @@ export interface StatusIndicatorDotProps {
 interface StatusConfig {
   color: string;
   needsBorder: boolean;
+  outlineColor?: string;
 }
 
-const getStatusConfig = (
+export const getStatusConfig = (
   theme: ReturnType<typeof useTheme>,
   status: AutoRefreshStatus,
 ): StatusConfig => {
@@ -75,6 +76,7 @@ const getStatusConfig = (
       return {
         color: theme.colorBgContainer,
         needsBorder: true,
+        outlineColor: 'currentColor',
       };
     default:
       return {
@@ -136,13 +138,15 @@ export const StatusIndicatorDot: FC<StatusIndicatorDotProps> = ({
       width: ${size}px;
       height: ${size}px;
       border-radius: 50%;
+      color: ${theme.colorTextSecondary};
       background-color: ${statusConfig.color};
       transition:
         background-color ${theme.motionDurationMid} ease-in-out,
         border-color ${theme.motionDurationMid} ease-in-out;
-      border: ${statusConfig.needsBorder
-        ? `1px solid ${theme.colorTextSecondary}`
-        : 'none'};
+      border: ${statusConfig.needsBorder ? '1px solid' : 'none'};
+      border-color: ${statusConfig.needsBorder
+        ? statusConfig.outlineColor
+        : 'transparent'};
       box-shadow: ${statusConfig.needsBorder
         ? 'none'
         : `0 0 0 2px ${theme.colorBgContainer}`};

--- a/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.tsx
+++ b/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.tsx
@@ -141,7 +141,7 @@ export const StatusIndicatorDot: FC<StatusIndicatorDotProps> = ({
         background-color ${theme.motionDurationMid} ease-in-out,
         border-color ${theme.motionDurationMid} ease-in-out;
       border: ${statusConfig.needsBorder
-        ? `1px solid ${theme.colorBorder}`
+        ? `1px solid ${theme.colorTextSecondary}`
         : 'none'};
       box-shadow: ${statusConfig.needsBorder
         ? 'none'


### PR DESCRIPTION
### SUMMARY

The auto-refresh status indicator's paused-state dot was using `theme.colorBorder` for its 1px outline, which is too dim against the surrounding container — making the dot nearly invisible. Switch the outline to `theme.colorTextSecondary` so it visually aligns with the adjacent play/pause icon (which already uses `colorTextSecondary` in the parent `iconButtonStyles`).

Single-line change in `StatusIndicatorDot.tsx` — only affects the `Paused` status; the other statuses (`Success`/`Idle`/`Fetching`/`Delayed`/`Error`) don't render a border.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** outline rendered with `colorBorder` — barely visible.
**After:** outline rendered with `colorTextSecondary` — matches the play icon color.

_(Screenshots to be attached.)_

### TESTING INSTRUCTIONS

1. Open a dashboard that has auto-refresh enabled (Edit dashboard → Properties → set a refresh interval).
2. The status indicator next to the play/pause button should be a colored dot (green/blue/yellow/red).
3. Click the pause button. The dot becomes a hollow circle outlined in the container background.
4. Verify the outline color matches the play icon color (both `colorTextSecondary`), not the dimmer `colorBorder`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API