### PR TITLE
feat: pass chart context to SQL query mutator

### DIFF
--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -40,7 +40,7 @@ You'll need to extend the Superset image to include a headless browser. Your opt
 - Use Firefox: you'll need to install geckodriver and Firefox.
 - Use Chrome without Playwright: you'll need to install Chrome and set the value of `WEBDRIVER_TYPE` to `"chrome"` in your `superset_config.py`.
 
-In Superset versions <=4.0x, users installed Firefox or Chrome and that was documented here.
+In Superset versions `<=4.0x`, users installed Firefox or Chrome and that was documented here.
 
 Only the worker container needs the browser.
 

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -264,6 +264,20 @@ class QueryContextProcessor:
         )
         return cache_key
 
+    def _get_sql_mutation_context(self) -> dict[str, Any]:
+        form_data = self._query_context.form_data or {}
+        slice_id = form_data.get("slice_id")
+        if slice_id is None and self._query_context.slice_:
+            slice_id = self._query_context.slice_.id
+
+        dashboard_id = form_data.get("dashboardId") or form_data.get("dashboard_id")
+
+        return {
+            "dashboard_id": dashboard_id,
+            "slice_id": slice_id,
+            "form_data": form_data,
+        }
+
     def get_query_result(self, query_object: QueryObject) -> QueryResult:
         """Returns a pandas dataframe based on the query object"""
         query_context = self._query_context
@@ -276,7 +290,10 @@ class QueryContextProcessor:
             # todo(hugh): add logic to manage all sip68 models here
             result = query_context.datasource.exc_query(query_object.to_dict())
         else:
-            result = query_context.datasource.query(query_object.to_dict())
+            result = query_context.datasource.query(
+                query_object.to_dict(),
+                mutation_context=self._get_sql_mutation_context(),
+            )
             query = result.query + ";\n\n"
 
         df = result.df
@@ -685,7 +702,10 @@ class QueryContextProcessor:
             if isinstance(self._qc_datasource, Query):
                 result = self._qc_datasource.exc_query(query_object_clone_dct)
             else:
-                result = self._qc_datasource.query(query_object_clone_dct)
+                result = self._qc_datasource.query(
+                    query_object_clone_dct,
+                    mutation_context=self._get_sql_mutation_context(),
+                )
 
             queries.append(result.query)
             cache_keys.append(None)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1632,6 +1632,7 @@ class SqlaTable(
                 self.catalog,
                 self.schema or None,
                 mutator=assign_column_label,
+                mutation_context=mutation_context,
             )
         except (SupersetErrorException, SupersetErrorsException):
             # SupersetError(s) exception should not be captured; instead, they should

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1586,9 +1586,16 @@ class SqlaTable(
 
         return or_(*groups)
 
-    def query(self, query_obj: QueryObjectDict) -> QueryResult:
+    def query(
+        self,
+        query_obj: QueryObjectDict,
+        mutation_context: dict[str, Any] | None = None,
+    ) -> QueryResult:
         qry_start_dttm = datetime.now()
-        query_str_ext = self.get_query_str_extended(query_obj)
+        query_str_ext = self.get_query_str_extended(
+            query_obj,
+            mutation_context=mutation_context,
+        )
         sql = query_str_ext.sql
         status = QueryStatus.SUCCESS
         errors = None

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -681,6 +681,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         catalog: str | None = None,
         schema: str | None = None,
         fetch_last_result: bool = False,
+        mutation_context: dict[str, Any] | None = None,
     ) -> tuple[Any, list[tuple[Any, ...]] | None, DbapiDescription | None]:
         """
         Internal method to execute SQL with mutation and logging.
@@ -718,6 +719,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
                 sql_ = self.mutate_sql_based_on_config(
                     statement.format(),
                     is_split=True,
+                    **(mutation_context or {}),
                 )
                 _log_query(sql_)
 
@@ -772,9 +774,14 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         catalog: str | None = None,
         schema: str | None = None,
         mutator: Callable[[pd.DataFrame], None] | None = None,
+        mutation_context: dict[str, Any] | None = None,
     ) -> pd.DataFrame:
         cursor, rows, description = self._execute_sql_with_mutation_and_logging(
-            sql, catalog, schema, fetch_last_result=True
+            sql,
+            catalog,
+            schema,
+            fetch_last_result=True,
+            mutation_context=mutation_context,
         )
 
         df = None

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -649,7 +649,12 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
     def get_reserved_words(self) -> set[str]:
         return self.get_dialect().preparer.reserved_words
 
-    def mutate_sql_based_on_config(self, sql_: str, is_split: bool = False) -> str:
+    def mutate_sql_based_on_config(
+        self,
+        sql_: str,
+        is_split: bool = False,
+        **kwargs: Any,
+    ) -> str:
         """
         Mutates the SQL query based on the app configuration.
 
@@ -666,6 +671,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
                 sql_,
                 security_manager=security_manager,
                 database=self,
+                **kwargs,
             )
         return sql_
 

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -905,6 +905,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         self,
         query_obj: QueryObjectDict,
         mutate: bool = True,
+        mutation_context: Optional[dict[str, Any]] = None,
     ) -> QueryStringExtended:
         sqlaq = self.get_sqla_query(**query_obj)
         sql = self.database.compile_sqla_query(
@@ -916,7 +917,10 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         sql = self._apply_cte(sql, sqlaq.cte)
 
         if mutate:
-            sql = self.database.mutate_sql_based_on_config(sql)
+            sql = self.database.mutate_sql_based_on_config(
+                sql,
+                **(mutation_context or {}),
+            )
         return QueryStringExtended(
             applied_template_filters=sqlaq.applied_template_filters,
             applied_filter_columns=sqlaq.applied_filter_columns,


### PR DESCRIPTION
Expose dashboard and slice identifiers to SQL_QUERY_MUTATOR for chart queries so warehouse query comments can map jobs back to Superset dashboards.