### PR TITLE
refactor: update SQLAlchemy select() syntax to 2.0

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,5 +18,13 @@
 testpaths =
     tests
 python_files = *_test.py test_*.py *_tests.py *viz/utils.py
-addopts = -p no:warnings
+# `-p no:warnings` temporarily disabled in favor of more finely tuned `filterwarnings`.
+#addopts = -p no:warnings
 asyncio_mode = auto
+
+# `ignore` virtually reproduces to `-p no:warnings`.
+# Always print RemovedIn20Warning when SQLALCHEMY_WARN_20=1.
+# Additionally, raise errors for refactored RemovedIn20Warning cases to prevent regression.
+filterwarnings =
+    ignore
+    always::sqlalchemy.exc.RemovedIn20Warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,3 +28,20 @@ asyncio_mode = auto
 filterwarnings =
     ignore
     always::sqlalchemy.exc.RemovedIn20Warning
+#    error:Passing a string to Connection.execute\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
+#    error:"Query" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"SavedQuery" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"SqlaTable" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"SqlMetric" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"TableColumn" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:"TaggedObject" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+#    error:The ``as_declarative\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
+#    error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning
+#    error:The connection.execute\(\) method:sqlalchemy.exc.RemovedIn20Warning
+#    error:The current statement is being autocommitted using implicit autocommit:sqlalchemy.exc.RemovedIn20Warning
+#    error:The `database` package is deprecated:sqlalchemy.exc.RemovedIn20Warning
+#    error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
+#    error:The Engine.execute\(\) method is considered legacy:sqlalchemy.exc.RemovedIn20Warning
+#    error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
+#    error:The "whens" argument to case:sqlalchemy.exc.RemovedIn20Warning
+#    error:"User" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,7 +22,7 @@ python_files = *_test.py test_*.py *_tests.py *viz/utils.py
 #addopts = -p no:warnings
 asyncio_mode = auto
 
-# `ignore` virtually reproduces to `-p no:warnings`.
+# `ignore` is effectively equivalent to `-p no:warnings`.
 # Always print RemovedIn20Warning when SQLALCHEMY_WARN_20=1.
 # Additionally, raise errors for refactored RemovedIn20Warning cases to prevent regression.
 filterwarnings =

--- a/pytest.ini
+++ b/pytest.ini
@@ -42,6 +42,6 @@ filterwarnings =
 #    error:The `database` package is deprecated:sqlalchemy.exc.RemovedIn20Warning
 #    error:The ``declarative_base\(\)`` function is now available:sqlalchemy.exc.RemovedIn20Warning
 #    error:The Engine.execute\(\) method is considered legacy:sqlalchemy.exc.RemovedIn20Warning
-#    error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
+    error:The legacy calling style of select\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
 #    error:The "whens" argument to case:sqlalchemy.exc.RemovedIn20Warning
 #    error:"User" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning

--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -362,7 +362,7 @@ def safe_insert_dashboard_chart_relationships(
     # Get existing relationships only for dashboards being updated
     dashboard_ids = {dashboard_id for dashboard_id, _ in dashboard_chart_ids}
     existing_relationships = db.session.execute(
-        select([dashboard_slices.c.dashboard_id, dashboard_slices.c.slice_id]).where(
+        select(dashboard_slices.c.dashboard_id, dashboard_slices.c.slice_id).where(
             dashboard_slices.c.dashboard_id.in_(dashboard_ids)
         )
     ).fetchall()

--- a/superset/common/tags.py
+++ b/superset/common/tags.py
@@ -32,11 +32,9 @@ def add_types_to_charts(
 
     charts = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                slices.c.id.label("object_id"),
-                literal(ObjectType.chart.name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            slices.c.id.label("object_id"),
+            literal(ObjectType.chart.name).label("object_type"),
         )
         .select_from(
             join(
@@ -64,11 +62,9 @@ def add_types_to_dashboards(
 
     dashboards = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                dashboard_table.c.id.label("object_id"),
-                literal(ObjectType.dashboard.name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            dashboard_table.c.id.label("object_id"),
+            literal(ObjectType.dashboard.name).label("object_type"),
         )
         .select_from(
             join(
@@ -96,11 +92,9 @@ def add_types_to_saved_queries(
 
     saved_queries = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                saved_query.c.id.label("object_id"),
-                literal(ObjectType.query.name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            saved_query.c.id.label("object_id"),
+            literal(ObjectType.query.name).label("object_type"),
         )
         .select_from(
             join(
@@ -128,11 +122,9 @@ def add_types_to_datasets(
 
     datasets = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                tables.c.id.label("object_id"),
-                literal(ObjectType.dataset.name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            tables.c.id.label("object_id"),
+            literal(ObjectType.dataset.name).label("object_type"),
         )
         .select_from(
             join(
@@ -238,11 +230,9 @@ def add_owners_to_charts(
 
     charts = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                slices.c.id.label("object_id"),
-                literal(ObjectType.chart.name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            slices.c.id.label("object_id"),
+            literal(ObjectType.chart.name).label("object_type"),
         )
         .select_from(
             join(
@@ -274,11 +264,9 @@ def add_owners_to_dashboards(
 
     dashboards = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                dashboard_table.c.id.label("object_id"),
-                literal(ObjectType.dashboard.name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            dashboard_table.c.id.label("object_id"),
+            literal(ObjectType.dashboard.name).label("object_type"),
         )
         .select_from(
             join(
@@ -310,11 +298,9 @@ def add_owners_to_saved_queries(
 
     saved_queries = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                saved_query.c.id.label("object_id"),
-                literal(ObjectType.query.name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            saved_query.c.id.label("object_id"),
+            literal(ObjectType.query.name).label("object_type"),
         )
         .select_from(
             join(
@@ -346,11 +332,9 @@ def add_owners_to_datasets(
 
     datasets = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                tables.c.id.label("object_id"),
-                literal(ObjectType.dataset.name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            tables.c.id.label("object_id"),
+            literal(ObjectType.dataset.name).label("object_type"),
         )
         .select_from(
             join(
@@ -440,7 +424,7 @@ def add_owners(metadata: MetaData) -> None:
     columns = ["tag_id", "object_id", "object_type"]
 
     # create a custom tag for each user
-    ids = select([users.c.id])
+    ids = select(users.c.id)
     insert = tag.insert()
     for (id_,) in db.session.execute(ids):
         with contextlib.suppress(IntegrityError):  # already exists
@@ -478,18 +462,16 @@ def add_favorites(metadata: MetaData) -> None:
     columns = ["tag_id", "object_id", "object_type"]
 
     # create a custom tag for each user
-    ids = select([users.c.id])
+    ids = select(users.c.id)
     insert = tag.insert()
     for (id_,) in db.session.execute(ids):
         with contextlib.suppress(IntegrityError):  # already exists
             db.session.execute(insert, name=f"favorited_by:{id_}", type=TagType.type)
     favstars = (
         select(
-            [
-                tag.c.id.label("tag_id"),
-                favstar.c.obj_id.label("object_id"),
-                func.lower(favstar.c.class_name).label("object_type"),
-            ]
+            tag.c.id.label("tag_id"),
+            favstar.c.obj_id.label("object_id"),
+            func.lower(favstar.c.class_name).label("object_type"),
         )
         .select_from(
             join(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1791,11 +1791,9 @@ class SqlaTable(
                     # for those we fall back to LIMIT 1.
                     tbl, _unused_cte = self.get_from_clause(template_processor)
                     if self.db_engine_spec.type_probe_needs_row:
-                        qry = sa.select([sqla_column]).limit(1).select_from(tbl)
+                        qry = sa.select(sqla_column).limit(1).select_from(tbl)
                     else:
-                        qry = (
-                            sa.select([sqla_column]).where(sa.false()).select_from(tbl)
-                        )
+                        qry = sa.select(sqla_column).where(sa.false()).select_from(tbl)
                     sql = self.database.compile_sqla_query(
                         qry,
                         catalog=self.catalog,

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1986,7 +1986,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             fields = cls._get_fields(cols)
 
         full_table_name = cls.quote_table(table, dialect)
-        qry = select(fields).select_from(text(full_table_name))
+        qry = select(*fields if isinstance(fields, list) else fields).select_from(
+            text(full_table_name)
+        )
 
         qry = qry.limit(limit)
         if latest_partition:

--- a/superset/extensions/metadb.py
+++ b/superset/extensions/metadb.py
@@ -368,7 +368,7 @@ class SupersetShillelaghAdapter(Adapter):
         """
         Build SQLAlchemy query object.
         """
-        query = select([self._table])
+        query = select(self._table)
 
         for column_name, filter_ in bounds.items():
             column = self._table.c[column_name]
@@ -452,7 +452,7 @@ class SupersetShillelaghAdapter(Adapter):
             if self._rowid:
                 return result.inserted_primary_key[0]
 
-            query = select([func.count()]).select_from(self._table)
+            query = select(func.count()).select_from(self._table)
             return connection.execute(query).scalar()
 
     @check_dml

--- a/superset/migrations/versions/2020-01-08_01-17_e96dbf2cfef0_datasource_cluster_fk.py
+++ b/superset/migrations/versions/2020-01-08_01-17_e96dbf2cfef0_datasource_cluster_fk.py
@@ -49,7 +49,7 @@ def upgrade():
     clusters = sa.Table("clusters", metadata, autoload=True)
 
     statement = datasources.update().values(
-        cluster_id=sa.select([clusters.c.id])
+        cluster_id=sa.select(clusters.c.id)
         .where(datasources.c.cluster_name == clusters.c.cluster_name)
         .as_scalar()
     )
@@ -91,7 +91,7 @@ def downgrade():
     clusters = sa.Table("clusters", metadata, autoload=True)
 
     statement = datasources.update().values(
-        cluster_name=sa.select([clusters.c.cluster_name])
+        cluster_name=sa.select(clusters.c.cluster_name)
         .where(datasources.c.cluster_id == clusters.c.id)
         .as_scalar()
     )

--- a/superset/migrations/versions/2020-01-08_01-17_e96dbf2cfef0_datasource_cluster_fk.py
+++ b/superset/migrations/versions/2020-01-08_01-17_e96dbf2cfef0_datasource_cluster_fk.py
@@ -51,7 +51,7 @@ def upgrade():
     statement = datasources.update().values(
         cluster_id=sa.select(clusters.c.id)
         .where(datasources.c.cluster_name == clusters.c.cluster_name)
-        .as_scalar()
+        .scalar_subquery()
     )
     bind.execute(statement)
 
@@ -93,7 +93,7 @@ def downgrade():
     statement = datasources.update().values(
         cluster_name=sa.select(clusters.c.cluster_name)
         .where(datasources.c.cluster_id == clusters.c.id)
-        .as_scalar()
+        .scalar_subquery()
     )
     bind.execute(statement)
 

--- a/superset/migrations/versions/2020-04-24_10-46_e557699a813e_add_tables_relation_to_row_level_.py
+++ b/superset/migrations/versions/2020-04-24_10-46_e557699a813e_add_tables_relation_to_row_level_.py
@@ -49,7 +49,7 @@ def upgrade():
     )
 
     rlsf = sa.Table("row_level_security_filters", metadata, autoload=True)
-    filter_ids = sa.select([rlsf.c.id, rlsf.c.table_id])
+    filter_ids = sa.select(rlsf.c.id, rlsf.c.table_id)
 
     for row in bind.execute(filter_ids):
         move_table_id = rls_filter_tables.insert().values(
@@ -85,7 +85,7 @@ def downgrade():
     rls_filter_tables = sa.Table("rls_filter_tables", metadata, autoload=True)
     rls_filter_roles = sa.Table("rls_filter_roles", metadata, autoload=True)
 
-    filter_tables = sa.select([rls_filter_tables.c.rls_filter_id]).group_by(
+    filter_tables = sa.select(rls_filter_tables.c.rls_filter_id).group_by(
         rls_filter_tables.c.rls_filter_id
     )
 
@@ -95,7 +95,7 @@ def downgrade():
         filter_params = dict(bind.execute(filter_query).fetchone())
         origin_id = filter_params.pop("id", None)
         table_ids = bind.execute(
-            sa.select([rls_filter_tables.c.table_id]).where(
+            sa.select(rls_filter_tables.c.table_id).where(
                 rls_filter_tables.c.rls_filter_id == row["rls_filter_id"]
             )
         ).fetchall()

--- a/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
+++ b/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
@@ -336,23 +336,21 @@ def copy_tables(session: Session) -> None:
     insert_from_select(
         NewTable,
         select(
-            [
-                # Tables need different uuid than datasets, since they are different
-                # entities. When INSERT FROM SELECT, we must provide a value for `uuid`,
-                # otherwise it'd use the default generated on Python side, which
-                # will cause duplicate values. They will be replaced by `assign_uuids` later.  # noqa: E501
-                SqlaTable.uuid,
-                SqlaTable.id.label("sqlatable_id"),
-                SqlaTable.created_on,
-                SqlaTable.changed_on,
-                SqlaTable.created_by_fk,
-                SqlaTable.changed_by_fk,
-                SqlaTable.table_name.label("name"),
-                SqlaTable.schema,
-                SqlaTable.database_id,
-                SqlaTable.is_managed_externally,
-                SqlaTable.external_url,
-            ]
+            # Tables need different uuid than datasets, since they are different
+            # entities. When INSERT FROM SELECT, we must provide a value for `uuid`,
+            # otherwise it'd use the default generated on Python side, which
+            # will cause duplicate values. They will be replaced by `assign_uuids` later.  # noqa: E501
+            SqlaTable.uuid,
+            SqlaTable.id.label("sqlatable_id"),
+            SqlaTable.created_on,
+            SqlaTable.changed_on,
+            SqlaTable.created_by_fk,
+            SqlaTable.changed_by_fk,
+            SqlaTable.table_name.label("name"),
+            SqlaTable.schema,
+            SqlaTable.database_id,
+            SqlaTable.is_managed_externally,
+            SqlaTable.external_url,
         )
         # use an inner join to filter out only tables with valid database ids
         .select_from(sa.join(SqlaTable, Database, SqlaTable.database_id == Database.id))
@@ -369,20 +367,18 @@ def copy_datasets(session: Session) -> None:
     insert_from_select(
         NewDataset,
         select(
-            [
-                SqlaTable.uuid,
-                SqlaTable.created_on,
-                SqlaTable.changed_on,
-                SqlaTable.created_by_fk,
-                SqlaTable.changed_by_fk,
-                SqlaTable.database_id,
-                SqlaTable.table_name.label("name"),
-                func.coalesce(SqlaTable.sql, SqlaTable.table_name).label("expression"),
-                is_physical_table.label("is_physical"),
-                SqlaTable.is_managed_externally,
-                SqlaTable.external_url,
-                SqlaTable.extra.label("extra_json"),
-            ]
+            SqlaTable.uuid,
+            SqlaTable.created_on,
+            SqlaTable.changed_on,
+            SqlaTable.created_by_fk,
+            SqlaTable.changed_by_fk,
+            SqlaTable.database_id,
+            SqlaTable.table_name.label("name"),
+            func.coalesce(SqlaTable.sql, SqlaTable.table_name).label("expression"),
+            is_physical_table.label("is_physical"),
+            SqlaTable.is_managed_externally,
+            SqlaTable.external_url,
+            SqlaTable.extra.label("extra_json"),
         ),
     )
 
@@ -390,7 +386,7 @@ def copy_datasets(session: Session) -> None:
     insert_from_select(
         dataset_user_association_table,
         select(
-            [NewDataset.id.label("dataset_id"), sqlatable_user_table.c.user_id]
+            NewDataset.id.label("dataset_id"), sqlatable_user_table.c.user_id
         ).select_from(
             sqlatable_user_table.join(
                 SqlaTable, SqlaTable.id == sqlatable_user_table.c.table_id
@@ -402,10 +398,8 @@ def copy_datasets(session: Session) -> None:
     insert_from_select(
         dataset_table_association_table,
         select(
-            [
-                NewDataset.id.label("dataset_id"),
-                NewTable.id.label("table_id"),
-            ]
+            NewDataset.id.label("dataset_id"),
+            NewTable.id.label("table_id"),
         ).select_from(
             sa.join(SqlaTable, NewTable, NewTable.sqlatable_id == SqlaTable.id).join(
                 NewDataset, NewDataset.uuid == SqlaTable.uuid
@@ -423,25 +417,23 @@ def copy_columns(session: Session) -> None:
     insert_from_select(
         NewColumn,
         select(
-            [
-                TableColumn.uuid,
-                TableColumn.created_on,
-                TableColumn.changed_on,
-                TableColumn.created_by_fk,
-                TableColumn.changed_by_fk,
-                TableColumn.groupby.label("is_dimensional"),
-                TableColumn.filterable.label("is_filterable"),
-                TableColumn.column_name.label("name"),
-                TableColumn.description,
-                func.coalesce(TableColumn.expression, TableColumn.column_name).label(
-                    "expression"
-                ),
-                sa.literal(False).label("is_aggregation"),
-                is_physical_column.label("is_physical"),
-                func.coalesce(TableColumn.is_dttm, False).label("is_temporal"),
-                func.coalesce(TableColumn.type, UNKNOWN_TYPE).label("type"),
-                TableColumn.extra.label("extra_json"),
-            ]
+            TableColumn.uuid,
+            TableColumn.created_on,
+            TableColumn.changed_on,
+            TableColumn.created_by_fk,
+            TableColumn.changed_by_fk,
+            TableColumn.groupby.label("is_dimensional"),
+            TableColumn.filterable.label("is_filterable"),
+            TableColumn.column_name.label("name"),
+            TableColumn.description,
+            func.coalesce(TableColumn.expression, TableColumn.column_name).label(
+                "expression"
+            ),
+            sa.literal(False).label("is_aggregation"),
+            is_physical_column.label("is_physical"),
+            func.coalesce(TableColumn.is_dttm, False).label("is_temporal"),
+            func.coalesce(TableColumn.type, UNKNOWN_TYPE).label("type"),
+            TableColumn.extra.label("extra_json"),
         ).select_from(active_table_columns),
     )
 
@@ -452,10 +444,8 @@ def copy_columns(session: Session) -> None:
     insert_from_select(
         dataset_column_association_table,
         select(
-            [
-                NewDataset.id.label("dataset_id"),
-                NewColumn.id.label("column_id"),
-            ],
+            NewDataset.id.label("dataset_id"),
+            NewColumn.id.label("column_id"),
         ).select_from(
             joined_columns_table.join(NewDataset, NewDataset.uuid == SqlaTable.uuid)
         ),
@@ -472,33 +462,31 @@ def copy_metrics(session: Session) -> None:
     insert_from_select(
         NewColumn,
         select(
-            [
-                SqlMetric.uuid,
-                SqlMetric.created_on,
-                SqlMetric.changed_on,
-                SqlMetric.created_by_fk,
-                SqlMetric.changed_by_fk,
-                SqlMetric.metric_name.label("name"),
-                SqlMetric.expression,
-                SqlMetric.description,
-                sa.literal(UNKNOWN_TYPE).label("type"),
-                (
-                    func.coalesce(
-                        sa.func.lower(SqlMetric.metric_type).in_(
-                            ADDITIVE_METRIC_TYPES_LOWER
-                        ),
-                        sa.literal(False),
-                    ).label("is_additive")
-                ),
-                sa.literal(True).label("is_aggregation"),
-                # metrics are by default not filterable
-                sa.literal(False).label("is_filterable"),
-                sa.literal(False).label("is_dimensional"),
-                sa.literal(False).label("is_physical"),
-                sa.literal(False).label("is_temporal"),
-                SqlMetric.extra.label("extra_json"),
-                SqlMetric.warning_text,
-            ]
+            SqlMetric.uuid,
+            SqlMetric.created_on,
+            SqlMetric.changed_on,
+            SqlMetric.created_by_fk,
+            SqlMetric.changed_by_fk,
+            SqlMetric.metric_name.label("name"),
+            SqlMetric.expression,
+            SqlMetric.description,
+            sa.literal(UNKNOWN_TYPE).label("type"),
+            (
+                func.coalesce(
+                    sa.func.lower(SqlMetric.metric_type).in_(
+                        ADDITIVE_METRIC_TYPES_LOWER
+                    ),
+                    sa.literal(False),
+                ).label("is_additive")
+            ),
+            sa.literal(True).label("is_aggregation"),
+            # metrics are by default not filterable
+            sa.literal(False).label("is_filterable"),
+            sa.literal(False).label("is_dimensional"),
+            sa.literal(False).label("is_physical"),
+            sa.literal(False).label("is_temporal"),
+            SqlMetric.extra.label("extra_json"),
+            SqlMetric.warning_text,
         ).select_from(active_metrics),
     )
 
@@ -506,10 +494,8 @@ def copy_metrics(session: Session) -> None:
     insert_from_select(
         dataset_column_association_table,
         select(
-            [
-                NewDataset.id.label("dataset_id"),
-                NewColumn.id.label("column_id"),
-            ],
+            NewDataset.id.label("dataset_id"),
+            NewColumn.id.label("column_id"),
         ).select_from(
             active_metrics.join(NewDataset, NewDataset.uuid == SqlaTable.uuid).join(
                 NewColumn, NewColumn.uuid == SqlMetric.uuid
@@ -568,15 +554,13 @@ def postprocess_datasets(session: Session) -> None:  # noqa: C901
             sqlalchemy_uri,
         ) in session.execute(
             select(
-                [
-                    NewDataset.database_id,
-                    NewDataset.id.label("dataset_id"),
-                    NewDataset.expression,
-                    SqlaTable.extra,
-                    NewDataset.is_physical,
-                    SqlaTable.schema,
-                    Database.sqlalchemy_uri,
-                ]
+                NewDataset.database_id,
+                NewDataset.id.label("dataset_id"),
+                NewDataset.expression,
+                SqlaTable.extra,
+                NewDataset.is_physical,
+                SqlaTable.schema,
+                Database.sqlalchemy_uri,
             )
             .select_from(joined_tables)
             .offset(offset)
@@ -725,29 +709,27 @@ def postprocess_columns(session: Session) -> None:  # noqa: C901
         query = (
             select(
                 # sorted alphabetically
-                [
-                    NewColumn.id.label("column_id"),
-                    TableColumn.column_name,
-                    NewColumn.changed_by_fk,
-                    NewColumn.changed_on,
-                    NewColumn.created_on,
-                    NewColumn.description,
-                    SqlMetric.d3format,
-                    NewDataset.external_url,
-                    NewColumn.extra_json,
-                    NewColumn.is_dimensional,
-                    NewColumn.is_filterable,
-                    NewDataset.is_managed_externally,
-                    NewColumn.is_physical,
-                    SqlMetric.metric_type,
-                    TableColumn.python_date_format,
-                    Database.sqlalchemy_uri,
-                    dataset_table_association_table.c.table_id,
-                    func.coalesce(
-                        TableColumn.verbose_name, SqlMetric.verbose_name
-                    ).label("verbose_name"),
-                    NewColumn.warning_text,
-                ]
+                NewColumn.id.label("column_id"),
+                TableColumn.column_name,
+                NewColumn.changed_by_fk,
+                NewColumn.changed_on,
+                NewColumn.created_on,
+                NewColumn.description,
+                SqlMetric.d3format,
+                NewDataset.external_url,
+                NewColumn.extra_json,
+                NewColumn.is_dimensional,
+                NewColumn.is_filterable,
+                NewDataset.is_managed_externally,
+                NewColumn.is_physical,
+                SqlMetric.metric_type,
+                TableColumn.python_date_format,
+                Database.sqlalchemy_uri,
+                dataset_table_association_table.c.table_id,
+                func.coalesce(TableColumn.verbose_name, SqlMetric.verbose_name).label(
+                    "verbose_name"
+                ),
+                NewColumn.warning_text,
             )
             .select_from(get_joined_tables(offset, limit))
             .where(
@@ -872,7 +854,7 @@ def postprocess_columns(session: Session) -> None:  # noqa: C901
     print("   Assign table column relations...")
     insert_from_select(
         table_column_association_table,
-        select([NewColumn.table_id, NewColumn.id.label("column_id")])
+        select(NewColumn.table_id, NewColumn.id.label("column_id"))
         .select_from(NewColumn)
         .where(and_(NewColumn.is_physical, NewColumn.table_id.isnot(None))),
     )

--- a/superset/migrations/versions/2024-01-17_13-09_96164e3017c6_tagged_object_unique_constraint.py
+++ b/superset/migrations/versions/2024-01-17_13-09_96164e3017c6_tagged_object_unique_constraint.py
@@ -59,12 +59,10 @@ def upgrade():
     # Delete duplicates if any
     min_id_subquery = (
         select(
-            [
-                func.min(tagged_object_table.c.id).label("min_id"),
-                tagged_object_table.c.tag_id,
-                tagged_object_table.c.object_id,
-                tagged_object_table.c.object_type,
-            ]
+            func.min(tagged_object_table.c.id).label("min_id"),
+            tagged_object_table.c.tag_id,
+            tagged_object_table.c.object_id,
+            tagged_object_table.c.object_type,
         )
         .group_by(
             tagged_object_table.c.tag_id,
@@ -75,7 +73,7 @@ def upgrade():
     )
 
     delete_query = tagged_object_table.delete().where(
-        tagged_object_table.c.id.notin_(select([min_id_subquery.c.min_id]))
+        tagged_object_table.c.id.notin_(select(min_id_subquery.c.min_id))
     )
 
     bind.execute(delete_query)

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2806,7 +2806,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 # automatically add a random alias to the projection because of the
                 # call to DISTINCT; others will uppercase the column names. This
                 # gives us a deterministic column name in the dataframe.
-                [target_col.get_sqla_col(template_processor=tp).label("column_values")]
+                target_col.get_sqla_col(template_processor=tp).label("column_values")
             )
             .select_from(tbl)
             .distinct()
@@ -2900,15 +2900,15 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     ) -> Select:
         """Build validation query based on expression type. Raises on error."""
         if expression_type == SqlExpressionType.COLUMN:
-            return sa.select([sa.literal_column(expression).label("test_col")])
+            return sa.select(sa.literal_column(expression).label("test_col"))
         elif expression_type == SqlExpressionType.METRIC:
-            return sa.select([sa.literal_column(expression).label("test_metric")])
+            return sa.select(sa.literal_column(expression).label("test_metric"))
         elif expression_type == SqlExpressionType.WHERE:
-            return sa.select([sa.literal(1)]).where(sa.text(expression))
+            return sa.select(sa.literal(1)).where(sa.text(expression))
         elif expression_type == SqlExpressionType.HAVING:
             dummy_col = sa.literal("A").label("dummy")
             return (
-                sa.select([dummy_col])
+                sa.select(dummy_col)
                 .group_by(sa.text("dummy"))
                 .having(sa.text(expression))
             )
@@ -3342,7 +3342,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         if not db_engine_spec.allows_hidden_orderby_agg:
             select_exprs = remove_duplicates(select_exprs + orderby_exprs)
 
-        qry = sa.select(select_exprs)
+        qry = sa.select(*select_exprs)
 
         if groupby_all_columns:
             qry = qry.group_by(*groupby_all_columns.values())
@@ -3682,7 +3682,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     inner_select_exprs.append(inner)
 
                 inner_select_exprs += [inner_main_metric_expr]
-                subq = sa.select(inner_select_exprs).select_from(tbl)
+                subq = sa.select(*inner_select_exprs).select_from(tbl)
                 inner_time_filter = []
 
                 if dttm_col and not db_engine_spec.time_groupby_inline:
@@ -3747,7 +3747,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     )
 
                     # Reconstruct query with modified expressions
-                    qry = sa.select(select_exprs)
+                    qry = sa.select(*select_exprs)
                     if groupby_all_columns:
                         qry = qry.group_by(*groupby_all_columns.values())
 
@@ -3821,7 +3821,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     )
 
                     # Reconstruct query with modified expressions
-                    qry = sa.select(select_exprs)
+                    qry = sa.select(*select_exprs)
                     if groupby_all_columns:
                         qry = qry.group_by(*groupby_all_columns.values())
 
@@ -3848,7 +3848,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 )
             label = "rowcount"
             col = self.make_sqla_column_compatible(literal_column("COUNT(*)"), label)
-            qry = sa.select([col]).select_from(qry.alias("rowcount_qry"))
+            qry = sa.select(col).select_from(qry.alias("rowcount_qry"))
             labels_expected = [label]
 
         filter_columns = [flt.get("col") for flt in filter] if filter else []

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -788,7 +788,7 @@ def pessimistic_connection_handling(some_engine: Engine) -> None:
             # run a SELECT 1.   use a core select() so that
             # the SELECT of a scalar value without a table is
             # appropriately formatted for the backend
-            connection.scalar(select([1]))
+            connection.scalar(select(1))
         except exc.DBAPIError as err:
             # catch SQLAlchemy's DBAPIError, which is a wrapper
             # for the DBAPI's exception.  It includes a .connection_invalidated
@@ -800,7 +800,7 @@ def pessimistic_connection_handling(some_engine: Engine) -> None:
                 # itself and establish a new connection.  The disconnect detection
                 # here also causes the whole connection pool to be invalidated
                 # so that all stale connections are discarded.
-                connection.scalar(select([1]))
+                connection.scalar(select(1))
             else:
                 raise
         finally:

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -80,7 +80,7 @@ def test_get_fields() -> None:
     ]
     fields = BigQueryEngineSpec._get_fields(columns)
 
-    query = select(fields)
+    query = select(*fields)
     assert str(query.compile(dialect=BigQueryDialect())) == (
         "SELECT `limit` AS `limit`, `name` AS `name`, "
         "`project`.`name` AS `project__name`"

--- a/tests/unit_tests/db_engine_specs/test_datastore.py
+++ b/tests/unit_tests/db_engine_specs/test_datastore.py
@@ -85,7 +85,7 @@ def test_get_fields() -> None:
     ]
     fields = DatastoreEngineSpec._get_fields(columns)
 
-    query = select(fields)
+    query = select(*fields)
     assert str(query.compile(dialect=CloudDatastoreDialect())) == (
         'SELECT "limit" AS "limit", name AS name, "project.name" AS project__name'
     )

--- a/tests/unit_tests/db_engine_specs/test_mssql.py
+++ b/tests/unit_tests/db_engine_specs/test_mssql.py
@@ -81,7 +81,7 @@ def test_where_clause_n_prefix() -> None:
 
     tbl = table("tbl")
     sel = (
-        select([str_col, unicode_col])
+        select(str_col, unicode_col)
         .select_from(tbl)
         .where(str_col == "abc")
         .where(unicode_col == "abc")


### PR DESCRIPTION
See #40273 .
Depends on #40274 .

### SUMMARY

Enable errors for deprecated `sqlalchemy.select()` syntax, and fix them all.

In addition to fixing all broken tests, I manually went through all results of `git grep select(`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

No errors:

```
$ SQLALCHEMY_WARN_20=1 TZ=UTC python3 -m pytest tests/unit_tests/
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
