### PR TITLE
fix(ux): use title case for button labels

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -379,7 +379,7 @@ const ResultSet = ({
             onConfirm: () => {
               window.location.href = getExportCsvUrl(query.id);
             },
-            confirmText: t('OK'),
+            confirmText: t('Confirm'),
             cancelText: t('Close'),
           });
         }

--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -395,7 +395,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
         show={confirmModalOpen}
         onHide={handleConfirmModalClose}
         onHandledPrimaryAction={handleConfirmSave}
-        primaryButtonName={t('OK')}
+        primaryButtonName={t('Confirm')}
         primaryButtonLoading={isSaving}
       >
         {getSaveDialog()}

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs/Tabs.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs/Tabs.tsx
@@ -582,7 +582,7 @@ const Tabs = (props: TabsProps): ReactElement => {
           show={!!tabToDelete}
           onHide={handleCancelTabDelete}
           onHandledPrimaryAction={handleConfirmTabDelete}
-          primaryButtonName={t('DELETE')}
+          primaryButtonName={t('Delete')}
           primaryButtonStyle="danger"
           title={t('Delete dashboard tab?')}
           centered

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.tsx
@@ -1147,7 +1147,7 @@ class AnnotationLayer extends PureComponent<
               disabled={!isValid}
               onClick={this.submitAnnotation}
             >
-              {t('OK')}
+              {t('Confirm')}
             </Button>
           </div>
         </div>

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -328,7 +328,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
           onClick={onHide}
           data-test={DateFilterTestKey.CancelButton}
         >
-          {t('CANCEL')}
+          {t('Cancel')}
         </Button>
         <Button
           buttonStyle="primary"
@@ -338,7 +338,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
           onClick={onSave}
           data-test={DateFilterTestKey.ApplyButton}
         >
-          {t('APPLY')}
+          {t('Apply')}
         </Button>
       </div>
     </ContentStyleWrapper>


### PR DESCRIPTION
### SUMMARY

Replaces ALL CAPS button labels with Title Case to align with the Superset design system convention. Six labels across five files were using uppercase strings that violate the established button label style.

Changes:
- `DateFilterLabel.tsx`: `CANCEL` → `Cancel`, `APPLY` → `Apply`
- `AnnotationLayer.tsx`: `OK` → `Confirm`
- `DatasourceModal/index.tsx`: `OK` → `Confirm`
- `Tabs.tsx`: `DELETE` → `Delete`
- `ResultSet/index.tsx`: `OK` → `Confirm`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: Button labels displayed in ALL CAPS (e.g. CANCEL, APPLY, OK, DELETE)
After: Button labels displayed in Title Case (e.g. Cancel, Apply, Confirm, Delete)

### TESTING INSTRUCTIONS

1. Open the Date Filter control → verify Cancel and Apply buttons are title case
2. Open an Annotation Layer → verify the submit button shows "Confirm"
3. Open a Datasource modal and trigger the confirm save dialog → verify "Confirm" button
4. On a dashboard with tabs, delete a tab → verify the danger button shows "Delete"
5. In SQL Lab, run a large query and export → verify the confirmation dialog shows "Confirm"

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API