### PR TITLE
ci(deps): bump lower bound on pip dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,11 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     open-pull-requests-limit: 10
+    # Bump the lower bound to the new version, not just widen the upper
+    # bound. Without this, a `sqlglot>=28.10.0, <29` constraint upgraded
+    # to `<30` would keep the stale lower bound forever, dragging
+    # transitively-resolved versions with it. See #40186 (review thread).
+    versioning-strategy: increase
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
### SUMMARY

Follow-up to @villebro's review on #40186 (sqlglot 28→30 bump). Dependabot's default behavior for the pip ecosystem is to only **widen the upper bound** of constraints in \`pyproject.toml\`, leaving the lower bound at the old version forever. Over time the lower bound becomes meaningless because no installed environment ever resolves that low.

Setting \`versioning-strategy: increase\` makes dependabot bump **both sides** of the range to the new version, e.g. \`sqlglot>=28.10.0, <29\` → \`sqlglot>=30.8.0, <31\` in one PR.

### BEFORE/AFTER

Take a bump from sqlglot 28.10.0 → 30.8.0:

| | Before | After |
|---|---|---|
| Upper bound | `<29` → `<31` | `<29` → `<31` |
| Lower bound | `>=28.10.0` (unchanged) | `>=30.8.0` |

The lower bound drift is what @villebro flagged on #40186 — over many bumps it becomes a fiction.

### What this PR doesn't do

Lockfile regeneration (\`./scripts/uv-pip-compile.sh\` against \`requirements/base.txt\` / \`development.txt\`) still needs a human or a separate hook. Dependabot for pip doesn't auto-run \`uv\` and won't update compiled pin files. That's a separate problem to solve later — this PR just fixes the \`pyproject.toml\`-side drift.

### TESTING INSTRUCTIONS

Config-only change. To validate, dependabot's next pip-ecosystem PR will set both bounds.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)