### PR TITLE
chore(frontend): export typed useAppDispatch / useAppSelector hooks

### DIFF
--- a/superset-frontend/src/hooks/apiResources/tables.test.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.test.ts
@@ -251,7 +251,7 @@ describe('useTables hook', () => {
     fetchMock.get(`glob:*/api/v1/database/${expectDbId}/schemas/*`, {
       result: fakeSchemaApiResult,
     });
-    const { result, waitFor } = renderHook(
+    const { result } = renderHook(
       () =>
         useTables({
           dbId: expectDbId,

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -22,6 +22,11 @@ import {
   createListenerMiddleware,
   StoreEnhancer,
 } from '@reduxjs/toolkit';
+import {
+  useDispatch,
+  useSelector,
+  type TypedUseSelectorHook,
+} from 'react-redux';
 import thunk from 'redux-thunk';
 import { api } from 'src/hooks/apiResources/queryApi';
 import messageToastReducer from 'src/components/MessageToasts/reducers';
@@ -177,3 +182,12 @@ export function setupStore({
 
 export const store = setupStore();
 export type RootState = ReturnType<typeof store.getState>;
+
+// Typed Redux hooks. Prefer these over the raw `useDispatch` / `useSelector`
+// from react-redux: `useAppDispatch` understands the store's middleware (so
+// thunks resolve correctly), and `useAppSelector` infers `RootState` without
+// callers having to annotate every selector. Required ahead of the
+// react-redux v8+ bump, which tightens dispatch typing — see #39927.
+export type AppDispatch = typeof store.dispatch;
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
### SUMMARY

First step of #39927 (the react-redux v7 → v8 migration spun off from #39890).

Adds typed Redux hooks alongside the existing store export in \`src/views/store.ts\`:

\`\`\`ts
export type AppDispatch = typeof store.dispatch;
export const useAppDispatch: () => AppDispatch = useDispatch;
export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
\`\`\`

This is **purely additive** — no existing call sites changed. The hooks work identically under react-redux v7 (current) and v8 (target). Landing them now means subsequent PRs can migrate \`useDispatch\` → \`useAppDispatch\` one feature area at a time, instead of one mega-PR alongside the v8 bump.

### Why now

The eventual v8 bump tightens \`useDispatch\` / \`connect\` typing so thunks no longer auto-resolve against \`Dispatch<AnyAction>\`. A spot-check from #39927 surfaced ~50 new TS errors in just three SqlLab files; the real migration surface is hundreds of call sites. Defining the typed hooks first lets that migration happen incrementally and reversibly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no runtime change; typed-hook exports only.

### TESTING INSTRUCTIONS

1. Pre-commit Type-Checking hook passes (\`pre-commit run --files superset-frontend/src/views/store.ts\`).
2. \`useAppDispatch\` and \`useAppSelector\` are importable from \`src/views/store\`. Try in a scratch file:
   \`\`\`ts
   import { useAppDispatch, useAppSelector } from 'src/views/store';
   \`\`\`
3. No existing test should change behavior — diff is additive only.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #39927 (sub-issue of #39890)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API