### PR TITLE
test(reports): regression for alerts CSV missing chart time filters (#25538)

### DIFF
--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -1478,3 +1478,46 @@ def test_success_state_report_sends_and_logs_success(
         ReportState.SUCCESS,
         error_message=None,
     )
+
+
+def test_get_url_for_csv_uses_post_processed_type(
+    app: SupersetApp,
+    mocker: MockerFixture,
+) -> None:
+    """Regression for #25538: when an alert/report generates a CSV for a
+    chart, the URL must request type=POST_PROCESSED so the chart's saved
+    filters (including time-range filters) are applied. The original report
+    described a chart with a "last 30 days" filter that returned only 14
+    rows in the UI, but the alert CSV came back with 219 rows (the entire
+    unfiltered table).
+
+    POST_PROCESSED is the marker that propagates the chart's query_context
+    -- including its time filter -- through to the CSV renderer. A
+    regression that switched to FULL or RAW would replicate the original
+    bug.
+    """
+    from datetime import datetime
+    from uuid import UUID
+
+    from superset.commands.report.execute import BaseReportState
+    from superset.common.chart_data import ChartDataResultFormat
+
+    app.config.update({"ALERT_REPORTS_EXECUTORS": {}})
+
+    report_schedule = create_report_schedule(mocker)
+    report_schedule.force_screenshot = False
+    report_schedule.chart_id = report_schedule.chart.id
+
+    state = BaseReportState(
+        report_schedule=report_schedule,
+        scheduled_dttm=datetime.now(),
+        execution_id=UUID("084e7ee6-5557-4ecd-9632-b7f39c9ec524"),
+    )
+
+    url = state._get_url(result_format=ChartDataResultFormat.CSV)
+
+    assert "format=csv" in url.lower(), f"expected csv format in URL: {url}"
+    assert "type=post_processed" in url.lower(), (
+        f"CSV report URL must use type=post_processed so chart filters "
+        f"(incl. time filters) are applied; got: {url}; see issue #25538"
+    )


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #25538.

#25538 (filed 2023-10) reports that after upgrading from Superset 2.1.0 to 3.0.0, a table chart with a *last 30 days* time filter sends a 14-row CSV in 2.1.0 but a 219-row CSV (the full unfiltered table) in 3.0.0 — even though the same chart in the UI and as an image still shows only the 14 filtered rows.

The mechanism that ensures the chart's saved query_context (including time filters) is applied to the CSV is the `type=POST_PROCESSED` flag on the `ChartDataRestApi.get_data` URL emitted by `BaseReportState._get_url`. A regression that emitted `type=FULL` or omitted `type` would re-introduce the original bug.

This PR adds one regression test:

1. **`test_get_url_for_csv_uses_post_processed_type`** — constructs a `BaseReportState` for a chart-based schedule, calls `_get_url(result_format=CSV)`, and asserts `format=csv` AND `type=post_processed` appear in the URL.

### How to interpret CI

- **CI green** → the CSV URL still uses POST_PROCESSED; merging closes #25538 and locks in the regression guard.
- **CI red** → the URL no longer carries POST_PROCESSED. Likely suspect: `superset/commands/report/execute.py::BaseReportState._get_url`.

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/unit_tests/commands/report/execute_test.py::test_get_url_for_csv_uses_post_processed_type -v
\`\`\`

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #25538
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)