### PR TITLE
test(datasets): regression coverage for #16141 (export with same table name, different schemas)

### DIFF
--- a/tests/unit_tests/datasets/commands/export_test.py
+++ b/tests/unit_tests/datasets/commands/export_test.py
@@ -18,6 +18,7 @@
 
 from uuid import UUID
 
+import yaml
 from sqlalchemy.orm.session import Session
 
 from superset import db
@@ -351,7 +352,7 @@ def test_export_two_datasets_same_table_name_different_schema(
 
     # And both YAML payloads must reflect their own schema, not be
     # silently merged or overwritten.
-    schemas_in_yaml = {c.split("schema:")[1].splitlines()[0].strip() for c in contents}
+    schemas_in_yaml = {yaml.safe_load(c)["schema"] for c in contents}
     assert schemas_in_yaml == {"prod", "dev"}, (
         f"Expected both prod and dev schemas in export, got {schemas_in_yaml}"
     )

--- a/tests/unit_tests/datasets/commands/export_test.py
+++ b/tests/unit_tests/datasets/commands/export_test.py
@@ -304,3 +304,54 @@ version: 1.0.0
 """,
         ),
     ]
+
+
+def test_export_two_datasets_same_table_name_different_schema(
+    session: Session,
+) -> None:
+    """
+    Regression coverage for GitHub issue #16141.
+
+    Exporting two datasets that share a `table_name` but live in
+    different schemas (e.g. prod.users + dev.users) must produce two
+    distinct entries in the export. Historically the pair could collide
+    onto a single filename — the export filename is now disambiguated by
+    dataset id, so this test pins that behavior so it can't silently
+    regress.
+    """
+    from superset.commands.dataset.export import ExportDatasetsCommand
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.core import Database
+
+    engine = db.session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    db.session.add(database)
+    db.session.flush()
+
+    prod = SqlaTable(table_name="users", schema="prod", database=database)
+    dev = SqlaTable(table_name="users", schema="dev", database=database)
+    db.session.add_all([prod, dev])
+    db.session.flush()
+
+    paths: list[str] = []
+    contents: list[str] = []
+    for ds in (prod, dev):
+        for path, content_fn in ExportDatasetsCommand._export(  # pylint: disable=protected-access
+            ds, export_related=False
+        ):
+            paths.append(path)
+            contents.append(content_fn())
+
+    # Both datasets must produce distinct export paths — no collision.
+    assert len(paths) == len(set(paths)), (
+        f"Export filenames collided for same-table-name datasets: {paths}"
+    )
+
+    # And both YAML payloads must reflect their own schema, not be
+    # silently merged or overwritten.
+    schemas_in_yaml = {c.split("schema:")[1].splitlines()[0].strip() for c in contents}
+    assert schemas_in_yaml == {"prod", "dev"}, (
+        f"Expected both prod and dev schemas in export, got {schemas_in_yaml}"
+    )


### PR DESCRIPTION
### SUMMARY

TDD-first regression coverage for [#16141](https://github.com/apache/superset/issues/16141) (Aug 2021): exporting two datasets with the same `table_name` but different schemas (e.g. `prod.users` + `dev.users`) historically returned only one file because the export filename did not disambiguate the pair.

The current `ExportDatasetsCommand` already produces `<table_name>_<id>.yaml`, so the original collision should no longer occur — but no test pinned the behavior, leaving the bug technically open and at risk of silent regression.

This PR is a small experiment in a *test-PR-first* workflow: open a failing-or-passing test that encodes the bug's contract before doing any code changes. If CI passes, the bug is provably fixed and #16141 can close. If CI fails, the test documents exactly what still needs work for whoever picks up the fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/datasets/commands/export_test.py::test_export_two_datasets_same_table_name_different_schema -xvs
```

The test creates two `SqlaTable` rows with identical `table_name="users"` and distinct schemas (`prod`, `dev`), runs `ExportDatasetsCommand._export` on each, and asserts:

1. The two emitted file paths are distinct (no filename collision).
2. Both emitted YAML payloads carry the correct `schema:` field — neither is silently overwritten.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Closes #16141
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API