### PR TITLE
test: enable SQLAlchemy deprecation warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,5 +18,13 @@
 testpaths =
     tests
 python_files = *_test.py test_*.py *_tests.py *viz/utils.py
-addopts = -p no:warnings
+# `-p no:warnings` temporarily disabled in favor of more finely tuned `filterwarnings`.
+#addopts = -p no:warnings
 asyncio_mode = auto
+
+# `ignore` virtually reproduces to `-p no:warnings`.
+# Always print RemovedIn20Warning when SQLALCHEMY_WARN_20=1.
+# Additionally, raise errors for refactored RemovedIn20Warning cases to prevent regression.
+filterwarnings =
+    ignore
+    always::sqlalchemy.exc.RemovedIn20Warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,3 +28,20 @@ asyncio_mode = auto
 filterwarnings =
     ignore
     always::sqlalchemy.exc.RemovedIn20Warning
+#    error:Passing a string to Connection.execute\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
+#    error:"Query" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"SavedQuery" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"SqlaTable" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"SqlMetric" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"TableColumn" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"TaggedObject" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:The ``as_declarative\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
+#    error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning
+#    error:The connection.execute\(\) method:sqlalchemy.exc.RemovedIn20Warning
+#    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
+#    error:The `database` package is deprecated:sqlalchemy.exc.RemovedIn20Warning
+#    error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
+#    error:The Engine.execute\(\) method is considered legacy:sqlalchemy.exc.RemovedIn20Warning
+#    error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
+#    error:The "whens" argument to case:sqlalchemy.exc.RemovedIn20Warning
+#    error:"User" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,6 +25,8 @@ asyncio_mode = auto
 # `ignore` is equivalent to `-p no:warnings`.
 # Always print RemovedIn20Warning when SQLALCHEMY_WARN_20=1.
 # Additionally, raise errors for refactored RemovedIn20Warning cases to prevent regression.
+# Later rules override earlier ones — pytest docs:
+# https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 filterwarnings =
     ignore
     always::sqlalchemy.exc.RemovedIn20Warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,7 +22,7 @@ python_files = *_test.py test_*.py *_tests.py *viz/utils.py
 #addopts = -p no:warnings
 asyncio_mode = auto
 
-# `ignore` virtually reproduces to `-p no:warnings`.
+# `ignore` is equivalent to `-p no:warnings`.
 # Always print RemovedIn20Warning when SQLALCHEMY_WARN_20=1.
 # Additionally, raise errors for refactored RemovedIn20Warning cases to prevent regression.
 filterwarnings =


### PR DESCRIPTION

### SUMMARY

See #40273 .

This PR refactors the unit test set-up to allow developers to locally enable deprecation warnings for the upcoming migration to SQLAlchemy 2.0.
The difference will only be for local developers actively working on this topic by deliberately setting the environment variable `SQLALCHEMY_WARN_20`.
The CI or any other testing set-up is _not_ affected by this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Only if you set the environment variable `SQLALCHEMY_WARN_20`, SQLAlchemy will emit warnings during unit tests:

```
SQLALCHEMY_WARN_20=1 TZ=UTC python3 -m pytest tests/unit_tests/
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
