### PR TITLE
fix(reports): keep body sized so standalone screenshots don't time out

### DIFF
--- a/superset/templates/superset/spa.html
+++ b/superset/templates/superset/spa.html
@@ -45,6 +45,13 @@
         color: #000;
       }
       {% endif %}
+      {% if standalone_mode %}
+      /* Keep body sized so screenshot waits don't see it as hidden before React mounts. */
+      html, body.standalone {
+        min-height: 100vh;
+        margin: 0;
+      }
+      {% endif %}
     </style>
 
     {% if dark_theme_bg and entry != 'embedded' %}

--- a/tests/unit_tests/extension_tests.py
+++ b/tests/unit_tests/extension_tests.py
@@ -68,3 +68,50 @@ def test_spa_template_includes_css_bundles():
         "spa.html must call css_bundle for the page entry to load "
         "entry-specific extracted CSS in production builds"
     )
+
+
+def test_spa_template_standalone_body_has_min_height():
+    """Standalone body must be measurable so screenshot waits don't time out."""
+    from jinja2 import DictLoader, Environment
+
+    template_path = join(SUPERSET_DIR, "templates", "superset", "spa.html")
+    with open(template_path) as f:
+        template_content = f.read()
+
+    env = Environment(  # noqa: S701
+        loader=DictLoader(
+            {
+                "spa.html": template_content,
+                # Stub out includes/imports that are not relevant for this test.
+                "appbuilder/general/lib.html": "",
+                "superset/partials/asset_bundle.html": (
+                    "{% macro css_bundle(prefix, entry) %}{% endmacro %}"
+                    "{% macro js_bundle(prefix, entry) %}{% endmacro %}"
+                ),
+                "superset/macros.html": ("{% macro get_nonce() %}{% endmacro %}"),
+                "tail_js_custom_extra.html": "",
+                "head_custom_extra.html": "",
+            }
+        )
+    )
+
+    appbuilder = Mock()
+    appbuilder.app.config = {"FAVICONS": []}
+
+    def render(standalone_mode: bool) -> str:
+        return env.get_template("spa.html").render(
+            appbuilder=appbuilder,
+            assets_prefix="",
+            bootstrap_data="{}",
+            entry="spa",
+            standalone_mode=standalone_mode,
+            theme_tokens={},
+            spinner_svg=None,
+        )
+
+    standalone_html = render(standalone_mode=True)
+    assert "body.standalone" in standalone_html
+    assert "min-height: 100vh" in standalone_html
+
+    non_standalone_html = render(standalone_mode=False)
+    assert "body.standalone" not in non_standalone_html


### PR DESCRIPTION
### SUMMARY

Scheduled Reports on dashboards (especially with native filters that take a moment to hydrate) intermittently fail screenshot capture with:

```
Failed taking a screenshot Locator.wait_for: Timeout 60000ms exceeded.
Call log:
  - waiting for locator(".standalone") to be visible
  114 × locator resolved to hidden <body class="standalone">…</body>
```

The body element does have `class="standalone"` (server-rendered), but Playwright reports it **hidden**. Root cause: the SSR'd `spa.html` body only contains an absolutely-positioned spinner, so before React mounts, the body's content height is `0` and Playwright's `wait_for(state="visible")` keeps reporting "hidden" until React fills the layout. On slow first paints (cold webpack compile, complex native filter hydration, etc.), React mount can exceed the 60s wait and the report errors out.

This is a regression-class issue independent of the multi-tab `urlParams` fix in #39884: the URL is correct, the body has the right class, but the locator's visibility check fails on the empty body box.

Reproduced locally by blocking JS/CSS subresources after `domcontentloaded`:
- **Before:** `body bbox = 1584 × 0`, Playwright says HIDDEN.
- **After:**  `body bbox = 1600 × 2000`, Playwright says VISIBLE.

The fix pins `html, body.standalone` to `min-height: 100vh; margin: 0;` in `spa.html` whenever `standalone_mode` is true. This is the screenshot/embed code path, so non-standalone navigations are untouched.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — change is in the SSR shell during a sub-second window before React mounts; not visually observable in the final report screenshot.

### TESTING INSTRUCTIONS

1. Set `FEATURE_FLAGS["ALERT_REPORTS"] = True`, `ALERT_REPORT_TABS = True`, `ALERT_REPORTS_FILTER = True`, `PLAYWRIGHT_REPORTS_AND_THUMBNAILS = True`, `ALERT_REPORTS_NOTIFICATION_DRY_RUN = True`.
2. On any dashboard with tabs + native filters (e.g. **Sales Dashboard**), create a per-minute Report (PNG): pick a single tab, add a `filter_select` value (e.g. `Country = USA`).
3. Watch `report_execution_log` — pre-fix, runs intermittently fail with `Locator.wait_for: ... .standalone`. Post-fix, the wait resolves immediately and screenshots succeed.

Automated coverage:

- `tests/unit_tests/extension_tests.py::test_spa_template_standalone_body_has_min_height` renders the Jinja template and asserts the `min-height: 100vh` rule is present in standalone responses and absent otherwise. Removing the rule from `spa.html` makes this test fail.
- All existing `tests/unit_tests/commands/report/execute_test.py` tests continue to pass — this PR does **not** touch the `_get_tabs_urls` / `urlParams` merge logic shipped in #39884.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `ALERT_REPORTS`, `PLAYWRIGHT_REPORTS_AND_THUMBNAILS` (existing)
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API