### PR TITLE
fix(rls): align view permission name with REST API canonical name (#33744)

### DIFF
--- a/superset/views/sqla.py
+++ b/superset/views/sqla.py
@@ -29,7 +29,12 @@ from superset.views.base import BaseSupersetView
 
 class RowLevelSecurityView(BaseSupersetView):
     route_base = "/rowlevelsecurity"
-    class_permission_name = "RowLevelSecurity"
+    # Use the canonical, spaced form used by the REST API and the security
+    # manager allow-list (see SupersetSecurityManager.ADMIN_ONLY_VIEW_MENUS).
+    # Prior to this, the view's class-derived name "RowLevelSecurity"
+    # produced a second, duplicate permission alongside "Row Level Security"
+    # in the admin UI — operators had to grant both for a role to work.
+    class_permission_name = "Row Level Security"
 
     @expose("/list/")
     @has_access

--- a/tests/unit_tests/views/test_sqla.py
+++ b/tests/unit_tests/views/test_sqla.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for ``superset/views/sqla.py``."""
+
+
+def test_row_level_security_view_uses_canonical_permission_name() -> None:
+    """
+    Regression for #33744: the RLS view's ``class_permission_name`` must
+    match the user-facing model name ("Row Level Security") so that only
+    one permission is registered.
+
+    Today the view sets ``class_permission_name = "RowLevelSecurity"``
+    (no spaces, derived from the Python class name), while the REST API
+    and the security manager allow-list use the spaced form
+    ("Row Level Security"). This produces two effectively identical
+    permissions in the admin UI:
+
+        - can read on Row Level Security
+        - can read on RowLevelSecurity
+
+    Operators have to grant both for a role to actually work, which is
+    confusing and error-prone (the second one looks like an
+    implementation detail leaking into the UI).
+
+    The fix is a one-line change in ``superset/views/sqla.py`` to align
+    ``class_permission_name`` with the canonical name used elsewhere in
+    the codebase. This test pins that contract.
+    """
+    # Cross-check: the security manager's allow-list (the canonical
+    # source of truth for RLS view-menu naming) uses the spaced form.
+    from superset.security.manager import SupersetSecurityManager
+    from superset.views.sqla import RowLevelSecurityView
+
+    assert "Row Level Security" in SupersetSecurityManager.ADMIN_ONLY_VIEW_MENUS
+    assert RowLevelSecurityView.class_permission_name == "Row Level Security", (
+        "RLS view's class_permission_name diverges from the canonical "
+        '"Row Level Security" used by the API and security manager — '
+        "produces a duplicate `can read on RowLevelSecurity` permission "
+        "alongside `can read on Row Level Security` in the admin UI."
+    )


### PR DESCRIPTION
### SUMMARY

Closes #33744.

The RLS view's `class_permission_name = "RowLevelSecurity"` (no spaces, derived from the Python class name) diverged from the spaced canonical name used by the REST API and the security manager allow-list (`"Row Level Security"`). This produced two effectively identical permissions in the admin UI:

  - `can read on Row Level Security`
  - `can read on RowLevelSecurity`

Operators had to grant both for a role to actually work — confusing and error-prone (the second one looked like an implementation detail leaking into the UI).

This PR:

1. **Aligns `RowLevelSecurityView.class_permission_name`** to `"Row Level Security"` (the canonical name used in `SupersetSecurityManager.ADMIN_ONLY_VIEW_MENUS` and the REST API).
2. **Adds a regression test** (`test_row_level_security_view_uses_canonical_permission_name`) that pins the contract so a future class-name-based recompute can't reintroduce the divergence.

### Migration note

Existing deployments may still carry an orphaned `RowLevelSecurity` view-menu / permission_view row from prior installs. After this fix:
- The view will register permissions against `"Row Level Security"` (the existing entry from the REST API or seeded by the allow-list — no new entry created).
- The orphaned `"RowLevelSecurity"` entry remains in the DB but is unreferenced by any active view.
- Admins can prune it from the FAB permissions UI, or it can be removed in a follow-up migration if desired.

I opted not to bundle a DB migration in this PR because: (a) the orphan is harmless (just a stale row), (b) automated cleanup risks deleting a permission an admin has actually granted somewhere, and (c) it's a one-time cosmetic cleanup that's easy to do manually.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend permission-naming change.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/views/test_sqla.py -v
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #33744
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)