### PR TITLE
fix(dashboard): use datasetUuid instead of datasetId in display controls export/import (SC-104655)

### DIFF
--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -146,6 +146,17 @@ class ExportDashboardsCommand(ExportModelsCommand):
                     if dataset:
                         target["datasetUuid"] = str(dataset.uuid)
 
+        # Replace display control dataset references with uuid
+        for customization in payload.get("metadata", {}).get(
+            "chart_customization_config", []
+        ):
+            for target in customization.get("targets", []):
+                dataset_id = target.pop("datasetId", None)
+                if dataset_id is not None:
+                    dataset = DatasetDAO.find_by_id(dataset_id)
+                    if dataset:
+                        target["datasetUuid"] = str(dataset.uuid)
+
         # the mapping between dashboard -> charts is inferred from the position
         # attribute, so if it's not present we need to add a default config
         if not payload.get("position"):
@@ -225,6 +236,17 @@ class ExportDashboardsCommand(ExportModelsCommand):
                 "native_filter_configuration", []
             ):
                 for target in native_filter.get("targets", []):
+                    dataset_id = target.pop("datasetId", None)
+                    if dataset_id is not None:
+                        dataset = DatasetDAO.find_by_id(dataset_id)
+                        if dataset:
+                            yield from ExportDatasetsCommand([dataset_id]).run()
+
+            # Export datasets referenced by display controls
+            for customization in payload.get("metadata", {}).get(
+                "chart_customization_config", []
+            ):
+                for target in customization.get("targets", []):
                     dataset_id = target.pop("datasetId", None)
                     if dataset_id is not None:
                         dataset = DatasetDAO.find_by_id(dataset_id)

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -42,6 +42,12 @@ def find_native_filter_datasets(metadata: dict[str, Any]) -> set[str]:
             dataset_uuid = target.get("datasetUuid")
             if dataset_uuid:
                 uuids.add(dataset_uuid)
+    for customization in metadata.get("chart_customization_config", []):
+        targets = customization.get("targets", [])
+        for target in targets:
+            dataset_uuid = target.get("datasetUuid")
+            if dataset_uuid:
+                uuids.add(dataset_uuid)
     return uuids
 
 
@@ -139,6 +145,18 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
             native_filter["scope"]["excluded"] = [
                 id_map[old_id] for old_id in scope_excluded if old_id in id_map
             ]
+
+    # fix display control dataset references
+    chart_customization_config = fixed.get("metadata", {}).get(
+        "chart_customization_config", []
+    )
+    for customization in chart_customization_config:
+        targets = customization.get("targets", [])
+        for target in targets:
+            dataset_uuid = target.pop("datasetUuid", None)
+            if dataset_uuid:
+                target["datasetId"] = dataset_info[dataset_uuid]["datasource_id"]
+
     fixed = update_cross_filter_scoping(fixed, id_map)
     return fixed
 

--- a/tests/unit_tests/commands/dashboard/export_test.py
+++ b/tests/unit_tests/commands/dashboard/export_test.py
@@ -1,0 +1,146 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from superset.utils import json
+
+
+def _make_mock_dashboard(json_metadata: dict[str, Any]) -> MagicMock:
+    dashboard = MagicMock()
+    dashboard.dashboard_title = "Test Dashboard"
+    dashboard.theme = None
+    dashboard.slices = []
+    dashboard.tags = []
+    dashboard.export_to_dict.return_value = {
+        "position_json": json.dumps(
+            {
+                "DASHBOARD_VERSION_KEY": "v2",
+                "ROOT_ID": {"children": ["GRID_ID"], "id": "ROOT_ID", "type": "ROOT"},
+                "GRID_ID": {
+                    "children": [],
+                    "id": "GRID_ID",
+                    "parents": ["ROOT_ID"],
+                    "type": "GRID",
+                },
+                "HEADER_ID": {
+                    "id": "HEADER_ID",
+                    "meta": {"text": "Test Dashboard"},
+                    "type": "HEADER",
+                },
+            }
+        ),
+        "json_metadata": json.dumps(json_metadata),
+    }
+    return dashboard
+
+
+def test_file_content_replaces_dataset_id_with_uuid_in_display_controls():
+    """
+    _file_content must replace datasetId with datasetUuid in chart_customization_config
+    targets, mirroring what it already does for native_filter_configuration.
+    """
+    from superset.commands.dashboard.export import ExportDashboardsCommand
+
+    dataset_uuid = str(uuid.uuid4())
+
+    mock_dashboard = _make_mock_dashboard(
+        {
+            "native_filter_configuration": [],
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-abc",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [{"datasetId": 99, "column": {"name": "col"}}],
+                },
+                {
+                    "id": "CUSTOMIZATION-divider",
+                    "type": "CHART_CUSTOMIZATION_DIVIDER",
+                    "targets": [],
+                },
+            ],
+        }
+    )
+
+    mock_dataset = MagicMock()
+    mock_dataset.uuid = dataset_uuid
+
+    with (
+        patch(
+            "superset.commands.dashboard.export.DatasetDAO.find_by_id",
+            return_value=mock_dataset,
+        ),
+        patch(
+            "superset.commands.dashboard.export.feature_flag_manager.is_feature_enabled",
+            return_value=False,
+        ),
+    ):
+        content = ExportDashboardsCommand._file_content(mock_dashboard)
+
+    result = yaml.safe_load(content)
+    customizations = result["metadata"]["chart_customization_config"]
+
+    # The datasetId must be replaced with datasetUuid
+    target = customizations[0]["targets"][0]
+    assert "datasetUuid" in target
+    assert target["datasetUuid"] == dataset_uuid
+    assert "datasetId" not in target
+
+    # Dividers with no targets must be unaffected
+    assert customizations[1]["targets"] == []
+
+
+def test_file_content_dataset_not_found_leaves_target_empty():
+    """
+    When DatasetDAO.find_by_id returns None for a display control target,
+    the target should have neither datasetId nor datasetUuid — not crash.
+    """
+    from superset.commands.dashboard.export import ExportDashboardsCommand
+
+    mock_dashboard = _make_mock_dashboard(
+        {
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-orphan",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [{"datasetId": 9999}],
+                },
+            ],
+        }
+    )
+
+    with (
+        patch(
+            "superset.commands.dashboard.export.DatasetDAO.find_by_id",
+            return_value=None,
+        ),
+        patch(
+            "superset.commands.dashboard.export.feature_flag_manager.is_feature_enabled",
+            return_value=False,
+        ),
+    ):
+        content = ExportDashboardsCommand._file_content(mock_dashboard)
+
+    result = yaml.safe_load(content)
+    target = result["metadata"]["chart_customization_config"][0]["targets"][0]
+    assert "datasetId" not in target
+    assert "datasetUuid" not in target

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -244,6 +244,77 @@ def test_update_id_refs_preserves_time_grains_in_native_filters():
     assert filter_config.get("filterType") == "filter_timegrain"
 
 
+def test_find_native_filter_datasets_includes_display_controls():
+    """
+    Test that find_native_filter_datasets also returns dataset UUIDs
+    from chart_customization_config (display controls).
+    """
+    from superset.commands.dashboard.importers.v1.utils import (
+        find_native_filter_datasets,
+    )
+
+    metadata = {
+        "native_filter_configuration": [
+            {"targets": [{"datasetUuid": "uuid-native-1"}]},
+        ],
+        "chart_customization_config": [
+            {"targets": [{"datasetUuid": "uuid-display-1"}]},
+            {"targets": [{"datasetUuid": "uuid-display-2"}]},
+            {"targets": []},
+        ],
+    }
+
+    uuids = find_native_filter_datasets(metadata)
+    assert uuids == {"uuid-native-1", "uuid-display-1", "uuid-display-2"}
+
+
+def test_update_id_refs_fixes_display_control_dataset_references():
+    """
+    Test that update_id_refs converts datasetUuid back to datasetId in
+    chart_customization_config (display controls) during import.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "native_filter_configuration": [],
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-abc",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [
+                        {"datasetUuid": "ds-uuid-1", "column": {"name": "col"}}
+                    ],
+                },
+                {
+                    "id": "CUSTOMIZATION-divider",
+                    "type": "CHART_CUSTOMIZATION_DIVIDER",
+                    "targets": [],
+                },
+            ],
+        },
+    }
+
+    chart_ids = {"uuid1": 1}
+    dataset_info: dict[str, dict[str, Any]] = {
+        "ds-uuid-1": {"datasource_id": 42},
+    }
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    customizations = fixed["metadata"]["chart_customization_config"]
+    assert customizations[0]["targets"][0].get("datasetId") == 42
+    assert "datasetUuid" not in customizations[0]["targets"][0]
+    assert customizations[1]["targets"] == []
+
+
 def test_update_id_refs_handles_missing_time_grains():
     """
     Test backward compatibility when time_grains is not present.


### PR DESCRIPTION
### SUMMARY

Display controls (the "Add display control" option in the filter sidebar) are stored in `chart_customization_config` inside `json_metadata`. Each display control can reference a dataset via `targets[].datasetId` (an environment-specific integer), exactly like native filters which reference datasets via `targets[].datasetId` in `native_filter_configuration`.

The export command already converts `datasetId` -> `datasetUuid` for native filters and exports the referenced datasets, but it completely skipped `chart_customization_config`. As a result, exported dashboard YAMLs contained integer dataset IDs for display controls, making them non-portable across environments.

**Root cause:** `ExportDashboardsCommand._file_content()` and `_export()` only iterated `native_filter_configuration` for the `datasetId` -> `datasetUuid` conversion. The import path had the symmetric gap: `find_native_filter_datasets()` and `update_id_refs()` both only processed `native_filter_configuration`.

**Fix:** Applied the same pattern to `chart_customization_config` in all four locations:
- `export.py _file_content()`: replace `datasetId` with `datasetUuid` in display control targets
- `export.py _export()`: emit `ExportDatasetsCommand` for datasets referenced by display controls
- `importers/v1/utils.py find_native_filter_datasets()`: collect display control dataset UUIDs so they are included in the import bundle
- `importers/v1/utils.py update_id_refs()`: restore `datasetId` from `datasetUuid` in display control targets on import

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — serialization bug, no visual change.

### TESTING INSTRUCTIONS

1. Create a dashboard with at least one display control that selects a dataset and column.
2. Export the dashboard (Dashboard > Export).
3. Open the exported ZIP and inspect `dashboards/*.yaml`.
4. **Before fix:** `chart_customization_config[*].targets[*]` contains `datasetId: <integer>`.
5. **After fix:** `chart_customization_config[*].targets[*]` contains `datasetUuid: <uuid-string>` and no `datasetId`.
6. Import the dashboard on a different Superset instance — display controls should resolve to the correct dataset.

Unit tests (no DB required):
```bash
pytest tests/unit_tests/commands/dashboard/export_test.py
pytest tests/unit_tests/dashboards/commands/importers/v1/utils_test.py::test_find_native_filter_datasets_includes_display_controls
pytest tests/unit_tests/dashboards/commands/importers/v1/utils_test.py::test_update_id_refs_fixes_display_control_dataset_references
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: SC-104655 (bluelabs.eu, P3)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Blast radius:** export and import of dashboards containing display controls only. Dashboards with only native filters or no filters are unaffected. The fix is purely additive.