### PR TITLE
fix(migrations): replace placeholder revision ID in granular export migration

### DIFF
--- a/superset/migrations/versions/2026-03-02_00-00_ce6bd21901ab_migrate_deckgl_and_mapbox.py
+++ b/superset/migrations/versions/2026-03-02_00-00_ce6bd21901ab_migrate_deckgl_and_mapbox.py
@@ -44,7 +44,7 @@ logger = logging.getLogger("alembic.env")
 
 # revision identifiers, used by Alembic.
 revision = "ce6bd21901ab"
-down_revision = "a1b2c3d4e5f6"
+down_revision = "41292324bf4e"
 
 DECKGL_VIZ_TYPES = [
     "deck_arc",

--- a/superset/migrations/versions/2026-03-02_12-00_41292324bf4e_add_granular_export_permissions.py
+++ b/superset/migrations/versions/2026-03-02_12-00_41292324bf4e_add_granular_export_permissions.py
@@ -16,14 +16,14 @@
 # under the License.
 """add granular export permissions
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 41292324bf4e
 Revises: 4b2a8c9d3e1f
 Create Date: 2026-03-02 12:00:00.000000
 
 """
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
+revision = "41292324bf4e"
 down_revision = "4b2a8c9d3e1f"
 
 from alembic import op  # noqa: E402


### PR DESCRIPTION
## Summary

The migration added in #38361 (`add_granular_export_permissions`) used a placeholder Alembic revision ID (`a1b2c3d4e5f6`) instead of a properly generated one. This replaces it with a real random hex ID (`41292324bf4e`) and updates the downstream migration's `down_revision` to match.

**Changes:**
- Renamed migration file to use real revision ID
- Updated `revision` inside the migration file
- Updated `down_revision` in the downstream `ce6bd21901ab` migration (deck.gl/mapbox, #38035)

**Migration chain (after fix):**
```
4b2a8c9d3e1f (create_tasks_table)
  → 41292324bf4e (add_granular_export_permissions)  ← was a1b2c3d4e5f6
    → ce6bd21901ab (migrate_deckgl_and_mapbox)
      → 33d7e0e21daa (add_semantic_layers_and_views)
```

**Note for deployments already past this migration:** The `alembic_version` table only stores the current head, so databases that have already run all migrations will not be affected. Any database stopped exactly at the old revision would need `alembic stamp 41292324bf4e`.