### PR TITLE
test(helpers): regression for humanize locale activation (#28331)

### DIFF
--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -2650,3 +2650,56 @@ def test_filter_by_verbose_name_resolves_to_column(
     assert "WHERE" in sql, f"Expected WHERE clause, got SQL: {sql}"
     assert "country_code" in sql, f"Expected filter on 'country_code', got SQL: {sql}"
     assert "'US'" in sql, f"Expected filter value 'US', got SQL: {sql}"
+
+
+def test_format_time_humanized_activates_non_english_locale(
+    mocker: MockerFixture,
+) -> None:
+    """Regression for #28331: `_format_time_humanized` must call
+    `humanize.i18n.activate(locale)` before formatting when the user's locale
+    is not English. The original report described last-modified strings on
+    the chart editor header always rendering in English regardless of the
+    user's language setting.
+    """
+    from datetime import datetime, timedelta
+
+    from superset.models.helpers import AuditMixinNullable
+
+    mocker.patch(
+        "superset.models.helpers.get_locale",
+        return_value="es",  # Spanish
+    )
+    mock_activate = mocker.patch("superset.models.helpers.humanize.i18n.activate")
+    mock_deactivate = mocker.patch("superset.models.helpers.humanize.i18n.deactivate")
+
+    # Detached instance — we only need the method, not a session-bound row.
+    instance = AuditMixinNullable()
+    result = instance._format_time_humanized(datetime.now() - timedelta(hours=2))
+
+    mock_activate.assert_called_once_with("es")
+    mock_deactivate.assert_called_once()
+    assert isinstance(result, str), f"expected str, got {type(result).__name__}"
+    assert result, "_format_time_humanized returned empty string"
+
+
+def test_format_time_humanized_skips_activation_for_english(
+    mocker: MockerFixture,
+) -> None:
+    """Companion to the #28331 regression: for English, humanize already
+    defaults to English, so the i18n.activate call is intentionally skipped
+    as a perf optimization. This pins that fast-path so a future refactor
+    doesn't accidentally start calling activate('en') unconditionally."""
+    from datetime import datetime, timedelta
+
+    from superset.models.helpers import AuditMixinNullable
+
+    mocker.patch(
+        "superset.models.helpers.get_locale",
+        return_value="en",
+    )
+    mock_activate = mocker.patch("superset.models.helpers.humanize.i18n.activate")
+
+    instance = AuditMixinNullable()
+    instance._format_time_humanized(datetime.now() - timedelta(hours=2))
+
+    mock_activate.assert_not_called()


### PR DESCRIPTION
### SUMMARY

This is a **test-only PR** opened as a TDD-style validation of issue #28331.

#28331 (filed 2024-05) reports that backend `humanize`-formatted strings (e.g. the last-modified label on the chart editor header) always render in English, ignoring the user's locale setting. The relevant code path is `_format_time_humanized` in `superset/models/helpers.py:632-645`, which should call `humanize.i18n.activate(locale)` for non-English locales.

This PR adds two regression tests:

1. **`test_format_time_humanized_activates_non_english_locale`** — patches `get_locale` to return `"es"` and asserts that `humanize.i18n.activate("es")` is called and `deactivate` follows.
2. **`test_format_time_humanized_skips_activation_for_english`** — pins the English fast-path so a future refactor doesn't regress the perf shortcut.

### How to interpret CI

- **CI green** → locale activation is correctly wired; merging closes #28331 and locks in the regression guard.
- **CI red** → `_format_time_humanized` isn't honoring the locale. Likely region: `superset/models/helpers.py:632`.

### TESTING INSTRUCTIONS

\`\`\`bash
pytest tests/unit_tests/models/helpers_test.py::test_format_time_humanized_activates_non_english_locale -v
pytest tests/unit_tests/models/helpers_test.py::test_format_time_humanized_skips_activation_for_english -v
\`\`\`

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #28331
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)