### PR TITLE
fix(deckgl): render all MultiPolygon parts in Polygon chart

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
@@ -369,6 +369,72 @@ describe('Polygon transformProps', () => {
     ]);
   });
 
+  test('should render every polygon part when boundary column contains GeoJSON MultiPolygon Geometry format', () => {
+    const geojsonMultiPolygonProps = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        metric: 'population',
+      },
+      queriesData: [
+        {
+          data: [
+            {
+              geom: JSON.stringify({
+                type: 'MultiPolygon',
+                coordinates: [
+                  [
+                    [
+                      [-122.4, 37.8],
+                      [-122.3, 37.8],
+                      [-122.3, 37.9],
+                      [-122.4, 37.9],
+                      [-122.4, 37.8],
+                    ],
+                  ],
+                  [
+                    [
+                      [-121.4, 36.8],
+                      [-121.3, 36.8],
+                      [-121.3, 36.9],
+                      [-121.4, 36.9],
+                      [-121.4, 36.8],
+                    ],
+                  ],
+                ],
+              }),
+              population: 50000,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformProps(geojsonMultiPolygonProps as ChartProps);
+
+    const features = result.payload.data.features as PolygonFeature[];
+    expect(features).toHaveLength(2);
+    expect(features.map(feature => feature.polygon)).toEqual([
+      [
+        [-122.4, 37.8],
+        [-122.3, 37.8],
+        [-122.3, 37.9],
+        [-122.4, 37.9],
+        [-122.4, 37.8],
+      ],
+      [
+        [-121.4, 36.8],
+        [-121.3, 36.8],
+        [-121.3, 36.9],
+        [-121.4, 36.9],
+        [-121.4, 36.8],
+      ],
+    ]);
+    expect(features.map(feature => feature.metrics?.population)).toEqual([
+      50000, 50000,
+    ]);
+  });
+
   test('should render polygons when boundary column contains JSON with nested geometry', () => {
     // Real-world format: {"type":"Polygon","geometry":{"type":"Polygon","coordinates":[...]}}
     const nonStandardProps = {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts
@@ -47,6 +47,17 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function getOwnRecordValue(
+  record: DataRecord,
+  key: string | undefined,
+): string | number | null | undefined {
+  if (!key || !Object.prototype.hasOwnProperty.call(record, key)) {
+    return undefined;
+  }
+
+  return record[key];
+}
+
 function getGeoJsonGeometry(value: unknown): Record<string, unknown> | null {
   if (!isPlainRecord(value)) {
     return null;
@@ -140,7 +151,7 @@ function processPolygonData(
     );
     feature = updatedFeature as unknown as PolygonFeature;
 
-    const rawPolygonData = record[line_column];
+    const rawPolygonData = getOwnRecordValue(record, line_column);
     if (!rawPolygonData) {
       return [];
     }
@@ -195,15 +206,16 @@ function processPolygonData(
 
       if (fixedElevationValue !== undefined) {
         feature.elevation = fixedElevationValue;
-      } else if (elevationLabel && record[elevationLabel] != null) {
-        const elevationValue = parseMetricValue(record[elevationLabel]);
+      } else {
+        const rawElevationValue = getOwnRecordValue(record, elevationLabel);
+        const elevationValue = parseMetricValue(rawElevationValue);
         if (elevationValue !== undefined) {
           feature.elevation = elevationValue;
         }
       }
 
-      if (metricLabel && record[metricLabel] != null) {
-        const metricValue = record[metricLabel];
+      if (metricLabel) {
+        const metricValue = getOwnRecordValue(record, metricLabel);
         if (
           typeof metricValue === 'string' ||
           typeof metricValue === 'number'
@@ -218,8 +230,12 @@ function processPolygonData(
         metrics: { ...feature.metrics },
         polygon: polygonCoords,
       }));
-    } catch {
-      return [];
+    } catch (error) {
+      if (error instanceof SyntaxError || error instanceof TypeError) {
+        return [];
+      }
+
+      throw error;
     }
   });
 }

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts
@@ -41,6 +41,49 @@ interface PolygonFeature {
   metrics?: Record<string, number | string>;
 }
 
+type PolygonCoordinates = number[][];
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getGeoJsonGeometry(value: unknown): Record<string, unknown> | null {
+  if (!isPlainRecord(value)) {
+    return null;
+  }
+
+  if (value.coordinates) {
+    return value;
+  }
+
+  return isPlainRecord(value.geometry) ? value.geometry : null;
+}
+
+function getPolygonCoordinateParts(
+  value: unknown,
+): PolygonCoordinates[] | null {
+  if (Array.isArray(value)) {
+    return [value as PolygonCoordinates];
+  }
+
+  const geometry = getGeoJsonGeometry(value);
+  if (!geometry?.coordinates || !Array.isArray(geometry.coordinates)) {
+    return null;
+  }
+
+  if (geometry.type === 'MultiPolygon') {
+    return geometry.coordinates.flatMap(polygon =>
+      Array.isArray(polygon)
+        ? [(polygon[0] || polygon) as PolygonCoordinates]
+        : [],
+    );
+  }
+
+  return [
+    (geometry.coordinates[0] || geometry.coordinates) as PolygonCoordinates,
+  ];
+}
+
 function processPolygonData(
   records: DataRecord[],
   formData: DeckPolygonFormData,
@@ -83,98 +126,102 @@ function processPolygonData(
 
   const excludeKeys = new Set([line_column, ...(js_columns || [])]);
 
-  return records
-    .map(record => {
-      let feature: PolygonFeature = {
-        extraProps: {},
-        metrics: {},
-      };
+  return records.flatMap(record => {
+    let feature: PolygonFeature = {
+      extraProps: {},
+      metrics: {},
+    };
 
-      feature = addJsColumnsToExtraProps(feature, record, js_columns);
-      const updatedFeature = addPropertiesToFeature(
-        feature as unknown as Record<string, unknown>,
-        record,
-        excludeKeys,
-      );
-      feature = updatedFeature as unknown as PolygonFeature;
+    feature = addJsColumnsToExtraProps(feature, record, js_columns);
+    const updatedFeature = addPropertiesToFeature(
+      feature as unknown as Record<string, unknown>,
+      record,
+      excludeKeys,
+    );
+    feature = updatedFeature as unknown as PolygonFeature;
 
-      const rawPolygonData = record[line_column];
-      if (!rawPolygonData) {
-        return null;
+    const rawPolygonData = record[line_column];
+    if (!rawPolygonData) {
+      return [];
+    }
+
+    try {
+      let polygonCoordParts: PolygonCoordinates[];
+
+      switch (line_type) {
+        case 'json': {
+          const parsed =
+            typeof rawPolygonData === 'string'
+              ? JSON.parse(rawPolygonData)
+              : rawPolygonData;
+          const parsedPolygonCoordParts = getPolygonCoordinateParts(parsed);
+
+          if (!parsedPolygonCoordParts) {
+            return [];
+          }
+
+          polygonCoordParts = parsedPolygonCoordParts;
+          break;
+        }
+        case 'geohash': {
+          const polygonCoords: PolygonCoordinates = [];
+          const decoded = decode_bbox(String(rawPolygonData));
+          if (decoded) {
+            polygonCoords.push([decoded[1], decoded[0]]); // SW (minLon, minLat)
+            polygonCoords.push([decoded[1], decoded[2]]); // NW (minLon, maxLat)
+            polygonCoords.push([decoded[3], decoded[2]]); // NE (maxLon, maxLat)
+            polygonCoords.push([decoded[3], decoded[0]]); // SE (maxLon, minLat)
+            polygonCoords.push([decoded[1], decoded[0]]); // SW (close polygon)
+          }
+          polygonCoordParts = [polygonCoords];
+          break;
+        }
+        case 'zipcode':
+        default: {
+          polygonCoordParts = [
+            Array.isArray(rawPolygonData)
+              ? (rawPolygonData as PolygonCoordinates)
+              : [],
+          ];
+          break;
+        }
       }
 
-      try {
-        let polygonCoords: number[][];
-
-        switch (line_type) {
-          case 'json': {
-            const parsed =
-              typeof rawPolygonData === 'string'
-                ? JSON.parse(rawPolygonData)
-                : rawPolygonData;
-
-            if (parsed.coordinates) {
-              polygonCoords = parsed.coordinates[0] || parsed.coordinates;
-            } else if (parsed.geometry?.coordinates) {
-              // Non-standard format with nested geometry
-              polygonCoords =
-                parsed.geometry.coordinates[0] || parsed.geometry.coordinates;
-            } else if (Array.isArray(parsed)) {
-              polygonCoords = parsed;
-            } else {
-              return null;
-            }
-            break;
-          }
-          case 'geohash':
-            polygonCoords = [];
-            const decoded = decode_bbox(String(rawPolygonData));
-            if (decoded) {
-              polygonCoords.push([decoded[1], decoded[0]]); // SW (minLon, minLat)
-              polygonCoords.push([decoded[1], decoded[2]]); // NW (minLon, maxLat)
-              polygonCoords.push([decoded[3], decoded[2]]); // NE (maxLon, maxLat)
-              polygonCoords.push([decoded[3], decoded[0]]); // SE (maxLon, minLat)
-              polygonCoords.push([decoded[1], decoded[0]]); // SW (close polygon)
-            }
-            break;
-          case 'zipcode':
-          default: {
-            polygonCoords = Array.isArray(rawPolygonData) ? rawPolygonData : [];
-            break;
-          }
-        }
-
-        if (reverse_long_lat && polygonCoords.length > 0) {
-          polygonCoords = polygonCoords.map(coord => [coord[1], coord[0]]);
-        }
-
-        feature.polygon = polygonCoords;
-
-        if (fixedElevationValue !== undefined) {
-          feature.elevation = fixedElevationValue;
-        } else if (elevationLabel && record[elevationLabel] != null) {
-          const elevationValue = parseMetricValue(record[elevationLabel]);
-          if (elevationValue !== undefined) {
-            feature.elevation = elevationValue;
-          }
-        }
-
-        if (metricLabel && record[metricLabel] != null) {
-          const metricValue = record[metricLabel];
-          if (
-            typeof metricValue === 'string' ||
-            typeof metricValue === 'number'
-          ) {
-            feature.metrics![metricLabel] = metricValue;
-          }
-        }
-      } catch {
-        return null;
+      if (reverse_long_lat) {
+        polygonCoordParts = polygonCoordParts.map(polygonCoords =>
+          polygonCoords.map(coord => [coord[1], coord[0]]),
+        );
       }
 
-      return feature;
-    })
-    .filter((feature): feature is PolygonFeature => feature !== null);
+      if (fixedElevationValue !== undefined) {
+        feature.elevation = fixedElevationValue;
+      } else if (elevationLabel && record[elevationLabel] != null) {
+        const elevationValue = parseMetricValue(record[elevationLabel]);
+        if (elevationValue !== undefined) {
+          feature.elevation = elevationValue;
+        }
+      }
+
+      if (metricLabel && record[metricLabel] != null) {
+        const metricValue = record[metricLabel];
+        if (
+          typeof metricValue === 'string' ||
+          typeof metricValue === 'number'
+        ) {
+          feature.metrics![metricLabel] = metricValue;
+        }
+      }
+
+      return polygonCoordParts.map(polygonCoords => ({
+        ...feature,
+        extraProps: { ...feature.extraProps },
+        metrics: { ...feature.metrics },
+        polygon: polygonCoords,
+      }));
+    } catch {
+      return [];
+    }
+  });
 }
 
 export default function transformProps(chartProps: ChartProps) {


### PR DESCRIPTION
### SUMMARY

Fixes #39572. Fixes #38660.

Both issues report the same DeckGL Polygon symptom on different Superset versions: a GeoJSON `MultiPolygon` value renders only the first polygon part. They share a single root cause and are resolved by the same change.

DeckGL Polygon previously treated every GeoJSON payload as if it were a single Polygon and selected coordinates[0]. That is the outer ring for a Polygon, but for a MultiPolygon it is only the first polygon part, so valid remaining parts were dropped before the layer rendered.

This change keeps the fix at the existing Polygon transformProps conversion boundary and expands GeoJSON MultiPolygon geometry into one DeckGL Polygon feature per polygon part. Each emitted part keeps the source row metric/elevation/extra properties, so one MultiPolygon row renders completely without requiring duplicated dataset rows.

Reviewer focus:
- `superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts` for the JSON geometry normalization and per-part feature expansion.
- `superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts` for the MultiPolygon regression coverage and adjacent conversion guarantees.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Same fixture row in both screenshots: one row whose boundary column is a GeoJSON `MultiPolygon` with two separated 5° × 5° squares (one at longitude -10 to -5, the other at longitude 5 to 10, both at latitude 0 to 5). Note the two screenshots were captured at different map zoom levels — the polygons are the same geographic size, only the camera distance differs, so the squares have different on-screen sizes between the images. The behavior change is "1 polygon part visible" → "both polygon parts visible at their expected positions, with the metric value preserved on each".

**Before fix** (only the western polygon part renders; the eastern part is missing):

<img width="1400" height="900" alt="gh39572-before" src="https://github.com/user-attachments/assets/3fef9961-e1e7-40b7-bf79-f7fe1dde00e3" />

**After fix** (both polygon parts render in their expected positions):

<img width="1280" height="900" alt="gh39572-after" src="https://github.com/user-attachments/assets/ac0a6eab-d91f-4850-b6be-8d07f70bcdf5" />

Live validation:
- Runtime / environment: local Superset development stack from this repo's `docker-compose.yml`, with the standard `examples` data initialized.
- Entry point / scenario: a single-row dataset whose boundary column is a GeoJSON `MultiPolygon` with two separated square parts (`[[[-10,0],[-5,0],[-5,5],[-10,5],[-10,0]]]` and `[[[5,0],[10,0],[10,5],[5,5],[5,0]]]`), surfaced through a DeckGL Polygon Explore chart with `line_type=json` against that boundary column. Configure `Metric` so the legend value is non-empty (the row metric in the probe was `100`).
- Observed signal (before): the rendered map showed only the western polygon part; the eastern polygon part was missing despite being present in the same MultiPolygon row. Pixel-level component analysis on the chart canvas counted exactly 1 large filled polygon component.
- Observed signal (after): the same chart on the same row rendered both separated polygon parts at their expected map positions, and the metric legend still showed the source row value (`100`) for both parts. Pixel-level component analysis counted 2 large filled polygon components of equal area, matching the two equal-sized squares in the fixture.
- Pass / regression condition: the DeckGL Polygon canvas must render one filled polygon per polygon part of a GeoJSON `MultiPolygon` boundary value, and each rendered part must carry the source row's metric value. Regression would be either fewer rendered parts than the input MultiPolygon contains, or per-part metrics differing from the source row.

### TESTING INSTRUCTIONS

- [x] `cd superset-frontend && npm run test -- plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts` - verifies MultiPolygon expansion plus adjacent Polygon, nested geometry, invalid JSON, geohash/default, metric, and elevation behavior at the transform boundary.
- [x] `cd superset-frontend && npx oxlint --config oxlint.json --quiet plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts` - verifies lint coverage for the changed frontend files.
- [x] `cd superset-frontend && npm run type` - verifies the TypeScript project typecheck.
- [x] `pre-commit run --files superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.ts superset-frontend/plugins/preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts` - verifies repository pre-commit hooks for the changed files.
- [x] Manual browser check in a local Superset development runtime: open a DeckGL Polygon chart configured with one GeoJSON MultiPolygon row containing two separated polygon parts; confirm both parts render and the metric legend still reflects the source row value.

### ADDITIONAL INFORMATION

<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #39572 and #38660
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
