### PR TITLE
test(sqllab): stabilize SaveDatasetModal overwrite-flow test helper

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -356,21 +356,31 @@ describe('SaveDatasetModal', () => {
 
   const setupOverwriteFlow = async () => {
     // Select the "Overwrite existing" radio
-    userEvent.click(screen.getByRole('radio', { name: /overwrite existing/i }));
-    // Open the select and pick an existing dataset
-    userEvent.click(
+    await userEvent.click(
+      screen.getByRole('radio', { name: /overwrite existing/i }),
+    );
+    // Open the select to load existing-dataset options
+    await userEvent.click(
       screen.getByRole('combobox', { name: /existing dataset/i }),
     );
-    await waitFor(() =>
-      expect(screen.queryByText('Loading...')).not.toBeVisible(),
-    );
-    userEvent.click(screen.getAllByText('coolest table 0')[1]);
+    // Advance timers to flush debounced fetches in AsyncSelect
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    // Wait for the loading indicator to clear
+    await waitFor(() => {
+      const loading = screen.queryByText('Loading...');
+      expect(loading === null || !loading.checkVisibility()).toBe(true);
+    });
+    // Pick an existing dataset (use the listbox item, not the input mirror)
+    const options = await screen.findAllByText('coolest table 0');
+    await userEvent.click(options[1]);
     // First overwrite click → confirmation screen
-    userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
+    await userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
     // Wait for the confirmation screen to render
     await screen.findByText(/are you sure you want to overwrite this dataset/i);
     // Second overwrite click → triggers the PUT
-    userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
+    await userEvent.click(screen.getByRole('button', { name: /overwrite/i }));
   };
 
   test('sends template_params when overwriting a dataset with include template parameters checked', async () => {
@@ -399,7 +409,7 @@ describe('SaveDatasetModal', () => {
     });
 
     // Check the "Include Template Parameters" checkbox
-    userEvent.click(screen.getByRole('checkbox'));
+    await userEvent.click(screen.getByRole('checkbox'));
 
     await setupOverwriteFlow();
 


### PR DESCRIPTION
### SUMMARY

The two `template_params` overwrite tests in `SaveDatasetModal.test.tsx` (added in #39501) were flaky on CI. The stack pointed at `setupOverwriteFlow()` line:

```ts
userEvent.click(screen.getAllByText('coolest table 0')[1]);
```

That `getAllByText` lookup happens immediately after the AsyncSelect is opened, before the debounced fetch behind `loadDatasetOverwriteOptions` (which calls `SupersetClient.get` inside `SaveDatasetModal/index.tsx`) has resolved and the listbox has rendered. The same file already has earlier passing tests that use the correct async pattern; `setupOverwriteFlow()` just wasn't following it.

This PR realigns the helper to match the existing async-safe pattern used elsewhere in the file:

- `await` every `userEvent.click` (including the previously-unawaited `checkbox` click in the "include template parameters checked" test)
- after opening the combobox, flush debounced fetches with `await act(async () => { jest.runAllTimers(); })`
- wait for the `Loading...` indicator to clear using the same defensive `null || !checkVisibility()` check used by the other tests
- replace the immediate `getAllByText` lookup with `await screen.findAllByText('coolest table 0')` — wait-based, retries until the listbox renders

The test intent is unchanged: select an existing dataset, click overwrite once to reach the confirmation screen, wait for the confirmation text, then click overwrite again to trigger the PUT.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only change.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx jest src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
```

The two overwrite/template-parameter tests should pass reliably:
- `sends template_params when overwriting a dataset with include template parameters checked`
- `does not send template_params when overwriting a dataset with include template parameters unchecked`

No production code is touched — only `SaveDatasetModal.test.tsx`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API