### PR TITLE
feat(mcp): add series_limit to generate_chart XY config

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -678,7 +678,7 @@ def _resolve_default_x_axis(
     return config.model_copy(update={"x": ColumnRef(name=dataset.main_dttm_col)})
 
 
-def map_xy_config(
+def map_xy_config(  # noqa: C901
     config: XYChartConfig, dataset_id: int | str | None = None
 ) -> Dict[str, Any]:
     """Map XY chart config to form_data with defensive validation."""
@@ -743,6 +743,9 @@ def map_xy_config(
         _ensure_temporal_adhoc_filter(form_data, config.x.name)
 
     form_data["row_limit"] = config.row_limit
+
+    if config.series_limit is not None:
+        form_data["series_limit"] = config.series_limit
 
     # Add stacking configuration
     if getattr(config, "stacked", False):

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -678,7 +678,13 @@ def _resolve_default_x_axis(
     return config.model_copy(update={"x": ColumnRef(name=dataset.main_dttm_col)})
 
 
-def map_xy_config(  # noqa: C901
+def _add_xy_limits(form_data: Dict[str, Any], config: XYChartConfig) -> None:
+    form_data["row_limit"] = config.row_limit
+    if config.series_limit is not None:
+        form_data["series_limit"] = config.series_limit
+
+
+def map_xy_config(
     config: XYChartConfig, dataset_id: int | str | None = None
 ) -> Dict[str, Any]:
     """Map XY chart config to form_data with defensive validation."""
@@ -742,10 +748,7 @@ def map_xy_config(  # noqa: C901
     if x_is_temporal:
         _ensure_temporal_adhoc_filter(form_data, config.x.name)
 
-    form_data["row_limit"] = config.row_limit
-
-    if config.series_limit is not None:
-        form_data["series_limit"] = config.series_limit
+    _add_xy_limits(form_data, config)
 
     # Add stacking configuration
     if getattr(config, "stacked", False):

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1438,6 +1438,16 @@ class XYChartConfig(UnknownFieldCheckMixin):
         "Do NOT use adhoc_filters or raw SQL expressions.",
     )
     row_limit: int = Field(10000, description="Max data points", ge=1, le=50000)
+    series_limit: int | None = Field(
+        None,
+        description=(
+            "Max number of series to show when group_by is set. "
+            "Limits the distinct values rendered as separate lines/bars. "
+            "Only applies when group_by is specified."
+        ),
+        ge=1,
+        le=10000,
+    )
 
     @field_validator("group_by", mode="before")
     @classmethod

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -452,6 +452,43 @@ class TestRowLimit:
                 row_limit=100000,
             )
 
+    def test_xy_chart_series_limit_default_none(self) -> None:
+        """Test that XYChartConfig series_limit defaults to None."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+        )
+        assert config.series_limit is None
+
+    def test_xy_chart_series_limit_custom(self) -> None:
+        """Test that XYChartConfig accepts a custom series_limit."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            group_by=[ColumnRef(name="region")],
+            series_limit=5,
+        )
+        assert config.series_limit == 5
+
+    def test_xy_chart_series_limit_validation(self) -> None:
+        """Test that XYChartConfig rejects invalid series_limit values."""
+        with pytest.raises(ValidationError):
+            XYChartConfig(
+                chart_type="xy",
+                x=ColumnRef(name="date"),
+                y=[ColumnRef(name="revenue", aggregate="SUM")],
+                series_limit=0,
+            )
+        with pytest.raises(ValidationError):
+            XYChartConfig(
+                chart_type="xy",
+                x=ColumnRef(name="date"),
+                y=[ColumnRef(name="revenue", aggregate="SUM")],
+                series_limit=10001,
+            )
+
     def test_table_chart_default_row_limit(self) -> None:
         """Test that TableChartConfig has default row_limit of 1000."""
         config = TableChartConfig(

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -452,6 +452,42 @@ class TestRowLimit:
                 row_limit=100000,
             )
 
+    def test_table_chart_default_row_limit(self) -> None:
+        """Test that TableChartConfig has default row_limit of 1000."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="product")],
+        )
+        assert config.row_limit == 1000
+
+    def test_table_chart_custom_row_limit(self) -> None:
+        """Test that TableChartConfig accepts custom row_limit."""
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="product")],
+            row_limit=500,
+        )
+        assert config.row_limit == 500
+
+    def test_table_chart_row_limit_validation(self) -> None:
+        """Test that TableChartConfig rejects invalid row_limit."""
+        with pytest.raises(ValidationError):
+            TableChartConfig(
+                chart_type="table",
+                columns=[ColumnRef(name="product")],
+                row_limit=0,
+            )
+        with pytest.raises(ValidationError):
+            TableChartConfig(
+                chart_type="table",
+                columns=[ColumnRef(name="product")],
+                row_limit=100000,
+            )
+
+
+class TestSeriesLimit:
+    """Test series_limit field on XYChartConfig."""
+
     def test_xy_chart_series_limit_default_none(self) -> None:
         """Test that XYChartConfig series_limit defaults to None."""
         config = XYChartConfig(
@@ -487,38 +523,6 @@ class TestRowLimit:
                 x=ColumnRef(name="date"),
                 y=[ColumnRef(name="revenue", aggregate="SUM")],
                 series_limit=10001,
-            )
-
-    def test_table_chart_default_row_limit(self) -> None:
-        """Test that TableChartConfig has default row_limit of 1000."""
-        config = TableChartConfig(
-            chart_type="table",
-            columns=[ColumnRef(name="product")],
-        )
-        assert config.row_limit == 1000
-
-    def test_table_chart_custom_row_limit(self) -> None:
-        """Test that TableChartConfig accepts custom row_limit."""
-        config = TableChartConfig(
-            chart_type="table",
-            columns=[ColumnRef(name="product")],
-            row_limit=500,
-        )
-        assert config.row_limit == 500
-
-    def test_table_chart_row_limit_validation(self) -> None:
-        """Test that TableChartConfig rejects invalid row_limit."""
-        with pytest.raises(ValidationError):
-            TableChartConfig(
-                chart_type="table",
-                columns=[ColumnRef(name="product")],
-                row_limit=0,
-            )
-        with pytest.raises(ValidationError):
-            TableChartConfig(
-                chart_type="table",
-                columns=[ColumnRef(name="product")],
-                row_limit=100000,
             )
 
 

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -832,6 +832,38 @@ class TestMapXYConfig:
         assert result["row_limit"] == 10000
 
     @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_map_xy_config_series_limit(self, mock_is_temporal) -> None:
+        """Test that series_limit is mapped to form_data when set."""
+        mock_is_temporal.return_value = True
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+            group_by=[ColumnRef(name="region")],
+            series_limit=10,
+        )
+
+        result = map_xy_config(config)
+
+        assert result["series_limit"] == 10
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
+    def test_map_xy_config_no_series_limit_by_default(self, mock_is_temporal) -> None:
+        """Test that series_limit is omitted from form_data when not set."""
+        mock_is_temporal.return_value = True
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="line",
+        )
+
+        result = map_xy_config(config)
+
+        assert "series_limit" not in result
+
+    @patch("superset.mcp_service.chart.chart_utils.is_column_truly_temporal")
     def test_map_xy_config_saved_metric(self, mock_is_temporal: Any) -> None:
         """Test XY config with saved metric emits string in metrics list"""
         mock_is_temporal.return_value = True


### PR DESCRIPTION
### SUMMARY

Adds a `series_limit` parameter to `XYChartConfig` in the `generate_chart` MCP tool.

When `group_by` is set on an XY chart (line, bar, area, scatter), users can now control the maximum number of distinct series rendered by specifying `series_limit`. The value is forwarded as `form_data["series_limit"]`, which Superset's echarts timeseries plugins use to cap the number of rendered series lines/bars.

**Usage example:**
```json
{
  "dataset_id": 123,
  "config": {
    "chart_type": "xy",
    "x": {"name": "order_date"},
    "y": [{"name": "revenue", "aggregate": "SUM"}],
    "group_by": [{"name": "region"}],
    "kind": "line",
    "series_limit": 10
  }
}
```

When `series_limit` is not set (default `None`), the field is omitted from form_data and Superset applies no series cap.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend schema change only.

### TESTING INSTRUCTIONS

1. Call `generate_chart` with an XY config that includes `group_by` and `series_limit: 5`
2. Verify the returned `form_data` contains `"series_limit": 5`
3. Open the explore URL — the chart should show at most 5 series
4. Call without `series_limit` — verify `form_data` does not contain `series_limit`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API