### PR TITLE
fix(i18n): translate DateFilter tooltip for time range values

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -125,7 +125,7 @@ const getTooltipTitle = (
 ) =>
   isLabelTruncated ? (
     <div>
-      {label && <strong>{label}</strong>}
+      {label && <strong>{t(label)}</strong>}
       {range && (
         <div
           css={(theme: SupersetTheme) => css`
@@ -160,7 +160,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
   const [timeRangeValue, setTimeRangeValue] = useState(value);
   const [validTimeRange, setValidTimeRange] = useState<boolean>(false);
   const [evalResponse, setEvalResponse] = useState<string>(value);
-  const [tooltipTitle, setTooltipTitle] = useState<ReactNode | null>(value);
+  const [tooltipTitle, setTooltipTitle] = useState<ReactNode | null>(t(value));
   const theme = useTheme();
   const [labelRef, labelIsTruncated] = useCSSTextTruncation<HTMLSpanElement>();
 
@@ -175,7 +175,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       if (error) {
         setEvalResponse(error || '');
         setValidTimeRange(false);
-        setTooltipTitle(value || null);
+        setTooltipTitle(t(value) || null);
       } else {
         /*
           HRT == human readable text


### PR DESCRIPTION
**SUMMARY**
The tooltip on the date filter pill (time range selector) was showing untranslated English text instead of the localized string. For example, when using Superset in Slovenian, the tooltip showed "Current day" instead of "Tekoči dan".

This happened because the raw value string (e.g. "Current day", "Last week") was used directly in the tooltip without passing it through t() for translation. The pill label itself was already translated (via t() in the DateLabel component), but the tooltip was missed.

**Three places were fixed:**
getTooltipTitle(): wrap label in t() so the tooltip shows the translated label when the pill text is truncated
Initial tooltipTitle state: wrap value in t() so the tooltip is translated before the time range API call resolves
Error fallback: wrap value in t() so the tooltip is translated when the API call fails
This affects all time range values shown in the tooltip: Current day/week/month/quarter/year, Last day/week/month/quarter/year, previous calendar week/month/quarter/year, and No filter.

**TESTING INSTRUCTIONS**
Configure Superset to use a non-English locale that has translations for time range values (e.g. Slovenian, German, Chinese)
Navigate to a dashboard or chart with a time range filter
Set the time range to a value like "Current day" or "Last week"
Hover over the date filter pill to see the tooltip
Verify the tooltip text is translated to the configured locale
Also verify when the pill text is truncated (narrow container) — the bold label in the tooltip should also be translated

**ADDITIONAL INFORMATION**
- Changes UI