### PR TITLE
fix(dashboard): preserve user selection when Dynamic Group By overlaps base

### DIFF
--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -141,9 +141,7 @@ function buildExistingColumnsSet(chart: ChartQueryPayload): Set<string> {
   const existingColumns = new Set<string>();
   const chartType = chart.form_data?.viz_type;
 
-  const existingGroupBy = ensureIsArray(chart.form_data?.groupby);
-  extractColumnNames(existingGroupBy).forEach(col => existingColumns.add(col));
-
+  // Base groupby is excluded: Dynamic Group By REPLACES it with the user's selection.
   const xAxisColumn = chart.form_data?.x_axis;
   if (xAxisColumn && chartType !== 'heatmap' && chartType !== 'heatmap_v2') {
     existingColumns.add(xAxisColumn);

--- a/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
@@ -433,14 +433,14 @@ test('dataset mismatch: display control for a different dataset does not affect 
   expectGroupBy(result, ['original_column']);
 });
 
-test('dynamic group by with overlapping selection preserves multi-column base groupby', () => {
+test('dynamic group by replaces base groupby with the user selection (subset case)', () => {
   const result = getFormDataWithExtraFilters(
     makeGroupByArgs(['status'], ['status', 'category']),
   );
-  expectGroupBy(result, ['status', 'category']);
+  expectGroupBy(result, ['status']);
 });
 
-test('timeseries chart: overlapping selection preserves multi-column base groupby', () => {
+test('timeseries chart: dynamic group by replaces base groupby with the user selection', () => {
   const customizationId = 'CHART_CUSTOMIZATION-groupby-1';
   const result = getFormDataWithExtraFilters({
     ...mockArgs,
@@ -466,112 +466,22 @@ test('timeseries chart: overlapping selection preserves multi-column base groupb
       createChartCustomization({ id: customizationId }),
     ],
   });
-  expectGroupBy(result, ['series_col', 'breakdown_col']);
+  expectGroupBy(result, ['series_col']);
 });
 
-test('partial overlap: only non-existing columns pass through as customization override', () => {
+test('SC-100237: selecting base dimension + new dimension keeps BOTH in groupby', () => {
+  const result = getFormDataWithExtraFilters(
+    makeGroupByArgs(['product_line', 'deal_size'], ['product_line']),
+  );
+  expectGroupBy(result, ['product_line', 'deal_size']);
+  expectGroupByLength(result, 2);
+});
+
+test('dynamic group by replaces base with mixed (overlap + new) selection', () => {
   const result = getFormDataWithExtraFilters(
     makeGroupByArgs(['status', 'new_col'], ['status', 'category']),
   );
-  expectGroupBy(result, ['new_col']);
-});
-
-test('object-typed groupby entries (AdhocColumn) are recognized as existing columns', () => {
-  const customizationId = 'CHART_CUSTOMIZATION-groupby-1';
-  const result = getFormDataWithExtraFilters({
-    ...mockArgs,
-    chart: {
-      ...mockChart,
-      form_data: {
-        ...mockChart.form_data,
-        viz_type: 'table',
-        datasource: '3__table',
-        groupby: [{ column_name: 'status' }, 'category'],
-      },
-    },
-    dataMask: {
-      [customizationId]: {
-        id: customizationId,
-        extraFormData: {},
-        filterState: { value: ['status', 'new_col'] },
-        ownState: {},
-      },
-    },
-    chartCustomizationItems: [
-      createChartCustomization({ id: customizationId }),
-    ],
-  });
-  // 'status' is already in groupby (as an object with column_name), so only 'new_col' passes through
-  expectGroupBy(result, ['new_col']);
-});
-
-test('AdhocColumn with sqlExpression (no column_name) is recognized as existing column', () => {
-  const customizationId = 'CHART_CUSTOMIZATION-groupby-1';
-  const result = getFormDataWithExtraFilters({
-    ...mockArgs,
-    chart: {
-      ...mockChart,
-      form_data: {
-        ...mockChart.form_data,
-        viz_type: 'table',
-        datasource: '3__table',
-        groupby: [
-          {
-            sqlExpression: 'CASE WHEN status = 1 THEN "active" END',
-            label: 'status_label',
-            expressionType: 'SQL',
-          },
-          'category',
-        ],
-      },
-    },
-    dataMask: {
-      [customizationId]: {
-        id: customizationId,
-        extraFormData: {},
-        filterState: { value: ['status_label', 'new_col'] },
-        ownState: {},
-      },
-    },
-    chartCustomizationItems: [
-      createChartCustomization({ id: customizationId }),
-    ],
-  });
-  // 'status_label' matches the AdhocColumn's label, so only 'new_col' passes through
-  expectGroupBy(result, ['new_col']);
-});
-
-test('AdhocColumn with empty label falls back to sqlExpression for identity', () => {
-  const customizationId = 'CHART_CUSTOMIZATION-groupby-1';
-  const sqlExpr = 'CASE WHEN status = 1 THEN "active" END';
-  const result = getFormDataWithExtraFilters({
-    ...mockArgs,
-    chart: {
-      ...mockChart,
-      form_data: {
-        ...mockChart.form_data,
-        viz_type: 'table',
-        datasource: '3__table',
-        groupby: [
-          { sqlExpression: sqlExpr, label: '', expressionType: 'SQL' },
-          'category',
-        ],
-      },
-    },
-    dataMask: {
-      [customizationId]: {
-        id: customizationId,
-        extraFormData: {},
-        filterState: { value: [sqlExpr, 'new_col'] },
-        ownState: {},
-      },
-    },
-    chartCustomizationItems: [
-      createChartCustomization({ id: customizationId }),
-    ],
-  });
-  // Empty label → falls back to sqlExpression; sqlExpr is in existingColumns, only 'new_col' passes
-  expectGroupBy(result, ['new_col']);
+  expectGroupBy(result, ['status', 'new_col']);
 });
 
 test('Scope boundary: display control with chartsInScope:[] does not affect the chart', () => {

--- a/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
@@ -469,6 +469,37 @@ test('timeseries chart: dynamic group by replaces base groupby with the user sel
   expectGroupBy(result, ['series_col']);
 });
 
+test('regression #39356: an all-conflicting selection keeps the base groupby and never empties it', () => {
+  // Selecting only the x_axis (already in use) contributes no new dimension, so the
+  // base groupby survives unchanged rather than the chart losing its dimensions.
+  const customizationId = 'CHART_CUSTOMIZATION-groupby-1';
+  const result = getFormDataWithExtraFilters({
+    ...mockArgs,
+    chart: {
+      ...mockChart,
+      form_data: {
+        ...mockChart.form_data,
+        viz_type: 'echarts_timeseries_line',
+        datasource: '3__table',
+        groupby: ['series_col', 'breakdown_col'],
+        x_axis: 'time_col',
+      },
+    },
+    dataMask: {
+      [customizationId]: {
+        id: customizationId,
+        extraFormData: {},
+        filterState: { value: ['time_col'] },
+        ownState: {},
+      },
+    },
+    chartCustomizationItems: [
+      createChartCustomization({ id: customizationId }),
+    ],
+  });
+  expectGroupBy(result, ['series_col', 'breakdown_col']);
+});
+
 test('SC-100237: selecting base dimension + new dimension keeps BOTH in groupby', () => {
   const result = getFormDataWithExtraFilters(
     makeGroupByArgs(['product_line', 'deal_size'], ['product_line']),


### PR DESCRIPTION
### SUMMARY

When a chart's base `groupby` overlapped with a Dynamic Group By option, picking the overlapping column plus a new one dropped the base dimension. Example: base `[product_line]`, user picks `[product_line, deal_size]`, chart groups by only `[deal_size]`.

`buildExistingColumnsSet` was adding the base `groupby` to the conflict set, so any overlapping user pick got filtered out before `applyChartSpecificGroupBy` set the final value. This PR removes that addition: the user's selection becomes the new groupby. What's shown in the dropdown matches what's plotted.

AdhocColumn extraction is kept (still applies to `box_plot.columns` and `pivot_table_v2.groupbyColumns`). Tests in `getFormDataWithExtraFilters.test.ts` were updated to the new semantics, plus a regression test for the reported case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, pure logic change. Verified via tests (18/18 pass).

### TESTING INSTRUCTIONS

1. Create a bar chart on a dataset with two categorical columns (e.g. `cleaned_sales_data` with `product_line` and `deal_size`). Set `product_line` as the dimension. Save.
2. Add the chart to a dashboard.
3. Add a Dynamic Group By customization for the chart with options `product_line` and `deal_size`.
4. Select both in the dropdown. The chart should group by both. Before this fix it grouped only by `deal_size`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
