### PR TITLE
refactor: update SQLAlchemy case() syntax to 2.0

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -43,5 +43,5 @@ filterwarnings =
 #    error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
 #    error:The Engine.execute\(\) method is considered legacy:sqlalchemy.exc.RemovedIn20Warning
     error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
-#    error:The "whens" argument to case:sqlalchemy.exc.RemovedIn20Warning
+    error:The "whens" argument to case:sqlalchemy.exc.RemovedIn20Warning
 #    error:"User" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2714,7 +2714,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 condition = condition_factory(expr.name, expr)
 
                 # Create CASE expression: condition true -> original, else "Others"
-                case_expr = sa.case([(condition, expr)], else_=sa.literal("Others"))
+                case_expr = sa.case((condition, expr), else_=sa.literal("Others"))
                 case_expr = self.make_sqla_column_compatible(case_expr, expr.name)
                 modified_select_exprs.append(case_expr)
             else:
@@ -2729,7 +2729,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
                 # Create CASE expression for groupby
                 case_expr = sa.case(
-                    [(condition, gby_expr)],
+                    (condition, gby_expr),
                     else_=sa.literal("Others"),
                 )
                 # Don't apply make_sqla_column_compatible to GROUP BY expressions.


### PR DESCRIPTION
See #40273 .
Depends on #40274 .

### SUMMARY

Enable errors for deprecated `sqlalchemy.case()` syntax, and fix them all.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

No errors:

```
$ SQLALCHEMY_WARN_20=1 TZ=UTC python3 -m pytest tests/unit_tests/
```


### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
