### PR TITLE
fix(ci): serialize Docs Deployment runs to avoid push races

### DIFF
--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -17,6 +17,16 @@ on:
 
   workflow_dispatch: {}
 
+# Serialize deploys: the action pushes to apache/superset-site without
+# rebasing, so concurrent runs race on the final push and the loser fails
+# with `! [rejected] asf-site -> asf-site (fetch first)`. Cancel any
+# in-progress run as soon as a newer one starts — the destination repo
+# isn't touched until the final push step, so canceling mid-build is safe,
+# and the freshest content always wins.
+concurrency:
+  group: docs-deploy-asf-site
+  cancel-in-progress: true
+
 jobs:
   config:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### SUMMARY

The `Docs Deployment` workflow has been flaky on master for a while. Root cause: the deploy step (`.github/actions/github-action-push-to-another-repository`) clones `apache/superset-site`, drops in the new build, commits, and force-pushes to `asf-site` **without rebasing**. When two triggers fire close together — which happens routinely because a `docs/**` push fires both the `push` trigger AND the `workflow_run` trigger after `Python-Integration` finishes for the same commit — the two runs build concurrently and race on the final push. The loser dies with:

```
! [rejected]        asf-site -> asf-site (fetch first)
error: failed to push some refs to 'https://***@github.com/apache/superset-site.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally.
```

Evidence in the recent run history (same SHA, two runs, one wins, one loses):

| Time | Conclusion | SHA |
|---|---|---|
| 2026-05-11 16:50:49Z | success | `96ad2031` |
| 2026-05-11 16:52:01Z | **failure** | `96ad2031` |
| 2026-05-11 15:59:09Z | failure | `3e1cfc6d` |
| 2026-05-11 15:59:16Z | success | `3e1cfc6d` |

Same pattern on `2fe6269c`, `1d1a0e6f`, `ad7075d2`, `6271272e`, `245fffca`, etc. — failures interspersed with successes on identical commits.

### FIX

Add a workflow-level `concurrency` group so only one deploy runs at a time. `cancel-in-progress: true` because:
- The destination repo isn't touched until the very last step (the final push), so canceling an in-progress run mid-build is safe.
- The freshest content is always the right thing to ship — there's no value in queueing stale builds behind newer ones.

```yaml
concurrency:
  group: docs-deploy-asf-site
  cancel-in-progress: true
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (CI config only).

### TESTING INSTRUCTIONS

After merge, watch `Docs Deployment` runs on master. Concurrent triggers should now see the older run get canceled the moment the newer one starts, and the surviving run should push cleanly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API