### PR TITLE
fix(pandas): suppress SettingWithCopyWarning in boxplot and histogram

### DIFF
--- a/superset/utils/pandas_postprocessing/boxplot.py
+++ b/superset/utils/pandas_postprocessing/boxplot.py
@@ -127,6 +127,6 @@ def boxplot(  # noqa: C901
     # that's used in the underlying function will fail
     for column in metrics:
         if df.dtypes[column] == np.object_:
-            df[column] = to_numeric(df[column], errors="coerce")
+            df.loc[:, column] = to_numeric(df[column], errors="coerce")
 
     return aggregate(df, groupby=groupby, aggregates=aggregates)

--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -48,8 +48,9 @@ def histogram(
     if groupby is None:
         groupby = []
 
-    # drop empty values from the target column
-    df = df.dropna(subset=[column])
+    # drop empty values from the target column;
+    # copy to avoid SettingWithCopyWarning on the to_numeric assignment below
+    df = df.dropna(subset=[column]).copy()
     if df.empty:
         return df
 

--- a/tests/unit_tests/pandas_postprocessing/test_boxplot.py
+++ b/tests/unit_tests/pandas_postprocessing/test_boxplot.py
@@ -14,7 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
+
 import pytest
+from pandas.errors import SettingWithCopyWarning
 
 from superset.exceptions import InvalidPostProcessingError
 from superset.utils.core import PostProcessingBoxplotWhiskerType
@@ -127,7 +130,7 @@ def test_boxplot_percentile_incorrect_params():
 
 
 def test_boxplot_type_coercion():
-    df = names_df
+    df = names_df.copy()
     df["cars"] = df["cars"].astype(str)
     df = boxplot(
         df=df,
@@ -149,3 +152,18 @@ def test_boxplot_type_coercion():
         "region",
     }
     assert len(df) == 4
+
+
+def test_boxplot_no_setting_with_copy_warning():
+    """Ensure to_numeric coercion does not raise SettingWithCopyWarning."""
+    df = names_df.copy()
+    df["cars"] = df["cars"].astype(str)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SettingWithCopyWarning)
+        result = boxplot(
+            df=df,
+            groupby=["region"],
+            whisker_type=PostProcessingBoxplotWhiskerType.TUKEY,
+            metrics=["cars"],
+        )
+    assert len(result) == 4

--- a/tests/unit_tests/pandas_postprocessing/test_histogram.py
+++ b/tests/unit_tests/pandas_postprocessing/test_histogram.py
@@ -14,7 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
+
 from pandas import DataFrame
+from pandas.errors import SettingWithCopyWarning
 
 from superset.utils.pandas_postprocessing import histogram
 
@@ -207,3 +210,17 @@ def test_histogram_with_no_groupby_and_all_null_values():
 
     result = histogram(data_with_no_groupby_and_all_nulls, "a", [], bins)
     assert result.empty
+
+
+def test_histogram_no_setting_with_copy_warning():
+    """dropna() may return a view; ensure to_numeric assignment does not warn."""
+    data_with_nulls = DataFrame(
+        {
+            "a": [1, 2, None, 4, 5],
+            "b": [1, 2, 3, 4, 5],
+        }
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SettingWithCopyWarning)
+        result = histogram(data_with_nulls, "a", [], bins=2)
+    assert not result.empty


### PR DESCRIPTION
### SUMMARY

Fixes #36530

`boxplot()` and `histogram()` in `superset/utils/pandas_postprocessing/` trigger pandas `SettingWithCopyWarning` during type coercion.

Two targeted fixes:

- **boxplot.py**: `df[column] = to_numeric(...)` assigns through a potential view. Changed to `df.loc[:, column]`.
- **histogram.py**: `dropna()` can return a view, so the subsequent `to_numeric` assignment warns. Appended `.copy()` to the `dropna()` call.

Also fixed a pre-existing test mutation bug where `test_boxplot_type_coercion` modified the shared `names_df` without `.copy()`.

Added two regression tests that promote `SettingWithCopyWarning` to an error and verify neither function raises it.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/pandas_postprocessing/test_boxplot.py -v
pytest tests/unit_tests/pandas_postprocessing/test_histogram.py -v
```

New tests:
- `test_boxplot_no_setting_with_copy_warning`
- `test_histogram_no_setting_with_copy_warning`

Both use `warnings.simplefilter("error", SettingWithCopyWarning)` to catch regressions. Existing tests continue to pass.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #36530
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API