### PR TITLE
docs: hide Component Playground top-level nav item

### DIFF
--- a/docs/versions-config.json
+++ b/docs/versions-config.json
@@ -70,7 +70,7 @@
     }
   },
   "components": {
-    "disabled": false,
+    "disabled": true,
     "lastVersion": "current",
     "includeCurrentVersion": true,
     "onlyIncludeVersions": [


### PR DESCRIPTION
### SUMMARY

Follow-up to #40126 (the 6.1.0 version-cut), which incidentally flipped `\"components\": { \"disabled\": true → false }` in `docs/versions-config.json`. That flag gates the top-level *Component Playground* navbar entry in `docs/docusaurus.config.ts:163`:

\`\`\`ts
if (!versionsConfig.components.disabled) {
  dynamicNavbarItems.push({
    label: 'Component Playground',
    to: '/components',
    ...
  });
}
\`\`\`

Flipping the flag back to `true` removes the navbar item. The 6.1.0 versioned components directory tree stays on disk and remains buildable — only the top-level navbar entry is suppressed.

### BEFORE/AFTER

Before: *Component Playground* appears as a top-level navbar item on the docs site.
After: navbar matches pre-#40126 layout.

### TESTING INSTRUCTIONS

\`\`\`bash
cd docs && npm run start
\`\`\`

Verify the *Component Playground* link no longer appears in the top navbar.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags
- [x] Changes UI (docs nav)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)