### PR TITLE
fix(dashboard): sort Dynamic Group By display values alphabetically

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -49,6 +49,10 @@ Two opt-in static gates control which extensions are allowed to load:
 
 Both default to empty (no behavior change). They apply to both the `LOCAL_EXTENSIONS` and `EXTENSIONS_PATH` load paths.
 
+### Dynamic Group By respects the sort toggle for display values
+
+The Dynamic Group By chart customization now orders its display values according to the "Sort display control values" toggle: ascending (A–Z), descending (Z–A), or the dataset's source order when the toggle is unset. Previously the dropdown always sorted alphabetically. Existing dashboards where the toggle was never set will show options in source order instead of A–Z; open the customization and enable the toggle to restore alphabetical ordering.
+
 ### Granular Export Controls
 
 A new feature flag `GRANULAR_EXPORT_CONTROLS` introduces three fine-grained permissions that replace the legacy `can_csv` permission:

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
@@ -102,7 +102,6 @@ export type ChartCustomization = {
   defaultDataMask: DataMask;
   controlValues: {
     sortAscending?: boolean;
-    sortMetric?: string;
     [key: string]: any;
   };
   description?: string;

--- a/superset-frontend/src/chartCustomizations/components/DynamicGroupBy/DynamicGroupByPlugin.test.tsx
+++ b/superset-frontend/src/chartCustomizations/components/DynamicGroupBy/DynamicGroupByPlugin.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ChartProps } from '@superset-ui/core';
+import { supersetTheme } from '@apache-superset/core/theme';
+import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import PluginFilterDynamicGroupBy from './DynamicGroupByPlugin';
+import transformProps from './transformProps';
+import { PluginFilterGroupByProps } from './types';
+
+const baseProps = {
+  width: 220,
+  height: 20,
+  hooks: {},
+  filterState: { value: [] },
+  queriesData: [
+    {
+      data: [
+        { column_name: 'banana' },
+        { column_name: 'apple' },
+        { column_name: 'cherry' },
+      ],
+    },
+  ],
+  formData: {
+    datasource: '1__table',
+    vizType: 'filter_groupby',
+    nativeFilterId: 'test-filter',
+    defaultValue: [],
+    inputRef: { current: null },
+  },
+};
+
+const renderPlugin = (sortAscending?: boolean) => {
+  const chartProps = new ChartProps({
+    ...baseProps,
+    formData: { ...baseProps.formData, sortAscending },
+    theme: supersetTheme,
+  });
+  return render(
+    <PluginFilterDynamicGroupBy
+      {...(transformProps(chartProps) as unknown as PluginFilterGroupByProps)}
+    />,
+  );
+};
+
+const getOpenedOptionOrder = async () => {
+  userEvent.click(screen.getAllByRole('combobox')[0]);
+  const options = await screen.findAllByRole('option');
+  return options.map(option => option.textContent);
+};
+
+test('sorts display control values A-Z when sortAscending is true', async () => {
+  renderPlugin(true);
+  expect(await getOpenedOptionOrder()).toEqual(['apple', 'banana', 'cherry']);
+});
+
+test('sorts display control values Z-A when sortAscending is false', async () => {
+  renderPlugin(false);
+  expect(await getOpenedOptionOrder()).toEqual(['cherry', 'banana', 'apple']);
+});
+
+test('preserves source order when sorting is disabled', async () => {
+  renderPlugin(undefined);
+  expect(await getOpenedOptionOrder()).toEqual(['banana', 'apple', 'cherry']);
+});

--- a/superset-frontend/src/chartCustomizations/components/DynamicGroupBy/DynamicGroupByPlugin.tsx
+++ b/superset-frontend/src/chartCustomizations/components/DynamicGroupBy/DynamicGroupByPlugin.tsx
@@ -18,13 +18,15 @@
  */
 import { t, tn } from '@apache-superset/core/translation';
 import { ensureIsArray, ExtraFormData } from '@superset-ui/core';
-import { useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import {
   FormItem,
   type FormItemProps,
+  LabeledValue,
   Select,
   type SelectValue,
 } from '@superset-ui/core/components';
+import { propertyComparator } from '@superset-ui/core/components/Select/utils';
 import { FilterPluginStyle, StatusMessage } from '../common';
 import { PluginFilterGroupByProps, ColumnOption, ColumnData } from './types';
 
@@ -116,6 +118,20 @@ export default function PluginFilterDynamicGroupBy(
     [data],
   );
 
+  const sortComparator = useCallback(
+    (a: LabeledValue, b: LabeledValue) => {
+      if (formData.sortAscending === undefined) {
+        return 0;
+      }
+      const labelComparator = propertyComparator('label');
+      if (formData.sortAscending) {
+        return labelComparator(a, b);
+      }
+      return labelComparator(b, a);
+    },
+    [formData.sortAscending],
+  );
+
   return (
     <FilterPluginStyle height={height} width={width}>
       <FormItem validateStatus={filterState.validateStatus} {...formItemData}>
@@ -132,6 +148,7 @@ export default function PluginFilterDynamicGroupBy(
             ref={inputRef}
             options={options}
             onOpenChange={setFilterActive}
+            sortComparator={sortComparator}
           />
         </div>
       </FormItem>

--- a/superset-frontend/src/chartCustomizations/components/DynamicGroupBy/types.ts
+++ b/superset-frontend/src/chartCustomizations/components/DynamicGroupBy/types.ts
@@ -76,7 +76,6 @@ export const DEFAULT_FORM_DATA: PluginFilterGroupByCustomizeProps = {
   dataset: null,
   column: null,
   sortFilter: false,
-  sortAscending: true,
   canSelectMultiple: true,
   defaultValue: null,
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { LabeledValue } from '@superset-ui/core/components';
+import { createLabelSortComparator } from './GroupByFilterCard';
+
+const apple: LabeledValue = { value: 'a', label: 'Apple' };
+const banana: LabeledValue = { value: 'b', label: 'Banana' };
+
+test('sorts display values A-Z when sortAscending is true', () => {
+  const compare = createLabelSortComparator(true);
+  expect(compare(apple, banana)).toBeLessThan(0);
+  expect(compare(banana, apple)).toBeGreaterThan(0);
+});
+
+test('sorts display values Z-A when sortAscending is false', () => {
+  const compare = createLabelSortComparator(false);
+  expect(compare(apple, banana)).toBeGreaterThan(0);
+  expect(compare(banana, apple)).toBeLessThan(0);
+});
+
+test('preserves source order when sortAscending is unset', () => {
+  const compare = createLabelSortComparator(undefined);
+  expect(compare(apple, banana)).toBe(0);
+  expect(compare(banana, apple)).toBe(0);
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -212,6 +212,18 @@ const DescriptionTooltip = ({ description }: { description: string }) => (
   </ToolTipContainer>
 );
 
+// Sort display values by label: ascending when sortAscending is true, descending
+// when false, and source order (no sort) when it is unset.
+export const createLabelSortComparator =
+  (sortAscending?: boolean) =>
+  (a: LabeledValue, b: LabeledValue): number => {
+    if (sortAscending === undefined) {
+      return 0;
+    }
+    const labelComparator = propertyComparator('label');
+    return sortAscending ? labelComparator(a, b) : labelComparator(b, a);
+  };
+
 const GroupByFilterCardContent: FC<{
   customizationItem: ChartCustomization;
   hidePopover: () => void;
@@ -333,14 +345,8 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
 
   const sortAscending = customizationItem.controlValues?.sortAscending;
 
-  const sortComparator = useCallback(
-    (a: LabeledValue, b: LabeledValue) => {
-      if (sortAscending === undefined) {
-        return 0;
-      }
-      const labelComparator = propertyComparator('label');
-      return sortAscending ? labelComparator(a, b) : labelComparator(b, a);
-    },
+  const sortComparator = useMemo(
+    () => createLabelSortComparator(sortAscending),
     [sortAscending],
   );
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -37,12 +37,14 @@ import {
 import {
   Typography,
   Select,
+  type LabeledValue,
   Popover,
   Loading,
   Icons,
   Tooltip,
   FormItem,
 } from '@superset-ui/core/components';
+import { propertyComparator } from '@superset-ui/core/components/Select/utils';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from 'src/dashboard/types';
 import { setPendingChartCustomization } from 'src/dashboard/actions/chartCustomizationActions';
@@ -329,6 +331,19 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
   const canSelectMultiple =
     customizationItem.controlValues?.canSelectMultiple ?? true;
 
+  const sortAscending = customizationItem.controlValues?.sortAscending;
+
+  const sortComparator = useCallback(
+    (a: LabeledValue, b: LabeledValue) => {
+      if (sortAscending === undefined) {
+        return 0;
+      }
+      const labelComparator = propertyComparator('label');
+      return sortAscending ? labelComparator(a, b) : labelComparator(b, a);
+    },
+    [sortAscending],
+  );
+
   const columnDisplayName = useMemo(() => {
     if (customizationItem.name) {
       return customizationItem.name;
@@ -581,6 +596,7 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
                   .toLowerCase()
                   .includes(input.toLowerCase())
               }
+              sortComparator={sortComparator}
               getPopupContainer={triggerNode => triggerNode.parentNode}
               oneLine={isHorizontalLayout}
               className="select-container"
@@ -610,6 +626,7 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
                 .toLowerCase()
                 .includes(input.toLowerCase())
             }
+            sortComparator={sortComparator}
             loading={loading}
           />
         </div>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -230,14 +230,6 @@ const GroupByFilterCardContent: FC<{
     return t('None');
   }, [dataset, datasetName]);
 
-  const aggregationDisplay = useMemo(() => {
-    const sortMetric = customizationItem.controlValues?.sortMetric;
-    if (sortMetric) {
-      return sortMetric.toUpperCase();
-    }
-    return t('None');
-  }, [customizationItem.controlValues?.sortMetric]);
-
   return (
     <div>
       <Row
@@ -270,11 +262,6 @@ const GroupByFilterCardContent: FC<{
         <RowValue>
           {typeof datasetLabel === 'string' ? datasetLabel : t('Dataset')}
         </RowValue>
-      </Row>
-
-      <Row>
-        <RowLabel>{t('Aggregation')}</RowLabel>
-        <RowValue>{aggregationDisplay}</RowValue>
       </Row>
     </div>
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -1418,7 +1418,7 @@ const FiltersConfigForm = (
                                           }}
                                         />
                                       </StyledRowFormItem>
-                                      {hasMetrics && (
+                                      {hasMetrics && !isChartCustomization && (
                                         <StyledRowSubFormItem
                                           expanded={expanded}
                                           name={[

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -287,7 +287,6 @@ function processGroupByCustomizations(
   >,
 ): {
   groupby?: string[];
-  order_by_cols?: string[];
   x_axis?: string;
   series?: string;
   columns?: string[];
@@ -332,7 +331,6 @@ function processGroupByCustomizations(
   const xAxisColumn = chart.form_data?.x_axis;
 
   const groupByColumns: string[] = [];
-  let orderByConfig: string[] | undefined;
   let heatmapColumnAdded = false;
 
   matchingCustomizations.forEach(item => {
@@ -380,12 +378,6 @@ function processGroupByCustomizations(
         }
       });
     }
-
-    const sortMetric = item.controlValues?.sortMetric;
-    const sortAscending = item.controlValues?.sortAscending;
-    if (sortMetric) {
-      orderByConfig = [JSON.stringify([sortMetric, !sortAscending])];
-    }
   });
 
   const groupByFormData = applyChartSpecificGroupBy(
@@ -394,10 +386,6 @@ function processGroupByCustomizations(
     existingGroupBy,
     xAxisColumn,
   );
-
-  if (orderByConfig) {
-    groupByFormData.order_by_cols = orderByConfig;
-  }
 
   return groupByFormData;
 }

--- a/superset-frontend/src/dashboard/util/migrateChartCustomization.test.ts
+++ b/superset-frontend/src/dashboard/util/migrateChartCustomization.test.ts
@@ -99,9 +99,9 @@ test('migrateChartCustomization handles basic legacy format', () => {
   expect(result.cascadeParentIds).toEqual([]);
   expect(result.controlValues).toEqual({
     sortAscending: true,
-    sortMetric: 'count',
     canSelectMultiple: true,
   });
+  expect(result.controlValues).not.toHaveProperty('sortMetric');
 });
 
 test('migrateChartCustomization handles dataset as string', () => {
@@ -301,11 +301,31 @@ test('migrateChartCustomization merges controlValues', () => {
 
   expect(result.controlValues).toEqual({
     sortAscending: false,
-    sortMetric: undefined,
     canSelectMultiple: undefined,
     enableEmptyFilter: true,
     customSetting: 'value',
   });
+  expect(result.controlValues).not.toHaveProperty('sortMetric');
+});
+
+test('migrateChartCustomization drops sortMetric nested in controlValues', () => {
+  const legacy = {
+    id: 'CUSTOMIZATION-1',
+    customization: {
+      name: 'Test',
+      dataset: 1,
+      column: 'country',
+      controlValues: {
+        sortMetric: 'count',
+        enableEmptyFilter: true,
+      },
+    },
+  };
+
+  const result = migrateChartCustomization(legacy);
+
+  expect(result.controlValues).not.toHaveProperty('sortMetric');
+  expect(result.controlValues.enableEmptyFilter).toBe(true);
 });
 
 test('migrateChartCustomization preserves removed flag', () => {

--- a/superset-frontend/src/dashboard/util/migrateChartCustomization.ts
+++ b/superset-frontend/src/dashboard/util/migrateChartCustomization.ts
@@ -78,12 +78,15 @@ export function migrateChartCustomization(
 
   const controlValues: ChartCustomization['controlValues'] = {
     sortAscending: customization.sortAscending,
-    sortMetric: customization.sortMetric,
     canSelectMultiple: customization.canSelectMultiple,
   };
 
   if (customization.controlValues) {
-    Object.assign(controlValues, customization.controlValues);
+    Object.entries(customization.controlValues).forEach(([key, value]) => {
+      if (key !== 'sortMetric') {
+        controlValues[key] = value;
+      }
+    });
   }
 
   let defaultDataMask = customization.defaultDataMask || {


### PR DESCRIPTION
### SUMMARY

The Dynamic Group By customization showed a "Sort display control values" option that exposed a **Sort Metric** dropdown. That setting only reordered the host chart's query (`order_by_cols`) and never affected the control's own option list — the displayed values were fetched unordered and never sorted, so the sort UI did nothing visible to the control.

This change:

- Hides the Sort Metric dropdown for chart customizations (it has no meaning for a list of column options).
- Sorts the control's option list by label, ascending or descending, based on the existing Sort ascending/descending toggle. The sort is applied inside `GroupByFilterCard` (the component `FilterControl` renders for `chart_customization_dynamic_groupby`, which bypasses the plugin render path). The same `propertyComparator('label')` + `sortComparator` pattern is also added to `DynamicGroupByPlugin` for parity with the Time Grain customization.
- Drops the `sortAscending: true` default so that, when sorting is not enabled, the source order is preserved (consistent with the Time Grain customization).

Result: enabling "Sort display control values" now sorts the displayed values A–Z / Z–A as expected, with no metric involved.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Customization config (Sort Metric dropdown removed):


Before:
![](https://files.catbox.moe/zmamzt.png)

After:
![](https://files.catbox.moe/fzycta.png)

Control dropdown with Sort descending enabled. Before, the toggle did nothing and values stayed A to Z. After, Z to A:

Before:
![](https://files.catbox.moe/avbru7.png)

After:
![](https://files.catbox.moe/zzukqe.png)

### TESTING INSTRUCTIONS

1. Add a Dynamic Group By customization to a chart on a dashboard, pointing at a column with several values.
2. Open the customization config and enable "Sort display control values".
3. Confirm there is no "Sort Metric" dropdown, only Sort ascending / Sort descending.
4. Open the control on the dashboard and confirm the options are sorted A–Z (ascending) and Z–A (descending), and that disabling the option restores the source order.

Unit tests: `superset-frontend/src/chartCustomizations/components/DynamicGroupBy/DynamicGroupByPlugin.test.tsx`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API
