### PR TITLE
fix(dashboard): use datasetUuid instead of datasetId in display controls export/import (SC-104655)

### DIFF
--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -146,16 +146,26 @@ class ExportDashboardsCommand(ExportModelsCommand):
                     if dataset:
                         target["datasetUuid"] = str(dataset.uuid)
 
-        # Replace display control dataset references with uuid
-        for customization in payload.get("metadata", {}).get(
-            "chart_customization_config", []
+        # Replace display control dataset references with uuid.
+        # datasetId is intentionally preserved alongside datasetUuid so that
+        # bundles remain importable by older versions that do not yet understand
+        # datasetUuid for display-control targets.
+        for customization in (
+            payload.get("metadata", {}).get("chart_customization_config") or []
         ):
             for target in customization.get("targets", []):
-                dataset_id = target.pop("datasetId", None)
+                dataset_id = target.get("datasetId")
                 if dataset_id is not None:
                     dataset = DatasetDAO.find_by_id(dataset_id)
                     if dataset:
                         target["datasetUuid"] = str(dataset.uuid)
+                    else:
+                        logger.warning(
+                            "Dashboard '%s': display control target references "
+                            "missing dataset %s; datasetUuid will not be set",
+                            model.dashboard_title,
+                            dataset_id,
+                        )
 
         # the mapping between dashboard -> charts is inferred from the position
         # attribute, so if it's not present we need to add a default config
@@ -243,8 +253,8 @@ class ExportDashboardsCommand(ExportModelsCommand):
                             yield from ExportDatasetsCommand([dataset_id]).run()
 
             # Export datasets referenced by display controls
-            for customization in payload.get("metadata", {}).get(
-                "chart_customization_config", []
+            for customization in (
+                payload.get("metadata", {}).get("chart_customization_config") or []
             ):
                 for target in customization.get("targets", []):
                     dataset_id = target.get("datasetId")

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -146,6 +146,17 @@ class ExportDashboardsCommand(ExportModelsCommand):
                     if dataset:
                         target["datasetUuid"] = str(dataset.uuid)
 
+        # Replace display control dataset references with uuid
+        for customization in payload.get("metadata", {}).get(
+            "chart_customization_config", []
+        ):
+            for target in customization.get("targets", []):
+                dataset_id = target.pop("datasetId", None)
+                if dataset_id is not None:
+                    dataset = DatasetDAO.find_by_id(dataset_id)
+                    if dataset:
+                        target["datasetUuid"] = str(dataset.uuid)
+
         # the mapping between dashboard -> charts is inferred from the position
         # attribute, so if it's not present we need to add a default config
         if not payload.get("position"):
@@ -225,6 +236,17 @@ class ExportDashboardsCommand(ExportModelsCommand):
                 "native_filter_configuration", []
             ):
                 for target in native_filter.get("targets", []):
+                    dataset_id = target.pop("datasetId", None)
+                    if dataset_id is not None:
+                        dataset = DatasetDAO.find_by_id(dataset_id)
+                        if dataset:
+                            yield from ExportDatasetsCommand([dataset_id]).run()
+
+            # Export datasets referenced by display controls
+            for customization in payload.get("metadata", {}).get(
+                "chart_customization_config", []
+            ):
+                for target in customization.get("targets", []):
                     dataset_id = target.pop("datasetId", None)
                     if dataset_id is not None:
                         dataset = DatasetDAO.find_by_id(dataset_id)

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -153,7 +153,7 @@ class ExportDashboardsCommand(ExportModelsCommand):
         for customization in (
             payload.get("metadata", {}).get("chart_customization_config") or []
         ):
-            for target in customization.get("targets", []):
+            for target in customization.get("targets") or []:
                 dataset_id = target.get("datasetId")
                 if dataset_id is not None:
                     dataset = DatasetDAO.find_by_id(dataset_id)
@@ -256,7 +256,7 @@ class ExportDashboardsCommand(ExportModelsCommand):
             for customization in (
                 payload.get("metadata", {}).get("chart_customization_config") or []
             ):
-                for target in customization.get("targets", []):
+                for target in customization.get("targets") or []:
                     dataset_id = target.get("datasetId")
                     if dataset_id is not None:
                         dataset = DatasetDAO.find_by_id(dataset_id)

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -247,7 +247,7 @@ class ExportDashboardsCommand(ExportModelsCommand):
                 "chart_customization_config", []
             ):
                 for target in customization.get("targets", []):
-                    dataset_id = target.pop("datasetId", None)
+                    dataset_id = target.get("datasetId")
                     if dataset_id is not None:
                         dataset = DatasetDAO.find_by_id(dataset_id)
                         if dataset:

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -42,7 +42,7 @@ def find_native_filter_datasets(metadata: dict[str, Any]) -> set[str]:
             dataset_uuid = target.get("datasetUuid")
             if dataset_uuid:
                 uuids.add(dataset_uuid)
-    for customization in metadata.get("chart_customization_config", []):
+    for customization in metadata.get("chart_customization_config") or []:
         targets = customization.get("targets", [])
         for target in targets:
             dataset_uuid = target.get("datasetUuid")
@@ -147,10 +147,9 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
             ]
 
     # fix display control dataset references
-    chart_customization_config = fixed.get("metadata", {}).get(
-        "chart_customization_config", []
-    )
-    for customization in chart_customization_config:
+    for customization in (
+        fixed.get("metadata", {}).get("chart_customization_config") or []
+    ):
         targets = customization.get("targets", [])
         for target in targets:
             dataset_uuid = target.pop("datasetUuid", None)
@@ -158,6 +157,12 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
                 info = dataset_info.get(dataset_uuid)
                 if info:
                     target["datasetId"] = info["datasource_id"]
+                else:
+                    logger.warning(
+                        "Display control target references unknown dataset UUID %s; "
+                        "datasetId will not be restored",
+                        dataset_uuid,
+                    )
 
     fixed = update_cross_filter_scoping(fixed, id_map)
     return fixed

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -43,8 +43,7 @@ def find_native_filter_datasets(metadata: dict[str, Any]) -> set[str]:
             if dataset_uuid:
                 uuids.add(dataset_uuid)
     for customization in metadata.get("chart_customization_config") or []:
-        targets = customization.get("targets", [])
-        for target in targets:
+        for target in customization.get("targets") or []:
             dataset_uuid = target.get("datasetUuid")
             if dataset_uuid:
                 uuids.add(dataset_uuid)
@@ -150,14 +149,17 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
     for customization in (
         fixed.get("metadata", {}).get("chart_customization_config") or []
     ):
-        targets = customization.get("targets", [])
-        for target in targets:
+        for target in customization.get("targets") or []:
             dataset_uuid = target.pop("datasetUuid", None)
             if dataset_uuid:
                 info = dataset_info.get(dataset_uuid)
                 if info:
                     target["datasetId"] = info["datasource_id"]
                 else:
+                    # UUID present but unresolvable — remove stale integer ID
+                    # so the control fails visibly rather than binding to
+                    # whatever dataset happens to own that ID in this environment
+                    target.pop("datasetId", None)
                     logger.warning(
                         "Display control target references unknown dataset UUID %s; "
                         "datasetId will not be restored",

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -42,6 +42,12 @@ def find_native_filter_datasets(metadata: dict[str, Any]) -> set[str]:
             dataset_uuid = target.get("datasetUuid")
             if dataset_uuid:
                 uuids.add(dataset_uuid)
+    for customization in metadata.get("chart_customization_config", []):
+        targets = customization.get("targets", [])
+        for target in targets:
+            dataset_uuid = target.get("datasetUuid")
+            if dataset_uuid:
+                uuids.add(dataset_uuid)
     return uuids
 
 
@@ -139,6 +145,18 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
             native_filter["scope"]["excluded"] = [
                 id_map[old_id] for old_id in scope_excluded if old_id in id_map
             ]
+
+    # fix display control dataset references
+    chart_customization_config = fixed.get("metadata", {}).get(
+        "chart_customization_config", []
+    )
+    for customization in chart_customization_config:
+        targets = customization.get("targets", [])
+        for target in targets:
+            dataset_uuid = target.pop("datasetUuid", None)
+            if dataset_uuid:
+                target["datasetId"] = dataset_info[dataset_uuid]["datasource_id"]
+
     fixed = update_cross_filter_scoping(fixed, id_map)
     return fixed
 

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -155,7 +155,9 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
         for target in targets:
             dataset_uuid = target.pop("datasetUuid", None)
             if dataset_uuid:
-                target["datasetId"] = dataset_info[dataset_uuid]["datasource_id"]
+                info = dataset_info.get(dataset_uuid)
+                if info:
+                    target["datasetId"] = info["datasource_id"]
 
     fixed = update_cross_filter_scoping(fixed, id_map)
     return fixed

--- a/tests/unit_tests/commands/dashboard/export_test.py
+++ b/tests/unit_tests/commands/dashboard/export_test.py
@@ -109,6 +109,62 @@ def test_file_content_replaces_dataset_id_with_uuid_in_display_controls():
     assert customizations[1]["targets"] == []
 
 
+def test_export_yields_dataset_files_for_display_controls():
+    """
+    _export must yield dataset files for datasets referenced by display controls.
+
+    The _export generator has a second pass over json_metadata (separate from
+    _file_content) whose job is to emit dataset YAML files into the bundle.
+    Without this, the round-trip fails: the UUID is in the dashboard YAML but
+    the dataset file is absent from the ZIP.
+    """
+    from superset.commands.dashboard.export import ExportDashboardsCommand
+
+    dataset_id = 42
+    mock_dashboard = _make_mock_dashboard(
+        {
+            "native_filter_configuration": [],
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-abc",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [{"datasetId": dataset_id}],
+                },
+            ],
+        }
+    )
+
+    mock_dataset = MagicMock()
+    sentinel_file = ("datasets/my_dataset.yaml", lambda: "dataset_content")
+    mock_datasets_cmd = MagicMock()
+    mock_datasets_cmd.run.return_value = iter([sentinel_file])
+
+    with (
+        patch(
+            "superset.commands.dashboard.export.DatasetDAO.find_by_id",
+            return_value=mock_dataset,
+        ),
+        patch(
+            "superset.commands.dashboard.export.ExportDatasetsCommand",
+            return_value=mock_datasets_cmd,
+        ) as mock_datasets_cls,
+        patch(
+            "superset.commands.dashboard.export.ExportChartsCommand"
+        ) as mock_charts_cls,
+        patch(
+            "superset.commands.dashboard.export.feature_flag_manager.is_feature_enabled",
+            return_value=False,
+        ),
+    ):
+        mock_charts_cls.return_value.run.return_value = iter([])
+        results = list(ExportDashboardsCommand._export(mock_dashboard))
+
+    mock_datasets_cls.assert_called_once_with([dataset_id])
+    mock_datasets_cmd.run.assert_called_once()
+    filenames = [name for name, _ in results]
+    assert "datasets/my_dataset.yaml" in filenames
+
+
 def test_file_content_dataset_not_found_leaves_target_empty():
     """
     When DatasetDAO.find_by_id returns None for a display control target,

--- a/tests/unit_tests/commands/dashboard/export_test.py
+++ b/tests/unit_tests/commands/dashboard/export_test.py
@@ -99,11 +99,10 @@ def test_file_content_replaces_dataset_id_with_uuid_in_display_controls():
     result = yaml.safe_load(content)
     customizations = result["metadata"]["chart_customization_config"]
 
-    # The datasetId must be replaced with datasetUuid
+    # datasetUuid must be added; datasetId preserved for backward compat
     target = customizations[0]["targets"][0]
-    assert "datasetUuid" in target
     assert target["datasetUuid"] == dataset_uuid
-    assert "datasetId" not in target
+    assert target["datasetId"] == 99
 
     # Dividers with no targets must be unaffected
     assert customizations[1]["targets"] == []
@@ -165,10 +164,35 @@ def test_export_yields_dataset_files_for_display_controls():
     assert "datasets/my_dataset.yaml" in filenames
 
 
-def test_file_content_dataset_not_found_leaves_target_empty():
+def test_file_content_null_chart_customization_config_does_not_raise():
+    """
+    When chart_customization_config is explicitly null in metadata,
+    _file_content must not raise — the `or []` guard handles it.
+    """
+    from superset.commands.dashboard.export import ExportDashboardsCommand
+
+    mock_dashboard = _make_mock_dashboard(
+        {
+            "native_filter_configuration": [],
+            "chart_customization_config": None,
+        }
+    )
+
+    with patch(
+        "superset.commands.dashboard.export.feature_flag_manager.is_feature_enabled",
+        return_value=False,
+    ):
+        content = ExportDashboardsCommand._file_content(mock_dashboard)
+
+    result = yaml.safe_load(content)
+    assert result["metadata"]["chart_customization_config"] is None
+
+
+def test_file_content_missing_dataset_preserves_dataset_id():
     """
     When DatasetDAO.find_by_id returns None for a display control target,
-    the target should have neither datasetId nor datasetUuid — not crash.
+    datasetId is preserved (dual-write: it was never popped) and no
+    datasetUuid is added — the target is not silently emptied.
     """
     from superset.commands.dashboard.export import ExportDashboardsCommand
 
@@ -198,5 +222,5 @@ def test_file_content_dataset_not_found_leaves_target_empty():
 
     result = yaml.safe_load(content)
     target = result["metadata"]["chart_customization_config"][0]["targets"][0]
-    assert "datasetId" not in target
+    assert target["datasetId"] == 9999
     assert "datasetUuid" not in target

--- a/tests/unit_tests/commands/dashboard/export_test.py
+++ b/tests/unit_tests/commands/dashboard/export_test.py
@@ -1,0 +1,146 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from superset.utils import json
+
+
+def _make_mock_dashboard(json_metadata: dict[str, Any]) -> MagicMock:
+    dashboard = MagicMock()
+    dashboard.dashboard_title = "Test Dashboard"
+    dashboard.theme = None
+    dashboard.slices = []
+    dashboard.tags = []
+    dashboard.export_to_dict.return_value = {
+        "position_json": json.dumps(
+            {
+                "DASHBOARD_VERSION_KEY": "v2",
+                "ROOT_ID": {"children": ["GRID_ID"], "id": "ROOT_ID", "type": "ROOT"},
+                "GRID_ID": {
+                    "children": [],
+                    "id": "GRID_ID",
+                    "parents": ["ROOT_ID"],
+                    "type": "GRID",
+                },
+                "HEADER_ID": {
+                    "id": "HEADER_ID",
+                    "meta": {"text": "Test Dashboard"},
+                    "type": "HEADER",
+                },
+            }
+        ),
+        "json_metadata": json.dumps(json_metadata),
+    }
+    return dashboard
+
+
+def test_file_content_replaces_dataset_id_with_uuid_in_display_controls():
+    """
+    _file_content must replace datasetId with datasetUuid in chart_customization_config
+    targets, mirroring what it already does for native_filter_configuration.
+    """
+    from superset.commands.dashboard.export import ExportDashboardsCommand
+
+    dataset_uuid = str(uuid.uuid4())
+
+    mock_dashboard = _make_mock_dashboard(
+        {
+            "native_filter_configuration": [],
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-abc",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [{"datasetId": 99, "column": {"name": "col"}}],
+                },
+                {
+                    "id": "CUSTOMIZATION-divider",
+                    "type": "CHART_CUSTOMIZATION_DIVIDER",
+                    "targets": [],
+                },
+            ],
+        }
+    )
+
+    mock_dataset = MagicMock()
+    mock_dataset.uuid = dataset_uuid
+
+    with (
+        patch(
+            "superset.commands.dashboard.export.DatasetDAO.find_by_id",
+            return_value=mock_dataset,
+        ),
+        patch(
+            "superset.commands.dashboard.export.feature_flag_manager.is_feature_enabled",
+            return_value=False,
+        ),
+    ):
+        content = ExportDashboardsCommand._file_content(mock_dashboard)
+
+    result = yaml.safe_load(content)
+    customizations = result["metadata"]["chart_customization_config"]
+
+    # The datasetId must be replaced with datasetUuid
+    target = customizations[0]["targets"][0]
+    assert "datasetUuid" in target
+    assert target["datasetUuid"] == dataset_uuid
+    assert "datasetId" not in target
+
+    # Dividers with no targets must be unaffected
+    assert customizations[1]["targets"] == []
+
+
+def test_file_content_dataset_not_found_leaves_target_empty():
+    """
+    When DatasetDAO.find_by_id returns None for a display control target,
+    the target should have neither datasetId nor datasetUuid — not crash.
+    """
+    from superset.commands.dashboard.export import ExportDashboardsCommand
+
+    mock_dashboard = _make_mock_dashboard(
+        {
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-orphan",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [{"datasetId": 9999}],
+                },
+            ],
+        }
+    )
+
+    with (
+        patch(
+            "superset.commands.dashboard.export.DatasetDAO.find_by_id",
+            return_value=None,
+        ),
+        patch(
+            "superset.commands.dashboard.export.feature_flag_manager.is_feature_enabled",
+            return_value=False,
+        ),
+    ):
+        content = ExportDashboardsCommand._file_content(mock_dashboard)
+
+    result = yaml.safe_load(content)
+    target = result["metadata"]["chart_customization_config"][0]["targets"][0]
+    assert "datasetId" not in target
+    assert "datasetUuid" not in target

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -289,8 +289,13 @@ def test_update_id_refs_fixes_display_control_dataset_references():
                 {
                     "id": "CUSTOMIZATION-abc",
                     "type": "CHART_CUSTOMIZATION",
+                    # dual-write format: both fields present in exported bundle
                     "targets": [
-                        {"datasetUuid": "ds-uuid-1", "column": {"name": "col"}}
+                        {
+                            "datasetId": 99,
+                            "datasetUuid": "ds-uuid-1",
+                            "column": {"name": "col"},
+                        }
                     ],
                 },
                 {
@@ -310,9 +315,40 @@ def test_update_id_refs_fixes_display_control_dataset_references():
     fixed = update_id_refs(config, chart_ids, dataset_info)
 
     customizations = fixed["metadata"]["chart_customization_config"]
-    assert customizations[0]["targets"][0].get("datasetId") == 42
-    assert "datasetUuid" not in customizations[0]["targets"][0]
+    target = customizations[0]["targets"][0]
+    assert target["datasetId"] == 42  # updated to destination-env ID
+    assert "datasetUuid" not in target  # consumed by import
     assert customizations[1]["targets"] == []
+
+
+def test_update_id_refs_removes_stale_dataset_id_when_uuid_unresolvable():
+    """
+    When a target has both datasetId and datasetUuid but the UUID is absent
+    from dataset_info, the stale datasetId must also be removed. A visibly
+    broken control is safer than one silently bound to whatever dataset
+    happens to own that integer ID in the destination environment.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {},
+        "metadata": {
+            "native_filter_configuration": [],
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-abc",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [{"datasetId": 99, "datasetUuid": "uuid-missing"}],
+                },
+            ],
+        },
+    }
+
+    fixed = update_id_refs(config, {}, {})
+
+    target = fixed["metadata"]["chart_customization_config"][0]["targets"][0]
+    assert "datasetUuid" not in target
+    assert "datasetId" not in target
 
 
 def test_update_id_refs_skips_display_control_target_on_missing_uuid():

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -315,6 +315,38 @@ def test_update_id_refs_fixes_display_control_dataset_references():
     assert customizations[1]["targets"] == []
 
 
+def test_update_id_refs_raises_on_missing_display_control_dataset_uuid():
+    """
+    update_id_refs raises KeyError when a display control target's datasetUuid
+    is absent from dataset_info.
+
+    This matches native filter behaviour (same bare dict lookup at line 141).
+    The import command is responsible for resolving every UUID returned by
+    find_native_filter_datasets before calling update_id_refs, so a missing
+    entry indicates a corrupted or incomplete bundle.
+    """
+    import pytest
+
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {},
+        "metadata": {
+            "native_filter_configuration": [],
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-abc",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [{"datasetUuid": "uuid-missing-from-bundle"}],
+                },
+            ],
+        },
+    }
+
+    with pytest.raises(KeyError):
+        update_id_refs(config, {}, {})
+
+
 def test_update_id_refs_handles_missing_time_grains():
     """
     Test backward compatibility when time_grains is not present.

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -315,18 +315,13 @@ def test_update_id_refs_fixes_display_control_dataset_references():
     assert customizations[1]["targets"] == []
 
 
-def test_update_id_refs_raises_on_missing_display_control_dataset_uuid():
+def test_update_id_refs_skips_display_control_target_on_missing_uuid():
     """
-    update_id_refs raises KeyError when a display control target's datasetUuid
-    is absent from dataset_info.
-
-    This matches native filter behaviour (same bare dict lookup at line 141).
-    The import command is responsible for resolving every UUID returned by
-    find_native_filter_datasets before calling update_id_refs, so a missing
-    entry indicates a corrupted or incomplete bundle.
+    When a display control target's datasetUuid is absent from dataset_info
+    (e.g. a partially corrupt export bundle), update_id_refs skips the target
+    silently rather than raising KeyError — the datasetUuid is popped and no
+    datasetId is written, leaving the target without a dataset reference.
     """
-    import pytest
-
     from superset.commands.dashboard.importers.v1.utils import update_id_refs
 
     config: dict[str, Any] = {
@@ -343,8 +338,11 @@ def test_update_id_refs_raises_on_missing_display_control_dataset_uuid():
         },
     }
 
-    with pytest.raises(KeyError):
-        update_id_refs(config, {}, {})
+    fixed = update_id_refs(config, {}, {})
+
+    target = fixed["metadata"]["chart_customization_config"][0]["targets"][0]
+    assert "datasetUuid" not in target
+    assert "datasetId" not in target
 
 
 def test_update_id_refs_handles_missing_time_grains():

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -244,6 +244,77 @@ def test_update_id_refs_preserves_time_grains_in_native_filters():
     assert filter_config.get("filterType") == "filter_timegrain"
 
 
+def test_find_native_filter_datasets_includes_display_controls():
+    """
+    Test that find_native_filter_datasets also returns dataset UUIDs
+    from chart_customization_config (display controls).
+    """
+    from superset.commands.dashboard.importers.v1.utils import (
+        find_native_filter_datasets,
+    )
+
+    metadata = {
+        "native_filter_configuration": [
+            {"targets": [{"datasetUuid": "uuid-native-1"}]},
+        ],
+        "chart_customization_config": [
+            {"targets": [{"datasetUuid": "uuid-display-1"}]},
+            {"targets": [{"datasetUuid": "uuid-display-2"}]},
+            {"targets": []},
+        ],
+    }
+
+    uuids = find_native_filter_datasets(metadata)
+    assert uuids == {"uuid-native-1", "uuid-display-1", "uuid-display-2"}
+
+
+def test_update_id_refs_fixes_display_control_dataset_references():
+    """
+    Test that update_id_refs converts datasetUuid back to datasetId in
+    chart_customization_config (display controls) during import.
+    """
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "native_filter_configuration": [],
+            "chart_customization_config": [
+                {
+                    "id": "CUSTOMIZATION-abc",
+                    "type": "CHART_CUSTOMIZATION",
+                    "targets": [
+                        {"datasetUuid": "ds-uuid-1", "column": {"name": "col"}}
+                    ],
+                },
+                {
+                    "id": "CUSTOMIZATION-divider",
+                    "type": "CHART_CUSTOMIZATION_DIVIDER",
+                    "targets": [],
+                },
+            ],
+        },
+    }
+
+    chart_ids = {"uuid1": 1}
+    dataset_info: dict[str, dict[str, Any]] = {
+        "ds-uuid-1": {"datasource_id": 42},
+    }
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    customizations = fixed["metadata"]["chart_customization_config"]
+    assert customizations[0]["targets"][0].get("datasetId") == 42
+    assert "datasetUuid" not in customizations[0]["targets"][0]
+    assert customizations[1]["targets"] == []
+
+
 def test_update_id_refs_handles_missing_time_grains():
     """
     Test backward compatibility when time_grains is not present.


### PR DESCRIPTION
## **User description**
### SUMMARY

**Root cause:** Display controls (`chart_customization_config` entries in dashboard JSON metadata) store dataset references as integer `datasetId` in their `targets` array. During dashboard export, the existing code converts `datasetId` → `datasetUuid` for `native_filter_configuration` entries, but the same conversion was missing for `chart_customization_config` (display controls). Similarly, the import path restored `datasetUuid` → `datasetId` for native filters but not for display controls.

**Impact:** Exporting a dashboard with display controls that reference a dataset, then importing it into another environment, left display controls pointing at the wrong dataset (or no dataset) because the integer ID was environment-specific and was never converted to a portable UUID.

**Fix:** Applied the same `datasetId` ↔ `datasetUuid` conversion logic to `chart_customization_config` in both export and import paths:

- `superset/commands/dashboard/export.py` (`_file_content`): Replace `datasetId` with `datasetUuid` in display control targets during export
- `superset/commands/dashboard/export.py` (`_export`): Export datasets referenced by display controls (so the dataset YAML files are included in the export bundle)
- `superset/commands/dashboard/importers/v1/utils.py` (`find_native_filter_datasets`): Collect dataset UUIDs from display controls so the importer knows which datasets to look up
- `superset/commands/dashboard/importers/v1/utils.py` (`update_id_refs`): Restore `datasetId` from `datasetUuid` in display control targets during import

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (backend serialization change — no UI difference).

### TESTING INSTRUCTIONS

1. Create a dashboard with a display control ("Add display control") that references a dataset and a column
2. Export the dashboard (dashboard > ... > Export)
3. Open the exported ZIP and inspect the dashboard YAML — confirm `chart_customization_config` targets now contain `datasetUuid` (not `datasetId`)
4. Import the ZIP into a fresh Superset instance that has the same dataset — confirm the display control is functional with the correct dataset/column

Or run the new unit tests:

```bash
pytest tests/unit_tests/commands/dashboard/export_test.py -v
pytest tests/unit_tests/dashboards/commands/importers/v1/utils_test.py::test_find_native_filter_datasets_includes_display_controls -v
pytest tests/unit_tests/dashboards/commands/importers/v1/utils_test.py::test_update_id_refs_fixes_display_control_dataset_references -v
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: SC-104655 (Shortcut)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Fixes SC-104655 — bluelabs.eu (P3)


___

## **CodeAnt-AI Description**
**Use dataset UUIDs for display controls during dashboard export and import**

### What Changed
- Dashboard export now writes display control dataset references as UUIDs while keeping the existing ID for compatibility with older bundles
- Export bundles now include dataset files used by display controls, so those controls keep working after import
- Dashboard import now restores display control dataset references from UUIDs and skips broken references instead of failing
- Added tests for display control export, import, missing datasets, and null metadata handling

### Impact
`✅ Reliable dashboard transfers`
`✅ Fewer broken display controls after import`
`✅ Safer exports from incomplete dashboard metadata`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=ot3sHu4CS5-Pz9x-yPqVjfFyISkA-jCC-mHWpC3rPyw&org=apache)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
