### PR TITLE
fix(database): extend shillelagh URI pattern to cover all driver variants

### DIFF
--- a/superset/security/analytics_db_safety.py
+++ b/superset/security/analytics_db_safety.py
@@ -29,8 +29,7 @@ BLOCKLIST = {
     # sqlite creates a local DB, which allows mapping server's filesystem
     re.compile(r"sqlite(?:\+[^\s]*)?$"),
     # shillelagh allows opening local files (eg, 'SELECT * FROM "csv:///etc/passwd"')
-    re.compile(r"shillelagh$"),
-    re.compile(r"shillelagh\+apsw$"),
+    re.compile(r"shillelagh(?:\+[^\s]*)?$"),
 }
 
 

--- a/tests/integration_tests/security/analytics_db_safety_tests.py
+++ b/tests/integration_tests/security/analytics_db_safety_tests.py
@@ -72,11 +72,30 @@ from superset.security.analytics_db_safety import check_sqlalchemy_uri
             True,
             "shillelagh cannot be used as a data source for security reasons.",
         ),
-        ("shillelagh+:///home/superset/bad.db", False, None),
+        (
+            "shillelagh+:///home/superset/bad.db",
+            True,
+            "shillelagh cannot be used as a data source for security reasons.",
+        ),
         (
             "shillelagh+something:///home/superset/bad.db",
-            False,
-            None,
+            True,
+            "shillelagh cannot be used as a data source for security reasons.",
+        ),
+        (
+            "shillelagh+csv:///etc/passwd",
+            True,
+            "shillelagh cannot be used as a data source for security reasons.",
+        ),
+        (
+            "shillelagh+json:///etc/passwd",
+            True,
+            "shillelagh cannot be used as a data source for security reasons.",
+        ),
+        (
+            "shillelagh+gsheets:///",
+            True,
+            "shillelagh cannot be used as a data source for security reasons.",
         ),
     ],
 )


### PR DESCRIPTION
### SUMMARY

The shillelagh URI blocklist in `analytics_db_safety.py` used two separate patterns (`shillelagh$` and `shillelagh\+apsw$`) that only matched the bare driver and one specific variant. Other driver suffixes such as `+csv`, `+json`, and `+gsheets` were not matched, allowing those URIs to bypass the blocklist check.

This PR replaces both patterns with a single regex `shillelagh(?:\+[^\s]*)?$` that blocks `shillelagh` regardless of the driver suffix, consistent with how the existing `sqlite` pattern already handles all its variants via `sqlite(?:\+[^\s]*)?$`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

1. Run the updated integration test:
   ```bash
   pytest tests/integration_tests/security/analytics_db_safety_tests.py -v
   ```
   All 15 test cases should pass, including the new `shillelagh+csv`, `shillelagh+json`, and `shillelagh+gsheets` variants.

2. Attempt to create a database connection with `sqlalchemy_uri: shillelagh+csv:///etc/passwd` via the API — should return a 422 error, not 201.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API