### PR TITLE
fix(tests): prevent SemanticLayerModal test from hanging indefinitely

### DIFF
--- a/superset-frontend/src/features/semanticLayers/SemanticLayerModal.test.tsx
+++ b/superset-frontend/src/features/semanticLayers/SemanticLayerModal.test.tsx
@@ -62,7 +62,7 @@ const props = {
 
 beforeEach(() => {
   mockJsonFormsChangeTriggered = false;
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   mockedGet.mockReset();
   mockedPost.mockReset();
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.test.tsx
@@ -42,14 +42,15 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  // Restore real timers FIRST so the flush below uses real setTimeout,
+  // preventing a deadlock if a test threw while fake timers were active.
+  jest.useRealTimers();
+
   // Flush pending React state updates within act() to prevent warnings
   // and "document global undefined" errors from async operations
   await act(async () => {
     await new Promise(resolve => setTimeout(resolve, 0));
   });
-
-  // Restore real timers in case a test using fake timers threw early
-  jest.useRealTimers();
 
   // Reset browser history state to prevent query params leaking between tests
   window.history.replaceState({}, '', '/');


### PR DESCRIPTION
## Summary
- The SemanticLayerModal test introduced in #37815 hangs forever, causing shard 6 of the frontend test suite to time out after 3+ hours
- The test uses fake timers to control a debounce, but our test environment patches out MessageChannel (to work around an rc-overflow issue). Without MessageChannel, React falls back to setTimeout for scheduling renders — and fake timers block those too, so React never re-renders and the test never finishes
- Fix: tell Jest to auto-advance fake timers (advanceTimers: true), which unblocks React's render scheduling while still letting the test explicitly control the 500ms debounce
- Also reorder the DatasetList.test.tsx cleanup to restore real timers before flushing async work, so a test failure mid-run can't cause the same kind of hang

## Test plan
- [x] SemanticLayerModal.test.tsx passes in ~14s (was hanging indefinitely)
- [x] All 28 DatasetList.test.tsx tests pass
- [ ] Shard 6/8 completes in CI without timeout