### PR TITLE
fix(echarts): suppress phantom x-axis label at axis edge when no time grain

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -589,7 +589,8 @@ export default function transformProps(
       ? getXAxisFormatter(xAxisTimeFormat, timeGrainSqla)
       : String;
 
-  const showMaxLabel = xAxisType === AxisType.Time && xAxisLabelRotation === 0;
+  const showMaxLabel =
+    xAxisType === AxisType.Time && xAxisLabelRotation === 0 && !!timeGrainSqla;
   const deduplicatedFormatter = showMaxLabel
     ? (() => {
         let lastLabel: string | undefined;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -861,7 +861,8 @@ export default function transformProps(
   // boundary that formats identically to the last data-point tick (e.g.
   // "2005" appears twice with Year grain). Wrap the formatter to suppress
   // consecutive duplicate labels.
-  const showMaxLabel = xAxisType === AxisType.Time && xAxisLabelRotation === 0;
+  const showMaxLabel =
+    xAxisType === AxisType.Time && xAxisLabelRotation === 0 && !!timeGrainSqla;
   const deduplicatedFormatter = showMaxLabel
     ? (() => {
         let lastLabel: string | undefined;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -1444,7 +1444,7 @@ test('x-axis formatter deduplicates consecutive identical labels for coarse time
   const chartProps = createTestChartProps({
     formData: {
       granularity_sqla: 'ds',
-      time_grain_sqla: TimeGranularity.YEAR,
+      timeGrainSqla: TimeGranularity.YEAR,
       xAxisTimeFormat: '%Y',
     },
     queriesData: [
@@ -1471,6 +1471,30 @@ test('x-axis formatter deduplicates consecutive identical labels for coarse time
   expect(label2).toBe('2004');
   expect(label3).toBe('2005');
   expect(label4).toBe('');
+});
+
+test('x-axis does not force showMaxLabel when no time grain is set', () => {
+  const data = [
+    { __timestamp: Date.UTC(2003, 0, 6), sales: 100 },
+    { __timestamp: Date.UTC(2004, 5, 15), sales: 200 },
+    { __timestamp: Date.UTC(2005, 4, 31), sales: 300 },
+  ];
+
+  const chartProps = createTestChartProps({
+    formData: {
+      granularity_sqla: 'ds',
+      timeGrainSqla: undefined,
+    },
+    queriesData: [
+      createTestQueryData(data, {
+        colnames: ['__timestamp', 'sales'],
+        coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+      }),
+    ],
+  });
+
+  const xAxisResult = transformProps(chartProps).echartOptions.xAxis as any;
+  expect(xAxisResult.axisLabel.showMaxLabel).not.toBe(true);
 });
 
 test('numeric x coltype routes through the number formatter (not the time formatter)', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -16,7 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { CategoricalColorScale, ChartProps } from '@superset-ui/core';
+import {
+  CategoricalColorScale,
+  ChartProps,
+  TimeGranularity,
+} from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import { supersetTheme } from '@apache-superset/core/theme';
 import type { SeriesOption } from 'echarts';
@@ -235,6 +239,7 @@ function buildTimeseriesChartProps(
       colorScheme: 'bnbColors',
       datasource: '3__table',
       granularity_sqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
       metric: 'sum__num',
       viz_type: 'my_viz',
       ...overrides,
@@ -263,6 +268,7 @@ test('should configure time axis labels to show max label for last month visibil
     colorScheme: 'bnbColors',
     datasource: '3__table',
     granularity_sqla: 'ds',
+    timeGrainSqla: TimeGranularity.MONTH,
     metric: 'sum__num',
     viz_type: 'my_viz',
   };


### PR DESCRIPTION
### SUMMARY

Stacked bar charts (and other ECharts time-series charts) configured with a temporal x-axis and Time Grain set to **None** rendered a spurious label like `.345ms` (or `:49s`) after the last legitimate label.

Root cause: the Timeseries and MixedTimeseries x-axis sets ECharts' `showMaxLabel: true` to force the very last data point's label to render. When a time grain is set, the axis end aligns to a sensible boundary (e.g. start of next month) and that forced label looks fine. With **Time Grain = None**, ECharts' axis end is not aligned to anything sensible, so the forced label lands on a sub-minute timestamp and the SMART_DATE multi-format renders it through its millisecond / second buckets, leaking next to the last legitimate label.

Only enable `showMaxLabel` when a time grain is set, which is the case #37181   originally added it for. Without a grain, ECharts' default boundary behavior takes over and the artifact disappears. The shared SMART_DATE formatter, Gantt, and BigNumber are untouched.

### BEFORE/AFTER SCREENSHOTS

Before:
<img width="963" height="885" alt="sc-105227-before" src="https://github.com/user-attachments/assets/d432d5dc-d0c1-4fe9-85f3-55eeada4f0fb" />

After:
<img width="963" height="885" alt="sc-105227-after" src="https://github.com/user-attachments/assets/e43eddd3-c34a-47c4-80f6-3f7db9538e1d" />

### TESTING INSTRUCTIONS

1. Connect any database with a `DATE` or `TIMESTAMP` column.
2. Create an ECharts Bar Chart, set X-axis to the date column, set Time Grain to **None**.
3. Add a numeric metric and a string dimension. In Customize, set Stacked Style to Stack.
4. Update the chart and inspect the rightmost x-axis label. It should match the format of the other labels (e.g., a month or year) with no `.XXXms` or `:XXs` artifact appended.
5. Repeat with a time grain set (e.g., Year): the last data point's label should still be forced visible (the existing `#37181` behavior).
6. `npm test plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
