### PR TITLE
perf(csv): avoid regex in CSV value escaping

### DIFF
--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -29,6 +29,15 @@ logger = logging.getLogger(__name__)
 PROBLEMATIC_CSV_PREFIXES = "-@+|=%"
 
 
+def _starts_with_formula_prefix(value: str) -> bool:
+    first = value[0]
+    if first in PROBLEMATIC_CSV_PREFIXES:
+        return True
+    if first == '"' and len(value) > 2:
+        return value[1] == '"' and value[2] in PROBLEMATIC_CSV_PREFIXES
+    return False
+
+
 def _starts_like_spreadsheet_formula(value: str) -> bool:
     # A leading tab or carriage return is treated as dangerous on its own
     # because some spreadsheet software trims that leading whitespace and
@@ -36,14 +45,10 @@ def _starts_like_spreadsheet_formula(value: str) -> bool:
     first = value[0]
     if first in ("\t", "\r"):
         return True
-    if first in PROBLEMATIC_CSV_PREFIXES:
-        return True
-    if first == '"' and len(value) > 2:
-        return value[1] == '"' and value[2] in PROBLEMATIC_CSV_PREFIXES
     if first.isspace():
         stripped = value.lstrip()
-        return bool(stripped) and stripped[0] in PROBLEMATIC_CSV_PREFIXES
-    return False
+        return bool(stripped) and _starts_with_formula_prefix(stripped)
+    return _starts_with_formula_prefix(value)
 
 
 def _is_negative_number(value: str) -> bool:

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-import re
 import urllib.request
 from typing import Any, Optional, Union
 from urllib.error import URLError
@@ -27,18 +26,32 @@ from superset.utils.core import GenericDataType
 
 logger = logging.getLogger(__name__)
 
-negative_number_re = re.compile(r"^-[0-9.]+$")
+PROBLEMATIC_CSV_PREFIXES = "-@+|=%"
 
-# This regex will match if the string starts with:
-#
-#     1. one of -, @, +, |, =, %, a tab, or a carriage return
-#     2. two double quotes immediately followed by one of -, @, +, |, =, %
-#     3. one or more spaces immediately followed by one of -, @, +, |, =, %
-#
-# A leading tab or carriage return is treated as dangerous on its own because
-# some spreadsheet software trims that leading whitespace and then evaluates
-# the remaining cell content as a formula.
-problematic_chars_re = re.compile(r'^(?:"{2}|\s{1,})(?=[\-@+|=%])|^[\-@+|=%\t\r]')
+
+def _starts_like_spreadsheet_formula(value: str) -> bool:
+    # A leading tab or carriage return is treated as dangerous on its own
+    # because some spreadsheet software trims that leading whitespace and
+    # then evaluates the remaining cell content as a formula.
+    first = value[0]
+    if first in ("\t", "\r"):
+        return True
+    if first in PROBLEMATIC_CSV_PREFIXES:
+        return True
+    if first == '"' and len(value) > 2:
+        return value[1] == '"' and value[2] in PROBLEMATIC_CSV_PREFIXES
+    if first.isspace():
+        stripped = value.lstrip()
+        return bool(stripped) and stripped[0] in PROBLEMATIC_CSV_PREFIXES
+    return False
+
+
+def _is_negative_number(value: str) -> bool:
+    return (
+        len(value) > 1
+        and value[0] == "-"
+        and all("0" <= character <= "9" or character == "." for character in value[1:])
+    )
 
 
 def escape_value(value: str) -> str:
@@ -47,10 +60,10 @@ def escape_value(value: str) -> str:
 
     http://georgemauer.net/2017/10/07/csv-injection.html
     """
-    needs_escaping = problematic_chars_re.match(value) is not None
-    is_negative_number = negative_number_re.match(value) is not None
+    if not value:
+        return value
 
-    if needs_escaping and not is_negative_number:
+    if _starts_like_spreadsheet_formula(value) and not _is_negative_number(value):
         # Escape pipe to be extra safe as this
         # can lead to remote code execution
         value = value.replace("|", "\\|")

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -26,7 +26,7 @@ from superset.utils.core import GenericDataType
 
 logger = logging.getLogger(__name__)
 
-PROBLEMATIC_CSV_PREFIXES = "-@+|=%"
+PROBLEMATIC_CSV_PREFIXES: str = "-@+|=%"
 
 
 def _starts_with_formula_prefix(value: str) -> bool:

--- a/tests/unit_tests/utils/csv_tests.py
+++ b/tests/unit_tests/utils/csv_tests.py
@@ -67,6 +67,9 @@ def test_escape_value():
     result = csv.escape_value(" =10+2")
     assert result == "' =10+2"
 
+    result = csv.escape_value('  ""=10+2')
+    assert result == '\'  ""=10+2'
+
     # A leading tab or carriage return followed by a dangerous char was already
     # handled by \s{1,} in the pre-existing regex. The cases below test the
     # new behavior: tab/CR alone (not followed by a dangerous char) are now


### PR DESCRIPTION
### SUMMARY
Avoid running two regular expressions for every CSV cell passed through `escape_value()`. The CSV export path can call this for every object-valued cell and header, so replacing the regex checks with direct prefix checks keeps the existing CSV injection behavior while reducing per-cell overhead.

The implementation preserves the currently tested cases for formula prefixes, doubled-quote prefixes, leading whitespace, pipe escaping, and negative numeric values. It also handles whitespace-prefixed doubled-quote formulas such as `  ""=10+2`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable.

### TESTING INSTRUCTIONS
Ran locally:

```bash
python3 -m py_compile superset/utils/csv.py tests/unit_tests/utils/csv_tests.py
git diff --check
```

Also ran a local microbenchmark comparing the previous regex logic with this implementation over mixed dashboard/CSV export values:

```text
old:     per_call_us min/med/max=2.006/2.746/4.318
patched: per_call_us min/med/max=1.617/2.015/2.696
patched_speedup_vs_old=1.36x
```

`python3 -m pytest tests/unit_tests/utils/csv_tests.py -q` was not runnable in this local checkout because `pytest` is not installed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
