### PR TITLE
fix(mcp): remove stale created_by_fk filter references from MCP privacy layer

### DIFF
--- a/superset/mcp_service/privacy.py
+++ b/superset/mcp_service/privacy.py
@@ -44,9 +44,10 @@ USER_DIRECTORY_FIELDS = frozenset(
     }
 )
 
-# User-directory columns that are valid as filter inputs even though they are
-# hidden from response payloads and select-column surfaces.  The system injects
-# the correct value server-side, so callers never need to supply user IDs.
+# Internal DAO filter column names generated server-side when translating the
+# created_by_me / owned_by_me boolean flags (see mcp_core._prepend_self_lookup_filters).
+# These columns are never exposed to LLM callers; they are excluded from the
+# filters_applied response field to avoid leaking internal implementation details.
 SELF_REFERENCING_FILTER_COLUMNS = frozenset(
     {"created_by_fk", "owner", "created_by_fk_or_owner"}
 )
@@ -129,30 +130,6 @@ def user_can_view_data_model_metadata() -> bool:
         )
     except Exception:  # noqa: BLE001
         return False
-
-
-def inject_current_user_for_self_referencing_filters(filters: Any, user: Any) -> Any:
-    """Replace the value of any self-referencing filter with the current user's ID.
-
-    Callers specify the column and operator; the system fills in the value.
-    This prevents enumeration of other users' content.
-    """
-    if not filters:
-        return filters
-    filter_list = filters if isinstance(filters, list) else [filters]
-    result = []
-    for f in filter_list:
-        col = f.get("col") if isinstance(f, dict) else getattr(f, "col", None)
-        if col in SELF_REFERENCING_FILTER_COLUMNS:
-            if not user or not getattr(user, "is_authenticated", False):
-                raise ValueError("This operation requires an authenticated user")
-            f = (
-                {**f, "value": user.id}
-                if isinstance(f, dict)
-                else f.model_copy(update={"value": user.id})
-            )
-        result.append(f)
-    return result
 
 
 def filter_user_directory_fields(data: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
### SUMMARY

`PR #39638` replaced `created_by_fk`/`changed_by_fk` as LLM-facing filter inputs with server-side `created_by_me`/`owned_by_me` boolean flags. Two stale artifacts remained in `superset/mcp_service/privacy.py`:

1. **`inject_current_user_for_self_referencing_filters`** — dead code. After the boolean-flag migration, user-ID injection is handled entirely in `mcp_core._prepend_self_lookup_filters`. This function was never called after that change. Removed.

2. **Comment on `SELF_REFERENCING_FILTER_COLUMNS`** — read _"valid as filter inputs"_, which is the opposite of current behaviour. Updated to describe the actual role: internal DAO column names that are excluded from the `filters_applied` response field to avoid leaking implementation details to LLM callers.

`get_schema` already surfaces no `created_by_fk`/`changed_by_fk` in `filter_columns` — the `USER_DIRECTORY_FIELDS` exclusion in `ModelGetSchemaCore` ensures this — so no changes are needed there.

No logic change; comment correction and dead-code removal only.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no UI changes.

### TESTING INSTRUCTIONS

1. `pytest tests/unit_tests/mcp_service/` — existing tests cover all affected paths (filter-rejection tests, `get_schema` privacy tests, `created_by_me` injection tests).
2. Confirm `grep -r "inject_current_user_for_self_referencing_filters" superset/` returns no matches.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [x] Removes existing feature or API