### PR TITLE
fix(chart): re-enable cross-filtering on categorical X-axis when groupby is empty (backport to 6.0)

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -73,6 +73,11 @@ export default function EchartsTimeseries({
 
   const hasDimensions = ensureIsArray(groupby).length > 0;
 
+  // Determine if X-axis can be used for cross-filtering (categorical axis without dimensions)
+  // Cross-filter using X-axis value when no dimensions are set (issue #25334)
+  const canCrossFilterByXAxis =
+    !hasDimensions && xAxis.type === AxisType.Category;
+
   const getModelInfo = (target: ViewRootGroup, globalModel: GlobalModel) => {
     let el = target;
     let model: ComponentModel | null = null;
@@ -130,6 +135,43 @@ export default function EchartsTimeseries({
     [groupby, labelMap, selectedValues],
   );
 
+  // Cross-filter using X-axis value when no dimensions are set (issue #25334)
+  const getXAxisCrossFilterDataMask = useCallback(
+    (xAxisValue: string | number) => {
+      const stringValue = String(xAxisValue);
+      const selected: string[] = Object.values(selectedValues);
+      let values: string[];
+      if (selected.includes(stringValue)) {
+        values = selected.filter(v => v !== stringValue);
+      } else {
+        values = [stringValue];
+      }
+      return {
+        dataMask: {
+          extraFormData: {
+            filters:
+              values.length === 0
+                ? []
+                : [
+                    {
+                      col: xAxis.label,
+                      op: 'IN' as const,
+                      val: values,
+                    },
+                  ],
+          },
+          filterState: {
+            label: values.length ? values : undefined,
+            value: values.length ? values : null,
+            selectedValues: values.length ? values : null,
+          },
+        },
+        isCurrentValueSelected: selected.includes(stringValue),
+      };
+    },
+    [selectedValues, xAxis.label],
+  );
+
   const handleChange = useCallback(
     (value: string) => {
       if (!emitCrossFilters) {
@@ -140,9 +182,21 @@ export default function EchartsTimeseries({
     [emitCrossFilters, setDataMask, getCrossFilterDataMask],
   );
 
+  // Handle cross-filter using X-axis value when no dimensions (issue #25334)
+  const handleXAxisChange = useCallback(
+    (xAxisValue: string | number) => {
+      if (!emitCrossFilters) {
+        return;
+      }
+      setDataMask(getXAxisCrossFilterDataMask(xAxisValue).dataMask);
+    },
+    [emitCrossFilters, setDataMask, getXAxisCrossFilterDataMask],
+  );
+
   const eventHandlers: EventHandlers = {
     click: props => {
-      if (!hasDimensions) {
+      // Allow cross-filter by dimensions OR by categorical X-axis (issue #25334)
+      if (!hasDimensions && !canCrossFilterByXAxis) {
         return;
       }
       if (clickTimer.current) {
@@ -150,8 +204,14 @@ export default function EchartsTimeseries({
       }
       // Ensure that double-click events do not trigger single click event. So we put it in the timer.
       clickTimer.current = setTimeout(() => {
-        const { seriesName: name } = props;
-        handleChange(name);
+        if (hasDimensions) {
+          // Cross-filter by dimension (original behavior)
+          const { seriesName: name } = props;
+          handleChange(name);
+        } else if (canCrossFilterByXAxis && props.data?.[0] != null) {
+          // Cross-filter by X-axis value when no dimensions (issue #25334)
+          handleXAxisChange(props.data[0]);
+        }
       }, TIMER_DURATION);
     },
     mouseout: () => {
@@ -228,12 +288,18 @@ export default function EchartsTimeseries({
           });
         });
 
+        // Provide cross-filter for dimensions OR categorical X-axis (issue #25334)
+        let crossFilter;
+        if (hasDimensions) {
+          crossFilter = getCrossFilterDataMask(seriesName);
+        } else if (canCrossFilterByXAxis && data?.[0] != null) {
+          crossFilter = getXAxisCrossFilterDataMask(data[0]);
+        }
+
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
           drillBy: { filters: drillByFilters, groupbyFieldName: 'groupby' },
-          crossFilter: hasDimensions
-            ? getCrossFilterDataMask(seriesName)
-            : undefined,
+          crossFilter,
         });
       }
     },


### PR DESCRIPTION
## Summary

Cross-filtering is silently broken in 6.0.0 for the most common bar chart pattern: charts that use a categorical `x_axis` column with no `groupby` series breakdown.

This is a backport of the fix already merged to `master` (issue #25334) to the `6.0-bug-fixes` branch.

### Root cause

`EchartsTimeseries.tsx` only emits a `crossFilter` object when `hasDimensions` is true (`groupby` is non-empty):

```typescript
crossFilter: hasDimensions
  ? getCrossFilterDataMask(seriesName)
  : undefined,   // ← always undefined when groupby is []
```

This was fine before PR #31582, which moved the categorical X-axis column from `groupby` to the dedicated `x_axis` field. After that migration, charts that only define an X-axis category have `groupby = []`, so `hasDimensions = false` and cross-filtering is permanently disabled — both right-click "Add Cross Filter" (appears grayed out) and left-click selection.

### Fix

Introduces `canCrossFilterByXAxis = !hasDimensions && xAxis.type === AxisType.Category` and a parallel `getXAxisCrossFilterDataMask` helper that builds the filter on `xAxis.label` from the clicked bar's category value (`props.data[0]`). Both the `click` and `contextmenu` handlers are updated to use this path when `groupby` is empty but the X-axis is categorical.

Toggle/deselect uses `Object.values(selectedValues)`, consistent with the existing `getCrossFilterDataMask` behaviour.

### Changes

- `superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx`

### Testing

Verified end-to-end in a Superset 6.0 instance:
- Bar chart with `x_axis = clinical_stage`, `groupby = []`
- Right-click → "Add Cross Filter" is now enabled (was grayed out)
- Left-click on a bar applies `clinical_stage IN [value]` and all connected charts update
- Clicking the same bar again deselects (toggle behaviour)
- Charts with `groupby` set continue to use the original dimension-based cross-filter path

### Notes

The equivalent fix was already applied to `master` (see issue #25334). This PR backports only the cross-filter change to `6.0-bug-fixes`, with no unrelated changes from `master`.

Fixes #25334 (backport to 6.0)