### PR TITLE
perf(sql-lab): use useDeferredValue for schema browser search

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/index.tsx
@@ -18,13 +18,13 @@
  */
 import {
   useCallback,
+  useDeferredValue,
   useEffect,
   useState,
   useRef,
   type ChangeEvent,
   useMemo,
 } from 'react';
-import { useDebounceValue } from 'src/hooks/useDebounceValue';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { styled, css, useTheme } from '@apache-superset/core/theme';
 import { t } from '@apache-superset/core/translation';
@@ -314,7 +314,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
   }, [sortedTreeData, sortedTables]);
 
   const [searchTerm, setSearchTerm] = useState('');
-  const debouncedSearchTerm = useDebounceValue(searchTerm);
+  const deferredSearchTerm = useDeferredValue(searchTerm);
   const handleSearchChange = useCallback(
     ({ target }: ChangeEvent<HTMLInputElement>) => setSearchTerm(target.value),
     [],
@@ -372,9 +372,9 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
 
   // Check if any nodes match the search term
   const hasMatchingNodes = useMemo(() => {
-    if (!debouncedSearchTerm) return true;
+    if (!deferredSearchTerm) return true;
 
-    const lowerTerm = debouncedSearchTerm.toLowerCase();
+    const lowerTerm = deferredSearchTerm.toLowerCase();
 
     const checkNode = (node: TreeNodeData): boolean => {
       if (node.type === 'empty') return false;
@@ -386,7 +386,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
     };
 
     return displayTreeData.some(node => checkNode(node));
-  }, [debouncedSearchTerm, displayTreeData]);
+  }, [deferredSearchTerm, displayTreeData]);
 
   // Node renderer for react-arborist
   const renderNode = useCallback(
@@ -395,7 +395,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
         {...props}
         manuallyOpenedNodes={manuallyOpenedNodes}
         loadingNodes={loadingNodes}
-        searchTerm={debouncedSearchTerm}
+        searchTerm={deferredSearchTerm}
         catalog={catalog}
         pinnedTableKeys={pinnedTableKeys}
         pinnedSchemas={pinnedSchemas}
@@ -425,7 +425,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
       toggleSortColumns,
       loadingNodes,
       manuallyOpenedNodes,
-      debouncedSearchTerm,
+      deferredSearchTerm,
     ],
   );
 
@@ -484,7 +484,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
               return <Skeleton active />;
             }
 
-            if (debouncedSearchTerm && !hasMatchingNodes) {
+            if (deferredSearchTerm && !hasMatchingNodes) {
               return (
                 <Empty
                   description={t('No matching results found')}
@@ -501,7 +501,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
                 height={height || 500}
                 rowHeight={ROW_HEIGHT}
                 indent={16}
-                searchTerm={debouncedSearchTerm}
+                searchTerm={deferredSearchTerm}
                 searchMatch={searchMatch}
                 disableDrag
                 disableDrop
@@ -527,7 +527,7 @@ const TableExploreTree: React.FC<Props> = ({ queryEditorId }) => {
                   // react-arborist marks all schemas as open (isOpen=true) even before any
                   // user interaction. Using treeRef in that case would treat every first
                   // click as a close action, so fall back to manuallyOpenedNodes instead.
-                  const wasOpen = debouncedSearchTerm
+                  const wasOpen = deferredSearchTerm
                     ? (treeRef.current?.get(id)?.isOpen ??
                       manuallyOpenedNodes[id] ??
                       false)


### PR DESCRIPTION
### SUMMARY

Refs #39890. First `useDeferredValue` adoption following the React 18 upgrade.

Replaces the fixed-delay `useDebounceValue` with `useDeferredValue` in `TableExploreTree`'s schema browser search (the recently-debounced search from #39489).

### Why useDeferredValue is strictly better here

- **No fixed timeout.** The deferred update runs as low-priority work and is automatically interrupted on each new keystroke, so the filter never lingers behind the input.
- **Input stays responsive** because it reads `searchTerm` directly (line 472 of the file). The expensive tree-filter computation reads `deferredSearchTerm` instead.
- **One fewer custom-hook dependency.** Uses the React primitive.

The other `useDebounceValue` consumers in the codebase (SQL editor auto-save, SQL validation, JS editor parsing) debounce API calls or expensive parsing — not UI filtering — so they stay debounced. They're listed in #39890 for case-by-case follow-up but are not the same pattern.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change. Behaviorally: typing into the schema-browser search field should feel snappier — the input never lags while the tree filter catches up, because React deprioritizes the filter under typing pressure.

### TESTING INSTRUCTIONS

1. Open SQL Lab and pick a database with many schemas/tables.
2. Type into the schema-browser search field rapidly. Input should feel responsive throughout.
3. Filter results should converge after you stop typing — same end state as before.
4. Clearing the field should restore the full tree.
5. `npm test -- --testPathPatterns='TableExploreTree'` — passes locally (11/11).

### ADDITIONAL INFORMATION

- [x] Has associated issue: #39890
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API