### PR TITLE
fix(native-filters): keep select dropdown below horizontal trigger

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -44,7 +44,9 @@ jest.useFakeTimers({ advanceTimers: true });
 
 test('disables vertical dropdown auto-adjustment for horizontal filter bars', () => {
   expect(getSelectDropdownAlign(FilterBarOrientation.Horizontal)).toEqual({
-    overflow: { adjustY: false },
+    points: ['tl', 'bl'],
+    offset: [0, 4],
+    overflow: { adjustX: 0, adjustY: false },
   });
   expect(getSelectDropdownAlign(FilterBarOrientation.Vertical)).toBeUndefined();
   expect(getSelectDropdownAlign()).toBeUndefined();

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -27,7 +27,10 @@ import {
   waitFor,
 } from 'spec/helpers/testing-library';
 import { NULL_STRING } from 'src/utils/common';
-import SelectFilterPlugin from './SelectFilterPlugin';
+import { FilterBarOrientation } from 'src/dashboard/types';
+import SelectFilterPlugin, {
+  getSelectDropdownAlign,
+} from './SelectFilterPlugin';
 import transformProps from './transformProps';
 import { FilterState } from '@superset-ui/core';
 import {
@@ -38,6 +41,14 @@ import {
 } from './types';
 
 jest.useFakeTimers({ advanceTimers: true });
+
+test('disables vertical dropdown auto-adjustment for horizontal filter bars', () => {
+  expect(getSelectDropdownAlign(FilterBarOrientation.Horizontal)).toEqual({
+    overflow: { adjustY: false },
+  });
+  expect(getSelectDropdownAlign(FilterBarOrientation.Vertical)).toBeUndefined();
+  expect(getSelectDropdownAlign()).toBeUndefined();
+});
 
 const selectMultipleProps = {
   formData: {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -39,6 +39,7 @@ import {
   Select,
   Space,
   Constants,
+  DROPDOWN_ALIGN_BOTTOM,
   Input,
 } from '@superset-ui/core/components';
 import {
@@ -120,7 +121,13 @@ export const getSelectDropdownAlign = (
   filterBarOrientation?: FilterBarOrientation,
 ) =>
   filterBarOrientation === FilterBarOrientation.Horizontal
-    ? { overflow: { adjustY: false } }
+    ? {
+        ...DROPDOWN_ALIGN_BOTTOM,
+        overflow: {
+          ...DROPDOWN_ALIGN_BOTTOM.overflow,
+          adjustY: false,
+        },
+      }
     : undefined;
 
 export default function PluginFilterSelect(props: PluginFilterSelectProps) {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -116,6 +116,13 @@ const StyledSpace = styled(Space)<{
 // Keep track of orientation changes outside component with filter ID
 const orientationMap = new Map<string, FilterBarOrientation>();
 
+export const getSelectDropdownAlign = (
+  filterBarOrientation?: FilterBarOrientation,
+) =>
+  filterBarOrientation === FilterBarOrientation.Horizontal
+    ? { overflow: { adjustY: false } }
+    : undefined;
+
 export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const {
     coltypeMap,
@@ -601,11 +608,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
                   : (trigger: HTMLElement) =>
                       (trigger?.parentNode as HTMLElement) || document.body
               }
-              dropdownAlign={
-                filterBarOrientation === FilterBarOrientation.Horizontal
-                  ? { overflow: { adjustY: false } }
-                  : undefined
-              }
+              dropdownAlign={getSelectDropdownAlign(filterBarOrientation)}
               showSearch={showSearch}
               mode={multiSelect ? 'multiple' : 'single'}
               placeholder={placeholderText}

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -601,6 +601,11 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
                   : (trigger: HTMLElement) =>
                       (trigger?.parentNode as HTMLElement) || document.body
               }
+              dropdownAlign={
+                filterBarOrientation === FilterBarOrientation.Horizontal
+                  ? { overflow: { adjustY: false } }
+                  : undefined
+              }
               showSearch={showSearch}
               mode={multiSelect ? 'multiple' : 'single'}
               placeholder={placeholderText}


### PR DESCRIPTION
### SUMMARY

Fixes the native dashboard value filter dropdown placement on short viewports / high zoom.

When the dashboard filter bar is horizontal, the Select popup can auto-flip upward when there is not enough vertical space below the trigger. In the smaller-screen case described in #34135, that places the options menu over the input itself, hiding the field the user is interacting with.

This keeps the Select popup aligned below its trigger for horizontal filter bars by disabling vertical auto-adjustment through `dropdownAlign`. Vertical filter bars and non-dashboard-filter contexts keep the existing behavior.

Fixes #34135

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not captured in this environment.

### TESTING INSTRUCTIONS

1. Open the example Sales Dashboard.
2. Reduce viewport height or increase browser zoom.
3. Click a native value/select filter in the horizontal dashboard filter bar.
4. Confirm the dropdown opens below the input instead of overlapping and hiding it.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #34135
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Local tests not run; this was applied as a narrowly scoped GitHub fork patch without the full Superset frontend workspace installed.