### PR TITLE
fix(sqllab): missing estimate action button

### DIFF
--- a/superset-frontend/src/SqlLab/components/EstimateQueryCostButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/EstimateQueryCostButton/index.tsx
@@ -113,7 +113,7 @@ const EstimateQueryCostButton = ({
         modalBody={renderModalBody()}
         triggerNode={
           <Button
-            color="primary"
+            color="default"
             variant="text"
             style={{ height: 32, padding: '4px 15px' }}
             onClick={onClickHandler}

--- a/superset/sqllab/utils.py
+++ b/superset/sqllab/utils.py
@@ -31,6 +31,7 @@ DATABASE_KEYS = [
     "allow_cvas",
     "allow_dml",
     "allow_run_async",
+    "allows_cost_estimate",
     "allows_subquery",
     "backend",
     "database_name",


### PR DESCRIPTION
### SUMMARY

Fixes a bug where the Estimate Query Cost button was missing in SQL Lab.

Two issues were causing the button to not appear:

1. Backend: allows_cost_estimate was missing from DATABASE_KEYS in superset/sqllab/utils.py. This key is used when serializing database metadata to the frontend, so its absence meant the frontend never received the flag indicating a database supports cost estimation — causing the button to be hidden.
2. Frontend: The EstimateQueryCostButton was using color="primary" with variant="text", which rendered the button as same as other sibling buttons.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="1127" height="686" alt="Screenshot 2026-05-13 at 5 36 29 PM" src="https://github.com/user-attachments/assets/4cd2ccd9-6370-436e-9c3b-e34d882b363b" />

After:

<img width="861" height="501" alt="Screenshot 2026-05-13 at 5 42 57 PM" src="https://github.com/user-attachments/assets/0f8d3bb0-c89c-4555-905c-366b89715b7a" />


### TESTING INSTRUCTIONS
1. Connect to a database that supports cost estimation (e.g., BigQuery, Presto/Trino)
2. Open SQL Lab and write a query
3. Verify the Estimate button appears in the toolbar
4. Click it and confirm the cost estimate modal opens correctly


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
