### PR TITLE
chore(mcp): Simplify chart preview response

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1929,23 +1929,6 @@ class ChartPreview(BaseModel):
     )
     performance: PerformanceMetadata = Field(description="Performance metrics")
 
-    # Backward compatibility fields (populated based on content type)
-    format: str | None = Field(
-        None, description="Format of the preview (ascii, table, vega_lite)"
-    )
-    ascii_chart: str | None = Field(
-        None, description="ASCII art chart for 'ascii' format"
-    )
-    table_data: str | None = Field(
-        None, description="Formatted table for 'table' format"
-    )
-    width: int | None = Field(
-        None, description="Width (pixels for images, characters for ASCII)"
-    )
-    height: int | None = Field(
-        None, description="Height (pixels for images, lines for ASCII)"
-    )
-
     # Inherit versioning
     schema_version: str = Field("2.0", description="Response schema version")
     api_version: str = Field("v1", description="MCP API version")

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -110,7 +110,7 @@ def _sanitize_chart_preview_for_llm_context(
     """Wrap chart preview read-path descriptive fields before LLM exposure."""
     payload = chart_preview.model_dump(mode="python")
 
-    for field_name in ("chart_name", "chart_description", "ascii_chart", "table_data"):
+    for field_name in ("chart_name", "chart_description"):
         payload[field_name] = sanitize_for_llm_context(
             payload.get(field_name),
             field_path=(field_name,),
@@ -1362,22 +1362,6 @@ async def _get_chart_preview_internal(  # noqa: C901
             performance=performance,
         )
 
-        # Add format-specific fields for backward compatibility
-        if isinstance(content, ASCIIPreview):
-            result.format = "ascii"
-            result.ascii_chart = content.ascii_content
-            result.width = content.width
-            result.height = content.height
-        elif isinstance(content, TablePreview):
-            result.format = "table"
-            result.table_data = content.table_data
-        elif isinstance(content, VegaLitePreview):
-            result.format = "vega_lite"
-        elif isinstance(content, URLPreview):
-            result.format = "url"
-            result.width = content.width
-            result.height = content.height
-
         return _sanitize_chart_preview_for_llm_context(result)
 
     except SQLAlchemyError as e:
@@ -1462,7 +1446,7 @@ async def get_chart_preview(
                 "has_preview_url=%s"
                 % (
                     getattr(result, "chart_id", None),
-                    result.format,
+                    getattr(result.content, "type", None),
                     bool(getattr(result, "preview_url", None)),
                 )
             )

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
@@ -263,13 +263,8 @@ class TestGetChartPreview:
             "performance",
         ]
 
-        # Additional fields that may be present for backward compatibility
+        # Versioning fields
         _ = [
-            "format",
-            "ascii_chart",
-            "table_data",
-            "width",
-            "height",
             "schema_version",
             "api_version",
         ]
@@ -366,10 +361,6 @@ class TestChartPreviewSanitization:
                 high_contrast_available=False,
             ),
             performance=PerformanceMetadata(query_duration_ms=8, cache_status="miss"),
-            format="ascii",
-            ascii_chart="North > South",
-            width=20,
-            height=5,
         )
 
         result = _sanitize_chart_preview_for_llm_context(preview)
@@ -380,7 +371,6 @@ class TestChartPreviewSanitization:
             "Preview of line: Regional Trend"
         )
         assert result.content.ascii_content == sanitize_for_llm_context("North > South")
-        assert result.ascii_chart == sanitize_for_llm_context("North > South")
         assert result.accessibility.alt_text == sanitize_for_llm_context(
             "Preview of Regional Trend"
         )
@@ -486,16 +476,11 @@ class TestChartPreviewSanitization:
                 high_contrast_available=False,
             ),
             performance=PerformanceMetadata(query_duration_ms=9, cache_status="miss"),
-            format="table",
-            table_data="Customer | Revenue\nAcme | 100",
         )
 
         result = _sanitize_chart_preview_for_llm_context(preview)
 
         assert result.content.table_data == sanitize_for_llm_context(
-            "Customer | Revenue\nAcme | 100"
-        )
-        assert result.table_data == sanitize_for_llm_context(
             "Customer | Revenue\nAcme | 100"
         )
         assert result.content.row_count == 1


### PR DESCRIPTION
### SUMMARY

The get_chart_preview response duplicates data — the same ASCII/table content appears in both content.ascii_content (or content.table_data) AND in flat top-level fields (ascii_chart, table_data). Both copies also get sanitized independently, wasting work.

Solution:
Remove the redundant flat fields (format, ascii_chart, table_data, width, height) from ChartPreview. Clients should read from the content discriminated union, which already has all of this data via ASCIIPreview, TablePreview, etc.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
