### PR TITLE
test(sql-parser): pin TimescaleDB hyperfunctions parse on postgresql (#32028)

### DIFF
--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1164,6 +1164,32 @@ def test_has_mutation(engine: str, sql: str, expected: bool) -> None:
     assert SQLScript(sql, engine).has_mutation() == expected
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT last(my_value_column, my_time_column) FROM my_table",
+        "SELECT first(my_value_column, my_time_column) FROM my_table",
+        "SELECT time_bucket('1 hour', my_time_column) AS bucket FROM my_table",
+    ],
+)
+def test_postgres_parses_timescaledb_hyperfunctions(sql: str) -> None:
+    """
+    Regression for #32028: TimescaleDB extends Postgres with hyperfunctions
+    (``last``, ``first``, ``time_bucket``, etc.) that take more arguments
+    than vanilla Postgres equivalents. SQL Lab tolerates them (it routes
+    raw SQL straight to the engine), but the dashboard chart path runs the
+    SQL through ``SQLScript`` for inspection. A strict per-function arity
+    check in sqlglot was rejecting these queries with ``The number of
+    provided arguments (2) is greater than the maximum number of supported
+    arguments (1)``, which broke dashboards built on TimescaleDB datasets.
+
+    These tests pin that the parse path tolerates Postgres-dialect SQL
+    using TimescaleDB hyperfunction signatures. If a future sqlglot
+    upgrade reintroduces the strict arity check, this fails immediately.
+    """
+    SQLScript(sql, "postgresql")  # Must not raise.
+
+
 def test_get_settings() -> None:
     """
     Test `get_settings` in some edge cases.


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #32028.

#32028 (filed 2025-01) reports that dashboards built on a TimescaleDB-extended Postgres database fail with \`sqlglot.errors.ParseError: The number of provided arguments (2) is greater than the maximum number of supported arguments (1)\` for queries using TimescaleDB hyperfunctions like \`last(value, time)\`, \`first(value, time)\`, or \`time_bucket(...)\`. SQL Lab works because it bypasses the parser; the dashboard path goes through \`SQLScript\` and trips the strict arity check.

This PR adds a parameterized regression test on \`SQLScript\` covering three representative TimescaleDB hyperfunctions:

- \`last(value, time_col)\`
- \`first(value, time_col)\`
- \`time_bucket('1 hour', time_col)\`

### How to interpret CI

- **CI green** → the sqlglot version Superset is pinned to now tolerates these hyperfunctions; merging closes #32028 and locks in the regression guard so a future sqlglot bump that re-tightens arity checks fails CI immediately.
- **CI red** → bug is still live for at least one of the three signatures. Likely fix: register a Postgres-dialect overlay in \`superset/sql/parse.py\` that whitelists these (and similar) TimescaleDB hyperfunctions, or pin sqlglot to a version that tolerates them.

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/unit_tests/sql/parse_tests.py::test_postgres_parses_timescaledb_hyperfunctions -v
\`\`\`

### ADDITIONAL INFORMATION

- [ ] Has associated issue: closes #32028
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)