### PR TITLE
feat(mcp): add create_plugin and update_plugin tools

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -722,9 +722,13 @@ from superset.mcp_service.explore.tool import (  # noqa: F401, E402
     generate_explore_link,
 )
 from superset.mcp_service.plugin.tool import (  # noqa: F401, E402
-    create_plugin,
     get_plugin_info,
     list_plugins,
+)
+from superset.mcp_service.plugin.tool.create_plugin import (  # noqa: F401, E402
+    create_plugin,
+)
+from superset.mcp_service.plugin.tool.update_plugin import (  # noqa: F401, E402
     update_plugin,
 )
 from superset.mcp_service.query.tool import (  # noqa: F401, E402

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -143,6 +143,7 @@ Tag Management:
 
 Plugin Management:
 - create_plugin: Register a new dynamic plugin by name, key, and bundle URL (requires DynamicPlugin write permission and DYNAMIC_PLUGINS feature flag)
+- update_plugin: Update an existing dynamic plugin's name, key, or bundle URL by ID (requires DynamicPlugin write permission and DYNAMIC_PLUGINS feature flag)
 
 Database Connections:
 - list_databases: List database connections with advanced filters (1-based pagination)
@@ -724,6 +725,7 @@ from superset.mcp_service.plugin.tool import (  # noqa: F401, E402
     create_plugin,
     get_plugin_info,
     list_plugins,
+    update_plugin,
 )
 from superset.mcp_service.query.tool import (  # noqa: F401, E402
     get_query_info,

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -141,6 +141,9 @@ Tag Management:
 - list_tags: List tags with advanced filters (1-based pagination)
 - get_tag_info: Get detailed tag information by ID
 
+Plugin Management:
+- create_plugin: Register a new dynamic plugin by name, key, and bundle URL (requires DynamicPlugin write permission and DYNAMIC_PLUGINS feature flag)
+
 Database Connections:
 - list_databases: List database connections with advanced filters (1-based pagination)
 - get_database_info: Get detailed database connection info by ID (backend, capabilities)
@@ -718,6 +721,7 @@ from superset.mcp_service.explore.tool import (  # noqa: F401, E402
     generate_explore_link,
 )
 from superset.mcp_service.plugin.tool import (  # noqa: F401, E402
+    create_plugin,
     get_plugin_info,
     list_plugins,
 )

--- a/superset/mcp_service/plugin/schemas.py
+++ b/superset/mcp_service/plugin/schemas.py
@@ -241,7 +241,7 @@ class CreatePluginRequest(BaseModel):
         max_length=_URL_MAX,
         description=(
             "Full URL pointing to the built plugin bundle "
-            "(e.g. a CDN-hosted JavaScript file)."
+            "(e.g. a CDN-hosted JavaScript file). Must use http or https scheme."
         ),
     )
 
@@ -286,11 +286,13 @@ class UpdatePluginRequest(BaseModel):
     name: str | None = Field(
         None,
         min_length=1,
+        max_length=_NAME_MAX,
         description="New human-friendly name for the plugin.",
     )
     key: str | None = Field(
         None,
         min_length=1,
+        max_length=_KEY_MAX,
         description=(
             "New unique plugin key. Should match the package name from the "
             "plugin's package.json (e.g. '@my-org/my-chart-plugin')."
@@ -299,18 +301,31 @@ class UpdatePluginRequest(BaseModel):
     bundle_url: str | None = Field(
         None,
         min_length=1,
+        max_length=_URL_MAX,
         description=(
             "New full URL pointing to the built plugin bundle "
-            "(e.g. a CDN-hosted JavaScript file)."
+            "(e.g. a CDN-hosted JavaScript file). Must use http or https scheme."
         ),
     )
 
-    @field_validator("name", "key", "bundle_url")
+    @field_validator("name", "key")
     @classmethod
     def must_not_be_blank(cls, v: str | None) -> str | None:
         if v is not None and not v.strip():
             raise ValueError("Field must not be blank")
         return v.strip() if v is not None else v
+
+    @field_validator("bundle_url")
+    @classmethod
+    def validate_bundle_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            raise ValueError("Field must not be blank")
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("bundle_url must use http or https scheme")
+        return v
 
     @model_validator(mode="after")
     def at_least_one_field(self) -> "UpdatePluginRequest":

--- a/superset/mcp_service/plugin/schemas.py
+++ b/superset/mcp_service/plugin/schemas.py
@@ -42,6 +42,10 @@ from superset.mcp_service.utils.schema_utils import (
     parse_json_or_model_list,
 )
 
+_NAME_MAX = 50
+_KEY_MAX = 50
+_URL_MAX = 1000
+
 DEFAULT_PLUGIN_COLUMNS = ["id", "name", "key", "bundle_url"]
 
 ALL_PLUGIN_COLUMNS = [
@@ -210,4 +214,66 @@ def serialize_plugin_object(plugin: Any) -> PluginInfo | None:
         bundle_url=getattr(plugin, "bundle_url", None),
         changed_on=getattr(plugin, "changed_on", None),
         created_on=getattr(plugin, "created_on", None),
+    )
+
+
+class CreatePluginRequest(BaseModel):
+    """Request schema for create_plugin."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=_NAME_MAX,
+        description="Human-friendly name for the plugin.",
+    )
+    key: str = Field(
+        ...,
+        min_length=1,
+        max_length=_KEY_MAX,
+        description=(
+            "Unique plugin key. Should match the package name from the plugin's "
+            "package.json (e.g. '@my-org/my-chart-plugin')."
+        ),
+    )
+    bundle_url: str = Field(
+        ...,
+        min_length=1,
+        max_length=_URL_MAX,
+        description=(
+            "Full URL pointing to the built plugin bundle "
+            "(e.g. a CDN-hosted JavaScript file)."
+        ),
+    )
+
+    @field_validator("name", "key")
+    @classmethod
+    def must_not_be_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Field must not be blank")
+        return v.strip()
+
+    @field_validator("bundle_url")
+    @classmethod
+    def validate_bundle_url(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Field must not be blank")
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("bundle_url must use http or https scheme")
+        return v
+
+
+class CreatePluginResponse(BaseModel):
+    """Response schema for create_plugin."""
+
+    id: int | None = Field(
+        None,
+        description="ID of the newly created plugin. None if creation failed.",
+    )
+    name: str | None = Field(None, description="Plugin name.")
+    key: str | None = Field(None, description="Plugin key.")
+    bundle_url: str | None = Field(None, description="Plugin bundle URL.")
+    error: str | None = Field(
+        None,
+        description="Error message if creation failed, otherwise null.",
     )

--- a/superset/mcp_service/plugin/schemas.py
+++ b/superset/mcp_service/plugin/schemas.py
@@ -277,3 +277,61 @@ class CreatePluginResponse(BaseModel):
         None,
         description="Error message if creation failed, otherwise null.",
     )
+
+
+class UpdatePluginRequest(BaseModel):
+    """Request schema for update_plugin."""
+
+    id: int = Field(..., description="ID of the plugin to update.")
+    name: str | None = Field(
+        None,
+        min_length=1,
+        description="New human-friendly name for the plugin.",
+    )
+    key: str | None = Field(
+        None,
+        min_length=1,
+        description=(
+            "New unique plugin key. Should match the package name from the "
+            "plugin's package.json (e.g. '@my-org/my-chart-plugin')."
+        ),
+    )
+    bundle_url: str | None = Field(
+        None,
+        min_length=1,
+        description=(
+            "New full URL pointing to the built plugin bundle "
+            "(e.g. a CDN-hosted JavaScript file)."
+        ),
+    )
+
+    @field_validator("name", "key", "bundle_url")
+    @classmethod
+    def must_not_be_blank(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("Field must not be blank")
+        return v.strip() if v is not None else v
+
+    @model_validator(mode="after")
+    def at_least_one_field(self) -> "UpdatePluginRequest":
+        if self.name is None and self.key is None and self.bundle_url is None:
+            raise ValueError(
+                "At least one of 'name', 'key', or 'bundle_url' must be provided."
+            )
+        return self
+
+
+class UpdatePluginResponse(BaseModel):
+    """Response schema for update_plugin."""
+
+    id: int | None = Field(
+        None,
+        description="ID of the updated plugin. None if the update failed.",
+    )
+    name: str | None = Field(None, description="Plugin name.")
+    key: str | None = Field(None, description="Plugin key.")
+    bundle_url: str | None = Field(None, description="Plugin bundle URL.")
+    error: str | None = Field(
+        None,
+        description="Error message if update failed, otherwise null.",
+    )

--- a/superset/mcp_service/plugin/tool/__init__.py
+++ b/superset/mcp_service/plugin/tool/__init__.py
@@ -18,9 +18,11 @@
 from .create_plugin import create_plugin
 from .get_plugin_info import get_plugin_info
 from .list_plugins import list_plugins
+from .update_plugin import update_plugin
 
 __all__ = [
     "create_plugin",
-    "list_plugins",
     "get_plugin_info",
+    "list_plugins",
+    "update_plugin",
 ]

--- a/superset/mcp_service/plugin/tool/__init__.py
+++ b/superset/mcp_service/plugin/tool/__init__.py
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .create_plugin import create_plugin
 from .get_plugin_info import get_plugin_info
 from .list_plugins import list_plugins
 
 __all__ = [
+    "create_plugin",
     "list_plugins",
     "get_plugin_info",
 ]

--- a/superset/mcp_service/plugin/tool/__init__.py
+++ b/superset/mcp_service/plugin/tool/__init__.py
@@ -15,10 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .create_plugin import create_plugin
 from .get_plugin_info import get_plugin_info
 from .list_plugins import list_plugins
-from .update_plugin import update_plugin
 
 __all__ = [
     "create_plugin",

--- a/superset/mcp_service/plugin/tool/create_plugin.py
+++ b/superset/mcp_service/plugin/tool/create_plugin.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.plugin.schemas import (
+    CreatePluginRequest,
+    CreatePluginResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="DynamicPlugin",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Register a dynamic plugin",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_plugin(
+    request: CreatePluginRequest, ctx: Context
+) -> CreatePluginResponse:
+    """Register a new dynamic (custom) plugin in Superset.
+
+    Requires the DYNAMIC_PLUGINS feature flag to be enabled and admin write
+    access to DynamicPlugin. The ``key`` must match the package name from the
+    plugin's package.json and be unique across all registered plugins.
+
+    After registration, Superset will load the plugin bundle from ``bundle_url``
+    on the next page load.
+    """
+    await ctx.info(
+        "Registering dynamic plugin: name=%r, key=%r" % (request.name, request.key)
+    )
+
+    try:
+        from sqlalchemy.exc import IntegrityError
+
+        from superset import is_feature_enabled
+        from superset.extensions import db
+        from superset.models.dynamic_plugins import DynamicPlugin
+
+        if not is_feature_enabled("DYNAMIC_PLUGINS"):
+            await ctx.warning("DYNAMIC_PLUGINS feature flag is not enabled")
+            return CreatePluginResponse(
+                error=(
+                    "The DYNAMIC_PLUGINS feature flag is not enabled on this instance."
+                )
+            )
+
+        with event_logger.log_context(action="mcp.create_plugin.create"):
+            plugin = DynamicPlugin(
+                name=request.name,
+                key=request.key,
+                bundle_url=request.bundle_url,
+            )
+            db.session.add(plugin)
+            db.session.commit()
+
+        await ctx.info(
+            "Dynamic plugin registered: id=%s, key=%r" % (plugin.id, plugin.key)
+        )
+
+        return CreatePluginResponse(
+            id=plugin.id,
+            name=plugin.name,
+            key=plugin.key,
+            bundle_url=plugin.bundle_url,
+        )
+
+    except IntegrityError as exc:
+        db.session.rollback()
+        msg = str(exc.orig) if exc.orig else str(exc)
+        await ctx.warning("Plugin creation failed (duplicate field): %s" % (msg,))
+        return CreatePluginResponse(
+            error=(
+                "A plugin with the same name, key, or bundle_url already exists. "
+                "Each field must be unique."
+            )
+        )
+    except Exception as exc:
+        db.session.rollback()
+        await ctx.error(
+            "Unexpected error creating plugin: %s: %s" % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/plugin/tool/create_plugin.py
+++ b/superset/mcp_service/plugin/tool/create_plugin.py
@@ -15,18 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
-
 from fastmcp import Context
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.extensions import event_logger
+from superset import is_feature_enabled
+from superset.extensions import db, event_logger
 from superset.mcp_service.plugin.schemas import (
     CreatePluginRequest,
     CreatePluginResponse,
 )
-
-logger = logging.getLogger(__name__)
+from superset.models.dynamic_plugins import DynamicPlugin
 
 
 @tool(
@@ -44,8 +43,8 @@ async def create_plugin(
 ) -> CreatePluginResponse:
     """Register a new dynamic (custom) plugin in Superset.
 
-    Requires the DYNAMIC_PLUGINS feature flag to be enabled and admin write
-    access to DynamicPlugin. The ``key`` must match the package name from the
+    Requires the DYNAMIC_PLUGINS feature flag to be enabled and DynamicPlugin
+    write permission. The ``key`` must match the package name from the
     plugin's package.json and be unique across all registered plugins.
 
     After registration, Superset will load the plugin bundle from ``bundle_url``
@@ -56,12 +55,6 @@ async def create_plugin(
     )
 
     try:
-        from sqlalchemy.exc import IntegrityError
-
-        from superset import is_feature_enabled
-        from superset.extensions import db
-        from superset.models.dynamic_plugins import DynamicPlugin
-
         if not is_feature_enabled("DYNAMIC_PLUGINS"):
             await ctx.warning("DYNAMIC_PLUGINS feature flag is not enabled")
             return CreatePluginResponse(
@@ -77,7 +70,7 @@ async def create_plugin(
                 bundle_url=request.bundle_url,
             )
             db.session.add(plugin)
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
 
         await ctx.info(
             "Dynamic plugin registered: id=%s, key=%r" % (plugin.id, plugin.key)
@@ -91,7 +84,10 @@ async def create_plugin(
         )
 
     except IntegrityError as exc:
-        db.session.rollback()
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            pass
         msg = str(exc.orig) if exc.orig else str(exc)
         await ctx.warning("Plugin creation failed (duplicate field): %s" % (msg,))
         return CreatePluginResponse(
@@ -101,7 +97,10 @@ async def create_plugin(
             )
         )
     except Exception as exc:
-        db.session.rollback()
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            pass
         await ctx.error(
             "Unexpected error creating plugin: %s: %s" % (type(exc).__name__, str(exc))
         )

--- a/superset/mcp_service/plugin/tool/update_plugin.py
+++ b/superset/mcp_service/plugin/tool/update_plugin.py
@@ -1,0 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.plugin.schemas import (
+    UpdatePluginRequest,
+    UpdatePluginResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="DynamicPlugin",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Update a dynamic plugin",
+        readOnlyHint=False,
+        destructiveHint=True,
+    ),
+)
+async def update_plugin(
+    request: UpdatePluginRequest, ctx: Context
+) -> UpdatePluginResponse:
+    """Update an existing dynamic plugin's name, key, or bundle URL.
+
+    Requires admin write access to DynamicPlugin and the DYNAMIC_PLUGINS
+    feature flag to be enabled. At least one of ``name``, ``key``, or
+    ``bundle_url`` must be provided; only the supplied fields are changed.
+
+    Use ``create_plugin`` to look up the plugin ID if you only know the key.
+    """
+    await ctx.info("Updating dynamic plugin: id=%s" % (request.id,))
+
+    try:
+        from sqlalchemy.exc import IntegrityError
+
+        from superset import is_feature_enabled
+        from superset.extensions import db
+        from superset.models.dynamic_plugins import DynamicPlugin
+
+        if not is_feature_enabled("DYNAMIC_PLUGINS"):
+            await ctx.warning("DYNAMIC_PLUGINS feature flag is not enabled")
+            return UpdatePluginResponse(
+                error=(
+                    "The DYNAMIC_PLUGINS feature flag is not enabled on this instance."
+                )
+            )
+
+        with event_logger.log_context(action="mcp.update_plugin.lookup"):
+            plugin = db.session.get(DynamicPlugin, request.id)
+
+        if plugin is None:
+            await ctx.warning("Plugin not found: id=%s" % (request.id,))
+            return UpdatePluginResponse(
+                error="No plugin found with id=%d. "
+                "Use the plugin ID returned by create_plugin." % request.id
+            )
+
+        if request.name is not None:
+            plugin.name = request.name
+        if request.key is not None:
+            plugin.key = request.key
+        if request.bundle_url is not None:
+            plugin.bundle_url = request.bundle_url
+
+        with event_logger.log_context(action="mcp.update_plugin.save"):
+            db.session.commit()
+
+        await ctx.info(
+            "Dynamic plugin updated: id=%s, key=%r" % (plugin.id, plugin.key)
+        )
+
+        return UpdatePluginResponse(
+            id=plugin.id,
+            name=plugin.name,
+            key=plugin.key,
+            bundle_url=plugin.bundle_url,
+        )
+
+    except IntegrityError as exc:
+        db.session.rollback()
+        msg = str(exc.orig) if exc.orig else str(exc)
+        await ctx.warning("Plugin update failed (duplicate field): %s" % (msg,))
+        return UpdatePluginResponse(
+            error=(
+                "A plugin with the same name, key, or bundle_url already exists. "
+                "Each field must be unique."
+            )
+        )
+    except Exception as exc:
+        db.session.rollback()
+        await ctx.error(
+            "Unexpected error updating plugin: %s: %s" % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/plugin/tool/update_plugin.py
+++ b/superset/mcp_service/plugin/tool/update_plugin.py
@@ -15,18 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
-
 from fastmcp import Context
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.extensions import event_logger
+from superset import is_feature_enabled
+from superset.extensions import db, event_logger
 from superset.mcp_service.plugin.schemas import (
     UpdatePluginRequest,
     UpdatePluginResponse,
 )
-
-logger = logging.getLogger(__name__)
+from superset.models.dynamic_plugins import DynamicPlugin
 
 
 @tool(
@@ -44,21 +43,16 @@ async def update_plugin(
 ) -> UpdatePluginResponse:
     """Update an existing dynamic plugin's name, key, or bundle URL.
 
-    Requires admin write access to DynamicPlugin and the DYNAMIC_PLUGINS
-    feature flag to be enabled. At least one of ``name``, ``key``, or
-    ``bundle_url`` must be provided; only the supplied fields are changed.
+    Requires DynamicPlugin write permission and the DYNAMIC_PLUGINS feature
+    flag to be enabled. At least one of ``name``, ``key``, or ``bundle_url``
+    must be provided; only the supplied fields are changed.
 
-    Use ``create_plugin`` to look up the plugin ID if you only know the key.
+    Use the plugin ID returned by ``create_plugin``, or look up the ID in
+    the Custom Plugins UI (Settings → Custom Plugins).
     """
     await ctx.info("Updating dynamic plugin: id=%s" % (request.id,))
 
     try:
-        from sqlalchemy.exc import IntegrityError
-
-        from superset import is_feature_enabled
-        from superset.extensions import db
-        from superset.models.dynamic_plugins import DynamicPlugin
-
         if not is_feature_enabled("DYNAMIC_PLUGINS"):
             await ctx.warning("DYNAMIC_PLUGINS feature flag is not enabled")
             return UpdatePluginResponse(
@@ -73,8 +67,11 @@ async def update_plugin(
         if plugin is None:
             await ctx.warning("Plugin not found: id=%s" % (request.id,))
             return UpdatePluginResponse(
-                error="No plugin found with id=%d. "
-                "Use the plugin ID returned by create_plugin." % request.id
+                error=(
+                    "No plugin found with id=%d. "
+                    "Look up the plugin ID in the Custom Plugins UI "
+                    "(Settings → Custom Plugins)." % request.id
+                )
             )
 
         if request.name is not None:
@@ -85,7 +82,7 @@ async def update_plugin(
             plugin.bundle_url = request.bundle_url
 
         with event_logger.log_context(action="mcp.update_plugin.save"):
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
 
         await ctx.info(
             "Dynamic plugin updated: id=%s, key=%r" % (plugin.id, plugin.key)
@@ -99,7 +96,10 @@ async def update_plugin(
         )
 
     except IntegrityError as exc:
-        db.session.rollback()
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            pass
         msg = str(exc.orig) if exc.orig else str(exc)
         await ctx.warning("Plugin update failed (duplicate field): %s" % (msg,))
         return UpdatePluginResponse(
@@ -109,7 +109,10 @@ async def update_plugin(
             )
         )
     except Exception as exc:
-        db.session.rollback()
+        try:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
+        except SQLAlchemyError:
+            pass
         await ctx.error(
             "Unexpected error updating plugin: %s: %s" % (type(exc).__name__, str(exc))
         )

--- a/tests/unit_tests/mcp_service/plugin/tool/test_plugin_tools.py
+++ b/tests/unit_tests/mcp_service/plugin/tool/test_plugin_tools.py
@@ -15,19 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from fastmcp import Client
 from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
 
 from superset.mcp_service.app import mcp
-from superset.mcp_service.plugin.schemas import ListPluginsRequest, PluginColumnFilter
+from superset.mcp_service.plugin.schemas import (
+    CreatePluginRequest,
+    ListPluginsRequest,
+    PluginColumnFilter,
+    UpdatePluginRequest,
+)
 from superset.utils import json
-
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
 
 
 def create_mock_plugin(
@@ -61,6 +63,11 @@ def mock_auth():
         yield mock_get_user
 
 
+# ---------------------------------------------------------------------------
+# PluginColumnFilter schema tests
+# ---------------------------------------------------------------------------
+
+
 class TestPluginColumnFilterSchema:
     def test_invalid_filter_column_rejected(self):
         with pytest.raises(ValidationError):
@@ -73,6 +80,11 @@ class TestPluginColumnFilterSchema:
     def test_valid_key_filter(self):
         f = PluginColumnFilter(col="key", opr="eq", value="my_plugin")
         assert f.col == "key"
+
+
+# ---------------------------------------------------------------------------
+# list_plugins / get_plugin_info tool tests
+# ---------------------------------------------------------------------------
 
 
 @patch("superset.mcp_service.plugin.dao.DynamicPluginDAO.list")
@@ -170,3 +182,406 @@ def test_list_plugins_request_rejects_search_and_filters():
             search="test",
             filters=[{"col": "name", "opr": "eq", "value": "x"}],
         )
+
+
+# ---------------------------------------------------------------------------
+# CreatePluginRequest / UpdatePluginRequest schema tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_plugin_request_valid() -> None:
+    req = CreatePluginRequest(
+        name="My Plugin",
+        key="@my-org/my-plugin",
+        bundle_url="https://cdn.example.com/bundle.js",
+    )
+    assert req.name == "My Plugin"
+    assert req.key == "@my-org/my-plugin"
+    assert req.bundle_url == "https://cdn.example.com/bundle.js"
+
+
+def test_create_plugin_request_blank_name_fails() -> None:
+    with pytest.raises(ValidationError, match="must not be blank"):
+        CreatePluginRequest(
+            name="   ",
+            key="@my-org/my-plugin",
+            bundle_url="https://cdn.example.com/bundle.js",
+        )
+
+
+def test_create_plugin_request_name_too_long_fails() -> None:
+    with pytest.raises(ValidationError):
+        CreatePluginRequest(
+            name="a" * 51,
+            key="@my-org/my-plugin",
+            bundle_url="https://cdn.example.com/bundle.js",
+        )
+
+
+def test_create_plugin_request_key_too_long_fails() -> None:
+    with pytest.raises(ValidationError):
+        CreatePluginRequest(
+            name="My Plugin",
+            key="k" * 51,
+            bundle_url="https://cdn.example.com/bundle.js",
+        )
+
+
+def test_create_plugin_request_bundle_url_too_long_fails() -> None:
+    with pytest.raises(ValidationError):
+        CreatePluginRequest(
+            name="My Plugin",
+            key="@my-org/my-plugin",
+            bundle_url="https://cdn.example.com/" + "a" * 980 + ".js",
+        )
+
+
+def test_create_plugin_request_invalid_url_scheme_fails() -> None:
+    with pytest.raises(ValidationError, match="http or https"):
+        CreatePluginRequest(
+            name="My Plugin",
+            key="@my-org/my-plugin",
+            bundle_url="ftp://cdn.example.com/bundle.js",
+        )
+
+
+def test_create_plugin_request_javascript_url_fails() -> None:
+    with pytest.raises(ValidationError, match="http or https"):
+        CreatePluginRequest(
+            name="My Plugin",
+            key="@my-org/my-plugin",
+            bundle_url="javascript:alert(1)",
+        )
+
+
+def test_update_plugin_request_valid() -> None:
+    req = UpdatePluginRequest(id=1, name="Updated Name")
+    assert req.id == 1
+    assert req.name == "Updated Name"
+    assert req.key is None
+    assert req.bundle_url is None
+
+
+def test_update_plugin_request_no_fields_fails() -> None:
+    with pytest.raises(ValidationError, match="At least one of"):
+        UpdatePluginRequest(id=1)
+
+
+def test_update_plugin_request_blank_name_fails() -> None:
+    with pytest.raises(ValidationError, match="must not be blank"):
+        UpdatePluginRequest(id=1, name="   ")
+
+
+def test_update_plugin_request_invalid_url_scheme_fails() -> None:
+    with pytest.raises(ValidationError, match="http or https"):
+        UpdatePluginRequest(id=1, bundle_url="data:text/javascript,alert(1)")
+
+
+def test_update_plugin_request_name_too_long_fails() -> None:
+    with pytest.raises(ValidationError):
+        UpdatePluginRequest(id=1, name="n" * 51)
+
+
+# ---------------------------------------------------------------------------
+# create_plugin tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_plugin_success(mcp_server: object) -> None:
+    """Happy path: plugin created, all fields returned."""
+    mock_plugin = MagicMock()
+    mock_plugin.id = 42
+    mock_plugin.name = "My Plugin"
+    mock_plugin.key = "@my-org/my-plugin"
+    mock_plugin.bundle_url = "https://cdn.example.com/bundle.js"
+
+    mock_db = MagicMock()
+    mock_db.session.add = MagicMock()
+    mock_db.session.commit = MagicMock()
+
+    with (
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.is_feature_enabled",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.db",
+            mock_db,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.DynamicPlugin",
+            return_value=mock_plugin,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_plugin",
+                {
+                    "request": {
+                        "name": "My Plugin",
+                        "key": "@my-org/my-plugin",
+                        "bundle_url": "https://cdn.example.com/bundle.js",
+                    }
+                },
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 42
+    assert data["name"] == "My Plugin"
+    assert data["key"] == "@my-org/my-plugin"
+    assert data["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_plugin_feature_flag_disabled(mcp_server: object) -> None:
+    """Returns error response when DYNAMIC_PLUGINS flag is off."""
+    with patch(
+        "superset.mcp_service.plugin.tool.create_plugin.is_feature_enabled",
+        return_value=False,
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_plugin",
+                {
+                    "request": {
+                        "name": "My Plugin",
+                        "key": "@my-org/my-plugin",
+                        "bundle_url": "https://cdn.example.com/bundle.js",
+                    }
+                },
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "DYNAMIC_PLUGINS" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_plugin_duplicate_key(mcp_server: object) -> None:
+    """IntegrityError from duplicate key is returned as structured error."""
+    mock_db = MagicMock()
+    mock_db.session.add = MagicMock()
+    mock_db.session.commit.side_effect = IntegrityError(
+        "UNIQUE constraint failed", None, None
+    )
+
+    with (
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.is_feature_enabled",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.db",
+            mock_db,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.DynamicPlugin",
+            return_value=MagicMock(),
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "create_plugin",
+                {
+                    "request": {
+                        "name": "My Plugin",
+                        "key": "@my-org/my-plugin",
+                        "bundle_url": "https://cdn.example.com/bundle.js",
+                    }
+                },
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "already exists" in data["error"]
+    mock_db.session.rollback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_plugin_unexpected_error_reraises(mcp_server: object) -> None:
+    """Unexpected exceptions are re-raised after rollback."""
+    from fastmcp.exceptions import ToolError
+
+    mock_db = MagicMock()
+    mock_db.session.commit.side_effect = RuntimeError("Unexpected DB failure")
+
+    with (
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.is_feature_enabled",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.db",
+            mock_db,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.create_plugin.DynamicPlugin",
+            return_value=MagicMock(),
+        ),
+    ):
+        with pytest.raises(ToolError):
+            async with Client(mcp_server) as client:
+                await client.call_tool(
+                    "create_plugin",
+                    {
+                        "request": {
+                            "name": "My Plugin",
+                            "key": "@my-org/my-plugin",
+                            "bundle_url": "https://cdn.example.com/bundle.js",
+                        }
+                    },
+                )
+
+    mock_db.session.rollback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# update_plugin tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_success(mcp_server: object) -> None:
+    """Happy path: plugin found and updated."""
+    mock_plugin = MagicMock()
+    mock_plugin.id = 7
+    mock_plugin.name = "Updated Name"
+    mock_plugin.key = "@my-org/my-plugin"
+    mock_plugin.bundle_url = "https://cdn.example.com/bundle.js"
+
+    mock_db = MagicMock()
+    mock_db.session.get.return_value = mock_plugin
+    mock_db.session.commit = MagicMock()
+
+    with (
+        patch(
+            "superset.mcp_service.plugin.tool.update_plugin.is_feature_enabled",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.update_plugin.db",
+            mock_db,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_plugin",
+                {"request": {"id": 7, "name": "Updated Name"}},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 7
+    assert data["name"] == "Updated Name"
+    assert data["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_feature_flag_disabled(mcp_server: object) -> None:
+    """Returns error response when DYNAMIC_PLUGINS flag is off."""
+    with patch(
+        "superset.mcp_service.plugin.tool.update_plugin.is_feature_enabled",
+        return_value=False,
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_plugin",
+                {"request": {"id": 1, "name": "Updated"}},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "DYNAMIC_PLUGINS" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_not_found(mcp_server: object) -> None:
+    """Returns error when plugin ID does not exist."""
+    mock_db = MagicMock()
+    mock_db.session.get.return_value = None
+
+    with (
+        patch(
+            "superset.mcp_service.plugin.tool.update_plugin.is_feature_enabled",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.update_plugin.db",
+            mock_db,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_plugin",
+                {"request": {"id": 999, "name": "Updated"}},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "No plugin found" in data["error"]
+    assert "Custom Plugins" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_duplicate_field(mcp_server: object) -> None:
+    """IntegrityError from conflicting update is returned as structured error."""
+    mock_plugin = MagicMock()
+    mock_db = MagicMock()
+    mock_db.session.get.return_value = mock_plugin
+    mock_db.session.commit.side_effect = IntegrityError(
+        "UNIQUE constraint failed", None, None
+    )
+
+    with (
+        patch(
+            "superset.mcp_service.plugin.tool.update_plugin.is_feature_enabled",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.update_plugin.db",
+            mock_db,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_plugin",
+                {"request": {"id": 1, "name": "Duplicate Name"}},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "already exists" in data["error"]
+    mock_db.session.rollback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_unexpected_error_reraises(mcp_server: object) -> None:
+    """Unexpected exceptions are re-raised after rollback."""
+    from fastmcp.exceptions import ToolError
+
+    mock_db = MagicMock()
+    mock_db.session.get.side_effect = RuntimeError("Session exploded")
+
+    with (
+        patch(
+            "superset.mcp_service.plugin.tool.update_plugin.is_feature_enabled",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.plugin.tool.update_plugin.db",
+            mock_db,
+        ),
+    ):
+        with pytest.raises(ToolError):
+            async with Client(mcp_server) as client:
+                await client.call_tool(
+                    "update_plugin",
+                    {"request": {"id": 1, "name": "Test"}},
+                )
+
+    mock_db.session.rollback.assert_called_once()


### PR DESCRIPTION
### SUMMARY

Adds two admin-only MCP mutation tools for managing dynamic (custom) plugins in Superset, living under `superset/mcp_service/plugin/`.

**`create_plugin`**
- Registers a new dynamic plugin with `name`, `key`, and `bundle_url`
- `key` must match the package name from the plugin's `package.json` and be unique
- Feature-gated: returns a structured error if `DYNAMIC_PLUGINS` is disabled
- Handles duplicate-field `IntegrityError` gracefully

**`update_plugin`**
- Updates an existing plugin's `name`, `key`, and/or `bundle_url` by ID
- Supports partial updates — at least one field required
- Returns a structured not-found error for unknown IDs
- Handles duplicate-field conflicts gracefully

Both tools require `DynamicPlugin` / `write` permission (admin-only), matching the access level of the existing `DynamicPluginsView`. Both are registered in `mcp_service/app.py` and included in the MCP instructions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

1. Enable `DYNAMIC_PLUGINS` in `superset_config.py`
2. Connect to the MCP service as an admin user
3. Call `create_plugin` with valid `name`, `key`, `bundle_url` → plugin appears in Settings → Custom Plugins
4. Call `update_plugin` with the returned `id` and a new `bundle_url` → change persists
5. Call `create_plugin` with a duplicate `key` → structured error, no exception
6. Call `update_plugin` with a nonexistent `id` → structured not-found error
7. Call either tool without admin permissions → rejected by RBAC

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: `DYNAMIC_PLUGINS` must be enabled
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API