### PR TITLE
fix(explore): restore spacing between tabs and content in control popovers

### DIFF
--- a/superset-frontend/src/explore/components/ExploreContentPopover.tsx
+++ b/superset-frontend/src/explore/components/ExploreContentPopover.tsx
@@ -22,12 +22,22 @@ export const ExplorePopoverContent = styled.div`
   .edit-popover-resize {
     transform: scaleX(-1);
     float: right;
-    margin-top: ${({ theme }) => theme.sizeUnit * 4}px;
-    margin-right: ${({ theme }) => theme.sizeUnit * -1}px;
+    margin-top: ${({ theme }) => theme.margin}px;
+    margin-right: ${({ theme }) => theme.marginXXS * -1}px;
     color: ${({ theme }) => theme.colorIcon};
     cursor: nwse-resize;
   }
   .filter-sql-editor {
     border: ${({ theme }) => theme.colorBorder} solid thin;
+  }
+  /* Restore spacing between tab navigation bar and tab content.
+     Superset's Tabs styled component sets margin: 0 on .ant-tabs-nav globally.
+     Use && to win the specificity race against the per-instance Tabs CSS. */
+  && .ant-tabs-nav {
+    margin-bottom: ${({ theme }) => theme.marginSM}px;
+  }
+  /* Tighten vertical spacing between form items inside these popovers. */
+  && .ant-form-item {
+    margin-bottom: ${({ theme }) => theme.marginXS}px;
   }
 `;

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
@@ -78,14 +78,6 @@ interface AdhocFilterEditPopoverState {
 }
 
 const FilterPopoverContentContainer = styled.div`
-  .adhoc-filter-edit-tabs > .nav-tabs {
-    margin-bottom: ${({ theme }) => theme.sizeUnit * 2}px;
-
-    & > li > a {
-      padding: ${({ theme }) => theme.sizeUnit}px;
-    }
-  }
-
   #filter-edit-popover {
     max-width: none;
   }
@@ -97,21 +89,17 @@ const FilterPopoverContentContainer = styled.div`
   .filter-edit-clause-section {
     display: flex;
     flex-direction: row;
-    gap: ${({ theme }) => theme.sizeUnit * 5}px;
-  }
-
-  .adhoc-filter-simple-column-dropdown {
-    margin-top: ${({ theme }) => theme.sizeUnit * 5}px;
+    gap: ${({ theme }) => theme.marginMD}px;
   }
 `;
 
 const FilterActionsContainer = styled.div`
-  margin-top: ${({ theme }) => theme.sizeUnit * 2}px;
+  margin-top: ${({ theme }) => theme.marginXS}px;
 `;
 
 const LayerSelectContainer = styled.div`
-  margin-top: ${({ theme }) => theme.sizeUnit * 2}px;
-  margin-bottom: ${({ theme }) => theme.sizeUnit * 12}px;
+  margin-top: ${({ theme }) => theme.marginXS}px;
+  margin-bottom: ${({ theme }) => theme.marginXXL}px;
 `;
 
 export default class AdhocFilterEditPopover extends Component<

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -523,8 +523,7 @@ const AdhocFilterEditPopoverSimpleTabContent: FC<Props> = props => {
   const subjectComponent = (
     <Select
       css={{
-        marginTop: theme.sizeUnit * 4,
-        marginBottom: theme.sizeUnit * 4,
+        marginBottom: theme.marginXS,
       }}
       data-test="select-element"
       options={columns.map(column => ({
@@ -565,7 +564,7 @@ const AdhocFilterEditPopoverSimpleTabContent: FC<Props> = props => {
         >
           <SelectWithLabel
             css={css`
-              margin-top: ${theme.sizeUnit * 4}px;
+              margin-top: ${theme.marginXS}px;
             `}
             labelText={labelText}
             options={suggestions}
@@ -581,7 +580,7 @@ const AdhocFilterEditPopoverSimpleTabContent: FC<Props> = props => {
         >
           <div
             css={css`
-              margin-top: ${theme.sizeUnit * 4}px;
+              margin-top: ${theme.marginXS}px;
             `}
           />
           <Input


### PR DESCRIPTION
### SUMMARY

The Superset global `Tabs` styled component overrides antd's default `margin-bottom` on `.ant-tabs-nav` to `0`, which removed all visual separation between the tab bar and the form content inside explore control popovers (metric editor, column selector, filter editor). This also caused the spacing between form items inside those popovers to fall back to antd's default `FormItem` margin-bottom of 24px, which is far too large for a compact popover panel.

**Changes:**

- **`ExplorePopoverContent`** – adds `&& .ant-tabs-nav { margin-bottom: 12px }` and `&& .ant-form-item { margin-bottom: 8px }` using the doubled `&&` class to win the CSS specificity race against the per-instance Tabs CSS (which injects at component render time, after global styles). Only affects Tabs inside explore popover content, not Tabs elsewhere in the app.
- **`FilterPopoverContentContainer`** – removes two dead CSS selectors that referenced Bootstrap class names (`.nav-tabs`, `.adhoc-filter-simple-column-dropdown`) which never matched any elements after the antd migration.
- **`FilterActionsContainer` / `LayerSelectContainer`** – replaces `sizeUnit` arithmetic with the named antd spacing tokens (`marginXS`, `marginXXL`, `marginMD`).
- **`AdhocFilterEditPopoverSimpleTabContent`** – removes the redundant `marginTop` from the subject (column) Select — the tab bar's own bottom margin now provides the leading gap — and reduces `marginTop`/`marginBottom` on filter selects from `sizeUnit * 4` (legacy) to `marginXS` (8px) so spacing between stacked selects is consistent with the rest of the panel.

**Spacing result (all explore control popovers):**

| Gap | Value | Token |
|-----|-------|-------|
| Tab bar → first item | 12px | `marginSM` |
| Between form items | 8px | `marginXS` |
| Between filter selects | 8px | `marginXS` |

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_Before_: The tab bar was flush against the form content (0px gap). FormItems had 24px separation.

_After_: 12px below the tab bar, 8px between form items — consistent with compact antd panel conventions.

### TESTING INSTRUCTIONS

1. Open the explore view for any chart
2. Click on a **metric** to open the metric editor popover (Saved / Simple / Custom SQL tabs)
3. Click on a **column** to open the column selector popover
4. Click on a **filter** to open the filter editor popover
5. Verify: there is visible breathing room (12px) between the tab bar and the first form control below it
6. Verify: spacing between stacked form controls (column → aggregate in metric editor; subject → operator → comparator in filter editor) is 8px, not 24px

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API