### PR TITLE
perf(explore): use useDeferredValue for explore menu search and JS editor parse

### DIFF
--- a/superset-frontend/src/explore/components/controls/JSEditorControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/JSEditorControl.test.tsx
@@ -45,10 +45,6 @@ jest.mock('src/core/editors', () => ({
   ),
 }));
 
-jest.mock('src/hooks/useDebounceValue', () => ({
-  useDebounceValue: (value: string) => value,
-}));
-
 const defaultProps = {
   name: 'echartOptions',
   label: 'EChart Options',

--- a/superset-frontend/src/explore/components/controls/JSEditorControl.tsx
+++ b/superset-frontend/src/explore/components/controls/JSEditorControl.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo } from 'react';
+import { useDeferredValue, useMemo } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import ControlHeader, {
   ControlHeaderProps,
@@ -28,7 +28,6 @@ import {
   EChartOptionsParseError,
 } from '@superset-ui/plugin-chart-echarts';
 import { EditorHost } from 'src/core/editors';
-import { useDebounceValue } from 'src/hooks/useDebounceValue';
 
 const Container = styled.div`
   border: 1px solid ${({ theme }) => theme.colorBorder};
@@ -50,10 +49,10 @@ export default function JSEditorControl({
   onChange,
   value,
 }: ControlHeaderProps & ControlComponentProps<string>) {
-  const debouncedValue = useDebounceValue(value);
+  const deferredValue = useDeferredValue(value);
   const error = useMemo(() => {
     try {
-      safeParseEChartOptions(debouncedValue ?? '');
+      safeParseEChartOptions(deferredValue ?? '');
       return null;
     } catch (err) {
       if (err instanceof EChartOptionsParseError) {
@@ -61,7 +60,7 @@ export default function JSEditorControl({
       }
       throw err;
     }
-  }, [debouncedValue]);
+  }, [deferredValue]);
   const headerProps = {
     name,
     label: label ?? name,

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
@@ -19,13 +19,13 @@
 import React, {
   ReactElement,
   useCallback,
+  useDeferredValue,
   useMemo,
   useState,
   Dispatch,
   SetStateAction,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useDebounceValue } from 'src/hooks/useDebounceValue';
 import {
   isFeatureEnabled,
   FeatureFlag,
@@ -213,10 +213,7 @@ export const useExploreAdditionalActionsMenu = (
   const dispatch = useDispatch();
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [dashboardSearchTerm, setDashboardSearchTerm] = useState('');
-  const debouncedDashboardSearchTerm = useDebounceValue(
-    dashboardSearchTerm,
-    300,
-  );
+  const deferredDashboardSearchTerm = useDeferredValue(dashboardSearchTerm);
   const chart = useSelector<ExploreState, ChartState | undefined>(state =>
     state.explore ? state.charts?.[getChartKey(state.explore)] : undefined,
   );
@@ -304,7 +301,7 @@ export const useExploreAdditionalActionsMenu = (
   const dashboardMenuItems = useDashboardsMenuItems({
     chartId: slice?.slice_id,
     dashboards,
-    searchTerm: debouncedDashboardSearchTerm,
+    searchTerm: deferredDashboardSearchTerm,
   });
 
   const showDashboardSearch = (dashboards?.length ?? 0) > SEARCH_THRESHOLD;
@@ -1054,7 +1051,7 @@ export const useExploreAdditionalActionsMenu = (
     dashboards,
     dashboardMenuItems,
     dashboardSearchTerm,
-    debouncedDashboardSearchTerm,
+    deferredDashboardSearchTerm,
     datasource,
     dispatch,
     exportCSV,


### PR DESCRIPTION
### SUMMARY

Refs #39890. Continues the React 18 \`useDeferredValue\` migration started in #39928 (TableExploreTree) and #39970 (DatasourcePanel).

Bundles two related swaps in the explore area:

1. **\`useExploreAdditionalActionsMenu\`** — dashboard search filter that powers the \"Add to dashboard\" sub-menu. Was using \`useDebounceValue(dashboardSearchTerm, 300)\`; now uses \`useDeferredValue\`. The input still reads \`dashboardSearchTerm\` directly so typing stays responsive; \`useDashboardsMenuItems\` consumes the deferred value.

2. **\`JSEditorControl\`** — ECharts JS-options parser. The expensive \`safeParseEChartOptions\` call inside \`useMemo\` now reads a deferred value. React schedules the parse as low-priority work and interrupts it on each keystroke, instead of waiting on a fixed debounce window before validating.

The companion \`JSEditorControl.test.tsx\` had a passthrough \`useDebounceValue\` mock — no longer needed, since \`useDeferredValue\` returns the value synchronously when there is no concurrent rendering pressure (which is the case in Jest without \`<StrictMode>\` wrapping). Removed.

### Why bundle

All three remaining \`useDebounceValue\` consumers in the explore area share the exact UI-filter-or-derived-computation pattern that \`useDeferredValue\` is designed for. The diff is mechanical (8 / 16 lines), the rationale is identical to the prior two PRs, and one review covers the whole template.

The remaining \`useDebounceValue\` consumers in the codebase (SQL editor auto-save, SQL validation API call) are debounced *I/O*, not derived UI computation, so they correctly stay on \`useDebounceValue\` and are not part of this migration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual change. Behaviorally:
- The explore overflow menu's dashboard search should feel snappier — typing never lags behind because the filter no longer waits on a 300ms window.
- The JS-editor validation error should converge faster after rapid edits — React interrupts in-flight parses on each new keystroke rather than holding onto the previous result for a fixed delay.

### TESTING INSTRUCTIONS

1. Open an explore view, click the chart's overflow menu, choose \"Add to dashboard.\" If the user has more than \`SEARCH_THRESHOLD\` dashboards, type in the search box — input stays responsive, the filtered list converges to the same end state as before.
2. Open a chart that exposes \`JSEditorControl\` (e.g. an ECharts viz with custom options). Type rapidly into the editor — input stays responsive, validation errors update once typing settles.
3. \`npm test -- --testPathPatterns='JSEditorControl|useExploreAdditionalActionsMenu'\` passes locally (20/20).

### ADDITIONAL INFORMATION

- [x] Has associated issue: #39890
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API