### PR TITLE
feat(ydb): switch to native YDB sqlglot dialect

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,10 @@ assists people when migrating to a new version.
 
 ## Next
 
+### YDB now uses a native sqlglot dialect
+
+YDB SQL parsing now relies on the dedicated [`ydb-sqlglot-plugin`](https://pypi.org/project/ydb-sqlglot-plugin/) dialect, which registers itself with sqlglot automatically. YDB users must install this plugin (e.g., via `pip install "apache-superset[ydb]"`) to avoid a `ValueError` when Superset parses YDB queries.
+
 ### Dataset import validates catalog against the target connection
 
 Importing a dataset now validates the `catalog` field against the target database connection. When the connection has multi-catalog disabled (`allow_multi_catalog` off) and the dataset's catalog is not the connection's default catalog, the import fails instead of silently persisting the non-default catalog. This matches the validation already enforced on the dataset update path and prevents imported datasets from querying an unintended database.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ netezza = ["nzalchemy>=11.0.2"]
 starrocks = ["starrocks>=1.0.0"]
 doris = ["pydoris>=1.0.0, <2.0.0"]
 oceanbase = ["oceanbase_py>=0.0.1"]
-ydb = ["ydb-sqlalchemy>=0.1.2"]
+ydb = ["ydb-sqlalchemy>=0.1.2", "ydb-sqlglot-plugin>=0.2.5"]
 development = [
     # no bounds for apache-superset-extensions-cli until a stable version
     "apache-superset-extensions-cli",

--- a/superset/db_engine_specs/ydb.py
+++ b/superset/db_engine_specs/ydb.py
@@ -63,7 +63,7 @@ class YDBEngineSpec(BaseEngineSpec):
             DatabaseCategory.TRADITIONAL_RDBMS,
             DatabaseCategory.OPEN_SOURCE,
         ],
-        "pypi_packages": ["ydb-sqlalchemy"],
+        "pypi_packages": ["ydb-sqlalchemy", "ydb-sqlglot-plugin"],
         "connection_string": "ydb://{host}:{port}/{database_name}",
         "default_port": 2135,
         "engine_parameters": [

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -114,7 +114,9 @@ SQLGLOT_DIALECTS = {
     "teradatasql": Dialects.TERADATA,
     "trino": Dialects.TRINO,
     "vertica": Vertica,
-    "yql": Dialects.CLICKHOUSE,
+    # "ydb" is a plugin dialect (ydb-sqlglot-plugin) auto-discovered via entry_points,
+    # hence a string name rather than a class reference like the built-in dialects.
+    "yql": "ydb",
 }
 
 


### PR DESCRIPTION
### SUMMARY

YDB now has a dedicated sqlglot dialect provided by
[ydb-sqlglot-plugin](https://pypi.org/project/ydb-sqlglot-plugin/),
which registers itself automatically through sqlglot's `entry_points`
mechanism (group `sqlglot.dialects`). Previously the `yql` engine was
mapped to the ClickHouse dialect as a temporary stand-in, since no YDB
dialect existed at the time the integration was added.

Changes:
- `SQLGLOT_DIALECTS["yql"]` switched from `Dialects.CLICKHOUSE` to `"ydb"`
- `ydb-sqlglot-plugin` added to `YDBEngineSpec.metadata["pypi_packages"]` so the Superset UI lists it as a required package
- `ydb-sqlglot-plugin` added to the `ydb` optional extras in `pyproject.toml`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. Install dependencies: `pip install "apache-superset[ydb]"`
2. Configure a YDB database connection in Superset
3. Run any YQL query — it should be parsed and executed correctly

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API