### PR TITLE
fix(mcp): use `name` URL param so AI-generated SQL Lab titles render

### DIFF
--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -285,7 +285,16 @@ class OpenSqlLabRequest(BaseModel):
         description="SQL to pre-populate in the editor",
         validation_alias=AliasChoices("sql", "query"),
     )
-    title: str | None = Field(None, description="Title for the SQL Lab tab/query")
+    title: str | None = Field(
+        None,
+        description=(
+            "Title for the SQL Lab tab. Generate a succinct, descriptive label "
+            "(roughly 3-6 words) from the conversation context or the query "
+            "intent — e.g. 'Top customers by revenue Q3' — instead of leaving "
+            "the tab untitled. Avoid generic names like 'Untitled Query'."
+        ),
+        max_length=256,
+    )
 
 
 class SqlLabResponse(_SchemaFieldNormalizer):

--- a/superset/mcp_service/sql_lab/schemas.py
+++ b/superset/mcp_service/sql_lab/schemas.py
@@ -296,6 +296,16 @@ class OpenSqlLabRequest(BaseModel):
         max_length=256,
     )
 
+    @field_validator("title")
+    @classmethod
+    def title_strip_or_none(cls, v: str | None) -> str | None:
+        # Whitespace-only would render as a blank tab label; fall back to
+        # SQL Lab's default "Untitled Query N" naming instead.
+        if v is None:
+            return None
+        stripped = v.strip()
+        return stripped or None
+
 
 class SqlLabResponse(_SchemaFieldNormalizer):
     """Response schema for SQL Lab URL generation."""

--- a/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
+++ b/superset/mcp_service/sql_lab/tool/open_sql_lab_with_context.py
@@ -37,7 +37,7 @@ from superset.mcp_service.utils.url_utils import get_superset_base_url
 
 logger = logging.getLogger(__name__)
 
-SQL_LAB_QUERY_PARAMS_TO_SANITIZE = frozenset({"sql", "title"})
+SQL_LAB_QUERY_PARAMS_TO_SANITIZE = frozenset({"sql", "name"})
 
 
 def _sanitize_sql_lab_url_for_llm_context(url: str) -> str:
@@ -128,7 +128,10 @@ def open_sql_lab_with_context(
             params["sql"] = request.sql
 
         if request.title:
-            params["title"] = request.title
+            # SQL Lab's PopEditorTab reads `name` from query string to set the
+            # tab label; keep the MCP-facing field as `title` (more natural for
+            # LLMs) but emit `name` on the URL.
+            params["name"] = request.title
 
         if request.dataset_in_context:
             # Add dataset context as a comment in the SQL if no SQL provided

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_open_sql_lab_with_context.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_open_sql_lab_with_context.py
@@ -272,6 +272,38 @@ class TestOpenSqlLabWithContext:
         finally:
             _restore_modules(saved_modules)
 
+    def test_whitespace_only_title_is_dropped(self) -> None:
+        """Whitespace-only titles must not produce a blank-looking tab label."""
+        mod, saved_modules = _get_tool_module()
+        try:
+            request = OpenSqlLabRequest(
+                database_id=7,
+                sql="SELECT 1",
+                title="   ",
+            )
+
+            with (
+                patch(
+                    "superset.daos.database.DatabaseDAO.find_by_id",
+                    return_value=Mock(database_name="examples"),
+                ),
+                patch.object(
+                    mod.event_logger, "log_context", return_value=nullcontext()
+                ),
+                patch.object(
+                    mod,
+                    "get_superset_base_url",
+                    return_value="https://superset.example.com",
+                ),
+            ):
+                response = mod.open_sql_lab_with_context(request, _make_mock_ctx())
+
+            params = parse_qs(urlsplit(response.url).query)
+            assert "name" not in params
+            assert response.title is None
+        finally:
+            _restore_modules(saved_modules)
+
     def test_sanitizes_error_and_keeps_empty_url_for_missing_database(self) -> None:
         mod, saved_modules = _get_tool_module()
         try:

--- a/tests/unit_tests/mcp_service/sql_lab/tool/test_open_sql_lab_with_context.py
+++ b/tests/unit_tests/mcp_service/sql_lab/tool/test_open_sql_lab_with_context.py
@@ -143,9 +143,10 @@ class TestOpenSqlLabWithContext:
             assert parsed.path == "/sqllab"
             assert params["dbid"] == ["7"]
             assert params["schema"] == ["analytics"]
-            assert params["title"] == [
-                sanitize_for_llm_context("Review this query", field_path=("title",))
+            assert params["name"] == [
+                sanitize_for_llm_context("Review this query", field_path=("name",))
             ]
+            assert "title" not in params
             assert params["sql"] == [
                 sanitize_for_llm_context(
                     "SELECT * FROM users LIMIT 10",
@@ -243,7 +244,7 @@ class TestOpenSqlLabWithContext:
         try:
             url = (
                 "https://superset.example.com/sqllab?"
-                "dbid=7&schema=analytics&sql=SELECT+1&title=Inspect+query"
+                "dbid=7&schema=analytics&sql=SELECT+1&name=Inspect+query"
             )
 
             response = mod._sanitize_sql_lab_response_for_llm_context(
@@ -261,8 +262,8 @@ class TestOpenSqlLabWithContext:
             assert params["sql"] == [
                 sanitize_for_llm_context("SELECT 1", field_path=("sql",))
             ]
-            assert params["title"] == [
-                sanitize_for_llm_context("Inspect query", field_path=("title",))
+            assert params["name"] == [
+                sanitize_for_llm_context("Inspect query", field_path=("name",))
             ]
             assert response.title == sanitize_for_llm_context(
                 "Inspect query",


### PR DESCRIPTION
### SUMMARY

`open_sql_lab_with_context` was emitting `?title=…` on the generated `/sqllab` URL, but SQL Lab's `PopEditorTab` only reads `?name=…` (it destructures `name` straight into `QueryEditor.name`). The LLM-provided title was silently dropped, so MCP-opened tabs landed with no label at all — not even `Untitled Query N`.

Keep the MCP-facing field as `title` (natural for LLMs), but emit it on the URL as `name` to match the existing frontend convention. Also tightened the schema description so models actually generate a descriptive label from conversation context instead of leaving the field unset.

```diff
- params["title"] = request.title
+ params["name"] = request.title  # PopEditorTab reads ?name=
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change to a URL query parameter; tab label is just the user-visible string.

### TESTING INSTRUCTIONS

1. Call the `open_sql_lab_with_context` MCP tool with a `title` (e.g. `"Top customers by revenue"`).
2. Open the returned URL.
3. The SQL Lab tab should open with that title; previously it opened blank.
4. Unit tests: `pytest tests/unit_tests/mcp_service/sql_lab/tool/test_open_sql_lab_with_context.py`.

### ADDITIONAL INFORMATION

- Has associated issue: No
- Required feature flags: None
- Changes UI: No — backend URL contract only; the tab label rendering already supports it
- Includes DB Migration: No
- Introduces new feature or API: No — fixes an existing one
- Removes existing feature or API: No