### PR TITLE
feat(mcp): add create_role and update_role tools

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -206,6 +206,7 @@ Task Management (requires GLOBAL_TASK_FRAMEWORK feature flag):
 
 Role Management:
 - create_role: Create a new FAB role, optionally assigning PermissionView IDs (admin only, requires write access)
+- update_role: Rename a role and/or replace its PermissionView assignments (admin only, requires write access)
 
 System Information:
 - get_instance_info: Get instance-wide statistics, metadata, and current user identity
@@ -432,8 +433,8 @@ Input format:
   save_sql_query, add_chart_to_existing_dashboard, update_chart_preview) require write
   permissions. These tools are only listed for users who have the necessary access.
   If a write tool does not appear in the tool list, the current user lacks write access.
-- create_role requires admin-level write access to the security permission class.
-  It will not appear in the tool list for non-admin users.
+- create_role and update_role require admin-level write access to the security
+  permission class. They will not appear in the tool list for non-admin users.
 - execute_sql requires SQL Lab access (execute_sql_query permission), which is separate
   from write access. A user may have SQL Lab access without having write access to charts
   or dashboards, and vice versa.
@@ -738,6 +739,7 @@ from superset.mcp_service.role.tool import (  # noqa: F401, E402
     create_role,
     get_role_info,
     list_roles,
+    update_role,
 )
 from superset.mcp_service.saved_query.tool import (  # noqa: F401, E402
     get_saved_query_info,

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -204,6 +204,9 @@ Task Management (requires GLOBAL_TASK_FRAMEWORK feature flag):
 - list_tasks: List background tasks with status filtering and pagination
 - get_task_info: Get task details by integer ID or UUID
 
+Role Management:
+- create_role: Create a new FAB role, optionally assigning PermissionView IDs (admin only, requires write access)
+
 System Information:
 - get_instance_info: Get instance-wide statistics, metadata, and current user identity
 - find_users: Resolve a person's name to user IDs for use as a filter value
@@ -429,6 +432,8 @@ Input format:
   save_sql_query, add_chart_to_existing_dashboard, update_chart_preview) require write
   permissions. These tools are only listed for users who have the necessary access.
   If a write tool does not appear in the tool list, the current user lacks write access.
+- create_role requires admin-level write access to the security permission class.
+  It will not appear in the tool list for non-admin users.
 - execute_sql requires SQL Lab access (execute_sql_query permission), which is separate
   from write access. A user may have SQL Lab access without having write access to charts
   or dashboards, and vice versa.
@@ -730,6 +735,7 @@ from superset.mcp_service.rls.tool import (  # noqa: F401, E402
     list_rls_filters,
 )
 from superset.mcp_service.role.tool import (  # noqa: F401, E402
+    create_role,
     get_role_info,
     list_roles,
 )

--- a/superset/mcp_service/role/schemas.py
+++ b/superset/mcp_service/role/schemas.py
@@ -277,6 +277,8 @@ class CreateRoleRequest(BaseModel):
 
     name: str = Field(
         ...,
+        min_length=1,
+        max_length=_ROLE_NAME_MAX_LEN,
         description="Name for the new role. Must be unique.",
     )
     permission_ids: list[int] = Field(
@@ -288,6 +290,14 @@ class CreateRoleRequest(BaseModel):
             "Leave empty to create a role with no permissions."
         ),
     )
+
+    @field_validator("name")
+    @classmethod
+    def name_must_not_be_blank(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("name must not be empty or whitespace")
+        return stripped
 
 
 class CreateRoleResponse(BaseModel):
@@ -305,6 +315,7 @@ class UpdateRoleRequest(BaseModel):
     id: int = Field(..., description="ID of the role to update.")
     name: str | None = Field(
         None,
+        max_length=_ROLE_NAME_MAX_LEN,
         description=(
             "New name for the role. Must be unique. Omit to keep the current name."
         ),
@@ -317,6 +328,16 @@ class UpdateRoleRequest(BaseModel):
             "not supported. Omit to leave permissions unchanged."
         ),
     )
+
+    @field_validator("name")
+    @classmethod
+    def name_must_not_be_blank(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("name must not be empty or whitespace")
+        return stripped
 
 
 class UpdateRoleResponse(BaseModel):

--- a/superset/mcp_service/role/schemas.py
+++ b/superset/mcp_service/role/schemas.py
@@ -262,3 +262,38 @@ def serialize_role_object(
         if permissions is not None
         else None,
     )
+
+
+# ---------------------------------------------------------------------------
+# create_role / update_role schemas
+# ---------------------------------------------------------------------------
+
+
+_ROLE_NAME_MAX_LEN = 64
+
+
+class CreateRoleRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(
+        ...,
+        description="Name for the new role. Must be unique.",
+    )
+    permission_ids: list[int] = Field(
+        default_factory=list,
+        description=(
+            "Optional list of PermissionView IDs to assign to the role. "
+            "These correspond to FAB permission-view-menu pairs "
+            "(e.g., can_read on Chart). "
+            "Leave empty to create a role with no permissions."
+        ),
+    )
+
+
+class CreateRoleResponse(BaseModel):
+    id: int | None = Field(None, description="ID of the created role.")
+    name: str | None = Field(None, description="Name of the created role.")
+    error: str | None = Field(
+        None,
+        description="Error message if role creation failed, otherwise null.",
+    )

--- a/superset/mcp_service/role/schemas.py
+++ b/superset/mcp_service/role/schemas.py
@@ -297,3 +297,32 @@ class CreateRoleResponse(BaseModel):
         None,
         description="Error message if role creation failed, otherwise null.",
     )
+
+
+class UpdateRoleRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: int = Field(..., description="ID of the role to update.")
+    name: str | None = Field(
+        None,
+        description=(
+            "New name for the role. Must be unique. Omit to keep the current name."
+        ),
+    )
+    permission_ids: list[int] | None = Field(
+        None,
+        description=(
+            "Replacement list of PermissionView IDs for the role. "
+            "Replaces the full existing permission set — partial updates are "
+            "not supported. Omit to leave permissions unchanged."
+        ),
+    )
+
+
+class UpdateRoleResponse(BaseModel):
+    id: int | None = Field(None, description="ID of the updated role.")
+    name: str | None = Field(None, description="Name of the updated role.")
+    error: str | None = Field(
+        None,
+        description="Error message if role update failed, otherwise null.",
+    )

--- a/superset/mcp_service/role/schemas.py
+++ b/superset/mcp_service/role/schemas.py
@@ -36,6 +36,7 @@ from superset.daos.base import ColumnOperator, ColumnOperatorEnum
 from superset.mcp_service.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from superset.mcp_service.system.schemas import PaginationInfo
 from superset.mcp_service.utils import sanitize_for_llm_context
+from superset.mcp_service.utils.sanitization import sanitize_user_input
 from superset.mcp_service.utils.schema_utils import (
     parse_json_or_list,
     parse_json_or_model_list,
@@ -293,11 +294,8 @@ class CreateRoleRequest(BaseModel):
 
     @field_validator("name")
     @classmethod
-    def name_must_not_be_blank(cls, v: str) -> str:
-        stripped = v.strip()
-        if not stripped:
-            raise ValueError("name must not be empty or whitespace")
-        return stripped
+    def sanitize_name(cls, v: str) -> str:
+        return sanitize_user_input(v, "Role name", max_length=_ROLE_NAME_MAX_LEN)  # type: ignore[return-value]
 
 
 class CreateRoleResponse(BaseModel):
@@ -331,13 +329,10 @@ class UpdateRoleRequest(BaseModel):
 
     @field_validator("name")
     @classmethod
-    def name_must_not_be_blank(cls, v: str | None) -> str | None:
+    def sanitize_name(cls, v: str | None) -> str | None:
         if v is None:
             return v
-        stripped = v.strip()
-        if not stripped:
-            raise ValueError("name must not be empty or whitespace")
-        return stripped
+        return sanitize_user_input(v, "Role name", max_length=_ROLE_NAME_MAX_LEN)
 
 
 class UpdateRoleResponse(BaseModel):

--- a/superset/mcp_service/role/tool/__init__.py
+++ b/superset/mcp_service/role/tool/__init__.py
@@ -18,9 +18,11 @@
 from .create_role import create_role
 from .get_role_info import get_role_info
 from .list_roles import list_roles
+from .update_role import update_role
 
 __all__ = [
     "create_role",
     "get_role_info",
     "list_roles",
+    "update_role",
 ]

--- a/superset/mcp_service/role/tool/__init__.py
+++ b/superset/mcp_service/role/tool/__init__.py
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .create_role import create_role
 from .get_role_info import get_role_info
 from .list_roles import list_roles
 
 __all__ = [
-    "list_roles",
+    "create_role",
     "get_role_info",
+    "list_roles",
 ]

--- a/superset/mcp_service/role/tool/create_role.py
+++ b/superset/mcp_service/role/tool/create_role.py
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.role.schemas import CreateRoleRequest, CreateRoleResponse
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="security",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Create a new role",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_role(request: CreateRoleRequest, ctx: Context) -> CreateRoleResponse:
+    """Create a new FAB role, optionally assigning PermissionView IDs.
+
+    Admin-only. Use this when you need to provision a new role in Superset's
+    role-based access control system. The created role starts with no
+    permissions unless ``permission_ids`` are supplied.
+
+    Workflow:
+    1. Call this tool with a unique role name
+    2. Optionally supply ``permission_ids`` to pre-assign permissions
+    3. Use the returned ``id`` to reference the role in downstream operations
+    """
+    await ctx.info(
+        "Creating role: name=%r, permission_ids=%s"
+        % (request.name, request.permission_ids)
+    )
+
+    try:
+        from flask_appbuilder.security.sqla.models import PermissionView
+
+        from superset import security_manager
+        from superset.extensions import db
+
+        # Reject creation if role already exists
+        existing = security_manager.find_role(request.name)
+        if existing is not None:
+            await ctx.warning("Role already exists: name=%r" % (request.name,))
+            return CreateRoleResponse(
+                error=f"Role '{request.name}' already exists (id={existing.id})."
+            )
+
+        with event_logger.log_context(action="mcp.create_role.create"):
+            role = security_manager.add_role(request.name)
+
+        if request.permission_ids:
+            pvms = (
+                db.session.query(PermissionView)
+                .filter(PermissionView.id.in_(request.permission_ids))
+                .all()
+            )
+            found_ids = {pvm.id for pvm in pvms}
+            missing = set(request.permission_ids) - found_ids
+            if missing:
+                await ctx.warning(
+                    "Some permission_ids not found and will be skipped: %s"
+                    % sorted(missing)
+                )
+
+            role.permissions = pvms
+            db.session.commit()
+
+        await ctx.info("Role created: id=%s, name=%r" % (role.id, role.name))
+        return CreateRoleResponse(id=role.id, name=role.name)
+
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error creating role: %s: %s" % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/role/tool/create_role.py
+++ b/superset/mcp_service/role/tool/create_role.py
@@ -19,6 +19,7 @@ import logging
 
 from fastmcp import Context
 from flask_appbuilder.security.sqla.models import PermissionView
+from sqlalchemy.exc import IntegrityError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset import security_manager
@@ -83,10 +84,29 @@ async def create_role(request: CreateRoleRequest, ctx: Context) -> CreateRoleRes
 
             with event_logger.log_context(action="mcp.create_role.assign_permissions"):
                 role.permissions = pvms
-                db.session.commit()
+
+        with event_logger.log_context(action="mcp.create_role.commit"):
+            db.session.commit()  # pylint: disable=consider-using-transaction
 
         await ctx.info("Role created: id=%s, name=%r" % (role.id, role.name))
         return CreateRoleResponse(id=role.id, name=role.name)
+
+    except IntegrityError:
+        db.session.rollback()  # pylint: disable=consider-using-transaction
+        # Race condition: another request created the same role between our
+        # find_role check and add_role call.
+        existing = security_manager.find_role(request.name)
+        if existing is not None:
+            await ctx.warning(
+                "Role already exists (race condition): name=%r" % (request.name,)
+            )
+            return CreateRoleResponse(
+                error=f"Role '{request.name}' already exists (id={existing.id})."
+            )
+        await ctx.error(
+            "IntegrityError creating role but role not found after rollback"
+        )
+        raise
 
     except Exception as exc:
         await ctx.error(

--- a/superset/mcp_service/role/tool/create_role.py
+++ b/superset/mcp_service/role/tool/create_role.py
@@ -18,9 +18,11 @@
 import logging
 
 from fastmcp import Context
+from flask_appbuilder.security.sqla.models import PermissionView
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.extensions import event_logger
+from superset import security_manager
+from superset.extensions import db, event_logger
 from superset.mcp_service.role.schemas import CreateRoleRequest, CreateRoleResponse
 
 logger = logging.getLogger(__name__)
@@ -54,11 +56,6 @@ async def create_role(request: CreateRoleRequest, ctx: Context) -> CreateRoleRes
     )
 
     try:
-        from flask_appbuilder.security.sqla.models import PermissionView
-
-        from superset import security_manager
-        from superset.extensions import db
-
         # Reject creation if role already exists
         existing = security_manager.find_role(request.name)
         if existing is not None:
@@ -84,8 +81,9 @@ async def create_role(request: CreateRoleRequest, ctx: Context) -> CreateRoleRes
                     % sorted(missing)
                 )
 
-            role.permissions = pvms
-            db.session.commit()
+            with event_logger.log_context(action="mcp.create_role.assign_permissions"):
+                role.permissions = pvms
+                db.session.commit()
 
         await ctx.info("Role created: id=%s, name=%r" % (role.id, role.name))
         return CreateRoleResponse(id=role.id, name=role.name)

--- a/superset/mcp_service/role/tool/update_role.py
+++ b/superset/mcp_service/role/tool/update_role.py
@@ -16,9 +16,12 @@
 # under the License.
 
 import logging
+from typing import Any
 
 from fastmcp import Context
+from flask import current_app
 from flask_appbuilder.security.sqla.models import PermissionView
+from sqlalchemy.exc import IntegrityError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset import security_manager
@@ -26,6 +29,18 @@ from superset.extensions import db, event_logger
 from superset.mcp_service.role.schemas import UpdateRoleRequest, UpdateRoleResponse
 
 logger = logging.getLogger(__name__)
+
+
+def _check_rename(role: Any, new_name: str, config: Any, sm: Any) -> str | None:
+    """Return an error string if the rename should be rejected, else None."""
+    admin_role = config.get("AUTH_ROLE_ADMIN", "Admin")
+    public_role = config.get("AUTH_ROLE_PUBLIC", "Public")
+    if role.name in {admin_role, public_role}:
+        return f"Cannot rename built-in role '{role.name}'."
+    existing = sm.find_role(new_name)
+    if existing is not None and existing.id != role.id:
+        return f"Role name '{new_name}' is already in use (id={existing.id})."
+    return None
 
 
 @tool(
@@ -65,16 +80,12 @@ async def update_role(request: UpdateRoleRequest, ctx: Context) -> UpdateRoleRes
 
         role = roles[0]
 
-        if request.name is not None:
-            existing = security_manager.find_role(request.name)
-            if existing is not None and existing.id != role.id:
-                await ctx.warning("Role name already in use: name=%r" % (request.name,))
-                return UpdateRoleResponse(
-                    error=(
-                        f"Role name '{request.name}' is already in use"
-                        f" (id={existing.id})."
-                    )
-                )
+        if request.name is not None and request.name != role.name:
+            if err := _check_rename(
+                role, request.name, current_app.config, security_manager
+            ):
+                await ctx.warning("Rename rejected: %s" % (err,))
+                return UpdateRoleResponse(error=err)
             role.name = request.name
 
         if request.permission_ids is not None:
@@ -97,6 +108,23 @@ async def update_role(request: UpdateRoleRequest, ctx: Context) -> UpdateRoleRes
 
         await ctx.info("Role updated: id=%s, name=%r" % (role.id, role.name))
         return UpdateRoleResponse(id=role.id, name=role.name)
+
+    except IntegrityError:
+        db.session.rollback()  # pylint: disable=consider-using-transaction
+        if request.name is not None:
+            conflicting = security_manager.find_role(request.name)
+            if conflicting is not None and conflicting.id != request.id:
+                await ctx.warning(
+                    "Role name conflict (race condition): name=%r" % (request.name,)
+                )
+                return UpdateRoleResponse(
+                    error=(
+                        f"Role name '{request.name}' is already in use"
+                        f" (id={conflicting.id})."
+                    )
+                )
+        await ctx.error("IntegrityError updating role; cause unclear after rollback")
+        raise
 
     except Exception as exc:
         await ctx.error(

--- a/superset/mcp_service/role/tool/update_role.py
+++ b/superset/mcp_service/role/tool/update_role.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from fastmcp import Context
+from flask_appbuilder.security.sqla.models import PermissionView
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset import security_manager
+from superset.extensions import db, event_logger
+from superset.mcp_service.role.schemas import UpdateRoleRequest, UpdateRoleResponse
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="security",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Update an existing role",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def update_role(request: UpdateRoleRequest, ctx: Context) -> UpdateRoleResponse:
+    """Update an existing FAB role's name and/or permission assignments.
+
+    Admin-only. Use this when you need to rename a role or change its
+    PermissionView assignments. When ``permission_ids`` is supplied it
+    replaces the full existing permission set — partial updates are not
+    supported.
+
+    Workflow:
+    1. Call with the role ``id`` to update
+    2. Supply ``name`` to rename the role (must be unique)
+    3. Supply ``permission_ids`` to replace all existing permissions
+    4. Omit a field to leave it unchanged
+    """
+    await ctx.info(
+        "Updating role: id=%s, name=%r, permission_ids=%s"
+        % (request.id, request.name, request.permission_ids)
+    )
+
+    try:
+        roles = security_manager.find_roles_by_id([request.id])
+        if not roles:
+            await ctx.warning("Role not found: id=%s" % (request.id,))
+            return UpdateRoleResponse(error=f"Role with id={request.id} not found.")
+
+        role = roles[0]
+
+        if request.name is not None:
+            existing = security_manager.find_role(request.name)
+            if existing is not None and existing.id != role.id:
+                await ctx.warning("Role name already in use: name=%r" % (request.name,))
+                return UpdateRoleResponse(
+                    error=(
+                        f"Role name '{request.name}' is already in use"
+                        f" (id={existing.id})."
+                    )
+                )
+            role.name = request.name
+
+        if request.permission_ids is not None:
+            pvms = (
+                db.session.query(PermissionView)
+                .filter(PermissionView.id.in_(request.permission_ids))
+                .all()
+            )
+            found_ids = {pvm.id for pvm in pvms}
+            missing = set(request.permission_ids) - found_ids
+            if missing:
+                await ctx.warning(
+                    "Some permission_ids not found and will be skipped: %s"
+                    % sorted(missing)
+                )
+            role.permissions = pvms
+
+        with event_logger.log_context(action="mcp.update_role.commit"):
+            db.session.commit()
+
+        await ctx.info("Role updated: id=%s, name=%r" % (role.id, role.name))
+        return UpdateRoleResponse(id=role.id, name=role.name)
+
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error updating role: %s: %s" % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/role/tool/update_role.py
+++ b/superset/mcp_service/role/tool/update_role.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
     annotations=ToolAnnotations(
         title="Update an existing role",
         readOnlyHint=False,
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 async def update_role(request: UpdateRoleRequest, ctx: Context) -> UpdateRoleResponse:
@@ -93,7 +93,7 @@ async def update_role(request: UpdateRoleRequest, ctx: Context) -> UpdateRoleRes
             role.permissions = pvms
 
         with event_logger.log_context(action="mcp.update_role.commit"):
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
 
         await ctx.info("Role updated: id=%s, name=%r" % (role.id, role.name))
         return UpdateRoleResponse(id=role.id, name=role.name)

--- a/tests/unit_tests/mcp_service/role/tool/test_role_tools.py
+++ b/tests/unit_tests/mcp_service/role/tool/test_role_tools.py
@@ -383,6 +383,16 @@ def test_create_role_request_default_empty_permissions() -> None:
     assert req.permission_ids == []
 
 
+def test_create_role_request_html_tags_stripped() -> None:
+    req = CreateRoleRequest(name="<b>Analyst</b>")
+    assert req.name == "Analyst"
+
+
+def test_update_role_request_html_tags_stripped() -> None:
+    req = UpdateRoleRequest(id=1, name="<b>Editor</b>")
+    assert req.name == "Editor"
+
+
 # ---------------------------------------------------------------------------
 # Schema validation tests — UpdateRoleRequest
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/mcp_service/role/tool/test_role_tools.py
+++ b/tests/unit_tests/mcp_service/role/tool/test_role_tools.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Unit tests for list_roles and get_role_info MCP tools."""
+"""Unit tests for role MCP tools (list_roles, get_role_info, create_role, update_role)."""
 
 from unittest.mock import MagicMock, Mock, patch
 
@@ -23,9 +23,15 @@ import pytest
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
 
 from superset.mcp_service.app import mcp
-from superset.mcp_service.role.schemas import ListRolesRequest, RoleFilter
+from superset.mcp_service.role.schemas import (
+    CreateRoleRequest,
+    ListRolesRequest,
+    RoleFilter,
+    UpdateRoleRequest,
+)
 from superset.utils import json
 
 
@@ -62,7 +68,7 @@ def mock_auth():
 
 
 # ---------------------------------------------------------------------------
-# Schema validation tests
+# Schema validation tests — RoleFilter / ListRolesRequest
 # ---------------------------------------------------------------------------
 
 
@@ -334,3 +340,441 @@ async def test_get_role_info_role_name_is_wrapped_in_untrusted_content(
     assert data["name"] != injected_name
     assert "<UNTRUSTED-CONTENT>" in data["name"]
     assert injected_name in data["name"]
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests — CreateRoleRequest
+# ---------------------------------------------------------------------------
+
+
+def test_create_role_request_valid() -> None:
+    req = CreateRoleRequest(name="Analyst", permission_ids=[1, 2])
+    assert req.name == "Analyst"
+    assert req.permission_ids == [1, 2]
+
+
+def test_create_role_request_strips_whitespace() -> None:
+    req = CreateRoleRequest(name="  Analyst  ")
+    assert req.name == "Analyst"
+
+
+def test_create_role_request_empty_name_fails() -> None:
+    with pytest.raises(ValidationError):
+        CreateRoleRequest(name="")
+
+
+def test_create_role_request_whitespace_only_name_fails() -> None:
+    with pytest.raises(ValidationError):
+        CreateRoleRequest(name="   ")
+
+
+def test_create_role_request_name_too_long_fails() -> None:
+    with pytest.raises(ValidationError):
+        CreateRoleRequest(name="a" * 65)
+
+
+def test_create_role_request_name_max_length_ok() -> None:
+    req = CreateRoleRequest(name="a" * 64)
+    assert len(req.name) == 64
+
+
+def test_create_role_request_default_empty_permissions() -> None:
+    req = CreateRoleRequest(name="Admin")
+    assert req.permission_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests — UpdateRoleRequest
+# ---------------------------------------------------------------------------
+
+
+def test_update_role_request_valid() -> None:
+    req = UpdateRoleRequest(id=1, name="New Name", permission_ids=[3, 4])
+    assert req.id == 1
+    assert req.name == "New Name"
+    assert req.permission_ids == [3, 4]
+
+
+def test_update_role_request_strips_whitespace() -> None:
+    req = UpdateRoleRequest(id=1, name="  Trimmed  ")
+    assert req.name == "Trimmed"
+
+
+def test_update_role_request_name_too_long_fails() -> None:
+    with pytest.raises(ValidationError):
+        UpdateRoleRequest(id=1, name="x" * 65)
+
+
+def test_update_role_request_name_whitespace_only_fails() -> None:
+    with pytest.raises(ValidationError):
+        UpdateRoleRequest(id=1, name="   ")
+
+
+def test_update_role_request_omit_name_ok() -> None:
+    req = UpdateRoleRequest(id=1)
+    assert req.name is None
+    assert req.permission_ids is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers for create_role / update_role tool tests
+# ---------------------------------------------------------------------------
+
+
+def _make_role(role_id: int = 1, name: str = "Analyst") -> MagicMock:
+    role = MagicMock()
+    role.id = role_id
+    role.name = name
+    role.permissions = []
+    return role
+
+
+def _make_pvm(pvm_id: int) -> MagicMock:
+    pvm = MagicMock()
+    pvm.id = pvm_id
+    return pvm
+
+
+# ---------------------------------------------------------------------------
+# create_role tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_role_success_no_permissions(mcp_server: object) -> None:
+    """Role is created and committed when no permission_ids are supplied."""
+    new_role = _make_role(role_id=5, name="Analyst")
+
+    with (
+        patch("superset.mcp_service.role.tool.create_role.security_manager") as mock_sm,
+        patch("superset.mcp_service.role.tool.create_role.db") as mock_db,
+    ):
+        mock_sm.find_role.return_value = None
+        mock_sm.add_role.return_value = new_role
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_role",
+                {"request": CreateRoleRequest(name="Analyst").model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 5
+    assert data["name"] == "Analyst"
+    assert data["error"] is None
+    mock_db.session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_role_success_with_permissions(mcp_server: object) -> None:
+    """Role is created, permissions assigned, and session committed."""
+    new_role = _make_role(role_id=7, name="Editor")
+    pvm1 = _make_pvm(10)
+    pvm2 = _make_pvm(20)
+
+    with (
+        patch("superset.mcp_service.role.tool.create_role.security_manager") as mock_sm,
+        patch("superset.mcp_service.role.tool.create_role.db") as mock_db,
+    ):
+        mock_sm.find_role.return_value = None
+        mock_sm.add_role.return_value = new_role
+        mock_db.session.query.return_value.filter.return_value.all.return_value = [
+            pvm1,
+            pvm2,
+        ]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_role",
+                {
+                    "request": CreateRoleRequest(
+                        name="Editor", permission_ids=[10, 20]
+                    ).model_dump()
+                },
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 7
+    assert data["name"] == "Editor"
+    assert data["error"] is None
+    assert new_role.permissions == [pvm1, pvm2]
+    mock_db.session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_role_duplicate(mcp_server: object) -> None:
+    """Returns structured error when role already exists."""
+    existing = _make_role(role_id=3, name="Analyst")
+
+    with patch(
+        "superset.mcp_service.role.tool.create_role.security_manager"
+    ) as mock_sm:
+        mock_sm.find_role.return_value = existing
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_role",
+                {"request": CreateRoleRequest(name="Analyst").model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "already exists" in data["error"]
+    assert "3" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_role_missing_permission_ids_warned(mcp_server: object) -> None:
+    """Warns about missing permission IDs and still creates the role."""
+    new_role = _make_role(role_id=9, name="Partial")
+    found_pvm = _make_pvm(10)
+
+    with (
+        patch("superset.mcp_service.role.tool.create_role.security_manager") as mock_sm,
+        patch("superset.mcp_service.role.tool.create_role.db") as mock_db,
+    ):
+        mock_sm.find_role.return_value = None
+        mock_sm.add_role.return_value = new_role
+        # Only pvm 10 found; pvm 99 is missing
+        mock_db.session.query.return_value.filter.return_value.all.return_value = [
+            found_pvm
+        ]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_role",
+                {
+                    "request": CreateRoleRequest(
+                        name="Partial", permission_ids=[10, 99]
+                    ).model_dump()
+                },
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 9
+    assert data["error"] is None
+    assert new_role.permissions == [found_pvm]
+
+
+@pytest.mark.asyncio
+async def test_create_role_integrity_error_race_condition(mcp_server: object) -> None:
+    """IntegrityError on concurrent creation returns structured duplicate error."""
+    conflicting_role = _make_role(role_id=11, name="Racing")
+
+    with (
+        patch("superset.mcp_service.role.tool.create_role.security_manager") as mock_sm,
+        patch("superset.mcp_service.role.tool.create_role.db") as mock_db,
+    ):
+        mock_sm.find_role.side_effect = [None, conflicting_role]
+        mock_sm.add_role.return_value = _make_role(role_id=12, name="Racing")
+        mock_db.session.commit.side_effect = IntegrityError(
+            "UNIQUE constraint failed", None, None
+        )
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_role",
+                {"request": CreateRoleRequest(name="Racing").model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "already exists" in data["error"]
+    mock_db.session.rollback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# update_role tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_role_success_rename(mcp_server: object) -> None:
+    """Role is renamed and committed."""
+    role = _make_role(role_id=1, name="OldName")
+
+    with (
+        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
+        patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
+        patch(
+            "superset.mcp_service.role.tool.update_role.current_app"
+        ) as mock_app,
+    ):
+        mock_sm.find_roles_by_id.return_value = [role]
+        mock_sm.find_role.return_value = None
+        mock_app.config = {"AUTH_ROLE_ADMIN": "Admin", "AUTH_ROLE_PUBLIC": "Public"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_role",
+                {"request": UpdateRoleRequest(id=1, name="NewName").model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["error"] is None
+    assert role.name == "NewName"
+    mock_db.session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_role_not_found(mcp_server: object) -> None:
+    """Returns structured error when role ID does not exist."""
+    with patch(
+        "superset.mcp_service.role.tool.update_role.security_manager"
+    ) as mock_sm:
+        mock_sm.find_roles_by_id.return_value = []
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_role",
+                {"request": UpdateRoleRequest(id=999).model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "999" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_role_name_conflict(mcp_server: object) -> None:
+    """Returns structured error when new name is taken by another role."""
+    role = _make_role(role_id=1, name="Alpha")
+    other = _make_role(role_id=2, name="Beta")
+
+    with (
+        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
+        patch(
+            "superset.mcp_service.role.tool.update_role.current_app"
+        ) as mock_app,
+    ):
+        mock_sm.find_roles_by_id.return_value = [role]
+        mock_sm.find_role.return_value = other  # name "Beta" belongs to id=2
+        mock_app.config = {"AUTH_ROLE_ADMIN": "Admin", "AUTH_ROLE_PUBLIC": "Public"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_role",
+                {"request": UpdateRoleRequest(id=1, name="Beta").model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "already in use" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_role_replace_permissions(mcp_server: object) -> None:
+    """Replacing permissions (including empty list) commits the full replacement."""
+    role = _make_role(role_id=1, name="Viewer")
+    role.permissions = [_make_pvm(5), _make_pvm(6)]
+    new_pvm = _make_pvm(7)
+
+    with (
+        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
+        patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
+    ):
+        mock_sm.find_roles_by_id.return_value = [role]
+        mock_sm.find_role.return_value = None
+        mock_db.session.query.return_value.filter.return_value.all.return_value = [
+            new_pvm
+        ]
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_role",
+                {"request": UpdateRoleRequest(id=1, permission_ids=[7]).model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["error"] is None
+    assert role.permissions == [new_pvm]
+    mock_db.session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_role_clear_permissions(mcp_server: object) -> None:
+    """Empty permission_ids list replaces all permissions with none."""
+    role = _make_role(role_id=1, name="Viewer")
+    role.permissions = [_make_pvm(5)]
+
+    with (
+        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
+        patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
+    ):
+        mock_sm.find_roles_by_id.return_value = [role]
+        mock_sm.find_role.return_value = None
+        mock_db.session.query.return_value.filter.return_value.all.return_value = []
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_role",
+                {"request": UpdateRoleRequest(id=1, permission_ids=[]).model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["error"] is None
+    assert role.permissions == []
+    mock_db.session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_role_blocks_renaming_admin_role(mcp_server: object) -> None:
+    """Renaming the built-in Admin role is rejected."""
+    admin_role = _make_role(role_id=1, name="Admin")
+
+    with (
+        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
+        patch(
+            "superset.mcp_service.role.tool.update_role.current_app"
+        ) as mock_app,
+    ):
+        mock_sm.find_roles_by_id.return_value = [admin_role]
+        mock_app.config = {"AUTH_ROLE_ADMIN": "Admin", "AUTH_ROLE_PUBLIC": "Public"}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_role",
+                {"request": UpdateRoleRequest(id=1, name="SuperAdmin").model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "built-in" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_role_integrity_error_race_condition(mcp_server: object) -> None:
+    """IntegrityError on commit returns structured error with rollback."""
+    role = _make_role(role_id=1, name="Alpha")
+    conflicting = _make_role(role_id=2, name="Beta")
+
+    with (
+        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
+        patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
+        patch(
+            "superset.mcp_service.role.tool.update_role.current_app"
+        ) as mock_app,
+    ):
+        mock_sm.find_roles_by_id.return_value = [role]
+        mock_sm.find_role.side_effect = [None, conflicting]
+        mock_app.config = {"AUTH_ROLE_ADMIN": "Admin", "AUTH_ROLE_PUBLIC": "Public"}
+        mock_db.session.commit.side_effect = IntegrityError(
+            "UNIQUE constraint failed", None, None
+        )
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_role",
+                {"request": UpdateRoleRequest(id=1, name="Beta").model_dump()},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "already in use" in data["error"]
+    mock_db.session.rollback.assert_called_once()

--- a/tests/unit_tests/mcp_service/role/tool/test_role_tools.py
+++ b/tests/unit_tests/mcp_service/role/tool/test_role_tools.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Unit tests for role MCP tools (list_roles, get_role_info, create_role, update_role)."""
+"""Unit tests for role MCP tools."""
 
 from unittest.mock import MagicMock, Mock, patch
 
@@ -446,7 +446,10 @@ async def test_create_role_success_no_permissions(mcp_server: object) -> None:
     new_role = _make_role(role_id=5, name="Analyst")
 
     with (
-        patch("superset.mcp_service.role.tool.create_role.security_manager") as mock_sm,
+        patch(
+            "superset.mcp_service.role.tool.create_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
         patch("superset.mcp_service.role.tool.create_role.db") as mock_db,
     ):
         mock_sm.find_role.return_value = None
@@ -473,7 +476,10 @@ async def test_create_role_success_with_permissions(mcp_server: object) -> None:
     pvm2 = _make_pvm(20)
 
     with (
-        patch("superset.mcp_service.role.tool.create_role.security_manager") as mock_sm,
+        patch(
+            "superset.mcp_service.role.tool.create_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
         patch("superset.mcp_service.role.tool.create_role.db") as mock_db,
     ):
         mock_sm.find_role.return_value = None
@@ -507,7 +513,8 @@ async def test_create_role_duplicate(mcp_server: object) -> None:
     existing = _make_role(role_id=3, name="Analyst")
 
     with patch(
-        "superset.mcp_service.role.tool.create_role.security_manager"
+        "superset.mcp_service.role.tool.create_role.security_manager",
+        new_callable=MagicMock,
     ) as mock_sm:
         mock_sm.find_role.return_value = existing
 
@@ -531,7 +538,10 @@ async def test_create_role_missing_permission_ids_warned(mcp_server: object) -> 
     found_pvm = _make_pvm(10)
 
     with (
-        patch("superset.mcp_service.role.tool.create_role.security_manager") as mock_sm,
+        patch(
+            "superset.mcp_service.role.tool.create_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
         patch("superset.mcp_service.role.tool.create_role.db") as mock_db,
     ):
         mock_sm.find_role.return_value = None
@@ -563,7 +573,10 @@ async def test_create_role_integrity_error_race_condition(mcp_server: object) ->
     conflicting_role = _make_role(role_id=11, name="Racing")
 
     with (
-        patch("superset.mcp_service.role.tool.create_role.security_manager") as mock_sm,
+        patch(
+            "superset.mcp_service.role.tool.create_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
         patch("superset.mcp_service.role.tool.create_role.db") as mock_db,
     ):
         mock_sm.find_role.side_effect = [None, conflicting_role]
@@ -596,11 +609,12 @@ async def test_update_role_success_rename(mcp_server: object) -> None:
     role = _make_role(role_id=1, name="OldName")
 
     with (
-        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
-        patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
         patch(
-            "superset.mcp_service.role.tool.update_role.current_app"
-        ) as mock_app,
+            "superset.mcp_service.role.tool.update_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
+        patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
+        patch("superset.mcp_service.role.tool.update_role.current_app") as mock_app,
     ):
         mock_sm.find_roles_by_id.return_value = [role]
         mock_sm.find_role.return_value = None
@@ -622,7 +636,8 @@ async def test_update_role_success_rename(mcp_server: object) -> None:
 async def test_update_role_not_found(mcp_server: object) -> None:
     """Returns structured error when role ID does not exist."""
     with patch(
-        "superset.mcp_service.role.tool.update_role.security_manager"
+        "superset.mcp_service.role.tool.update_role.security_manager",
+        new_callable=MagicMock,
     ) as mock_sm:
         mock_sm.find_roles_by_id.return_value = []
 
@@ -645,10 +660,11 @@ async def test_update_role_name_conflict(mcp_server: object) -> None:
     other = _make_role(role_id=2, name="Beta")
 
     with (
-        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
         patch(
-            "superset.mcp_service.role.tool.update_role.current_app"
-        ) as mock_app,
+            "superset.mcp_service.role.tool.update_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
+        patch("superset.mcp_service.role.tool.update_role.current_app") as mock_app,
     ):
         mock_sm.find_roles_by_id.return_value = [role]
         mock_sm.find_role.return_value = other  # name "Beta" belongs to id=2
@@ -674,7 +690,10 @@ async def test_update_role_replace_permissions(mcp_server: object) -> None:
     new_pvm = _make_pvm(7)
 
     with (
-        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
+        patch(
+            "superset.mcp_service.role.tool.update_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
         patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
     ):
         mock_sm.find_roles_by_id.return_value = [role]
@@ -702,7 +721,10 @@ async def test_update_role_clear_permissions(mcp_server: object) -> None:
     role.permissions = [_make_pvm(5)]
 
     with (
-        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
+        patch(
+            "superset.mcp_service.role.tool.update_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
         patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
     ):
         mock_sm.find_roles_by_id.return_value = [role]
@@ -727,10 +749,11 @@ async def test_update_role_blocks_renaming_admin_role(mcp_server: object) -> Non
     admin_role = _make_role(role_id=1, name="Admin")
 
     with (
-        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
         patch(
-            "superset.mcp_service.role.tool.update_role.current_app"
-        ) as mock_app,
+            "superset.mcp_service.role.tool.update_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
+        patch("superset.mcp_service.role.tool.update_role.current_app") as mock_app,
     ):
         mock_sm.find_roles_by_id.return_value = [admin_role]
         mock_app.config = {"AUTH_ROLE_ADMIN": "Admin", "AUTH_ROLE_PUBLIC": "Public"}
@@ -754,11 +777,12 @@ async def test_update_role_integrity_error_race_condition(mcp_server: object) ->
     conflicting = _make_role(role_id=2, name="Beta")
 
     with (
-        patch("superset.mcp_service.role.tool.update_role.security_manager") as mock_sm,
-        patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
         patch(
-            "superset.mcp_service.role.tool.update_role.current_app"
-        ) as mock_app,
+            "superset.mcp_service.role.tool.update_role.security_manager",
+            new_callable=MagicMock,
+        ) as mock_sm,
+        patch("superset.mcp_service.role.tool.update_role.db") as mock_db,
+        patch("superset.mcp_service.role.tool.update_role.current_app") as mock_app,
     ):
         mock_sm.find_roles_by_id.return_value = [role]
         mock_sm.find_role.side_effect = [None, conflicting]


### PR DESCRIPTION
### SUMMARY

Adds two Admin-only MCP tools for managing FAB roles programmatically via the Model Context Protocol service.

**New / modified files:**
- `superset/mcp_service/role/schemas.py` — `CreateRoleRequest`, `CreateRoleResponse`, `UpdateRoleRequest`, `UpdateRoleResponse` Pydantic schemas
- `superset/mcp_service/role/tool/create_role.py` — `create_role` async tool
- `superset/mcp_service/role/tool/update_role.py` — `update_role` async tool (new)
- `superset/mcp_service/role/tool/__init__.py` and `role/__init__.py` — module exports
- `superset/mcp_service/app.py` — tool registration + DEFAULT_INSTRUCTIONS update

**`create_role` behaviour:**
- Rejects creation if a role with the same name already exists (returns structured error)
- Optionally accepts `permission_ids` (list of PermissionView IDs) to pre-assign permissions
- Warns (but does not fail) if any supplied `permission_ids` are not found

**`update_role` behaviour:**
- Looks up role by `id`; returns structured error if not found
- Optionally renames the role (`name`) — rejects if the new name is already in use by a different role
- Optionally replaces the full permission set (`permission_ids`) — partial updates not supported; warns on unknown IDs
- Omitting both fields is a no-op (returns current state)

Both tools are gated via `class_permission_name="security"` + `method_permission_name="write"` — only visible to users who have the FAB `can_write on security` permission (Admins). Follow the existing mutation tool pattern (`create_virtual_dataset`, `update_chart`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

**create_role:**
1. Start the MCP service with an Admin API key
2. Call `create_role(request={"name": "MyNewRole"})` — expect `{"id": <int>, "name": "MyNewRole", "error": null}`
3. Call again with the same name — expect `{"error": "Role 'MyNewRole' already exists (id=<int>)."}`
4. Call with `permission_ids=[1, 2]` — permissions are assigned; invalid IDs are skipped with a warning
5. With a non-Admin user the tool should not appear in the tool list

**update_role:**
1. Call `update_role(request={"id": <int>, "name": "RenamedRole"})` — expect updated name in response
2. Call with a name already used by another role — expect structured error
3. Call with `permission_ids=[3, 4]` — full permission set replaced; old permissions removed
4. Call with an unknown `id` — expect `{"error": "Role with id=<int> not found."}`
5. Omit both optional fields — expect no-op, current state returned

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API