### PR TITLE
fix: coerce out-of-bounds nanosecond timestamps to NaT instead of raising

### DIFF
--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -21,6 +21,7 @@ from typing import Any
 from urllib import request
 
 import pandas as pd
+from pandas.errors import OutOfBoundsDatetime
 from flask import current_app as app
 from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, String, Text
 from sqlalchemy.exc import MultipleResultsFound
@@ -192,6 +193,27 @@ def import_dataset(  # noqa: C901
     return dataset
 
 
+def _convert_temporal_columns(
+    df: pd.DataFrame, dtype: dict[str, Any]
+) -> None:
+    """Convert Date/DateTime columns in-place, coercing only out-of-bounds values."""
+    for column_name, sqla_type in dtype.items():
+        if isinstance(sqla_type, (Date, DateTime)):
+            try:
+                df[column_name] = pd.to_datetime(df[column_name])
+            except OutOfBoundsDatetime:
+                converted = pd.to_datetime(df[column_name], errors="coerce")
+                # net-new NaTs from coercion, excluding pre-existing nulls
+                n_coerced = int(converted.isna().sum() - df[column_name].isna().sum())
+                if n_coerced > 0:
+                    logger.warning(
+                        "Coerced %d out-of-bounds datetime value(s) in column '%s' to NaT",
+                        n_coerced,
+                        column_name,
+                    )
+                df[column_name] = converted
+
+
 def load_data(data_uri: str, dataset: SqlaTable, database: Database) -> None:
     """
     Load data from a data URI into a dataset.
@@ -212,10 +234,7 @@ def load_data(data_uri: str, dataset: SqlaTable, database: Database) -> None:
     df = pd.read_csv(data, encoding="utf-8")
     dtype = get_dtype(df, dataset)
 
-    # convert temporal columns
-    for column_name, sqla_type in dtype.items():
-        if isinstance(sqla_type, (Date, DateTime)):
-            df[column_name] = pd.to_datetime(df[column_name])
+    _convert_temporal_columns(df, dtype)
 
     # reuse session when loading data if possible, to make import atomic
     if database.sqlalchemy_uri == app.config.get("SQLALCHEMY_DATABASE_URI"):

--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -200,9 +200,22 @@ def _convert_temporal_columns(df: pd.DataFrame, dtype: dict[str, Any]) -> None:
             try:
                 df[column_name] = pd.to_datetime(df[column_name])
             except OutOfBoundsDatetime:
-                converted = pd.to_datetime(df[column_name], errors="coerce")
-                # net-new NaTs from coercion, excluding pre-existing nulls
-                n_coerced = int(converted.isna().sum() - df[column_name].isna().sum())
+                # Row-level fallback: coerce only OOB values; re-raise for malformed
+                # strings. Whole-column errors="coerce" would silently swallow
+                # malformed values that happen to share a column with an OOB date.
+                original = df[column_name].copy()
+                result = []
+                for val in original:
+                    if pd.isna(val):
+                        result.append(pd.NaT)
+                        continue
+                    try:
+                        result.append(pd.to_datetime(val))
+                    except OutOfBoundsDatetime:
+                        result.append(pd.NaT)
+                    # Other exceptions (e.g. malformed strings) propagate
+                converted = pd.Series(result, index=original.index)
+                n_coerced = int(converted.isna().sum() - original.isna().sum())
                 if n_coerced > 0:
                     logger.warning(
                         "Coerced %d out-of-bounds datetime value(s) "

--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -21,8 +21,8 @@ from typing import Any
 from urllib import request
 
 import pandas as pd
-from pandas.errors import OutOfBoundsDatetime
 from flask import current_app as app
+from pandas.errors import OutOfBoundsDatetime
 from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, String, Text
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.sql.visitors import VisitableType
@@ -193,9 +193,7 @@ def import_dataset(  # noqa: C901
     return dataset
 
 
-def _convert_temporal_columns(
-    df: pd.DataFrame, dtype: dict[str, Any]
-) -> None:
+def _convert_temporal_columns(df: pd.DataFrame, dtype: dict[str, Any]) -> None:
     """Convert Date/DateTime columns in-place, coercing only out-of-bounds values."""
     for column_name, sqla_type in dtype.items():
         if isinstance(sqla_type, (Date, DateTime)):
@@ -207,7 +205,8 @@ def _convert_temporal_columns(
                 n_coerced = int(converted.isna().sum() - df[column_name].isna().sum())
                 if n_coerced > 0:
                     logger.warning(
-                        "Coerced %d out-of-bounds datetime value(s) in column '%s' to NaT",
+                        "Coerced %d out-of-bounds datetime value(s) "
+                        "in column '%s' to NaT",
                         n_coerced,
                         column_name,
                     )

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -207,7 +207,7 @@ class SupersetResultSet:
                             if sample.tzinfo:
                                 tz = sample.tzinfo
                                 series = pd.Series(array[column])
-                                series = pd.to_datetime(series, utc=True)
+                                series = pd.to_datetime(series, utc=True, errors="coerce")
                                 pa_data[i] = pa.Array.from_pandas(
                                     series,
                                     type=pa.timestamp("ns", tz=tz),

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -207,7 +207,9 @@ class SupersetResultSet:
                             if sample.tzinfo:
                                 tz = sample.tzinfo
                                 series = pd.Series(array[column])
-                                series = pd.to_datetime(series, utc=True, errors="coerce")
+                                series = pd.to_datetime(
+                                    series, utc=True, errors="coerce"
+                                )
                                 pa_data[i] = pa.Array.from_pandas(
                                     series,
                                     type=pa.timestamp("ns", tz=tz),

--- a/tests/unit_tests/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/commands/importers/v1/utils_test.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for superset/commands/dataset/importers/v1/utils.py temporal helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+def _make_dataset_col(col_type: str) -> MagicMock:
+    from sqlalchemy import Date, DateTime
+
+    col = MagicMock()
+    col.column_name = "ts"
+    col.type = DateTime() if col_type == "datetime" else Date()
+    return col
+
+
+def _apply_temporal_conversion(df: pd.DataFrame, col_name: str) -> pd.DataFrame:
+    """
+    Exercise the temporal-column conversion block from load_data() in isolation,
+    by importing and calling the relevant logic directly.
+    """
+    from sqlalchemy import DateTime
+
+    from superset.commands.dataset.importers.v1.utils import _convert_temporal_columns
+
+    dtype = {col_name: DateTime()}
+    _convert_temporal_columns(df, dtype)
+    return df
+
+
+class TestConvertTemporalColumns:
+    def test_normal_dates_converted(self) -> None:
+        """Valid in-range dates are converted to datetime64 normally."""
+        from sqlalchemy import DateTime
+
+        from superset.commands.dataset.importers.v1.utils import (
+            _convert_temporal_columns,
+        )
+
+        df = pd.DataFrame({"ts": ["2023-01-01", "2024-06-15"]})
+        _convert_temporal_columns(df, {"ts": DateTime()})
+        assert pd.api.types.is_datetime64_any_dtype(df["ts"])
+
+    def test_out_of_bounds_coerced_to_nat(self) -> None:
+        """
+        Dates beyond ~2262-04-11 overflow pandas' int64 nanosecond limit.
+        load_data() must coerce them to NaT and warn, not raise.
+        """
+        from sqlalchemy import DateTime
+
+        from superset.commands.dataset.importers.v1.utils import (
+            _convert_temporal_columns,
+        )
+
+        df = pd.DataFrame({"ts": ["3118-01-01"]})
+        with patch(
+            "superset.commands.dataset.importers.v1.utils.logger"
+        ) as mock_logger:
+            _convert_temporal_columns(df, {"ts": DateTime()})
+
+        assert pd.isna(df["ts"].iloc[0])
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "out-of-bounds" in warning_msg
+
+    def test_malformed_dates_still_raise(self) -> None:
+        """
+        Completely malformed date strings are NOT silently coerced — only
+        out-of-bounds timestamps are. This preserves the original import-fail
+        behavior for bad data.
+        """
+        from sqlalchemy import DateTime
+
+        from superset.commands.dataset.importers.v1.utils import (
+            _convert_temporal_columns,
+        )
+
+        df = pd.DataFrame({"ts": ["not-a-date"]})
+        with pytest.raises(Exception):  # noqa: B017
+            _convert_temporal_columns(df, {"ts": DateTime()})
+
+    def test_warning_count_excludes_preexisting_nulls(self) -> None:
+        """
+        The warning count reflects only net-new NaTs from coercion,
+        not nulls that were already present in the source data.
+        """
+        from sqlalchemy import DateTime
+
+        from superset.commands.dataset.importers.v1.utils import (
+            _convert_temporal_columns,
+        )
+
+        df = pd.DataFrame({"ts": [None, "3118-01-01", "3119-06-01"]})
+        with patch(
+            "superset.commands.dataset.importers.v1.utils.logger"
+        ) as mock_logger:
+            _convert_temporal_columns(df, {"ts": DateTime()})
+
+        call_args = mock_logger.warning.call_args[0]
+        assert call_args[1] == 2  # 2 out-of-bounds, 1 pre-existing null

--- a/tests/unit_tests/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/commands/importers/v1/utils_test.py
@@ -93,7 +93,7 @@ class TestConvertTemporalColumns:
         )
 
         df = pd.DataFrame({"ts": ["not-a-date"]})
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(pd.errors.ParserError):
             _convert_temporal_columns(df, {"ts": DateTime()})
 
     def test_warning_count_excludes_preexisting_nulls(self) -> None:

--- a/tests/unit_tests/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/commands/importers/v1/utils_test.py
@@ -16,33 +16,10 @@
 # under the License.
 """Tests for superset/commands/dataset/importers/v1/utils.py temporal helpers."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
-
-
-def _make_dataset_col(col_type: str) -> MagicMock:
-    from sqlalchemy import Date, DateTime
-
-    col = MagicMock()
-    col.column_name = "ts"
-    col.type = DateTime() if col_type == "datetime" else Date()
-    return col
-
-
-def _apply_temporal_conversion(df: pd.DataFrame, col_name: str) -> pd.DataFrame:
-    """
-    Exercise the temporal-column conversion block from load_data() in isolation,
-    by importing and calling the relevant logic directly.
-    """
-    from sqlalchemy import DateTime
-
-    from superset.commands.dataset.importers.v1.utils import _convert_temporal_columns
-
-    dtype = {col_name: DateTime()}
-    _convert_temporal_columns(df, dtype)
-    return df
 
 
 class TestConvertTemporalColumns:
@@ -93,7 +70,32 @@ class TestConvertTemporalColumns:
         )
 
         df = pd.DataFrame({"ts": ["not-a-date"]})
-        with pytest.raises(pd.errors.ParserError):
+        with pytest.raises((ValueError, pd.errors.ParserError)):
+            _convert_temporal_columns(df, {"ts": DateTime()})
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            ["3118-01-01", "not-a-date"],
+            ["not-a-date", "3118-01-01"],
+        ],
+    )
+    def test_mixed_out_of_bounds_and_malformed_still_raises(
+        self, values: list[str]
+    ) -> None:
+        """
+        A column mixing out-of-bounds and malformed dates must raise, not silently
+        coerce the malformed value to NaT. Both orderings are tested to ensure the
+        invariant holds regardless of which error pandas encounters first.
+        """
+        from sqlalchemy import DateTime
+
+        from superset.commands.dataset.importers.v1.utils import (
+            _convert_temporal_columns,
+        )
+
+        df = pd.DataFrame({"ts": values})
+        with pytest.raises((ValueError, pd.errors.ParserError)):
             _convert_temporal_columns(df, {"ts": DateTime()})
 
     def test_warning_count_excludes_preexisting_nulls(self) -> None:

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -167,6 +167,26 @@ def test_timezone_series(mocker: MockerFixture) -> None:
     logger.exception.assert_not_called()
 
 
+def test_out_of_bounds_datetime_coerced_to_nat(mocker: MockerFixture) -> None:
+    """
+    Dates beyond ~2262-04-11 overflow pandas' int64 nanosecond representation.
+    SupersetResultSet must coerce them to NaT rather than raising OutOfBoundsDatetime
+    and logging an ERROR (which would surface as noise in observability tooling).
+    """
+    logger = mocker.patch("superset.result_set.logger")
+
+    data = [[datetime(3118, 1, 1, tzinfo=timezone.utc)]]
+    description = [(b"dt", "datetime", None, None, None, None, False)]
+    result_set = SupersetResultSet(
+        data,
+        description,  # type: ignore
+        BaseEngineSpec,
+    )
+    df = result_set.to_pandas_df()
+    assert pd.isna(df["dt"].iloc[0])
+    logger.exception.assert_not_called()
+
+
 def test_get_column_description_from_empty_data_using_cursor_description(
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

- `result_set.py`: `pd.to_datetime(series, utc=True)` defaults to `errors='raise'`. Dates beyond ~2262-04-11 overflow pandas' int64 nanosecond representation and raise `OutOfBoundsDatetime`. The surrounding `except Exception` catches it but logs at ERROR level via `logger.exception()`, causing the error to surface repeatedly in observability tooling for any auto-refreshing chart that queries the affected table.
- `commands/dataset/importers/v1/utils.py`: same missing `errors="coerce"` on the CSV import path — belt-and-suspenders fix. Note: silent coercion during import could mask a data-quality issue (e.g. a file with bogus timestamps imports silently with NaT instead of failing visibly).

`NaT` is preferable to clamping (clamping silently lies — year 3118 would show as 2262 in charts) and to converting to string (breaks the PyArrow column schema).

## Test plan

- [ ] Query a dataset containing a timezone-aware datetime column with a value beyond 2262 (e.g. `3118-01-01`) — chart should render with a null cell instead of logging an error
- [ ] Import a CSV with an out-of-range datetime column — import should succeed with NaT for the out-of-range values
- [ ] Confirm no regressions on normal datetime columns within the representable range

🤖 Generated with [Claude Code](https://claude.com/claude-code)