### PR TITLE
fix: OAuth2 exception should be 403

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -353,9 +353,9 @@ class OAuth2RedirectError(SupersetErrorException):
 
     See the `OAuth2RedirectMessage.tsx` component for more details of how this
     information is handled.
-
-    TODO (betodealmeida): change status to 403.
     """
+
+    status = 403
 
     def __init__(self, url: str, tab_id: str, redirect_uri: str):
         super().__init__(

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -2250,7 +2250,7 @@ def test_catalogs_with_oauth2(
     security_manager.get_catalogs_accessible_by_user.return_value = {"db2"}
 
     response = client.get("/api/v1/database/1/catalogs/")
-    assert response.status_code == 500
+    assert response.status_code == 403
     assert response.json == {
         "errors": [
             {
@@ -2351,7 +2351,7 @@ def test_schemas_with_oauth2(
     security_manager.get_schemas_accessible_by_user.return_value = {"schema2"}
 
     response = client.get("/api/v1/database/1/schemas/")
-    assert response.status_code == 500
+    assert response.status_code == 403
     assert response.json == {
         "errors": [
             {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Setting the right HTTP status code for OAuth exceptions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Updated tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
