### PR TITLE
chore(oxlint): enable import/newline-after-import + react/no-unstable-nested-components

### DIFF
--- a/superset-frontend/oxlint.json
+++ b/superset-frontend/oxlint.json
@@ -39,7 +39,7 @@
     // oxlint versions (not actually enforced). Documented here for future
     // maintainers — if/when oxlint adds them, re-enable in the relevant
     // plugin section above.
-    //   import: newline-after-import, no-extraneous-dependencies,
+    //   import: no-extraneous-dependencies,
     //           no-import-module-exports, no-relative-packages,
     //           no-unresolved, no-useless-path-segments
     //   react:  default-props-match-prop-types, destructuring-assignment,
@@ -47,7 +47,6 @@
     //           forbid-prop-types, function-component-definition,
     //           jsx-no-bind, jsx-uses-vars, no-access-state-in-setstate,
     //           no-deprecated, no-did-update-set-state, no-typos,
-    //           no-unstable-nested-components,
     //           no-unused-class-component-methods, no-unused-prop-types,
     //           no-unused-state, prefer-stateless-function, prop-types,
     //           require-default-props, sort-comp, static-property-placement
@@ -137,6 +136,7 @@
     "import/no-self-import": "error",
     "import/no-cycle": "off",
     "import/prefer-default-export": "off",
+    "import/newline-after-import": "error",
 
     // === React plugin rules ===
     "react/jsx-filename-extension": [
@@ -184,6 +184,10 @@
       "error",
       { "button": true, "submit": true, "reset": false }
     ],
+    // TODO: Graduate to "error" after cleanup pass — ~150 violations
+    // across the codebase require hoisting nested component definitions
+    // out of their parent render functions.
+    "react/no-unstable-nested-components": "warn",
 
     // === React Hooks rules ===
     // TODO: Fix conditional hook usage and anonymous component issues
@@ -271,7 +275,10 @@
   },
   "overrides": [
     {
-      "files": ["plugins/plugin-chart-table/src/TableChart.tsx", "plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx"],
+      "files": [
+        "plugins/plugin-chart-table/src/TableChart.tsx",
+        "plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx"
+      ],
       "rules": {
         "jsx-a11y/no-redundant-roles": "off"
       }

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -48,6 +48,7 @@ import NoResultsComponent from './NoResultsComponent';
 import { isMatrixifyEnabled } from '../types/matrixify';
 import MatrixifyGridRenderer from './Matrixify/MatrixifyGridRenderer';
 import { supersetTheme, SupersetTheme } from '@apache-superset/core/theme';
+
 export type FallbackPropsWithDimension = FallbackProps & Partial<Dimension>;
 
 export type WrapperProps = Dimension & {

--- a/superset-frontend/src/dashboard/actions/dashboardLayout.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardLayout.ts
@@ -34,6 +34,7 @@ import { DropResult } from 'src/dashboard/components/dnd/dragDroppableConfig';
 import { GetState, LayoutItem, RootState } from '../types';
 import { updateLayoutComponents } from './dashboardFilters';
 import { setUnsavedChanges } from './dashboardState';
+
 type AppDispatch = ThunkDispatch<RootState, undefined, AnyAction>;
 
 // Component CRUD -------------------------------------------------------------

--- a/superset-frontend/webpack.proxy-config.js
+++ b/superset-frontend/webpack.proxy-config.js
@@ -21,6 +21,7 @@ const { ZSTDDecompress } = require('simple-zstd');
 
 const yargs = require('yargs');
 const { hideBin } = require('yargs/helpers');
+
 const parsedArgs = yargs(hideBin(process.argv)).parse();
 
 const parsedEnvArg = () => {


### PR DESCRIPTION
### SUMMARY

oxlint 1.66 (bumped via #40318) added support for two ESLint rules that were previously listed in `oxlint.json` as not-implemented. This PR enables them.

**Rules enabled:**

| Rule | Level | Violations | Action |
|---|---|---:|---|
| `import/newline-after-import` | `error` | 3 | Auto-fixed via `npx oxlint --fix` |
| `react/no-unstable-nested-components` | `warn` | 150 | Surfaced as warnings with a TODO to graduate to `error` after a cleanup pass |

The 3 `newline-after-import` errors were all simple missing blank lines after imports and were fully auto-fixable. They are now at **0 errors** in the config.

The 150 `no-unstable-nested-components` violations require real refactoring (hoisting component definitions out of parent render functions) and are too risky to fix in a single PR. They are set to `"warn"` with an inline TODO comment so we can graduate them to `"error"` after a dedicated cleanup pass.

**Note on `no-implied-eval`:** the user also asked about this rule — it was already enabled as `"error"` (`superset-frontend/oxlint.json:91`), so no change is needed there.

**Also updated** the "Rules carried over from ESLint that oxlint does NOT implement" comment block (around lines 36-61) to remove these two rules from the not-implemented list.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — lint config change.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx oxlint --config oxlint.json 2>&1 | grep -c "import(newline-after-import)"        # -> 0
npx oxlint --config oxlint.json 2>&1 | grep -c "react(no-unstable-nested-components)" # -> 150 (all warnings, non-blocking)
```

The newly introduced lint baseline contributes **0 new errors** to the build. Pre-existing errors on master (32x `require-to-throw-message`) are untouched.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API