### PR TITLE
fix(drill): coerce temporal drill filter values

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -253,9 +253,11 @@ const getDrillFilterFormattedValue = (
     value.trim() !== '' && Number.isFinite(Number(value))
       ? Number(value)
       : value;
-  return (formatter as ((value: DataRecordValue) => string) | undefined)?.(
-    valueToFormat,
-  ) || String(value);
+  return (
+    (formatter as ((value: DataRecordValue) => string) | undefined)?.(
+      valueToFormat,
+    ) || String(value)
+  );
 };
 
 /* If you change this logic, please update the corresponding Python
@@ -537,9 +539,7 @@ export default function PivotTableChart(props: PivotTableProps) {
                         op: 'IS NULL' as const,
                       };
                     const formatter =
-                      typeof col === 'string'
-                        ? dateFormatters[col]
-                        : undefined;
+                      typeof col === 'string' ? dateFormatters[col] : undefined;
                     return {
                       col,
                       op: 'IN' as const,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -248,7 +248,15 @@ const getCrossFilterValue = (
 const getDrillFilterFormattedValue = (
   value: string,
   formatter: DateFormatter | undefined,
-) => formatter?.(Number(value)) || String(value);
+) => {
+  const valueToFormat: DataRecordValue =
+    value.trim() !== '' && Number.isFinite(Number(value))
+      ? Number(value)
+      : value;
+  return (formatter as ((value: DataRecordValue) => string) | undefined)?.(
+    valueToFormat,
+  ) || String(value);
+};
 
 /* If you change this logic, please update the corresponding Python
  * function (https://github.com/apache/superset/blob/master/superset/charts/post_processing.py),

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -43,6 +43,7 @@ import {
 import { styled, useTheme } from '@apache-superset/core/theme';
 import { aggregatorTemplates, PivotTable, sortAs } from './react-pivottable';
 import {
+  DateFormatter,
   FilterType,
   MetricsLayoutEnum,
   PivotTableProps,
@@ -217,6 +218,43 @@ const aggregatorsFactory = (formatter: NumberFormatter) => ({
     formatter,
   ),
 });
+
+const getDrillFilterValue = (
+  value: string,
+  formatter: DateFormatter | undefined,
+): string | number => {
+  if (formatter && value.trim() !== '' && Number.isFinite(Number(value))) {
+    return Number(value);
+  }
+  return value;
+};
+
+const getCrossFilterValue = (
+  value: DataRecordValue,
+  formatter: DateFormatter | undefined,
+): DataRecordValue => {
+  if (
+    formatter &&
+    typeof value === 'string' &&
+    value.trim() !== '' &&
+    Number.isFinite(Number(value))
+  ) {
+    return Number(value);
+  }
+  return value;
+};
+
+const getDrillFilterFormattedValue = (
+  value: string,
+  formatter: DateFormatter | undefined,
+) => {
+  const filterValue = getDrillFilterValue(value, formatter);
+  return (
+    formatter?.(
+      typeof filterValue === 'number' ? filterValue : Number(value),
+    ) || String(value)
+  );
+};
 
 /* If you change this logic, please update the corresponding Python
  * function (https://github.com/apache/superset/blob/master/superset/charts/post_processing.py),
@@ -419,10 +457,13 @@ export default function PivotTableChart(props: PivotTableProps) {
                       col,
                       op: 'IS NULL',
                     };
+                  const formatter = dateFormatters[col];
                   return {
                     col,
                     op: 'IN',
-                    val: val as (string | number | boolean)[],
+                    val: (val as DataRecordValue[]).map(value =>
+                      getCrossFilterValue(value, formatter),
+                    ) as (string | number | boolean)[],
                   };
                 }),
         },
@@ -436,7 +477,7 @@ export default function PivotTableChart(props: PivotTableProps) {
         },
       });
     },
-    [groupbyColumnsRaw, groupbyRowsRaw, setDataMask],
+    [dateFormatters, groupbyColumnsRaw, groupbyRowsRaw, setDataMask],
   );
 
   const isActiveFilterValue = useCallback(
@@ -492,10 +533,13 @@ export default function PivotTableChart(props: PivotTableProps) {
                         col,
                         op: 'IS NULL' as const,
                       };
+                    const formatter = dateFormatters[col];
                     return {
                       col,
                       op: 'IN' as const,
-                      val: val as (string | number | boolean)[],
+                      val: (val as DataRecordValue[]).map(value =>
+                        getCrossFilterValue(value, formatter),
+                      ) as (string | number | boolean)[],
                     };
                   }),
           },
@@ -511,7 +555,13 @@ export default function PivotTableChart(props: PivotTableProps) {
         isCurrentValueSelected: isActiveFilterValue(key, val),
       };
     },
-    [groupbyColumnsRaw, groupbyRowsRaw, isActiveFilterValue, selectedFilters],
+    [
+      dateFormatters,
+      groupbyColumnsRaw,
+      groupbyRowsRaw,
+      isActiveFilterValue,
+      selectedFilters,
+    ],
   );
 
   const toggleFilter = useCallback(
@@ -637,12 +687,12 @@ export default function PivotTableChart(props: PivotTableProps) {
           colKey.forEach((val, i) => {
             const col = cols[i];
             const formatter = dateFormatters[col];
-            const formattedVal = formatter?.(Number(val)) || String(val);
+            const formattedVal = getDrillFilterFormattedValue(val, formatter);
             if (i > 0) {
               drillToDetailFilters.push({
                 col,
                 op: '==',
-                val,
+                val: getDrillFilterValue(val, formatter),
                 formattedVal,
                 grain: formatter ? timeGrainSqla : undefined,
               });
@@ -653,11 +703,11 @@ export default function PivotTableChart(props: PivotTableProps) {
           rowKey.forEach((val, i) => {
             const col = rows[i];
             const formatter = dateFormatters[col];
-            const formattedVal = formatter?.(Number(val)) || String(val);
+            const formattedVal = getDrillFilterFormattedValue(val, formatter);
             drillToDetailFilters.push({
               col,
               op: '==',
-              val,
+              val: getDrillFilterValue(val, formatter),
               formattedVal,
               grain: formatter ? timeGrainSqla : undefined,
             });

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -248,7 +248,7 @@ const getCrossFilterValue = (
 const getDrillFilterFormattedValue = (
   value: string,
   formatter: DateFormatter | undefined,
-) => {
+): string => {
   const valueToFormat: DataRecordValue =
     value.trim() !== '' && Number.isFinite(Number(value))
       ? Number(value)

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -28,6 +28,7 @@ import {
   BinaryQueryObjectFilterClause,
   Currency,
   CurrencyFormatter,
+  DataRecord,
   DataRecordValue,
   FeatureFlag,
   getColumnLabel,
@@ -247,14 +248,7 @@ const getCrossFilterValue = (
 const getDrillFilterFormattedValue = (
   value: string,
   formatter: DateFormatter | undefined,
-) => {
-  const filterValue = getDrillFilterValue(value, formatter);
-  return (
-    formatter?.(
-      typeof filterValue === 'number' ? filterValue : Number(value),
-    ) || String(value)
-  );
-};
+) => formatter?.(Number(value)) || String(value);
 
 /* If you change this logic, please update the corresponding Python
  * function (https://github.com/apache/superset/blob/master/superset/charts/post_processing.py),
@@ -380,7 +374,7 @@ export default function PivotTableChart(props: PivotTableProps) {
   const unpivotedData = useMemo(
     () =>
       data.reduce(
-        (acc: Record<string, any>[], record: Record<string, any>) => [
+        (acc: DataRecord[], record: DataRecord) => [
           ...acc,
           ...metricNames
             .map((name: string) => ({
@@ -457,7 +451,8 @@ export default function PivotTableChart(props: PivotTableProps) {
                       col,
                       op: 'IS NULL',
                     };
-                  const formatter = dateFormatters[col];
+                  const formatter =
+                    typeof col === 'string' ? dateFormatters[col] : undefined;
                   return {
                     col,
                     op: 'IN',
@@ -533,7 +528,10 @@ export default function PivotTableChart(props: PivotTableProps) {
                         col,
                         op: 'IS NULL' as const,
                       };
-                    const formatter = dateFormatters[col];
+                    const formatter =
+                      typeof col === 'string'
+                        ? dateFormatters[col]
+                        : undefined;
                     return {
                       col,
                       op: 'IN' as const,
@@ -585,7 +583,10 @@ export default function PivotTableChart(props: PivotTableProps) {
       const filtersCopy = { ...filters };
       delete filtersCopy[METRIC_KEY];
 
-      const filtersEntries = Object.entries(filtersCopy);
+      const filtersEntries = Object.entries(filtersCopy) as [
+        string,
+        DataRecordValue,
+      ][];
       if (filtersEntries.length === 0) {
         return;
       }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -461,8 +461,10 @@ export default function PivotTableChart(props: PivotTableProps) {
                       col,
                       op: 'IS NULL',
                     };
-                  const formatter =
-                    typeof col === 'string' ? dateFormatters[col] : undefined;
+                  // Resolve the formatter by the header key/label so adhoc
+                  // temporal groupby columns (where `col` is an object, not a
+                  // string) still get epoch coercion, matching physical columns.
+                  const formatter = dateFormatters[key];
                   return {
                     col,
                     op: 'IN',
@@ -538,8 +540,11 @@ export default function PivotTableChart(props: PivotTableProps) {
                         col,
                         op: 'IS NULL' as const,
                       };
-                    const formatter =
-                      typeof col === 'string' ? dateFormatters[col] : undefined;
+                    // Resolve the formatter by the header key/label so adhoc
+                    // temporal groupby columns (where `col` is an object, not a
+                    // string) still get epoch coercion, matching physical
+                    // columns.
+                    const formatter = dateFormatters[key];
                     return {
                       col,
                       op: 'IN' as const,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
@@ -363,7 +363,7 @@ test('emits drill filters from formatted column headers', () => {
       {
         col: adhocColumn,
         op: 'IN',
-        val: [String(timestamp)],
+        val: [timestamp],
       },
     ],
   });

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
@@ -32,7 +32,9 @@ function renderWithTheme(ui: ReactElement) {
   return render(<ThemeProvider theme={supersetTheme}>{ui}</ThemeProvider>);
 }
 
-function createProps(overrides: Partial<PivotTableProps> = {}): PivotTableProps {
+function createProps(
+  overrides: Partial<PivotTableProps> = {},
+): PivotTableProps {
   return {
     data: [],
     height: 400,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
@@ -91,6 +91,68 @@ test('emits numeric temporal values for drill-to-detail filters on formatted row
   ]);
 });
 
+test('keeps non-numeric temporal values for drill-to-detail formatted labels', () => {
+  const onContextMenu = jest.fn();
+  const dateValue = '2024-01-01';
+  const props: PivotTableProps = {
+    data: [{ install_date: dateValue, value: 1 }],
+    height: 400,
+    width: 600,
+    margin: 0,
+    groupbyRows: ['install_date'],
+    groupbyColumns: [],
+    metrics: ['value'],
+    tableRenderer: 'Table',
+    colOrder: 'key_a_to_z',
+    rowOrder: 'key_a_to_z',
+    aggregateFunction: 'Count',
+    transposePivot: false,
+    combineMetric: false,
+    rowSubtotalPosition: false,
+    colSubtotalPosition: false,
+    colTotals: false,
+    colSubTotals: false,
+    rowTotals: false,
+    rowSubTotals: false,
+    valueFormat: 'SMART_NUMBER',
+    currencyFormat: { symbol: 'USD', symbolPosition: 'prefix' },
+    setDataMask: jest.fn(),
+    emitCrossFilters: true,
+    selectedFilters: {},
+    verboseMap: {},
+    columnFormats: {},
+    currencyFormats: {},
+    metricsLayout: MetricsLayoutEnum.COLUMNS,
+    metricColorFormatters: [],
+    dateFormatters: {
+      install_date: (value: DataRecordValue) => String(value),
+    },
+    legacy_order_by: null,
+    order_desc: false,
+    onContextMenu,
+    timeGrainSqla: TimeGranularity.DAY,
+    allowRenderHtml: false,
+  };
+
+  renderWithTheme(<PivotTableChart {...props} />);
+
+  const rowHeader = screen.getByText(dateValue).closest('th');
+  expect(rowHeader).not.toBeNull();
+  fireEvent.contextMenu(rowHeader!);
+
+  expect(onContextMenu).toHaveBeenCalledTimes(1);
+  const contextMenuFilters = onContextMenu.mock.calls[0][2];
+  expect(contextMenuFilters?.drillToDetail).toEqual([
+    {
+      col: 'install_date',
+      op: '==',
+      val: dateValue,
+      formattedVal: dateValue,
+      grain: TimeGranularity.DAY,
+    },
+  ]);
+});
+
 test('emits numeric temporal values for cross-filters on formatted row headers', () => {
   const setDataMask = jest.fn();
   const timestamp = 1777248000000;

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
@@ -20,7 +20,7 @@ import type { ReactElement } from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
-import { TimeGranularity } from '@superset-ui/core';
+import { TimeGranularity, type DataRecordValue } from '@superset-ui/core';
 import PivotTableChart from '../src/PivotTableChart';
 import { MetricsLayoutEnum, type PivotTableProps } from '../src/types';
 
@@ -35,6 +35,7 @@ test('emits numeric temporal values for drill-to-detail filters on formatted row
     data: [{ install_date: String(timestamp), value: 1 }],
     height: 400,
     width: 600,
+    margin: 0,
     groupbyRows: ['install_date'],
     groupbyColumns: [],
     metrics: ['value'],
@@ -61,7 +62,8 @@ test('emits numeric temporal values for drill-to-detail filters on formatted row
     metricsLayout: MetricsLayoutEnum.COLUMNS,
     metricColorFormatters: [],
     dateFormatters: {
-      install_date: value => new Date(Number(value)).toISOString().slice(0, 10),
+      install_date: (value: DataRecordValue) =>
+        new Date(Number(value)).toISOString().slice(0, 10),
     },
     legacy_order_by: null,
     order_desc: false,
@@ -96,6 +98,7 @@ test('emits numeric temporal values for cross-filters on formatted row headers',
     data: [{ install_date: String(timestamp), value: 1 }],
     height: 400,
     width: 600,
+    margin: 0,
     groupbyRows: ['install_date'],
     groupbyColumns: [],
     metrics: ['value'],
@@ -122,7 +125,8 @@ test('emits numeric temporal values for cross-filters on formatted row headers',
     metricsLayout: MetricsLayoutEnum.COLUMNS,
     metricColorFormatters: [],
     dateFormatters: {
-      install_date: value => new Date(Number(value)).toISOString().slice(0, 10),
+      install_date: (value: DataRecordValue) =>
+        new Date(Number(value)).toISOString().slice(0, 10),
     },
     legacy_order_by: null,
     order_desc: false,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
@@ -20,12 +20,56 @@ import type { ReactElement } from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
-import { TimeGranularity, type DataRecordValue } from '@superset-ui/core';
+import {
+  TimeGranularity,
+  type DataRecordValue,
+  type QueryFormColumn,
+} from '@superset-ui/core';
 import PivotTableChart from '../src/PivotTableChart';
 import { MetricsLayoutEnum, type PivotTableProps } from '../src/types';
 
 function renderWithTheme(ui: ReactElement) {
   return render(<ThemeProvider theme={supersetTheme}>{ui}</ThemeProvider>);
+}
+
+function createProps(overrides: Partial<PivotTableProps> = {}): PivotTableProps {
+  return {
+    data: [],
+    height: 400,
+    width: 600,
+    margin: 0,
+    groupbyRows: [],
+    groupbyColumns: [],
+    metrics: ['value'],
+    tableRenderer: 'Table',
+    colOrder: 'key_a_to_z',
+    rowOrder: 'key_a_to_z',
+    aggregateFunction: 'Count',
+    transposePivot: false,
+    combineMetric: false,
+    rowSubtotalPosition: false,
+    colSubtotalPosition: false,
+    colTotals: false,
+    colSubTotals: false,
+    rowTotals: false,
+    rowSubTotals: false,
+    valueFormat: 'SMART_NUMBER',
+    currencyFormat: { symbol: 'USD', symbolPosition: 'prefix' },
+    setDataMask: jest.fn(),
+    emitCrossFilters: true,
+    selectedFilters: {},
+    verboseMap: {},
+    columnFormats: {},
+    currencyFormats: {},
+    metricsLayout: MetricsLayoutEnum.COLUMNS,
+    metricColorFormatters: [],
+    dateFormatters: {},
+    legacy_order_by: null,
+    order_desc: false,
+    timeGrainSqla: TimeGranularity.DAY,
+    allowRenderHtml: false,
+    ...overrides,
+  };
 }
 
 test('emits numeric temporal values for drill-to-detail filters on formatted row headers', () => {
@@ -153,6 +197,33 @@ test('keeps non-numeric temporal values for drill-to-detail formatted labels', (
   ]);
 });
 
+test('keeps non-formatted drill-to-detail values as strings', () => {
+  const onContextMenu = jest.fn();
+  const props = createProps({
+    data: [{ country: 'US', value: 1 }],
+    groupbyRows: ['country'],
+    onContextMenu,
+  });
+
+  renderWithTheme(<PivotTableChart {...props} />);
+
+  const rowHeader = screen.getByText('US').closest('th');
+  expect(rowHeader).not.toBeNull();
+  fireEvent.contextMenu(rowHeader!);
+
+  expect(onContextMenu).toHaveBeenCalledTimes(1);
+  const contextMenuFilters = onContextMenu.mock.calls[0][2];
+  expect(contextMenuFilters?.drillToDetail).toEqual([
+    {
+      col: 'country',
+      op: '==',
+      val: 'US',
+      formattedVal: 'US',
+      grain: undefined,
+    },
+  ]);
+});
+
 test('emits numeric temporal values for cross-filters on formatted row headers', () => {
   const setDataMask = jest.fn();
   const timestamp = 1777248000000;
@@ -215,4 +286,83 @@ test('emits numeric temporal values for cross-filters on formatted row headers',
       },
     }),
   );
+});
+
+test('keeps non-numeric temporal values for cross-filters on formatted row headers', () => {
+  const setDataMask = jest.fn();
+  const dateValue = '2024-01-01';
+  const props = createProps({
+    data: [{ install_date: dateValue, value: 1 }],
+    groupbyRows: ['install_date'],
+    setDataMask,
+    dateFormatters: {
+      install_date: (value: DataRecordValue) => String(value),
+    },
+  });
+
+  renderWithTheme(<PivotTableChart {...props} />);
+
+  const rowHeader = screen.getByText(dateValue).closest('th');
+  expect(rowHeader).not.toBeNull();
+  fireEvent.click(rowHeader!);
+
+  expect(setDataMask).toHaveBeenCalledWith(
+    expect.objectContaining({
+      extraFormData: {
+        filters: [
+          {
+            col: 'install_date',
+            op: 'IN',
+            val: [dateValue],
+          },
+        ],
+      },
+    }),
+  );
+});
+
+test('emits drill filters from formatted column headers', () => {
+  const onContextMenu = jest.fn();
+  const timestamp = 1778630400000;
+  const adhocColumn: QueryFormColumn = {
+    label: 'Install date expression',
+    sqlExpression: 'install_date',
+    expressionType: 'SQL',
+  };
+  const props = createProps({
+    data: [{ 'Install date expression': String(timestamp), value: 1 }],
+    groupbyColumns: [adhocColumn],
+    dateFormatters: {
+      'Install date expression': (value: DataRecordValue) =>
+        new Date(Number(value)).toISOString().slice(0, 10),
+    },
+    onContextMenu,
+  });
+
+  renderWithTheme(<PivotTableChart {...props} />);
+
+  const columnHeader = screen.getByText('2026-05-13').closest('th');
+  expect(columnHeader).not.toBeNull();
+  fireEvent.contextMenu(columnHeader!);
+
+  expect(onContextMenu).toHaveBeenCalledTimes(1);
+  const contextMenuFilters = onContextMenu.mock.calls[0][2];
+  expect(contextMenuFilters?.drillToDetail).toEqual([
+    {
+      col: 'Install date expression',
+      op: '==',
+      val: timestamp,
+      formattedVal: '2026-05-13',
+      grain: TimeGranularity.DAY,
+    },
+  ]);
+  expect(contextMenuFilters?.crossFilter?.dataMask.extraFormData).toEqual({
+    filters: [
+      {
+        col: adhocColumn,
+        op: 'IN',
+        val: [String(timestamp)],
+      },
+    ],
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/PivotTableChart.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { ReactElement } from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
+import { TimeGranularity } from '@superset-ui/core';
+import PivotTableChart from '../src/PivotTableChart';
+import { MetricsLayoutEnum, type PivotTableProps } from '../src/types';
+
+function renderWithTheme(ui: ReactElement) {
+  return render(<ThemeProvider theme={supersetTheme}>{ui}</ThemeProvider>);
+}
+
+test('emits numeric temporal values for drill-to-detail filters on formatted row headers', () => {
+  const onContextMenu = jest.fn();
+  const timestamp = 1778630400000;
+  const props: PivotTableProps = {
+    data: [{ install_date: String(timestamp), value: 1 }],
+    height: 400,
+    width: 600,
+    groupbyRows: ['install_date'],
+    groupbyColumns: [],
+    metrics: ['value'],
+    tableRenderer: 'Table',
+    colOrder: 'key_a_to_z',
+    rowOrder: 'key_a_to_z',
+    aggregateFunction: 'Count',
+    transposePivot: false,
+    combineMetric: false,
+    rowSubtotalPosition: false,
+    colSubtotalPosition: false,
+    colTotals: false,
+    colSubTotals: false,
+    rowTotals: false,
+    rowSubTotals: false,
+    valueFormat: 'SMART_NUMBER',
+    currencyFormat: { symbol: 'USD', symbolPosition: 'prefix' },
+    setDataMask: jest.fn(),
+    emitCrossFilters: true,
+    selectedFilters: {},
+    verboseMap: {},
+    columnFormats: {},
+    currencyFormats: {},
+    metricsLayout: MetricsLayoutEnum.COLUMNS,
+    metricColorFormatters: [],
+    dateFormatters: {
+      install_date: value => new Date(Number(value)).toISOString().slice(0, 10),
+    },
+    legacy_order_by: null,
+    order_desc: false,
+    onContextMenu,
+    timeGrainSqla: TimeGranularity.DAY,
+    allowRenderHtml: false,
+  };
+
+  renderWithTheme(<PivotTableChart {...props} />);
+
+  const rowHeader = screen.getByText('2026-05-13').closest('th');
+  expect(rowHeader).not.toBeNull();
+  fireEvent.contextMenu(rowHeader!);
+
+  expect(onContextMenu).toHaveBeenCalledTimes(1);
+  const contextMenuFilters = onContextMenu.mock.calls[0][2];
+  expect(contextMenuFilters?.drillToDetail).toEqual([
+    {
+      col: 'install_date',
+      op: '==',
+      val: timestamp,
+      formattedVal: '2026-05-13',
+      grain: TimeGranularity.DAY,
+    },
+  ]);
+});
+
+test('emits numeric temporal values for cross-filters on formatted row headers', () => {
+  const setDataMask = jest.fn();
+  const timestamp = 1777248000000;
+  const props: PivotTableProps = {
+    data: [{ install_date: String(timestamp), value: 1 }],
+    height: 400,
+    width: 600,
+    groupbyRows: ['install_date'],
+    groupbyColumns: [],
+    metrics: ['value'],
+    tableRenderer: 'Table',
+    colOrder: 'key_a_to_z',
+    rowOrder: 'key_a_to_z',
+    aggregateFunction: 'Count',
+    transposePivot: false,
+    combineMetric: false,
+    rowSubtotalPosition: false,
+    colSubtotalPosition: false,
+    colTotals: false,
+    colSubTotals: false,
+    rowTotals: false,
+    rowSubTotals: false,
+    valueFormat: 'SMART_NUMBER',
+    currencyFormat: { symbol: 'USD', symbolPosition: 'prefix' },
+    setDataMask,
+    emitCrossFilters: true,
+    selectedFilters: {},
+    verboseMap: {},
+    columnFormats: {},
+    currencyFormats: {},
+    metricsLayout: MetricsLayoutEnum.COLUMNS,
+    metricColorFormatters: [],
+    dateFormatters: {
+      install_date: value => new Date(Number(value)).toISOString().slice(0, 10),
+    },
+    legacy_order_by: null,
+    order_desc: false,
+    timeGrainSqla: TimeGranularity.DAY,
+    allowRenderHtml: false,
+  };
+
+  renderWithTheme(<PivotTableChart {...props} />);
+
+  const rowHeader = screen.getByText('2026-04-27').closest('th');
+  expect(rowHeader).not.toBeNull();
+  fireEvent.click(rowHeader!);
+
+  expect(setDataMask).toHaveBeenCalledWith(
+    expect.objectContaining({
+      extraFormData: {
+        filters: [
+          {
+            col: 'install_date',
+            op: 'IN',
+            val: [timestamp],
+          },
+        ],
+      },
+    }),
+  );
+});

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -1328,7 +1328,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                 col.toggleSortBy();
               }
             }}
-            role="columnheader button"
             onClick={onClick}
             data-column-name={col.id}
             {...(allowRearrangeColumns && {

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -108,6 +108,25 @@ interface TableSize {
   height: number;
 }
 
+const getCrossFilterValue = (
+  value: DataRecordValue,
+  column: DataColumnMeta | undefined,
+): DataRecordValue => {
+  const input = value instanceof DateWithFormatter ? value.input : value;
+  if (
+    column?.dataType === GenericDataType.Temporal &&
+    typeof input === 'string' &&
+    input.trim() !== '' &&
+    Number.isFinite(Number(input))
+  ) {
+    return Number(input);
+  }
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  return value;
+};
+
 const ACTION_KEYS = {
   enter: 'Enter',
   spacebar: 'Spacebar',
@@ -533,6 +552,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                     // so that cross-filters work on the receiving chart
                     const resolvedCol = columnLabelToNameMap[col] ?? col;
                     const val = ensureIsArray(updatedFilters?.[col]);
+                    const column = columnsMeta.find(
+                      columnMeta => columnMeta.key === col,
+                    );
                     if (
                       !val.length ||
                       val[0] === null ||
@@ -546,9 +568,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                     return {
                       col: resolvedCol,
                       op: 'IN' as const,
-                      val: val.map(el =>
-                        el instanceof Date ? el.getTime() : el!,
-                      ),
+                      val: val.map(el => getCrossFilterValue(el!, column)),
                       grain: resolvedCol === DTTM_ALIAS ? timeGrain : undefined,
                     };
                   }),
@@ -571,6 +591,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       timestampFormatter,
       timeGrain,
       columnLabelToNameMap,
+      columnsMeta,
     ],
   );
 

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -1843,6 +1843,54 @@ describe('plugin-chart-table', () => {
         expect(secondCallArg.extraFormData.filters).toEqual([]);
       });
 
+      test('clicking a temporal numeric-string cell emits numeric cross-filter values', () => {
+        const setDataMask = jest.fn();
+        const timestamp = 1777248000000;
+        const props = transformProps({
+          ...testData.basic,
+          hooks: { setDataMask },
+          emitCrossFilters: true,
+        });
+
+        render(
+          <ProviderWrapper>
+            <TableChart
+              {...props}
+              data={[{ install_date: String(timestamp) }]}
+              columns={[
+                {
+                  key: 'install_date',
+                  label: 'install_date',
+                  dataType: GenericDataType.Temporal,
+                  isNumeric: false,
+                  isMetric: false,
+                  isPercentMetric: false,
+                  formatter: String,
+                  config: {},
+                },
+              ]}
+              emitCrossFilters
+              setDataMask={setDataMask}
+              sticky={false}
+            />
+          </ProviderWrapper>,
+        );
+
+        fireEvent.click(screen.getByText(String(timestamp)));
+
+        const crossFilterCall = setDataMask.mock.calls.find(
+          (call: any[]) => call[0]?.filterState?.filters,
+        );
+        expect(crossFilterCall).toBeDefined();
+        expect(crossFilterCall![0].extraFormData.filters).toEqual([
+          {
+            col: 'install_date',
+            op: 'IN',
+            val: [timestamp],
+          },
+        ]);
+      });
+
       test('cross-filter toggle works with DateWithFormatter values', () => {
         const setDataMask = jest.fn();
         const props = transformProps({

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -31,6 +31,7 @@ import {
 } from '@superset-ui/core/spec';
 import { cloneDeep } from 'lodash-es';
 import {
+  type DataMask,
   QueryMode,
   TimeGranularity,
   SMART_DATE_ID,
@@ -1844,7 +1845,7 @@ describe('plugin-chart-table', () => {
       });
 
       test('clicking a temporal numeric-string cell emits numeric cross-filter values', () => {
-        const setDataMask = jest.fn();
+        const setDataMask = jest.fn<void, [DataMask]>();
         const timestamp = 1777248000000;
         const props = transformProps({
           ...testData.basic,
@@ -1879,10 +1880,10 @@ describe('plugin-chart-table', () => {
         fireEvent.click(screen.getByText(String(timestamp)));
 
         const crossFilterCall = setDataMask.mock.calls.find(
-          (call: any[]) => call[0]?.filterState?.filters,
+          call => call[0].filterState?.filters,
         );
         expect(crossFilterCall).toBeDefined();
-        expect(crossFilterCall![0].extraFormData.filters).toEqual([
+        expect(crossFilterCall?.[0].extraFormData?.filters).toEqual([
           {
             col: 'install_date',
             op: 'IN',

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3683,6 +3683,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     target_native_type=col_type,
                     is_list_target=is_list_target,
                     db_engine_spec=db_engine_spec,
+                    db_extra=self.db_extra,
                 )
 
                 # Get ADVANCED_DATA_TYPES from config when needed

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2659,7 +2659,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
             if isinstance(value, (float, int)) and not isinstance(value, bool):
                 epoch_ms: float = value
-            elif isinstance(value, str) and re.fullmatch(r"\d+", value):
+            elif isinstance(value, str) and re.fullmatch(r"[+-]?\d+", value):
                 epoch_ms = int(value)
             else:
                 return value

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2637,7 +2637,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         if values is None:
             return None
 
-        temporal_comparison_operators = {
+        temporal_comparison_operators: set[utils.FilterOperator] = {
             utils.FilterOperator.EQUALS,
             utils.FilterOperator.NOT_EQUALS,
             utils.FilterOperator.IN,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2657,27 +2657,18 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             ):
                 return value
 
-            dttm: datetime | None = None
             if isinstance(value, (float, int)) and not isinstance(value, bool):
-                try:
-                    dttm = datetime.utcfromtimestamp(value / 1000)
-                except (OverflowError, OSError, ValueError):
-                    return value
-            elif isinstance(value, str):
-                if re.fullmatch(r"[+-]?\d+(?:\.\d+)?", value):
-                    try:
-                        dttm = datetime.utcfromtimestamp(float(value) / 1000)
-                    except (OverflowError, OSError, ValueError):
-                        return value
-                else:
-                    try:
-                        dttm = dateutil.parser.parse(value)
-                    except (dateutil.parser.ParserError, OverflowError, ValueError):
-                        return value
-                    if dttm.tzinfo is not None:
-                        dttm = dttm.astimezone(pytz.utc).replace(tzinfo=None)
+                epoch_ms: float = value
+            elif isinstance(value, str) and re.fullmatch(r"\d+", value):
+                epoch_ms = int(value)
+            else:
+                return value
 
-            if dttm is None:
+            try:
+                dttm = datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc).replace(
+                    tzinfo=None
+                )
+            except (OverflowError, OSError, ValueError):
                 return value
 
             temporal_sql = db_engine_spec.convert_dttm(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2637,21 +2637,59 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         if values is None:
             return None
 
+        temporal_comparison_operators = {
+            utils.FilterOperator.EQUALS,
+            utils.FilterOperator.NOT_EQUALS,
+            utils.FilterOperator.IN,
+            utils.FilterOperator.NOT_IN,
+            utils.FilterOperator.GREATER_THAN,
+            utils.FilterOperator.LESS_THAN,
+            utils.FilterOperator.GREATER_THAN_OR_EQUALS,
+            utils.FilterOperator.LESS_THAN_OR_EQUALS,
+        }
+
+        def handle_temporal_value(value: FilterValue) -> FilterValue | ColumnElement:
+            if (
+                operator not in temporal_comparison_operators
+                or target_generic_type != utils.GenericDataType.TEMPORAL
+                or target_native_type is None
+                or db_engine_spec is None
+            ):
+                return value
+
+            dttm: datetime | None = None
+            if isinstance(value, (float, int)) and not isinstance(value, bool):
+                try:
+                    dttm = datetime.utcfromtimestamp(value / 1000)
+                except (OverflowError, OSError, ValueError):
+                    return value
+            elif isinstance(value, str):
+                if re.fullmatch(r"[+-]?\d+(?:\.\d+)?", value):
+                    try:
+                        dttm = datetime.utcfromtimestamp(float(value) / 1000)
+                    except (OverflowError, OSError, ValueError):
+                        return value
+                else:
+                    try:
+                        dttm = dateutil.parser.parse(value)
+                    except (dateutil.parser.ParserError, OverflowError, ValueError):
+                        return value
+                    if dttm.tzinfo is not None:
+                        dttm = dttm.astimezone(pytz.utc).replace(tzinfo=None)
+
+            if dttm is None:
+                return value
+
+            temporal_sql = db_engine_spec.convert_dttm(
+                target_type=target_native_type,
+                dttm=dttm,
+                db_extra=db_extra,
+            )
+            return literal_column(temporal_sql) if temporal_sql is not None else value
+
         def handle_single_value(value: Optional[FilterValue]) -> Optional[FilterValue]:
             if operator == utils.FilterOperator.TEMPORAL_RANGE:
                 return value
-            if (
-                isinstance(value, (float, int))
-                and target_generic_type == utils.GenericDataType.TEMPORAL
-                and target_native_type is not None
-                and db_engine_spec is not None
-            ):
-                value = db_engine_spec.convert_dttm(
-                    target_type=target_native_type,
-                    dttm=datetime.utcfromtimestamp(value / 1000),
-                    db_extra=db_extra,
-                )
-                value = literal_column(value)
             if isinstance(value, str):
                 value = value.strip("\t\n")
 
@@ -2672,6 +2710,9 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     return None
                 if value == EMPTY_STRING:
                     return ""
+                value = handle_temporal_value(value)
+            elif value is not None:
+                value = handle_temporal_value(value)
             if target_generic_type == utils.GenericDataType.BOOLEAN:
                 return utils.cast_to_boolean(value)
             return value

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3432,6 +3432,22 @@ def test_temporal_epoch_string_filter_is_coerced_for_bigquery() -> None:
     assert str(value) == "CAST('2026-05-13' AS DATE)"
 
 
+def test_temporal_negative_epoch_string_filter_is_coerced_for_bigquery() -> None:
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = ExploreMixin.filter_values_handler(
+        values="-1778630400000",
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DATE",
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert isinstance(value, ColumnElement)
+    assert str(value) == "CAST('1913-08-22' AS DATE)"
+
+
 @pytest.mark.parametrize(
     "operator",
     [FilterOperator.IN, FilterOperator.NOT_IN],

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3448,6 +3448,57 @@ def test_temporal_negative_epoch_string_filter_is_coerced_for_bigquery() -> None
     assert str(value) == "CAST('1913-08-22' AS DATE)"
 
 
+@pytest.mark.parametrize("value", [1778630400000, 1778630400000.0])
+def test_temporal_numeric_filter_is_coerced_for_bigquery(
+    value: int | float,
+) -> None:
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    result = ExploreMixin.filter_values_handler(
+        values=value,
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DATE",
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert isinstance(result, ColumnElement)
+    assert str(result) == "CAST('2026-05-13' AS DATE)"
+
+
+def test_temporal_overflow_epoch_filter_is_not_coerced() -> None:
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = "999999999999999999999999999999999999999"
+
+    result = ExploreMixin.filter_values_handler(
+        values=value,
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DATE",
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert result == value
+
+
+def test_temporal_epoch_filter_is_not_coerced_without_engine_literal() -> None:
+    from superset.db_engine_specs.base import BaseEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    result = ExploreMixin.filter_values_handler(
+        values="1778630400000",
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="UNKNOWN_TYPE",
+        db_engine_spec=BaseEngineSpec,
+    )
+
+    assert result == "1778630400000"
+
+
 @pytest.mark.parametrize(
     "operator",
     [FilterOperator.IN, FilterOperator.NOT_IN],

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3659,7 +3659,7 @@ def test_temporal_epoch_string_filter_is_coerced_for_datetime_bigquery(
 
 
 def test_temporal_non_numeric_string_filter_is_not_coerced() -> None:
-    """Only digit strings (JS epoch ms) are coerced — anything else passes through."""
+    """Non-integer temporal strings pass through without epoch coercion."""
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
     from superset.models.helpers import ExploreMixin
 

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -3461,22 +3461,6 @@ def test_temporal_epoch_string_filter_list_is_coerced_for_bigquery(
     assert str(values[0]) == "CAST('2026-04-27' AS DATE)"
 
 
-def test_temporal_iso_string_filter_is_coerced_for_clickhouse() -> None:
-    from superset.db_engine_specs.clickhouse import ClickHouseEngineSpec
-    from superset.models.helpers import ExploreMixin
-
-    value = ExploreMixin.filter_values_handler(
-        values="2025-12-20T00:00:00.000Z",
-        operator=FilterOperator.EQUALS,
-        target_generic_type=GenericDataType.TEMPORAL,
-        target_native_type="DateTime",
-        db_engine_spec=ClickHouseEngineSpec,
-    )
-
-    assert isinstance(value, ColumnElement)
-    assert str(value) == "toDateTime('2025-12-20 00:00:00')"
-
-
 def test_temporal_epoch_string_filter_list_is_coerced_for_clickhouse() -> None:
     from superset.db_engine_specs.clickhouse import ClickHouseEngineSpec
     from superset.models.helpers import ExploreMixin
@@ -3572,3 +3556,52 @@ def test_temporal_range_filter_value_is_not_coerced() -> None:
     )
 
     assert value == "No filter"
+
+
+@pytest.mark.parametrize(
+    "target_type,expected",
+    [
+        (
+            "DATETIME",
+            "CAST('2026-05-13T14:30:00.123000' AS DATETIME)",
+        ),
+        (
+            "TIMESTAMP",
+            "CAST('2026-05-13T14:30:00.123000' AS TIMESTAMP)",
+        ),
+    ],
+)
+def test_temporal_epoch_string_filter_is_coerced_for_datetime_bigquery(
+    target_type: str,
+    expected: str,
+) -> None:
+    """Sub-second epoch precision survives DATETIME / TIMESTAMP coercion."""
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = ExploreMixin.filter_values_handler(
+        values="1778682600123",
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type=target_type,
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert isinstance(value, ColumnElement)
+    assert str(value) == expected
+
+
+def test_temporal_non_numeric_string_filter_is_not_coerced() -> None:
+    """Only digit strings (JS epoch ms) are coerced — anything else passes through."""
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = ExploreMixin.filter_values_handler(
+        values="2025-12-20",
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DATE",
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert value == "2025-12-20"

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -32,7 +32,7 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.elements import ColumnElement
 
 from superset.superset_typing import AdhocColumn, AdhocMetric, OrderBy
-from superset.utils.core import GenericDataType
+from superset.utils.core import FilterOperator, GenericDataType
 from tests.unit_tests.conftest import with_feature_flags
 
 if TYPE_CHECKING:
@@ -3410,3 +3410,165 @@ def test_get_sqla_query_dotted_struct_column_bigquery(
     # ```forecasts.original`.`total_cost``` (the regression), so this negative
     # assertion catches the actual failure mode, not just an exact-string match.
     assert "`forecasts.original`" not in sql
+
+
+def test_temporal_epoch_string_filter_is_coerced_for_bigquery() -> None:
+    """
+    Drill-to-detail can send JavaScript timestamp strings for temporal values.
+    BigQuery DATE filters must receive a DATE literal instead of the raw string.
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = ExploreMixin.filter_values_handler(
+        values="1778630400000",
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DATE",
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert isinstance(value, ColumnElement)
+    assert str(value) == "CAST('2026-05-13' AS DATE)"
+
+
+@pytest.mark.parametrize(
+    "operator",
+    [FilterOperator.IN, FilterOperator.NOT_IN],
+)
+def test_temporal_epoch_string_filter_list_is_coerced_for_bigquery(
+    operator: FilterOperator,
+) -> None:
+    """
+    Cross-filtering can send JavaScript timestamp strings inside IN lists.
+    BigQuery DATE filters must receive DATE literals instead of raw strings.
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    values = ExploreMixin.filter_values_handler(
+        values=["1777248000000"],
+        operator=operator,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DATE",
+        is_list_target=True,
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert isinstance(values, list)
+    assert len(values) == 1
+    assert isinstance(values[0], ColumnElement)
+    assert str(values[0]) == "CAST('2026-04-27' AS DATE)"
+
+
+def test_temporal_iso_string_filter_is_coerced_for_clickhouse() -> None:
+    from superset.db_engine_specs.clickhouse import ClickHouseEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = ExploreMixin.filter_values_handler(
+        values="2025-12-20T00:00:00.000Z",
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DateTime",
+        db_engine_spec=ClickHouseEngineSpec,
+    )
+
+    assert isinstance(value, ColumnElement)
+    assert str(value) == "toDateTime('2025-12-20 00:00:00')"
+
+
+def test_temporal_epoch_string_filter_list_is_coerced_for_clickhouse() -> None:
+    from superset.db_engine_specs.clickhouse import ClickHouseEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    values = ExploreMixin.filter_values_handler(
+        values=["1777248000000"],
+        operator=FilterOperator.IN,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="Date",
+        is_list_target=True,
+        db_engine_spec=ClickHouseEngineSpec,
+    )
+
+    assert isinstance(values, list)
+    assert len(values) == 1
+    assert isinstance(values[0], ColumnElement)
+    assert str(values[0]) == "toDate('2026-04-27')"
+
+
+@pytest.mark.parametrize(
+    "target_type,expected",
+    [
+        ("DATE", "TO_DATE('2026-05-13', 'YYYY-MM-DD')"),
+        (
+            "TIMESTAMP",
+            "TO_TIMESTAMP('2026-05-13 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')",
+        ),
+    ],
+)
+def test_temporal_epoch_string_filter_is_coerced_for_postgres(
+    target_type: str,
+    expected: str,
+) -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = ExploreMixin.filter_values_handler(
+        values="1778630400000",
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type=target_type,
+        db_engine_spec=PostgresEngineSpec,
+    )
+
+    assert isinstance(value, ColumnElement)
+    assert str(value) == expected
+
+
+def test_temporal_epoch_string_filter_list_is_coerced_for_postgres() -> None:
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    values = ExploreMixin.filter_values_handler(
+        values=["1777248000000"],
+        operator=FilterOperator.IN,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DATE",
+        is_list_target=True,
+        db_engine_spec=PostgresEngineSpec,
+    )
+
+    assert isinstance(values, list)
+    assert len(values) == 1
+    assert isinstance(values[0], ColumnElement)
+    assert str(values[0]) == "TO_DATE('2026-04-27', 'YYYY-MM-DD')"
+
+
+def test_non_temporal_numeric_string_filter_is_not_coerced() -> None:
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = ExploreMixin.filter_values_handler(
+        values="1778630400000",
+        operator=FilterOperator.EQUALS,
+        target_generic_type=GenericDataType.STRING,
+        target_native_type="DATE",
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert value == "1778630400000"
+
+
+def test_temporal_range_filter_value_is_not_coerced() -> None:
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+    from superset.models.helpers import ExploreMixin
+
+    value = ExploreMixin.filter_values_handler(
+        values="No filter",
+        operator=FilterOperator.TEMPORAL_RANGE,
+        target_generic_type=GenericDataType.TEMPORAL,
+        target_native_type="DATE",
+        db_engine_spec=BigQueryEngineSpec,
+    )
+
+    assert value == "No filter"


### PR DESCRIPTION
### SUMMARY
Fixes temporal drill-to-detail and cross-filter requests that send epoch-millisecond values for temporal columns.

Pivot and table interactions can emit filters such as `date_column == "1778630400000"` or `date_column IN ["1777248000000"]`. 
For BigQuery and ClickHouse-backed datasets, those values can compile as raw string literals against temporal columns and fail at query time. 
This change coerces temporal scalar and IN-list filter values through the active engine spec before SQL compilation, and normalizes pivot/table interaction output so temporal epoch values are emitted as numbers where possible.

Fixes #36776
Fixes #40167

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable. This change does not alter the rendered UI.

### TESTING INSTRUCTIONS
- `pytest tests/unit_tests/models/helpers_test.py -q`
- `SKIP=prettier-frontend,helm-docs pre-commit run --files $(git diff --name-only origin/master...HEAD)`
- Verify a dashboard cross-filter on a temporal table or pivot header sends a successful chart-data request when the filter contains an epoch-millisecond value.
- Verify a drill-to-detail request for a BigQuery or ClickHouse-backed temporal column compiles the filter as an engine-specific temporal literal instead of a raw epoch string.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #36776, #40167
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
