### PR TITLE
test(prophet): pin yhat_lower can be negative for negative series (#21734)

### DIFF
--- a/tests/unit_tests/pandas_postprocessing/test_prophet.py
+++ b/tests/unit_tests/pandas_postprocessing/test_prophet.py
@@ -184,3 +184,112 @@ def test_prophet_incorrect_time_grain():
             periods=10,
             confidence_interval=0.8,
         )
+
+
+def test_prophet_uncertainty_lower_bound_can_be_negative_for_negative_series():
+    """
+    Regression for #21734: when the input series contains negative values,
+    the forecast's lower confidence bound (``__yhat_lower``) must be allowed
+    to go below zero. The original bug claimed Superset clipped the lower
+    bound at 0, hiding the natural shape of the uncertainty interval for
+    series like temperatures or signed deltas.
+
+    Superset's wrapper passes through Prophet's output unchanged (no
+    clipping in ``superset/utils/pandas_postprocessing/prophet.py``); this
+    test pins that contract end-to-end. If a future refactor introduces
+    a ``max(0, lower)`` clamp, this test fails immediately.
+    """
+    if find_spec("prophet") is None:
+        pytest.skip("prophet not installed")
+
+    # All-negative monthly series — any reasonable forecast must predict
+    # negative values (and therefore negative uncertainty bounds) too.
+    negative_df = pd.DataFrame(
+        {
+            DTTM_ALIAS: [datetime(2020, m, 1) for m in range(1, 13)]
+            + [datetime(2021, m, 1) for m in range(1, 13)],
+            "temperature": [
+                -5.0,
+                -7.0,
+                -3.0,
+                1.0,
+                8.0,
+                14.0,
+                17.0,
+                16.0,
+                11.0,
+                5.0,
+                -1.0,
+                -4.0,
+                -6.0,
+                -8.0,
+                -2.0,
+                2.0,
+                9.0,
+                15.0,
+                18.0,
+                17.0,
+                12.0,
+                6.0,
+                0.0,
+                -3.0,
+            ],
+        }
+    )
+
+    result = prophet(
+        df=negative_df,
+        time_grain="P1M",
+        periods=3,
+        confidence_interval=0.9,
+    )
+
+    assert "temperature__yhat_lower" in result.columns
+    # At least one forecast point's lower bound must be negative for a
+    # series whose actuals span both signs. A clamp at zero would force
+    # this assertion to fail.
+    assert (result["temperature__yhat_lower"] < 0).any(), (
+        "Forecast lower bound was non-negative everywhere despite a "
+        "series with negative actuals — suggests an unexpected clamp at "
+        "zero was reintroduced (regression of #21734)."
+    )
+
+
+def test_prophet_does_not_clamp_yhat_below_zero_for_negative_actuals():
+    """
+    Companion to the lower-bound test above: the central forecast
+    (``__yhat``) must also be allowed to go negative.
+    A bug that clamps the central forecast at zero would force the lower
+    bound non-negative as a side effect, masking the wider issue.
+    """
+    if find_spec("prophet") is None:
+        pytest.skip("prophet not installed")
+
+    negative_df = pd.DataFrame(
+        {
+            DTTM_ALIAS: [datetime(2020, m, 1) for m in range(1, 13)],
+            "balance": [
+                -100.0,
+                -110.0,
+                -95.0,
+                -120.0,
+                -130.0,
+                -125.0,
+                -140.0,
+                -135.0,
+                -150.0,
+                -145.0,
+                -160.0,
+                -155.0,
+            ],
+        }
+    )
+
+    result = prophet(
+        df=negative_df,
+        time_grain="P1M",
+        periods=2,
+        confidence_interval=0.8,
+    )
+
+    assert (result["balance__yhat"] < 0).any()

--- a/tests/unit_tests/pandas_postprocessing/test_prophet.py
+++ b/tests/unit_tests/pandas_postprocessing/test_prophet.py
@@ -245,12 +245,15 @@ def test_prophet_uncertainty_lower_bound_can_be_negative_for_negative_series():
     )
 
     assert "temperature__yhat_lower" in result.columns
-    # At least one forecast point's lower bound must be negative for a
-    # series whose actuals span both signs. A clamp at zero would force
-    # this assertion to fail.
-    assert (result["temperature__yhat_lower"] < 0).any(), (
-        "Forecast lower bound was non-negative everywhere despite a "
-        "series with negative actuals — suggests an unexpected clamp at "
+    # Restrict to the forecast horizon (the last `periods` rows). The full
+    # output also contains historical fitted points, which can be negative
+    # for in-sample data even if a future-only clamp were introduced — so
+    # asserting on the whole frame would let a future-only clamp slip past.
+    forecast_periods = 3
+    forecast_lower = result["temperature__yhat_lower"].iloc[-forecast_periods:]
+    assert (forecast_lower < 0).any(), (
+        "Forecast (future) lower bound was non-negative everywhere despite "
+        "a series with negative actuals — suggests an unexpected clamp at "
         "zero was reintroduced (regression of #21734)."
     )
 
@@ -292,4 +295,9 @@ def test_prophet_does_not_clamp_yhat_below_zero_for_negative_actuals():
         confidence_interval=0.8,
     )
 
-    assert (result["balance__yhat"] < 0).any()
+    # Restrict to the forecast horizon — see lower-bound test above for the
+    # rationale. A future-only clamp on `__yhat` could leave historical
+    # in-sample fitted points negative and pass an unrestricted assertion.
+    forecast_periods = 2
+    forecast_yhat = result["balance__yhat"].iloc[-forecast_periods:]
+    assert (forecast_yhat < 0).any()


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #21734.

#21734 (filed 2022-10) reports that Prophet forecast uncertainty intervals are clipped at zero, hiding the natural shape of the lower bound for series like temperatures or signed deltas.

The Superset wrapper (\`superset/utils/pandas_postprocessing/prophet.py\`) does not contain any clamp — it passes Prophet's output through unchanged. This PR pins that contract end-to-end:

1. **\`test_prophet_uncertainty_lower_bound_can_be_negative_for_negative_series\`** — runs Prophet against a 24-month signed-temperature series and asserts at least one forecast point's \`__yhat_lower\` is negative.
2. **\`test_prophet_does_not_clamp_yhat_below_zero_for_negative_actuals\`** — companion that pins the central forecast (\`__yhat\`); a clamp at zero on the central value would force the lower bound non-negative as a side effect, masking the wider issue.

Both tests skip when \`prophet\` is not installed, matching the existing pattern in this file.

### How to interpret CI

- **CI green** → Superset doesn't clamp — the bug as described isn't in our code. Merging closes #21734 and locks in the regression guard so a future refactor can't reintroduce a clamp.
- **CI red** → either (a) a clamp was added somewhere (real Superset bug to fix), or (b) Prophet's behavior on signed series doesn't naturally produce negative bounds, in which case the issue should be redirected to upstream.

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/unit_tests/pandas_postprocessing/test_prophet.py::test_prophet_uncertainty_lower_bound_can_be_negative_for_negative_series -v
pytest tests/unit_tests/pandas_postprocessing/test_prophet.py::test_prophet_does_not_clamp_yhat_below_zero_for_negative_actuals -v
\`\`\`

### ADDITIONAL INFORMATION

- [ ] Has associated issue: closes #21734
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)