### PR TITLE
fix(treemap): remove gaps between chart nodes

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/constants.ts
@@ -21,8 +21,8 @@ import { TreePathInfo } from '../types';
 
 export const COLOR_SATURATION = [0.7, 0.4];
 export const LABEL_FONTSIZE = 11;
-export const BORDER_WIDTH = 2;
-export const GAP_WIDTH = 2;
+export const BORDER_WIDTH = 0;
+export const GAP_WIDTH = 0;
 
 export const extractTreePathInfo = (
   treePathInfo: TreePathInfo[] | undefined,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -214,7 +214,8 @@ export default function transformProps(
               colorAlpha: OpacityEnum.SemiTransparent,
               color: theme.colorText,
               borderColor: theme.colorBgBase,
-              borderWidth: 2,
+              borderWidth: BORDER_WIDTH,
+              gapWidth: GAP_WIDTH,
             },
             label: {
               ...labelProps,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
@@ -18,6 +18,7 @@
  */
 import { ChartProps } from '@superset-ui/core';
 import { supersetTheme } from '@apache-superset/core/theme';
+import { OpacityEnum } from '../../src/constants';
 import { EchartsTreemapChartProps } from '../../src/Treemap/types';
 import transformProps from '../../src/Treemap/transformProps';
 
@@ -75,24 +76,35 @@ describe('Treemap transformProps', () => {
     );
   });
 
-  test('should not render gaps between treemap nodes', () => {
-    expect(transformProps(chartProps as EchartsTreemapChartProps)).toEqual(
+  test('should not render gaps between treemap nodes when filtered', () => {
+    const filteredChartProps = new ChartProps({
+      ...chartProps,
+      filterState: { selectedValues: ['Sylvester,bar1'] },
+    });
+
+    expect(
+      transformProps(filteredChartProps as EchartsTreemapChartProps),
+    ).toEqual(
       expect.objectContaining({
         echartOptions: expect.objectContaining({
           series: [
             expect.objectContaining({
               data: expect.arrayContaining([
                 expect.objectContaining({
-                  itemStyle: expect.objectContaining({
-                    borderWidth: 0,
-                    gapWidth: 0,
-                  }),
                   children: expect.arrayContaining([
                     expect.objectContaining({
-                      itemStyle: expect.objectContaining({
-                        borderWidth: 0,
-                        gapWidth: 0,
-                      }),
+                      name: 'Arnold',
+                      children: expect.arrayContaining([
+                        expect.objectContaining({
+                          name: 'bar2',
+                          itemStyle: expect.objectContaining({
+                            borderWidth: 0,
+                            gapWidth: 0,
+                            colorAlpha: OpacityEnum.SemiTransparent,
+                          }),
+                          label: expect.objectContaining({}),
+                        }),
+                      ]),
                     }),
                   ]),
                 }),

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
@@ -74,4 +74,33 @@ describe('Treemap transformProps', () => {
       }),
     );
   });
+
+  test('should not render gaps between treemap nodes', () => {
+    expect(transformProps(chartProps as EchartsTreemapChartProps)).toEqual(
+      expect.objectContaining({
+        echartOptions: expect.objectContaining({
+          series: [
+            expect.objectContaining({
+              data: expect.arrayContaining([
+                expect.objectContaining({
+                  itemStyle: expect.objectContaining({
+                    borderWidth: 0,
+                    gapWidth: 0,
+                  }),
+                  children: expect.arrayContaining([
+                    expect.objectContaining({
+                      itemStyle: expect.objectContaining({
+                        borderWidth: 0,
+                        gapWidth: 0,
+                      }),
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          ],
+        }),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Remove Treemap node border/gap spacing so tiles render flush again
- Add a transformProps regression test covering the root and child node item styles

## Before and after screenshots

Before: treemap nodes showed visible seams from border and gap spacing.

![Before: treemap nodes with visible gaps](https://gist.githubusercontent.com/ya-nsh/2d744010b85157cb192e9b2385b101c8/raw/e26520dcaa6f04ef0f7d5b80c2ff4cf0c40da7ab/treemap-before-gaps.svg)

After: tiles render flush with zero border and gap spacing, including the filtered-node path covered by the regression test.

![After: treemap nodes rendered flush](https://gist.githubusercontent.com/ya-nsh/2d744010b85157cb192e9b2385b101c8/raw/803c5e148aca53e663866d02c98c87fc7b753cbf/treemap-after-flush.svg)

## Testing
- `npm run test -- plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts`
- `npm run lint -- plugins/plugin-chart-echarts/src/Treemap/constants.ts plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts`
- `uvx pre-commit run --files superset-frontend/plugins/plugin-chart-echarts/src/Treemap/constants.ts superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts`

Partial fix for #36807: this addresses the visible gap between Treemap nodes. The sequential color behavior described in the issue appears to be separate and is left unchanged here to keep this PR focused.

