### PR TITLE
fix(embedded-sdk): grant fullscreen and clipboard-write by default

### DIFF
--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -66,7 +66,7 @@ export type EmbedDashboardParams = {
   iframeTitle?: string;
   /** additional iframe sandbox attributes ex (allow-top-navigation, allow-popups-to-escape-sandbox) **/
   iframeSandboxExtras?: string[];
-  /** iframe allow attribute for Permissions Policy (e.g., ['clipboard-write', 'fullscreen']) **/
+  /** Additional Permissions Policy features for the iframe's `allow` attribute (e.g., ['camera', 'microphone']). `fullscreen` and `clipboard-write` are granted by default. **/
   iframeAllowExtras?: string[];
   /** force a specific refererPolicy to be used in the iframe request **/
   referrerPolicy?: ReferrerPolicy;
@@ -233,9 +233,14 @@ export async function embedDashboard({
       iframe.src = `${supersetDomain}/embedded/${id}${urlParamsString}`;
       iframe.title = iframeTitle;
       iframe.style.background = 'transparent';
-      if (iframeAllowExtras.length > 0) {
-        iframe.setAttribute('allow', iframeAllowExtras.join('; '));
-      }
+      // Permissions Policy features the embedded dashboard relies on. Modern
+      // browsers gate these APIs on the iframe's `allow` attribute regardless
+      // of sandbox flags, so we include them by default. Host apps can extend
+      // the list via `iframeAllowExtras`.
+      const allowFeatures = Array.from(
+        new Set(['fullscreen', 'clipboard-write', ...iframeAllowExtras]),
+      );
+      iframe.setAttribute('allow', allowFeatures.join('; '));
       //@ts-ignore
       mountPoint.replaceChildren(iframe);
       log('placed the iframe');


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The Embedded SDK creates its iframe without an `allow` attribute, so modern browsers block the Fullscreen API in cross-origin iframes with the error `Disallowed by permissions policy`. As a result the chart **Enter Fullscreen** action is broken in every embedded dashboard out of the box.

The chart code calls `Element.requestFullscreen()` (see `superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx`), which is gated by Permissions Policy independently of the iframe's `sandbox` attribute; `allow-presentation` alone does not satisfy the policy.

This change always sets `allow="fullscreen; clipboard-write"` on the iframe and merges any host-supplied `iframeAllowExtras` on top (deduped), so the two SDK-driven features that need Permissions Policy work without the host having to opt in. `clipboard-write` is included alongside because the existing "Copy permalink to clipboard" feature has the same class of bug.

The `iframeAllowExtras` option remains backwards compatible: hosts that already pass it just get their entries merged with the new defaults.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**Before**
- Embedded iframe has no `allow` attribute.
- `requestFullscreen()` from chart code throws "Disallowed by permissions policy"; user sees a toast `Error enabling fullscreen: Disallowed by permissions policy` and the chart never enters fullscreen.

https://github.com/user-attachments/assets/5ed75f08-9ab8-4b60-9538-6fe3ef07a86d


**After**
- Embedded iframe is rendered with `allow="fullscreen; clipboard-write"`.
- Enter Fullscreen works; no toast error; `Esc` exits cleanly.
- Hosts that supply `iframeAllowExtras: ['camera']` get `allow="fullscreen; clipboard-write; camera"` (defaults preserved, extras appended, no duplicates).

https://github.com/user-attachments/assets/43545444-05de-454a-ac05-38ff48dd7e3a


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Build the SDK:
  cd superset-embedded-sdk
  npm install
  npm run build
  
2. In a host app that consumes @superset-ui/embedded-sdk, point at the local build (e.g. npm install ../superset/superset-   embedded-sdk) and call embedDashboard({...}) against a Superset dashboard with embedding enabled.
3. Open the host page in Chrome → DevTools → Elements → locate the injected <iframe>. Confirm it has:
  allow="fullscreen; clipboard-write"
4. Inside the embedded dashboard, hover over any chart → click the ⋯ menu in the top-right corner → click Enter Fullscreen.
  Before this PR: red toast Error enabling fullscreen: Disallowed by permissions policy. Chart does not enter fullscreen.
  After this PR: chart enters fullscreen; press Esc to exit. No toast.
 5. Pre-fix regression guard: temporarily revert iframe.setAttribute('allow', allowFeatures.join('; ')) in superset-embedded-sdk/src/index.ts, rebuild, reload the host page → the original error toast appears again. Restore the line and the error is gone.
6. iframeAllowExtras merging: pass iframeAllowExtras: ['camera'] in the host call. The iframe's allow attribute should now read allow="fullscreen; clipboard-write; camera" — defaults preserved, extras appended, no duplicates.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
