### PR TITLE
feat(mcp): return browser-friendly hello page for GET /mcp from browsers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,6 +21,7 @@ include README.md
 include superset-frontend/package.json
 recursive-include superset/examples *
 recursive-include superset/migrations *
+recursive-include superset/mcp_service *.html
 recursive-include superset/templates *
 recursive-include superset/translations *
 recursive-include superset/static *

--- a/superset/mcp_service/hello.html
+++ b/superset/mcp_service/hello.html
@@ -1,0 +1,115 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Superset MCP Server</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f5f5;
+      color: #1a1a1a;
+      margin: 0;
+      padding: 40px 16px;
+      line-height: 1.6;
+    }
+    .card {
+      max-width: 640px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 8px;
+      box-shadow: 0 1px 4px rgba(0,0,0,.12);
+      padding: 40px 40px 32px;
+    }
+    h1 { font-size: 1.4rem; margin: 0 0 8px; }
+    .badge {
+      display: inline-block;
+      background: #e8f4fd;
+      color: #0070c0;
+      font-size: .75rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 4px;
+      margin-bottom: 20px;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+    }
+    p { margin: 0 0 20px; color: #444; }
+    h2 { font-size: 1rem; margin: 24px 0 8px; color: #1a1a1a; }
+    pre {
+      background: #f0f0f0;
+      border-radius: 6px;
+      padding: 16px;
+      font-size: .85rem;
+      overflow-x: auto;
+      margin: 0 0 24px;
+    }
+    code {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }
+    .note {
+      font-size: .85rem;
+      color: #666;
+      border-left: 3px solid #ddd;
+      padding-left: 12px;
+      margin-top: 24px;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge">MCP API Endpoint</div>
+    <h1>Superset MCP Server</h1>
+    <p>
+      This is the <strong>Model Context Protocol (MCP)</strong> endpoint for
+      Apache Superset. It is an API designed for AI coding assistants —
+      not a web page to browse directly.
+    </p>
+    <h2>How to connect</h2>
+    <p>Add the following to your MCP client configuration,
+    replacing the URL and API key with your actual values:</p>
+    <pre><code>{
+  "mcpServers": {
+    "superset": {
+      "url": "&lt;this-url&gt;",
+      "transport": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer &lt;your-api-key&gt;"
+      }
+    }
+  }
+}</code></pre>
+    <h2>Supported clients</h2>
+    <p>This endpoint works with any MCP-compatible client, including:</p>
+    <ul style="color:#444;margin:0 0 20px;padding-left:20px;">
+      <li>Claude Desktop</li>
+      <li>Claude Code (CLI)</li>
+      <li>Cursor</li>
+      <li>Any client that supports the <code>streamable-http</code> transport</li>
+    </ul>
+    <div class="note">
+      Replace <code>&lt;this-url&gt;</code> with the full URL of this page and
+      <code>&lt;your-api-key&gt;</code> with a valid Superset API key or JWT token.
+    </div>
+  </div>
+</body>
+</html>

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -62,11 +62,18 @@ _jwt_failure_reason: ContextVar[str | None] = ContextVar(
     "_jwt_failure_reason", default=None
 )
 
-_MCP_BROWSER_HELLO_HTML: str = (
-    _resource_files("superset.mcp_service")
-    .joinpath("hello.html")
-    .read_text(encoding="utf-8")
-)
+_MCP_BROWSER_HELLO_HTML: str | None = None
+
+
+def _get_browser_hello_html() -> str:
+    global _MCP_BROWSER_HELLO_HTML
+    if _MCP_BROWSER_HELLO_HTML is None:
+        _MCP_BROWSER_HELLO_HTML = (
+            _resource_files("superset.mcp_service")
+            .joinpath("hello.html")
+            .read_text(encoding="utf-8")
+        )
+    return _MCP_BROWSER_HELLO_HTML
 
 
 def _prefers_browser_html(conn: HTTPConnection) -> bool:
@@ -101,7 +108,7 @@ def _auth_error_handler(conn: HTTPConnection, exc: AuthenticationError) -> Respo
         - CVE-2022-29266, CVE-2019-7644: verbose JWT errors led to exploits
     """
     if _prefers_browser_html(conn):
-        return HTMLResponse(status_code=200, content=_MCP_BROWSER_HELLO_HTML)
+        return HTMLResponse(status_code=200, content=_get_browser_hello_html())
 
     # Log detailed reason server-side only
     logger.warning("JWT authentication failed: %s", exc)

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -45,7 +45,7 @@ from starlette.authentication import AuthenticationError
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import HTTPConnection
-from starlette.responses import HTMLResponse, JSONResponse
+from starlette.responses import HTMLResponse, JSONResponse, Response
 
 from superset.utils import json
 
@@ -160,28 +160,38 @@ _MCP_BROWSER_HELLO_HTML = """<!DOCTYPE html>
 </html>"""
 
 
-def _json_auth_error_handler(
-    conn: HTTPConnection, exc: AuthenticationError
-) -> JSONResponse | HTMLResponse:
-    """Auth error handler for authentication failures.
+def _prefers_browser_html(conn: HTTPConnection) -> bool:
+    """Return True when the request looks like a browser navigation.
 
-    Returns a friendly HTML page when the request comes from a browser
-    (Accept: text/html), so users who open the MCP URL in a browser see
-    setup instructions rather than a raw JSON 401.
+    Checks both the HTTP method (GET/HEAD only) and the Accept header
+    (text/html present, application/json and text/event-stream absent).
+    Case-insensitive to handle unusual but valid header values.
+    """
+    if conn.scope.get("method") not in ("GET", "HEAD"):
+        return False
+    accept = conn.headers.get("accept", "").lower()
+    return (
+        "text/html" in accept
+        and "application/json" not in accept
+        and "text/event-stream" not in accept
+    )
 
-    For all other clients (API, SSE) returns a standard JSON 401 per
-    RFC 6750 Section 3.1.
+
+def _auth_error_handler(conn: HTTPConnection, exc: AuthenticationError) -> Response:
+    """Auth error handler for unauthenticated MCP requests.
+
+    Returns a friendly HTML page for browser navigation requests so users
+    who open the MCP URL in a browser see setup instructions instead of a
+    raw JSON 401.
+
+    For all other clients (API, SSE, non-GET methods) returns a standard
+    JSON 401 per RFC 6750 Section 3.1.
 
     References:
         - RFC 6750 Section 3.1: https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
         - CVE-2022-29266, CVE-2019-7644: verbose JWT errors led to exploits
     """
-    accept = conn.headers.get("accept", "")
-    if (
-        "text/html" in accept
-        and "application/json" not in accept
-        and "text/event-stream" not in accept
-    ):
+    if _prefers_browser_html(conn):
         return HTMLResponse(status_code=200, content=_MCP_BROWSER_HELLO_HTML)
 
     # Log detailed reason server-side only
@@ -197,6 +207,28 @@ def _json_auth_error_handler(
             "WWW-Authenticate": 'Bearer error="invalid_token"',
         },
     )
+
+
+class MCPJWTVerifier(JWTVerifier):
+    """JWTVerifier with Superset MCP auth error handling.
+
+    Provides browser-friendly HTML responses for unauthenticated browser
+    navigation requests (GET/HEAD with Accept: text/html), while maintaining
+    RFC 6750-compliant JSON 401 responses for API and SSE clients.
+
+    Use this as the base for all Superset JWT verifiers so the browser hello
+    page is active regardless of which verifier variant is configured.
+    """
+
+    def get_middleware(self) -> list[Any]:
+        return [
+            Middleware(
+                AuthenticationMiddleware,
+                backend=BearerAuthBackend(self),
+                on_error=_auth_error_handler,
+            ),
+            Middleware(AuthContextMiddleware),
+        ]
 
 
 class DetailedBearerAuthBackend(BearerAuthBackend):
@@ -232,7 +264,7 @@ class DetailedBearerAuthBackend(BearerAuthBackend):
         return None
 
 
-class DetailedJWTVerifier(JWTVerifier):
+class DetailedJWTVerifier(MCPJWTVerifier):
     """
     JWT verifier with tiered server-side logging for each validation step.
 
@@ -408,7 +440,7 @@ class DetailedJWTVerifier(JWTVerifier):
             Middleware(
                 AuthenticationMiddleware,
                 backend=DetailedBearerAuthBackend(self),
-                on_error=_json_auth_error_handler,
+                on_error=_auth_error_handler,
             ),
             Middleware(AuthContextMiddleware),
         ]

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -29,6 +29,7 @@ import base64
 import logging
 import time
 from contextvars import ContextVar
+from importlib.resources import files as _resource_files
 from typing import Any, cast
 
 from authlib.jose.errors import (
@@ -61,103 +62,11 @@ _jwt_failure_reason: ContextVar[str | None] = ContextVar(
     "_jwt_failure_reason", default=None
 )
 
-_MCP_BROWSER_HELLO_HTML = """<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Superset MCP Server</title>
-  <style>
-    *, *::before, *::after { box-sizing: border-box; }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      background: #f5f5f5;
-      color: #1a1a1a;
-      margin: 0;
-      padding: 40px 16px;
-      line-height: 1.6;
-    }
-    .card {
-      max-width: 640px;
-      margin: 0 auto;
-      background: #ffffff;
-      border-radius: 8px;
-      box-shadow: 0 1px 4px rgba(0,0,0,.12);
-      padding: 40px 40px 32px;
-    }
-    h1 { font-size: 1.4rem; margin: 0 0 8px; }
-    .badge {
-      display: inline-block;
-      background: #e8f4fd;
-      color: #0070c0;
-      font-size: .75rem;
-      font-weight: 600;
-      padding: 2px 8px;
-      border-radius: 4px;
-      margin-bottom: 20px;
-      letter-spacing: .04em;
-      text-transform: uppercase;
-    }
-    p { margin: 0 0 20px; color: #444; }
-    h2 { font-size: 1rem; margin: 24px 0 8px; color: #1a1a1a; }
-    pre {
-      background: #f0f0f0;
-      border-radius: 6px;
-      padding: 16px;
-      font-size: .85rem;
-      overflow-x: auto;
-      margin: 0 0 24px;
-    }
-    code {
-      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-    }
-    .note {
-      font-size: .85rem;
-      color: #666;
-      border-left: 3px solid #ddd;
-      padding-left: 12px;
-      margin-top: 24px;
-    }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <div class="badge">MCP API Endpoint</div>
-    <h1>Superset MCP Server</h1>
-    <p>
-      This is the <strong>Model Context Protocol (MCP)</strong> endpoint for
-      Apache Superset. It is an API designed for AI coding assistants —
-      not a web page to browse directly.
-    </p>
-    <h2>How to connect</h2>
-    <p>Add the following to your MCP client configuration,
-    replacing the URL and API key with your actual values:</p>
-    <pre><code>{
-  "mcpServers": {
-    "superset": {
-      "url": "&lt;this-url&gt;",
-      "transport": "streamable-http",
-      "headers": {
-        "Authorization": "Bearer &lt;your-api-key&gt;"
-      }
-    }
-  }
-}</code></pre>
-    <h2>Supported clients</h2>
-    <p>This endpoint works with any MCP-compatible client, including:</p>
-    <ul style="color:#444;margin:0 0 20px;padding-left:20px;">
-      <li>Claude Desktop</li>
-      <li>Claude Code (CLI)</li>
-      <li>Cursor</li>
-      <li>Any client that supports the <code>streamable-http</code> transport</li>
-    </ul>
-    <div class="note">
-      Replace <code>&lt;this-url&gt;</code> with the full URL of this page and
-      <code>&lt;your-api-key&gt;</code> with a valid Superset API key or JWT token.
-    </div>
-  </div>
-</body>
-</html>"""
+_MCP_BROWSER_HELLO_HTML: str = (
+    _resource_files("superset.mcp_service")
+    .joinpath("hello.html")
+    .read_text(encoding="utf-8")
+)
 
 
 def _prefers_browser_html(conn: HTTPConnection) -> bool:

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -45,7 +45,7 @@ from starlette.authentication import AuthenticationError
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import HTTPConnection
-from starlette.responses import JSONResponse
+from starlette.responses import HTMLResponse, JSONResponse
 
 from superset.utils import json
 
@@ -61,21 +61,129 @@ _jwt_failure_reason: ContextVar[str | None] = ContextVar(
     "_jwt_failure_reason", default=None
 )
 
+_MCP_BROWSER_HELLO_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Superset MCP Server</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f5f5;
+      color: #1a1a1a;
+      margin: 0;
+      padding: 40px 16px;
+      line-height: 1.6;
+    }
+    .card {
+      max-width: 640px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 8px;
+      box-shadow: 0 1px 4px rgba(0,0,0,.12);
+      padding: 40px 40px 32px;
+    }
+    h1 { font-size: 1.4rem; margin: 0 0 8px; }
+    .badge {
+      display: inline-block;
+      background: #e8f4fd;
+      color: #0070c0;
+      font-size: .75rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 4px;
+      margin-bottom: 20px;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+    }
+    p { margin: 0 0 20px; color: #444; }
+    h2 { font-size: 1rem; margin: 24px 0 8px; color: #1a1a1a; }
+    pre {
+      background: #f0f0f0;
+      border-radius: 6px;
+      padding: 16px;
+      font-size: .85rem;
+      overflow-x: auto;
+      margin: 0 0 24px;
+    }
+    code {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    }
+    .note {
+      font-size: .85rem;
+      color: #666;
+      border-left: 3px solid #ddd;
+      padding-left: 12px;
+      margin-top: 24px;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge">MCP API Endpoint</div>
+    <h1>Superset MCP Server</h1>
+    <p>
+      This is the <strong>Model Context Protocol (MCP)</strong> endpoint for
+      Apache Superset. It is an API designed for AI coding assistants —
+      not a web page to browse directly.
+    </p>
+    <h2>How to connect</h2>
+    <p>Add the following to your MCP client configuration,
+    replacing the URL and API key with your actual values:</p>
+    <pre><code>{
+  "mcpServers": {
+    "superset": {
+      "url": "&lt;this-url&gt;",
+      "transport": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer &lt;your-api-key&gt;"
+      }
+    }
+  }
+}</code></pre>
+    <h2>Supported clients</h2>
+    <p>This endpoint works with any MCP-compatible client, including:</p>
+    <ul style="color:#444;margin:0 0 20px;padding-left:20px;">
+      <li>Claude Desktop</li>
+      <li>Claude Code (CLI)</li>
+      <li>Cursor</li>
+      <li>Any client that supports the <code>streamable-http</code> transport</li>
+    </ul>
+    <div class="note">
+      Replace <code>&lt;this-url&gt;</code> with the full URL of this page and
+      <code>&lt;your-api-key&gt;</code> with a valid Superset API key or JWT token.
+    </div>
+  </div>
+</body>
+</html>"""
+
 
 def _json_auth_error_handler(
     conn: HTTPConnection, exc: AuthenticationError
-) -> JSONResponse:
-    """JSON 401 error handler for authentication failures.
+) -> JSONResponse | HTMLResponse:
+    """Auth error handler for authentication failures.
 
-    Per RFC 6750 Section 3.1, error responses MUST NOT leak server
-    configuration or token claim values. Only generic error codes are
-    returned to clients. Detailed failure reasons are logged server-side
-    only for debugging.
+    Returns a friendly HTML page when the request comes from a browser
+    (Accept: text/html), so users who open the MCP URL in a browser see
+    setup instructions rather than a raw JSON 401.
+
+    For all other clients (API, SSE) returns a standard JSON 401 per
+    RFC 6750 Section 3.1.
 
     References:
         - RFC 6750 Section 3.1: https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
         - CVE-2022-29266, CVE-2019-7644: verbose JWT errors led to exploits
     """
+    accept = conn.headers.get("accept", "")
+    if (
+        "text/html" in accept
+        and "application/json" not in accept
+        and "text/event-stream" not in accept
+    ):
+        return HTMLResponse(status_code=200, content=_MCP_BROWSER_HELLO_HTML)
+
     # Log detailed reason server-side only
     logger.warning("JWT authentication failed: %s", exc)
 

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -343,10 +343,10 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
 
             auth_provider = DetailedJWTVerifier(**common_kwargs)
         else:
-            # Default JWTVerifier: minimal logging, generic error responses.
-            from fastmcp.server.auth.providers.jwt import JWTVerifier
+            # MCPJWTVerifier: minimal logging + browser-friendly error page.
+            from superset.mcp_service.jwt_verifier import MCPJWTVerifier
 
-            auth_provider = JWTVerifier(**common_kwargs)
+            auth_provider = MCPJWTVerifier(**common_kwargs)
 
         return auth_provider
     except Exception:

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -26,7 +26,7 @@ import pytest
 from authlib.jose.errors import BadSignatureError, DecodeError, ExpiredTokenError
 
 from superset.mcp_service.jwt_verifier import (
-    _json_auth_error_handler,
+    _auth_error_handler,
     _jwt_failure_reason,
     DetailedBearerAuthBackend,
     DetailedJWTVerifier,
@@ -400,7 +400,7 @@ def test_get_middleware_returns_custom_components(hs256_verifier):
         == "DetailedBearerAuthBackend"
     )
     # on_error should be the RFC 6750-compliant generic handler
-    assert auth_middleware.kwargs["on_error"] is _json_auth_error_handler
+    assert auth_middleware.kwargs["on_error"] is _auth_error_handler
 
 
 class _FakeHeaders(dict[str, str]):
@@ -496,7 +496,7 @@ def test_error_handler_never_leaks_jwt_details():
 
     for reason in sensitive_reasons:
         exc = AuthenticationError(reason)
-        response = _json_auth_error_handler(mock_conn, exc)
+        response = _auth_error_handler(mock_conn, exc)
 
         assert response.status_code == 401
 

--- a/tests/unit_tests/mcp_service/test_jwt_verifier_browser_hello.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier_browser_hello.py
@@ -15,26 +15,27 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Tests for browser-friendly hello page in _json_auth_error_handler."""
+"""Tests for browser-friendly hello page in _auth_error_handler."""
 
 from unittest.mock import MagicMock
 
 from starlette.authentication import AuthenticationError
 from starlette.responses import HTMLResponse, JSONResponse
 
-from superset.mcp_service.jwt_verifier import _json_auth_error_handler
+from superset.mcp_service.jwt_verifier import _auth_error_handler
 
 
-def _make_conn(accept: str) -> MagicMock:
+def _make_conn(accept: str, method: str = "GET") -> MagicMock:
     conn = MagicMock()
     conn.headers = {"accept": accept} if accept else {}
+    conn.scope = {"method": method}
     return conn
 
 
 def test_browser_accept_returns_html_200() -> None:
     conn = _make_conn("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
     exc = AuthenticationError("no token")
-    response = _json_auth_error_handler(conn, exc)
+    response = _auth_error_handler(conn, exc)
     assert isinstance(response, HTMLResponse)
     assert response.status_code == 200
     assert b"MCP" in response.body
@@ -44,7 +45,7 @@ def test_browser_accept_returns_html_200() -> None:
 def test_browser_accept_html_only_returns_200() -> None:
     conn = _make_conn("text/html")
     exc = AuthenticationError("no token")
-    response = _json_auth_error_handler(conn, exc)
+    response = _auth_error_handler(conn, exc)
     assert isinstance(response, HTMLResponse)
     assert response.status_code == 200
 
@@ -52,7 +53,7 @@ def test_browser_accept_html_only_returns_200() -> None:
 def test_json_accept_returns_401() -> None:
     conn = _make_conn("application/json")
     exc = AuthenticationError("bad token")
-    response = _json_auth_error_handler(conn, exc)
+    response = _auth_error_handler(conn, exc)
     assert isinstance(response, JSONResponse)
     assert response.status_code == 401
 
@@ -60,16 +61,17 @@ def test_json_accept_returns_401() -> None:
 def test_event_stream_accept_returns_401() -> None:
     conn = _make_conn("text/event-stream")
     exc = AuthenticationError("bad token")
-    response = _json_auth_error_handler(conn, exc)
+    response = _auth_error_handler(conn, exc)
     assert isinstance(response, JSONResponse)
     assert response.status_code == 401
 
 
 def test_no_accept_header_returns_401() -> None:
     conn = MagicMock()
-    conn.headers = {}  # empty dict; .get("accept", "") returns "" naturally
+    conn.headers = {}
+    conn.scope = {"method": "GET"}
     exc = AuthenticationError("bad token")
-    response = _json_auth_error_handler(conn, exc)
+    response = _auth_error_handler(conn, exc)
     assert isinstance(response, JSONResponse)
     assert response.status_code == 401
 
@@ -77,7 +79,7 @@ def test_no_accept_header_returns_401() -> None:
 def test_json_401_body_is_rfc6750_compliant() -> None:
     conn = _make_conn("application/json")
     exc = AuthenticationError("expired")
-    response = _json_auth_error_handler(conn, exc)
+    response = _auth_error_handler(conn, exc)
     assert response.status_code == 401
     assert response.headers.get("www-authenticate") == 'Bearer error="invalid_token"'
 
@@ -85,7 +87,7 @@ def test_json_401_body_is_rfc6750_compliant() -> None:
 def test_html_accepted_alongside_other_types_but_not_json() -> None:
     conn = _make_conn("text/html, */*")
     exc = AuthenticationError("no token")
-    response = _json_auth_error_handler(conn, exc)
+    response = _auth_error_handler(conn, exc)
     assert isinstance(response, HTMLResponse)
     assert response.status_code == 200
 
@@ -94,6 +96,31 @@ def test_accept_both_html_and_json_returns_401() -> None:
     # When a client lists both, treat it as an API client (application/json wins)
     conn = _make_conn("text/html, application/json")
     exc = AuthenticationError("bad token")
-    response = _json_auth_error_handler(conn, exc)
+    response = _auth_error_handler(conn, exc)
     assert isinstance(response, JSONResponse)
     assert response.status_code == 401
+
+
+def test_post_with_html_accept_returns_401() -> None:
+    # Non-GET/HEAD methods always get JSON 401, even with text/html Accept
+    conn = _make_conn("text/html", method="POST")
+    exc = AuthenticationError("no token")
+    response = _auth_error_handler(conn, exc)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
+
+
+def test_head_with_html_accept_returns_html_200() -> None:
+    conn = _make_conn("text/html", method="HEAD")
+    exc = AuthenticationError("no token")
+    response = _auth_error_handler(conn, exc)
+    assert isinstance(response, HTMLResponse)
+    assert response.status_code == 200
+
+
+def test_accept_header_case_insensitive() -> None:
+    conn = _make_conn("TEXT/HTML")
+    exc = AuthenticationError("no token")
+    response = _auth_error_handler(conn, exc)
+    assert isinstance(response, HTMLResponse)
+    assert response.status_code == 200

--- a/tests/unit_tests/mcp_service/test_jwt_verifier_browser_hello.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier_browser_hello.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for browser-friendly hello page in _json_auth_error_handler."""
+
+from unittest.mock import MagicMock
+
+from starlette.authentication import AuthenticationError
+from starlette.responses import HTMLResponse, JSONResponse
+
+from superset.mcp_service.jwt_verifier import _json_auth_error_handler
+
+
+def _make_conn(accept: str) -> MagicMock:
+    conn = MagicMock()
+    conn.headers = {"accept": accept} if accept else {}
+    return conn
+
+
+def test_browser_accept_returns_html_200() -> None:
+    conn = _make_conn("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+    exc = AuthenticationError("no token")
+    response = _json_auth_error_handler(conn, exc)
+    assert isinstance(response, HTMLResponse)
+    assert response.status_code == 200
+    assert b"MCP" in response.body
+    assert b"mcpServers" in response.body
+
+
+def test_browser_accept_html_only_returns_200() -> None:
+    conn = _make_conn("text/html")
+    exc = AuthenticationError("no token")
+    response = _json_auth_error_handler(conn, exc)
+    assert isinstance(response, HTMLResponse)
+    assert response.status_code == 200
+
+
+def test_json_accept_returns_401() -> None:
+    conn = _make_conn("application/json")
+    exc = AuthenticationError("bad token")
+    response = _json_auth_error_handler(conn, exc)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
+
+
+def test_event_stream_accept_returns_401() -> None:
+    conn = _make_conn("text/event-stream")
+    exc = AuthenticationError("bad token")
+    response = _json_auth_error_handler(conn, exc)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
+
+
+def test_no_accept_header_returns_401() -> None:
+    conn = MagicMock()
+    conn.headers = {}  # empty dict; .get("accept", "") returns "" naturally
+    exc = AuthenticationError("bad token")
+    response = _json_auth_error_handler(conn, exc)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
+
+
+def test_json_401_body_is_rfc6750_compliant() -> None:
+    conn = _make_conn("application/json")
+    exc = AuthenticationError("expired")
+    response = _json_auth_error_handler(conn, exc)
+    assert response.status_code == 401
+    assert response.headers.get("www-authenticate") == 'Bearer error="invalid_token"'
+
+
+def test_html_accepted_alongside_other_types_but_not_json() -> None:
+    conn = _make_conn("text/html, */*")
+    exc = AuthenticationError("no token")
+    response = _json_auth_error_handler(conn, exc)
+    assert isinstance(response, HTMLResponse)
+    assert response.status_code == 200
+
+
+def test_accept_both_html_and_json_returns_401() -> None:
+    # When a client lists both, treat it as an API client (application/json wins)
+    conn = _make_conn("text/html, application/json")
+    exc = AuthenticationError("bad token")
+    response = _json_auth_error_handler(conn, exc)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401


### PR DESCRIPTION
### SUMMARY

When a user navigates to the MCP server URL in a browser, they currently see a raw JSON 401 error (`{"error": "invalid_token", "error_description": "Authentication failed"}`). This confuses users who don't realize they need to configure an MCP client — they think the server is broken and file support tickets.

This PR detects browser requests by inspecting the `Accept` header: if it contains `text/html` and does **not** contain `application/json` or `text/event-stream`, a friendly 200 HTML page is returned instead. The page explains:
- This is an MCP API endpoint, not a web page
- How to configure it in Claude Desktop, Claude Code, or Cursor
- What credentials are needed

All programmatic MCP clients (which always send `application/json` or `text/event-stream`) are completely unaffected — they continue to receive the existing JSON 401.

Implementation: `_json_auth_error_handler()` in `superset/mcp_service/jwt_verifier.py` — the Starlette `on_error` callback for `AuthenticationMiddleware` — already receives the `HTTPConnection` with headers, making this a minimal, surgical change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** `{"error": "invalid_token", "error_description": "Authentication failed"}` (401)

**After:** Clean HTML page with "Superset MCP Server" heading, explanation blurb, ready-to-paste JSON config block for MCP clients, and supported clients list.

### TESTING INSTRUCTIONS

1. Start the MCP server: `superset run-mcp-server`
2. Open `http://localhost:5008/mcp/` in a browser — you should see the friendly HTML page
3. `curl -H "Accept: application/json" http://localhost:5008/mcp/` — should still return JSON 401
4. Run unit tests: `pytest tests/unit_tests/mcp_service/test_jwt_verifier_browser_hello.py -v`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API