### PR TITLE
fix(mcp): improve not-found errors to suggest corresponding list_* tools

### DIFF
--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -199,9 +199,10 @@ async def get_chart_data(  # noqa: C901
 
         if not chart:
             await ctx.warning("Chart not found: identifier=%s" % (request.identifier,))
+            safe_id = str(request.identifier)[:200]
             return ChartError(
                 error=(
-                    f"No chart found with identifier: {request.identifier}."
+                    f"No chart found with identifier: {safe_id}."
                     " Use list_charts to get valid chart IDs."
                 ),
                 error_type="NotFound",

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -200,7 +200,10 @@ async def get_chart_data(  # noqa: C901
         if not chart:
             await ctx.warning("Chart not found: identifier=%s" % (request.identifier,))
             return ChartError(
-                error=f"No chart found with identifier: {request.identifier}",
+                error=(
+                    f"No chart found with identifier: {request.identifier}."
+                    " Use list_charts to get valid chart IDs."
+                ),
                 error_type="NotFound",
             )
 

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -199,7 +199,9 @@ async def get_chart_data(  # noqa: C901
 
         if not chart:
             await ctx.warning("Chart not found: identifier=%s" % (request.identifier,))
-            safe_id = str(request.identifier)[:200]
+            safe_id = sanitize_for_llm_context(
+                str(request.identifier)[:200], field_path=("identifier",)
+            )
             return ChartError(
                 error=(
                     f"No chart found with identifier: {safe_id}."

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -46,7 +46,10 @@ from superset.mcp_service.chart.schemas import (
     GetChartDataRequest,
     PerformanceMetadata,
 )
-from superset.mcp_service.utils import sanitize_for_llm_context
+from superset.mcp_service.utils import (
+    escape_llm_context_delimiters,
+    sanitize_for_llm_context,
+)
 from superset.mcp_service.utils.cache_utils import get_cache_status_from_result
 from superset.mcp_service.utils.oauth2_utils import (
     build_oauth2_redirect_message,
@@ -199,9 +202,7 @@ async def get_chart_data(  # noqa: C901
 
         if not chart:
             await ctx.warning("Chart not found: identifier=%s" % (request.identifier,))
-            safe_id = sanitize_for_llm_context(
-                str(request.identifier)[:200], field_path=("identifier",)
-            )
+            safe_id = escape_llm_context_delimiters(str(request.identifier)[:200])
             return ChartError(
                 error=(
                     f"No chart found with identifier: {safe_id}."

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1193,7 +1193,10 @@ async def _get_chart_preview_internal(  # noqa: C901
         if not chart:
             await ctx.warning("Chart not found: identifier=%s" % (request.identifier,))
             return ChartError(
-                error=f"No chart found with identifier: {request.identifier}",
+                error=(
+                    f"No chart found with identifier: {request.identifier}."
+                    " Use list_charts to get valid chart IDs."
+                ),
                 error_type="NotFound",
             )
 

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1192,11 +1192,22 @@ async def _get_chart_preview_internal(  # noqa: C901
 
         if not chart:
             await ctx.warning("Chart not found: identifier=%s" % (request.identifier,))
+            safe_id = str(request.identifier)[:200]
+            is_form_data_key = (
+                isinstance(request.identifier, str)
+                and len(request.identifier) > 8
+                and not request.identifier.isdigit()
+            )
+            if is_form_data_key:
+                recovery = (
+                    "If using a form_data_key, it may have expired — "
+                    "use generate_explore_link to get a fresh key, "
+                    "or use list_charts to find a saved chart by ID."
+                )
+            else:
+                recovery = "Use list_charts to get valid chart IDs."
             return ChartError(
-                error=(
-                    f"No chart found with identifier: {request.identifier}."
-                    " Use list_charts to get valid chart IDs."
-                ),
+                error=f"No chart found with identifier: {safe_id}. {recovery}",
                 error_type="NotFound",
             )
 

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -47,7 +47,10 @@ from superset.mcp_service.chart.schemas import (
     URLPreview,
     VegaLitePreview,
 )
-from superset.mcp_service.utils import sanitize_for_llm_context
+from superset.mcp_service.utils import (
+    escape_llm_context_delimiters,
+    sanitize_for_llm_context,
+)
 from superset.mcp_service.utils.oauth2_utils import (
     build_oauth2_redirect_message,
     OAUTH2_CONFIG_ERROR_MESSAGE,
@@ -1205,9 +1208,7 @@ async def _get_chart_preview_internal(  # noqa: C901
                 )
             else:
                 recovery = "Use list_charts to get valid chart IDs."
-            safe_id = sanitize_for_llm_context(
-                str(request.identifier)[:200], field_path=("identifier",)
-            )
+            safe_id = escape_llm_context_delimiters(str(request.identifier)[:200])
             return ChartError(
                 error=f"No chart found with identifier: {safe_id}. {recovery}",
                 error_type="NotFound",

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1192,7 +1192,6 @@ async def _get_chart_preview_internal(  # noqa: C901
 
         if not chart:
             await ctx.warning("Chart not found: identifier=%s" % (request.identifier,))
-            safe_id = str(request.identifier)[:200]
             is_form_data_key = (
                 isinstance(request.identifier, str)
                 and len(request.identifier) > 8
@@ -1206,6 +1205,9 @@ async def _get_chart_preview_internal(  # noqa: C901
                 )
             else:
                 recovery = "Use list_charts to get valid chart IDs."
+            safe_id = sanitize_for_llm_context(
+                str(request.identifier)[:200], field_path=("identifier",)
+            )
             return ChartError(
                 error=f"No chart found with identifier: {safe_id}. {recovery}",
                 error_type="NotFound",

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -343,10 +343,12 @@ async def update_chart(  # noqa: C901
                     "error": {
                         "error_type": "NotFound",
                         "message": (
-                            f"No chart found with identifier: {request.identifier}"
+                            f"No chart found with identifier: {request.identifier}."
+                            " Use list_charts to get valid chart IDs."
                         ),
                         "details": (
-                            f"No chart found with identifier: {request.identifier}"
+                            f"No chart found with identifier: {request.identifier}."
+                            " Use list_charts to get valid chart IDs."
                         ),
                     },
                     "success": False,

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -337,19 +337,18 @@ async def update_chart(  # noqa: C901
             chart = find_chart_by_identifier(request.identifier)
 
         if not chart:
+            safe_id = str(request.identifier)[:200]
+            not_found_msg = (
+                f"No chart found with identifier: {safe_id}."
+                " Use list_charts to get valid chart IDs."
+            )
             return GenerateChartResponse.model_validate(
                 {
                     "chart": None,
                     "error": {
                         "error_type": "NotFound",
-                        "message": (
-                            f"No chart found with identifier: {request.identifier}."
-                            " Use list_charts to get valid chart IDs."
-                        ),
-                        "details": (
-                            f"No chart found with identifier: {request.identifier}."
-                            " Use list_charts to get valid chart IDs."
-                        ),
+                        "message": not_found_msg,
+                        "details": not_found_msg,
                     },
                     "success": False,
                     "schema_version": "2.0",

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -47,6 +47,7 @@ from superset.mcp_service.chart.schemas import (
     PerformanceMetadata,
     UpdateChartRequest,
 )
+from superset.mcp_service.utils import sanitize_for_llm_context
 from superset.mcp_service.utils.oauth2_utils import (
     build_oauth2_redirect_message,
     OAUTH2_CONFIG_ERROR_MESSAGE,
@@ -337,7 +338,9 @@ async def update_chart(  # noqa: C901
             chart = find_chart_by_identifier(request.identifier)
 
         if not chart:
-            safe_id = str(request.identifier)[:200]
+            safe_id = sanitize_for_llm_context(
+                str(request.identifier)[:200], field_path=("identifier",)
+            )
             not_found_msg = (
                 f"No chart found with identifier: {safe_id}."
                 " Use list_charts to get valid chart IDs."

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -47,7 +47,7 @@ from superset.mcp_service.chart.schemas import (
     PerformanceMetadata,
     UpdateChartRequest,
 )
-from superset.mcp_service.utils import sanitize_for_llm_context
+from superset.mcp_service.utils import escape_llm_context_delimiters
 from superset.mcp_service.utils.oauth2_utils import (
     build_oauth2_redirect_message,
     OAUTH2_CONFIG_ERROR_MESSAGE,
@@ -338,9 +338,7 @@ async def update_chart(  # noqa: C901
             chart = find_chart_by_identifier(request.identifier)
 
         if not chart:
-            safe_id = sanitize_for_llm_context(
-                str(request.identifier)[:200], field_path=("identifier",)
-            )
+            safe_id = escape_llm_context_delimiters(str(request.identifier)[:200])
             not_found_msg = (
                 f"No chart found with identifier: {safe_id}."
                 " Use list_charts to get valid chart IDs."

--- a/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/add_chart_to_existing_dashboard.py
@@ -334,7 +334,10 @@ def _find_and_authorize_dashboard(
             dashboard=None,
             dashboard_url=None,
             position=None,
-            error=f"Dashboard with ID {dashboard_id} not found",
+            error=(
+                f"Dashboard with ID {dashboard_id} not found."
+                " Use list_dashboards to get valid dashboard IDs."
+            ),
         )
 
     try:
@@ -392,7 +395,10 @@ def add_chart_to_existing_dashboard(
                     dashboard=None,
                     dashboard_url=None,
                     position=None,
-                    error=f"Chart with ID {request.chart_id} not found",
+                    error=(
+                        f"Chart with ID {request.chart_id} not found."
+                        " Use list_charts to get valid chart IDs."
+                    ),
                 )
 
             # Validate dataset access for the chart.

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -230,7 +230,10 @@ def generate_dashboard(  # noqa: C901
                 return GenerateDashboardResponse(
                     dashboard=None,
                     dashboard_url=None,
-                    error=f"Charts not found: {list(missing_chart_ids)}",
+                    error=(
+                        f"Charts not found: {list(missing_chart_ids)}."
+                        " Use list_charts to get valid chart IDs."
+                    ),
                 )
 
             # Validate dataset access for each chart.

--- a/superset/mcp_service/dashboard/tool/generate_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/generate_dashboard.py
@@ -231,7 +231,7 @@ def generate_dashboard(  # noqa: C901
                     dashboard=None,
                     dashboard_url=None,
                     error=(
-                        f"Charts not found: {list(missing_chart_ids)}."
+                        f"Charts not found: {sorted(missing_chart_ids)}."
                         " Use list_charts to get valid chart IDs."
                     ),
                 )

--- a/superset/mcp_service/dataset/tool/query_dataset.py
+++ b/superset/mcp_service/dataset/tool/query_dataset.py
@@ -183,7 +183,10 @@ async def query_dataset(  # noqa: C901
         if dataset is None:
             await ctx.error("Dataset not found: identifier=%s" % (request.dataset_id,))
             return DatasetError.create(
-                error=f"No dataset found with identifier: {request.dataset_id}",
+                error=(
+                    f"No dataset found with identifier: {request.dataset_id}."
+                    " Use list_datasets to get valid dataset IDs."
+                ),
                 error_type="NotFound",
             )
 

--- a/superset/mcp_service/sql_lab/tool/execute_sql.py
+++ b/superset/mcp_service/sql_lab/tool/execute_sql.py
@@ -100,7 +100,10 @@ async def execute_sql(request: ExecuteSqlRequest, ctx: Context) -> ExecuteSqlRes
                 )
                 return ExecuteSqlResponse(
                     success=False,
-                    error=f"Database with ID {request.database_id} not found",
+                    error=(
+                        f"Database with ID {request.database_id} not found."
+                        " Use list_databases to get valid database IDs."
+                    ),
                     error_type=SupersetErrorType.DATABASE_NOT_FOUND_ERROR.value,
                 )
 

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -103,7 +103,8 @@ def open_sql_lab_with_context(
             database = DatabaseDAO.find_by_id(request.database_connection_id)
         if not database:
             error_message = (
-                f"Database with ID {request.database_connection_id} not found"
+                f"Database with ID {request.database_connection_id} not found."
+                " Use list_databases to get valid database IDs."
             )
             return _sanitize_sql_lab_response_for_llm_context(
                 SqlLabResponse(

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_open_sql_lab_with_context.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_open_sql_lab_with_context.py
@@ -298,7 +298,8 @@ class TestOpenSqlLabWithContext:
                 field_path=("title",),
             )
             assert response.error == sanitize_for_llm_context(
-                "Database with ID 404 not found",
+                "Database with ID 404 not found."
+                " Use list_databases to get valid database IDs.",
                 field_path=("error",),
             )
         finally:


### PR DESCRIPTION
### SUMMARY

When MCP tools return "not found" errors for invalid resource IDs (database, chart, dataset, dashboard), the LLM has no signal to recover. This change adds actionable recovery guidance to all "not found" error messages in MCP tools.

**Before:**
```
Database with ID -1 not found
```

**After:**
```
Database with ID -1 not found. Use list_databases to get valid database IDs.
```

**Affected tools:**
- `execute_sql` — database not found → suggest `list_databases`
- `open_sql_lab_with_context` — database not found → suggest `list_databases`
- `query_dataset` — dataset not found → suggest `list_datasets`
- `get_chart_data` — chart not found → suggest `list_charts`
- `get_chart_preview` — chart not found → suggest `list_charts`
- `update_chart` — chart not found → suggest `list_charts`
- `add_chart_to_existing_dashboard` — dashboard/chart not found → suggest `list_dashboards`/`list_charts`
- `generate_dashboard` — charts not found → suggest `list_charts`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — error message text change only.

### TESTING INSTRUCTIONS

1. Call `execute_sql` with an invalid `database_id` (e.g., `-1`)
2. Verify the error message now includes `Use list_databases to get valid database IDs.`
3. Repeat for other tools with invalid IDs

Unit tests updated in `tests/unit_tests/mcp_service/sql_lab/tool/test_open_sql_lab_with_context.py`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API