### PR TITLE
fix(mixed-timeseries): preserve all-NaN metric columns after pivot when Jinja evaluates to NULL

### DIFF
--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -16,6 +16,7 @@
 # under the License.
 from typing import Any, Optional
 
+import pandas as pd
 from flask_babel import gettext as _
 from pandas import DataFrame
 
@@ -25,6 +26,35 @@ from superset.utils.pandas_postprocessing.utils import (
     _get_aggregate_funcs,
     validate_column_args,
 )
+
+
+def _restore_dropped_metric_columns(
+    df: DataFrame, expected_metrics: list[str]
+) -> DataFrame:
+    """Re-add metric columns that pivot_table dropped due to all-NaN values.
+
+    When drop_missing_columns=True, pandas pivot_table silently removes columns
+    whose entries are all NaN. This breaks downstream post-processing steps
+    (rename, rolling) that use validate_column_args to assert the columns exist.
+    Restoring the columns as all-NaN preserves the expected schema.
+    """
+    if isinstance(df.columns, pd.MultiIndex):
+        existing_metrics = set(df.columns.get_level_values(0))
+        missing = [m for m in expected_metrics if m not in existing_metrics]
+        if missing:
+            category_values = (
+                df.columns.get_level_values(-1).unique()
+                if len(df.columns) > 0
+                else [None]
+            )
+            for metric in missing:
+                for cat in category_values:
+                    df[(metric, cat)] = float("nan")
+    else:
+        for metric in expected_metrics:
+            if metric not in df.columns:
+                df[metric] = float("nan")
+    return df
 
 
 @validate_column_args("index", "columns")
@@ -99,6 +129,9 @@ def pivot(  # pylint: disable=too-many-arguments
         margins=marginal_distributions,
         margins_name=marginal_distribution_name,
     )
+
+    if drop_missing_columns:
+        df = _restore_dropped_metric_columns(df, list(aggfunc.keys()))
 
     if not drop_missing_columns and len(series_set) > 0 and not df.empty:
         df = df.drop(df.columns.difference(series_set), axis=PandasAxis.COLUMN)

--- a/tests/unit_tests/pandas_postprocessing/test_pivot.py
+++ b/tests/unit_tests/pandas_postprocessing/test_pivot.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import numpy as np
+import pandas as pd
 import pytest
 from pandas import DataFrame, to_datetime
 
@@ -203,3 +204,59 @@ def test_pivot_eliminate_cartesian_product_columns():
         "metric2, 1, 1",
     ]
     assert np.isnan(df["metric, 1, 1"][0])
+
+
+def test_pivot_preserves_all_nan_metric_flat():
+    """
+    Pivot with drop_missing_columns=True must not drop metric columns whose entries
+    are all NaN. This prevents downstream post-processing (e.g. rename) from failing
+    with "Referenced columns not available in DataFrame" when a Jinja metric
+    expression evaluates to NULL for every row (SC-100398).
+    """
+    mock_df = DataFrame(
+        {
+            "dttm": to_datetime(["2019-01-01", "2019-01-02", "2019-01-03"]),
+            "metric": [np.nan, np.nan, np.nan],
+        }
+    )
+
+    df = pivot(
+        df=mock_df,
+        index=["dttm"],
+        aggregates={"metric": {"operator": "mean"}},
+        drop_missing_columns=True,
+    )
+
+    assert "metric" in df.columns
+    assert df["metric"].isna().all()
+
+
+def test_pivot_preserves_all_nan_metric_with_columns():
+    """
+    Pivot with groupby columns and drop_missing_columns=True must preserve the
+    metric at MultiIndex level 0 even when all values for that metric are NaN.
+    After flatten the metric column must appear in the result.
+    """
+    mock_df = DataFrame(
+        {
+            "dttm": to_datetime(["2019-01-01", "2019-01-01"]),
+            "category": ["A", "B"],
+            "metric": [np.nan, np.nan],
+        }
+    )
+
+    df = pivot(
+        df=mock_df,
+        index=["dttm"],
+        columns=["category"],
+        aggregates={"metric": {"operator": "mean"}},
+        drop_missing_columns=True,
+    )
+
+    assert isinstance(df.columns, pd.MultiIndex)
+    assert "metric" in df.columns.get_level_values(0)
+
+    df = flatten(df)
+    metric_cols = [c for c in df.columns if c.startswith("metric")]
+    assert len(metric_cols) > 0
+    assert df[metric_cols].isna().all().all()


### PR DESCRIPTION
### SUMMARY

When a Jinja conditional metric expression (e.g. `{% if filter_values('x') %}SUM(col){% else %}null{% endif %}`) evaluates to `null` because no dashboard filter is selected, the SQL query returns an all-NULL column for that metric. pandas `pivot_table` with `dropna=True` (the default, controlled by `drop_missing_columns: !show_empty_columns` in `pivotOperator.ts`) then **silently drops** that column from the pivot result.

Downstream post-processing steps — `rename` and `rolling` — use `validate_column_args` to assert that all referenced columns exist before executing. Because the metric column was dropped, they raise:

```
InvalidPostProcessingError("Referenced columns not available in DataFrame.")
```

This surfaces as an error on mixed-timeseries charts whenever `rename` (triggered by groupby + `truncate_metric`) or `rolling` is configured.

**Root cause chain:**
1. Jinja template with `filter_values()` evaluates to `null` when no filter selected
2. SQL returns all-NULL column for the metric
3. `pivot_table(dropna=True)` drops the all-NaN column
4. `rename` / `rolling` post-processing fails because column is missing

**Fix:** Introduce `_restore_dropped_metric_columns()` in `pivot.py` which re-adds any expected metric columns that `pivot_table` dropped due to all-NaN values. This preserves the expected DataFrame schema for downstream post-processing, while still dropping sparse category combinations (the intended behavior of `drop_missing_columns`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: Mixed-timeseries chart with Jinja SQL metric and no active dashboard filter shows error "Referenced columns not available in DataFrame."

After: Chart renders correctly (empty series since metric evaluates to NULL, but no error).

### TESTING INSTRUCTIONS

1. Create a mixed-timeseries chart with a SQL-type custom metric using a Jinja conditional:
   ```sql
   {% if filter_values('my_column') %}
     SUM(CASE WHEN my_column IN {{ filter_values('my_column') | where_in }} THEN value ELSE 0 END)
   {% else %}
     null
   {% endif %}
   ```
2. View the chart without any dashboard filter selected
3. **Before fix:** chart shows "Referenced columns not available in DataFrame" error
4. **After fix:** chart renders without error (no data series shown for the NULL metric)

### ADDITIONAL INFORMATION

- [x] Has associated issue: SC-100398
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Regression tests added in `tests/unit_tests/pandas_postprocessing/test_pivot.py`:
- `test_pivot_preserves_all_nan_metric_flat`: flat pivot (no groupby) — metric column restored as all-NaN
- `test_pivot_preserves_all_nan_metric_with_columns`: MultiIndex pivot (with groupby) — metric level preserved at level 0