### PR TITLE
fix(sqllab): handle scientific notation in big number JSON responses

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
@@ -63,7 +63,8 @@ export default async function parseResponse<T extends ParseMethod = 'json'>(
           (value?.isGreaterThan?.(Number.MAX_SAFE_INTEGER) ||
             value?.isLessThan?.(Number.MIN_SAFE_INTEGER))
         ) {
-          return BigInt(value);
+          // toFixed() avoids scientific notation, which BigInt() rejects.
+          return BigInt(value.toFixed());
         }
         // // `json-bigint` could not handle floats well, see sidorares/json-bigint#62
         // // TODO: clean up after json-bigint>1.0.1 is released

--- a/superset-frontend/packages/superset-ui-core/test/connection/callApi/parseResponse.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/callApi/parseResponse.test.ts
@@ -183,6 +183,26 @@ describe('parseResponse()', () => {
     expect(responseBigNumber.json.constructor).toEqual('constructor');
   });
 
+  test('handles big numbers in scientific notation when `parseMethod=json-bigint`', async () => {
+    const mockScientificUrl = '/mock/get/scientific';
+    const mockScientificPayload =
+      '{ "big_double": 4.799703045723905e+32, "negative_big": -4.799703045723905e+32, "small": 1 }';
+    fetchMock.get(mockScientificUrl, mockScientificPayload);
+
+    const responseBigNumber = await parseResponse(
+      callApi({ url: mockScientificUrl, method: 'GET' }),
+      'json-bigint',
+    );
+
+    expect(`${responseBigNumber.json.big_double}`).toEqual(
+      '479970304572390500000000000000000',
+    );
+    expect(`${responseBigNumber.json.negative_big}`).toEqual(
+      '-479970304572390500000000000000000',
+    );
+    expect(responseBigNumber.json.small).toEqual(1);
+  });
+
   test('rejects if request.ok=false', async () => {
     expect.assertions(3);
     const mockNotOkayUrl = '/mock/notokay/url';


### PR DESCRIPTION
### SUMMARY
SQL Lab queries that returned a number in scientific notation with high mantissa precision (e.g. 4.799703045723905e+32) were considered failed by the UI even though the backend returned HTTP 200 with the correct
data.

Root cause: when parseMethod: 'json-bigint' is used, the response parser at superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts walks the JSON tree with cloneDeepWith and promotes
BigNumber values that exceed Number.MAX_SAFE_INTEGER to BigInt. The promotion was done with BigInt(value), which calls value.toString() implicitly. For values whose mantissa exceeds Number's ~15-digit precision,
BigNumber.toString() returns scientific notation (e.g. "4.799703045723905e+32"), and BigInt() rejects that format with a SyntaxError. The thrown error escaped the response parser, the SQL Lab action treated the
response as invalid, and the UI reported the query as failed at the "Validate query" step.

Fix: use BigNumber.toFixed() to obtain a plain-digit string before passing it to BigInt(). The branch is already gated by value.isInteger() === true, so toFixed() is guaranteed to return a string of digits with
no decimal point. This matches the original intent of the code (preserve precision for very large integers) without changing behavior for any other case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1131" height="796" alt="image" src="https://github.com/user-attachments/assets/304134a7-cecb-44ee-91a3-5eaaa1ef6b4c" />

After:
<img width="954" height="514" alt="Screenshot 2026-05-10 at 10 32 12" src="https://github.com/user-attachments/assets/621a625a-e99b-407a-b061-392b4bf38ef6" />


### TESTING INSTRUCTIONS
1. Navigate to SQL Lab.
2. Pick any database (the examples SQLite DB works).
3. Execute:
SELECT 4.799703045723905e+32 AS big_double, 1 AS one;
4. Verify the query succeeds and the results table renders one row with both columns populated.
5. Without the fix the same query fails at the "Validate query" step with SyntaxError: Cannot convert 4.799703045723905e+32 to a BigInt in the browser console, even though /api/v1/sqllab/execute/ returns 200 with
 the data.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
