### PR TITLE
fix: allow clearing database/schema in DatasourceModal

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -114,14 +114,15 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   const buildPayload = (datasource: Record<string, any>) => {
     const payload: Record<string, any> = {
       table_name: datasource.table_name,
-      database_id: datasource.database?.id ?? null,
+      database_id: datasource.database?.id,
       sql: datasource.sql,
       filter_select_enabled: datasource.filter_select_enabled,
       fetch_values_predicate: datasource.fetch_values_predicate,
       schema:
         datasource.tableSelector?.schema ??
         datasource.databaseSelector?.schema ??
-        datasource.schema ?? null,
+        datasource.schema ??
+        null,
       description: datasource.description,
       main_dttm_col: datasource.main_dttm_col,
       currency_code_column: datasource.currency_code_column ?? null,

--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -114,14 +114,14 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   const buildPayload = (datasource: Record<string, any>) => {
     const payload: Record<string, any> = {
       table_name: datasource.table_name,
-      database_id: datasource.database?.id,
+      database_id: datasource.database?.id ?? null,
       sql: datasource.sql,
       filter_select_enabled: datasource.filter_select_enabled,
       fetch_values_predicate: datasource.fetch_values_predicate,
       schema:
-        datasource.tableSelector?.schema ||
-        datasource.databaseSelector?.schema ||
-        datasource.schema,
+        datasource.tableSelector?.schema ??
+        datasource.databaseSelector?.schema ??
+        datasource.schema ?? null,
       description: datasource.description,
       main_dttm_col: datasource.main_dttm_col,
       currency_code_column: datasource.currency_code_column ?? null,

--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -113,14 +113,14 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   const buildPayload = (datasource: Record<string, any>) => {
     const payload: Record<string, any> = {
       table_name: datasource.table_name,
-      database_id: datasource.database?.id,
+      database_id: datasource.database?.id ?? null,
       sql: datasource.sql,
       filter_select_enabled: datasource.filter_select_enabled,
       fetch_values_predicate: datasource.fetch_values_predicate,
       schema:
-        datasource.tableSelector?.schema ||
-        datasource.databaseSelector?.schema ||
-        datasource.schema,
+        datasource.tableSelector?.schema ??
+        datasource.databaseSelector?.schema ??
+        datasource.schema ?? null,
       description: datasource.description,
       main_dttm_col: datasource.main_dttm_col,
       currency_code_column: datasource.currency_code_column ?? null,

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -175,7 +175,7 @@ class DatasetPostSchema(Schema):
 
 class DatasetPutSchema(Schema):
     table_name = fields.String(allow_none=True, validate=Length(1, 250))
-    database_id = fields.Integer()
+    database_id = fields.Integer(allow_none=True)
     sql = fields.String(allow_none=True)
     filter_select_enabled = fields.Boolean(allow_none=True)
     fetch_values_predicate = fields.String(allow_none=True, validate=Length(0, 1000))

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -175,7 +175,7 @@ class DatasetPostSchema(Schema):
 
 class DatasetPutSchema(Schema):
     table_name = fields.String(allow_none=True, validate=Length(1, 250))
-    database_id = fields.Integer(allow_none=True)
+    database_id = fields.Integer()
     sql = fields.String(allow_none=True)
     filter_select_enabled = fields.Boolean(allow_none=True)
     fetch_values_predicate = fields.String(allow_none=True, validate=Length(0, 1000))

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -174,7 +174,7 @@ class DatasetPostSchema(Schema):
 
 class DatasetPutSchema(Schema):
     table_name = fields.String(allow_none=True, validate=Length(1, 250))
-    database_id = fields.Integer()
+    database_id = fields.Integer(allow_none=True)
     sql = fields.String(allow_none=True)
     filter_select_enabled = fields.Boolean(allow_none=True)
     fetch_values_predicate = fields.String(allow_none=True, validate=Length(0, 1000))


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
quick fix to enable specifying 'null' for database and schema fields to allow clearing them

### TESTING INSTRUCTIONS
edit a dataset, clear the database or schema, save

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
    - Fixes #36683
    - Fixes #33573
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
