### PR TITLE
fix(i18n): add Slovenian translation for 'Range type' in DateFilter

### DIFF
--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -9927,9 +9927,8 @@ msgstr "Doseg"
 msgid "Range Inputs"
 msgstr "Razponi"
 
-#, fuzzy
 msgid "Range Type"
-msgstr "TIP OBDOBJA"
+msgstr "Tip obdobja"
 
 msgid "Range filter"
 msgstr "Filter obdobja"
@@ -9940,9 +9939,8 @@ msgstr "Vtičnik za filter obdobja z uporabo AntD"
 msgid "Range labels"
 msgstr "Oznake razponov"
 
-#, fuzzy
 msgid "Range type"
-msgstr "TIP OBDOBJA"
+msgstr "Tip obdobja"
 
 msgid "Ranges"
 msgstr "Razponi"


### PR DESCRIPTION
**SUMMARY**
The "Range type" label in the DateFilter popover was showing untranslated in Slovenian. The translation entries for `"Range Type"` and `"Range type"` existed in the `.po` file but were marked as `#, fuzzy`, which means they are ignored by the translation system. This PR removes the fuzzy flag and corrects the translation casing to `"Tip obdobja"`.

**TESTING INSTRUCTIONS**
Configure Superset with Slovenian locale
Open a chart or dashboard time range filter
The label above the range type dropdown should now show "Tip obdobja" instead of "Range type"

**ADDITIONAL INFORMATION**
- Changes UI
