### PR TITLE
feat(mcp): add create_annotation_layer and update_annotation_layer tools

### DIFF
--- a/superset/mcp_service/annotation_layer/schemas.py
+++ b/superset/mcp_service/annotation_layer/schemas.py
@@ -45,6 +45,71 @@ DEFAULT_LAYER_COLUMNS = ["id", "name", "descr"]
 DEFAULT_ANNOTATION_COLUMNS = ["id", "short_descr", "start_dttm", "end_dttm", "layer_id"]
 
 
+# ---------------------------------------------------------------------------
+# Mutation schemas (create / update)
+# ---------------------------------------------------------------------------
+
+
+class CreateAnnotationLayerRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=250,
+        description="Unique name for the annotation layer",
+    )
+    descr: str | None = Field(
+        None, description="Optional description of the annotation layer"
+    )
+
+
+class CreateAnnotationLayerResponse(BaseModel):
+    id: int | None = Field(
+        None,
+        description="ID of the created annotation layer, or None if failed",
+    )
+    name: str = Field(..., description="Name of the annotation layer")
+    descr: str | None = Field(None, description="Description of the annotation layer")
+    error: str | None = Field(None, description="Error message if creation failed")
+
+
+class UpdateAnnotationLayerRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: int = Field(..., description="ID of the annotation layer to update")
+    name: str | None = Field(
+        None,
+        min_length=1,
+        max_length=250,
+        description="New name for the annotation layer",
+    )
+    descr: str | None = Field(
+        None, description="New description for the annotation layer"
+    )
+
+    @model_validator(mode="after")
+    def at_least_one_field(self) -> "UpdateAnnotationLayerRequest":
+        if self.name is None and self.descr is None:
+            raise ValueError("At least one of 'name' or 'descr' must be provided")
+        return self
+
+
+class UpdateAnnotationLayerResponse(BaseModel):
+    id: int | None = Field(
+        None,
+        description="ID of the updated annotation layer, or None if failed",
+    )
+    name: str | None = Field(None, description="Name of the annotation layer")
+    descr: str | None = Field(None, description="Description of the annotation layer")
+    error: str | None = Field(None, description="Error message if update failed")
+
+
+# ---------------------------------------------------------------------------
+# Read schemas (list / get)
+# ---------------------------------------------------------------------------
+
+
 class AnnotationLayerFilter(ColumnOperator):
     """Filter object for annotation layer listing."""
 

--- a/superset/mcp_service/annotation_layer/tool/__init__.py
+++ b/superset/mcp_service/annotation_layer/tool/__init__.py
@@ -15,14 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .create_annotation_layer import create_annotation_layer
 from .get_annotation_layer_info import get_annotation_layer_info
 from .get_layer_annotation_info import get_layer_annotation_info
 from .list_annotation_layers import list_annotation_layers
 from .list_layer_annotations import list_layer_annotations
+from .update_annotation_layer import update_annotation_layer
 
 __all__ = [
     "list_annotation_layers",
     "get_annotation_layer_info",
     "list_layer_annotations",
     "get_layer_annotation_info",
+    "create_annotation_layer",
+    "update_annotation_layer",
 ]

--- a/superset/mcp_service/annotation_layer/tool/create_annotation_layer.py
+++ b/superset/mcp_service/annotation_layer/tool/create_annotation_layer.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.annotation_layer.schemas import (
+    CreateAnnotationLayerRequest,
+    CreateAnnotationLayerResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="Annotation",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Create annotation layer",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_annotation_layer(
+    request: CreateAnnotationLayerRequest, ctx: Context
+) -> CreateAnnotationLayerResponse:
+    """Create a named annotation layer in Superset.
+
+    Annotation layers group annotations that can be overlaid on charts.
+    Use this tool to create a new layer before adding annotations to it.
+
+    Workflow:
+    1. Call this tool with a unique name and optional description
+    2. Use the returned ``id`` to add annotations via the Superset API
+    """
+    await ctx.info("Creating annotation layer: name=%r" % (request.name,))
+
+    try:
+        from superset.commands.annotation_layer.create import (
+            CreateAnnotationLayerCommand,
+        )
+        from superset.commands.annotation_layer.exceptions import (
+            AnnotationLayerCreateFailedError,
+            AnnotationLayerInvalidError,
+        )
+
+        properties: dict[str, Any] = {"name": request.name}
+        if request.descr is not None:
+            properties["descr"] = request.descr
+
+        with event_logger.log_context(action="mcp.create_annotation_layer.create"):
+            layer = CreateAnnotationLayerCommand(properties).run()
+
+        await ctx.info(
+            "Annotation layer created: id=%s, name=%r" % (layer.id, layer.name)
+        )
+
+        return CreateAnnotationLayerResponse(
+            id=layer.id,
+            name=layer.name,
+            descr=layer.descr,
+        )
+
+    except AnnotationLayerInvalidError as exc:
+        messages = exc.normalized_messages()
+        await ctx.warning("Annotation layer validation failed: %s" % (messages,))
+        return CreateAnnotationLayerResponse(
+            id=None,
+            name=request.name,
+            descr=request.descr,
+            error=str(messages),
+        )
+    except AnnotationLayerCreateFailedError as exc:
+        await ctx.error("Annotation layer creation failed: %s" % (str(exc),))
+        return CreateAnnotationLayerResponse(
+            id=None,
+            name=request.name,
+            descr=request.descr,
+            error=f"Failed to create annotation layer: {exc}",
+        )
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error creating annotation layer: %s: %s"
+            % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/annotation_layer/tool/update_annotation_layer.py
+++ b/superset/mcp_service/annotation_layer/tool/update_annotation_layer.py
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.annotation_layer.schemas import (
+    UpdateAnnotationLayerRequest,
+    UpdateAnnotationLayerResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="Annotation",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Update annotation layer",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def update_annotation_layer(
+    request: UpdateAnnotationLayerRequest, ctx: Context
+) -> UpdateAnnotationLayerResponse:
+    """Update an existing annotation layer's name or description.
+
+    Use this tool to rename an annotation layer or update its description.
+    At least one of ``name`` or ``descr`` must be provided.
+
+    Workflow:
+    1. Call this tool with the layer ``id`` and the fields to change
+    2. The updated layer ``id`` and new values are returned on success
+    """
+    await ctx.info(
+        "Updating annotation layer: id=%s, name=%r" % (request.id, request.name)
+    )
+
+    try:
+        from superset.commands.annotation_layer.exceptions import (
+            AnnotationLayerInvalidError,
+            AnnotationLayerNotFoundError,
+            AnnotationLayerUpdateFailedError,
+        )
+        from superset.commands.annotation_layer.update import (
+            UpdateAnnotationLayerCommand,
+        )
+
+        properties: dict[str, Any] = {}
+        if request.name is not None:
+            properties["name"] = request.name
+        if request.descr is not None:
+            properties["descr"] = request.descr
+
+        with event_logger.log_context(action="mcp.update_annotation_layer.update"):
+            layer = UpdateAnnotationLayerCommand(request.id, properties).run()
+
+        await ctx.info(
+            "Annotation layer updated: id=%s, name=%r" % (layer.id, layer.name)
+        )
+
+        return UpdateAnnotationLayerResponse(
+            id=layer.id,
+            name=layer.name,
+            descr=layer.descr,
+        )
+
+    except AnnotationLayerNotFoundError:
+        await ctx.warning("Annotation layer not found: id=%s" % (request.id,))
+        return UpdateAnnotationLayerResponse(
+            id=None,
+            name=request.name,
+            descr=request.descr,
+            error=f"Annotation layer {request.id} not found",
+        )
+    except AnnotationLayerInvalidError as exc:
+        messages = exc.normalized_messages()
+        await ctx.warning("Annotation layer validation failed: %s" % (messages,))
+        return UpdateAnnotationLayerResponse(
+            id=None,
+            name=request.name,
+            descr=request.descr,
+            error=str(messages),
+        )
+    except AnnotationLayerUpdateFailedError as exc:
+        await ctx.error("Annotation layer update failed: %s" % (str(exc),))
+        return UpdateAnnotationLayerResponse(
+            id=None,
+            name=request.name,
+            descr=request.descr,
+            error=f"Failed to update annotation layer: {exc}",
+        )
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error updating annotation layer: %s: %s"
+            % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -136,6 +136,8 @@ Annotation Layers:
 - get_annotation_layer_info: Get annotation layer details by ID
 - list_layer_annotations: List annotations within a layer (requires layer_id, 1-based pagination)
 - get_layer_annotation_info: Get annotation details by layer_id and annotation_id
+- create_annotation_layer: Create a new annotation layer (requires write access)
+- update_annotation_layer: Update an annotation layer's name or description (requires write access)
 
 Tag Management:
 - list_tags: List tags with advanced filters (1-based pagination)
@@ -673,10 +675,12 @@ from superset.mcp_service.action_log.tool import (  # noqa: F401, E402
     list_action_logs,
 )
 from superset.mcp_service.annotation_layer.tool import (  # noqa: F401, E402
+    create_annotation_layer,
     get_annotation_layer_info,
     get_layer_annotation_info,
     list_annotation_layers,
     list_layer_annotations,
+    update_annotation_layer,
 )
 from superset.mcp_service.chart import (  # noqa: F401, E402
     prompts as chart_prompts,

--- a/tests/unit_tests/mcp_service/annotation_layer/tool/test_create_annotation_layer.py
+++ b/tests/unit_tests/mcp_service/annotation_layer/tool/test_create_annotation_layer.py
@@ -1,0 +1,172 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.annotation_layer.schemas import (
+    CreateAnnotationLayerRequest,
+)
+from superset.mcp_service.app import mcp
+from superset.utils import json
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mcp_server():
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_user.username = "admin"
+        mock_get_user.return_value = mock_user
+        yield mock_get_user
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_annotation_layer_request_valid() -> None:
+    req = CreateAnnotationLayerRequest(name="My Layer")
+    assert req.name == "My Layer"
+    assert req.descr is None
+
+
+def test_create_annotation_layer_request_with_descr() -> None:
+    req = CreateAnnotationLayerRequest(name="My Layer", descr="A description")
+    assert req.name == "My Layer"
+    assert req.descr == "A description"
+
+
+def test_create_annotation_layer_request_empty_name_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateAnnotationLayerRequest(name="")
+
+
+def test_create_annotation_layer_request_name_too_long() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateAnnotationLayerRequest(name="a" * 251)
+
+
+def test_create_annotation_layer_request_max_name_accepted() -> None:
+    req = CreateAnnotationLayerRequest(name="a" * 250)
+    assert len(req.name) == 250
+
+
+# ---------------------------------------------------------------------------
+# Tool logic tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_layer(id: int = 7, name: str = "Events", descr: str | None = None):
+    layer = MagicMock()
+    layer.id = id
+    layer.name = name
+    layer.descr = descr
+    return layer
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_layer_success(mcp_server: object) -> None:
+    """Happy path: layer created, id and name returned."""
+    mock_layer = _make_mock_layer(id=7, name="Events")
+    mock_command = MagicMock()
+    mock_command.run.return_value = mock_layer
+
+    with patch(
+        "superset.commands.annotation_layer.create.CreateAnnotationLayerCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = CreateAnnotationLayerRequest(name="Events")
+            result = await client.call_tool(
+                "create_annotation_layer", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 7
+    assert data["name"] == "Events"
+    assert data["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_layer_invalid_error(mcp_server: object) -> None:
+    """AnnotationLayerInvalidError is caught and returned as an error response."""
+    from superset.commands.annotation_layer.exceptions import (
+        AnnotationLayerInvalidError,
+        AnnotationLayerNameUniquenessValidationError,
+    )
+
+    invalid_exc = AnnotationLayerInvalidError()
+    invalid_exc.append(AnnotationLayerNameUniquenessValidationError())
+    mock_command = MagicMock()
+    mock_command.run.side_effect = invalid_exc
+
+    with patch(
+        "superset.commands.annotation_layer.create.CreateAnnotationLayerCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = CreateAnnotationLayerRequest(name="Duplicate")
+            result = await client.call_tool(
+                "create_annotation_layer", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_layer_create_failed(mcp_server: object) -> None:
+    """AnnotationLayerCreateFailedError is caught and returned as an error response."""
+    from superset.commands.annotation_layer.exceptions import (
+        AnnotationLayerCreateFailedError,
+    )
+
+    mock_command = MagicMock()
+    mock_command.run.side_effect = AnnotationLayerCreateFailedError()
+
+    with patch(
+        "superset.commands.annotation_layer.create.CreateAnnotationLayerCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = CreateAnnotationLayerRequest(name="My Layer")
+            result = await client.call_tool(
+                "create_annotation_layer", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "Failed to create annotation layer" in data["error"]

--- a/tests/unit_tests/mcp_service/annotation_layer/tool/test_update_annotation_layer.py
+++ b/tests/unit_tests/mcp_service/annotation_layer/tool/test_update_annotation_layer.py
@@ -1,0 +1,208 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.annotation_layer.schemas import (
+    UpdateAnnotationLayerRequest,
+)
+from superset.mcp_service.app import mcp
+from superset.utils import json
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mcp_server():
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_user.username = "admin"
+        mock_get_user.return_value = mock_user
+        yield mock_get_user
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_annotation_layer_request_valid() -> None:
+    req = UpdateAnnotationLayerRequest(id=1, name="New Name")
+    assert req.id == 1
+    assert req.name == "New Name"
+    assert req.descr is None
+
+
+def test_update_annotation_layer_request_descr_only() -> None:
+    req = UpdateAnnotationLayerRequest(id=5, descr="Updated description")
+    assert req.id == 5
+    assert req.name is None
+    assert req.descr == "Updated description"
+
+
+def test_update_annotation_layer_request_name_too_long() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        UpdateAnnotationLayerRequest(id=1, name="a" * 251)
+
+
+def test_update_annotation_layer_request_empty_name_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        UpdateAnnotationLayerRequest(id=1, name="")
+
+
+def test_update_annotation_layer_request_max_name_accepted() -> None:
+    req = UpdateAnnotationLayerRequest(id=1, name="a" * 250)
+    assert req.name is not None
+    assert len(req.name) == 250
+
+
+def test_update_annotation_layer_request_no_fields_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        UpdateAnnotationLayerRequest(id=1)
+
+
+# ---------------------------------------------------------------------------
+# Tool logic tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_layer(id: int = 7, name: str = "Events", descr: str | None = None):
+    layer = MagicMock()
+    layer.id = id
+    layer.name = name
+    layer.descr = descr
+    return layer
+
+
+@pytest.mark.asyncio
+async def test_update_annotation_layer_success(mcp_server: object) -> None:
+    """Happy path: layer updated, id and name returned."""
+    mock_layer = _make_mock_layer(id=7, name="Renamed Layer")
+    mock_command = MagicMock()
+    mock_command.run.return_value = mock_layer
+
+    with patch(
+        "superset.commands.annotation_layer.update.UpdateAnnotationLayerCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateAnnotationLayerRequest(id=7, name="Renamed Layer")
+            result = await client.call_tool(
+                "update_annotation_layer", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 7
+    assert data["name"] == "Renamed Layer"
+    assert data["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_annotation_layer_not_found(mcp_server: object) -> None:
+    """AnnotationLayerNotFoundError is caught and returned as an error response."""
+    from superset.commands.annotation_layer.exceptions import (
+        AnnotationLayerNotFoundError,
+    )
+
+    mock_command = MagicMock()
+    mock_command.run.side_effect = AnnotationLayerNotFoundError()
+
+    with patch(
+        "superset.commands.annotation_layer.update.UpdateAnnotationLayerCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateAnnotationLayerRequest(id=999, name="Ghost")
+            result = await client.call_tool(
+                "update_annotation_layer", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "999" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_annotation_layer_invalid_error(mcp_server: object) -> None:
+    """AnnotationLayerInvalidError is caught and returned as an error response."""
+    from superset.commands.annotation_layer.exceptions import (
+        AnnotationLayerInvalidError,
+        AnnotationLayerNameUniquenessValidationError,
+    )
+
+    invalid_exc = AnnotationLayerInvalidError()
+    invalid_exc.append(AnnotationLayerNameUniquenessValidationError())
+    mock_command = MagicMock()
+    mock_command.run.side_effect = invalid_exc
+
+    with patch(
+        "superset.commands.annotation_layer.update.UpdateAnnotationLayerCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateAnnotationLayerRequest(id=7, name="Duplicate")
+            result = await client.call_tool(
+                "update_annotation_layer", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+@pytest.mark.asyncio
+async def test_update_annotation_layer_update_failed(mcp_server: object) -> None:
+    """AnnotationLayerUpdateFailedError is caught and returned as an error response."""
+    from superset.commands.annotation_layer.exceptions import (
+        AnnotationLayerUpdateFailedError,
+    )
+
+    mock_command = MagicMock()
+    mock_command.run.side_effect = AnnotationLayerUpdateFailedError()
+
+    with patch(
+        "superset.commands.annotation_layer.update.UpdateAnnotationLayerCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateAnnotationLayerRequest(id=7, name="My Layer")
+            result = await client.call_tool(
+                "update_annotation_layer", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "Failed to update annotation layer" in data["error"]

--- a/tests/unit_tests/mcp_service/annotation_layer/tool/test_update_annotation_layer.py
+++ b/tests/unit_tests/mcp_service/annotation_layer/tool/test_update_annotation_layer.py
@@ -125,6 +125,7 @@ async def test_update_annotation_layer_success(mcp_server: object) -> None:
 
     assert data["id"] == 7
     assert data["name"] == "Renamed Layer"
+    assert data["descr"] is None
     assert data["error"] is None
 
 


### PR DESCRIPTION
### SUMMARY

Adds two new MCP mutation tools for annotation layers:

- **`create_annotation_layer`**: creates a new named annotation layer (`name` required, `descr` optional). Calls `CreateAnnotationLayerCommand`, validates uniqueness, returns `id`/`name`/`descr`.
- **`update_annotation_layer`**: updates an existing annotation layer by `id` (`name` and/or `descr` optional). Calls `UpdateAnnotationLayerCommand`, handles not-found, uniqueness, and update-failed errors.

Both tools follow the existing mutation pattern (`create_virtual_dataset`) with `tags=["mutate"]`, `class_permission_name="Annotation"`, `method_permission_name="write"`, Pydantic schemas, `event_logger` instrumentation, and unit tests.

**New files:**
- `superset/mcp_service/annotation_layer/__init__.py`
- `superset/mcp_service/annotation_layer/schemas.py` — request/response schemas for both tools
- `superset/mcp_service/annotation_layer/tool/__init__.py`
- `superset/mcp_service/annotation_layer/tool/create_annotation_layer.py`
- `superset/mcp_service/annotation_layer/tool/update_annotation_layer.py`
- `tests/unit_tests/mcp_service/annotation_layer/tool/test_create_annotation_layer.py`
- `tests/unit_tests/mcp_service/annotation_layer/tool/test_update_annotation_layer.py`

**Modified:**
- `superset/mcp_service/app.py` — registers both new tools

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

1. Start a Superset instance with MCP enabled
2. Connect an MCP client and call `create_annotation_layer` with `{"request": {"name": "My Layer"}}`
3. Verify a new annotation layer appears in Superset → Manage → Annotation Layers
4. Call `update_annotation_layer` with `{"request": {"id": <returned_id>, "name": "Renamed Layer"}}`
5. Verify the annotation layer name changed
6. Call `create_annotation_layer` again with the same name — verify a validation error is returned (name uniqueness)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API