### PR TITLE
feat(mcp): add create_user and update_user tools

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -749,6 +749,7 @@ from superset.mcp_service.theme.tool import (  # noqa: F401, E402
     list_themes,
 )
 from superset.mcp_service.user.tool import (  # noqa: F401, E402
+    create_user,
     get_user_info,
     list_users,
 )

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -749,11 +749,11 @@ from superset.mcp_service.theme.tool import (  # noqa: F401, E402
     list_themes,
 )
 from superset.mcp_service.user.tool import (  # noqa: F401, E402
-    create_user,
     get_user_info,
     list_users,
-    update_user,
 )
+from superset.mcp_service.user.tool.create_user import create_user  # noqa: F401, E402
+from superset.mcp_service.user.tool.update_user import update_user  # noqa: F401, E402
 
 
 def _remove_disabled_tools(disabled_tools: set[str]) -> None:

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -752,6 +752,7 @@ from superset.mcp_service.user.tool import (  # noqa: F401, E402
     create_user,
     get_user_info,
     list_users,
+    update_user,
 )
 
 

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -185,18 +185,17 @@ _SENSITIVE_PARAM_KEYS = frozenset(
 
 
 def _sanitize_params(params: dict[str, Any]) -> dict[str, Any]:
-    """Remove sensitive fields from params before logging."""
+    """Remove sensitive fields from params before logging; recurses into dicts."""
     if not isinstance(params, dict):
         return params
-    result: dict[str, Any] = {}
-    for k, v in params.items():
-        if k.lower() in _SENSITIVE_PARAM_KEYS:
-            result[k] = "[REDACTED]"
-        elif k == "arguments" and isinstance(v, dict):
-            result[k] = _sanitize_params(v)
-        else:
-            result[k] = v
-    return result
+    return {
+        k: "[REDACTED]"
+        if k.lower() in _SENSITIVE_PARAM_KEYS
+        else _sanitize_params(v)
+        if isinstance(v, dict)
+        else v
+        for k, v in params.items()
+    }
 
 
 class LoggingMiddleware(Middleware):

--- a/superset/mcp_service/user/schemas.py
+++ b/superset/mcp_service/user/schemas.py
@@ -341,7 +341,8 @@ class CreateUserRequest(BaseModel):
         description=(
             "List of role IDs to assign to the user. "
             "At least one role is required. "
-            "Use get_instance_info to discover available roles and their IDs."
+            "Role IDs are available from the Superset REST API: "
+            "GET /api/v1/security/roles/"
         ),
     )
 

--- a/superset/mcp_service/user/schemas.py
+++ b/superset/mcp_service/user/schemas.py
@@ -382,3 +382,72 @@ class CreateUserResponse(BaseModel):
         None,
         description="Error message if creation failed, otherwise null.",
     )
+
+
+class UpdateUserRequest(BaseModel):
+    """Request schema for update_user."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: int = Field(
+        ...,
+        description="ID of the user to update.",
+    )
+    first_name: str | None = Field(
+        None,
+        min_length=1,
+        max_length=64,
+        description="New first name. Omit to leave unchanged.",
+    )
+    last_name: str | None = Field(
+        None,
+        min_length=1,
+        max_length=64,
+        description="New last name. Omit to leave unchanged.",
+    )
+    email: EmailStr | None = Field(
+        None,
+        description="New email address. Omit to leave unchanged.",
+    )
+    password: str | None = Field(
+        None,
+        min_length=1,
+        description=(
+            "New plain-text password; will be hashed before storage. "
+            "Omit to leave unchanged."
+        ),
+    )
+    role_ids: list[int] | None = Field(
+        None,
+        min_length=1,
+        description=(
+            "New list of role IDs to assign to the user. "
+            "Replaces all existing roles. At least one role is required if provided. "
+            "Omit to leave roles unchanged. "
+            "Role IDs are available from the Superset REST API: "
+            "GET /api/v1/security/roles/"
+        ),
+    )
+    active: bool | None = Field(
+        None,
+        description=(
+            "Set to true to activate or false to deactivate the account. "
+            "Omit to leave unchanged."
+        ),
+    )
+
+
+class UpdateUserResponse(BaseModel):
+    """Response schema for update_user — exposes only non-sensitive fields."""
+
+    id: int | None = Field(
+        None,
+        description="ID of the updated user. None if update failed.",
+    )
+    username: str | None = Field(None, description="Username of the updated user.")
+    first_name: str | None = Field(None, description="First name of the updated user.")
+    last_name: str | None = Field(None, description="Last name of the updated user.")
+    error: str | None = Field(
+        None,
+        description="Error message if update failed, otherwise null.",
+    )

--- a/superset/mcp_service/user/schemas.py
+++ b/superset/mcp_service/user/schemas.py
@@ -25,6 +25,7 @@ from typing import Annotated, Any, List, Literal
 from pydantic import (
     BaseModel,
     ConfigDict,
+    EmailStr,
     Field,
     field_validator,
     model_serializer,
@@ -299,4 +300,84 @@ def serialize_user_object(
         if roles is not None
         else None,
         changed_on=getattr(user, "changed_on", None),
+    )
+
+
+class CreateUserRequest(BaseModel):
+    """Request schema for create_user."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    username: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Unique username for the new account.",
+    )
+    first_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="First name of the user.",
+    )
+    last_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Last name of the user.",
+    )
+    email: EmailStr = Field(
+        ...,
+        description="Email address for the user account.",
+    )
+    password: str = Field(
+        ...,
+        min_length=1,
+        description="Plain-text password; will be hashed before storage.",
+    )
+    role_ids: list[int] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "List of role IDs to assign to the user. "
+            "At least one role is required. "
+            "Use get_instance_info to discover available roles and their IDs."
+        ),
+    )
+
+    @field_validator("username")
+    @classmethod
+    def username_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("username must not be empty or whitespace")
+        return v.strip()
+
+    @field_validator("first_name")
+    @classmethod
+    def first_name_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("first_name must not be empty or whitespace")
+        return v.strip()
+
+    @field_validator("last_name")
+    @classmethod
+    def last_name_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("last_name must not be empty or whitespace")
+        return v.strip()
+
+
+class CreateUserResponse(BaseModel):
+    """Response schema for create_user — exposes only non-sensitive fields."""
+
+    id: int | None = Field(
+        None,
+        description="ID of the created user. None if creation failed.",
+    )
+    username: str | None = Field(None, description="Username of the created user.")
+    first_name: str | None = Field(None, description="First name of the created user.")
+    last_name: str | None = Field(None, description="Last name of the created user.")
+    error: str | None = Field(
+        None,
+        description="Error message if creation failed, otherwise null.",
     )

--- a/superset/mcp_service/user/tool/__init__.py
+++ b/superset/mcp_service/user/tool/__init__.py
@@ -18,9 +18,11 @@
 from .create_user import create_user
 from .get_user_info import get_user_info
 from .list_users import list_users
+from .update_user import update_user
 
 __all__ = [
     "create_user",
+    "update_user",
     "list_users",
     "get_user_info",
 ]

--- a/superset/mcp_service/user/tool/__init__.py
+++ b/superset/mcp_service/user/tool/__init__.py
@@ -15,14 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .create_user import create_user
 from .get_user_info import get_user_info
 from .list_users import list_users
-from .update_user import update_user
 
 __all__ = [
-    "create_user",
-    "update_user",
     "list_users",
     "get_user_info",
 ]

--- a/superset/mcp_service/user/tool/__init__.py
+++ b/superset/mcp_service/user/tool/__init__.py
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .create_user import create_user
 from .get_user_info import get_user_info
 from .list_users import list_users
 
 __all__ = [
+    "create_user",
     "list_users",
     "get_user_info",
 ]

--- a/superset/mcp_service/user/tool/create_user.py
+++ b/superset/mcp_service/user/tool/create_user.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
-
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
@@ -26,8 +24,6 @@ from superset.extensions import (
     security_manager,  # avoids superset.__init__ → create_app bootstrap
 )
 from superset.mcp_service.user.schemas import CreateUserRequest, CreateUserResponse
-
-logger = logging.getLogger(__name__)
 
 
 @tool(
@@ -55,8 +51,7 @@ async def create_user(request: CreateUserRequest, ctx: Context) -> CreateUserRes
     the user next authenticates through that provider.
     """
     await ctx.info(
-        "Creating user: username=%r, email=%r, role_ids=%s"
-        % (request.username, request.email, request.role_ids)
+        "Creating user: username=%r, role_ids=%s" % (request.username, request.role_ids)
     )
 
     try:

--- a/superset/mcp_service/user/tool/create_user.py
+++ b/superset/mcp_service/user/tool/create_user.py
@@ -20,7 +20,11 @@ import logging
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.extensions import event_logger
+from superset.extensions import (
+    db,
+    event_logger,
+    security_manager,  # avoids superset.__init__ → create_app bootstrap
+)
 from superset.mcp_service.user.schemas import CreateUserRequest, CreateUserResponse
 
 logger = logging.getLogger(__name__)
@@ -43,10 +47,12 @@ async def create_user(request: CreateUserRequest, ctx: Context) -> CreateUserRes
     password, and one or more roles. After creation, the user can log in
     with the supplied credentials.
 
-    Workflow:
-    1. Call get_instance_info to discover available role names and IDs
-    2. Call this tool with the desired credentials and role IDs
-    3. The returned ``id`` uniquely identifies the new user
+    To discover available role IDs, query the Superset REST API:
+    ``GET /api/v1/security/roles/``
+
+    Note: in deployments where user identity is managed by an external
+    provider (e.g. SSO / SCIM), role assignments may be overridden when
+    the user next authenticates through that provider.
     """
     await ctx.info(
         "Creating user: username=%r, email=%r, role_ids=%s"
@@ -54,12 +60,8 @@ async def create_user(request: CreateUserRequest, ctx: Context) -> CreateUserRes
     )
 
     try:
-        from superset import security_manager
-
         # Resolve role objects from the supplied IDs
         with event_logger.log_context(action="mcp.create_user.resolve_roles"):
-            from superset.extensions import db
-
             roles = []
             missing_ids = []
             for role_id in request.role_ids:
@@ -73,7 +75,8 @@ async def create_user(request: CreateUserRequest, ctx: Context) -> CreateUserRes
                 await ctx.warning("Role IDs not found: %s" % (missing_ids,))
                 return CreateUserResponse(
                     error="Role IDs not found: %s. "
-                    "Use get_instance_info to discover valid role IDs." % (missing_ids,)
+                    "Valid role IDs are available from GET /api/v1/security/roles/"
+                    % (missing_ids,)
                 )
 
         # Create the user via FAB security manager

--- a/superset/mcp_service/user/tool/create_user.py
+++ b/superset/mcp_service/user/tool/create_user.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.user.schemas import CreateUserRequest, CreateUserResponse
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="User",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Create a new user account",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_user(request: CreateUserRequest, ctx: Context) -> CreateUserResponse:
+    """Create a new Superset user account. Admin access is required.
+
+    Use this tool to provision a new user with a username, name, email,
+    password, and one or more roles. After creation, the user can log in
+    with the supplied credentials.
+
+    Workflow:
+    1. Call get_instance_info to discover available role names and IDs
+    2. Call this tool with the desired credentials and role IDs
+    3. The returned ``id`` uniquely identifies the new user
+    """
+    await ctx.info(
+        "Creating user: username=%r, email=%r, role_ids=%s"
+        % (request.username, request.email, request.role_ids)
+    )
+
+    try:
+        from superset import security_manager
+
+        # Resolve role objects from the supplied IDs
+        with event_logger.log_context(action="mcp.create_user.resolve_roles"):
+            from superset.extensions import db
+
+            roles = []
+            missing_ids = []
+            for role_id in request.role_ids:
+                role = db.session.get(security_manager.role_model, role_id)
+                if role is None:
+                    missing_ids.append(role_id)
+                else:
+                    roles.append(role)
+
+            if missing_ids:
+                await ctx.warning("Role IDs not found: %s" % (missing_ids,))
+                return CreateUserResponse(
+                    error="Role IDs not found: %s. "
+                    "Use get_instance_info to discover valid role IDs." % (missing_ids,)
+                )
+
+        # Create the user via FAB security manager
+        with event_logger.log_context(action="mcp.create_user.create"):
+            user = security_manager.add_user(
+                username=request.username,
+                first_name=request.first_name,
+                last_name=request.last_name,
+                email=request.email,
+                role=roles,
+                password=request.password,
+            )
+
+        if not user:
+            await ctx.error(
+                "User creation failed for username=%r — "
+                "security_manager.add_user returned False" % (request.username,)
+            )
+            return CreateUserResponse(
+                error="Failed to create user. "
+                "The username or email may already be in use."
+            )
+
+        await ctx.info("User created: id=%s, username=%r" % (user.id, user.username))
+
+        # Return only non-sensitive fields (no email, password, roles)
+        return CreateUserResponse(
+            id=user.id,
+            username=user.username,
+            first_name=user.first_name,
+            last_name=user.last_name,
+        )
+
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error creating user: %s: %s" % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/user/tool/update_user.py
+++ b/superset/mcp_service/user/tool/update_user.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
-
 from fastmcp import Context
 from flask import current_app
 from flask_appbuilder.security.sqla.models import User
@@ -31,8 +29,6 @@ from superset.extensions import (
     security_manager,  # avoids superset.__init__ → create_app bootstrap
 )
 from superset.mcp_service.user.schemas import UpdateUserRequest, UpdateUserResponse
-
-logger = logging.getLogger(__name__)
 
 
 def _apply_field_updates(user: User, request: UpdateUserRequest) -> None:

--- a/superset/mcp_service/user/tool/update_user.py
+++ b/superset/mcp_service/user/tool/update_user.py
@@ -1,0 +1,143 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from fastmcp import Context
+from flask import current_app
+from flask_appbuilder.security.sqla.models import User
+from sqlalchemy.exc import NoResultFound
+from superset_core.mcp.decorators import tool, ToolAnnotations
+from werkzeug.security import generate_password_hash
+
+from superset.daos.user import UserDAO
+from superset.extensions import (
+    db,
+    event_logger,
+    security_manager,  # avoids superset.__init__ → create_app bootstrap
+)
+from superset.mcp_service.user.schemas import UpdateUserRequest, UpdateUserResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_field_updates(user: User, request: UpdateUserRequest) -> None:
+    """Apply optional scalar field updates to the user model object."""
+    if request.first_name is not None:
+        user.first_name = request.first_name
+    if request.last_name is not None:
+        user.last_name = request.last_name
+    if request.email is not None:
+        user.email = request.email
+    if request.active is not None:
+        user.active = request.active
+    if request.password is not None:
+        user.password = generate_password_hash(
+            password=request.password,
+            method=current_app.config.get("FAB_PASSWORD_HASH_METHOD", "scrypt"),
+            salt_length=current_app.config.get("FAB_PASSWORD_HASH_SALT_LENGTH", 16),
+        )
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="User",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Update an existing user account",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def update_user(request: UpdateUserRequest, ctx: Context) -> UpdateUserResponse:
+    """Update an existing Superset user account. Admin access is required.
+
+    Use this tool to modify a user's name, email, password, role assignments,
+    or active status. Only the fields you supply are changed; omitted fields
+    remain as-is.
+
+    To discover available role IDs, query the Superset REST API:
+    ``GET /api/v1/security/roles/``
+
+    Note: in deployments where user identity is managed by an external
+    provider (e.g. SSO / SCIM), role assignments may be overridden when
+    the user next authenticates through that provider.
+    """
+    await ctx.info("Updating user: id=%d" % request.id)
+
+    try:
+        # Fetch the existing user record
+        with event_logger.log_context(action="mcp.update_user.fetch"):
+            try:
+                user = UserDAO.get_by_id(request.id)
+            except NoResultFound:
+                await ctx.warning("User not found: id=%d" % request.id)
+                return UpdateUserResponse(
+                    error="User with id=%d not found." % request.id
+                )
+
+        # Resolve new roles if role_ids was supplied
+        if request.role_ids is not None:
+            with event_logger.log_context(action="mcp.update_user.resolve_roles"):
+                roles = []
+                missing_ids = []
+                for role_id in request.role_ids:
+                    role = db.session.get(security_manager.role_model, role_id)
+                    if role is None:
+                        missing_ids.append(role_id)
+                    else:
+                        roles.append(role)
+
+                if missing_ids:
+                    await ctx.warning("Role IDs not found: %s" % (missing_ids,))
+                    return UpdateUserResponse(
+                        error="Role IDs not found: %s. "
+                        "Valid role IDs are available from GET /api/v1/security/roles/"
+                        % (missing_ids,)
+                    )
+            user.roles = roles
+
+        _apply_field_updates(user, request)
+
+        # Commit via FAB security manager to fire pre/post-commit signals
+        with event_logger.log_context(action="mcp.update_user.update"):
+            result = security_manager.update_user(user)
+
+        if result is False:
+            await ctx.error(
+                "User update failed for id=%d — "
+                "security_manager.update_user returned False" % request.id
+            )
+            return UpdateUserResponse(
+                error="Failed to update user. "
+                "The email may already be in use by another account."
+            )
+
+        await ctx.info("User updated: id=%s, username=%r" % (user.id, user.username))
+
+        return UpdateUserResponse(
+            id=user.id,
+            username=user.username,
+            first_name=user.first_name,
+            last_name=user.last_name,
+        )
+
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error updating user: %s: %s" % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/tests/unit_tests/mcp_service/user/tool/test_user_tools.py
+++ b/tests/unit_tests/mcp_service/user/tool/test_user_tools.py
@@ -18,7 +18,7 @@
 """Unit tests for user MCP tools."""
 
 import importlib
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastmcp import Client
@@ -499,7 +499,7 @@ async def test_create_user_success(mcp_server: object) -> None:
     ):
         mock_db.session.get.return_value = mock_role
         mock_sm.role_model = MagicMock()
-        mock_sm.add_user.return_value = mock_user
+        mock_sm.add_user = MagicMock(return_value=mock_user)
 
         async with Client(mcp_server) as client:
             request = CreateUserRequest(
@@ -534,7 +534,7 @@ async def test_create_user_response_omits_sensitive_fields(mcp_server: object) -
     ):
         mock_db.session.get.return_value = mock_role
         mock_sm.role_model = MagicMock()
-        mock_sm.add_user.return_value = mock_user
+        mock_sm.add_user = MagicMock(return_value=mock_user)
 
         async with Client(mcp_server) as client:
             request = CreateUserRequest(
@@ -595,7 +595,7 @@ async def test_create_user_add_user_failure(mcp_server: object) -> None:
     ):
         mock_db.session.get.return_value = mock_role
         mock_sm.role_model = MagicMock()
-        mock_sm.add_user.return_value = False
+        mock_sm.add_user = MagicMock(return_value=False)
 
         async with Client(mcp_server) as client:
             request = CreateUserRequest(
@@ -630,7 +630,7 @@ async def test_update_user_success(mcp_server: object) -> None:
         patch("superset.mcp_service.user.tool.update_user.security_manager") as mock_sm,
     ):
         mock_dao.get_by_id.return_value = mock_user
-        mock_sm.update_user.return_value = mock_user
+        mock_sm.update_user = MagicMock(return_value=mock_user)
 
         async with Client(mcp_server) as client:
             request = UpdateUserRequest(id=42, first_name="Jane")
@@ -655,7 +655,7 @@ async def test_update_user_response_omits_sensitive_fields(mcp_server: object) -
         patch("superset.mcp_service.user.tool.update_user.security_manager") as mock_sm,
     ):
         mock_dao.get_by_id.return_value = mock_user
-        mock_sm.update_user.return_value = mock_user
+        mock_sm.update_user = MagicMock(return_value=mock_user)
 
         async with Client(mcp_server) as client:
             request = UpdateUserRequest(id=42, last_name="Smith")
@@ -725,7 +725,7 @@ async def test_update_user_update_failure(mcp_server: object) -> None:
         patch("superset.mcp_service.user.tool.update_user.security_manager") as mock_sm,
     ):
         mock_dao.get_by_id.return_value = mock_user
-        mock_sm.update_user.return_value = False
+        mock_sm.update_user = MagicMock(return_value=False)
 
         async with Client(mcp_server) as client:
             request = UpdateUserRequest(id=42, email="taken@example.com")

--- a/tests/unit_tests/mcp_service/user/tool/test_user_tools.py
+++ b/tests/unit_tests/mcp_service/user/tool/test_user_tools.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Unit tests for list_users and get_user_info MCP tools."""
+"""Unit tests for user MCP tools."""
 
 import importlib
 from unittest.mock import MagicMock, Mock, patch
@@ -26,7 +26,12 @@ from fastmcp.exceptions import ToolError
 from pydantic import ValidationError
 
 from superset.mcp_service.app import mcp
-from superset.mcp_service.user.schemas import ListUsersRequest, UserFilter
+from superset.mcp_service.user.schemas import (
+    CreateUserRequest,
+    ListUsersRequest,
+    UpdateUserRequest,
+    UserFilter,
+)
 from superset.utils import json
 
 list_users_module = importlib.import_module("superset.mcp_service.user.tool.list_users")
@@ -74,7 +79,7 @@ def mcp_server():
 def mock_auth():
     """Mock authentication for all tests."""
     with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
-        mock_user = Mock()
+        mock_user = MagicMock()
         mock_user.id = 1
         mock_user.username = "admin"
         mock_get_user.return_value = mock_user
@@ -447,3 +452,287 @@ async def test_get_user_info_user_controlled_fields_are_wrapped_in_untrusted_con
     assert "<UNTRUSTED-CONTENT>" in data["last_name"]
     assert injected_first in data["first_name"]
     assert injected_last in data["last_name"]
+
+
+# ---------------------------------------------------------------------------
+# create_user / update_user helper factories
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_user(
+    user_id: int = 42,
+    username: str = "jdoe",
+    first_name: str = "John",
+    last_name: str = "Doe",
+    email: str = "jdoe@example.com",
+) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    user.username = username
+    user.first_name = first_name
+    user.last_name = last_name
+    user.email = email
+    return user
+
+
+def _make_mock_role(role_id: int = 1, name: str = "Alpha") -> MagicMock:
+    role = MagicMock()
+    role.id = role_id
+    role.name = name
+    return role
+
+
+# ---------------------------------------------------------------------------
+# create_user
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_user_success(mcp_server: object) -> None:
+    """Happy path: user created, non-sensitive fields returned."""
+    mock_user = _make_mock_user()
+    mock_role = _make_mock_role()
+
+    with (
+        patch("superset.mcp_service.user.tool.create_user.db") as mock_db,
+        patch("superset.mcp_service.user.tool.create_user.security_manager") as mock_sm,
+    ):
+        mock_db.session.get.return_value = mock_role
+        mock_sm.role_model = MagicMock()
+        mock_sm.add_user.return_value = mock_user
+
+        async with Client(mcp_server) as client:
+            request = CreateUserRequest(
+                username="jdoe",
+                first_name="John",
+                last_name="Doe",
+                email="jdoe@example.com",
+                password="secret123",  # noqa: S106
+                role_ids=[1],
+            )
+            result = await client.call_tool(
+                "create_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 42
+    assert data["username"] == "jdoe"
+    assert data["first_name"] == "John"
+    assert data["last_name"] == "Doe"
+    assert data["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_user_response_omits_sensitive_fields(mcp_server: object) -> None:
+    """Response must not contain email, password, or role data."""
+    mock_user = _make_mock_user()
+    mock_role = _make_mock_role()
+
+    with (
+        patch("superset.mcp_service.user.tool.create_user.db") as mock_db,
+        patch("superset.mcp_service.user.tool.create_user.security_manager") as mock_sm,
+    ):
+        mock_db.session.get.return_value = mock_role
+        mock_sm.role_model = MagicMock()
+        mock_sm.add_user.return_value = mock_user
+
+        async with Client(mcp_server) as client:
+            request = CreateUserRequest(
+                username="jdoe",
+                first_name="John",
+                last_name="Doe",
+                email="jdoe@example.com",
+                password="secret123",  # noqa: S106
+                role_ids=[1],
+            )
+            result = await client.call_tool(
+                "create_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert "email" not in data
+    assert "password" not in data
+    assert "roles" not in data
+
+
+@pytest.mark.asyncio
+async def test_create_user_missing_role(mcp_server: object) -> None:
+    """When a role ID does not exist, an error response is returned."""
+    with (
+        patch("superset.mcp_service.user.tool.create_user.db") as mock_db,
+        patch("superset.mcp_service.user.tool.create_user.security_manager") as mock_sm,
+    ):
+        mock_db.session.get.return_value = None  # role not found
+        mock_sm.role_model = MagicMock()
+
+        async with Client(mcp_server) as client:
+            request = CreateUserRequest(
+                username="jdoe",
+                first_name="John",
+                last_name="Doe",
+                email="jdoe@example.com",
+                password="secret123",  # noqa: S106
+                role_ids=[999],
+            )
+            result = await client.call_tool(
+                "create_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "999" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_user_add_user_failure(mcp_server: object) -> None:
+    """When security_manager.add_user returns falsy, an error response is returned."""
+    mock_role = _make_mock_role()
+
+    with (
+        patch("superset.mcp_service.user.tool.create_user.db") as mock_db,
+        patch("superset.mcp_service.user.tool.create_user.security_manager") as mock_sm,
+    ):
+        mock_db.session.get.return_value = mock_role
+        mock_sm.role_model = MagicMock()
+        mock_sm.add_user.return_value = False
+
+        async with Client(mcp_server) as client:
+            request = CreateUserRequest(
+                username="duplicate",
+                first_name="John",
+                last_name="Doe",
+                email="dup@example.com",
+                password="secret123",  # noqa: S106
+                role_ids=[1],
+            )
+            result = await client.call_tool(
+                "create_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# update_user
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_user_success(mcp_server: object) -> None:
+    """Happy path: user updated, non-sensitive fields returned."""
+    mock_user = _make_mock_user(first_name="Jane")
+
+    with (
+        patch("superset.mcp_service.user.tool.update_user.UserDAO") as mock_dao,
+        patch("superset.mcp_service.user.tool.update_user.security_manager") as mock_sm,
+    ):
+        mock_dao.get_by_id.return_value = mock_user
+        mock_sm.update_user.return_value = mock_user
+
+        async with Client(mcp_server) as client:
+            request = UpdateUserRequest(id=42, first_name="Jane")
+            result = await client.call_tool(
+                "update_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 42
+    assert data["username"] == "jdoe"
+    assert data["first_name"] == "Jane"
+    assert data["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_user_response_omits_sensitive_fields(mcp_server: object) -> None:
+    """Response must not contain email, password, or role data."""
+    mock_user = _make_mock_user()
+
+    with (
+        patch("superset.mcp_service.user.tool.update_user.UserDAO") as mock_dao,
+        patch("superset.mcp_service.user.tool.update_user.security_manager") as mock_sm,
+    ):
+        mock_dao.get_by_id.return_value = mock_user
+        mock_sm.update_user.return_value = mock_user
+
+        async with Client(mcp_server) as client:
+            request = UpdateUserRequest(id=42, last_name="Smith")
+            result = await client.call_tool(
+                "update_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert "email" not in data
+    assert "password" not in data
+    assert "roles" not in data
+
+
+@pytest.mark.asyncio
+async def test_update_user_not_found(mcp_server: object) -> None:
+    """When user ID does not exist, an error response is returned."""
+    from sqlalchemy.exc import NoResultFound
+
+    with patch("superset.mcp_service.user.tool.update_user.UserDAO") as mock_dao:
+        mock_dao.get_by_id.side_effect = NoResultFound()
+
+        async with Client(mcp_server) as client:
+            request = UpdateUserRequest(id=9999)
+            result = await client.call_tool(
+                "update_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "9999" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_user_missing_role(mcp_server: object) -> None:
+    """When a supplied role ID does not exist, an error response is returned."""
+    mock_user = _make_mock_user()
+
+    with (
+        patch("superset.mcp_service.user.tool.update_user.UserDAO") as mock_dao,
+        patch("superset.mcp_service.user.tool.update_user.db") as mock_db,
+        patch("superset.mcp_service.user.tool.update_user.security_manager") as mock_sm,
+    ):
+        mock_dao.get_by_id.return_value = mock_user
+        mock_db.session.get.return_value = None  # role not found
+        mock_sm.role_model = MagicMock()
+
+        async with Client(mcp_server) as client:
+            request = UpdateUserRequest(id=42, role_ids=[999])
+            result = await client.call_tool(
+                "update_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "999" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_user_update_failure(mcp_server: object) -> None:
+    """When security_manager.update_user returns False, an error is returned."""
+    mock_user = _make_mock_user()
+
+    with (
+        patch("superset.mcp_service.user.tool.update_user.UserDAO") as mock_dao,
+        patch("superset.mcp_service.user.tool.update_user.security_manager") as mock_sm,
+    ):
+        mock_dao.get_by_id.return_value = mock_user
+        mock_sm.update_user.return_value = False
+
+        async with Client(mcp_server) as client:
+            request = UpdateUserRequest(id=42, email="taken@example.com")
+            result = await client.call_tool(
+                "update_user", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None


### PR DESCRIPTION
## Summary

Adds two admin-only MCP tools for user provisioning and management:

- **`create_user`** — provisions a new Superset user with username, name, email, password, and role assignments. Uses `security_manager.add_user()` to ensure FAB password hashing and pre/post-commit signals fire correctly.
- **`update_user`** — updates an existing user by ID. All fields except `id` are optional; only supplied fields are changed. Supports updating name, email, password (re-hashed), role assignments (full replacement), and active status.

Both tools:
- Require admin access (`class_permission_name="User"`, `method_permission_name="write"`)
- Return only non-sensitive fields (`id`, `username`, `first_name`, `last_name`) — no email, password, or roles in response
- Include SSO/SCIM caveat in docstring noting that role assignments may be overridden on external-provider login
- Follow the `@tool(tags=["mutate"])` mutation pattern

## Test plan

- [ ] Verify `create_user` creates a user that can log in with the supplied credentials
- [ ] Verify `create_user` with an unknown `role_id` returns a structured error
- [ ] Verify `create_user` with a duplicate username/email returns a structured error
- [ ] Verify `update_user` updates only the fields supplied (omitted fields unchanged)
- [ ] Verify `update_user` with an unknown `id` returns a structured error
- [ ] Verify `update_user` with unknown `role_ids` returns a structured error
- [ ] Verify response never includes email, password, or role data

🤖 Generated with [Claude Code](https://claude.com/claude-code)