### PR TITLE
fix(dashboard): prevent native filter Select dropdown from obscuring input on small screens

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -27,7 +27,9 @@ import {
   waitFor,
 } from 'spec/helpers/testing-library';
 import { NULL_STRING } from 'src/utils/common';
-import SelectFilterPlugin from './SelectFilterPlugin';
+import SelectFilterPlugin, {
+  getSelectPopupContainer,
+} from './SelectFilterPlugin';
 import transformProps from './transformProps';
 import { FilterState } from '@superset-ui/core';
 import {
@@ -201,6 +203,30 @@ describe('SelectFilterPlugin', () => {
         excludeFilterValues: true,
       },
     });
+  });
+
+  test('uses document.body as popup container in dashboard filter bar', () => {
+    const container = getSelectPopupContainer(AppSection.Dashboard, false);
+    expect(container(document.createElement('div'))).toBe(document.body);
+  });
+
+  test('uses parent ref as popup container for overflowed filters', () => {
+    const parentNode = document.createElement('div');
+    const container = getSelectPopupContainer(AppSection.Dashboard, true, {
+      current: parentNode,
+    });
+    expect(container()).toBe(parentNode);
+  });
+
+  test('keeps trigger parent popup container outside dashboard filter bar', () => {
+    const triggerParent = document.createElement('div');
+    const trigger = document.createElement('div');
+    triggerParent.appendChild(trigger);
+    const container = getSelectPopupContainer(
+      AppSection.FilterConfigModal,
+      false,
+    );
+    expect(container(trigger)).toBe(triggerParent);
   });
 
   test('Remove multiple values when required', () => {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -17,7 +17,14 @@
  * under the License.
  */
 /* eslint-disable no-param-reassign */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { t } from '@apache-superset/core/translation';
 import {
   AppSection,
@@ -92,6 +99,26 @@ function reducer(draft: DataMask, action: DataMaskAction) {
       return draft;
   }
 }
+
+export const getSelectPopupContainer = (
+  appSection: AppSection,
+  showOverflow: boolean,
+  parentRef?: RefObject<any>,
+) => {
+  if (showOverflow) {
+    return () => (parentRef?.current as HTMLElement) || document.body;
+  }
+
+  if (
+    appSection === AppSection.Dashboard ||
+    appSection === AppSection.FilterBar
+  ) {
+    return () => document.body;
+  }
+
+  return (trigger: HTMLElement) =>
+    (trigger?.parentNode as HTMLElement) || document.body;
+};
 
 const StyledSpace = styled(Space)<{
   inverseSelection: boolean;
@@ -595,12 +622,11 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
               allowSelectAll={!searchAllOptions}
               value={multiSelect ? filterState.value || [] : filterState.value}
               disabled={isDisabled}
-              getPopupContainer={
-                showOverflow
-                  ? () => (parentRef?.current as HTMLElement) || document.body
-                  : (trigger: HTMLElement) =>
-                      (trigger?.parentNode as HTMLElement) || document.body
-              }
+              getPopupContainer={getSelectPopupContainer(
+                appSection,
+                showOverflow,
+                parentRef,
+              )}
               showSearch={showSearch}
               mode={multiSelect ? 'multiple' : 'single'}
               placeholder={placeholderText}


### PR DESCRIPTION
### SUMMARY

The Value filter dropdown in the dashboard native filter bar was mounting its popup to the trigger's parent node. On smaller viewports or with elevated browser zoom the constrained parent prevented antd's overflow logic from flipping the menu, so the dropdown rendered over the input field.

This PR routes Dashboard/FilterBar Select filters through a new shared `getSelectPopupContainer` helper that mounts to `document.body` when the filter is not overflowed. That lets `DROPDOWN_ALIGN_BOTTOM`'s `overflow: { adjustY: 1 }` position the menu against the viewport — so the popup flips above the input when there is no space below. Overflowed filters (which render inside the filter-bar popover) and the filter-config modal keep their existing container behavior to avoid regressing those positioning contexts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!-- TODO: capture short clip of small-viewport repro before/after -->

### TESTING INSTRUCTIONS

1. Open the example Sales Dashboard.
2. Reduce the viewport height (or increase browser zoom) until there isn't enough room below the Value filter for a normal dropdown.
3. Click a Value filter.
4. Confirm the dropdown flips above the input instead of obscuring it.
5. Verify these still work as before:
   - Overflowed native filters (filter bar with many filters in horizontal mode).
   - Filter-config modal value selects.
   - Non-dashboard Select usage of this plugin.

Unit tests: `npm test -- SelectFilterPlugin.test` (36/36 pass, including 3 new tests for the helper).

### ADDITIONAL INFORMATION

- [x] Has associated issue: #34135
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
