### PR TITLE
fix(echarts): preserve dataZoom range across setOption(notMerge)

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -280,12 +280,37 @@ function Echart(
 
       const notMerge = !isDashboardRefreshing;
       chartRef.current?.dispatchAction({ type: 'hideTip' });
+      // setOption(notMerge:true) replaces the dataZoom config, dropping any
+      // range the user has engaged. Preserve it across the call.
+      const previousZoom = notMerge
+        ? (chartRef.current?.getOption() as any)?.dataZoom
+        : undefined;
       chartRef.current?.setOption(themedEchartOptions, {
         notMerge,
         replaceMerge: notMerge ? undefined : ['series'],
         // lazyUpdate defers render, causing tooltip crashes on stale shapes (#39247)
         lazyUpdate: false,
       });
+      if (previousZoom?.length) {
+        const batch = previousZoom
+          .map((dz: any, dataZoomIndex: number) => ({
+            dataZoomIndex,
+            start: dz.start,
+            end: dz.end,
+            startValue: dz.startValue,
+            endValue: dz.endValue,
+          }))
+          .filter(
+            (b: any) =>
+              b.start !== undefined ||
+              b.end !== undefined ||
+              b.startValue !== undefined ||
+              b.endValue !== undefined,
+          );
+        if (batch.length) {
+          chartRef.current?.dispatchAction({ type: 'dataZoom', batch });
+        }
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- isDashboardRefreshing intentionally excluded to prevent extra setOption calls
   }, [didMount, echartOptions, eventHandlers, zrEventHandlers, theme, vizType]);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -56,6 +56,7 @@ import {
   VisualMapComponent,
   LegendComponent,
   DataZoomComponent,
+  type DataZoomComponentOption,
   ToolboxComponent,
   GraphicComponent,
   AriaComponent,
@@ -283,7 +284,8 @@ function Echart(
       // setOption(notMerge:true) replaces the dataZoom config, dropping any
       // range the user has engaged. Preserve it across the call.
       const previousZoom = notMerge
-        ? (chartRef.current?.getOption() as any)?.dataZoom
+        ? (chartRef.current?.getOption() as { dataZoom?: DataZoomComponentOption[] })
+            ?.dataZoom
         : undefined;
       chartRef.current?.setOption(themedEchartOptions, {
         notMerge,
@@ -292,23 +294,41 @@ function Echart(
         lazyUpdate: false,
       });
       if (previousZoom?.length) {
-        const batch = previousZoom
-          .map((dz: any, dataZoomIndex: number) => ({
-            dataZoomIndex,
-            start: dz.start,
-            end: dz.end,
-            startValue: dz.startValue,
-            endValue: dz.endValue,
-          }))
-          .filter(
-            (b: any) =>
-              b.start !== undefined ||
-              b.end !== undefined ||
-              b.startValue !== undefined ||
-              b.endValue !== undefined,
-          );
-        if (batch.length) {
-          chartRef.current?.dispatchAction({ type: 'dataZoom', batch });
+        // Skip restore when the new option reshapes dataZoom (different count
+        // means index-based restore could land on the wrong component).
+        const newZoom = (
+          chartRef.current?.getOption() as {
+            dataZoom?: DataZoomComponentOption[];
+          }
+        )?.dataZoom;
+        if (newZoom?.length === previousZoom.length) {
+          const batch = previousZoom
+            .map((dz, dataZoomIndex) => ({
+              dataZoomIndex,
+              start: dz.start,
+              end: dz.end,
+              startValue: dz.startValue,
+              endValue: dz.endValue,
+            }))
+            .filter(b => {
+              const hasAny =
+                b.start !== undefined ||
+                b.end !== undefined ||
+                b.startValue !== undefined ||
+                b.endValue !== undefined;
+              if (!hasAny) return false;
+              // Default full-range zoom is functionally identical to the
+              // fresh state setOption already produces — skip the dispatch.
+              const isDefaultRange =
+                b.start === 0 &&
+                b.end === 100 &&
+                b.startValue === undefined &&
+                b.endValue === undefined;
+              return !isDefaultRange;
+            });
+          if (batch.length) {
+            chartRef.current?.dispatchAction({ type: 'dataZoom', batch });
+          }
         }
       }
     }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/components/Echart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/components/Echart.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { EChartsCoreOption } from 'echarts/core';
+import { render, waitFor } from 'spec/helpers/testing-library';
+
+const setOption = jest.fn();
+const on = jest.fn();
+const off = jest.fn();
+const resize = jest.fn();
+const dispose = jest.fn();
+const dispatchAction = jest.fn();
+const getOption = jest.fn();
+
+const mockInstance = {
+  setOption,
+  on,
+  off,
+  resize,
+  dispose,
+  dispatchAction,
+  getOption,
+  getZr: () => ({ on: jest.fn(), off: jest.fn() }),
+};
+
+jest.mock('echarts/core', () => ({
+  __esModule: true,
+  use: jest.fn(),
+  init: jest.fn(() => mockInstance),
+  registerLocale: jest.fn(),
+}));
+jest.mock('echarts/charts', () => ({}));
+jest.mock('echarts/renderers', () => ({}));
+jest.mock('echarts/components', () => ({}));
+jest.mock('echarts/features', () => ({}));
+
+// eslint-disable-next-line import/first
+import Echart from '../../src/components/Echart';
+
+const renderEchart = (echartOptions: EChartsCoreOption) => {
+  const refs = { divRef: undefined };
+  return render(
+    <Echart
+      width={400}
+      height={300}
+      echartOptions={echartOptions}
+      refs={refs}
+    />,
+    { useRedux: true, useTheme: true },
+  );
+};
+
+beforeEach(() => {
+  setOption.mockClear();
+  on.mockClear();
+  off.mockClear();
+  resize.mockClear();
+  dispatchAction.mockClear();
+  getOption.mockReset();
+});
+
+test('preserves user dataZoom range across setOption(notMerge)', async () => {
+  // After the user has zoomed, ECharts reports the current dataZoom range
+  // via getOption().dataZoom. We expect Echart to capture this before
+  // setOption replaces the option payload, then restore it via dispatchAction.
+  getOption.mockReturnValue({
+    dataZoom: [{ start: 12, end: 48 }],
+  });
+
+  const { rerender } = renderEchart({ xAxis: {}, series: [] });
+
+  // Trigger another setOption call by changing the echartOptions reference
+  rerender(
+    <Echart
+      width={400}
+      height={300}
+      echartOptions={{ xAxis: {}, series: [{ type: 'line' }] }}
+      refs={{ divRef: undefined }}
+    />,
+  );
+
+  await waitFor(() =>
+    expect(dispatchAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'dataZoom',
+        batch: [
+          expect.objectContaining({ dataZoomIndex: 0, start: 12, end: 48 }),
+        ],
+      }),
+    ),
+  );
+});
+
+test('does not restore when no prior zoom range exists', async () => {
+  // Fresh chart with no engaged zoom: dataZoom config has no start/end.
+  getOption.mockReturnValue({
+    dataZoom: [{ type: 'slider', show: true }],
+  });
+
+  const { rerender } = renderEchart({ xAxis: {}, series: [] });
+  await waitFor(() => expect(setOption).toHaveBeenCalledTimes(1));
+
+  rerender(
+    <Echart
+      width={400}
+      height={300}
+      echartOptions={{ xAxis: {}, series: [{ type: 'line' }] }}
+      refs={{ divRef: undefined }}
+    />,
+  );
+
+  await waitFor(() => expect(setOption).toHaveBeenCalledTimes(2));
+  const dataZoomCalls = dispatchAction.mock.calls.filter(
+    ([action]) => action?.type === 'dataZoom',
+  );
+  expect(dataZoomCalls).toHaveLength(0);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/components/Echart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/components/Echart.test.tsx
@@ -130,3 +130,63 @@ test('does not restore when no prior zoom range exists', async () => {
   );
   expect(dataZoomCalls).toHaveLength(0);
 });
+
+test('does not restore when prior zoom is at default full range', async () => {
+  // ECharts populates start:0/end:100 on slider dataZoom by default, so
+  // every untouched timeseries would otherwise dispatch a redundant action
+  // on each re-render. Skip the dispatch when the range is just the default.
+  getOption.mockReturnValue({
+    dataZoom: [{ type: 'slider', show: true, start: 0, end: 100 }],
+  });
+
+  const { rerender } = renderEchart({ xAxis: {}, series: [] });
+  await waitFor(() => expect(setOption).toHaveBeenCalledTimes(1));
+
+  rerender(
+    <Echart
+      width={400}
+      height={300}
+      echartOptions={{ xAxis: {}, series: [{ type: 'line' }] }}
+      refs={{ divRef: undefined }}
+    />,
+  );
+
+  await waitFor(() => expect(setOption).toHaveBeenCalledTimes(2));
+  const dataZoomCalls = dispatchAction.mock.calls.filter(
+    ([action]) => action?.type === 'dataZoom',
+  );
+  expect(dataZoomCalls).toHaveLength(0);
+});
+
+test('does not restore when the new option reshapes dataZoom', async () => {
+  // 1st render starts with no engaged zoom; 2nd render captures an engaged
+  // range but the post-setOption dataZoom has a different count, so
+  // index-based restore could write to the wrong component. Skip in that case.
+  getOption
+    // 1st render: previousZoom + newZoom (no engaged values, nothing to dispatch)
+    .mockReturnValueOnce({ dataZoom: [{ type: 'slider' }] })
+    .mockReturnValueOnce({ dataZoom: [{ type: 'slider' }] })
+    // 2nd render: previousZoom has user range, but newZoom has 2 entries
+    .mockReturnValueOnce({ dataZoom: [{ start: 12, end: 48 }] })
+    .mockReturnValueOnce({
+      dataZoom: [{ start: 12, end: 48 }, { type: 'inside' }],
+    });
+
+  const { rerender } = renderEchart({ xAxis: {}, series: [] });
+  await waitFor(() => expect(setOption).toHaveBeenCalledTimes(1));
+
+  rerender(
+    <Echart
+      width={400}
+      height={300}
+      echartOptions={{ xAxis: {}, series: [{ type: 'line' }] }}
+      refs={{ divRef: undefined }}
+    />,
+  );
+
+  await waitFor(() => expect(setOption).toHaveBeenCalledTimes(2));
+  const dataZoomCalls = dispatchAction.mock.calls.filter(
+    ([action]) => action?.type === 'dataZoom',
+  );
+  expect(dataZoomCalls).toHaveLength(0);
+});


### PR DESCRIPTION
### SUMMARY

Zooming into an ECharts chart with the data zoom slider and then hovering it could snap the zoom back to default.

The trigger is a container width change. A rich tooltip that lists many series makes the page taller, a vertical scrollbar appears, the chart container narrows, and upstream `transformProps` re-runs and returns a new `echartOptions` reference. The `setOption` effect in `Echart.tsx` then runs again with `notMerge: true`, which replaces the whole option payload and drops whatever dataZoom range the user had set.

This captures `getOption().dataZoom` right before `setOption` when `notMerge` is true, and restores the range with `dispatchAction` afterwards. A fresh chart with no engaged range restores nothing, so default behavior is unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE
(zoomed, X 1-7)
<img width="1280" height="720" alt="before-1-zoomed" src="https://github.com/user-attachments/assets/4ab315a6-317c-48f3-86b7-31212848bb7e" />
(after width change, zoom lost, X 1-12)
<img width="1264" height="720" alt="before-2-reset" src="https://github.com/user-attachments/assets/94032884-247a-4d41-a973-3eb28283bdc7" />

AFTER
 (zoomed, X 1-7) 
<img width="1280" height="720" alt="after-1-zoomed" src="https://github.com/user-attachments/assets/333b3895-0aa4-4b38-a87a-3a3343c5d2ea" />
 (after width change, zoom held, X 1-7)
<img width="1264" height="720" alt="after-2-held" src="https://github.com/user-attachments/assets/5a63dbfd-5670-4dfc-93cb-b7c0e352d096" />

### TESTING INSTRUCTIONS

1. Create a line chart on a dataset with a dimension that produces many series. Enable zoom and rich tooltip.
2. Add it to a dashboard sized so the chart fits without a scrollbar.
3. Drag the data zoom slider to zoom in.
4. Hover the chart so the rich tooltip renders and extends the page (a scrollbar appears).
5. The zoom stays where you set it. Before this fix it reset to default.

Unit tests: `superset-frontend/plugins/plugin-chart-echarts/test/components/Echart.test.tsx` (2/2 pass).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
