### PR TITLE
fix(explore): remove leftover debug console.log in ZoomConfigControl

### DIFF
--- a/superset-frontend/src/explore/components/controls/ZoomConfigControl/ZoomConfigControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ZoomConfigControl/ZoomConfigControl.tsx
@@ -66,7 +66,6 @@ export const ZoomConfigControl: FC<ZoomConfigsControlProps> = ({
   };
 
   const onBaseWidthChange = (width: number) => {
-    console.log('now in onbasewidthcahnge');
     setBaseWidth(width);
     if (!value) {
       return;


### PR DESCRIPTION
### SUMMARY

Drops a leftover debug `console.log('now in onbasewidthcahnge')` (note the typo) from `onBaseWidthChange` in `ZoomConfigControl.tsx`. The statement fires on every drag of the Base Width slider in the Explore view, polluting the browser console during normal usage. Pure cleanup — no behavior change.

Fixes apache/superset#39622 — *Leftover Debug Statement Polluting Console in ZoomConfigControl*

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — the only observable change is the absence of one line in the DevTools console while dragging the Base Width slider.

### TESTING INSTRUCTIONS

#### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can confirm by inspection — only the exact message changes between BEFORE and AFTER.

```bash
# --- one-time setup ---
git clone https://github.com/apache/superset.git /tmp/repro && cd /tmp/repro

# --- BEFORE (origin/master) ---
git checkout origin/master
grep -n "onbasewidthcahnge" superset-frontend/src/explore/components/controls/ZoomConfigControl/ZoomConfigControl.tsx
# Expected: line 69 prints `console.log('now in onbasewidthcahnge');`

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/superset.git feat/39622-remove-zoomconfig-debug-log
git checkout FETCH_HEAD
grep -n "onbasewidthcahnge" superset-frontend/src/explore/components/controls/ZoomConfigControl/ZoomConfigControl.tsx
# Expected: no output; the debug statement is gone.

# Optional UI verification (requires the superset-frontend dev server):
#   cd superset-frontend && npm ci && npm run dev-server
# Open Explore on a chart that uses ZoomConfigControl, drag the Base Width
# slider, and inspect the browser DevTools console.
# BEFORE: 'now in onbasewidthcahnge' fires on every drag event.
# AFTER : the console stays clean during dragging.
```

#### What I ran locally

- `grep -n "console\." superset-frontend/src/explore/components/controls/ZoomConfigControl/` — confirmed the file no longer has any `console.*` calls after the change.
- The repository's frontend ESLint config sets `no-console: 'warn'` (not `error`), which is why this leftover slipped through CI; this PR does not change that policy.
- No regression test added: this is a pure-cleanup one-line removal with no behavioral divergence to assert. The grep above is the equivalence check.

### ADDITIONAL INFORMATION

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Default behavior | drag Base Width slider | console stays clean | grep on file confirms line removed |

- [x] Has associated issue: #39622
- [ ] Required feature flags:
- [x] Changes UI (only in the sense of console output during dev usage; visible chart behavior is unchanged)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

#### Risk / blast radius

Zero. The removed line was a `console.log` with no surrounding control flow. `setBaseWidth(width)` and the rest of `onBaseWidthChange` are untouched.

```release-note
Removed a leftover debug console.log from the Base Width slider in ZoomConfigControl.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against apache/superset's source. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*
