### PR TITLE
chore(docker): remove debugger flag from Flask dev server startup

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -80,7 +80,7 @@ case "${1}" in
     ;;
   app)
     echo "Starting web app (using development server)..."
-    flask run -p $PORT --reload --debugger --host=0.0.0.0 --exclude-patterns "*/node_modules/*:*/.venv/*:*/build/*:*/__pycache__/*:*/superset-frontend/*"
+    flask run -p $PORT --reload --host=0.0.0.0 --exclude-patterns "*/node_modules/*:*/.venv/*:*/build/*:*/__pycache__/*:*/superset-frontend/*"
     ;;
   app-gunicorn)
     echo "Starting web app..."


### PR DESCRIPTION
## Summary

Removes the `--debugger` flag from the `flask run` command in `docker/docker-bootstrap.sh`.

The Werkzeug interactive debugger console (EVALEX) is not needed for development workflows in Docker — hot-reloading (`--reload`) provides the primary developer benefit. The console is not used in normal development flows and adds unnecessary surface area when the server is bound to `0.0.0.0`.

## Changes

- `docker/docker-bootstrap.sh`: removed `--debugger` from the `app` case `flask run` invocation

## Testing

1. Start dev Docker with `docker compose up`
2. Verify the app starts and serves the Superset UI normally
3. Confirm `GET /console` returns 404
4. Confirm `ps aux | grep flask` shows no `--debugger` flag
5. Verify hot-reload still works by editing a Python file and observing the server restart