### PR TITLE
fix(OAuth2): Re-query the OAuth2 token to avoid stale reference

### DIFF
--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -149,6 +149,13 @@ def refresh_oauth2_token(
         if token is None:
             return None
 
+        if token.access_token and datetime.now() < token.access_token_expiration:
+            return token.access_token
+
+        if not token.refresh_token:
+            db.session.delete(token)
+            return None
+
         try:
             token_response = db_engine_spec.get_oauth2_fresh_token(
                 config,

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -38,7 +38,7 @@ from superset.superset_typing import OAuth2ClientConfig, OAuth2State
 
 if TYPE_CHECKING:
     from superset.db_engine_specs.base import BaseEngineSpec
-    from superset.models.core import Database, DatabaseUserOAuth2Tokens
+    from superset.models.core import Database
 
 JWT_EXPIRATION = timedelta(minutes=5)
 
@@ -116,7 +116,7 @@ def get_oauth2_access_token(
         return token.access_token
 
     if token.refresh_token:
-        return refresh_oauth2_token(config, database_id, user_id, db_engine_spec, token)
+        return refresh_oauth2_token(config, database_id, user_id, db_engine_spec)
 
     # since the access token is expired and there's no refresh token, delete the entry
     db.session.delete(token)
@@ -129,8 +129,10 @@ def refresh_oauth2_token(
     database_id: int,
     user_id: int,
     db_engine_spec: type[BaseEngineSpec],
-    token: DatabaseUserOAuth2Tokens,
 ) -> str | None:
+    # pylint: disable=import-outside-toplevel
+    from superset.models.core import DatabaseUserOAuth2Tokens
+
     # Use longer TTL for OAuth2 token refresh (may involve network calls)
     with DistributedLock(
         namespace="refresh_oauth2_token",
@@ -138,6 +140,15 @@ def refresh_oauth2_token(
         user_id=user_id,
         database_id=database_id,
     ):
+        # Short circuit in case another request already deleted the token
+        token = (
+            db.session.query(DatabaseUserOAuth2Tokens)
+            .filter_by(user_id=user_id, database_id=database_id)
+            .one_or_none()
+        )
+        if token is None:
+            return None
+
         try:
             token_response = db_engine_spec.get_oauth2_fresh_token(
                 config,

--- a/tests/unit_tests/utils/oauth2_tests.py
+++ b/tests/unit_tests/utils/oauth2_tests.py
@@ -131,6 +131,7 @@ def test_refresh_oauth2_token_deletes_token_on_oauth2_exception(
         "Token revoked"
     )
     token = mocker.MagicMock()
+    token.access_token = None
     token.refresh_token = "refresh-token"  # noqa: S105
     db.session.query().filter_by().one_or_none.return_value = token
 
@@ -161,6 +162,7 @@ def test_refresh_oauth2_token_keeps_token_on_other_exception(
     db_engine_spec.oauth2_exception = OAuth2ExceptionError
     db_engine_spec.get_oauth2_fresh_token.side_effect = Exception("Network error")
     token = mocker.MagicMock()
+    token.access_token = None
     token.refresh_token = "refresh-token"  # noqa: S105
     db.session.query().filter_by().one_or_none.return_value = token
 
@@ -185,6 +187,7 @@ def test_refresh_oauth2_token_no_access_token_in_response(
         "error": "invalid_grant",
     }
     token = mocker.MagicMock()
+    token.access_token = None
     token.refresh_token = "refresh-token"  # noqa: S105
     db.session.query().filter_by().one_or_none.return_value = token
 
@@ -211,6 +214,7 @@ def test_refresh_oauth2_token_updates_refresh_token(
         "refresh_token": "new-refresh-token",
     }
     token = mocker.MagicMock()
+    token.access_token = None
     token.refresh_token = "old-refresh-token"  # noqa: S105
     db.session.query().filter_by().one_or_none.return_value = token
 
@@ -240,6 +244,7 @@ def test_refresh_oauth2_token_keeps_refresh_token(
         "expires_in": 3600,
     }
     token = mocker.MagicMock()
+    token.access_token = None
     token.refresh_token = "original-refresh-token"  # noqa: S105
     db.session.query().filter_by().one_or_none.return_value = token
 
@@ -249,6 +254,94 @@ def test_refresh_oauth2_token_keeps_refresh_token(
     assert token.access_token == "new-access-token"  # noqa: S105
     assert token.refresh_token == "original-refresh-token"  # noqa: S105
     db.session.add.assert_called_with(token)
+
+
+def test_refresh_oauth2_token_refreshes_when_access_token_expired_under_lock(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that refresh_oauth2_token triggers a refresh when the access_token is expired.
+
+    When the re-query under the lock returns a token whose access_token has expired
+    but a refresh_token is available, the function should call the token endpoint
+    and persist the new access_token.
+    """
+    db = mocker.patch("superset.utils.oauth2.db")
+    mocker.patch("superset.utils.oauth2.DistributedLock")
+    db_engine_spec = mocker.MagicMock()
+    db_engine_spec.get_oauth2_fresh_token.return_value = {
+        "access_token": "new-access-token",
+        "expires_in": 3600,
+    }
+    token = mocker.MagicMock()
+    token.access_token = "expired-token"  # noqa: S105
+    token.access_token_expiration = datetime(2024, 1, 1)
+    token.refresh_token = "refresh-token"  # noqa: S105
+    db.session.query().filter_by().one_or_none.return_value = token
+
+    with freeze_time("2024-01-02"):
+        result = refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
+
+    assert result == "new-access-token"
+    db_engine_spec.get_oauth2_fresh_token.assert_called_once_with(
+        DUMMY_OAUTH2_CONFIG, "refresh-token"
+    )
+    db.session.add.assert_called_with(token)
+
+
+def test_refresh_oauth2_token_returns_existing_token_when_still_valid_under_lock(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that refresh_oauth2_token returns the existing access_token if still valid.
+
+    When concurrent requests are triggered and the first one refreshes the token and
+    releases the lock before the second one gets to `refresh_oauth2_token`, the second
+    request should pick up the already-refreshed access_token instead of refreshing
+    it again.
+    """
+    db = mocker.patch("superset.utils.oauth2.db")
+    mocker.patch("superset.utils.oauth2.DistributedLock")
+    db_engine_spec = mocker.MagicMock()
+    token = mocker.MagicMock()
+    token.access_token = "fresh-access-token"  # noqa: S105
+    token.access_token_expiration = datetime(2024, 1, 2)
+    token.refresh_token = "refresh-token"  # noqa: S105
+    db.session.query().filter_by().one_or_none.return_value = token
+
+    with freeze_time("2024-01-01"):
+        result = refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
+
+    assert result == "fresh-access-token"
+    db_engine_spec.get_oauth2_fresh_token.assert_not_called()
+    db.session.delete.assert_not_called()
+
+
+def test_refresh_oauth2_token_deletes_when_no_refresh_token_under_lock(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that refresh_oauth2_token deletes the row when there's no refresh_token.
+
+    When the token has expired and the re-query under the lock shows no refresh_token
+    is available, the row should be deleted and None returned so the caller can
+    trigger the OAuth2 dance.
+    """
+    db = mocker.patch("superset.utils.oauth2.db")
+    mocker.patch("superset.utils.oauth2.DistributedLock")
+    db_engine_spec = mocker.MagicMock()
+    token = mocker.MagicMock()
+    token.access_token = "expired-token"  # noqa: S105
+    token.access_token_expiration = datetime(2024, 1, 1)
+    token.refresh_token = None
+    db.session.query().filter_by().one_or_none.return_value = token
+
+    with freeze_time("2024-01-02"):
+        result = refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
+
+    assert result is None
+    db.session.delete.assert_called_with(token)
+    db_engine_spec.get_oauth2_fresh_token.assert_not_called()
 
 
 def test_refresh_oauth2_token_returns_none_when_row_deleted_under_lock(

--- a/tests/unit_tests/utils/oauth2_tests.py
+++ b/tests/unit_tests/utils/oauth2_tests.py
@@ -132,9 +132,10 @@ def test_refresh_oauth2_token_deletes_token_on_oauth2_exception(
     )
     token = mocker.MagicMock()
     token.refresh_token = "refresh-token"  # noqa: S105
+    db.session.query().filter_by().one_or_none.return_value = token
 
     with pytest.raises(OAuth2ExceptionError):
-        refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec, token)
+        refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
 
     db.session.delete.assert_called_with(token)
     db.session.flush.assert_called_once()
@@ -161,9 +162,10 @@ def test_refresh_oauth2_token_keeps_token_on_other_exception(
     db_engine_spec.get_oauth2_fresh_token.side_effect = Exception("Network error")
     token = mocker.MagicMock()
     token.refresh_token = "refresh-token"  # noqa: S105
+    db.session.query().filter_by().one_or_none.return_value = token
 
     with pytest.raises(Exception, match="Network error"):
-        refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec, token)
+        refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
 
     db.session.delete.assert_not_called()
 
@@ -176,7 +178,7 @@ def test_refresh_oauth2_token_no_access_token_in_response(
 
     This can happen when the refresh token was revoked.
     """
-    mocker.patch("superset.utils.oauth2.db")
+    db = mocker.patch("superset.utils.oauth2.db")
     mocker.patch("superset.utils.oauth2.DistributedLock")
     db_engine_spec = mocker.MagicMock()
     db_engine_spec.get_oauth2_fresh_token.return_value = {
@@ -184,8 +186,9 @@ def test_refresh_oauth2_token_no_access_token_in_response(
     }
     token = mocker.MagicMock()
     token.refresh_token = "refresh-token"  # noqa: S105
+    db.session.query().filter_by().one_or_none.return_value = token
 
-    result = refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec, token)
+    result = refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
 
     assert result is None
 
@@ -209,9 +212,10 @@ def test_refresh_oauth2_token_updates_refresh_token(
     }
     token = mocker.MagicMock()
     token.refresh_token = "old-refresh-token"  # noqa: S105
+    db.session.query().filter_by().one_or_none.return_value = token
 
     with freeze_time("2024-01-01"):
-        refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec, token)
+        refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
 
     assert token.access_token == "new-access-token"  # noqa: S105
     assert token.access_token_expiration == datetime(2024, 1, 1, 1)
@@ -237,13 +241,35 @@ def test_refresh_oauth2_token_keeps_refresh_token(
     }
     token = mocker.MagicMock()
     token.refresh_token = "original-refresh-token"  # noqa: S105
+    db.session.query().filter_by().one_or_none.return_value = token
 
     with freeze_time("2024-01-01"):
-        refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec, token)
+        refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
 
     assert token.access_token == "new-access-token"  # noqa: S105
     assert token.refresh_token == "original-refresh-token"  # noqa: S105
     db.session.add.assert_called_with(token)
+
+
+def test_refresh_oauth2_token_returns_none_when_row_deleted_under_lock(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that refresh_oauth2_token returns None when the row is gone under the lock.
+
+    When concurrent requests are triggered and the first one deletes the token row and
+    releases the lock before the second one gets to `refresh_oauth2_token`, the token
+    is queried again to avoid a stale reference.
+    """
+    db = mocker.patch("superset.utils.oauth2.db")
+    mocker.patch("superset.utils.oauth2.DistributedLock")
+    db_engine_spec = mocker.MagicMock()
+    db.session.query().filter_by().one_or_none.return_value = None
+
+    result = refresh_oauth2_token(DUMMY_OAUTH2_CONFIG, 1, 1, db_engine_spec)
+
+    assert result is None
+    db_engine_spec.get_oauth2_fresh_token.assert_not_called()
 
 
 def test_generate_code_verifier_length() -> None:


### PR DESCRIPTION
### SUMMARY
This PR fixes a very rare race condition that could happen with the OAuth2 flow. When loading a dashboard powered by a DB connection authenticated with OAuth2, multiple requests would hit `get_oauth2_access_token`, load the existing OAuth2 token for the user, and if needed call `refresh_oauth2_token`. We currently have a lock to prevent several requests from hitting `refresh_oauth2_token` in parallel, however there was still an edge case where:
1. Request A is fired, hits `get_oauth2_access_token`, loads the token, check that it's expired and accesses `refresh_oauth2_token` passing this token, acquiring a lock.
2. Request B is fired, hits `get_oauth2_access_token` and loads the token.
3. Request A completes `refresh_oauth2_token` and delete the token as part of the process, releasing the lock.
4. Request B hits `refresh_oauth2_token` passing the token loaded in step 2.
5. When trying to access one of the token properties, the token is actually deleted.

The fix is to get the token again in `refresh_oauth2_token`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Tests updated and new test added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
