### PR TITLE
chore(ci): add explicit permissions to release and docs workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - "master"
       - "[0-9].[0-9]*"
 
+permissions:
+  contents: read
+
 jobs:
   config:
     runs-on: ubuntu-24.04

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -17,6 +17,10 @@ on:
 
   workflow_dispatch: {}
 
+permissions:
+  actions: read
+  contents: read
+
 # Serialize deploys: the action pushes to apache/superset-site without
 # rebasing, so concurrent runs race on the final push and the loser fails
 # with `! [rejected] asf-site -> asf-site (fetch first)`. Cancel any

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -11,6 +11,10 @@ on:
     workflows: ["Python-Integration"]
     types: [completed]
 
+permissions:
+  actions: read
+  contents: read
+
 # cancel previous workflow jobs for PRs
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.run_id }}


### PR DESCRIPTION
### SUMMARY
Add explicit `GITHUB_TOKEN` permissions to the remaining release/docs workflows that were still relying on repository defaults:

- `.github/workflows/release.yml`
  - `permissions: { contents: read }`
- `.github/workflows/superset-docs-deploy.yml`
  - `permissions: { contents: read, actions: read }`
- `.github/workflows/superset-docs-verify.yml`
  - `permissions: { contents: read, actions: read }`

`actions: read` is included for the docs workflows because they download artifacts from other workflow runs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable.

### TESTING INSTRUCTIONS
- Validated YAML parsing for edited files with `python3` + `yaml.safe_load`.
- Ran required hook command: `/Users/arpitjain/Library/Python/3.9/bin/pre-commit run --all-files`.
  - In this environment, several hooks fail due missing local toolchain dependencies (`yarn`, `ruff`, `tscw-config`, `helm-docs`) plus Python interpreter mismatch for some hooks.
  - Any unrelated auto-edits from those hooks were reverted; only the workflow permission changes are included in this PR.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API