### PR TITLE
chore(gha): pin github/codeql-action to a SHA

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,6 +53,6 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: steps.check.outputs.python || steps.check.outputs.frontend
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
### SUMMARY

Pin both \`github/codeql-action/init@v4\` and \`github/codeql-action/analyze@v4\` in \`.github/workflows/codeql-analysis.yml\` to the commit SHA the \`v4\` tag currently dereferences to:

\`\`\`yaml
uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
\`\`\`

\`# v4\` is kept as a trailing comment for readability and matches the existing convention for \`actions/checkout\` on line 34 of the same file.

This is the standard mitigation for the supply-chain risk of mutable tags (a tag can be force-pushed by an attacker who compromises the upstream repo; a SHA cannot). Verified that \`refs/tags/v4\` on \`github/codeql-action\` dereferences to \`68bde559dea0fdcac2102bfdf6230c5f70eb485e\` at the time of this PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — workflow change only.

### TESTING INSTRUCTIONS

GitHub Actions workflow files aren't unit-testable in this repo's test suite. Verifiable by inspection: both \`uses:\` lines now reference a 40-char SHA followed by \`# v4\`, matching the \`actions/checkout\` line above them.

CodeQL analysis behavior is unchanged — the action source code at the pinned SHA is byte-identical to what \`@v4\` resolved to on the previous run.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API