### PR TITLE
fix(ux): remove CSS-forced uppercase from button labels

### DIFF
--- a/superset-frontend/src/explore/components/controls/LayerConfigsControl/LayerConfigsPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/LayerConfigsControl/LayerConfigsPopoverContent.tsx
@@ -64,7 +64,6 @@ export const StyledCloseButton = styled(Button)`
     color: ${theme.colorPrimaryText};
     font-size: ${theme.fontSizeSM}px;
     font-weight: ${theme.fontWeightStrong};
-    text-transform: uppercase;
     min-width: ${theme.sizeUnit * 36};
     min-height: ${theme.sizeUnit * 8};
     box-shadow: none;
@@ -113,7 +112,6 @@ export const StyledSaveButton = styled(Button)`
     color: ${theme.colorTextLightSolid};
     font-size: ${theme.fontSizeSM}px;
     font-weight: ${theme.fontWeightStrong};
-    text-transform: uppercase;
     min-width: ${theme.sizeUnit * 36};
     min-height: ${theme.sizeUnit * 8};
     box-shadow: none;

--- a/superset-frontend/src/explore/components/controls/MapViewControl/MapViewControl.tsx
+++ b/superset-frontend/src/explore/components/controls/MapViewControl/MapViewControl.tsx
@@ -36,7 +36,6 @@ export const StyledExtentButton = styled(Button)`
     color: ${theme.colorPrimaryText};
     font-size: ${theme.fontSizeSM}px;
     font-weight: ${theme.fontWeightStrong};
-    text-transform: uppercase;
     min-width: ${theme.sizeUnit * 36};
     min-height: ${theme.sizeUnit * 8};
     box-shadow: none;


### PR DESCRIPTION
### SUMMARY

Two styled button components in the deck.gl/map controls were using `text-transform: uppercase` in their CSS, which forced button labels to ALL CAPS. This is inconsistent with the rest of the Superset design system where buttons render in their natural casing.

Removed `text-transform: uppercase` from:
- `StyledCloseButton` in `LayerConfigsPopoverContent.tsx`
- `StyledSaveButton` in `LayerConfigsPopoverContent.tsx`
- `StyledExtentButton` in `MapViewControl.tsx`

### TESTING INSTRUCTIONS

1. Open a dashboard with a deck.gl map chart
2. Open the layer configuration popover
3. Verify "Save" and "Close" buttons render in natural casing (not ALL CAPS)
4. Open the map view control popover
5. Verify the extent button renders in natural casing

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API