### PR TITLE
fix(reports): guard null dashboard height in Playwright screenshots

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -337,7 +337,10 @@ class WebDriverPlaywright(WebDriverProxy):
                         'document.querySelectorAll(".chart-container").length'
                     )
                     dashboard_height = page.evaluate(
-                        f'document.querySelector(".{element_name}").scrollHeight || 0'
+                        f"""() => {{
+                            const target = document.querySelector(\".{element_name}\");
+                            return target ? target.scrollHeight : 0;
+                        }}"""
                     )
                     chart_threshold = app.config.get(
                         "SCREENSHOT_TILED_CHART_THRESHOLD", 20
@@ -348,6 +351,14 @@ class WebDriverPlaywright(WebDriverProxy):
                     tile_height = app.config.get(
                         "SCREENSHOT_TILED_VIEWPORT_HEIGHT", viewport_height
                     )
+
+                    if dashboard_height == 0:
+                        logger.warning(
+                            "Could not determine dashboard height for element %s "
+                            "at url %s; falling back to standard screenshot behavior",
+                            element_name,
+                            url,
+                        )
 
                     # Use tiled screenshots for large dashboards
                     use_tiled = (

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -702,3 +702,90 @@ class TestWebDriverPlaywrightErrorHandling:
         mock_logger.exception.assert_any_call(
             "Timed out requesting url %s", "http://example.com"
         )
+
+    @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+    @patch("superset.utils.webdriver.sync_playwright")
+    @patch("superset.utils.webdriver.logger")
+    def test_missing_element_for_dashboard_height_falls_back_without_crashing(
+        self, mock_logger, mock_sync_playwright
+    ):
+        """Missing dashboard element should not crash height evaluation."""
+        mock_user = MagicMock()
+        mock_user.username = "test_user"
+
+        mock_playwright_instance = MagicMock()
+        mock_browser = MagicMock()
+        mock_context = MagicMock()
+        mock_page = MagicMock()
+        mock_element = MagicMock()
+        mock_chart_container = MagicMock()
+
+        mock_sync_playwright.return_value.__enter__.return_value = (
+            mock_playwright_instance
+        )
+        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_browser.new_context.return_value = mock_context
+        mock_context.new_page.return_value = mock_page
+
+        def locator_side_effect(selector):
+            if selector == ".dashboard":
+                return mock_element
+            if selector == ".chart-container":
+                locator = MagicMock()
+                locator.all.return_value = [mock_chart_container]
+                return locator
+            if selector == ".loading":
+                locator = MagicMock()
+                locator.all.return_value = []
+                return locator
+            return MagicMock()
+
+        mock_page.locator.side_effect = locator_side_effect
+        mock_element.wait_for.return_value = None
+        mock_element.screenshot.return_value = b"fake_screenshot"
+        mock_chart_container.wait_for.return_value = None
+        mock_page.wait_for_timeout.return_value = None
+
+        def evaluate_side_effect(script):
+            if script == 'document.querySelectorAll(".chart-container").length':
+                return 1
+            if "const target = document.querySelector" in script:
+                return 0
+            return None
+
+        mock_page.evaluate.side_effect = evaluate_side_effect
+
+        with patch("superset.utils.webdriver.app") as mock_app:
+            mock_app.config = {
+                "WEBDRIVER_OPTION_ARGS": [],
+                "WEBDRIVER_WINDOW": {"pixel_density": 1},
+                "SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT": 30000,
+                "SCREENSHOT_PLAYWRIGHT_WAIT_EVENT": "networkidle",
+                "SCREENSHOT_SELENIUM_HEADSTART": 5,
+                "SCREENSHOT_SELENIUM_ANIMATION_WAIT": 1,
+                "SCREENSHOT_LOCATE_WAIT": 10,
+                "SCREENSHOT_LOAD_WAIT": 10,
+                "SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE": 10,
+                "SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE": 10,
+                "SCREENSHOT_REPLACE_UNEXPECTED_ERRORS": False,
+                "SCREENSHOT_TILED_ENABLED": True,
+                "SCREENSHOT_TILED_CHART_THRESHOLD": 20,
+                "SCREENSHOT_TILED_HEIGHT_THRESHOLD": 5000,
+                "SCREENSHOT_TILED_VIEWPORT_HEIGHT": 600,
+            }
+
+            with patch.object(WebDriverPlaywright, "auth") as mock_auth:
+                mock_auth.return_value = mock_context
+
+                driver = WebDriverPlaywright("chrome")
+                result = driver.get_screenshot(
+                    "http://example.com", "dashboard", mock_user
+                )
+
+        assert result == b"fake_screenshot"
+        mock_logger.warning.assert_any_call(
+            "Could not determine dashboard height for element %s at url %s; "
+            "falling back to standard screenshot behavior",
+            "dashboard",
+            "http://example.com",
+        )


### PR DESCRIPTION
### SUMMARY

Follow-up to #39895.

This fixes a Playwright screenshot regression in `superset/utils/webdriver.py` when tiled screenshot detection evaluates dashboard height.

In some report render paths, the target element can be temporarily missing when we call:

```python
document.querySelector(".{element_name}").scrollHeight
```

That causes Playwright to fail with:

```text
Page.evaluate: TypeError: Cannot read properties of null (reading 'scrollHeight')
```

This change makes the dashboard height lookup null-safe and logs a warning when the height cannot be determined, allowing screenshot generation to fall back gracefully instead of failing the worker.

### CHANGES

- guard dashboard height evaluation in `WebDriverPlaywright.get_screenshot`
- return `0` when the target element is missing instead of throwing
- log a warning when height cannot be determined
- add a regression test covering the missing-element case

### TESTING INSTRUCTIONS

1. Run:
   `pytest tests/unit_tests/utils/webdriver_test.py`
2. Exercise a report / thumbnail render path with tiled screenshots enabled.
3. Verify the worker no longer fails with:
   `TypeError: Cannot read properties of null (reading 'scrollHeight')`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API