### PR TITLE
fix(tests): prevent jest hangs caused by MessageChannel-mocked React scheduler

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -1160,7 +1160,7 @@ test('does not fire onChange if the same value is selected in single mode', asyn
 
 // Reference for the bug this tests: https://github.com/apache/superset/pull/33043#issuecomment-2809419640
 test('typing and deleting the last character for a new option displays correctly', async () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   render(<Select {...defaultProps} allowNewOptions />);
 
   await open();

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
@@ -53,7 +53,7 @@ describe('QueryAutoRefresh', () => {
   const refreshApi = 'glob:*/api/v1/query/updated_since?*';
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({ advanceTimers: true });
   });
 
   afterEach(() => {

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -45,7 +45,7 @@ fetchMock.get('glob:*/api/v1/dataset/?*', {
   dataset_count: 3,
 });
 
-jest.useFakeTimers();
+jest.useFakeTimers({ advanceTimers: true });
 
 // Mock the user
 const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -611,7 +611,7 @@ test('should refresh the charts', async () => {
 });
 
 test('auto-refresh uses onRefresh with skipped filters and toggles refresh state', async () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   onRefresh.mockResolvedValue(undefined);
 
   const originalRequestAnimationFrame = window.requestAnimationFrame;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -39,7 +39,7 @@ import FilterBar from '.';
 import { FILTERS_CONFIG_MODAL_TEST_ID } from '../FiltersConfigModal/FiltersConfigModal';
 import * as dataMaskActions from 'src/dataMask/actions';
 
-jest.useFakeTimers();
+jest.useFakeTimers({ advanceTimers: true });
 
 jest.mock('@superset-ui/core', () => ({
   ...jest.requireActual('@superset-ui/core'),

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeInitialization.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeInitialization.test.tsx
@@ -31,7 +31,7 @@ describe('FilterScope TreeInitialization', () => {
   let formRef: { current: FormInstance | null };
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({ advanceTimers: true });
     formRef = { current: null };
   });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeSelection.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeSelection.test.tsx
@@ -31,7 +31,7 @@ describe('FilterScope TreeSelection', () => {
   let formRef: { current: FormInstance | null };
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    jest.useFakeTimers({ advanceTimers: true });
     formRef = { current: null };
   });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/TimeGrainPreFilter.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/TimeGrainPreFilter.test.tsx
@@ -50,7 +50,7 @@ const TIME_GRAIN_TUPLES: [string, string][] = [
 // "state update on unmounted component" warnings. Scoped fake timers let us
 // clear pending work deterministically during teardown for this test only.
 beforeEach(() => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
 });
 
 afterEach(() => {

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CustomFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CustomFrame.test.tsx
@@ -28,7 +28,7 @@ import {
 import { CustomFrame } from '../components';
 
 const TODAY = '2024-06-03';
-jest.useFakeTimers();
+jest.useFakeTimers({ advanceTimers: true });
 jest.setSystemTime(new Date(TODAY).getTime());
 
 const emptyValue = '';

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -45,7 +45,7 @@ import VizTypeControl, { VIZ_TYPE_CONTROL_TEST_ID } from './index';
 // Mock scrollIntoView to avoid errors in test environment
 jest.mock('scroll-into-view-if-needed', () => jest.fn());
 
-jest.useFakeTimers();
+jest.useFakeTimers({ advanceTimers: true });
 
 class MainPreset extends Preset {
   constructor() {

--- a/superset-frontend/src/features/semanticLayers/SemanticLayerModal.test.tsx
+++ b/superset-frontend/src/features/semanticLayers/SemanticLayerModal.test.tsx
@@ -62,7 +62,7 @@ const props = {
 
 beforeEach(() => {
   mockJsonFormsChangeTriggered = false;
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   mockedGet.mockReset();
   mockedPost.mockReset();
 

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -37,7 +37,7 @@ import {
   PluginFilterSelectQueryFormData,
 } from './types';
 
-jest.useFakeTimers();
+jest.useFakeTimers({ advanceTimers: true });
 
 const selectMultipleProps = {
   formData: {
@@ -1286,7 +1286,7 @@ test('resets dependent filter to first item when value does not exist in data', 
 });
 
 test('renders text input instead of dropdown when operatorType is ILIKE contains', () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();
   const props = buildSelectFilterProps({
     formData: { operatorType: SelectFilterOperatorType.Contains },
@@ -1316,7 +1316,7 @@ test('renders text input instead of dropdown when operatorType is ILIKE contains
 });
 
 test('renders text input with starts-with placeholder', () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();
   const props = buildSelectFilterProps({
     formData: { operatorType: SelectFilterOperatorType.StartsWith },
@@ -1345,7 +1345,7 @@ test('renders text input with starts-with placeholder', () => {
 });
 
 test('typing in LIKE input calls setDataMask with ILIKE Contains payload', async () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();
   const props = buildSelectFilterProps({
     formData: { operatorType: SelectFilterOperatorType.Contains },
@@ -1391,7 +1391,7 @@ test('typing in LIKE input calls setDataMask with ILIKE Contains payload', async
 });
 
 test('typing in LIKE input with inverse selection calls setDataMask with NOT ILIKE payload', async () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();
   const props = buildSelectFilterProps({
     formData: {
@@ -1440,7 +1440,7 @@ test('typing in LIKE input with inverse selection calls setDataMask with NOT ILI
 });
 
 test('clear-all resets LIKE input value and calls setDataMask with empty state', async () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();
   const likeProps = buildSelectFilterProps({
     formData: { operatorType: SelectFilterOperatorType.Contains },
@@ -1506,7 +1506,7 @@ test('clear-all resets LIKE input value and calls setDataMask with empty state',
 });
 
 test('pending LIKE debounce still applies after rerender recreates updateDataMask', async () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();
   const likeProps = buildSelectFilterProps({
     formData: { operatorType: SelectFilterOperatorType.Contains },
@@ -1573,7 +1573,7 @@ test('pending LIKE debounce still applies after rerender recreates updateDataMas
 });
 
 test('pending LIKE debounce is canceled when operatorType switches back to Exact', async () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();
   const likeProps = buildSelectFilterProps({
     formData: { operatorType: SelectFilterOperatorType.Contains },
@@ -1628,7 +1628,7 @@ test('pending LIKE debounce is canceled when operatorType switches back to Exact
 });
 
 test('renders standard Select dropdown when operatorType is Exact', () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();
   const props = buildSelectFilterProps({
     formData: { operatorType: SelectFilterOperatorType.Exact },

--- a/superset-frontend/src/pages/DatasetList/DatasetList.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.test.tsx
@@ -42,14 +42,15 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  // Restore real timers FIRST so the flush below uses real setTimeout,
+  // preventing a deadlock if a test threw while fake timers were active.
+  jest.useRealTimers();
+
   // Flush pending React state updates within act() to prevent warnings
   // and "document global undefined" errors from async operations
   await act(async () => {
     await new Promise(resolve => setTimeout(resolve, 0));
   });
-
-  // Restore real timers in case a test using fake timers threw early
-  jest.useRealTimers();
 
   // Reset browser history state to prevent query params leaking between tests
   window.history.replaceState({}, '', '/');

--- a/superset-frontend/src/pages/FileHandler/index.test.tsx
+++ b/superset-frontend/src/pages/FileHandler/index.test.tsx
@@ -115,6 +115,12 @@ type LaunchQueue = {
   ) => void;
 };
 
+const pendingTimerIds = new Set<ReturnType<typeof setTimeout>>();
+const MAX_CONSUMER_POLL_ATTEMPTS = 50;
+
+// Defer the consumer call to a macrotask so it doesn't fire synchronously inside
+// the component's useEffect — calling it inline deadlocks Jest because the
+// MessageChannel mock in jsDomWithFetchAPI forces React to schedule via setTimeout.
 const setupLaunchQueue = (fileHandle: MockFileHandle | null = null) => {
   let savedConsumer:
     | ((params: { files?: MockFileHandle[] }) => void | Promise<void>)
@@ -123,7 +129,11 @@ const setupLaunchQueue = (fileHandle: MockFileHandle | null = null) => {
     setConsumer: (consumer: (params: { files?: MockFileHandle[] }) => void) => {
       savedConsumer = consumer;
       if (fileHandle) {
-        consumer({ files: [fileHandle] });
+        const id = setTimeout(() => {
+          pendingTimerIds.delete(id);
+          consumer({ files: [fileHandle] });
+        }, 0);
+        pendingTimerIds.add(id);
       }
     },
   };
@@ -132,25 +142,34 @@ const setupLaunchQueue = (fileHandle: MockFileHandle | null = null) => {
       // In slower CI runners, useEffect may not have registered the consumer yet.
       // Wait briefly for it before triggering.
       let attempts = 0;
-      while (!savedConsumer && attempts < 50) {
+      while (!savedConsumer && attempts < MAX_CONSUMER_POLL_ATTEMPTS) {
         // eslint-disable-next-line no-await-in-loop
         await new Promise(resolve => {
           setTimeout(resolve, 0);
         });
         attempts += 1;
       }
-      await savedConsumer?.(params);
+      if (!savedConsumer) {
+        throw new Error(
+          `LaunchQueue consumer was never registered after ${MAX_CONSUMER_POLL_ATTEMPTS} polling attempts`,
+        );
+      }
+      await savedConsumer(params);
     },
   };
 };
 
 beforeEach(() => {
   jest.clearAllMocks();
-  delete (window as any).launchQueue;
+  delete (window as unknown as Window & { launchQueue?: LaunchQueue })
+    .launchQueue;
 });
 
 afterEach(() => {
-  delete (window as any).launchQueue;
+  pendingTimerIds.forEach(id => clearTimeout(id));
+  pendingTimerIds.clear();
+  delete (window as unknown as Window & { launchQueue?: LaunchQueue })
+    .launchQueue;
 });
 
 test('shows error when launchQueue is not supported', async () => {


### PR DESCRIPTION
## Summary

Several frontend Jest tests hang indefinitely until the test runner times out. The hang is non-deterministic in some files (depends on test ordering, parallelism, and dependency-tree changes that shift React's render-scheduling timing) and consistent in others (every test in `FileHandler/index.test.tsx` times out at the per-test 60s limit, totalling ~7 minutes).

## Root Cause

`superset-frontend/spec/helpers/jsDomWithFetchAPI.ts` patches out `MessageChannel` and `MessagePort` to work around an rc-overflow leak (#34871):

```ts
this.global.MessageChannel = undefined as any;
this.global.MessagePort = undefined as any;
```

With `MessageChannel` undefined, React's scheduler falls back to `setTimeout` for scheduling renders. This produces two distinct failure modes:

### Mode 1 — Fake-timer deadlock

When a test calls `jest.useFakeTimers()`, React's `setTimeout`-scheduled renders sit in the fake timer queue and never fire (nothing advances the fake clock between renders). Two consequences:

1. **`waitFor` deadlock** — RTL's `waitFor` polls every 50ms expecting eventual consistency. With fake timers active *and* React renders blocked on a fake `setTimeout`, the polled assertion never becomes true, so `waitFor` runs until its 1s timeout (or the suite-level timeout), per test.
2. **`afterEach` cleanup deadlock** — an `afterEach` that does `await act(async () => { await new Promise(r => setTimeout(r, 0)); })` to flush pending state will park forever if the prior test threw mid-flight while fake timers were still installed.

This is latent — it existed in the affected files for some time, but a recent dependency change (#37815, which pulled in `@jsonforms/*` and `@rjsf/antd`) shifted React/scheduler timing enough to expose it.

### Mode 2 — Synchronous-consumer-during-useEffect deadlock

`FileHandler/index.test.tsx` doesn't use fake timers. Its hang has a different mechanism: `setupLaunchQueue` mocks `window.launchQueue.setConsumer` to call the async consumer **synchronously** inside the component's `useEffect`. The consumer's state setters (`setUploadFile`, `setUploadType`, …) then fire on a microtask continuation during React's commit phase. With React's scheduler on the `setTimeout` fallback, this combination deadlocks Jest — every test times out at its 60s limit (~7 minutes total). #37815 removed the macrotask defer that previously avoided this; PR #38430 had originally added it.

## Fix

**Mode 1 fixes** — `SemanticLayerModal.test.tsx`, `SelectFilterPlugin.test.tsx`, and 12 additional fake-timer test files (`Select.test.tsx`, `TimezoneSelector*.test.tsx`, `QueryAutoRefresh.test.tsx`, `SaveDatasetModal.test.tsx`, `Header.test.tsx`, `FilterBar.test.tsx`, `TreeInitialization.test.tsx`, `TreeSelection.test.tsx`, `TimeGrainPreFilter.test.tsx`, `CustomFrame.test.tsx`, `VizTypeControl.test.tsx`): pass `{ advanceTimers: true }` to every `jest.useFakeTimers()` call. This auto-advances the fake clock based on real-time elapsed, so React's scheduled `setTimeout`-based renders fire and `waitFor` can observe state changes. Manual `jest.advanceTimersByTime(...)` for explicit debounce control still works on top of the auto-advance.

**Mode 1 cleanup robustness** — `DatasetList.test.tsx`: reorder the `afterEach` so `jest.useRealTimers()` runs *before* the `await act` flush. If a test throws mid-flight and leaves fake timers installed, cleanup no longer deadlocks.

**Mode 2 fix** — `FileHandler/index.test.tsx`: restore the macrotask defer in `setupLaunchQueue`'s mock so the async consumer is called via `setTimeout(..., 0)` instead of synchronously. State setters then fire after React's commit phase finishes. Test runtime: 7+ min hang → 2.7s.

## Test Plan

- [x] `SemanticLayerModal.test.tsx` — passes locally
- [x] `DatasetList.test.tsx` — passes locally; cleanup is robust to mid-test throws
- [x] `SelectFilterPlugin.test.tsx` — 33/33 tests pass locally in 15.9s
- [x] `FileHandler/index.test.tsx` — 10/10 tests pass locally in 2.7s (was hanging ~7min)
- [ ] Full CI passes without per-shard hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)