### PR TITLE
test(api): regression test for Admin empty dashboard/chart list (#25890)

### DIFF
--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -760,6 +760,54 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             db.session.delete(dashboard)
             db.session.commit()
 
+    def test_get_dashboards_admin_sees_existing_dashboards(self):
+        """Regression for #25890: GET /api/v1/dashboard/ as an Admin user should
+        return existing dashboards, not an empty list. The original report
+        showed an Admin getting {"count": 0, "ids": []} despite dashboards
+        existing in the database."""
+        admin = self.get_user("admin")
+        dashboard = self.insert_dashboard(
+            "regression_25890_dashboard", "regression-25890", [admin.id]
+        )
+        try:
+            self.login(ADMIN_USERNAME)
+            rv = self.client.get("api/v1/dashboard/")
+            assert rv.status_code == 200
+            data = json.loads(rv.data.decode("utf-8"))
+            assert data["count"] >= 1, (
+                f"Admin received empty dashboard list despite "
+                f"{dashboard.dashboard_title!r} existing; see issue #25890"
+            )
+            titles = [d["dashboard_title"] for d in data["result"]]
+            assert dashboard.dashboard_title in titles, (
+                f"Admin list missing the inserted dashboard. Got titles: {titles}"
+            )
+        finally:
+            db.session.delete(dashboard)
+            db.session.commit()
+
+    def test_get_charts_admin_sees_existing_charts(self):
+        """Regression for #25890: GET /api/v1/chart/ as an Admin user should
+        return existing charts, not an empty list."""
+        admin = self.get_user("admin")
+        chart = self.insert_chart("regression_25890_chart", [admin.id], 1, params="{}")
+        try:
+            self.login(ADMIN_USERNAME)
+            rv = self.client.get("api/v1/chart/")
+            assert rv.status_code == 200
+            data = json.loads(rv.data.decode("utf-8"))
+            assert data["count"] >= 1, (
+                f"Admin received empty chart list despite "
+                f"{chart.slice_name!r} existing; see issue #25890"
+            )
+            names = [c["slice_name"] for c in data["result"]]
+            assert chart.slice_name in names, (
+                f"Admin list missing the inserted chart. Got slice_names: {names}"
+            )
+        finally:
+            db.session.delete(chart)
+            db.session.commit()
+
     def test_get_dashboards_filter(self):
         """
         Dashboard API: Test get dashboards filter


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #25890.

#25890 (filed 2023-11) reports that `GET /api/v1/dashboard/` and `GET /api/v1/chart/` return `{\"count\": 0, \"ids\": []}` when called by an Admin-role user, even when dashboards/charts exist in the database.

This PR adds two regression tests on the list endpoints:

1. **`test_get_dashboards_admin_sees_existing_dashboards`** — inserts a dashboard, logs in as admin, asserts the response `count >= 1` and the inserted title appears.
2. **`test_get_charts_admin_sees_existing_charts`** — same pattern for `api/v1/chart/`.

### How to interpret CI

- **CI green** → Admin RBAC on these endpoints is correct; merging closes #25890 and locks in the regression guard.
- **CI red** → bug is still live. Likely fix region: base filter / `BaseFilter` chain in `superset/dashboards/filters.py` and `superset/charts/filters.py`, or the `RoleModelView` permission grants for Admin.

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/integration_tests/dashboards/api_tests.py::TestDashboardApi::test_get_dashboards_admin_sees_existing_dashboards -v
pytest tests/integration_tests/dashboards/api_tests.py::TestDashboardApi::test_get_charts_admin_sees_existing_charts -v
\`\`\`

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #25890
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)