### PR TITLE
ci(docs): soft-fail badge localization on transient fetch errors

### DIFF
--- a/docs/plugins/remark-localize-badges.mjs
+++ b/docs/plugins/remark-localize-badges.mjs
@@ -206,12 +206,26 @@ async function downloadBadge(url, staticDir) {
       badgeCache.set(url, webPath);
       return webPath;
     } catch (error) {
-      // Fail the build on badge download failure
-      throw new Error(
-        `[remark-localize-badges] Failed to download badge: ${url}\n` +
-          `Error: ${error.message}\n` +
-          `Build cannot continue with broken badges. Please fix the badge URL or remove it.`,
+      // Soft fallback: keep the original remote URL in the rendered output
+      // so the badge still appears for readers, and the docs build continues.
+      // External badge services (notably img.shields.io) rate-limit CI IPs
+      // aggressively, and a transient fetch failure shouldn't take the whole
+      // docs build down with it. Set REMARK_BADGES_STRICT=true to opt back
+      // into hard-fail-the-build behavior (e.g. for release builds where you
+      // want to catch genuinely broken badge URLs).
+      if (process.env.REMARK_BADGES_STRICT === 'true') {
+        throw new Error(
+          `[remark-localize-badges] Failed to download badge: ${url}\n` +
+            `Error: ${error.message}\n` +
+            `Build cannot continue with broken badges (REMARK_BADGES_STRICT=true).`,
+        );
+      }
+      console.warn(
+        `[remark-localize-badges] Could not localize ${url} ` +
+          `(${error.message}); falling back to remote URL.`,
       );
+      badgeCache.set(url, url);
+      return url;
     } finally {
       // Clean up the in-flight tracker
       inFlightDownloads.delete(url);


### PR DESCRIPTION
### SUMMARY

The **Docs Testing** workflow has been the single biggest CI flake source on master: **61 failures in the last 2 weeks**. Almost every one fails with the same signature:

```
Cause: [remark-localize-badges] Failed to download badge:
  https://img.shields.io/badge/slack-join-orange.svg
Error: fetch failed
Build cannot continue with broken badges. Please fix the badge URL or remove it.
```

[`remark-localize-badges`](https://github.com/apache/superset/blob/master/docs/plugins/remark-localize-badges.mjs) already retries 3× with backoff and a 30s timeout per attempt. When `img.shields.io` (or `codecov.io`, `badgen.net`, etc.) rate-limits the CI runner anyway — common from GitHub Actions IP ranges — the plugin throws and the entire docs build dies. The badge URL itself is fine; this is an external-service flake, not a real broken link.

This PR changes the terminal failure path to:

- **Log a warning** (`console.warn`) with the URL and the underlying error.
- **Fall back to the original remote URL** so the rendered docs still display the badge (just unlocalized for this build).
- **Keep going** — the docs build succeeds, and the next successful build re-localizes the badge.

Adds a `REMARK_BADGES_STRICT=true` env var as an opt-in for the old "fail-the-build" behavior, for release pipelines that want to catch genuinely broken badge URLs.

### BEFORE/AFTER

| | Before | After |
|---|---|---|
| Transient shields.io 429/timeout | Whole docs build fails | Build succeeds; badge served from `img.shields.io` directly |
| Genuinely broken badge URL | Hard fail (good) | Same with `REMARK_BADGES_STRICT=true` (opt-in) |
| Successful download | Local SVG cached + rewritten | Unchanged |
| Retry policy (3× with backoff, 30s timeout) | Unchanged | Unchanged |

### TESTING INSTRUCTIONS

Plugin smoke-loads correctly (`node -e "import('./plugins/remark-localize-badges.mjs')..."`). Full validation will happen via this PR's CI run of the `Docs Testing` job. To validate the opt-in:

```bash
cd docs && REMARK_BADGES_STRICT=true npm run build  # should keep current strict behavior
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)