### PR TITLE
test(datasets): regression test for Jinja not rendered on sync columns (#25839)

### DIFF
--- a/tests/unit_tests/connectors/sqla/utils_test.py
+++ b/tests/unit_tests/connectors/sqla/utils_test.py
@@ -137,3 +137,38 @@ def test_get_virtual_table_metadata_multiple(mocker: MockerFixture) -> None:
     with pytest.raises(SupersetSecurityException) as excinfo:
         get_virtual_table_metadata(dataset)
     assert str(excinfo.value) == "Only single queries supported"
+
+
+def test_get_virtual_table_metadata_renders_jinja(mocker: MockerFixture) -> None:
+    """Regression for #25839: Jinja templates in a virtual dataset's SQL must
+    be rendered via the template processor before SQL parsing. Otherwise the
+    raw Jinja tokens reach sqlglot and the parser rejects them as a syntax
+    error (the user-visible symptom is "Invalid SQL" when clicking
+    "SYNC COLUMNS FROM SOURCE" on a dataset that uses {{ from_dttm }} etc.).
+    """
+    mocker.patch(
+        "superset.connectors.sqla.utils.get_columns_description",
+        return_value=[{"name": "rendered_col", "type": "INTEGER"}],
+    )
+
+    raw_sql = "SELECT * FROM tbl WHERE ts > '{{ from_dttm }}'"
+    rendered_sql = "SELECT * FROM tbl WHERE ts > '2024-01-01 00:00:00'"
+
+    dataset = mocker.MagicMock(sql=raw_sql)
+    dataset.database.db_engine_spec.engine = "postgresql"
+    dataset.template_params_dict = {}
+    dataset.get_template_processor().process_template.return_value = rendered_sql
+
+    # If Jinja rendering is skipped, sqlglot tries to parse the raw {{ ... }}
+    # and raises SupersetGenericDBErrorException / SupersetParseError.
+    assert get_virtual_table_metadata(dataset) == [
+        {"name": "rendered_col", "type": "INTEGER"}
+    ]
+
+    # The template processor MUST have been called with the raw SQL (the
+    # whole point of the bug fix). A future regression that re-introduces
+    # the "Jinja not rendered" path would either skip this call or call it
+    # with the wrong input.
+    dataset.get_template_processor().process_template.assert_any_call(
+        raw_sql, **dataset.template_params_dict
+    )

--- a/tests/unit_tests/connectors/sqla/utils_test.py
+++ b/tests/unit_tests/connectors/sqla/utils_test.py
@@ -146,7 +146,7 @@ def test_get_virtual_table_metadata_renders_jinja(mocker: MockerFixture) -> None
     error (the user-visible symptom is "Invalid SQL" when clicking
     "SYNC COLUMNS FROM SOURCE" on a dataset that uses {{ from_dttm }} etc.).
     """
-    mocker.patch(
+    mock_get_columns_description = mocker.patch(
         "superset.connectors.sqla.utils.get_columns_description",
         return_value=[{"name": "rendered_col", "type": "INTEGER"}],
     )
@@ -171,4 +171,17 @@ def test_get_virtual_table_metadata_renders_jinja(mocker: MockerFixture) -> None
     # with the wrong input.
     dataset.get_template_processor().process_template.assert_any_call(
         raw_sql, **dataset.template_params_dict
+    )
+
+    # End-to-end guard: the rendered SQL must reach get_columns_description,
+    # not the raw Jinja string. A regression where rendering is used for
+    # parsing only and the raw SQL leaks downstream would pass the
+    # process_template assertion above but fail this one.
+    call_args = mock_get_columns_description.call_args
+    assert call_args is not None, "get_columns_description was never called"
+    passed_query = call_args.kwargs.get("query")
+    if passed_query is None and call_args.args:
+        passed_query = call_args.args[-1]
+    assert passed_query == rendered_sql, (
+        f"get_columns_description received unrendered SQL: {passed_query!r}"
     )


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #25839.

#25839 (filed 2023-11) reports that clicking *SYNC COLUMNS FROM SOURCE* on a virtual dataset containing Jinja (e.g. \`{{ from_dttm }}\`) produces an *Invalid SQL* error because Jinja is not rendered before the SQL parser sees it.

This PR adds one regression test on \`get_virtual_table_metadata\`:

1. **\`test_get_virtual_table_metadata_renders_jinja\`** — constructs a virtual dataset with \`'{{ from_dttm }}'\` in its SQL, mocks the template processor to return rendered SQL, calls \`get_virtual_table_metadata\`, and asserts that (a) no exception is raised, (b) the template processor was called with the raw Jinja SQL.

### How to interpret CI

- **CI green** → \`get_virtual_table_metadata\` correctly runs the template processor before SQL parsing; merging closes #25839 and locks in the regression guard.
- **CI red** → Jinja-rendering step is missing or out of order. Likely fix region: \`superset/connectors/sqla/utils.py::get_virtual_table_metadata\` lines 105–110.

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/unit_tests/connectors/sqla/utils_test.py::test_get_virtual_table_metadata_renders_jinja -v
\`\`\`

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #25839
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)