### PR TITLE
fix(mixed-timeseries): stop duplicating first metric in multi-metric + group-by series names

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -457,13 +457,23 @@ export default function transformProps(
     const seriesName = inverted[entryName] || entryName;
     const colorScaleKey = getOriginalSeries(seriesName, array);
 
+    const labelMapValues = rawLabelMap?.[seriesName];
+
     let displayName: string;
 
     if (groupby.length > 0) {
-      // When we have groupby, format as "metric, dimension"
+      // When we have groupby, format as "metric, dimension". Each series
+      // belongs to the metric recorded in its label-map tuple
+      // ([metric, ...dimensions]) — always using the first metric would
+      // prepend it to every other metric's series (#37921). Tuples without
+      // a metric part fall back to the first metric as before.
+      const metricDisplayName =
+        labelMapValues && labelMapValues.length > 1
+          ? getMetricDisplayName(labelMapValues[0], verboseMap)
+          : MetricDisplayNameA;
       const metricPart: string = showQueryIdentifiers
-        ? `${MetricDisplayNameA} (Query A)`
-        : MetricDisplayNameA;
+        ? `${metricDisplayName} (Query A)`
+        : metricDisplayName;
       displayName = entryName.includes(metricPart)
         ? entryName
         : `${metricPart}, ${entryName}`;
@@ -471,8 +481,6 @@ export default function transformProps(
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query A)` : entryName;
     }
-
-    const labelMapValues = rawLabelMap?.[seriesName];
     if (labelMapValues) {
       displayLabelMap[displayName] = labelMapValues;
     }
@@ -536,13 +544,23 @@ export default function transformProps(
     const seriesEntry = inverted[entryName] || entryName;
     const colorScaleKey = getOriginalSeries(seriesEntry, array);
 
+    const labelMapValuesB = rawLabelMapB?.[seriesEntry];
+
     let displayName: string;
 
     if (groupbyB.length > 0) {
-      // When we have groupby, format as "metric, dimension"
+      // When we have groupby, format as "metric, dimension". Each series
+      // belongs to the metric recorded in its label-map tuple
+      // ([metric, ...dimensions]) — always using the first metric would
+      // prepend it to every other metric's series (#37921). Tuples without
+      // a metric part fall back to the first metric as before.
+      const metricDisplayName =
+        labelMapValuesB && labelMapValuesB.length > 1
+          ? getMetricDisplayName(labelMapValuesB[0], verboseMap)
+          : MetricDisplayNameB;
       const metricPart: string = showQueryIdentifiers
-        ? `${MetricDisplayNameB} (Query B)`
-        : MetricDisplayNameB;
+        ? `${metricDisplayName} (Query B)`
+        : metricDisplayName;
       displayName = entryName.includes(metricPart)
         ? entryName
         : `${metricPart}, ${entryName}`;
@@ -550,8 +568,6 @@ export default function transformProps(
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query B)` : entryName;
     }
-
-    const labelMapValuesB = rawLabelMapB?.[seriesEntry];
     if (labelMapValuesB) {
       displayLabelMapB[displayName] = labelMapValuesB;
     }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -1228,11 +1228,12 @@ test('regression #37921: multi-metric Query A with groupby does not duplicate fi
 
   // Each (metric, dim_value) combo from Query A should appear exactly once
   // with the *correct* metric prefix — not the first-metric-prepended-to-
-  // everything-else form.
-  expect(queryASeriesNames).toContain('score_one, A');
-  expect(queryASeriesNames).toContain('score_one, B');
-  expect(queryASeriesNames).toContain('score_two, A');
-  expect(queryASeriesNames).toContain('score_two, B');
+  // everything-else form. Comparing the sorted array (rather than using
+  // separate toContain assertions) also catches a regression that emits
+  // duplicate series for the same name.
+  expect([...queryASeriesNames].sort()).toEqual(
+    ['score_one, A', 'score_one, B', 'score_two, A', 'score_two, B'].sort(),
+  );
 
   // And explicitly: no series name should contain *both* metric names —
   // that's the smoking gun for the duplication bug.

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -1161,3 +1161,82 @@ test('x-axis dedup keeps the forced min label when the endpoints format identica
 
   expect(formatter(min)).toBe('May');
 });
+
+test('regression #37921: multi-metric Query A with groupby does not duplicate first metric in series names', () => {
+  // Regression test for https://github.com/apache/superset/issues/37921
+  // ("Residual" follow-up to #37055).
+  //
+  // When Query A has multiple metrics + at least one Group By dimension,
+  // the display-name builder in transformProps.ts used to prepend the FIRST
+  // metric's display name to every series that didn't literally contain it:
+  //   name: `${MetricDisplayNameA}, ${entryName}`
+  // For series belonging to the *second* metric, this produced a
+  // cross-contaminated label like `score_one, score_two, A` — the
+  // user-visible "first metric duplicated" symptom in the legend / tooltip.
+  // The fix derives each series' metric from its label-map tuple instead.
+  const multiMetricRows = [
+    {
+      'score_one, A': 1,
+      'score_one, B': 2,
+      'score_two, A': 3,
+      'score_two, B': 4,
+      ds: 599616000000,
+    },
+    {
+      'score_one, A': 5,
+      'score_one, B': 6,
+      'score_two, A': 7,
+      'score_two, B': 8,
+      ds: 599916000000,
+    },
+  ];
+  const multiMetricLabelMap = {
+    ds: ['ds'],
+    'score_one, A': ['score_one', 'A'],
+    'score_one, B': ['score_one', 'B'],
+    'score_two, A': ['score_two', 'A'],
+    'score_two, B': ['score_two', 'B'],
+  };
+
+  const queryAData = createTestQueryData(multiMetricRows, {
+    label_map: multiMetricLabelMap,
+  });
+  // Query B keeps the existing single-metric shape — the bug is on
+  // Query A's path so we just need a valid Query B alongside.
+  const queryBData = createTestQueryData(defaultQueryRows, {
+    label_map: defaultLabelMap,
+  });
+
+  const chartProps = createEchartsTimeseriesTestChartProps<
+    EchartsMixedTimeseriesFormData,
+    EchartsMixedTimeseriesProps
+  >({
+    ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
+    defaultQueriesData: [queryAData, queryBData],
+    formData: {
+      ...formData,
+      metrics: ['score_one', 'score_two'],
+      groupby: ['category'],
+    },
+    queriesData: [queryAData, queryBData],
+  });
+  const transformed = transformProps(chartProps);
+
+  const queryASeriesNames = (transformed.echartOptions.series as any[])
+    .map((s: any) => String(s.name))
+    .filter((n: string) => n.includes('score_'));
+
+  // Each (metric, dim_value) combo from Query A should appear exactly once
+  // with the *correct* metric prefix — not the first-metric-prepended-to-
+  // everything-else form.
+  expect(queryASeriesNames).toContain('score_one, A');
+  expect(queryASeriesNames).toContain('score_one, B');
+  expect(queryASeriesNames).toContain('score_two, A');
+  expect(queryASeriesNames).toContain('score_two, B');
+
+  // And explicitly: no series name should contain *both* metric names —
+  // that's the smoking gun for the duplication bug.
+  for (const name of queryASeriesNames) {
+    expect(name).not.toMatch(/score_one,\s+score_two/);
+  }
+});


### PR DESCRIPTION
### SUMMARY

Fixes #37921 ("Residual" follow-up to #37055): in a Mixed Chart, when Query A (or B) has **multiple metrics plus at least one Group By dimension**, the first metric's label got prepended to every other metric's series, producing legend/tooltip entries like `score_one, score_two, A` instead of `score_two, A`.

**Root cause:** in `MixedTimeseries/transformProps.ts` the "metric, dimension" display-name builder always used `metrics[0]` (`MetricDisplayNameA` / `MetricDisplayNameB`). The guard was `entryName.includes(metricPart)`, which is false for every series belonging to `metrics[1+]`, so those series got the *first* metric's label prepended on top of their own.

**Fix:** each series' metric is derived from its `label_map` tuple (`[metric, ...dimensions]`), which the backend already provides and which the per-series formatter lookup was already using. When the tuple doesn't carry a metric part (single-element tuples), behavior falls back to the first metric exactly as before, so single-metric charts and the `showQueryIdentifiers` naming are unchanged. The same fix is applied to both the Query A and Query B paths.

This PR originally landed as a deliberately-failing regression test; it has been reworked to include the actual fix, and the test passes. The test:

- Builds a Mixed Chart with `metrics: ['score_one', 'score_two']` + `groupby: ['category']` on Query A
- Provides 4-column query data (`score_one, A`, `score_one, B`, `score_two, A`, `score_two, B`) with a matching `label_map`
- Asserts each `(metric, dim_value)` combo appears exactly once with the correct metric prefix
- Asserts no series name contains both metric labels concatenated (`/score_one,\s+score_two/`)

Verified red→green locally: on master without the fix the series come back as `["score_one, score_two, B", "score_one, score_two, A", "score_one, B", "score_one, A"]`; with the fix they are the expected four distinct `metric, dimension` names.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — string-level series naming in `transformProps`; see the issue for the user-visible legend symptom.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
```

All 37 MixedTimeseries tests (and the full 722-test plugin-chart-echarts suite) pass locally.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #37921
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
