### PR TITLE
fix: Normalize epoch timestamp generation to UTC

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -26,7 +26,7 @@ import logging
 import re
 import uuid
 from collections.abc import Hashable
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import (
     Any,
     Callable,
@@ -2389,7 +2389,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
         if tf:
             if tf in {"epoch_ms", "epoch_s"}:
-                seconds_since_epoch = int(dttm.timestamp())
+                seconds_since_epoch = int(dttm.replace(tzinfo=UTC).timestamp())
                 if tf == "epoch_s":
                     return str(seconds_since_epoch)
                 return str(seconds_since_epoch * 1000)
@@ -3532,4 +3532,4 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             labels_expected=labels_expected,
             sqla_query=qry,
             prequeries=prequeries,
-        )
+        ) 


### PR DESCRIPTION
Fixes #39781.

Normalizes epoch timestamp generation to UTC when handling timezone-naive datetimes in `dttm_sql_literal()`.

Previously, `datetime.timestamp()` depended on the local machine timezone, causing `test_dttm_sql_literal()` to fail on non-UTC environments.

This change ensures deterministic epoch conversion behavior across environments by explicitly treating naive datetimes as UTC before generating epoch literals.

Note: I was unable to fully run the local test suite because the Superset development dependencies are not fully installed in my environment (`alembic` missing).
