### PR TITLE
fix(query): restrict query cancellation to the query owner

### DIFF
--- a/superset/daos/query.py
+++ b/superset/daos/query.py
@@ -58,7 +58,11 @@ class QueryDAO(BaseDAO[Query]):
 
     @staticmethod
     def stop_query(client_id: str) -> None:
-        query = db.session.query(Query).filter_by(client_id=client_id).one_or_none()
+        query = (
+            db.session.query(Query)
+            .filter(Query.client_id == client_id, Query.user_id == get_user_id())
+            .one_or_none()
+        )
         if not query:
             raise QueryNotFoundException(f"Query with client_id {client_id} not found")
 

--- a/tests/unit_tests/dao/queries_test.py
+++ b/tests/unit_tests/dao/queries_test.py
@@ -279,3 +279,49 @@ def test_query_dao_stop_query(
     QueryDAO.stop_query(query_obj.client_id)
     query = db.session.query(Query).one()
     assert query.status == QueryStatus.STOPPED
+
+
+def test_query_dao_stop_query_wrong_user(
+    mocker: MockerFixture, app: Any, session: Session
+) -> None:
+    """A user cannot stop a query that belongs to a different user."""
+    from superset import db
+    from superset.common.db_query_status import QueryStatus
+    from superset.models.core import Database
+    from superset.models.sql_lab import Query
+
+    engine = db.session.get_bind()
+    Query.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+
+    query_obj = Query(
+        client_id="foo",
+        database=database,
+        tab_name="test_tab",
+        sql_editor_id="test_editor_id",
+        sql="select * from bar",
+        select_sql="select * from bar",
+        executed_sql="select * from bar",
+        limit=100,
+        select_as_cta=False,
+        rows=100,
+        error_message="none",
+        results_key="abc",
+        status=QueryStatus.RUNNING,
+        user_id=1,
+    )
+
+    db.session.add(database)
+    db.session.add(query_obj)
+
+    # Simulate a different user (user 2) attempting to stop user 1's query
+    mocker.patch("superset.daos.query.get_user_id", return_value=2)
+
+    from superset.daos.query import QueryDAO
+
+    with pytest.raises(QueryNotFoundException):
+        QueryDAO.stop_query(query_obj.client_id)
+
+    query = db.session.query(Query).one()
+    assert query.status == QueryStatus.RUNNING


### PR DESCRIPTION
### SUMMARY

`QueryDAO.stop_query()` previously looked up a query by `client_id` alone, without verifying that the query belongs to the requesting user. This allowed any authenticated user to cancel any other user's running query by providing its `client_id`.

This PR adds a `user_id` filter to the query lookup so that only the owner of a query can cancel it. Requests from other users return a `QueryNotFoundException` (404).

The `get_user_id` utility is already imported in the module; no new imports are needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

1. Run the unit tests:
   ```bash
   pytest tests/unit_tests/dao/queries_test.py -v
   ```
   All 7 tests should pass, including the new `test_query_dao_stop_query_wrong_user` case.

2. Start a long-running query as user A, then attempt to cancel it via `DELETE /api/v1/query/stop` as user B — should return 404 instead of succeeding.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API