### PR TITLE
feat(deckgl): take over geojson point radius controls

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/Geojson.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/Geojson.test.ts
@@ -22,6 +22,7 @@ import {
   computeGeoJsonTextOptionsFromFormData,
   computeGeoJsonIconOptionsFromJsOutput,
   computeGeoJsonIconOptionsFromFormData,
+  getLayer,
 } from './Geojson';
 
 jest.mock('react-map-gl/maplibre', () => ({
@@ -119,4 +120,54 @@ test('computeGeoJsonIconOptionsFromFormData computes icon options based on form 
     height: 128,
     width: 128,
   });
+});
+
+const baseFormData: SqlaFormData = {
+  datasource: 'test_datasource',
+  viz_type: 'deck_geojson',
+  slice_id: 1,
+  fill_color_picker: { r: 0, g: 0, b: 255, a: 1 },
+  stroke_color_picker: { r: 0, g: 0, b: 0, a: 1 },
+};
+
+const baseLayerArgs = {
+  onContextMenu: jest.fn(),
+  filterState: undefined,
+  setDataMask: jest.fn(),
+  payload: { data: { type: 'FeatureCollection', features: [] } },
+  setTooltip: jest.fn(),
+  emitCrossFilters: false,
+};
+
+test('getLayer preserves rendering for existing charts without new point radius fields', () => {
+  // Simulate form data from an existing chart that only has point_radius_scale
+  const legacyFormData = {
+    ...baseFormData,
+    point_radius_scale: 200,
+    // point_radius and point_radius_units intentionally absent
+  };
+
+  const layer = getLayer({ formData: legacyFormData, ...baseLayerArgs });
+  const { props } = layer;
+
+  // Should match deck.gl defaults, NOT the new control panel defaults
+  expect(props.getPointRadius).toBe(1); // deck.gl default, not 10
+  expect(props.pointRadiusUnits).toBe('meters'); // deck.gl default, not 'pixels'
+  expect(props.pointRadiusScale).toBe(200); // user's saved value preserved
+});
+
+test('getLayer uses control panel defaults for new charts', () => {
+  const newChartFormData = {
+    ...baseFormData,
+    point_radius: 10,
+    point_radius_units: 'pixels',
+    point_radius_scale: 1,
+  };
+
+  const layer = getLayer({ formData: newChartFormData, ...baseLayerArgs });
+  const { props } = layer;
+
+  expect(props.getPointRadius).toBe(10);
+  expect(props.pointRadiusUnits).toBe('pixels');
+  expect(props.pointRadiusScale).toBe(1);
 });

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/Geojson.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/Geojson.tsx
@@ -326,7 +326,11 @@ export const getLayer: GetLayerType<GeoJsonLayer> = function ({
       getFillColor(feature, filterState?.value),
     getLineColor,
     getLineWidth: fd.line_width || 1,
-    pointRadiusScale: fd.point_radius_scale,
+    // Use deck.gl defaults as fallbacks for backward compatibility with existing charts.
+    // New charts will get control panel defaults (point_radius=10, units='pixels', scale=1).
+    getPointRadius: fd.point_radius ?? 1,
+    pointRadiusUnits: fd.point_radius_units ?? 'meters',
+    pointRadiusScale: fd.point_radius_scale ?? 1,
     lineWidthUnits: fd.line_width_unit,
     pointType,
     ...labelOpts,

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
@@ -22,6 +22,8 @@ import {
   legacyValidateInteger,
   isFeatureEnabled,
   FeatureFlag,
+  validateNumber,
+  validateInteger,
 } from '@superset-ui/core';
 import { formatSelectOptions } from '../../utilities/utils';
 import {
@@ -351,14 +353,55 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'point_radius',
+            config: {
+              type: 'SelectControl',
+              freeForm: true,
+              label: t('Point Radius'),
+              description: t(
+                'The radius of point features, in the units specified below. ' +
+                  'The final rendered size is this value multiplied by Point Radius Scale.',
+              ),
+              validators: [validateInteger],
+              default: 10,
+              choices: formatSelectOptions([1, 5, 10, 20, 50, 100]),
+              renderTrigger: true,
+            },
+          },
+          {
             name: 'point_radius_scale',
             config: {
               type: 'SelectControl',
               freeForm: true,
               label: t('Point Radius Scale'),
-              validators: [legacyValidateInteger],
-              default: null,
-              choices: formatSelectOptions([0, 100, 200, 300, 500]),
+              description: t(
+                'A multiplier applied to the point radius. ' +
+                  'Use this to uniformly scale all points.',
+              ),
+              validators: [validateNumber],
+              default: 1,
+              choices: formatSelectOptions([0.1, 0.5, 1, 2, 5, 10]),
+              renderTrigger: true,
+            },
+          },
+        ],
+        [
+          {
+            name: 'point_radius_units',
+            config: {
+              type: 'SelectControl',
+              label: t('Point Radius Units'),
+              description: t(
+                'The unit for point radius. Use "pixels" for consistent ' +
+                  'screen-space sizing regardless of zoom level.',
+              ),
+              default: 'pixels',
+              choices: [
+                ['pixels', t('Pixels')],
+                ['meters', t('Meters')],
+                ['common', t('Common (unit per pixel at zoom 0)')],
+              ],
+              renderTrigger: true,
             },
           },
         ],


### PR DESCRIPTION
### SUMMARY

Takes over the GeoJSON point radius controls work from #33247 into a fork-based branch so it can continue moving forward.

This carries over the same three user-facing pieces from the existing PR:

- adds a new `Point Radius` control
- adds a new `Point Radius Units` control
- keeps `Point Radius Scale`, but makes it work with more intuitive defaults

It also preserves the backward-compatibility follow-up from the earlier review:

- existing charts without the new fields fall back to deck.gl defaults
- new charts still get the improved control-panel defaults
- tests cover both legacy and new-chart behavior

### TESTING INSTRUCTIONS

1. Create a GeoJSON chart with point features.
2. In the chart controls, verify you can set `Point Radius`, `Point Radius Units`, and `Point Radius Scale`.
3. Check that:
   - small values like `1`, `5`, or `10` work with `Pixels`
   - `Meters` scales with zoom
   - older charts without the new saved fields keep their prior behavior

### ADDITIONAL INFORMATION

- Follow-up/takeover of #33247
- Related bounty issue: #34398
