### PR TITLE
test(sql-parser): pin quoted identifiers with spaces are not subqueries (#32541, #32684)

### DIFF
--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -3054,6 +3054,42 @@ def test_has_subquery(sql: str, engine: str, expected: bool) -> None:
 
 
 @pytest.mark.parametrize(
+    "sql, engine",
+    [
+        # Double-quoted identifiers (#32684 — postgres dataset)
+        ('"Adresse E-mail"', "postgresql"),
+        ('"Nom de structure"', "postgresql"),
+        # Backtick-quoted identifiers (#32541 — mysql view)
+        ("`Answer Created Time`", "mysql"),
+        ("`Correction Time`", "mysql"),
+        # Diacritics, slash, and dot — listed as "working" in #32684 but
+        # easily broken by overzealous parser changes; pin them too.
+        ('"Appartement / étage"', "postgresql"),
+        ('"Bâtiment / Résidence"', "postgresql"),
+        ('"C.Postal"', "postgresql"),
+    ],
+)
+def test_quoted_column_name_with_spaces_is_not_subquery(sql: str, engine: str) -> None:
+    r"""
+    Regression for #32541 and #32684: a quoted identifier that happens to
+    contain spaces (or a slash, accents, dots) must not be misclassified
+    as a subquery.
+
+    The original symptom was an opaque ``Custom SQL fields cannot contain
+    sub-queries.`` error when the user added a column like ``"Adresse
+    E-mail"`` (Postgres) or a backtick-quoted equivalent (MySQL) to a
+    chart. Snake-case aliases worked; multi-word display names did not.
+    The check that raises that error is
+    ``parsed_statement.has_subquery()`` in
+    ``superset/models/helpers.py:206``.
+    """
+    assert not SQLStatement(sql, engine).has_subquery(), (
+        f"Quoted identifier {sql!r} on {engine!r} was misclassified as a "
+        "subquery — would block the column from being used in any chart."
+    )
+
+
+@pytest.mark.parametrize(
     "sql, engine, expected_tables",
     [
         # Issue #31853: Backtick-quoted table names with "Other" database type


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issues #32541 and #32684 (the same bug reported twice).

Both issues report an opaque \`Custom SQL fields cannot contain sub-queries.\` error when a user adds a column whose name contains spaces (or accents, slashes, dots) to a chart — e.g. \`"Adresse E-mail"\` (Postgres) or \`\`\`Answer Created Time\`\`\` (MySQL). Snake-case aliases worked; multi-word display names did not.

The check that raises that error is \`parsed_statement.has_subquery()\` in \`superset/models/helpers.py:206\`.

This PR adds a parameterized regression test on \`SQLStatement.has_subquery()\` covering:

- Postgres double-quoted identifiers with spaces, accents, slashes, dots
- MySQL backtick-quoted identifiers with spaces

### How to interpret CI

- **CI green** → quoted identifiers are no longer misclassified as subqueries; merging closes #32541 and #32684 and locks in the regression guard.
- **CI red** → bug is still live in at least one of the cases. Likely fix: in \`superset/sql/parse.py\`, \`SQLStatement.has_subquery()\` should restrict its subquery-detection traversal so a bare quoted identifier in expression position doesn't trip the check.

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/unit_tests/sql/parse_tests.py::test_quoted_column_name_with_spaces_is_not_subquery -v
\`\`\`

### ADDITIONAL INFORMATION

- [ ] Has associated issue: closes #32541, closes #32684
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)