### PR TITLE
fix(datasource): map combined_list to can_read so Gamma can list datasets

### DIFF
--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -42,6 +42,10 @@ class DatasourceRestApi(BaseSupersetApi):
     class_permission_name = "Datasource"
     resource_name = "datasource"
     openapi_spec_tag = "Datasources"
+    # Map the combined list endpoint to the generic `can_read on Datasource`
+    # permission so it inherits the Gamma/Alpha/Admin grants instead of
+    # creating a method-specific permission that is Alpha-only by default.
+    method_permission_name = {"combined_list": "read"}
 
     @expose(
         "/<datasource_type>/<int:datasource_id>/column/<column_name>/values/",

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -235,10 +235,8 @@ class TestDatasourceApi(SupersetTestCase):
         run_mock,
         can_access_mock,
     ):
-        security_manager.add_permission_view_menu("can_combined_list", "Datasource")
-        perm = security_manager.find_permission_view_menu(
-            "can_combined_list", "Datasource"
-        )
+        security_manager.add_permission_view_menu("can_read", "Datasource")
+        perm = security_manager.find_permission_view_menu("can_read", "Datasource")
         admin_role = security_manager.find_role("Admin")
         security_manager.add_permission_role(admin_role, perm)
         can_access_mock.return_value = True

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -212,10 +212,8 @@ class TestDatasourceApi(SupersetTestCase):
         run_mock,
         can_access_mock,
     ):
-        security_manager.add_permission_view_menu("can_combined_list", "Datasource")
-        perm = security_manager.find_permission_view_menu(
-            "can_combined_list", "Datasource"
-        )
+        security_manager.add_permission_view_menu("can_read", "Datasource")
+        perm = security_manager.find_permission_view_menu("can_read", "Datasource")
         admin_role = security_manager.find_role("Admin")
         security_manager.add_permission_role(admin_role, perm)
         can_access_mock.side_effect = [True, True]


### PR DESCRIPTION
### SUMMARY

`DatasourceRestApi.combined_list` (added in #37815) relied on the auto-derived `can_combined_list on Datasource` permission. Because `can_combined_list` is not in `SupersetSecurityManager.READ_ONLY_PERMISSION`, `_is_alpha_only` flags it as Alpha-only and excludes it from the Gamma role, so Gamma users get a 403 on the dataset list page (`/api/v1/datasource/?q=...`).

Map the method to `read` via `method_permission_name` so the FAB check uses `can_read on Datasource`, which is already a `READ_ONLY_PERMISSION` and gets granted to Admin/Alpha/Gamma via the standard role sync.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend permission mapping change, no UI difference.

### TESTING INSTRUCTIONS

1. Apply the patch and run `superset init` to register `can_read on Datasource` and re-sync role grants.
2. Log in as a Gamma user and navigate to the datasets list — request to `/api/v1/datasource/?q=...` should return 200 instead of 403.
3. Verify Admin/Alpha still load the page as before.
4. Run `pytest tests/integration_tests/datasource/api_tests.py::TestDatasourceApi::test_combined_list_invalid_order_column tests/integration_tests/datasource/api_tests.py::TestDatasourceApi::test_combined_list_semantic_layers_off`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [ ] Changes UI: No — backend-only
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

Note: deployments must run `superset init` after upgrading so the new `can_read on Datasource` permission is registered and granted to existing roles.