### PR TITLE
feat(mcp): add create_rls_filter and update_rls_filter tools

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -726,6 +726,7 @@ from superset.mcp_service.query.tool import (  # noqa: F401, E402
     list_queries,
 )
 from superset.mcp_service.rls.tool import (  # noqa: F401, E402
+    create_rls_filter,
     get_rls_filter_info,
     list_rls_filters,
 )

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -729,6 +729,7 @@ from superset.mcp_service.rls.tool import (  # noqa: F401, E402
     create_rls_filter,
     get_rls_filter_info,
     list_rls_filters,
+    update_rls_filter,
 )
 from superset.mcp_service.role.tool import (  # noqa: F401, E402
     get_role_info,

--- a/superset/mcp_service/rls/schemas.py
+++ b/superset/mcp_service/rls/schemas.py
@@ -16,7 +16,7 @@
 # under the License.
 
 """
-Pydantic schemas for row level security filter responses.
+Pydantic schemas for RLS (row-level security) MCP tools.
 """
 
 from __future__ import annotations
@@ -252,4 +252,68 @@ def serialize_rls_filter_object(rls_filter: Any) -> RlsFilterInfo | None:
         clause=getattr(rls_filter, "clause", None),
         group_key=getattr(rls_filter, "group_key", None),
         changed_on=getattr(rls_filter, "changed_on", None),
+    )
+
+
+class CreateRLSFilterRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(..., min_length=1, description="Name for the RLS filter rule.")
+    filter_type: Literal["Regular", "Base"] = Field(
+        ...,
+        description=(
+            'Type of filter. "Regular" hides rows from the specified roles '
+            'unless the clause matches. "Base" shows only rows where the '
+            "clause matches to the specified roles."
+        ),
+    )
+    tables: list[int] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "List of table IDs this filter applies to. Use list_datasets to find IDs."
+        ),
+    )
+    roles: list[int] = Field(
+        ...,
+        description="List of role IDs that see this filter applied.",
+    )
+    clause: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "SQL WHERE clause applied to matching tables (e.g. \"region = 'EMEA'\")."
+        ),
+    )
+    group_key: str | None = Field(
+        None,
+        description="Optional group key for grouping related filters.",
+    )
+    description: str | None = Field(
+        None,
+        description="Optional human-readable description of the filter.",
+    )
+
+
+class CreateRLSFilterResponse(BaseModel):
+    id: int | None = Field(
+        None,
+        description="Created RLS filter ID. None if creation failed.",
+    )
+    name: str = Field(..., description="Name of the RLS filter.")
+    filter_type: str | None = Field(None, description="Filter type: Regular or Base.")
+    clause: str | None = Field(None, description="SQL WHERE clause of the filter.")
+    tables: list[int] = Field(
+        default_factory=list,
+        description="Table IDs this filter applies to.",
+    )
+    roles: list[int] = Field(
+        default_factory=list,
+        description="Role IDs affected by this filter.",
+    )
+    group_key: str | None = Field(None, description="Group key for the filter.")
+    description: str | None = Field(None, description="Description of the filter.")
+    error: str | None = Field(
+        None,
+        description="Error message if creation failed, otherwise null.",
     )

--- a/superset/mcp_service/rls/schemas.py
+++ b/superset/mcp_service/rls/schemas.py
@@ -298,9 +298,9 @@ class CreateRLSFilterRequest(BaseModel):
 class CreateRLSFilterResponse(BaseModel):
     id: int | None = Field(
         None,
-        description="Created RLS filter ID. None if creation failed.",
+        description="RLS filter ID. None if the operation failed.",
     )
-    name: str = Field(..., description="Name of the RLS filter.")
+    name: str | None = Field(None, description="Name of the RLS filter.")
     filter_type: str | None = Field(None, description="Filter type: Regular or Base.")
     clause: str | None = Field(None, description="SQL WHERE clause of the filter.")
     tables: list[int] = Field(
@@ -315,5 +315,53 @@ class CreateRLSFilterResponse(BaseModel):
     description: str | None = Field(None, description="Description of the filter.")
     error: str | None = Field(
         None,
-        description="Error message if creation failed, otherwise null.",
+        description="Error message if the operation failed, otherwise null.",
+    )
+
+
+class UpdateRLSFilterRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: int = Field(..., description="ID of the RLS filter rule to update.")
+    name: str | None = Field(
+        None,
+        min_length=1,
+        description="New name for the RLS filter rule. Omit to keep existing.",
+    )
+    filter_type: Literal["Regular", "Base"] | None = Field(
+        None,
+        description=(
+            "New filter type. Omit to keep existing. "
+            '"Regular" hides rows from the specified roles unless the clause matches. '
+            '"Base" shows only rows where the clause matches to the specified roles.'
+        ),
+    )
+    tables: list[int] | None = Field(
+        None,
+        description=(
+            "New list of table IDs this filter applies to. "
+            "Omit to keep existing. Pass [] to remove all tables."
+        ),
+    )
+    roles: list[int] | None = Field(
+        None,
+        description=(
+            "New list of role IDs that see this filter applied. "
+            "Omit to keep existing. Pass [] to remove all roles."
+        ),
+    )
+    clause: str | None = Field(
+        None,
+        min_length=1,
+        description=(
+            "New SQL WHERE clause. Omit to keep existing. Example: \"region = 'EMEA'\"."
+        ),
+    )
+    group_key: str | None = Field(
+        None,
+        description="New group key. Omit to keep existing.",
+    )
+    description: str | None = Field(
+        None,
+        description="New description. Omit to keep existing.",
     )

--- a/superset/mcp_service/rls/schemas.py
+++ b/superset/mcp_service/rls/schemas.py
@@ -33,6 +33,7 @@ from pydantic import (
     model_validator,
     PositiveInt,
 )
+from typing_extensions import Self
 
 from superset.daos.base import ColumnOperator, ColumnOperatorEnum
 from superset.mcp_service.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
@@ -258,7 +259,9 @@ def serialize_rls_filter_object(rls_filter: Any) -> RlsFilterInfo | None:
 class CreateRLSFilterRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    name: str = Field(..., min_length=1, description="Name for the RLS filter rule.")
+    name: str = Field(
+        ..., min_length=1, max_length=255, description="Name for the RLS filter rule."
+    )
     filter_type: Literal["Regular", "Base"] = Field(
         ...,
         description=(
@@ -331,6 +334,7 @@ class UpdateRLSFilterRequest(BaseModel):
     name: str | None = Field(
         None,
         min_length=1,
+        max_length=255,
         description="New name for the RLS filter rule. Omit to keep existing.",
     )
     filter_type: Literal["Regular", "Base"] | None = Field(
@@ -374,3 +378,24 @@ class UpdateRLSFilterRequest(BaseModel):
         None,
         description="New description. Omit to keep existing.",
     )
+
+    @model_validator(mode="after")
+    def reject_explicit_nulls(self) -> Self:
+        """Reject fields that were explicitly set to null.
+
+        Omitting a field (not in model_fields_set) means "keep existing".
+        Passing null explicitly is not a valid intent — it cannot clear a
+        required scalar, and for list fields the caller should use [] to clear.
+        """
+        nullable_disallowed = ("name", "filter_type", "clause", "tables", "roles")
+        for field in nullable_disallowed:
+            if field in self.model_fields_set and getattr(self, field) is None:
+                raise ValueError(
+                    f"'{field}' cannot be null. Omit it to keep the existing value"
+                    + (
+                        ", or pass [] to clear it."
+                        if field in ("tables", "roles")
+                        else "."
+                    )
+                )
+        return self

--- a/superset/mcp_service/rls/schemas.py
+++ b/superset/mcp_service/rls/schemas.py
@@ -262,9 +262,10 @@ class CreateRLSFilterRequest(BaseModel):
     filter_type: Literal["Regular", "Base"] = Field(
         ...,
         description=(
-            'Type of filter. "Regular" hides rows from the specified roles '
-            'unless the clause matches. "Base" shows only rows where the '
-            "clause matches to the specified roles."
+            'Type of filter. "Regular": the clause is applied only to users with '
+            "the specified roles (restricts their row access; all other users see "
+            'all rows). "Base": the clause is applied to ALL users EXCEPT users '
+            "with the specified roles (those roles bypass the filter and see all rows)."
         ),
     )
     tables: list[int] = Field(
@@ -276,7 +277,11 @@ class CreateRLSFilterRequest(BaseModel):
     )
     roles: list[int] = Field(
         ...,
-        description="List of role IDs that see this filter applied.",
+        description=(
+            "List of role IDs. For Regular filters: users with these roles see only "
+            "rows matching the clause. For Base filters: users with these roles are "
+            "EXEMPT from the filter and see all rows."
+        ),
     )
     clause: str = Field(
         ...,
@@ -295,7 +300,7 @@ class CreateRLSFilterRequest(BaseModel):
     )
 
 
-class CreateRLSFilterResponse(BaseModel):
+class RLSFilterResponse(BaseModel):
     id: int | None = Field(
         None,
         description="RLS filter ID. None if the operation failed.",
@@ -332,8 +337,10 @@ class UpdateRLSFilterRequest(BaseModel):
         None,
         description=(
             "New filter type. Omit to keep existing. "
-            '"Regular" hides rows from the specified roles unless the clause matches. '
-            '"Base" shows only rows where the clause matches to the specified roles.'
+            '"Regular": the clause is applied only to users with the specified roles '
+            "(restricts their row access; all other users see all rows). "
+            '"Base": the clause is applied to ALL users EXCEPT users with the '
+            "specified roles (those roles bypass the filter and see all rows)."
         ),
     )
     tables: list[int] | None = Field(
@@ -346,7 +353,9 @@ class UpdateRLSFilterRequest(BaseModel):
     roles: list[int] | None = Field(
         None,
         description=(
-            "New list of role IDs that see this filter applied. "
+            "New list of role IDs. For Regular filters: users with these roles see "
+            "only rows matching the clause. For Base filters: users with these roles "
+            "are EXEMPT from the filter and see all rows. "
             "Omit to keep existing. Pass [] to remove all roles."
         ),
     )

--- a/superset/mcp_service/rls/tool/__init__.py
+++ b/superset/mcp_service/rls/tool/__init__.py
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .create_rls_filter import create_rls_filter
 from .get_rls_filter_info import get_rls_filter_info
 from .list_rls_filters import list_rls_filters
 
 __all__ = [
-    "list_rls_filters",
+    "create_rls_filter",
     "get_rls_filter_info",
+    "list_rls_filters",
 ]

--- a/superset/mcp_service/rls/tool/__init__.py
+++ b/superset/mcp_service/rls/tool/__init__.py
@@ -18,9 +18,11 @@
 from .create_rls_filter import create_rls_filter
 from .get_rls_filter_info import get_rls_filter_info
 from .list_rls_filters import list_rls_filters
+from .update_rls_filter import update_rls_filter
 
 __all__ = [
     "create_rls_filter",
     "get_rls_filter_info",
     "list_rls_filters",
+    "update_rls_filter",
 ]

--- a/superset/mcp_service/rls/tool/create_rls_filter.py
+++ b/superset/mcp_service/rls/tool/create_rls_filter.py
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.rls.schemas import (
+    CreateRLSFilterRequest,
+    CreateRLSFilterResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="Row Level Security",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Create RLS filter",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_rls_filter(
+    request: CreateRLSFilterRequest, ctx: Context
+) -> CreateRLSFilterResponse:
+    """Create a row-level security (RLS) filter rule.
+
+    RLS filters restrict which rows users can see based on their role membership.
+    Use this to enforce data access policies at the row level.
+
+    Filter types:
+    - "Regular": Hides rows from the specified roles unless the clause matches.
+    - "Base": Shows only rows where the clause matches to the specified roles.
+
+    Workflow:
+    1. Use list_datasets to find the table IDs to protect.
+    2. Use find_users to locate role IDs to apply the filter to.
+    3. Call this tool with the SQL WHERE clause to enforce.
+    """
+    await ctx.info(
+        "Creating RLS filter: name=%r, filter_type=%r, tables=%s"
+        % (request.name, request.filter_type, request.tables)
+    )
+
+    try:
+        from superset.commands.exceptions import (
+            DatasourceNotFoundValidationError,
+            RolesNotFoundValidationError,
+        )
+        from superset.commands.security.create import CreateRLSRuleCommand
+
+        properties: dict[str, object] = {
+            "name": request.name,
+            "filter_type": request.filter_type,
+            "tables": request.tables,
+            "roles": request.roles,
+            "clause": request.clause,
+        }
+        if request.group_key is not None:
+            properties["group_key"] = request.group_key
+        if request.description is not None:
+            properties["description"] = request.description
+
+        with event_logger.log_context(action="mcp.create_rls_filter.create"):
+            rls_rule = CreateRLSRuleCommand(properties).run()
+
+        table_ids = [t.id for t in getattr(rls_rule, "tables", [])]
+        role_ids = [r.id for r in getattr(rls_rule, "roles", [])]
+
+        await ctx.info(
+            "RLS filter created: id=%s, name=%r" % (rls_rule.id, rls_rule.name)
+        )
+
+        return CreateRLSFilterResponse(
+            id=rls_rule.id,
+            name=rls_rule.name,
+            filter_type=rls_rule.filter_type,
+            clause=rls_rule.clause,
+            tables=table_ids,
+            roles=role_ids,
+            group_key=getattr(rls_rule, "group_key", None),
+            description=getattr(rls_rule, "description", None),
+        )
+
+    except RolesNotFoundValidationError as exc:
+        await ctx.warning("Role not found while creating RLS filter: %s" % (str(exc),))
+        return CreateRLSFilterResponse(
+            id=None,
+            name=request.name,
+            filter_type=request.filter_type,
+            clause=request.clause,
+            tables=request.tables,
+            roles=request.roles,
+            error=str(exc),
+        )
+    except DatasourceNotFoundValidationError as exc:
+        await ctx.warning("Table not found while creating RLS filter: %s" % (str(exc),))
+        return CreateRLSFilterResponse(
+            id=None,
+            name=request.name,
+            filter_type=request.filter_type,
+            clause=request.clause,
+            tables=request.tables,
+            roles=request.roles,
+            error=str(exc),
+        )
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error creating RLS filter: %s: %s"
+            % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/rls/tool/create_rls_filter.py
+++ b/superset/mcp_service/rls/tool/create_rls_filter.py
@@ -23,7 +23,7 @@ from superset_core.mcp.decorators import tool, ToolAnnotations
 from superset.extensions import event_logger
 from superset.mcp_service.rls.schemas import (
     CreateRLSFilterRequest,
-    CreateRLSFilterResponse,
+    RLSFilterResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -41,19 +41,21 @@ logger = logging.getLogger(__name__)
 )
 async def create_rls_filter(
     request: CreateRLSFilterRequest, ctx: Context
-) -> CreateRLSFilterResponse:
+) -> RLSFilterResponse:
     """Create a row-level security (RLS) filter rule.
 
     RLS filters restrict which rows users can see based on their role membership.
     Use this to enforce data access policies at the row level.
 
     Filter types:
-    - "Regular": Hides rows from the specified roles unless the clause matches.
-    - "Base": Shows only rows where the clause matches to the specified roles.
+    - "Regular": Applies the clause only to users with the specified roles
+      (those roles see only matching rows; all other users see all rows).
+    - "Base": Applies the clause to ALL users EXCEPT users with the specified
+      roles (those roles bypass the filter and see all rows).
 
     Workflow:
     1. Use list_datasets to find the table IDs to protect.
-    2. Use find_users to locate role IDs to apply the filter to.
+    2. Look up role IDs from the Superset Roles admin page (/roles/list/).
     3. Call this tool with the SQL WHERE clause to enforce.
     """
     await ctx.info(
@@ -90,7 +92,7 @@ async def create_rls_filter(
             "RLS filter created: id=%s, name=%r" % (rls_rule.id, rls_rule.name)
         )
 
-        return CreateRLSFilterResponse(
+        return RLSFilterResponse(
             id=rls_rule.id,
             name=rls_rule.name,
             filter_type=rls_rule.filter_type,
@@ -103,7 +105,7 @@ async def create_rls_filter(
 
     except RolesNotFoundValidationError as exc:
         await ctx.warning("Role not found while creating RLS filter: %s" % (str(exc),))
-        return CreateRLSFilterResponse(
+        return RLSFilterResponse(
             id=None,
             name=request.name,
             filter_type=request.filter_type,
@@ -114,7 +116,7 @@ async def create_rls_filter(
         )
     except DatasourceNotFoundValidationError as exc:
         await ctx.warning("Table not found while creating RLS filter: %s" % (str(exc),))
-        return CreateRLSFilterResponse(
+        return RLSFilterResponse(
             id=None,
             name=request.name,
             filter_type=request.filter_type,

--- a/superset/mcp_service/rls/tool/update_rls_filter.py
+++ b/superset/mcp_service/rls/tool/update_rls_filter.py
@@ -1,0 +1,147 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.rls.schemas import (
+    CreateRLSFilterResponse,
+    UpdateRLSFilterRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _build_update_properties(
+    request: UpdateRLSFilterRequest, existing: Any
+) -> dict[str, object]:
+    """Build the properties dict for UpdateRLSRuleCommand from a partial request.
+
+    Omitted fields default to their current values from ``existing`` so the
+    caller only needs to specify what changed.
+    """
+    set_fields = request.model_fields_set
+    properties: dict[str, object] = {}
+
+    for field in ("name", "filter_type", "clause"):
+        value = getattr(request, field)
+        if field in set_fields and value is not None:
+            properties[field] = value
+
+    for field in ("group_key", "description"):
+        if field in set_fields:
+            properties[field] = getattr(request, field)
+
+    if "tables" in set_fields and request.tables is not None:
+        properties["tables"] = request.tables
+    else:
+        properties["tables"] = [t.id for t in getattr(existing, "tables", [])]
+
+    if "roles" in set_fields and request.roles is not None:
+        properties["roles"] = request.roles
+    else:
+        properties["roles"] = [r.id for r in getattr(existing, "roles", [])]
+
+    return properties
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="Row Level Security",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Update RLS filter",
+        readOnlyHint=False,
+        destructiveHint=True,
+    ),
+)
+async def update_rls_filter(
+    request: UpdateRLSFilterRequest, ctx: Context
+) -> CreateRLSFilterResponse:
+    """Update an existing row-level security (RLS) filter rule.
+
+    Only the fields you provide are updated; omitted fields retain their
+    current values. To explicitly clear a list field, pass an empty list
+    (e.g. tables=[] removes all table associations).
+
+    Use create_rls_filter to create a new rule, or find the rule id from
+    the Row Level Security admin page.
+    """
+    await ctx.info("Updating RLS filter: id=%s" % (request.id,))
+
+    try:
+        from superset.commands.exceptions import (
+            DatasourceNotFoundValidationError,
+            RolesNotFoundValidationError,
+        )
+        from superset.commands.security.exceptions import RLSRuleNotFoundError
+        from superset.commands.security.update import UpdateRLSRuleCommand
+        from superset.daos.security import RLSDAO
+
+        existing = RLSDAO.find_by_id(request.id)
+        if not existing:
+            await ctx.warning("RLS filter not found: id=%s" % (request.id,))
+            return CreateRLSFilterResponse(
+                id=None,
+                error=f"RLS filter with id={request.id} not found.",
+            )
+
+        properties = _build_update_properties(request, existing)
+
+        with event_logger.log_context(action="mcp.update_rls_filter.update"):
+            rls_rule = UpdateRLSRuleCommand(request.id, properties).run()
+
+        table_ids = [t.id for t in getattr(rls_rule, "tables", [])]
+        role_ids = [r.id for r in getattr(rls_rule, "roles", [])]
+
+        await ctx.info(
+            "RLS filter updated: id=%s, name=%r" % (rls_rule.id, rls_rule.name)
+        )
+
+        return CreateRLSFilterResponse(
+            id=rls_rule.id,
+            name=rls_rule.name,
+            filter_type=rls_rule.filter_type,
+            clause=rls_rule.clause,
+            tables=table_ids,
+            roles=role_ids,
+            group_key=getattr(rls_rule, "group_key", None),
+            description=getattr(rls_rule, "description", None),
+        )
+
+    except RLSRuleNotFoundError:
+        await ctx.warning("RLS filter not found: id=%s" % (request.id,))
+        return CreateRLSFilterResponse(
+            id=None,
+            error=f"RLS filter with id={request.id} not found.",
+        )
+    except RolesNotFoundValidationError as exc:
+        await ctx.warning("Role not found while updating RLS filter: %s" % (str(exc),))
+        return CreateRLSFilterResponse(id=None, error=str(exc))
+    except DatasourceNotFoundValidationError as exc:
+        await ctx.warning("Table not found while updating RLS filter: %s" % (str(exc),))
+        return CreateRLSFilterResponse(id=None, error=str(exc))
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error updating RLS filter: %s: %s"
+            % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/rls/tool/update_rls_filter.py
+++ b/superset/mcp_service/rls/tool/update_rls_filter.py
@@ -23,7 +23,7 @@ from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
 from superset.mcp_service.rls.schemas import (
-    CreateRLSFilterResponse,
+    RLSFilterResponse,
     UpdateRLSFilterRequest,
 )
 
@@ -75,7 +75,7 @@ def _build_update_properties(
 )
 async def update_rls_filter(
     request: UpdateRLSFilterRequest, ctx: Context
-) -> CreateRLSFilterResponse:
+) -> RLSFilterResponse:
     """Update an existing row-level security (RLS) filter rule.
 
     Only the fields you provide are updated; omitted fields retain their
@@ -99,7 +99,7 @@ async def update_rls_filter(
         existing = RLSDAO.find_by_id(request.id)
         if not existing:
             await ctx.warning("RLS filter not found: id=%s" % (request.id,))
-            return CreateRLSFilterResponse(
+            return RLSFilterResponse(
                 id=None,
                 error=f"RLS filter with id={request.id} not found.",
             )
@@ -116,7 +116,7 @@ async def update_rls_filter(
             "RLS filter updated: id=%s, name=%r" % (rls_rule.id, rls_rule.name)
         )
 
-        return CreateRLSFilterResponse(
+        return RLSFilterResponse(
             id=rls_rule.id,
             name=rls_rule.name,
             filter_type=rls_rule.filter_type,
@@ -129,16 +129,16 @@ async def update_rls_filter(
 
     except RLSRuleNotFoundError:
         await ctx.warning("RLS filter not found: id=%s" % (request.id,))
-        return CreateRLSFilterResponse(
+        return RLSFilterResponse(
             id=None,
             error=f"RLS filter with id={request.id} not found.",
         )
     except RolesNotFoundValidationError as exc:
         await ctx.warning("Role not found while updating RLS filter: %s" % (str(exc),))
-        return CreateRLSFilterResponse(id=None, error=str(exc))
+        return RLSFilterResponse(id=None, error=str(exc))
     except DatasourceNotFoundValidationError as exc:
         await ctx.warning("Table not found while updating RLS filter: %s" % (str(exc),))
-        return CreateRLSFilterResponse(id=None, error=str(exc))
+        return RLSFilterResponse(id=None, error=str(exc))
     except Exception as exc:
         await ctx.error(
             "Unexpected error updating RLS filter: %s: %s"

--- a/tests/unit_tests/mcp_service/rls/tool/test_create_rls_filter.py
+++ b/tests/unit_tests/mcp_service/rls/tool/test_create_rls_filter.py
@@ -87,6 +87,22 @@ _BASE_REQUEST = {
 }
 
 
+def test_create_rls_filter_name_too_long() -> None:
+    """CreateRLSFilterRequest rejects names longer than 255 characters."""
+    from pydantic import ValidationError
+
+    from superset.mcp_service.rls.schemas import CreateRLSFilterRequest
+
+    with pytest.raises(ValidationError):
+        CreateRLSFilterRequest(
+            name="x" * 256,
+            filter_type="Regular",
+            tables=[1],
+            roles=[2],
+            clause="region = 'EMEA'",
+        )
+
+
 @patch("superset.commands.security.create.CreateRLSRuleCommand")
 @pytest.mark.asyncio
 async def test_create_rls_filter_success(

--- a/tests/unit_tests/mcp_service/rls/tool/test_create_rls_filter.py
+++ b/tests/unit_tests/mcp_service/rls/tool/test_create_rls_filter.py
@@ -1,0 +1,198 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for the create_rls_filter MCP tool.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+
+
+@pytest.fixture
+def mcp_server() -> object:
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        user = MagicMock()
+        user.id = 1
+        user.username = "admin"
+        mock_get_user.return_value = user
+        yield mock_get_user
+
+
+def _make_rls_rule(
+    id: int = 42,
+    name: str = "EMEA filter",
+    filter_type: str = "Regular",
+    clause: str = "region = 'EMEA'",
+    table_ids: list[int] | None = None,
+    role_ids: list[int] | None = None,
+) -> MagicMock:
+    rule = MagicMock()
+    rule.id = id
+    rule.name = name
+    rule.filter_type = filter_type
+    rule.clause = clause
+
+    table_ids = table_ids or [1]
+    role_ids = role_ids or [2]
+
+    tables = []
+    for tid in table_ids:
+        t = MagicMock()
+        t.id = tid
+        tables.append(t)
+    rule.tables = tables
+
+    roles = []
+    for rid in role_ids:
+        r = MagicMock()
+        r.id = rid
+        roles.append(r)
+    rule.roles = roles
+
+    rule.group_key = None
+    rule.description = None
+    return rule
+
+
+_BASE_REQUEST = {
+    "name": "EMEA filter",
+    "filter_type": "Regular",
+    "tables": [1],
+    "roles": [2],
+    "clause": "region = 'EMEA'",
+}
+
+
+@patch("superset.commands.security.create.CreateRLSRuleCommand")
+@pytest.mark.asyncio
+async def test_create_rls_filter_success(
+    mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Happy path: returns id, name, filter_type, clause, and table/role IDs."""
+    rule = _make_rls_rule()
+    mock_cmd = MagicMock()
+    mock_cmd.run.return_value = rule
+    mock_cmd_cls.return_value = mock_cmd
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("create_rls_filter", {"request": _BASE_REQUEST})
+
+    data = result.structured_content
+    assert data["id"] == 42
+    assert data["name"] == "EMEA filter"
+    assert data["filter_type"] == "Regular"
+    assert data["clause"] == "region = 'EMEA'"
+    assert data["tables"] == [1]
+    assert data["roles"] == [2]
+    assert data["error"] is None
+
+
+@patch("superset.commands.security.create.CreateRLSRuleCommand")
+@pytest.mark.asyncio
+async def test_create_rls_filter_role_not_found(
+    mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Returns structured error when a role ID does not exist."""
+    from superset.commands.exceptions import RolesNotFoundValidationError
+
+    mock_cmd = MagicMock()
+    mock_cmd.run.side_effect = RolesNotFoundValidationError()
+    mock_cmd_cls.return_value = mock_cmd
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("create_rls_filter", {"request": _BASE_REQUEST})
+
+    data = result.structured_content
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+@patch("superset.commands.security.create.CreateRLSRuleCommand")
+@pytest.mark.asyncio
+async def test_create_rls_filter_table_not_found(
+    mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Returns structured error when a table ID does not exist."""
+    from superset.commands.exceptions import DatasourceNotFoundValidationError
+
+    mock_cmd = MagicMock()
+    mock_cmd.run.side_effect = DatasourceNotFoundValidationError()
+    mock_cmd_cls.return_value = mock_cmd
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("create_rls_filter", {"request": _BASE_REQUEST})
+
+    data = result.structured_content
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+@patch("superset.commands.security.create.CreateRLSRuleCommand")
+@pytest.mark.asyncio
+async def test_create_rls_filter_base_type(
+    mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Base filter type is stored and returned correctly."""
+    rule = _make_rls_rule(filter_type="Base")
+    mock_cmd = MagicMock()
+    mock_cmd.run.return_value = rule
+    mock_cmd_cls.return_value = mock_cmd
+
+    request = {**_BASE_REQUEST, "filter_type": "Base"}
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("create_rls_filter", {"request": request})
+
+    data = result.structured_content
+    assert data["filter_type"] == "Base"
+    assert data["error"] is None
+
+
+@patch("superset.commands.security.create.CreateRLSRuleCommand")
+@pytest.mark.asyncio
+async def test_create_rls_filter_with_optional_fields(
+    mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Optional group_key and description are included in the response."""
+    rule = _make_rls_rule()
+    rule.group_key = "geo"
+    rule.description = "Restrict to EMEA region"
+    mock_cmd = MagicMock()
+    mock_cmd.run.return_value = rule
+    mock_cmd_cls.return_value = mock_cmd
+
+    request = {
+        **_BASE_REQUEST,
+        "group_key": "geo",
+        "description": "Restrict to EMEA region",
+    }
+    async with Client(mcp_server) as client:
+        result = await client.call_tool("create_rls_filter", {"request": request})
+
+    data = result.structured_content
+    assert data["group_key"] == "geo"
+    assert data["description"] == "Restrict to EMEA region"
+    assert data["error"] is None

--- a/tests/unit_tests/mcp_service/rls/tool/test_update_rls_filter.py
+++ b/tests/unit_tests/mcp_service/rls/tool/test_update_rls_filter.py
@@ -179,6 +179,56 @@ async def test_update_rls_filter_table_not_found(
     assert data["error"] is not None
 
 
+def test_update_rls_filter_name_too_long() -> None:
+    """UpdateRLSFilterRequest rejects names longer than 255 characters."""
+    from pydantic import ValidationError
+
+    from superset.mcp_service.rls.schemas import UpdateRLSFilterRequest
+
+    with pytest.raises(ValidationError):
+        UpdateRLSFilterRequest(id=1, name="x" * 256)
+
+
+def test_update_rls_filter_explicit_null_name() -> None:
+    """Explicit null for 'name' raises a validation error."""
+    from pydantic import ValidationError
+
+    from superset.mcp_service.rls.schemas import UpdateRLSFilterRequest
+
+    with pytest.raises(ValidationError, match="name"):
+        UpdateRLSFilterRequest.model_validate({"id": 1, "name": None})
+
+
+def test_update_rls_filter_explicit_null_clause() -> None:
+    """Explicit null for 'clause' raises a validation error."""
+    from pydantic import ValidationError
+
+    from superset.mcp_service.rls.schemas import UpdateRLSFilterRequest
+
+    with pytest.raises(ValidationError, match="clause"):
+        UpdateRLSFilterRequest.model_validate({"id": 1, "clause": None})
+
+
+def test_update_rls_filter_explicit_null_tables() -> None:
+    """Explicit null for 'tables' raises a validation error."""
+    from pydantic import ValidationError
+
+    from superset.mcp_service.rls.schemas import UpdateRLSFilterRequest
+
+    with pytest.raises(ValidationError, match="tables"):
+        UpdateRLSFilterRequest.model_validate({"id": 1, "tables": None})
+
+
+def test_update_rls_filter_explicit_null_roles() -> None:
+    """Explicit null for 'roles' raises a validation error."""
+    from pydantic import ValidationError
+
+    from superset.mcp_service.rls.schemas import UpdateRLSFilterRequest
+
+    with pytest.raises(ValidationError, match="roles"):
+        UpdateRLSFilterRequest.model_validate({"id": 1, "roles": None})
+
+
 @patch("superset.commands.security.update.UpdateRLSRuleCommand")
 @patch("superset.daos.security.RLSDAO")
 @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/rls/tool/test_update_rls_filter.py
+++ b/tests/unit_tests/mcp_service/rls/tool/test_update_rls_filter.py
@@ -1,0 +1,206 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for the update_rls_filter MCP tool.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+
+
+@pytest.fixture
+def mcp_server() -> object:
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        user = MagicMock()
+        user.id = 1
+        user.username = "admin"
+        mock_get_user.return_value = user
+        yield mock_get_user
+
+
+def _make_rls_rule(
+    id: int = 42,
+    name: str = "EMEA filter",
+    filter_type: str = "Regular",
+    clause: str = "region = 'EMEA'",
+    table_ids: list[int] | None = None,
+    role_ids: list[int] | None = None,
+) -> MagicMock:
+    rule = MagicMock()
+    rule.id = id
+    rule.name = name
+    rule.filter_type = filter_type
+    rule.clause = clause
+
+    table_ids = table_ids or [1]
+    role_ids = role_ids or [2]
+
+    tables = []
+    for tid in table_ids:
+        t = MagicMock()
+        t.id = tid
+        tables.append(t)
+    rule.tables = tables
+
+    roles = []
+    for rid in role_ids:
+        r = MagicMock()
+        r.id = rid
+        roles.append(r)
+    rule.roles = roles
+
+    rule.group_key = None
+    rule.description = None
+    return rule
+
+
+@patch("superset.commands.security.update.UpdateRLSRuleCommand")
+@patch("superset.daos.security.RLSDAO")
+@pytest.mark.asyncio
+async def test_update_rls_filter_success(
+    mock_dao: MagicMock, mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Happy path: returns updated id, name, and changed clause."""
+    existing = _make_rls_rule()
+    mock_dao.find_by_id.return_value = existing
+
+    updated = _make_rls_rule(clause="region = 'APAC'")
+    mock_cmd = MagicMock()
+    mock_cmd.run.return_value = updated
+    mock_cmd_cls.return_value = mock_cmd
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "update_rls_filter",
+            {"request": {"id": 42, "clause": "region = 'APAC'"}},
+        )
+
+    data = result.structured_content
+    assert data["id"] == 42
+    assert data["clause"] == "region = 'APAC'"
+    assert data["error"] is None
+
+
+@patch("superset.daos.security.RLSDAO")
+@pytest.mark.asyncio
+async def test_update_rls_filter_not_found(
+    mock_dao: MagicMock, mcp_server: object
+) -> None:
+    """Returns a structured error when the RLS rule ID does not exist."""
+    mock_dao.find_by_id.return_value = None
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "update_rls_filter",
+            {"request": {"id": 999}},
+        )
+
+    data = result.structured_content
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "999" in (data["error"] or "")
+
+
+@patch("superset.commands.security.update.UpdateRLSRuleCommand")
+@patch("superset.daos.security.RLSDAO")
+@pytest.mark.asyncio
+async def test_update_rls_filter_role_not_found(
+    mock_dao: MagicMock, mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Returns structured error when a role ID does not exist."""
+    from superset.commands.exceptions import RolesNotFoundValidationError
+
+    existing = _make_rls_rule()
+    mock_dao.find_by_id.return_value = existing
+
+    mock_cmd = MagicMock()
+    mock_cmd.run.side_effect = RolesNotFoundValidationError()
+    mock_cmd_cls.return_value = mock_cmd
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "update_rls_filter",
+            {"request": {"id": 42, "roles": [9999]}},
+        )
+
+    data = result.structured_content
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+@patch("superset.commands.security.update.UpdateRLSRuleCommand")
+@patch("superset.daos.security.RLSDAO")
+@pytest.mark.asyncio
+async def test_update_rls_filter_table_not_found(
+    mock_dao: MagicMock, mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Returns structured error when a table ID does not exist."""
+    from superset.commands.exceptions import DatasourceNotFoundValidationError
+
+    existing = _make_rls_rule()
+    mock_dao.find_by_id.return_value = existing
+
+    mock_cmd = MagicMock()
+    mock_cmd.run.side_effect = DatasourceNotFoundValidationError()
+    mock_cmd_cls.return_value = mock_cmd
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "update_rls_filter",
+            {"request": {"id": 42, "tables": [9999]}},
+        )
+
+    data = result.structured_content
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+@patch("superset.commands.security.update.UpdateRLSRuleCommand")
+@patch("superset.daos.security.RLSDAO")
+@pytest.mark.asyncio
+async def test_update_rls_filter_partial_update(
+    mock_dao: MagicMock, mock_cmd_cls: MagicMock, mcp_server: object
+) -> None:
+    """Omitted fields retain existing values; only the changed field is updated."""
+    existing = _make_rls_rule(name="Old name", clause="region = 'EMEA'")
+    mock_dao.find_by_id.return_value = existing
+
+    updated = _make_rls_rule(name="New name", clause="region = 'EMEA'")
+    mock_cmd = MagicMock()
+    mock_cmd.run.return_value = updated
+    mock_cmd_cls.return_value = mock_cmd
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "update_rls_filter",
+            {"request": {"id": 42, "name": "New name"}},
+        )
+
+    data = result.structured_content
+    assert data["name"] == "New name"
+    assert data["clause"] == "region = 'EMEA'"
+    assert data["error"] is None


### PR DESCRIPTION
### SUMMARY

Adds two admin-only MCP mutation tools for managing row-level security (RLS) filter rules.

**`create_rls_filter`** — creates a new RLS rule:
- Required: `name`, `filter_type` ("Regular" or "Base"), `tables` (list of table IDs), `roles` (list of role IDs), `clause` (SQL WHERE clause)
- Optional: `group_key`, `description`
- Uses `CreateRLSRuleCommand` — the same command as `POST /api/v1/rowlevelsecurity/`

**`update_rls_filter`** — partially updates an existing rule by `id`:
- Omitted fields retain their current values (pre-fetch pattern via RLSDAO)
- Pass `tables=[]` or `roles=[]` to explicitly clear associations
- Uses `UpdateRLSRuleCommand` — the same command as `PUT /api/v1/rowlevelsecurity/{pk}`

Both tools:
- Tagged `mutate` with `readOnlyHint=False`
- Require `Row Level Security` write permission (`class_permission_name="Row Level Security"`)
- Located in `superset/mcp_service/rls/` following the existing module structure
- Return structured error responses (not exceptions) for validation failures (role/table not found, rule not found)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only MCP tools.

### TESTING INSTRUCTIONS

**create_rls_filter:**
1. Start the Superset MCP server
2. Connect an MCP client with admin credentials
3. Call `create_rls_filter` with:
   ```json
   {
     "name": "EMEA filter",
     "filter_type": "Regular",
     "tables": [<valid_table_id>],
     "roles": [<valid_role_id>],
     "clause": "region = 'EMEA'"
   }
   ```
4. Verify the filter appears under Security → Row Level Security

**update_rls_filter:**
1. Using the `id` from the create step above, call `update_rls_filter`:
   ```json
   {"id": <id>, "clause": "region = 'APAC'"}
   ```
2. Verify only the clause changed; tables and roles are preserved
3. Test `tables=[]` to verify it clears table associations

**Error cases:**
- Invalid table ID → `error` field with `DatasourceNotFoundValidationError` message
- Invalid role ID → `error` field with `RolesNotFoundValidationError` message
- Non-existent filter ID (update) → `error` field with not-found message

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API