### PR TITLE
fix(UserListModal): Success notification mentions user and not group

### DIFF
--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -94,7 +94,7 @@ function UserListModal({
     } else {
       try {
         await createUser(values);
-        addSuccessToast(t('The group has been created successfully.'));
+        addSuccessToast(t('The user has been created successfully.'));
       } catch (err) {
         await handleError(err, Actions.CREATE);
       }


### PR DESCRIPTION
Simple fix for a wrong notification (fixes #40244)

"group" is replaced by "user"