### PR TITLE
fix(gha): use sound condition gating for latest-tag step

### DIFF
--- a/.github/workflows/latest-release-tag.yml
+++ b/.github/workflows/latest-release-tag.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Run latest-tag
       uses: ./.github/actions/latest-tag
-      if: (! ${{ steps.latest-tag.outputs.SKIP_TAG }} )
+      if: steps.latest-tag.outputs.SKIP_TAG != 'true'
       with:
         description: Superset latest release
         tag-name: latest


### PR DESCRIPTION
### SUMMARY

The `if:` on the `Run latest-tag` step in `.github/workflows/latest-release-tag.yml` used a `${{ }}` template interpolation inside an expression context — the zizmor [`unsound-condition`](https://woodruffw.github.io/zizmor/audits/#unsound-condition) pattern. The expression is template-substituted *before* it is parsed, so the value of `steps.latest-tag.outputs.SKIP_TAG` is spliced in literally:

```yaml
if: (! ${{ steps.latest-tag.outputs.SKIP_TAG }} )
```

becomes one of:
- `(! true )`  → expression parses to `false` → step skipped ✓
- `(! false )` → expression parses to `true`  → step runs    ✓
- `(! )`       → **malformed expression** when `SKIP_TAG` is empty/undefined → GitHub Actions treats it as falsy → step skipped ✗

That third case is reachable in practice. `scripts/tag_latest_release.sh` has a "no latest tags yet" path (`scripts/tag_latest_release.sh:126-131`) that calls `run_git_tag` and exits *without* ever writing `SKIP_TAG` to `$GITHUB_OUTPUT`. Under the workflow's `--dry-run` invocation, `run_git_tag` is a no-op, so the script exits with `SKIP_TAG` unset. The buggy condition then evaluates `(! )` and **skips the tag step on the very first release**, exactly when it most needs to run.

This PR replaces the interpolated condition with a sound direct comparison:

```yaml
if: steps.latest-tag.outputs.SKIP_TAG != 'true'
```

which:
- evaluates correctly in all cases (`''`, `'false'`, `'true'`),
- matches the script's intent (skip only when `SKIP_TAG` is explicitly `"true"`),
- mirrors the idiomatic GHA pattern used elsewhere in this repo.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI/workflow change only.

### TESTING INSTRUCTIONS

GitHub Actions workflow conditions can't be unit-tested in the repo's test suite. The fix can be reasoned about against the GHA expression docs and validated by inspection of `scripts/tag_latest_release.sh` paths:

| `SKIP_TAG` value | Old condition `(! ${{ ... }} )` | New condition `... != 'true'` | Intent |
|---|---|---|---|
| `"true"`  (equal / older release) | `(! true )` → `false` → skip | `'true' != 'true'` → `false` → skip | skip |
| `"false"` (newer release) | `(! false )` → `true` → run | `'false' != 'true'` → `true` → run | run |
| `""` (no-latest-tags path) | `(! )` → malformed → skip | `'' != 'true'` → `true` → run | run |

### ADDITIONAL INFORMATION

The same workflow has a separate finding at line 23:

```yaml
source ./scripts/tag_latest_release.sh $(echo ${{ github.event.release.tag_name }}) --dry-run
```

`${{ github.event.release.tag_name }}` is interpolated directly into a shell command — a zizmor `template-injection` class issue. That is a distinct fix (move the tag name to an `env:` var and reference it as `"$TAG_NAME"`) and is intentionally out of scope for this PR.

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API