### PR TITLE
chore(superset-ui-switchboard): forward-compat fixes for TypeScript 6.0 (Phase E)

### DIFF
--- a/superset-frontend/packages/superset-ui-switchboard/src/switchboard.test.ts
+++ b/superset-frontend/packages/superset-ui-switchboard/src/switchboard.test.ts
@@ -95,8 +95,11 @@ class FakeMessageChannel {
     const port2 = new FakeMessagePort();
     port1.otherPort = port2;
     port2.otherPort = port1;
-    this.port1 = port1;
-    this.port2 = port2;
+    // FakeMessagePort only implements the subset of MessagePort that
+    // Switchboard exercises; cast at the boundary so the fake satisfies
+    // the consumer signature without weakening the production type.
+    this.port1 = port1 as unknown as MessagePort;
+    this.port2 = port2 as unknown as MessagePort;
   }
 }
 

--- a/superset-frontend/packages/superset-ui-switchboard/src/switchboard.ts
+++ b/superset-frontend/packages/superset-ui-switchboard/src/switchboard.ts
@@ -88,7 +88,7 @@ function isError(message: Message): message is ErrorMessage {
  * Calling methods on the switchboard causes messages to be sent through the channel.
  */
 export class Switchboard {
-  port: MessagePort;
+  port!: MessagePort;
 
   name = '';
 
@@ -97,9 +97,9 @@ export class Switchboard {
   // used to make unique ids
   incrementor = 1;
 
-  debugMode: boolean;
+  debugMode = false;
 
-  private isInitialised: boolean;
+  private isInitialised = false;
 
   constructor(params?: Params) {
     if (!params) {


### PR DESCRIPTION
Part of #39539 (TypeScript 5.4 → 6.0 migration tracking issue).

### SUMMARY

Phase E of the per-package TypeScript 6.0 migration. Scoped to `packages/superset-ui-switchboard`. Compiles cleanly on TypeScript 5.4.5 (current CI) **and** eliminates all TS 6.0 source errors in this package — specifically 3 × `TS2564` (strict property initialization) and 2 × `TS2322` (DOM `MessagePort` overload tightening).

**Fixes:**

- **`src/switchboard.ts`** — the `Switchboard` class assigns `port`, `debugMode`, and `isInitialised` inside `init()` rather than the constructor, so strict-init complains under TS 6.0:
  - `port!: MessagePort` — definite-assignment; the class is unusable until `init()` is called and there's no sensible default for a transport handle.
  - `debugMode = false` / `private isInitialised = false` — natural defaults that already match the runtime semantics in `init()` (where `debug = false` is the destructuring default and `isInitialised` is checked-falsy at the top of the method).

- **`src/switchboard.test.ts`** — TS 6.0's stricter inference rejects assigning a `FakeMessagePort` to a `MessagePort` field because `addEventListener`'s overload set no longer accepts a simplified `(event: 'message', handler: EventHandler) => void` signature. The fake only implements the subset of `MessagePort` that `Switchboard` exercises; cast at the boundary with `as unknown as MessagePort` per the playbook (no production-type widening).

`packages/generator-superset` was in scope per #39539 but measured zero TS 6.0 source errors, so it's left untouched.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no user-visible changes.

### TESTING INSTRUCTIONS

- `cd superset-frontend && npx tsc --build packages/superset-ui-switchboard` — clean (TS 5.4.5).
- `cd superset-frontend && npx -p typescript@6.0.3 tsc --noEmit -p packages/superset-ui-switchboard/tsconfig.json` — clean once `ignoreDeprecations: "6.0"` is added to suppress the unrelated `TS5101` baseUrl warning (deferred to the final config-cleanup PR).
- `npx jest packages/superset-ui-switchboard` — 13/13 tests pass.
- `pre-commit run --files superset-frontend/packages/superset-ui-switchboard/src/switchboard.ts superset-frontend/packages/superset-ui-switchboard/src/switchboard.test.ts` — all hooks green.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: #39539
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

**Migration roadmap** (for reviewers):

- ✅ Phase A — #39530 (declaration-emit fixes)
- 🔄 Phase B — #39535 (`packages/superset-ui-core`, rebased and mergeable)
- ✅ Phase C — #39537 (`packages/superset-core`)
- 📋 Phase D — `packages/superset-ui-chart-controls` (blocked on B)
- ← **Phase E (this PR)** — `packages/superset-ui-switchboard` (+ `generator-superset` — clean, no changes needed)
- 📋 Phase F — `superset-frontend/src/` (may split into F1/F2/…; blocked on B/C/D)
- 📋 Config cleanup — root tsconfig `baseUrl` migration + `typescript@6.0.3` pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)