### PR TITLE
fix(i18n): correct Czech translation variables for SQL Lab query message

### DIFF
--- a/superset/translations/cs/LC_MESSAGES/messages.po
+++ b/superset/translations/cs/LC_MESSAGES/messages.po
@@ -10403,7 +10403,7 @@ msgstr "Běží"
 
 #, fuzzy, python-format
 msgid "Running block %(block_num)s out of %(block_count)s"
-msgstr "Spouští se příkaz %(statement_num)s z %(statement_count)s"
+msgstr "Spouští se příkaz %(block_num)s z %(block_count)s"
 
 msgid "SAT"
 msgstr "SO"


### PR DESCRIPTION
### SUMMARY

Fixes #40165. Same bug pattern as #39566 (French), which was fixed by #38494. Czech was missed in that original sweep.

`superset/sql_lab.py:494` calls `__(\"Running block %(block_num)s out of %(block_count)s\", block_num=..., block_count=...)`. The Czech `.po` substituted `%(statement_num)s` / `%(statement_count)s` — variables that don't exist in the call — causing `KeyError('statement_num')` to propagate as `SupersetErrorsException` and break every SQL Lab query when `BABEL_DEFAULT_LOCALE = "cs"`.

### BEFORE/AFTER

```diff
 #, fuzzy, python-format
 msgid "Running block %(block_num)s out of %(block_count)s"
-msgstr "Spouští se příkaz %(statement_num)s z %(statement_count)s"
+msgstr "Spouští se příkaz %(block_num)s z %(block_count)s"
```

### TESTING INSTRUCTIONS

1. In `superset_config.py` set `BABEL_DEFAULT_LOCALE = "cs"`
2. Restart Superset
3. Open SQL Lab and run any query (e.g. `SELECT 1`)
4. Before: query fails with `'statement_num'`. After: query executes normally.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #40165
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API