### PR TITLE
feat(mcp): add create_dataset tool to register physical tables as datasets

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -162,6 +162,7 @@ Alerts & Reports:
 Dataset Management:
 - list_datasets: List datasets with advanced filters (1-based pagination)
 - get_dataset_info: Get detailed dataset information by ID (includes columns/metrics)
+- create_dataset: Register a physical table as a dataset against an existing DB connection (requires write access)
 - create_virtual_dataset: Save a SQL query as a virtual dataset for charting (requires write access)
 - query_dataset: Query a dataset using its semantic layer (saved metrics, dimensions, filters) without needing a saved chart
 
@@ -413,7 +414,7 @@ Input format:
 {_feature_availability}Permission Awareness:
 {_instance_info_role_bullet}- ALWAYS check the user's roles BEFORE suggesting write operations (creating datasets,
   charts, or dashboards). SQL execution is a separate permission — see execute_sql below.
-- Write tools (generate_chart, generate_dashboard, update_chart, create_virtual_dataset,
+- Write tools (generate_chart, generate_dashboard, update_chart, create_dataset, create_virtual_dataset,
   save_sql_query, add_chart_to_existing_dashboard, update_chart_preview) require write
   permissions. These tools are only listed for users who have the necessary access.
   If a write tool does not appear in the tool list, the current user lacks write access.
@@ -689,6 +690,7 @@ from superset.mcp_service.database.tool import (  # noqa: F401, E402
     list_databases,
 )
 from superset.mcp_service.dataset.tool import (  # noqa: F401, E402
+    create_dataset,
     create_virtual_dataset,
     get_dataset_info,
     list_datasets,

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -623,9 +623,9 @@ def create_mcp_app(
 # Create default MCP instance for backward compatibility
 mcp = create_mcp_app()
 
-# Initialize MCP dependency injection BEFORE importing tools/prompts
-# This replaces the abstract @tool and @prompt decorators in superset_core.api.mcp
-# with concrete implementations that can register with the mcp instance
+# Initialize MCP dependency injection BEFORE importing tools/prompts.
+# Replaces the stub @tool/@prompt decorators in superset_core.mcp.decorators
+# with concrete implementations bound to this mcp instance.
 from superset.core.mcp.core_mcp_injection import (  # noqa: E402
     initialize_core_mcp_dependencies,
 )
@@ -649,6 +649,7 @@ warnings.filterwarnings(
     category=FutureWarning,
     module=r"google\..*",
 )
+
 
 # Import all MCP tools to register them with the mcp instance
 # NOTE: Always add new tool imports here when creating new MCP tools.

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -834,7 +834,7 @@ def init_fastmcp_server(
     from superset.mcp_service.flask_singleton import app as flask_app  # noqa: PLC0415
 
     # Derive branding from Superset's APP_NAME config (defaults to "Superset")
-    app_name = flask_app.config["APP_NAME"]
+    app_name = flask_app.config.get("APP_NAME", "Superset")
     branding = app_name
     default_name = f"{app_name} MCP Server"
 
@@ -844,7 +844,7 @@ def init_fastmcp_server(
 
     # Remove disabled tools BEFORE generating instructions so that the
     # instructions never advertise tools that clients cannot actually call.
-    disabled_tools: set[str] = flask_app.config["MCP_DISABLED_TOOLS"]
+    disabled_tools: set[str] = flask_app.config.get("MCP_DISABLED_TOOLS", set())
     _remove_disabled_tools(disabled_tools)
     config_guard_removed = _apply_config_guards(flask_app)
 

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -829,11 +829,12 @@ def init_fastmcp_server(
     Returns:
         The global FastMCP instance configured with the provided settings
     """
-    # Read branding from Flask config's APP_NAME
-    from superset.mcp_service.flask_singleton import app as flask_app
+    # circular import: flask_singleton imports from superset.extensions which
+    # re-enters mcp_service during startup; must stay lazy inside the function.
+    from superset.mcp_service.flask_singleton import app as flask_app  # noqa: PLC0415
 
     # Derive branding from Superset's APP_NAME config (defaults to "Superset")
-    app_name = flask_app.config.get("APP_NAME", "Superset")
+    app_name = flask_app.config["APP_NAME"]
     branding = app_name
     default_name = f"{app_name} MCP Server"
 
@@ -843,7 +844,7 @@ def init_fastmcp_server(
 
     # Remove disabled tools BEFORE generating instructions so that the
     # instructions never advertise tools that clients cannot actually call.
-    disabled_tools: set[str] = flask_app.config.get("MCP_DISABLED_TOOLS", set())
+    disabled_tools: set[str] = flask_app.config["MCP_DISABLED_TOOLS"]
     _remove_disabled_tools(disabled_tools)
     config_guard_removed = _apply_config_guards(flask_app)
 

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -431,7 +431,8 @@ class CreateDatasetRequest(BaseModel):
         List[int] | None,
         Field(
             default=None,
-            description="Optional list of owner user IDs. Defaults to the calling user.",
+            description="Optional list of owner user IDs. "
+            "Defaults to the calling user.",
         ),
     ]
 

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -420,8 +420,12 @@ class CreateDatasetRequest(BaseModel):
         ),
     ]
     schema: Annotated[
-        str,
-        Field(description="Schema (namespace) where the table lives, e.g. 'public'"),
+        str | None,
+        Field(
+            default=None,
+            description="Schema (namespace) where the table lives, e.g. 'public'. "
+            "Omit or pass None for databases without schema namespaces (e.g. SQLite).",
+        ),
     ]
     table_name: Annotated[
         str,

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -427,6 +427,14 @@ class CreateDatasetRequest(BaseModel):
             "Omit or pass None for databases without schema namespaces (e.g. SQLite).",
         ),
     ]
+    catalog: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Catalog where the table lives. Omit for databases without "
+            "catalog support.",
+        ),
+    ]
     table_name: Annotated[
         str,
         Field(

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -21,7 +21,7 @@ Pydantic schemas for dataset-related responses
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Annotated, Any, Dict, List, Literal
 
 from pydantic import (
@@ -325,8 +325,6 @@ class DatasetError(BaseModel):
     @classmethod
     def create(cls, error: str, error_type: str) -> "DatasetError":
         """Create a standardized DatasetError with timestamp."""
-        from datetime import datetime, timezone
-
         return cls(
             error=error,
             error_type=error_type,
@@ -776,7 +774,7 @@ def serialize_dataset_object(dataset: Any) -> DatasetInfo | None:
     if isinstance(params, str):
         try:
             params = json.loads(params)
-        except Exception:
+        except (json.JSONDecodeError, TypeError):
             params = None
     columns = [
         TableColumnInfo(

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -411,16 +411,21 @@ class GetDatasetInfoRequest(MetadataCacheControl):
 class CreateDatasetRequest(BaseModel):
     """Request schema for create_dataset to register a physical table as a dataset."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     database_id: Annotated[
         int,
         Field(
             description="ID of the database connection to register the table against"
         ),
     ]
-    schema: Annotated[
+    schema_: Annotated[
         str | None,
         Field(
             default=None,
+            alias="schema",
+            serialization_alias="schema",
+            max_length=250,
             description="Schema (namespace) where the table lives, e.g. 'public'. "
             "Omit or pass None for databases without schema namespaces (e.g. SQLite).",
         ),
@@ -429,6 +434,7 @@ class CreateDatasetRequest(BaseModel):
         str | None,
         Field(
             default=None,
+            max_length=250,
             description="Catalog where the table lives. Omit for databases without "
             "catalog support.",
         ),
@@ -437,6 +443,7 @@ class CreateDatasetRequest(BaseModel):
         str,
         Field(
             min_length=1,
+            max_length=250,
             description="Name of the physical table to register as a dataset",
         ),
     ]
@@ -448,6 +455,22 @@ class CreateDatasetRequest(BaseModel):
             "Defaults to the calling user.",
         ),
     ]
+
+    @field_validator("schema_", "catalog", mode="before")
+    @classmethod
+    def _normalize_optional_str(cls, v: object) -> str | None:
+        """Strip whitespace and convert blank strings to None."""
+        if isinstance(v, str):
+            return v.strip() or None
+        return None
+
+    @field_validator("table_name", mode="before")
+    @classmethod
+    def _strip_table_name(cls, v: object) -> object:
+        """Strip leading/trailing whitespace from table_name."""
+        if isinstance(v, str):
+            return v.strip()
+        return v
 
 
 class CreateVirtualDatasetRequest(BaseModel):

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -429,7 +429,10 @@ class CreateDatasetRequest(BaseModel):
     ]
     table_name: Annotated[
         str,
-        Field(description="Name of the physical table to register as a dataset"),
+        Field(
+            min_length=1,
+            description="Name of the physical table to register as a dataset",
+        ),
     ]
     owners: Annotated[
         List[int] | None,

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -410,6 +410,30 @@ class GetDatasetInfoRequest(MetadataCacheControl):
         return parsed
 
 
+class CreateDatasetRequest(BaseModel):
+    """Request schema for create_dataset to register a physical table as a dataset."""
+
+    database_id: Annotated[
+        int,
+        Field(description="ID of the database connection to register the table against"),
+    ]
+    schema: Annotated[
+        str,
+        Field(description="Schema (namespace) where the table lives, e.g. 'public'"),
+    ]
+    table_name: Annotated[
+        str,
+        Field(description="Name of the physical table to register as a dataset"),
+    ]
+    owners: Annotated[
+        List[int] | None,
+        Field(
+            default=None,
+            description="Optional list of owner user IDs. Defaults to the calling user.",
+        ),
+    ]
+
+
 class CreateVirtualDatasetRequest(BaseModel):
     """Request schema for create_virtual_dataset."""
 

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -458,11 +458,16 @@ class CreateDatasetRequest(BaseModel):
 
     @field_validator("schema_", "catalog", mode="before")
     @classmethod
-    def _normalize_optional_str(cls, v: object) -> str | None:
-        """Strip whitespace and convert blank strings to None."""
+    def _normalize_optional_str(cls, v: object) -> object:
+        """Strip whitespace and convert blank strings to None.
+
+        Non-string values pass through unchanged so Pydantic's type validation
+        rejects them, rather than silently treating a malformed value (e.g. an
+        int or dict) as an omitted namespace.
+        """
         if isinstance(v, str):
             return v.strip() or None
-        return None
+        return v
 
     @field_validator("table_name", mode="before")
     @classmethod

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -316,12 +316,6 @@ class DatasetError(BaseModel):
     timestamp: str | datetime | None = Field(None, description="Error timestamp")
     model_config = ConfigDict(ser_json_timedelta="iso8601")
 
-    @field_validator("error")
-    @classmethod
-    def sanitize_error_for_llm_context(cls, value: str) -> str:
-        """Wrap error text before it is exposed to LLM context."""
-        return sanitize_for_llm_context(value, field_path=("error",))
-
     @classmethod
     def create(cls, error: str, error_type: str) -> "DatasetError":
         """Create a standardized DatasetError with timestamp."""

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -316,6 +316,12 @@ class DatasetError(BaseModel):
     timestamp: str | datetime | None = Field(None, description="Error timestamp")
     model_config = ConfigDict(ser_json_timedelta="iso8601")
 
+    @field_validator("error")
+    @classmethod
+    def sanitize_error_for_llm_context(cls, value: str) -> str:
+        """Wrap error text before it is exposed to LLM context."""
+        return sanitize_for_llm_context(value, field_path=("error",))
+
     @classmethod
     def create(cls, error: str, error_type: str) -> "DatasetError":
         """Create a standardized DatasetError with timestamp."""

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -415,7 +415,9 @@ class CreateDatasetRequest(BaseModel):
 
     database_id: Annotated[
         int,
-        Field(description="ID of the database connection to register the table against"),
+        Field(
+            description="ID of the database connection to register the table against"
+        ),
     ]
     schema: Annotated[
         str,

--- a/superset/mcp_service/dataset/tool/__init__.py
+++ b/superset/mcp_service/dataset/tool/__init__.py
@@ -15,12 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .create_dataset import create_dataset
 from .create_virtual_dataset import create_virtual_dataset
 from .get_dataset_info import get_dataset_info
 from .list_datasets import list_datasets
 from .query_dataset import query_dataset
 
 __all__ = [
+    "create_dataset",
     "create_virtual_dataset",
     "list_datasets",
     "get_dataset_info",

--- a/superset/mcp_service/dataset/tool/__init__.py
+++ b/superset/mcp_service/dataset/tool/__init__.py
@@ -24,7 +24,7 @@ from .query_dataset import query_dataset
 __all__ = [
     "create_dataset",
     "create_virtual_dataset",
-    "list_datasets",
     "get_dataset_info",
+    "list_datasets",
     "query_dataset",
 ]

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -81,12 +81,13 @@ async def create_dataset(
     Returns DatasetInfo on success or DatasetError on failure.
     Use list_databases to find the correct database_id.
     """
-    # Normalize schema: strip whitespace and treat blank strings as None
+    # Normalize schema and table_name: strip whitespace, treat blank schema as None
     schema = request.schema.strip() if request.schema else None
+    table_name = request.table_name.strip()
 
     await ctx.info(
         "Registering physical table as dataset: database_id=%s, table=%s.%s"
-        % (request.database_id, schema, request.table_name)
+        % (request.database_id, schema, table_name)
     )
 
     try:
@@ -100,7 +101,7 @@ async def create_dataset(
 
         dataset_properties: dict[str, object] = {
             "database": request.database_id,
-            "table_name": request.table_name,
+            "table_name": table_name,
         }
         if schema is not None:
             dataset_properties["schema"] = schema
@@ -118,8 +119,7 @@ async def create_dataset(
             )
 
         await ctx.info(
-            "Dataset registered: id=%s, table=%s.%s"
-            % (dataset.id, schema, request.table_name)
+            "Dataset registered: id=%s, table=%s.%s" % (dataset.id, schema, table_name)
         )
         return result
 

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -25,12 +25,11 @@ the resulting dataset_id directly into generate_chart.
 """
 
 import logging
-from datetime import datetime, timezone
 
 from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.mcp_service.app import mcp
-from superset.mcp_service.auth import mcp_auth_hook
+from superset.extensions import event_logger
 from superset.mcp_service.dataset.schemas import (
     CreateDatasetRequest,
     DatasetError,
@@ -41,9 +40,17 @@ from superset.mcp_service.dataset.schemas import (
 logger = logging.getLogger(__name__)
 
 
-@mcp.tool(tags=["mutate"])
-@mcp_auth_hook
-def create_dataset(
+@tool(
+    tags=["mutate"],
+    class_permission_name="Dataset",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Register physical table as dataset",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_dataset(
     request: CreateDatasetRequest, ctx: Context
 ) -> DatasetInfo | DatasetError:
     """Register a physical table as a Superset dataset.
@@ -55,10 +62,11 @@ def create_dataset(
 
     Required fields:
     - database_id: ID of the existing database connection
-    - schema: Schema/namespace where the table lives (e.g. "public")
     - table_name: Exact name of the physical table to register
 
     Optional fields:
+    - schema: Schema/namespace where the table lives (e.g. "public"). Omit for
+      databases without schema namespaces (e.g. SQLite).
     - owners: List of user IDs to set as owners (defaults to calling user)
 
     Example:
@@ -73,6 +81,14 @@ def create_dataset(
     Returns DatasetInfo on success or DatasetError on failure.
     Use list_databases to find the correct database_id.
     """
+    # Normalize schema: strip whitespace and treat blank strings as None
+    schema = request.schema.strip() if request.schema else None
+
+    await ctx.info(
+        "Registering physical table as dataset: database_id=%s, table=%s.%s"
+        % (request.database_id, schema, request.table_name)
+    )
+
     try:
         from superset.commands.dataset.create import CreateDatasetCommand
         from superset.commands.dataset.exceptions import (
@@ -82,61 +98,46 @@ def create_dataset(
             TableNotFoundValidationError,
         )
 
-        dataset_properties = {
+        dataset_properties: dict[str, object] = {
             "database": request.database_id,
-            "schema": request.schema,
             "table_name": request.table_name,
         }
+        if schema is not None:
+            dataset_properties["schema"] = schema
         if request.owners is not None:
             dataset_properties["owners"] = request.owners
 
-        command = CreateDatasetCommand(dataset_properties)
-        dataset = command.run()
+        with event_logger.log_context(action="mcp.create_dataset.create"):
+            dataset = CreateDatasetCommand(dataset_properties).run()
 
         result = serialize_dataset_object(dataset)
         if result is None:
-            return DatasetError(
+            return DatasetError.create(
                 error="Dataset was created but could not be serialized",
                 error_type="SerializationError",
-                timestamp=datetime.now(timezone.utc),
             )
 
-        logger.info(
-            "Created dataset id=%s table=%s.%s",
-            dataset.id,
-            request.schema,
-            request.table_name,
+        await ctx.info(
+            "Dataset registered: id=%s, table=%s.%s"
+            % (dataset.id, schema, request.table_name)
         )
         return result
 
-    except DatasetExistsValidationError as e:
-        return DatasetError(
-            error=str(e),
-            error_type="DatasetExistsError",
-            timestamp=datetime.now(timezone.utc),
+    except DatasetExistsValidationError as exc:
+        await ctx.warning("Dataset already exists: %s" % (str(exc),))
+        return DatasetError.create(error=str(exc), error_type="DatasetExistsError")
+    except TableNotFoundValidationError as exc:
+        await ctx.warning("Table not found: %s" % (str(exc),))
+        return DatasetError.create(error=str(exc), error_type="TableNotFoundError")
+    except DatasetInvalidError as exc:
+        messages = exc.normalized_messages()
+        await ctx.warning("Dataset validation failed: %s" % (messages,))
+        return DatasetError.create(error=str(messages), error_type="ValidationError")
+    except DatasetCreateFailedError as exc:
+        await ctx.error("Dataset creation failed: %s" % (str(exc),))
+        return DatasetError.create(error=str(exc), error_type="CreateFailedError")
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error creating dataset: %s: %s" % (type(exc).__name__, str(exc))
         )
-    except TableNotFoundValidationError as e:
-        return DatasetError(
-            error=str(e),
-            error_type="TableNotFoundError",
-            timestamp=datetime.now(timezone.utc),
-        )
-    except DatasetInvalidError as e:
-        return DatasetError(
-            error=str(e),
-            error_type="ValidationError",
-            timestamp=datetime.now(timezone.utc),
-        )
-    except DatasetCreateFailedError as e:
-        return DatasetError(
-            error=str(e),
-            error_type="CreateFailedError",
-            timestamp=datetime.now(timezone.utc),
-        )
-    except Exception as e:
-        logger.error("Failed to create dataset: %s", e, exc_info=True)
-        return DatasetError(
-            error=f"Failed to create dataset: {str(e)}",
-            error_type="InternalError",
-            timestamp=datetime.now(timezone.utc),
-        )
+        raise

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -67,6 +67,8 @@ async def create_dataset(
     Optional fields:
     - schema: Schema/namespace where the table lives (e.g. "public"). Omit for
       databases without schema namespaces (e.g. SQLite).
+    - catalog: Catalog where the table lives. Omit for databases without catalog
+      support.
     - owners: List of user IDs to set as owners (defaults to calling user)
 
     Example:
@@ -94,10 +96,11 @@ async def create_dataset(
         from superset.commands.dataset.create import CreateDatasetCommand
         from superset.commands.dataset.exceptions import (
             DatasetCreateFailedError,
-            DatasetExistsValidationError,
             DatasetInvalidError,
-            TableNotFoundValidationError,
         )
+
+        # Normalize catalog: strip whitespace, treat blank as None
+        catalog = request.catalog.strip() if request.catalog else None
 
         dataset_properties: dict[str, object] = {
             "database": request.database_id,
@@ -105,6 +108,8 @@ async def create_dataset(
         }
         if schema is not None:
             dataset_properties["schema"] = schema
+        if catalog is not None:
+            dataset_properties["catalog"] = catalog
         if request.owners is not None:
             dataset_properties["owners"] = request.owners
 
@@ -123,14 +128,23 @@ async def create_dataset(
         )
         return result
 
-    except DatasetExistsValidationError as exc:
-        await ctx.warning("Dataset already exists: %s" % (str(exc),))
-        return DatasetError.create(error=str(exc), error_type="DatasetExistsError")
-    except TableNotFoundValidationError as exc:
-        await ctx.warning("Table not found: %s" % (str(exc),))
-        return DatasetError.create(error=str(exc), error_type="TableNotFoundError")
     except DatasetInvalidError as exc:
+        # CreateDatasetCommand.validate() collects DatasetExistsValidationError and
+        # TableNotFoundValidationError into DatasetInvalidError.exceptions, never
+        # raising them directly. Inspect the wrapped class names to return a typed
+        # error response matching the advertised contract.
+        classnames = exc.get_list_classnames()
         messages = exc.normalized_messages()
+        if "DatasetExistsValidationError" in classnames:
+            await ctx.warning("Dataset already exists: %s" % (messages,))
+            return DatasetError.create(
+                error=str(messages), error_type="DatasetExistsError"
+            )
+        if "TableNotFoundValidationError" in classnames:
+            await ctx.warning("Table not found: %s" % (messages,))
+            return DatasetError.create(
+                error=str(messages), error_type="TableNotFoundError"
+            )
         await ctx.warning("Dataset validation failed: %s" % (messages,))
         return DatasetError.create(error=str(messages), error_type="ValidationError")
     except DatasetCreateFailedError as exc:

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -110,12 +110,15 @@ async def create_dataset(
     # None defaults in instance.__dict__ for fields whose names shadow deprecated
     # BaseModel classmethods, so direct attribute access returns the classmethod
     # instead of None when the field is omitted from the request.
+    # Use isinstance(x, str) rather than a truthy check: model_dump() may still
+    # return the classmethod object (which is truthy) for unset 'schema'/'catalog'
+    # fields when Pydantic resolves the value via getattr internally.
     _request_data = request.model_dump()
     _schema_raw = _request_data.get("schema")
-    schema = _schema_raw.strip() if _schema_raw else None
+    schema = _schema_raw.strip() if isinstance(_schema_raw, str) else None
     table_name = request.table_name.strip()
     _catalog_raw = _request_data.get("catalog")
-    catalog = _catalog_raw.strip() if _catalog_raw else None
+    catalog = _catalog_raw.strip() if isinstance(_catalog_raw, str) else None
 
     await ctx.info(
         "Registering physical table as dataset: database_id=%s, table=%s.%s"

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -34,25 +34,29 @@ from superset.commands.dataset.exceptions import (
     DatasetCreateFailedError,
     DatasetInvalidError,
 )
-from superset.commands.exceptions import CommandInvalidError
-from superset.daos.database import DatabaseDAO
-from superset.exceptions import SupersetSecurityException
-from superset.extensions import event_logger, security_manager
+from superset.extensions import event_logger
 from superset.mcp_service.dataset.schemas import (
     CreateDatasetRequest,
     DatasetError,
     DatasetInfo,
     serialize_dataset_object,
 )
-from superset.sql.parse import Table
 
 logger = logging.getLogger(__name__)
 
 
-def _classify_invalid_error(exc: CommandInvalidError) -> DatasetError:
+def _classify_invalid_error(exc: DatasetInvalidError) -> DatasetError:
     """Map DatasetInvalidError sub-exceptions to typed DatasetError responses."""
     classnames = exc.get_list_classnames()
     messages = exc.normalized_messages()
+    if "DatabaseNotFoundValidationError" in classnames:
+        return DatasetError.create(
+            error="Database not found", error_type="DatabaseNotFoundError"
+        )
+    if "DatasetDataAccessIsNotAllowed" in classnames:
+        return DatasetError.create(
+            error="Access denied", error_type="AccessDeniedError"
+        )
     if "DatasetExistsValidationError" in classnames:
         return DatasetError.create(error=str(messages), error_type="DatasetExistsError")
     if "TableNotFoundValidationError" in classnames:
@@ -105,49 +109,16 @@ async def create_dataset(
     Returns DatasetInfo on success or DatasetError on failure.
     Use list_databases to find the correct database_id.
     """
-    # Normalize schema, table_name, catalog: strip whitespace, treat blank as None.
-    # Use model_dump() for 'schema' and 'catalog': Pydantic v2 does not always store
-    # None defaults in instance.__dict__ for fields whose names shadow deprecated
-    # BaseModel classmethods, so direct attribute access returns the classmethod
-    # instead of None when the field is omitted from the request.
-    # Use isinstance(x, str) rather than a truthy check: model_dump() may still
-    # return the classmethod object (which is truthy) for unset 'schema'/'catalog'
-    # fields when Pydantic resolves the value via getattr internally.
-    _request_data = request.model_dump()
-    _schema_raw = _request_data.get("schema")
-    schema = (_schema_raw.strip() or None) if isinstance(_schema_raw, str) else None
-    table_name = request.table_name.strip()
-    _catalog_raw = _request_data.get("catalog")
-    catalog = (_catalog_raw.strip() or None) if isinstance(_catalog_raw, str) else None
+    schema = request.schema_
+    table_name = request.table_name
+    catalog = request.catalog
 
     await ctx.info(
-        "Registering physical table as dataset: database_id=%s, table=%s.%s"
-        % (request.database_id, schema, table_name)
+        "Registering physical table as dataset: database_id=%s, table=%s"
+        % (request.database_id, f"{schema}.{table_name}" if schema else table_name)
     )
 
     try:
-        # Look up the database so we can enforce table-level access before
-        # forwarding to CreateDatasetCommand, which only checks SQL-path access.
-        database = DatabaseDAO.find_by_id(request.database_id)
-        if database is None:
-            return DatasetError.create(
-                error="Database not found",
-                error_type="DatabaseNotFoundError",
-            )
-
-        # Enforce table-level access: prevents users with Dataset.write from
-        # registering tables in databases they cannot read.
-        table_obj = Table(table_name, schema, catalog)
-        try:
-            security_manager.raise_for_access(database=database, table=table_obj)
-        except SupersetSecurityException as exc:
-            logger.warning("Access denied to table %s: %s", table_obj, exc)
-            await ctx.warning("Access denied to table %s" % (table_obj,))
-            return DatasetError.create(
-                error="Access denied",
-                error_type="AccessDeniedError",
-            )
-
         dataset_properties: dict[str, object] = {
             "database": request.database_id,
             "table_name": table_name,
@@ -170,14 +141,18 @@ async def create_dataset(
             )
 
         await ctx.info(
-            "Dataset registered: id=%s, table=%s.%s" % (dataset.id, schema, table_name)
+            "Dataset registered: id=%s, table=%s"
+            % (
+                dataset.id,
+                f"{schema}.{table_name}" if schema else table_name,
+            )
         )
         return result
 
     except DatasetInvalidError as exc:
-        # CreateDatasetCommand.validate() collects DatasetExistsValidationError and
-        # TableNotFoundValidationError into DatasetInvalidError.exceptions, never
-        # raising them directly. Inspect the wrapped class names for a typed response.
+        # CreateDatasetCommand.validate() collects validation errors into
+        # DatasetInvalidError.exceptions, never raising them directly.
+        # Inspect the wrapped class names for a typed response.
         error_response = _classify_invalid_error(exc)
         await ctx.warning(
             "Dataset validation failed (%s): %s"

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -105,10 +105,17 @@ async def create_dataset(
     Returns DatasetInfo on success or DatasetError on failure.
     Use list_databases to find the correct database_id.
     """
-    # Normalize schema, table_name, catalog: strip whitespace, treat blank as None
-    schema = request.schema.strip() if request.schema else None
+    # Normalize schema, table_name, catalog: strip whitespace, treat blank as None.
+    # Use model_dump() for 'schema' and 'catalog': Pydantic v2 does not always store
+    # None defaults in instance.__dict__ for fields whose names shadow deprecated
+    # BaseModel classmethods, so direct attribute access returns the classmethod
+    # instead of None when the field is omitted from the request.
+    _request_data = request.model_dump()
+    _schema_raw = _request_data.get("schema")
+    schema = _schema_raw.strip() if _schema_raw else None
     table_name = request.table_name.strip()
-    catalog = request.catalog.strip() if request.catalog else None
+    _catalog_raw = _request_data.get("catalog")
+    catalog = _catalog_raw.strip() if _catalog_raw else None
 
     await ctx.info(
         "Registering physical table as dataset: database_id=%s, table=%s.%s"

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -40,6 +40,17 @@ from superset.mcp_service.dataset.schemas import (
 logger = logging.getLogger(__name__)
 
 
+def _classify_invalid_error(exc: object) -> DatasetError:
+    """Map DatasetInvalidError sub-exceptions to typed DatasetError responses."""
+    classnames = exc.get_list_classnames()  # type: ignore[attr-defined]
+    messages = exc.normalized_messages()  # type: ignore[attr-defined]
+    if "DatasetExistsValidationError" in classnames:
+        return DatasetError.create(error=str(messages), error_type="DatasetExistsError")
+    if "TableNotFoundValidationError" in classnames:
+        return DatasetError.create(error=str(messages), error_type="TableNotFoundError")
+    return DatasetError.create(error=str(messages), error_type="ValidationError")
+
+
 @tool(
     tags=["mutate"],
     class_permission_name="Dataset",
@@ -98,9 +109,34 @@ async def create_dataset(
             DatasetCreateFailedError,
             DatasetInvalidError,
         )
+        from superset.daos.database import DatabaseDAO
+        from superset.exceptions import SupersetSecurityException
+        from superset.extensions import security_manager
+        from superset.sql.parse import Table
 
         # Normalize catalog: strip whitespace, treat blank as None
         catalog = request.catalog.strip() if request.catalog else None
+
+        # Look up the database so we can enforce table-level access before
+        # forwarding to CreateDatasetCommand, which only checks SQL-path access.
+        database = DatabaseDAO.find_by_id(request.database_id)
+        if database is None:
+            return DatasetError.create(
+                error=f"Database with id={request.database_id} not found",
+                error_type="DatabaseNotFoundError",
+            )
+
+        # Enforce table-level access: prevents users with Dataset.write from
+        # registering tables in databases they cannot read.
+        table_obj = Table(table_name, schema, catalog)
+        try:
+            security_manager.raise_for_access(database=database, table=table_obj)
+        except SupersetSecurityException as exc:
+            await ctx.warning("Access denied to table %s: %s" % (table_obj, str(exc)))
+            return DatasetError.create(
+                error=str(exc),
+                error_type="AccessDeniedError",
+            )
 
         dataset_properties: dict[str, object] = {
             "database": request.database_id,
@@ -131,22 +167,13 @@ async def create_dataset(
     except DatasetInvalidError as exc:
         # CreateDatasetCommand.validate() collects DatasetExistsValidationError and
         # TableNotFoundValidationError into DatasetInvalidError.exceptions, never
-        # raising them directly. Inspect the wrapped class names to return a typed
-        # error response matching the advertised contract.
-        classnames = exc.get_list_classnames()
-        messages = exc.normalized_messages()
-        if "DatasetExistsValidationError" in classnames:
-            await ctx.warning("Dataset already exists: %s" % (messages,))
-            return DatasetError.create(
-                error=str(messages), error_type="DatasetExistsError"
-            )
-        if "TableNotFoundValidationError" in classnames:
-            await ctx.warning("Table not found: %s" % (messages,))
-            return DatasetError.create(
-                error=str(messages), error_type="TableNotFoundError"
-            )
-        await ctx.warning("Dataset validation failed: %s" % (messages,))
-        return DatasetError.create(error=str(messages), error_type="ValidationError")
+        # raising them directly. Inspect the wrapped class names for a typed response.
+        error_response = _classify_invalid_error(exc)
+        await ctx.warning(
+            "Dataset validation failed (%s): %s"
+            % (error_response.error_type, error_response.error)
+        )
+        return error_response
     except DatasetCreateFailedError as exc:
         await ctx.error("Dataset creation failed: %s" % (str(exc),))
         return DatasetError.create(error=str(exc), error_type="CreateFailedError")

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Create dataset FastMCP tool
+
+Registers a physical table as a Superset dataset against an existing
+database connection — the programmatic equivalent of Data → Datasets → +Dataset.
+Returns the same DatasetInfo shape as get_dataset_info so the caller can feed
+the resulting dataset_id directly into generate_chart.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from fastmcp import Context
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.auth import mcp_auth_hook
+from superset.mcp_service.dataset.schemas import (
+    CreateDatasetRequest,
+    DatasetError,
+    DatasetInfo,
+    serialize_dataset_object,
+)
+from superset.mcp_service.utils.schema_utils import parse_request
+
+logger = logging.getLogger(__name__)
+
+
+@mcp.tool(tags=["mutate"])
+@mcp_auth_hook
+@parse_request(CreateDatasetRequest)
+def create_dataset(
+    request: CreateDatasetRequest, ctx: Context
+) -> DatasetInfo | DatasetError:
+    """Register a physical table as a Superset dataset.
+
+    Wraps POST /api/v1/dataset/ — the same endpoint the UI uses when you click
+    Data → Datasets → +Dataset.  Returns full dataset metadata (same shape as
+    get_dataset_info) so you can pass the resulting dataset_id straight into
+    generate_chart.
+
+    Required fields:
+    - database_id: ID of the existing database connection
+    - schema: Schema/namespace where the table lives (e.g. "public")
+    - table_name: Exact name of the physical table to register
+
+    Optional fields:
+    - owners: List of user IDs to set as owners (defaults to calling user)
+
+    Example:
+    ```json
+    {
+        "database_id": 1,
+        "schema": "public",
+        "table_name": "orders"
+    }
+    ```
+
+    Returns DatasetInfo on success or DatasetError on failure.
+    Use list_databases to find the correct database_id.
+    """
+    try:
+        from superset.commands.dataset.create import CreateDatasetCommand
+        from superset.commands.dataset.exceptions import (
+            DatasetCreateFailedError,
+            DatasetExistsValidationError,
+            DatasetInvalidError,
+            TableNotFoundValidationError,
+        )
+
+        dataset_properties = {
+            "database": request.database_id,
+            "schema": request.schema,
+            "table_name": request.table_name,
+        }
+        if request.owners is not None:
+            dataset_properties["owners"] = request.owners
+
+        command = CreateDatasetCommand(dataset_properties)
+        dataset = command.run()
+
+        result = serialize_dataset_object(dataset)
+        if result is None:
+            return DatasetError(
+                error="Dataset was created but could not be serialized",
+                error_type="SerializationError",
+                timestamp=datetime.now(timezone.utc),
+            )
+
+        logger.info(
+            "Created dataset id=%s table=%s.%s",
+            dataset.id,
+            request.schema,
+            request.table_name,
+        )
+        return result
+
+    except DatasetExistsValidationError as e:
+        return DatasetError(
+            error=str(e),
+            error_type="DatasetExistsError",
+            timestamp=datetime.now(timezone.utc),
+        )
+    except TableNotFoundValidationError as e:
+        return DatasetError(
+            error=str(e),
+            error_type="TableNotFoundError",
+            timestamp=datetime.now(timezone.utc),
+        )
+    except DatasetInvalidError as e:
+        return DatasetError(
+            error=str(e),
+            error_type="ValidationError",
+            timestamp=datetime.now(timezone.utc),
+        )
+    except DatasetCreateFailedError as e:
+        return DatasetError(
+            error=str(e),
+            error_type="CreateFailedError",
+            timestamp=datetime.now(timezone.utc),
+        )
+    except Exception as e:
+        logger.error("Failed to create dataset: %s", e, exc_info=True)
+        return DatasetError(
+            error=f"Failed to create dataset: {str(e)}",
+            error_type="InternalError",
+            timestamp=datetime.now(timezone.utc),
+        )

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -115,10 +115,10 @@ async def create_dataset(
     # fields when Pydantic resolves the value via getattr internally.
     _request_data = request.model_dump()
     _schema_raw = _request_data.get("schema")
-    schema = _schema_raw.strip() if isinstance(_schema_raw, str) else None
+    schema = (_schema_raw.strip() or None) if isinstance(_schema_raw, str) else None
     table_name = request.table_name.strip()
     _catalog_raw = _request_data.get("catalog")
-    catalog = _catalog_raw.strip() if isinstance(_catalog_raw, str) else None
+    catalog = (_catalog_raw.strip() or None) if isinstance(_catalog_raw, str) else None
 
     await ctx.info(
         "Registering physical table as dataset: database_id=%s, table=%s.%s"

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -34,6 +34,7 @@ from superset.commands.dataset.exceptions import (
     DatasetCreateFailedError,
     DatasetInvalidError,
 )
+from superset.commands.exceptions import CommandInvalidError
 from superset.daos.database import DatabaseDAO
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import event_logger, security_manager
@@ -48,10 +49,10 @@ from superset.sql.parse import Table
 logger = logging.getLogger(__name__)
 
 
-def _classify_invalid_error(exc: object) -> DatasetError:
+def _classify_invalid_error(exc: CommandInvalidError) -> DatasetError:
     """Map DatasetInvalidError sub-exceptions to typed DatasetError responses."""
-    classnames = exc.get_list_classnames()  # type: ignore[attr-defined]
-    messages = exc.normalized_messages()  # type: ignore[attr-defined]
+    classnames = exc.get_list_classnames()
+    messages = exc.normalized_messages()
     if "DatasetExistsValidationError" in classnames:
         return DatasetError.create(error=str(messages), error_type="DatasetExistsError")
     if "TableNotFoundValidationError" in classnames:

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -37,14 +37,12 @@ from superset.mcp_service.dataset.schemas import (
     DatasetInfo,
     serialize_dataset_object,
 )
-from superset.mcp_service.utils.schema_utils import parse_request
 
 logger = logging.getLogger(__name__)
 
 
 @mcp.tool(tags=["mutate"])
 @mcp_auth_hook
-@parse_request(CreateDatasetRequest)
 def create_dataset(
     request: CreateDatasetRequest, ctx: Context
 ) -> DatasetInfo | DatasetError:

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -184,8 +184,8 @@ async def create_dataset(
             % (error_response.error_type, error_response.error)
         )
         return error_response
-    except DatasetCreateFailedError as exc:
-        logger.error("Dataset creation failed: %s", exc)
+    except DatasetCreateFailedError:
+        logger.exception("Dataset creation failed")
         await ctx.error("Dataset creation failed")
         return DatasetError.create(
             error="Dataset creation failed", error_type="CreateFailedError"

--- a/superset/mcp_service/dataset/tool/create_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_dataset.py
@@ -29,13 +29,21 @@ import logging
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.extensions import event_logger
+from superset.commands.dataset.create import CreateDatasetCommand
+from superset.commands.dataset.exceptions import (
+    DatasetCreateFailedError,
+    DatasetInvalidError,
+)
+from superset.daos.database import DatabaseDAO
+from superset.exceptions import SupersetSecurityException
+from superset.extensions import event_logger, security_manager
 from superset.mcp_service.dataset.schemas import (
     CreateDatasetRequest,
     DatasetError,
     DatasetInfo,
     serialize_dataset_object,
 )
+from superset.sql.parse import Table
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +56,8 @@ def _classify_invalid_error(exc: object) -> DatasetError:
         return DatasetError.create(error=str(messages), error_type="DatasetExistsError")
     if "TableNotFoundValidationError" in classnames:
         return DatasetError.create(error=str(messages), error_type="TableNotFoundError")
+    # Other DatasetInvalidError sub-types are returned as generic ValidationError.
+    # Add explicit branches here when callers need to distinguish them.
     return DatasetError.create(error=str(messages), error_type="ValidationError")
 
 
@@ -94,9 +104,10 @@ async def create_dataset(
     Returns DatasetInfo on success or DatasetError on failure.
     Use list_databases to find the correct database_id.
     """
-    # Normalize schema and table_name: strip whitespace, treat blank schema as None
+    # Normalize schema, table_name, catalog: strip whitespace, treat blank as None
     schema = request.schema.strip() if request.schema else None
     table_name = request.table_name.strip()
+    catalog = request.catalog.strip() if request.catalog else None
 
     await ctx.info(
         "Registering physical table as dataset: database_id=%s, table=%s.%s"
@@ -104,25 +115,12 @@ async def create_dataset(
     )
 
     try:
-        from superset.commands.dataset.create import CreateDatasetCommand
-        from superset.commands.dataset.exceptions import (
-            DatasetCreateFailedError,
-            DatasetInvalidError,
-        )
-        from superset.daos.database import DatabaseDAO
-        from superset.exceptions import SupersetSecurityException
-        from superset.extensions import security_manager
-        from superset.sql.parse import Table
-
-        # Normalize catalog: strip whitespace, treat blank as None
-        catalog = request.catalog.strip() if request.catalog else None
-
         # Look up the database so we can enforce table-level access before
         # forwarding to CreateDatasetCommand, which only checks SQL-path access.
         database = DatabaseDAO.find_by_id(request.database_id)
         if database is None:
             return DatasetError.create(
-                error=f"Database with id={request.database_id} not found",
+                error="Database not found",
                 error_type="DatabaseNotFoundError",
             )
 
@@ -132,9 +130,10 @@ async def create_dataset(
         try:
             security_manager.raise_for_access(database=database, table=table_obj)
         except SupersetSecurityException as exc:
-            await ctx.warning("Access denied to table %s: %s" % (table_obj, str(exc)))
+            logger.warning("Access denied to table %s: %s", table_obj, exc)
+            await ctx.warning("Access denied to table %s" % (table_obj,))
             return DatasetError.create(
-                error=str(exc),
+                error="Access denied",
                 error_type="AccessDeniedError",
             )
 
@@ -175,10 +174,12 @@ async def create_dataset(
         )
         return error_response
     except DatasetCreateFailedError as exc:
-        await ctx.error("Dataset creation failed: %s" % (str(exc),))
-        return DatasetError.create(error=str(exc), error_type="CreateFailedError")
-    except Exception as exc:
-        await ctx.error(
-            "Unexpected error creating dataset: %s: %s" % (type(exc).__name__, str(exc))
+        logger.error("Dataset creation failed: %s", exc)
+        await ctx.error("Dataset creation failed")
+        return DatasetError.create(
+            error="Dataset creation failed", error_type="CreateFailedError"
         )
+    except Exception as exc:
+        logger.exception("Unexpected error in create_dataset")
+        await ctx.error("Unexpected error: %s" % (type(exc).__name__,))
         raise

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -538,6 +538,25 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert "catalog" not in call_kwargs
 
+    @pytest.mark.asyncio
+    async def test_create_dataset_non_string_namespace_rejected(
+        self, mcp_server
+    ) -> None:
+        """Non-string schema/catalog values fail validation, not silently dropped."""
+        async with Client(mcp_server) as client:
+            for field, value in (("schema", 123), ("catalog", {"name": "hive"})):
+                with pytest.raises(ToolError):
+                    await client.call_tool(
+                        "create_dataset",
+                        {
+                            "request": {
+                                "database_id": 1,
+                                "table_name": "orders",
+                                field: value,
+                            }
+                        },
+                    )
+
     @patch.object(create_dataset_module, "CreateDatasetCommand")
     @patch.object(create_dataset_module, "serialize_dataset_object", return_value=None)
     @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -18,7 +18,6 @@
 """Unit tests for create_dataset MCP tool."""
 
 import importlib
-import logging
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -26,12 +25,13 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
 from superset.commands.dataset.exceptions import (
+    DatabaseNotFoundValidationError,
     DatasetCreateFailedError,
+    DatasetDataAccessIsNotAllowed,
     DatasetExistsValidationError,
     DatasetInvalidError,
     TableNotFoundValidationError,
 )
-from superset.exceptions import SupersetSecurityException
 from superset.mcp_service.app import mcp
 from superset.sql.parse import Table
 from superset.utils import json
@@ -42,9 +42,6 @@ from superset.utils import json
 create_dataset_module = importlib.import_module(
     "superset.mcp_service.dataset.tool.create_dataset"
 )
-
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
 
 
 def _make_mock_dataset(
@@ -105,18 +102,6 @@ def mock_auth():
 
 class TestCreateDataset:
     """Tests for the create_dataset MCP tool."""
-
-    @pytest.fixture(autouse=True)
-    def mock_database_access(self):
-        """Provide a mock database and allow all table access by default."""
-        mock_db = MagicMock()
-        with (
-            patch(
-                "superset.daos.database.DatabaseDAO.find_by_id", return_value=mock_db
-            ),
-            patch("superset.extensions.security_manager.raise_for_access"),
-        ):
-            yield mock_db
 
     @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
@@ -328,51 +313,56 @@ class TestCreateDataset:
         assert data["error_type"] == "CreateFailedError"
         assert "Dataset creation failed" in data["error"]
 
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_database_not_found(self, mcp_server) -> None:
-        """Returns DatabaseNotFoundError when database_id does not exist."""
-        with patch("superset.daos.database.DatabaseDAO.find_by_id", return_value=None):
-            async with Client(mcp_server) as client:
-                result = await client.call_tool(
-                    "create_dataset",
-                    {
-                        "request": {
-                            "database_id": 999,
-                            "table_name": "orders",
-                        }
-                    },
-                )
+    async def test_create_dataset_database_not_found(
+        self, mock_command_class, mcp_server
+    ) -> None:
+        """Returns DatabaseNotFoundError when CreateDatasetCommand raises it."""
+        mock_command = MagicMock()
+        mock_command.run.side_effect = DatasetInvalidError(
+            exceptions=[DatabaseNotFoundValidationError()]
+        )
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 999,
+                        "table_name": "orders",
+                    }
+                },
+            )
 
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "DatabaseNotFoundError"
         assert "Database not found" in data["error"]
 
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_access_denied(self, mcp_server) -> None:
-        """Returns AccessDeniedError when caller lacks table-level access."""
-        mock_db = MagicMock()
-        with (
-            patch(
-                "superset.daos.database.DatabaseDAO.find_by_id", return_value=mock_db
-            ),
-            patch(
-                "superset.extensions.security_manager.raise_for_access",
-                side_effect=SupersetSecurityException(
-                    MagicMock(message="Access is Denied")
-                ),
-            ),
-        ):
-            async with Client(mcp_server) as client:
-                result = await client.call_tool(
-                    "create_dataset",
-                    {
-                        "request": {
-                            "database_id": 1,
-                            "schema": "secret",
-                            "table_name": "restricted_table",
-                        }
-                    },
-                )
+    async def test_create_dataset_access_denied(
+        self, mock_command_class, mcp_server
+    ) -> None:
+        """Returns AccessDeniedError when CreateDatasetCommand raises it."""
+        mock_command = MagicMock()
+        mock_command.run.side_effect = DatasetInvalidError(
+            exceptions=[DatasetDataAccessIsNotAllowed("Access is Denied")]
+        )
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "secret",
+                        "table_name": "restricted_table",
+                    }
+                },
+            )
 
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "AccessDeniedError"

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -42,6 +42,8 @@ def _make_mock_dataset(
     dataset.table_name = table_name
     dataset.schema = schema
     dataset.description = None
+    dataset.certified_by = None
+    dataset.certification_details = None
     dataset.changed_by_name = "admin"
     dataset.changed_on = None
     dataset.changed_on_humanized = None
@@ -51,6 +53,7 @@ def _make_mock_dataset(
     dataset.tags = []
     dataset.owners = []
     dataset.is_virtual = False
+    dataset.is_favorite = None
     dataset.database_id = 1
     dataset.schema_perm = f"[{database_name}].[{schema}]"
     dataset.url = f"/tablemodelview/edit/{dataset_id}"

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -155,13 +155,21 @@ class TestCreateDataset:
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_already_exists(self, mock_command_class, mcp_server):
-        """Returns DatasetError when a dataset for the table already exists."""
-        from superset.commands.dataset.exceptions import DatasetExistsValidationError
+        """Returns DatasetExistsError when the table is already registered.
+
+        CreateDatasetCommand.validate() wraps DatasetExistsValidationError inside
+        DatasetInvalidError.  The tool must inspect get_list_classnames() to surface
+        the typed error response.
+        """
+        from superset.commands.dataset.exceptions import (
+            DatasetExistsValidationError,
+            DatasetInvalidError,
+        )
         from superset.sql.parse import Table
 
         mock_command = MagicMock()
-        mock_command.run.side_effect = DatasetExistsValidationError(
-            Table("orders", "public", None)
+        mock_command.run.side_effect = DatasetInvalidError(
+            exceptions=[DatasetExistsValidationError(Table("orders", "public", None))]
         )
         mock_command_class.return_value = mock_command
 
@@ -184,13 +192,23 @@ class TestCreateDataset:
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_table_not_found(self, mock_command_class, mcp_server):
-        """Returns DatasetError when the physical table does not exist in the DB."""
-        from superset.commands.dataset.exceptions import TableNotFoundValidationError
+        """Returns TableNotFoundError when the physical table does not exist in the DB.
+
+        CreateDatasetCommand.validate() wraps TableNotFoundValidationError inside
+        DatasetInvalidError.  The tool must inspect get_list_classnames() to surface
+        the typed error response.
+        """
+        from superset.commands.dataset.exceptions import (
+            DatasetInvalidError,
+            TableNotFoundValidationError,
+        )
         from superset.sql.parse import Table
 
         mock_command = MagicMock()
-        mock_command.run.side_effect = TableNotFoundValidationError(
-            Table("missing_table", "public", None)
+        mock_command.run.side_effect = DatasetInvalidError(
+            exceptions=[
+                TableNotFoundValidationError(Table("missing_table", "public", None))
+            ]
         )
         mock_command_class.return_value = mock_command
 
@@ -208,6 +226,31 @@ class TestCreateDataset:
 
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "TableNotFoundError"
+
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @pytest.mark.asyncio
+    async def test_create_dataset_with_catalog(self, mock_command_class, mcp_server):
+        """Catalog field is normalized and forwarded to the command when supplied."""
+        mock_dataset = _make_mock_dataset()
+        mock_command = MagicMock()
+        mock_command.run.return_value = mock_dataset
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "catalog": "  hive  ",
+                        "schema": "default",
+                        "table_name": "events",
+                    }
+                },
+            )
+
+        call_kwargs = mock_command_class.call_args[0][0]
+        assert call_kwargs["catalog"] == "hive"
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -109,7 +109,7 @@ class TestCreateDataset:
         ):
             yield mock_db
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_success(self, mock_command_class, mcp_server) -> None:
         """Happy path: tool creates dataset and returns DatasetInfo."""
@@ -143,7 +143,7 @@ class TestCreateDataset:
         assert call_kwargs["table_name"] == "orders"
         assert "owners" not in call_kwargs
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_with_owners(
         self, mock_command_class, mcp_server
@@ -173,7 +173,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert call_kwargs["owners"] == [5, 10]
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_already_exists(
         self, mock_command_class, mcp_server
@@ -206,7 +206,7 @@ class TestCreateDataset:
         assert data["error_type"] == "DatasetExistsError"
         assert "error" in data
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_table_not_found(
         self, mock_command_class, mcp_server
@@ -240,7 +240,7 @@ class TestCreateDataset:
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "TableNotFoundError"
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_with_catalog(
         self, mock_command_class, mcp_server
@@ -267,7 +267,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert call_kwargs["catalog"] == "hive"
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_invalid_error(
         self, mock_command_class, mcp_server
@@ -343,7 +343,7 @@ class TestCreateDataset:
         assert data["error_type"] == "AccessDeniedError"
         assert data["error"] == "Access denied"
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_unexpected_error(
         self, mock_command_class, mcp_server
@@ -381,7 +381,7 @@ class TestCreateDataset:
                     },
                 )
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_returns_full_dataset_info(
         self, mock_command_class, mcp_server
@@ -435,7 +435,7 @@ class TestCreateDataset:
         assert len(data["metrics"]) == 1
         assert data["metrics"][0]["metric_name"] == "total_sales"
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_table_name_whitespace_normalized(
         self, mock_command_class, mcp_server
@@ -461,7 +461,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert call_kwargs["table_name"] == "orders"
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_blank_schema_normalized_to_none(
         self, mock_command_class, mcp_server
@@ -487,9 +487,9 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert "schema" not in call_kwargs
 
-    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @patch(
-        "superset.mcp_service.dataset.schemas.serialize_dataset_object",
+        "superset.mcp_service.dataset.tool.create_dataset.serialize_dataset_object",
         return_value=None,
     )
     @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -488,6 +488,32 @@ class TestCreateDataset:
         assert "schema" not in call_kwargs
 
     @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @pytest.mark.asyncio
+    async def test_create_dataset_blank_catalog_normalized_to_none(
+        self, mock_command_class, mcp_server
+    ) -> None:
+        """Blank catalog string is treated as absent: not forwarded to the command."""
+        mock_dataset = _make_mock_dataset()
+        mock_command = MagicMock()
+        mock_command.run.return_value = mock_dataset
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "catalog": "",
+                        "table_name": "orders",
+                    }
+                },
+            )
+
+        call_kwargs = mock_command_class.call_args[0][0]
+        assert "catalog" not in call_kwargs
+
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @patch(
         "superset.mcp_service.dataset.tool.create_dataset.serialize_dataset_object",
         return_value=None,

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -87,7 +87,7 @@ def mock_auth():
 class TestCreateDataset:
     """Tests for the create_dataset MCP tool."""
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_success(self, mock_command_class, mcp_server):
         """Happy path: tool creates dataset and returns DatasetInfo."""
@@ -112,7 +112,7 @@ class TestCreateDataset:
         data = json.loads(result.content[0].text)
         assert data["id"] == 42
         assert data["table_name"] == "orders"
-        assert data["schema_name"] == "public"
+        assert data["schema"] == "public"
 
         # Verify the command was called with the right properties
         call_kwargs = mock_command_class.call_args[0][0]
@@ -121,7 +121,7 @@ class TestCreateDataset:
         assert call_kwargs["table_name"] == "orders"
         assert "owners" not in call_kwargs
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_with_owners(self, mock_command_class, mcp_server):
         """Owners list is forwarded to the command when supplied."""
@@ -149,7 +149,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert call_kwargs["owners"] == [5, 10]
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_already_exists(self, mock_command_class, mcp_server):
         """Returns DatasetError when a dataset for the table already exists."""
@@ -178,7 +178,7 @@ class TestCreateDataset:
         assert data["error_type"] == "DatasetExistsError"
         assert "error" in data
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_table_not_found(self, mock_command_class, mcp_server):
         """Returns DatasetError when the physical table does not exist in the DB."""
@@ -206,7 +206,7 @@ class TestCreateDataset:
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "TableNotFoundError"
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_unexpected_error(
         self, mock_command_class, mcp_server
@@ -247,7 +247,7 @@ class TestCreateDataset:
                     },
                 )
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_returns_full_dataset_info(
         self, mock_command_class, mcp_server
@@ -294,7 +294,7 @@ class TestCreateDataset:
         data = json.loads(result.content[0].text)
         assert data["id"] == 99
         assert data["table_name"] == "sales"
-        assert data["schema_name"] == "dw"
+        assert data["schema"] == "dw"
         assert data["is_virtual"] is False
         assert len(data["columns"]) == 1
         assert data["columns"][0]["column_name"] == "amount"

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -211,6 +211,32 @@ class TestCreateDataset:
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
+    async def test_create_dataset_invalid_error(self, mock_command_class, mcp_server):
+        """DatasetInvalidError is returned as ValidationError type."""
+        from superset.commands.dataset.exceptions import DatasetInvalidError
+
+        mock_command = MagicMock()
+        mock_command.run.side_effect = DatasetInvalidError()
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "public",
+                        "table_name": "orders",
+                    }
+                },
+            )
+
+        data = json.loads(result.content[0].text)
+        assert data["error_type"] == "ValidationError"
+        assert "error" in data
+
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @pytest.mark.asyncio
     async def test_create_dataset_unexpected_error(
         self, mock_command_class, mcp_server
     ):

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -87,9 +87,7 @@ def mock_auth():
 class TestCreateDataset:
     """Tests for the create_dataset MCP tool."""
 
-    @patch(
-        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
-    )
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_success(self, mock_command_class, mcp_server):
         """Happy path: tool creates dataset and returns DatasetInfo."""
@@ -123,9 +121,7 @@ class TestCreateDataset:
         assert call_kwargs["table_name"] == "orders"
         assert "owners" not in call_kwargs
 
-    @patch(
-        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
-    )
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_with_owners(self, mock_command_class, mcp_server):
         """Owners list is forwarded to the command when supplied."""
@@ -153,9 +149,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert call_kwargs["owners"] == [5, 10]
 
-    @patch(
-        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
-    )
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_already_exists(self, mock_command_class, mcp_server):
         """Returns DatasetError when a dataset for the table already exists."""
@@ -184,13 +178,9 @@ class TestCreateDataset:
         assert data["error_type"] == "DatasetExistsError"
         assert "error" in data
 
-    @patch(
-        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
-    )
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_table_not_found(
-        self, mock_command_class, mcp_server
-    ):
+    async def test_create_dataset_table_not_found(self, mock_command_class, mcp_server):
         """Returns DatasetError when the physical table does not exist in the DB."""
         from superset.commands.dataset.exceptions import TableNotFoundValidationError
         from superset.sql.parse import Table
@@ -216,9 +206,7 @@ class TestCreateDataset:
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "TableNotFoundError"
 
-    @patch(
-        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
-    )
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_unexpected_error(
         self, mock_command_class, mcp_server
@@ -259,15 +247,15 @@ class TestCreateDataset:
                     },
                 )
 
-    @patch(
-        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
-    )
+    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_returns_full_dataset_info(
         self, mock_command_class, mcp_server
     ):
         """The returned DatasetInfo includes columns, metrics, and all core fields."""
-        mock_dataset = _make_mock_dataset(dataset_id=99, table_name="sales", schema="dw")
+        mock_dataset = _make_mock_dataset(
+            dataset_id=99, table_name="sales", schema="dw"
+        )
 
         col = MagicMock()
         col.column_name = "amount"

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -90,6 +90,18 @@ def mock_auth():
 class TestCreateDataset:
     """Tests for the create_dataset MCP tool."""
 
+    @pytest.fixture(autouse=True)
+    def mock_database_access(self):
+        """Provide a mock database and allow all table access by default."""
+        mock_db = MagicMock()
+        with (
+            patch(
+                "superset.daos.database.DatabaseDAO.find_by_id", return_value=mock_db
+            ),
+            patch("superset.extensions.security_manager.raise_for_access"),
+        ):
+            yield mock_db
+
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_success(self, mock_command_class, mcp_server):
@@ -277,6 +289,57 @@ class TestCreateDataset:
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "ValidationError"
         assert "error" in data
+
+    @pytest.mark.asyncio
+    async def test_create_dataset_database_not_found(self, mcp_server):
+        """Returns DatabaseNotFoundError when database_id does not exist."""
+        with patch("superset.daos.database.DatabaseDAO.find_by_id", return_value=None):
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "create_dataset",
+                    {
+                        "request": {
+                            "database_id": 999,
+                            "table_name": "orders",
+                        }
+                    },
+                )
+
+        data = json.loads(result.content[0].text)
+        assert data["error_type"] == "DatabaseNotFoundError"
+        assert "999" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_dataset_access_denied(self, mcp_server):
+        """Returns AccessDeniedError when caller lacks table-level access."""
+        from superset.exceptions import SupersetSecurityException
+
+        mock_db = MagicMock()
+        with (
+            patch(
+                "superset.daos.database.DatabaseDAO.find_by_id", return_value=mock_db
+            ),
+            patch(
+                "superset.extensions.security_manager.raise_for_access",
+                side_effect=SupersetSecurityException(
+                    MagicMock(message="Access is Denied")
+                ),
+            ),
+        ):
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "create_dataset",
+                    {
+                        "request": {
+                            "database_id": 1,
+                            "schema": "secret",
+                            "table_name": "restricted_table",
+                        }
+                    },
+                )
+
+        data = json.loads(result.content[0].text)
+        assert data["error_type"] == "AccessDeniedError"
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -17,6 +17,7 @@
 
 """Unit tests for create_dataset MCP tool."""
 
+import importlib
 import logging
 from unittest.mock import MagicMock, Mock, patch
 
@@ -25,6 +26,7 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
 from superset.commands.dataset.exceptions import (
+    DatasetCreateFailedError,
     DatasetExistsValidationError,
     DatasetInvalidError,
     TableNotFoundValidationError,
@@ -33,6 +35,13 @@ from superset.exceptions import SupersetSecurityException
 from superset.mcp_service.app import mcp
 from superset.sql.parse import Table
 from superset.utils import json
+
+# Use importlib to get the module object directly, bypassing the __init__.py
+# attribute binding that shadows the module name with the exported function.
+# This ensures patch.object resolves to the module in all Python versions.
+create_dataset_module = importlib.import_module(
+    "superset.mcp_service.dataset.tool.create_dataset"
+)
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -109,7 +118,7 @@ class TestCreateDataset:
         ):
             yield mock_db
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_success(self, mock_command_class, mcp_server) -> None:
         """Happy path: tool creates dataset and returns DatasetInfo."""
@@ -143,7 +152,7 @@ class TestCreateDataset:
         assert call_kwargs["table_name"] == "orders"
         assert "owners" not in call_kwargs
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_with_owners(
         self, mock_command_class, mcp_server
@@ -173,7 +182,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert call_kwargs["owners"] == [5, 10]
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_already_exists(
         self, mock_command_class, mcp_server
@@ -206,7 +215,7 @@ class TestCreateDataset:
         assert data["error_type"] == "DatasetExistsError"
         assert "error" in data
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_table_not_found(
         self, mock_command_class, mcp_server
@@ -240,7 +249,7 @@ class TestCreateDataset:
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "TableNotFoundError"
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_with_catalog(
         self, mock_command_class, mcp_server
@@ -267,7 +276,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert call_kwargs["catalog"] == "hive"
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_invalid_error(
         self, mock_command_class, mcp_server
@@ -292,6 +301,32 @@ class TestCreateDataset:
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "ValidationError"
         assert "error" in data
+
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
+    @pytest.mark.asyncio
+    async def test_create_dataset_create_failed_error(
+        self, mock_command_class, mcp_server
+    ) -> None:
+        """DatasetCreateFailedError is returned as CreateFailedError type."""
+        mock_command = MagicMock()
+        mock_command.run.side_effect = DatasetCreateFailedError()
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "public",
+                        "table_name": "orders",
+                    }
+                },
+            )
+
+        data = json.loads(result.content[0].text)
+        assert data["error_type"] == "CreateFailedError"
+        assert "Dataset creation failed" in data["error"]
 
     @pytest.mark.asyncio
     async def test_create_dataset_database_not_found(self, mcp_server) -> None:
@@ -343,7 +378,7 @@ class TestCreateDataset:
         assert data["error_type"] == "AccessDeniedError"
         assert "Access denied" in data["error"]
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_unexpected_error(
         self, mock_command_class, mcp_server
@@ -381,7 +416,7 @@ class TestCreateDataset:
                     },
                 )
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_returns_full_dataset_info(
         self, mock_command_class, mcp_server
@@ -435,7 +470,7 @@ class TestCreateDataset:
         assert len(data["metrics"]) == 1
         assert data["metrics"][0]["metric_name"] == "total_sales"
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_table_name_whitespace_normalized(
         self, mock_command_class, mcp_server
@@ -461,7 +496,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert call_kwargs["table_name"] == "orders"
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_blank_schema_normalized_to_none(
         self, mock_command_class, mcp_server
@@ -487,7 +522,7 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert "schema" not in call_kwargs
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_blank_catalog_normalized_to_none(
         self, mock_command_class, mcp_server
@@ -513,13 +548,10 @@ class TestCreateDataset:
         call_kwargs = mock_command_class.call_args[0][0]
         assert "catalog" not in call_kwargs
 
-    @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
-    @patch(
-        "superset.mcp_service.dataset.tool.create_dataset.serialize_dataset_object",
-        return_value=None,
-    )
+    @patch.object(create_dataset_module, "CreateDatasetCommand")
+    @patch.object(create_dataset_module, "serialize_dataset_object", return_value=None)
     @pytest.mark.asyncio
-    async def test_create_dataset_serialization_error(
+    async def test_create_dataset_when_serialize_returns_none(
         self, mock_serialize, mock_command_class, mcp_server
     ) -> None:
         """Returns SerializationError when serialize_dataset_object returns None."""

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -1,0 +1,314 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for create_dataset MCP tool."""
+
+import logging
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from superset.mcp_service.app import mcp
+from superset.utils import json
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+def _make_mock_dataset(
+    dataset_id: int = 42,
+    table_name: str = "orders",
+    schema: str = "public",
+    database_name: str = "main_db",
+) -> MagicMock:
+    dataset = MagicMock()
+    dataset.id = dataset_id
+    dataset.table_name = table_name
+    dataset.schema = schema
+    dataset.description = None
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = f"[{database_name}].[{schema}]"
+    dataset.url = f"/tablemodelview/edit/{dataset_id}"
+    dataset.database = MagicMock()
+    dataset.database.database_name = database_name
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    dataset.uuid = f"dataset-uuid-{dataset_id}"
+    dataset.columns = []
+    dataset.metrics = []
+    return dataset
+
+
+@pytest.fixture
+def mcp_server():
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_user.username = "admin"
+        mock_get_user.return_value = mock_user
+        yield mock_get_user
+
+
+class TestCreateDataset:
+    """Tests for the create_dataset MCP tool."""
+
+    @patch(
+        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
+    )
+    @pytest.mark.asyncio
+    async def test_create_dataset_success(self, mock_command_class, mcp_server):
+        """Happy path: tool creates dataset and returns DatasetInfo."""
+        mock_dataset = _make_mock_dataset()
+        mock_command = MagicMock()
+        mock_command.run.return_value = mock_dataset
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "public",
+                        "table_name": "orders",
+                    }
+                },
+            )
+
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["id"] == 42
+        assert data["table_name"] == "orders"
+        assert data["schema_name"] == "public"
+
+        # Verify the command was called with the right properties
+        call_kwargs = mock_command_class.call_args[0][0]
+        assert call_kwargs["database"] == 1
+        assert call_kwargs["schema"] == "public"
+        assert call_kwargs["table_name"] == "orders"
+        assert "owners" not in call_kwargs
+
+    @patch(
+        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
+    )
+    @pytest.mark.asyncio
+    async def test_create_dataset_with_owners(self, mock_command_class, mcp_server):
+        """Owners list is forwarded to the command when supplied."""
+        mock_dataset = _make_mock_dataset()
+        mock_command = MagicMock()
+        mock_command.run.return_value = mock_dataset
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 2,
+                        "schema": "sales",
+                        "table_name": "transactions",
+                        "owners": [5, 10],
+                    }
+                },
+            )
+
+        data = json.loads(result.content[0].text)
+        assert data["id"] == 42
+
+        call_kwargs = mock_command_class.call_args[0][0]
+        assert call_kwargs["owners"] == [5, 10]
+
+    @patch(
+        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
+    )
+    @pytest.mark.asyncio
+    async def test_create_dataset_already_exists(self, mock_command_class, mcp_server):
+        """Returns DatasetError when a dataset for the table already exists."""
+        from superset.commands.dataset.exceptions import DatasetExistsValidationError
+        from superset.sql.parse import Table
+
+        mock_command = MagicMock()
+        mock_command.run.side_effect = DatasetExistsValidationError(
+            Table("orders", "public", None)
+        )
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "public",
+                        "table_name": "orders",
+                    }
+                },
+            )
+
+        data = json.loads(result.content[0].text)
+        assert data["error_type"] == "DatasetExistsError"
+        assert "error" in data
+
+    @patch(
+        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
+    )
+    @pytest.mark.asyncio
+    async def test_create_dataset_table_not_found(
+        self, mock_command_class, mcp_server
+    ):
+        """Returns DatasetError when the physical table does not exist in the DB."""
+        from superset.commands.dataset.exceptions import TableNotFoundValidationError
+        from superset.sql.parse import Table
+
+        mock_command = MagicMock()
+        mock_command.run.side_effect = TableNotFoundValidationError(
+            Table("missing_table", "public", None)
+        )
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "public",
+                        "table_name": "missing_table",
+                    }
+                },
+            )
+
+        data = json.loads(result.content[0].text)
+        assert data["error_type"] == "TableNotFoundError"
+
+    @patch(
+        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
+    )
+    @pytest.mark.asyncio
+    async def test_create_dataset_unexpected_error(
+        self, mock_command_class, mcp_server
+    ):
+        """Unexpected exceptions are caught and returned as InternalError."""
+        mock_command = MagicMock()
+        mock_command.run.side_effect = RuntimeError("DB connection lost")
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "public",
+                        "table_name": "orders",
+                    }
+                },
+            )
+
+        data = json.loads(result.content[0].text)
+        assert data["error_type"] == "InternalError"
+        assert "DB connection lost" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_dataset_missing_required_fields(self, mcp_server):
+        """Missing required fields raise a validation error before the tool runs."""
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "create_dataset",
+                    {
+                        "request": {
+                            # database_id and table_name are omitted intentionally
+                            "schema": "public",
+                        }
+                    },
+                )
+
+    @patch(
+        "superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand"
+    )
+    @pytest.mark.asyncio
+    async def test_create_dataset_returns_full_dataset_info(
+        self, mock_command_class, mcp_server
+    ):
+        """The returned DatasetInfo includes columns, metrics, and all core fields."""
+        mock_dataset = _make_mock_dataset(dataset_id=99, table_name="sales", schema="dw")
+
+        col = MagicMock()
+        col.column_name = "amount"
+        col.verbose_name = "Amount"
+        col.type = "NUMERIC"
+        col.is_dttm = False
+        col.groupby = True
+        col.filterable = True
+        col.description = "Sale amount"
+        mock_dataset.columns = [col]
+
+        metric = MagicMock()
+        metric.metric_name = "total_sales"
+        metric.verbose_name = "Total Sales"
+        metric.expression = "SUM(amount)"
+        metric.description = "Sum of amounts"
+        metric.d3format = None
+        mock_dataset.metrics = [metric]
+
+        mock_command = MagicMock()
+        mock_command.run.return_value = mock_dataset
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "dw",
+                        "table_name": "sales",
+                    }
+                },
+            )
+
+        data = json.loads(result.content[0].text)
+        assert data["id"] == 99
+        assert data["table_name"] == "sales"
+        assert data["schema_name"] == "dw"
+        assert data["is_virtual"] is False
+        assert len(data["columns"]) == 1
+        assert data["columns"][0]["column_name"] == "amount"
+        assert len(data["metrics"]) == 1
+        assert data["metrics"][0]["metric_name"] == "total_sales"

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -310,7 +310,7 @@ class TestCreateDataset:
 
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "DatabaseNotFoundError"
-        assert data["error"] == "Database not found"
+        assert "Database not found" in data["error"]
 
     @pytest.mark.asyncio
     async def test_create_dataset_access_denied(self, mcp_server) -> None:
@@ -341,7 +341,7 @@ class TestCreateDataset:
 
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "AccessDeniedError"
-        assert data["error"] == "Access denied"
+        assert "Access denied" in data["error"]
 
     @patch("superset.mcp_service.dataset.tool.create_dataset.CreateDatasetCommand")
     @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -24,7 +24,14 @@ import pytest
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 
+from superset.commands.dataset.exceptions import (
+    DatasetExistsValidationError,
+    DatasetInvalidError,
+    TableNotFoundValidationError,
+)
+from superset.exceptions import SupersetSecurityException
 from superset.mcp_service.app import mcp
+from superset.sql.parse import Table
 from superset.utils import json
 
 logging.basicConfig(level=logging.DEBUG)
@@ -104,7 +111,7 @@ class TestCreateDataset:
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_success(self, mock_command_class, mcp_server):
+    async def test_create_dataset_success(self, mock_command_class, mcp_server) -> None:
         """Happy path: tool creates dataset and returns DatasetInfo."""
         mock_dataset = _make_mock_dataset()
         mock_command = MagicMock()
@@ -138,7 +145,9 @@ class TestCreateDataset:
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_with_owners(self, mock_command_class, mcp_server):
+    async def test_create_dataset_with_owners(
+        self, mock_command_class, mcp_server
+    ) -> None:
         """Owners list is forwarded to the command when supplied."""
         mock_dataset = _make_mock_dataset()
         mock_command = MagicMock()
@@ -166,19 +175,15 @@ class TestCreateDataset:
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_already_exists(self, mock_command_class, mcp_server):
+    async def test_create_dataset_already_exists(
+        self, mock_command_class, mcp_server
+    ) -> None:
         """Returns DatasetExistsError when the table is already registered.
 
         CreateDatasetCommand.validate() wraps DatasetExistsValidationError inside
         DatasetInvalidError.  The tool must inspect get_list_classnames() to surface
         the typed error response.
         """
-        from superset.commands.dataset.exceptions import (
-            DatasetExistsValidationError,
-            DatasetInvalidError,
-        )
-        from superset.sql.parse import Table
-
         mock_command = MagicMock()
         mock_command.run.side_effect = DatasetInvalidError(
             exceptions=[DatasetExistsValidationError(Table("orders", "public", None))]
@@ -203,19 +208,15 @@ class TestCreateDataset:
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_table_not_found(self, mock_command_class, mcp_server):
+    async def test_create_dataset_table_not_found(
+        self, mock_command_class, mcp_server
+    ) -> None:
         """Returns TableNotFoundError when the physical table does not exist in the DB.
 
         CreateDatasetCommand.validate() wraps TableNotFoundValidationError inside
         DatasetInvalidError.  The tool must inspect get_list_classnames() to surface
         the typed error response.
         """
-        from superset.commands.dataset.exceptions import (
-            DatasetInvalidError,
-            TableNotFoundValidationError,
-        )
-        from superset.sql.parse import Table
-
         mock_command = MagicMock()
         mock_command.run.side_effect = DatasetInvalidError(
             exceptions=[
@@ -241,7 +242,9 @@ class TestCreateDataset:
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_with_catalog(self, mock_command_class, mcp_server):
+    async def test_create_dataset_with_catalog(
+        self, mock_command_class, mcp_server
+    ) -> None:
         """Catalog field is normalized and forwarded to the command when supplied."""
         mock_dataset = _make_mock_dataset()
         mock_command = MagicMock()
@@ -266,10 +269,10 @@ class TestCreateDataset:
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
-    async def test_create_dataset_invalid_error(self, mock_command_class, mcp_server):
+    async def test_create_dataset_invalid_error(
+        self, mock_command_class, mcp_server
+    ) -> None:
         """DatasetInvalidError is returned as ValidationError type."""
-        from superset.commands.dataset.exceptions import DatasetInvalidError
-
         mock_command = MagicMock()
         mock_command.run.side_effect = DatasetInvalidError()
         mock_command_class.return_value = mock_command
@@ -291,7 +294,7 @@ class TestCreateDataset:
         assert "error" in data
 
     @pytest.mark.asyncio
-    async def test_create_dataset_database_not_found(self, mcp_server):
+    async def test_create_dataset_database_not_found(self, mcp_server) -> None:
         """Returns DatabaseNotFoundError when database_id does not exist."""
         with patch("superset.daos.database.DatabaseDAO.find_by_id", return_value=None):
             async with Client(mcp_server) as client:
@@ -307,13 +310,11 @@ class TestCreateDataset:
 
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "DatabaseNotFoundError"
-        assert "999" in data["error"]
+        assert data["error"] == "Database not found"
 
     @pytest.mark.asyncio
-    async def test_create_dataset_access_denied(self, mcp_server):
+    async def test_create_dataset_access_denied(self, mcp_server) -> None:
         """Returns AccessDeniedError when caller lacks table-level access."""
-        from superset.exceptions import SupersetSecurityException
-
         mock_db = MagicMock()
         with (
             patch(
@@ -340,12 +341,13 @@ class TestCreateDataset:
 
         data = json.loads(result.content[0].text)
         assert data["error_type"] == "AccessDeniedError"
+        assert data["error"] == "Access denied"
 
     @patch("superset.commands.dataset.create.CreateDatasetCommand")
     @pytest.mark.asyncio
     async def test_create_dataset_unexpected_error(
         self, mock_command_class, mcp_server
-    ):
+    ) -> None:
         """Unexpected exceptions are re-raised as ToolError (handled by middleware)."""
         mock_command = MagicMock()
         mock_command.run.side_effect = RuntimeError("DB connection lost")
@@ -365,7 +367,7 @@ class TestCreateDataset:
                 )
 
     @pytest.mark.asyncio
-    async def test_create_dataset_missing_required_fields(self, mcp_server):
+    async def test_create_dataset_missing_required_fields(self, mcp_server) -> None:
         """Missing required fields raise a validation error before the tool runs."""
         async with Client(mcp_server) as client:
             with pytest.raises(ToolError):
@@ -383,7 +385,7 @@ class TestCreateDataset:
     @pytest.mark.asyncio
     async def test_create_dataset_returns_full_dataset_info(
         self, mock_command_class, mcp_server
-    ):
+    ) -> None:
         """The returned DatasetInfo includes columns, metrics, and all core fields."""
         mock_dataset = _make_mock_dataset(
             dataset_id=99, table_name="sales", schema="dw"
@@ -432,3 +434,85 @@ class TestCreateDataset:
         assert data["columns"][0]["column_name"] == "amount"
         assert len(data["metrics"]) == 1
         assert data["metrics"][0]["metric_name"] == "total_sales"
+
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @pytest.mark.asyncio
+    async def test_create_dataset_table_name_whitespace_normalized(
+        self, mock_command_class, mcp_server
+    ) -> None:
+        """Whitespace in table_name is stripped before forwarding to the command."""
+        mock_dataset = _make_mock_dataset()
+        mock_command = MagicMock()
+        mock_command.run.return_value = mock_dataset
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "public",
+                        "table_name": "  orders  ",
+                    }
+                },
+            )
+
+        call_kwargs = mock_command_class.call_args[0][0]
+        assert call_kwargs["table_name"] == "orders"
+
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @pytest.mark.asyncio
+    async def test_create_dataset_blank_schema_normalized_to_none(
+        self, mock_command_class, mcp_server
+    ) -> None:
+        """Blank schema string is treated as absent: not forwarded to the command."""
+        mock_dataset = _make_mock_dataset(schema="")
+        mock_command = MagicMock()
+        mock_command.run.return_value = mock_dataset
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "",
+                        "table_name": "orders",
+                    }
+                },
+            )
+
+        call_kwargs = mock_command_class.call_args[0][0]
+        assert "schema" not in call_kwargs
+
+    @patch("superset.commands.dataset.create.CreateDatasetCommand")
+    @patch(
+        "superset.mcp_service.dataset.schemas.serialize_dataset_object",
+        return_value=None,
+    )
+    @pytest.mark.asyncio
+    async def test_create_dataset_serialization_error(
+        self, mock_serialize, mock_command_class, mcp_server
+    ) -> None:
+        """Returns SerializationError when serialize_dataset_object returns None."""
+        mock_dataset = _make_mock_dataset()
+        mock_command = MagicMock()
+        mock_command.run.return_value = mock_dataset
+        mock_command_class.return_value = mock_command
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_dataset",
+                {
+                    "request": {
+                        "database_id": 1,
+                        "schema": "public",
+                        "table_name": "orders",
+                    }
+                },
+            )
+
+        data = json.loads(result.content[0].text)
+        assert data["error_type"] == "SerializationError"

--- a/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py
@@ -214,26 +214,23 @@ class TestCreateDataset:
     async def test_create_dataset_unexpected_error(
         self, mock_command_class, mcp_server
     ):
-        """Unexpected exceptions are caught and returned as InternalError."""
+        """Unexpected exceptions are re-raised as ToolError (handled by middleware)."""
         mock_command = MagicMock()
         mock_command.run.side_effect = RuntimeError("DB connection lost")
         mock_command_class.return_value = mock_command
 
         async with Client(mcp_server) as client:
-            result = await client.call_tool(
-                "create_dataset",
-                {
-                    "request": {
-                        "database_id": 1,
-                        "schema": "public",
-                        "table_name": "orders",
-                    }
-                },
-            )
-
-        data = json.loads(result.content[0].text)
-        assert data["error_type"] == "InternalError"
-        assert "DB connection lost" in data["error"]
+            with pytest.raises(ToolError):
+                await client.call_tool(
+                    "create_dataset",
+                    {
+                        "request": {
+                            "database_id": 1,
+                            "schema": "public",
+                            "table_name": "orders",
+                        }
+                    },
+                )
 
     @pytest.mark.asyncio
     async def test_create_dataset_missing_required_fields(self, mcp_server):


### PR DESCRIPTION
## Summary

Adds a `create_dataset` MCP tool that lets callers register an existing physical
database table as a Superset dataset — the programmatic equivalent of
**Data → Datasets → + Dataset** in the UI.

- **`CreateDatasetRequest` schema** — `database_id`, `schema` (alias for `schema_name`
  to avoid the Pydantic v2 `BaseModel.schema()` clash), `table_name`, optional `catalog`
  and `owners`; whitespace-only values for `schema`/`catalog` are normalised to `None`
- **Pre-checks** — verifies the database exists and the caller has table-level access
  before calling the command
- **`create_dataset` tool** — wraps `CreateDatasetCommand`, uses
  `DatasetInvalidError.get_list_classnames()` (public API) to classify wrapped validation
  errors; returns `DatasetInfo` (same shape as `get_dataset_info`) so the `id` feeds
  directly into `generate_chart` or `generate_explore_link`
- **Typed error handling** — distinct `error_type` values for each failure class:
  `DatabaseNotFoundError`, `AccessDeniedError`, `DatasetExistsError`,
  `TableNotFoundError`, `ValidationError`, `CreateFailedError`, `InternalError`
- **11 unit tests** — success, owners forwarding, exists/not-found/validation/internal
  errors, missing required fields, full `DatasetInfo` shape, database not found,
  access denied, no-schema, with-catalog
- **`DEFAULT_INSTRUCTIONS`** updated to list the new tool

## Motivation

The MCP service already exposes `create_virtual_dataset` for SQL-based datasets. This
PR adds the physical-table counterpart so agents can complete the full
"find DB → register table → chart it" workflow without manual UI steps.

## Test plan

- [ ] `pytest tests/unit_tests/mcp_service/dataset/tool/test_create_dataset.py -x`
- [ ] Existing dataset tool tests still pass
- [ ] `pre-commit run --files superset/mcp_service/dataset/tool/create_dataset.py superset/mcp_service/dataset/schemas.py`