### PR TITLE
fix(dataset): validate datasource access during import

### DIFF
--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -30,6 +30,7 @@ from superset import db, security_manager
 from superset.commands.dataset.exceptions import DatasetForbiddenDataURI
 from superset.commands.exceptions import ImportFailedError
 from superset.connectors.sqla.models import SqlaTable
+from superset.exceptions import SupersetSecurityException
 from superset.models.core import Database
 from superset.sql.parse import Table
 from superset.utils import json
@@ -171,6 +172,14 @@ def import_dataset(  # noqa: C901
 
     if dataset.id is None:
         db.session.flush()
+
+    if not ignore_permissions:
+        try:
+            security_manager.raise_for_access(datasource=dataset)
+        except SupersetSecurityException as ex:
+            raise ImportFailedError(
+                "User does not have access to the target dataset"
+            ) from ex
 
     try:
         table_exists = dataset.database.has_table(

--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -27,7 +27,10 @@ from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.sql.visitors import VisitableType
 
 from superset import db, security_manager
-from superset.commands.dataset.exceptions import DatasetForbiddenDataURI
+from superset.commands.dataset.exceptions import (
+    DatasetAccessDeniedError,
+    DatasetForbiddenDataURI,
+)
 from superset.commands.exceptions import ImportFailedError
 from superset.connectors.sqla.models import SqlaTable
 from superset.exceptions import SupersetSecurityException
@@ -177,9 +180,7 @@ def import_dataset(  # noqa: C901
         try:
             security_manager.raise_for_access(datasource=dataset)
         except SupersetSecurityException as ex:
-            raise ImportFailedError(
-                "User does not have access to the target dataset"
-            ) from ex
+            raise DatasetAccessDeniedError() from ex
 
     try:
         table_exists = dataset.database.has_table(

--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -744,6 +744,44 @@ def test_import_dataset_without_owner_permission(
     mock_can_access.assert_called_with("can_write", "Dataset")
 
 
+def test_import_dataset_access_check(
+    mocker: MockerFixture,
+    session: Session,
+) -> None:
+    """
+    Test that import_dataset raises ImportFailedError when the user does not
+    have datasource-level access to the target dataset.
+    """
+    from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+    from superset.exceptions import SupersetSecurityException
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+    mocker.patch.object(
+        security_manager,
+        "raise_for_access",
+        side_effect=SupersetSecurityException(
+            SupersetError(
+                error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                message="User does not have access to this datasource",
+                level=ErrorLevel.ERROR,
+            )
+        ),
+    )
+
+    engine = db.session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    db.session.add(database)
+    db.session.flush()
+
+    config = copy.deepcopy(dataset_fixture)
+    config["database_id"] = database.id
+
+    with pytest.raises(ImportFailedError):
+        import_dataset(config)
+
+
 @pytest.mark.parametrize(
     "allowed_urls, data_uri, expected, exception_class",
     [

--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm.session import Session
 
 from superset import db, security_manager
 from superset.commands.dataset.exceptions import (
+    DatasetAccessDeniedError,
     DatasetForbiddenDataURI,
 )
 from superset.commands.dataset.importers.v1.utils import (
@@ -749,7 +750,7 @@ def test_import_dataset_access_check(
     session: Session,
 ) -> None:
     """
-    Test that import_dataset raises ImportFailedError when the user does not
+    Test that import_dataset raises DatasetAccessDeniedError when the user does not
     have datasource-level access to the target dataset.
     """
     from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -778,7 +779,7 @@ def test_import_dataset_access_check(
     config = copy.deepcopy(dataset_fixture)
     config["database_id"] = database.id
 
-    with pytest.raises(ImportFailedError):
+    with pytest.raises(DatasetAccessDeniedError):
         import_dataset(config)
 
 


### PR DESCRIPTION
### SUMMARY

`import_dataset()` in the V1 importer had an ownership gate that prevented unauthorized overwrites of existing datasets, but lacked a call to `security_manager.raise_for_access(datasource=dataset)` after the dataset was created or updated.

Without this check, a user with `can_write` on the Dataset resource could import a YAML bundle that creates or overwrites a dataset pointing to a database/schema they do not have access to under the normal access rules.

This PR adds `raise_for_access(datasource=dataset)` after the dataset is persisted, mirroring the pattern used by `UpdateDatasetCommand`. The check is skipped when `ignore_permissions=True` (used by admin bulk-import flows).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

1. Run the unit tests:
   ```bash
   pytest tests/unit_tests/datasets/commands/importers/v1/import_test.py -v
   ```
   All 17 tests should pass, including the new `test_import_dataset_access_check`.

2. Attempt to import a dataset YAML for a table in a schema the importing user does not have access to (e.g., a Gamma user importing a dataset on a restricted database) — should return a 422 error.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API