### PR TITLE
[codex] Enable bulk tag selection without other actions

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -307,6 +307,7 @@ export function ListView<T extends object = any>({
   addSuccessToast,
   addDangerToast,
 }: ListViewProps<T>) {
+  const allowBulkTagActions = Boolean(bulkTagResourceName && enableBulkTag);
   const {
     getTableProps,
     getTableBodyProps,
@@ -324,7 +325,8 @@ export function ListView<T extends object = any>({
     query,
   } = useListViewState({
     bulkSelectColumnConfig,
-    bulkSelectMode: bulkSelectEnabled && Boolean(bulkActions.length),
+    bulkSelectMode:
+      bulkSelectEnabled && Boolean(bulkActions.length || allowBulkTagActions),
     columns,
     count,
     data,
@@ -335,7 +337,6 @@ export function ListView<T extends object = any>({
     renderCard: Boolean(renderCard),
     defaultViewMode,
   });
-  const allowBulkTagActions = bulkTagResourceName && enableBulkTag;
   const filterable = Boolean(filters.length);
   if (filterable) {
     const columnAccessors = columns.reduce(
@@ -464,7 +465,7 @@ export function ListView<T extends object = any>({
                           {action.name}
                         </Button>
                       ))}
-                      {enableBulkTag && (
+                      {allowBulkTagActions && (
                         <span
                           data-test="bulk-select-tag-btn"
                           role="button"

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -250,6 +250,7 @@ function ChartList(props: ChartListProps) {
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
+  const canBulkTag = isFeatureEnabled(FeatureFlag.TaggingSystem);
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
   const handleBulkChartExport = useCallback(
@@ -839,7 +840,7 @@ function ChartList(props: ChartListProps) {
     });
   }
 
-  if (canDelete || canExport) {
+  if (canDelete || canExport || canBulkTag) {
     subMenuButtons.push({
       name: t('Bulk select'),
       buttonStyle: 'secondary',
@@ -876,7 +877,6 @@ function ChartList(props: ChartListProps) {
         onConfirm={handleBulkChartDelete}
       >
         {confirmDelete => {
-          const enableBulkTag = isFeatureEnabled(FeatureFlag.TaggingSystem);
           const bulkActions: ListViewProps['bulkActions'] = [];
           if (canDelete) {
             bulkActions.push({
@@ -911,7 +911,7 @@ function ChartList(props: ChartListProps) {
               loading={loading}
               pageSize={PAGE_SIZE}
               renderCard={renderCard}
-              enableBulkTag={enableBulkTag}
+              enableBulkTag={canBulkTag}
               bulkTagResourceName="chart"
               addSuccessToast={addSuccessToast}
               addDangerToast={addDangerToast}

--- a/superset-frontend/src/pages/DashboardList/DashboardList.permissions.test.tsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.permissions.test.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import fetchMock from 'fetch-mock';
+import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
@@ -58,6 +59,7 @@ const PERMISSIONS = {
   READ_ONLY: [],
   EXPORT_ONLY: [['can_export', 'Dashboard']],
   WRITE_ONLY: [['can_write', 'Dashboard']],
+  TAG_ONLY: [['can_read', 'Tag']],
 };
 
 const createMockUser = (overrides = {}) => ({
@@ -295,6 +297,22 @@ describe('DashboardList - Permission-based UI Tests', () => {
     await screen.findByTestId('dashboard-list-view');
 
     expect(screen.queryByTestId('bulk-select')).not.toBeInTheDocument();
+  });
+
+  test('shows bulk select for tag-only users when tagging is enabled', async () => {
+    await renderWithPermissions(PERMISSIONS.TAG_ONLY, 1, { tagging: true });
+    await screen.findByTestId('dashboard-list-view');
+
+    const bulkSelectButton = screen.getByTestId('bulk-select');
+    expect(bulkSelectButton).toBeInTheDocument();
+
+    await userEvent.click(bulkSelectButton);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('checkbox')).toHaveLength(
+        mockDashboards.length + 1,
+      );
+    });
   });
 
   test('shows Create and Import buttons for users with write permissions', async () => {

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -221,6 +221,7 @@ function DashboardList(props: DashboardListProps) {
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
+  const canBulkTag = isFeatureEnabled(FeatureFlag.TaggingSystem);
 
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
@@ -718,7 +719,7 @@ function DashboardList(props: DashboardListProps) {
     });
   }
 
-  if (canDelete || canExport) {
+  if (canDelete || canExport || canBulkTag) {
     subMenuButtons.push({
       name: t('Bulk select'),
       buttonStyle: 'secondary',
@@ -748,7 +749,6 @@ function DashboardList(props: DashboardListProps) {
         onConfirm={handleBulkDashboardDelete}
       >
         {confirmDelete => {
-          const enableBulkTag = isFeatureEnabled(FeatureFlag.TaggingSystem);
           const bulkActions: ListViewProps['bulkActions'] = [];
           if (canDelete) {
             bulkActions.push({
@@ -828,7 +828,7 @@ function DashboardList(props: DashboardListProps) {
                     ? 'card'
                     : 'table'
                 }
-                enableBulkTag={enableBulkTag}
+                enableBulkTag={canBulkTag}
                 bulkTagResourceName="dashboard"
               />
             </>

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -166,6 +166,7 @@ function SavedQueryList({
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
+  const canBulkTag = isFeatureEnabled(FeatureFlag.TaggingSystem);
 
   const handleSavedQueryPreview = useCallback(
     (id: number) => {
@@ -210,7 +211,7 @@ function SavedQueryList({
     });
   }
 
-  if (canDelete) {
+  if (canDelete || canExport || canBulkTag) {
     subMenuButtons.push({
       name: t('Bulk select'),
       onClick: toggleBulkSelect,
@@ -627,7 +628,6 @@ function SavedQueryList({
         onConfirm={handleBulkQueryDelete}
       >
         {confirmDelete => {
-          const enableBulkTag = isFeatureEnabled(FeatureFlag.TaggingSystem);
           const bulkActions: ListViewProps['bulkActions'] = [];
           if (canDelete) {
             bulkActions.push({
@@ -662,7 +662,7 @@ function SavedQueryList({
               bulkSelectEnabled={bulkSelectEnabled}
               disableBulkSelect={toggleBulkSelect}
               highlightRowId={savedQueryCurrentlyPreviewing?.id}
-              enableBulkTag={enableBulkTag}
+              enableBulkTag={canBulkTag}
               bulkTagResourceName="query"
               refreshData={refreshData}
             />


### PR DESCRIPTION
## Summary

This fixes a gap in list views that support bulk tagging. Previously, `ListView` only entered bulk-select mode when there was at least one regular bulk action, such as delete or export. As a result, a user could have the tagging feature enabled but still be unable to select rows for `Add Tag` if the page did not expose another bulk action.

Changes:
- Allow `ListView` bulk-select mode when bulk tagging is available, even if `bulkActions` is empty.
- Show the `Bulk select` button on dashboard, chart, and saved query lists when the tagging feature is enabled.
- Reuse the same computed bulk-tag flag for the button and the `ListView` prop.
- Add DashboardList permission coverage for a tag-only scenario.

## Impact

Users can bulk-select dashboards for tagging without needing unrelated delete/export actions. The generic fix also keeps chart and saved-query tagging behavior consistent.

## Validation

- `git diff --check`
- Attempted `npm test -- DashboardList.permissions.test.tsx --runInBand`, but the cloned frontend has no `node_modules`; `npm ci` failed because upstream `package.json` and `package-lock.json` are not currently in sync in this checkout, and the local Node/npm versions do not match the repo engine requirement.
