### PR TITLE
fix(dashboard): keep native filter dropdown from covering input

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -1658,3 +1658,42 @@ test('renders standard Select dropdown when operatorType is Exact', () => {
 
   expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0);
 });
+
+test('renders dashboard select dropdown popup under document body', async () => {
+  jest.useFakeTimers({ advanceTimers: true });
+  render(<SelectFilterPlugin {...buildSelectFilterProps()} />, {
+    useRedux: true,
+    initialState: {
+      nativeFilters: {
+        filters: { 'test-filter': { name: 'Test Filter' } },
+      },
+      dataMask: {
+        'test-filter': {
+          extraFormData: {
+            filters: [{ col: 'gender', op: 'IN', val: ['boy'] }],
+          },
+          filterState: {
+            value: ['boy'],
+            label: 'boy',
+            excludeFilterValues: true,
+          },
+        },
+      },
+    },
+  });
+
+  const [filterSelect] = screen.getAllByRole('combobox');
+  userEvent.click(filterSelect);
+
+  let dropdown: Element | undefined;
+  await waitFor(() => {
+    dropdown = Array.from(
+      document.querySelectorAll('.ant-select-dropdown'),
+    ).find(
+      element => !element.classList.contains('ant-select-dropdown-hidden'),
+    );
+    expect(dropdown).toBeDefined();
+  });
+
+  expect(dropdown?.parentElement).toBe(document.body);
+});

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -584,6 +584,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
                 { value: 'false', label: t('is') },
               ]}
               onChange={handleExclusionToggle}
+              getPopupContainer={getSelectPopupContainer}
             />
           )}
           {isLikeOperator ? (

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -539,6 +539,19 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     [debouncedLikeChange],
   );
 
+  const getSelectPopupContainer = useCallback(
+    (trigger: HTMLElement) => {
+      if (showOverflow) {
+        return (parentRef?.current as HTMLElement) || document.body;
+      }
+      if (appSection === AppSection.FilterConfigModal) {
+        return (trigger?.parentNode as HTMLElement) || document.body;
+      }
+      return document.body;
+    },
+    [appSection, parentRef, showOverflow],
+  );
+
   const likeInputPlaceholder = useMemo(() => {
     switch (operatorType) {
       case SelectFilterOperatorType.Contains:
@@ -595,12 +608,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
               allowSelectAll={!searchAllOptions}
               value={multiSelect ? filterState.value || [] : filterState.value}
               disabled={isDisabled}
-              getPopupContainer={
-                showOverflow
-                  ? () => (parentRef?.current as HTMLElement) || document.body
-                  : (trigger: HTMLElement) =>
-                      (trigger?.parentNode as HTMLElement) || document.body
-              }
+              getPopupContainer={getSelectPopupContainer}
               showSearch={showSearch}
               mode={multiSelect ? 'multiple' : 'single'}
               placeholder={placeholderText}


### PR DESCRIPTION
### SUMMARY
Fixes #34135.

Dashboard Value filters previously mounted the select dropdown into the input's parent element. On short viewports or high browser zoom, that relative container can place the dropdown over the trigger field and hide the current input. This changes dashboard filter selects to mount their popup under `document.body`, while preserving the existing parent-container behavior for the filter config modal and overflow filter menu.

A unit test verifies dashboard select dropdowns are portaled to `document.body`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
See the linked issue for the before screenshot.

### TESTING INSTRUCTIONS
1. Open the example Sales Dashboard.
2. Reduce the browser height or increase browser zoom.
3. Open a dashboard Value filter.
4. Confirm the dropdown no longer overlaps and hides the select input.

Local checks run:
- `npx prettier@3.8.3 --check superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx`
- `npx oxlint@1.62.0 --quiet --config superset-frontend/oxlint.json superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx` (0 errors)
- `git diff --check`

### ADDITIONAL INFORMATION
- [x] Has associated issue: #34135
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API