### PR TITLE
fix(users): show 0 for null login_count and fail_login_count

### DIFF
--- a/superset-frontend/src/pages/UsersList/UsersList.test.tsx
+++ b/superset-frontend/src/pages/UsersList/UsersList.test.tsx
@@ -30,10 +30,7 @@ import {
 import { MemoryRouter } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
-import UsersList, {
-  renderLoginCountCell,
-  renderFailLoginCountCell,
-} from './index';
+import UsersList from './index';
 
 const mockStore = configureStore([thunk]);
 const store = mockStore({});
@@ -196,52 +193,5 @@ describe('UsersList', () => {
     expect(editAction).toBeInTheDocument();
     fireEvent.click(editAction);
     expect(screen.queryByTestId('Edit User-modal')).toBeInTheDocument();
-  });
-  test('login_count cell renders 0 when value is null', () => {
-    expect(
-      renderLoginCountCell({
-        row: { original: { login_count: null } as any },
-      }),
-    ).toBe(0);
-  });
-
-  test('login_count cell renders 0 when value is undefined', () => {
-    expect(
-      renderLoginCountCell({
-        row: { original: {} as any },
-      }),
-    ).toBe(0);
-  });
-
-  test('login_count cell renders the actual count when set', () => {
-    expect(
-      renderLoginCountCell({
-        row: { original: { login_count: 42 } as any },
-      }),
-    ).toBe(42);
-  });
-
-  test('fail_login_count cell renders 0 when value is null', () => {
-    expect(
-      renderFailLoginCountCell({
-        row: { original: { fail_login_count: null } as any },
-      }),
-    ).toBe(0);
-  });
-
-  test('fail_login_count cell renders 0 when value is undefined', () => {
-    expect(
-      renderFailLoginCountCell({
-        row: { original: {} as any },
-      }),
-    ).toBe(0);
-  });
-
-  test('fail_login_count cell renders the actual count when set', () => {
-    expect(
-      renderFailLoginCountCell({
-        row: { original: { fail_login_count: 7 } as any },
-      }),
-    ).toBe(7);
   });
 });

--- a/superset-frontend/src/pages/UsersList/UsersList.test.tsx
+++ b/superset-frontend/src/pages/UsersList/UsersList.test.tsx
@@ -30,7 +30,10 @@ import {
 import { MemoryRouter } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
-import UsersList from './index';
+import UsersList, {
+  renderLoginCountCell,
+  renderFailLoginCountCell,
+} from './index';
 
 const mockStore = configureStore([thunk]);
 const store = mockStore({});
@@ -193,5 +196,52 @@ describe('UsersList', () => {
     expect(editAction).toBeInTheDocument();
     fireEvent.click(editAction);
     expect(screen.queryByTestId('Edit User-modal')).toBeInTheDocument();
+  });
+  test('login_count cell renders 0 when value is null', () => {
+    expect(
+      renderLoginCountCell({
+        row: { original: { login_count: null } as any },
+      }),
+    ).toBe(0);
+  });
+
+  test('login_count cell renders 0 when value is undefined', () => {
+    expect(
+      renderLoginCountCell({
+        row: { original: {} as any },
+      }),
+    ).toBe(0);
+  });
+
+  test('login_count cell renders the actual count when set', () => {
+    expect(
+      renderLoginCountCell({
+        row: { original: { login_count: 42 } as any },
+      }),
+    ).toBe(42);
+  });
+
+  test('fail_login_count cell renders 0 when value is null', () => {
+    expect(
+      renderFailLoginCountCell({
+        row: { original: { fail_login_count: null } as any },
+      }),
+    ).toBe(0);
+  });
+
+  test('fail_login_count cell renders 0 when value is undefined', () => {
+    expect(
+      renderFailLoginCountCell({
+        row: { original: {} as any },
+      }),
+    ).toBe(0);
+  });
+
+  test('fail_login_count cell renders the actual count when set', () => {
+    expect(
+      renderFailLoginCountCell({
+        row: { original: { fail_login_count: 7 } as any },
+      }),
+    ).toBe(7);
   });
 });

--- a/superset-frontend/src/pages/UsersList/index.tsx
+++ b/superset-frontend/src/pages/UsersList/index.tsx
@@ -287,14 +287,14 @@ function UsersList({ user }: UsersListProps) {
         id: 'login_count',
         Header: t('Login count'),
         hidden: true,
-        Cell: ({ row: { original } }: any) => original.login_count,
+        Cell: ({ row: { original } }: any) => original.login_count ?? 0,
       },
       {
         accessor: 'fail_login_count',
         id: 'fail_login_count',
         Header: t('Fail login count'),
         hidden: true,
-        Cell: ({ row: { original } }: any) => original.fail_login_count,
+        Cell: ({ row: { original } }: any) => original.fail_login_count ?? 0,
       },
       {
         accessor: 'created_on',

--- a/superset-frontend/src/pages/UsersList/index.tsx
+++ b/superset-frontend/src/pages/UsersList/index.tsx
@@ -62,6 +62,22 @@ const isActiveOptions = [
   },
 ];
 
+// Exported cell renderers for the Login count / Fail login count columns.
+// FAB's User model declares both fields as nullable integers (NULL until the
+// first login / first failed login), so we coalesce null / undefined to 0
+// rather than rendering an empty cell.
+export const renderLoginCountCell = ({
+  row: { original },
+}: {
+  row: { original: UserObject };
+}) => original.login_count ?? 0;
+
+export const renderFailLoginCountCell = ({
+  row: { original },
+}: {
+  row: { original: UserObject };
+}) => original.fail_login_count ?? 0;
+
 function UsersList({ user }: UsersListProps) {
   const { addDangerToast, addSuccessToast } = useToasts();
   const {
@@ -287,14 +303,14 @@ function UsersList({ user }: UsersListProps) {
         id: 'login_count',
         Header: t('Login count'),
         hidden: true,
-        Cell: ({ row: { original } }: any) => original.login_count ?? 0,
+        Cell: renderLoginCountCell,
       },
       {
         accessor: 'fail_login_count',
         id: 'fail_login_count',
         Header: t('Fail login count'),
         hidden: true,
-        Cell: ({ row: { original } }: any) => original.fail_login_count ?? 0,
+        Cell: renderFailLoginCountCell,
       },
       {
         accessor: 'created_on',

--- a/superset-frontend/src/pages/UsersList/index.tsx
+++ b/superset-frontend/src/pages/UsersList/index.tsx
@@ -62,22 +62,6 @@ const isActiveOptions = [
   },
 ];
 
-// Exported cell renderers for the Login count / Fail login count columns.
-// FAB's User model declares both fields as nullable integers (NULL until the
-// first login / first failed login), so we coalesce null / undefined to 0
-// rather than rendering an empty cell.
-export const renderLoginCountCell = ({
-  row: { original },
-}: {
-  row: { original: UserObject };
-}) => original.login_count ?? 0;
-
-export const renderFailLoginCountCell = ({
-  row: { original },
-}: {
-  row: { original: UserObject };
-}) => original.fail_login_count ?? 0;
-
 function UsersList({ user }: UsersListProps) {
   const { addDangerToast, addSuccessToast } = useToasts();
   const {
@@ -303,14 +287,14 @@ function UsersList({ user }: UsersListProps) {
         id: 'login_count',
         Header: t('Login count'),
         hidden: true,
-        Cell: renderLoginCountCell,
+        Cell: ({ row: { original } }: any) => original.login_count ?? 0,
       },
       {
         accessor: 'fail_login_count',
         id: 'fail_login_count',
         Header: t('Fail login count'),
         hidden: true,
-        Cell: renderFailLoginCountCell,
+        Cell: ({ row: { original } }: any) => original.fail_login_count ?? 0,
       },
       {
         accessor: 'created_on',


### PR DESCRIPTION
### SUMMARY

The "Login count" and "Fail login count" columns in the Users list page rendered as empty cells for users who had never logged in (or never had a failed login). Both fields are nullable in Flask-AppBuilder's `User` model (`login_count: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)`) and remain `NULL` until the corresponding event happens, so newly created users always showed empty cells.

This change coalesces `null` / `undefined` to `0` in the two cell renderers in `superset-frontend/src/pages/UsersList/index.tsx`, matching the semantic of a counter column and the `number` type already declared in `UserObject` (`types.ts`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: "Login count" column blank for users who haven't logged in (see screenshot in #40243).

After: column shows `0` for those users.

### TESTING INSTRUCTIONS

1. Go to `Settings > List Users` (`/users/list/`).
2. Add a new user via the "+ User" modal (or use any existing user who has never logged in).
3. Toggle the "Login count" and "Fail login count" columns to visible in the column picker.
4. Expected: both columns display `0` for new / never-logged-in users (previously: empty).
5. For users who have logged in, the columns continue to display the actual integer count from the API.

The existing test fixture in `UsersList.test.tsx` already covers the `null` case (`login_count: null`, `fail_login_count: null`), so the rendering layer is now consistent with the fixtures.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #40243
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API