### PR TITLE
fix(event-log): add event logging for embedded Superset

### DIFF
--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -33,7 +33,7 @@ import { ensureAppRoot } from '../utils/pathUtils';
 import type { DashboardInfo, DashboardLayoutState } from '../dashboard/types';
 import type { QueryEditor } from '../SqlLab/types';
 
-type LogEventSource = 'dashboard' | 'explore' | 'sqlLab' | 'slice';
+type LogEventSource = 'dashboard' | 'embedded_dashboard' | 'explore' | 'sqlLab' | 'slice';
 
 interface LogEventData {
   source?: LogEventSource;
@@ -99,7 +99,7 @@ const sendBeacon = (events: LogEventData[]): void => {
   const [firstEvent] = events;
   const { source, source_id } = firstEvent;
   // backend logs treat these request params as first-class citizens
-  if (source === 'dashboard') {
+  if (source === 'dashboard' || source === 'embedded_dashboard') {
     endpoint += `&dashboard_id=${source_id}`;
   } else if (source === 'slice') {
     endpoint += `&slice_id=${source_id}`;
@@ -162,9 +162,10 @@ const loggerMiddleware: Middleware<
     }
     const path = navPath || window?.location?.href;
 
-    if (dashboardInfo?.id && path?.includes('/dashboard/')) {
+    const isEmbedded = path?.includes('/embedded/');
+    if (dashboardInfo?.id && (path?.includes('/dashboard/') || isEmbedded)) {
       logMetadata = {
-        source: 'dashboard',
+        source: isEmbedded ? 'embedded_dashboard' : 'dashboard',
         source_id: dashboardInfo.id,
         dashboard_id: dashboardInfo.id,
         ...logMetadata,


### PR DESCRIPTION
### SUMMARY

Embedded dashboards (served at `/embedded/<uuid>/`) were not attaching `source`, `source_id`, or `dashboard_id` to event-log payloads. The `loggerMiddleware` only entered the dashboard metadata branch when the URL path contained `/dashboard/`, so every event from an embedded session shipped without those fields:

**Before (embedded)**
```json
{"impression_id": "3sAIlceysG24nfh8J4_E0", "version": "v2", "ts": 1778614340914, "event_name": "mount_dashboard", ...}
```

**After (embedded)**
```json
{"source": "embedded_dashboard", "source_id": 30009, "dashboard_id": 30009, "impression_id": "3sAIlceysG24nfh8J4_E0", "version": "v2", "ts": 1778614340914, "event_name": "mount_dashboard", ...}
```

**Changes:**
- Broaden the URL check to also match `/embedded/` paths.
- Emit `source: 'embedded_dashboard'` (distinct from `'dashboard'`) so analytics can differentiate embedded sessions from regular dashboard views.
- Extend the `sendBeacon` endpoint builder to append `&dashboard_id=` for the new source value, keeping the backend query-param path working.
- Add `'embedded_dashboard'` to the `LogEventSource` TypeScript union type.

Chart-level events (`load_chart`, `render_chart`, drill-by, etc.) fired inside an embedded dashboard are also covered: the middleware infers `source` from Redux state (`dashboardInfo.id` is hydrated for embedded sessions), not from the event name, so all chart events automatically carry the new source fields alongside their own `slice_id`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — change is in the event-log JSON payload sent to `/superset/log/`.

### TESTING INSTRUCTIONS

1. Load an embedded dashboard via the embedded SDK (route `/embedded/<uuid>/`).
2. Open DevTools → Network → filter on `/superset/log/`.
3. Interact with the dashboard (charts will load, triggering `mount_dashboard`, `load_chart`, etc.).
4. Inspect the form-encoded `events` field in the POST payload — each event should now contain:
   - `"source": "embedded_dashboard"`
   - `"source_id": <dashboard_id>`
   - `"dashboard_id": <dashboard_id>`
5. Confirm that regular (non-embedded) dashboard events still show `"source": "dashboard"` (no regression).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API