### PR TITLE
fix(mcp): handle SSL connection drop during pre-call session teardown

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -552,7 +552,7 @@ def _remove_session_safe() -> None:
                 "Could not invalidate session after connection error: %s",
                 invalidate_exc,
             )
-        db.session.remove()
+        db.session.remove()  # retry: session deregisters cleanly after invalidation
 
 
 def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -523,7 +523,9 @@ def _remove_session_safe() -> None:
     the session is removed to prevent a prior request's thread-local session
     from leaking into the next one.  If the underlying DBAPI connection died
     between requests (e.g. RDS SSL idle-timeout or max-connection-age), the
-    rollback implicit in ``session.close()`` raises ``OperationalError``.
+    rollback implicit in ``session.close()`` raises a ``DBAPIError`` subclass
+    (``OperationalError`` for psycopg2, ``InterfaceError`` for some other
+    drivers).
 
     When that happens:
     1. Invalidate the dead connection so the pool discards it (rather than
@@ -533,13 +535,13 @@ def _remove_session_safe() -> None:
     The tool call still proceeds because a fresh connection will be obtained
     on the next DB access.
     """
-    from sqlalchemy.exc import OperationalError
+    from sqlalchemy.exc import DBAPIError
 
     from superset.extensions import db
 
     try:
         db.session.remove()
-    except OperationalError as exc:
+    except DBAPIError as exc:
         logger.warning(
             "Connection error during pre-call session cleanup "
             "(likely SSL/idle timeout); invalidating connection and retrying: %s",

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -516,6 +516,45 @@ def _cleanup_session_on_error() -> None:
         logger.warning("Error cleaning up session after exception: %s", e)
 
 
+def _remove_session_safe() -> None:
+    """Remove the scoped SQLAlchemy session, tolerating SSL/connection errors.
+
+    Thread-pool workers reuse threads across requests.  Before each tool call
+    the session is removed to prevent a prior request's thread-local session
+    from leaking into the next one.  If the underlying DBAPI connection died
+    between requests (e.g. RDS SSL idle-timeout or max-connection-age), the
+    rollback implicit in ``session.close()`` raises ``OperationalError``.
+
+    When that happens:
+    1. Invalidate the dead connection so the pool discards it (rather than
+       returning a broken connection to the next caller).
+    2. Retry ``remove()`` to deregister the session from the scoped registry.
+
+    The tool call still proceeds because a fresh connection will be obtained
+    on the next DB access.
+    """
+    from sqlalchemy.exc import OperationalError
+
+    from superset.extensions import db
+
+    try:
+        db.session.remove()
+    except OperationalError as exc:
+        logger.warning(
+            "Connection error during pre-call session cleanup "
+            "(likely SSL/idle timeout); invalidating connection and retrying: %s",
+            exc,
+        )
+        try:
+            db.session.invalidate()
+        except Exception as invalidate_exc:
+            logger.debug(
+                "Could not invalidate session after connection error: %s",
+                invalidate_exc,
+            )
+        db.session.remove()
+
+
 def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
     """
     Authentication and authorization decorator for MCP tools.
@@ -638,9 +677,7 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                 # still be bound to a different tenant's DB engine. Removing it here
                 # ensures the next DB access creates a fresh session bound to the
                 # correct engine for the current request.
-                from superset.extensions import db
-
-                db.session.remove()
+                _remove_session_safe()
                 user = _setup_user_context()
 
                 # No Flask context - this is a FastMCP internal operation

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -352,9 +352,9 @@ def test_mcp_auth_hook_preserves_g_user_in_request_context(app) -> None:
 
     def _assert_preserved_then_return():
         """Verify g.user was preserved (not cleared) before returning."""
-        assert hasattr(
-            g, "user"
-        ), "g.user should be preserved in request context but was removed"
+        assert hasattr(g, "user"), (
+            "g.user should be preserved in request context but was removed"
+        )
         assert g.user is middleware_user, (
             "g.user should be preserved in request context but was changed; "
             f"g.user={g.user}"
@@ -430,20 +430,15 @@ def test_sync_wrapper_handles_ssl_error_on_pre_call_remove(app) -> None:
 
     wrapped = mcp_auth_hook(dummy_tool)
 
-    remove_call_count = 0
-
-    def _flaky_remove() -> None:
-        nonlocal remove_call_count
-        remove_call_count += 1
-        if remove_call_count == 1:
-            raise SAOperationalError(
-                "SSL connection has been closed unexpectedly", None, None
-            )
-
     with app.test_request_context():
         g.user = fresh_user
         with patch("superset.extensions.db") as mock_db:
-            mock_db.session.remove.side_effect = _flaky_remove
+            mock_db.session.remove.side_effect = [
+                SAOperationalError(
+                    "SSL connection has been closed unexpectedly", None, None
+                ),
+                None,  # second call succeeds
+            ]
 
             with patch(
                 "superset.mcp_service.auth.get_user_from_request",
@@ -453,7 +448,9 @@ def test_sync_wrapper_handles_ssl_error_on_pre_call_remove(app) -> None:
 
     assert result == "fresh"
     assert mock_db.session.invalidate.called, "invalidate() must be called on SSL error"
-    assert remove_call_count == 2, "remove() must be retried after SSL error"
+    assert mock_db.session.remove.call_count == 2, (
+        "remove() must be retried after SSL error"
+    )
 
 
 # -- default_user_resolver --

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -352,9 +352,9 @@ def test_mcp_auth_hook_preserves_g_user_in_request_context(app) -> None:
 
     def _assert_preserved_then_return():
         """Verify g.user was preserved (not cleared) before returning."""
-        assert hasattr(g, "user"), (
-            "g.user should be preserved in request context but was removed"
-        )
+        assert hasattr(
+            g, "user"
+        ), "g.user should be preserved in request context but was removed"
         assert g.user is middleware_user, (
             "g.user should be preserved in request context but was changed; "
             f"g.user={g.user}"
@@ -407,6 +407,53 @@ def test_mcp_auth_hook_removes_stale_db_session_in_sync_wrapper(app) -> None:
                 result = wrapped()
 
     assert result == "fresh"
+
+
+def test_sync_wrapper_handles_ssl_error_on_pre_call_remove(app) -> None:
+    """sync_wrapper tolerates OperationalError from db.session.remove() before the call.
+
+    If the underlying DBAPI connection died between requests (e.g. RDS SSL
+    idle-timeout), the rollback implicit in session.close() raises
+    OperationalError.  _remove_session_safe() should:
+    - Log a warning
+    - Call session.invalidate() to mark the dead connection for pool discard
+    - Retry session.remove() so the registry is clean
+    - Allow the tool to run successfully
+    """
+    from sqlalchemy.exc import OperationalError as SAOperationalError
+
+    fresh_user = _make_mock_user("fresh")
+
+    def dummy_tool() -> str:
+        """Dummy sync tool."""
+        return g.user.username
+
+    wrapped = mcp_auth_hook(dummy_tool)
+
+    remove_call_count = 0
+
+    def _flaky_remove() -> None:
+        nonlocal remove_call_count
+        remove_call_count += 1
+        if remove_call_count == 1:
+            raise SAOperationalError(
+                "SSL connection has been closed unexpectedly", None, None
+            )
+
+    with app.test_request_context():
+        g.user = fresh_user
+        with patch("superset.extensions.db") as mock_db:
+            mock_db.session.remove.side_effect = _flaky_remove
+
+            with patch(
+                "superset.mcp_service.auth.get_user_from_request",
+                return_value=fresh_user,
+            ):
+                result = wrapped()
+
+    assert result == "fresh"
+    assert mock_db.session.invalidate.called, "invalidate() must be called on SSL error"
+    assert remove_call_count == 2, "remove() must be retried after SSL error"
 
 
 # -- default_user_resolver --


### PR DESCRIPTION
### SUMMARY
MCP tools running in thread-pool workers (sync tools) call `db.session.remove()` before each invocation to clear any stale thread-local session. If the underlying DBAPI connection died between requests — e.g. RDS dropped it due to SSL idle-timeout or max-connection-age — the implicit `rollback()` inside `session.close()` raises `OperationalError`. This caused the tool call to fail with a stack trace, even when the operation itself had completed successfully.

**Root cause:** `sync_wrapper` in `auth.py` called `db.session.remove()` bare, with no handling for connection-level errors.

**Fix:** Extract `_remove_session_safe()` which:
1. Catches `OperationalError` from `session.remove()`
2. Calls `session.invalidate()` to mark the dead connection for pool discard (prevents it being checked out again by another thread)
3. Retries `session.remove()` to deregister the scoped session

The tool call proceeds normally; a fresh connection is obtained on the next DB access.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend-only change

### TESTING INSTRUCTIONS
1. Unit test: `pytest tests/unit_tests/mcp_service/test_auth_user_resolution.py::test_sync_wrapper_handles_ssl_error_on_pre_call_remove`
2. To reproduce manually: configure a short RDS SSL idle timeout, make an MCP tool call after an idle period — observe no error in logs.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API