### PR TITLE
fix(ci): handle schedule event in change_detector and actually trigger all-changed

### DIFF
--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -20,7 +20,7 @@ import json
 import os
 import re
 import subprocess
-from typing import List
+from typing import List, Optional
 from urllib.request import Request, urlopen
 
 # Define patterns for each group of files you're interested in
@@ -111,7 +111,7 @@ def main(event_type: str, sha: str, repo: str) -> None:
     """Main function to check for file changes based on event context."""
     print("SHA:", sha)
     print("EVENT_TYPE", event_type)
-    files = []
+    files: Optional[List[str]] = []
     if event_type == "pull_request":
         pr_number = os.getenv("GITHUB_REF", "").split("/")[-2]
         if is_int(pr_number):
@@ -124,11 +124,15 @@ def main(event_type: str, sha: str, repo: str) -> None:
         print("Files touched since previous commit:")
         print_files(files)
 
-    elif event_type == "workflow_dispatch":
-        print("Workflow dispatched, assuming all changed")
+    elif event_type in ("workflow_dispatch", "schedule"):
+        # Manual or cron-triggered runs aren't tied to a specific diff, so
+        # treat every group as changed. `files = None` makes the loop below
+        # short-circuit to True for every group via `files is None or ...`.
+        print(f"{event_type} run, assuming all changed")
+        files = None
 
     else:
-        raise ValueError("Unsupported event type")
+        raise ValueError(f"Unsupported event type: {event_type}")
 
     changes_detected = {}
     for group, regex_patterns in PATTERNS.items():
@@ -144,7 +148,7 @@ def main(event_type: str, sha: str, repo: str) -> None:
             # NOTE: as noted above, we assume that if 100 files are touched, we should
             # trigger all checks. This is a workaround for the GitHub API limit of 100
             # files. Using >= 99 because off-by-one errors are not uncommon
-            if changed or len(files) >= 99:
+            if changed or (files is not None and len(files) >= 99):
                 print(f"{check}=true", file=f)
                 print(f"Triggering group: {check}")
 


### PR DESCRIPTION
### SUMMARY

The daily scheduled CodeQL scan has been failing on master with:

```
EVENT_TYPE schedule
ValueError: Unsupported event type
```

…because `scripts/change_detector.py` only handled `pull_request`, `push`, and `workflow_dispatch` events, and CodeQL's schedule trigger (`cron: "0 4 * * *"`) hits the unhandled `else` branch. Example: https://github.com/apache/superset/actions/runs/25843430105/job/75933296431

This was masked because the same commit also got a push-triggered Analyze run that succeeded, so the failure only shows up on whichever commit is master HEAD when the cron fires.

### What this PR does

- Add a `schedule` branch alongside `workflow_dispatch`. Both trigger types aren't tied to a specific diff, so both should treat every group as changed.
- Fix a latent bug while here: the `workflow_dispatch` branch printed "assuming all changed" but actually triggered **nothing** — it left `files = []`, and `detect_changes([], ...)` returns `False`, so no group flag was set in the output. Setting `files = None` makes the existing `files is None or detect_changes(...)` short-circuit fire for every group, matching the printed intent. Same fix benefits both event types.
- Include the unsupported event name in the `ValueError` message so future surprises are easier to debug.
- Mypy plumbing: `files: Optional[List[str]]` and a `None` guard on the `len(files) >= 99` check.

### Verified locally

```
$ python scripts/change_detector.py --event-type schedule --sha <sha> --repo apache/superset
SHA: ...
EVENT_TYPE schedule
schedule run, assuming all changed
Triggering group: python
Triggering group: frontend
Triggering group: docker
Triggering group: docs
Triggering group: superset-extensions-cli
```

Same output for `--event-type workflow_dispatch`. `pull_request` and `push` paths untouched.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A.

### TESTING INSTRUCTIONS

After merge, the next scheduled CodeQL run (cron: 04:00 UTC) should complete cleanly instead of failing with `Unsupported event type`. Or trigger a `workflow_dispatch` run manually on the CodeQL workflow — Analyze should now actually run instead of silently skipping.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
