### PR TITLE
chore(gha): pass commenter login through env in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,12 +17,11 @@ jobs:
     steps:
       - name: Check if user is allowed
         id: check
+        env:
+          COMMENTER: ${{ github.event.comment.user.login }}
         run: |
           # List of allowed users
           ALLOWED_USERS="mistercrunch,rusackas"
-
-          # Get the commenter's username
-          COMMENTER="${{ github.event.comment.user.login }}"
 
           echo "Checking permissions for user: $COMMENTER"
 
@@ -45,9 +44,12 @@ jobs:
     steps:
       - name: Comment access denied
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENTER_LOGIN: ${{ github.event.comment.user.login || github.event.review.user.login || github.event.issue.user.login }}
         with:
           script: |
-            const message = `👋 Hi @${{ github.event.comment.user.login || github.event.review.user.login || github.event.issue.user.login }}!
+            const commenter = process.env.COMMENTER_LOGIN;
+            const message = `👋 Hi @${commenter}!
 
             Thanks for trying to use Claude Code, but currently only certain team members have access to this feature.
 


### PR DESCRIPTION
### SUMMARY

Small hardening of \`.github/workflows/claude.yml\`: move the \`github.event.*.user.login\` references off inline \`\${{ }}\` expansion inside the shell and \`actions/github-script\` bodies and onto step-level \`env:\` blocks, then read the values as \`\$COMMENTER\` / \`process.env.COMMENTER_LOGIN\`. This is the standard mitigation pattern recommended by [zizmor's template-injection rule](https://woodruffw.github.io/zizmor/audits/#template-injection) and matches the broader Superset workflow conventions.

No behavior change — the values resolved are identical, they just arrive via the runner-set environment instead of being interpolated into the script source before execution.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — workflow change only.

### TESTING INSTRUCTIONS

GitHub Actions workflow files aren't unit-testable in this repo's test suite. The change is verifiable by inspection:

- The shell step (\`Check if user is allowed\`) now declares \`env: COMMENTER: \${{ github.event.comment.user.login }}\` and reads \`\$COMMENTER\` from the environment.
- The \`actions/github-script\` step (\`Comment access denied\`) declares \`env: COMMENTER_LOGIN: ...\` and reads \`process.env.COMMENTER_LOGIN\`.

The allowed-users gating logic is unchanged.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API