### PR TITLE
fix(oauth2): idempotent OAuth2 completion and resilient listener

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
@@ -180,4 +180,29 @@ describe('OAuth2RedirectMessage Component', () => {
 
     expect(reRunQuery).not.toHaveBeenCalled();
   });
+
+  test('dispatches only once when both BroadcastChannel and storage signals arrive', async () => {
+    render(setup());
+
+    simulateBroadcastMessage({ tabId: 'tabId' });
+    simulateStorageMessage({ tabId: 'tabId' });
+
+    await waitFor(() => {
+      expect(reRunQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('falls back to storage events when BroadcastChannel construction throws', async () => {
+    (global as any).BroadcastChannel = jest.fn().mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    render(setup());
+
+    simulateStorageMessage({ tabId: 'tabId' });
+
+    await waitFor(() => {
+      expect(reRunQuery).toHaveBeenCalledWith({ sql: 'SELECT * FROM table' });
+    });
+  });
 });

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { act } from 'react';
 import * as reduxHooks from 'react-redux';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
@@ -199,6 +200,55 @@ describe('OAuth2RedirectMessage Component', () => {
 
     render(setup());
 
+    simulateStorageMessage({ tabId: 'tabId' });
+
+    await waitFor(() => {
+      expect(reRunQuery).toHaveBeenCalledWith({ sql: 'SELECT * FROM table' });
+    });
+  });
+
+  test('re-processes a later signal when the first arrived before state was ready', async () => {
+    const initialState = {
+      sqlLab: {
+        queries: {},
+        queryEditors: [{ id: 'editor-id' }],
+        tabHistory: ['editor-id'],
+      },
+      explore: { slice: { slice_id: 123 } },
+      charts: { '1': {}, '2': {} },
+      dashboardInfo: { id: 'dashboard-id' },
+    };
+    const dynamicStore = createStore(
+      (state: any = initialState, action: any) => {
+        if (action.type === 'SET_READY') {
+          return {
+            ...state,
+            sqlLab: {
+              ...state.sqlLab,
+              queries: { 'query-id': { sql: 'SELECT * FROM table' } },
+              queryEditors: [{ id: 'editor-id', latestQueryId: 'query-id' }],
+            },
+          };
+        }
+        return state;
+      },
+    );
+
+    render(
+      <Provider store={dynamicStore}>
+        <OAuth2RedirectMessage {...defaultProps} />
+      </Provider>,
+    );
+
+    // First signal arrives before the SQL Lab query state is populated;
+    // nothing dispatches and `handled` must NOT be flipped.
+    simulateBroadcastMessage({ tabId: 'tabId' });
+    expect(reRunQuery).not.toHaveBeenCalled();
+
+    // Query state becomes available, then the storage fallback signal fires.
+    act(() => {
+      dynamicStore.dispatch({ type: 'SET_READY' });
+    });
     simulateStorageMessage({ tabId: 'tabId' });
 
     await waitFor(() => {

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
@@ -125,7 +125,6 @@ export function OAuth2RedirectMessage({
       if (tabId !== extra.tab_id || handled) {
         return;
       }
-      handled = true;
       const {
         source: src,
         query: q,
@@ -133,11 +132,17 @@ export function OAuth2RedirectMessage({
         chartList: cList,
         dashboardId: dId,
       } = latestStateRef.current;
+      // Only flip `handled` once a dispatch actually runs so a later fallback
+      // signal can still succeed if the first arrived before state was ready
+      // (e.g. `query` still null in SQL Lab).
       if (src === 'sqllab' && q) {
+        handled = true;
         dispatch(reRunQuery(q));
       } else if (src === 'explore' && cId) {
+        handled = true;
         dispatch(triggerQuery(true, cId));
       } else if (src === 'dashboard') {
+        handled = true;
         dispatch(onRefresh(cList.map(Number), true, 0, dId));
       }
     };

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { QueryEditor, SqlLabRootState } from 'src/SqlLab/types';
@@ -99,29 +99,61 @@ export function OAuth2RedirectMessage({
 
   const dispatch = useDispatch();
 
+  // `chartList` is rebuilt from `Object.keys` on every store update; keeping
+  // the listener state in a ref avoids tearing down/recreating the
+  // BroadcastChannel on each render and the race window that comes with it.
+  const latestStateRef = useRef({
+    source,
+    query,
+    chartId,
+    chartList,
+    dashboardId,
+  });
+  latestStateRef.current = {
+    source,
+    query,
+    chartId,
+    chartList,
+    dashboardId,
+  };
+
   useEffect(() => {
+    // Guard against duplicate dispatches if both the BroadcastChannel and the
+    // storage fallback ever deliver the same completion.
+    let handled = false;
     const handleOAuthComplete = (tabId?: string) => {
-      if (tabId !== extra.tab_id) {
+      if (tabId !== extra.tab_id || handled) {
         return;
       }
-      if (source === 'sqllab' && query) {
-        dispatch(reRunQuery(query));
-      } else if (source === 'explore' && chartId) {
-        dispatch(triggerQuery(true, chartId));
-      } else if (source === 'dashboard') {
-        dispatch(onRefresh(chartList.map(Number), true, 0, dashboardId));
+      handled = true;
+      const {
+        source: src,
+        query: q,
+        chartId: cId,
+        chartList: cList,
+        dashboardId: dId,
+      } = latestStateRef.current;
+      if (src === 'sqllab' && q) {
+        dispatch(reRunQuery(q));
+      } else if (src === 'explore' && cId) {
+        dispatch(triggerQuery(true, cId));
+      } else if (src === 'dashboard') {
+        dispatch(onRefresh(cList.map(Number), true, 0, dId));
       }
     };
 
-    const channel =
-      typeof BroadcastChannel !== 'undefined'
-        ? new BroadcastChannel(OAUTH_CHANNEL_NAME)
-        : null;
-
-    if (channel) {
-      channel.onmessage = event => {
-        handleOAuthComplete(event.data?.tabId);
-      };
+    // `BroadcastChannel` may exist on `window` but throw at construction time
+    // in restricted contexts; fall back to the storage listener if so.
+    let channel: BroadcastChannel | null = null;
+    if (typeof BroadcastChannel !== 'undefined') {
+      try {
+        channel = new BroadcastChannel(OAUTH_CHANNEL_NAME);
+        channel.onmessage = event => {
+          handleOAuthComplete(event.data?.tabId);
+        };
+      } catch {
+        channel = null;
+      }
     }
 
     const handleStorage = (event: StorageEvent) => {
@@ -143,7 +175,7 @@ export function OAuth2RedirectMessage({
       window.removeEventListener('storage', handleStorage);
       channel?.close();
     };
-  }, [source, extra.tab_id, dispatch, query, chartId, chartList, dashboardId]);
+  }, [extra.tab_id, dispatch]);
 
   const body = (
     <p>

--- a/superset/templates/superset/oauth2.html
+++ b/superset/templates/superset/oauth2.html
@@ -25,24 +25,22 @@ under the License.
   <body>
     <script nonce="{{ macros.get_nonce() }}">
       const message = { tabId: '{{ tab_id }}' };
-      let broadcasted = false;
+      // Emit on both channels: postMessage success doesn't guarantee the original
+      // tab's listener was attached. The receiver dedupes via a `handled` flag.
       if (typeof BroadcastChannel !== 'undefined') {
         try {
           const channel = new BroadcastChannel('oauth');
           channel.postMessage(message);
           channel.close();
-          broadcasted = true;
         } catch (e) {
-          // fall through to the localStorage fallback below
+          // ignore; storage path below still fires
         }
       }
-      if (!broadcasted) {
-        try {
-          localStorage.setItem('oauth2_auth_complete', JSON.stringify(message));
-          localStorage.removeItem('oauth2_auth_complete');
-        } catch (e) {
-          // storage may be unavailable (e.g. blocked or restricted); ignore
-        }
+      try {
+        localStorage.setItem('oauth2_auth_complete', JSON.stringify(message));
+        localStorage.removeItem('oauth2_auth_complete');
+      } catch (e) {
+        // storage may be unavailable (e.g. blocked or restricted); ignore
       }
       window.close();
     </script>

--- a/superset/templates/superset/oauth2.html
+++ b/superset/templates/superset/oauth2.html
@@ -25,13 +25,25 @@ under the License.
   <body>
     <script nonce="{{ macros.get_nonce() }}">
       const message = { tabId: '{{ tab_id }}' };
+      let broadcasted = false;
       if (typeof BroadcastChannel !== 'undefined') {
-        const channel = new BroadcastChannel('oauth');
-        channel.postMessage(message);
-        channel.close();
+        try {
+          const channel = new BroadcastChannel('oauth');
+          channel.postMessage(message);
+          channel.close();
+          broadcasted = true;
+        } catch (e) {
+          // fall through to the localStorage fallback below
+        }
       }
-      localStorage.setItem('oauth2_auth_complete', JSON.stringify(message));
-      localStorage.removeItem('oauth2_auth_complete');
+      if (!broadcasted) {
+        try {
+          localStorage.setItem('oauth2_auth_complete', JSON.stringify(message));
+          localStorage.removeItem('oauth2_auth_complete');
+        } catch (e) {
+          // storage may be unavailable (e.g. blocked or restricted); ignore
+        }
+      }
       window.close();
     </script>
     <p>You can close this window and re-run the query.</p>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The OAuth2 callback page always emitted both `BroadcastChannel` and `localStorage` signals when `BroadcastChannel` was supported, so a single completion re-triggered `reRunQuery` / `triggerQuery` / `onRefresh` twice in the original tab. This PR makes the sender's storage path a true fallback (only when `BroadcastChannel` is unavailable or its construction throws), and guard the receiver against duplicate dispatches as a safety net.

Additionally, it wraps channel/storage operations in `try/catch` so restricted contexts can't abort the flow, and stabilize the listener's effect by reading volatile selector values (`chartList`, `query`, etc.) from a `ref` so `chartList` changes don't churn the channel and open a race window.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
