### PR TITLE
feat(mcp): add create_report and update_report tools

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -725,6 +725,9 @@ from superset.mcp_service.query.tool import (  # noqa: F401, E402
     get_query_info,
     list_queries,
 )
+from superset.mcp_service.report.tool import (  # noqa: F401, E402
+    create_report,
+)
 from superset.mcp_service.rls.tool import (  # noqa: F401, E402
     get_rls_filter_info,
     list_rls_filters,

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -727,6 +727,7 @@ from superset.mcp_service.query.tool import (  # noqa: F401, E402
 )
 from superset.mcp_service.report.tool import (  # noqa: F401, E402
     create_report,
+    update_report,
 )
 from superset.mcp_service.rls.tool import (  # noqa: F401, E402
     get_rls_filter_info,

--- a/superset/mcp_service/report/__init__.py
+++ b/superset/mcp_service/report/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/mcp_service/report/schemas.py
+++ b/superset/mcp_service/report/schemas.py
@@ -193,3 +193,148 @@ class CreateReportResponse(BaseModel):
         None,
         description="Error message if creation failed, otherwise null.",
     )
+
+
+class UpdateReportRequest(BaseModel):
+    """Request schema for update_report. All fields except id are optional."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: int = Field(
+        ...,
+        description=(
+            "ID of the report schedule to update. "
+            "Use list_reports or the id returned by create_report."
+        ),
+    )
+    name: str | None = Field(
+        None,
+        max_length=150,
+        description="New name for the schedule. Omit to keep the current name.",
+    )
+    type: str | None = Field(
+        None,
+        description=(
+            "Change the schedule type: 'Report' or 'Alert'. "
+            "Omit to keep the current type."
+        ),
+    )
+    crontab: str | None = Field(
+        None,
+        description=(
+            "New cron expression for the schedule "
+            "(e.g., '0 9 * * 1' for every Monday at 9 AM). "
+            "Omit to keep the current schedule."
+        ),
+    )
+    description: str | None = Field(
+        None,
+        description="New description. Omit to keep the current description.",
+    )
+    active: bool | None = Field(
+        None,
+        description=(
+            "Set to True to enable or False to disable the schedule. "
+            "Omit to keep the current state."
+        ),
+    )
+    timezone: str | None = Field(
+        None,
+        description=(
+            "New timezone for interpreting the cron schedule "
+            "(e.g., 'America/New_York'). Omit to keep the current timezone."
+        ),
+    )
+    recipients: list[RecipientConfig] | None = Field(
+        None,
+        description=(
+            "Replacement list of notification recipients. "
+            "Replaces the entire recipient list when provided. "
+            "Omit to keep the current recipients."
+        ),
+    )
+    dashboard_id: int | None = Field(
+        None,
+        description=(
+            "ID of the dashboard to attach this schedule to. "
+            "Omit to keep the current dashboard association."
+        ),
+    )
+    chart_id: int | None = Field(
+        None,
+        description=(
+            "ID of the chart to attach this schedule to. "
+            "Omit to keep the current chart association."
+        ),
+    )
+    database_id: int | None = Field(
+        None,
+        description=(
+            "ID of the database for the alert condition. "
+            "Required when changing type to 'Alert'."
+        ),
+    )
+    sql: str | None = Field(
+        None,
+        description=(
+            "New SQL query for the alert condition. Omit to keep the current query."
+        ),
+    )
+
+    @field_validator("type")
+    @classmethod
+    def type_must_be_valid(cls, v: str | None) -> str | None:
+        if v is not None and v not in (valid_types := {"Report", "Alert"}):
+            raise ValueError(
+                f"Invalid type {v!r}. Must be one of: {sorted(valid_types)}"
+            )
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def name_must_not_be_empty(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("name must not be empty")
+        return v.strip() if v is not None else v
+
+    @field_validator("crontab")
+    @classmethod
+    def crontab_must_not_be_empty(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("crontab must not be empty")
+        return v.strip() if v is not None else v
+
+
+class UpdateReportResponse(BaseModel):
+    """Response schema for update_report."""
+
+    id: int | None = Field(
+        None,
+        description="ID of the updated report schedule. None if update failed.",
+    )
+    name: str | None = Field(
+        None,
+        description="Name of the schedule after the update.",
+    )
+    type: str | None = Field(
+        None,
+        description="Type of the schedule ('Report' or 'Alert').",
+    )
+    crontab: str | None = Field(
+        None,
+        description="Cron expression for the schedule.",
+    )
+    active: bool | None = Field(
+        None,
+        description="Whether the schedule is active.",
+    )
+    url: str | None = Field(
+        None,
+        description=(
+            "URL to manage the report schedule in Superset. None if update failed."
+        ),
+    )
+    error: str | None = Field(
+        None,
+        description="Error message if update failed, otherwise null.",
+    )

--- a/superset/mcp_service/report/schemas.py
+++ b/superset/mcp_service/report/schemas.py
@@ -15,7 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+import re
+
+from croniter import croniter
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+_EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 
 
 class RecipientConfig(BaseModel):
@@ -54,6 +59,19 @@ class RecipientConfig(BaseModel):
         if not v.strip():
             raise ValueError("target must not be empty")
         return v.strip()
+
+    @model_validator(mode="after")
+    def validate_email_target(self) -> "RecipientConfig":
+        if self.type != "Email":
+            return self
+        invalid = [
+            addr.strip()
+            for addr in re.split(r"[,;]", self.target)
+            if addr.strip() and not _EMAIL_REGEX.match(addr.strip())
+        ]
+        if invalid:
+            raise ValueError(f"Invalid email address(es): {', '.join(invalid)}")
+        return self
 
 
 class CreateReportRequest(BaseModel):
@@ -154,10 +172,13 @@ class CreateReportRequest(BaseModel):
 
     @field_validator("crontab")
     @classmethod
-    def crontab_must_not_be_empty(cls, v: str) -> str:
+    def crontab_must_be_valid(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("crontab must not be empty")
-        return v.strip()
+        stripped = v.strip()
+        if not croniter.is_valid(stripped):
+            raise ValueError(f"Invalid cron expression: {stripped!r}")
+        return stripped
 
 
 class CreateReportResponse(BaseModel):
@@ -299,10 +320,15 @@ class UpdateReportRequest(BaseModel):
 
     @field_validator("crontab")
     @classmethod
-    def crontab_must_not_be_empty(cls, v: str | None) -> str | None:
-        if v is not None and not v.strip():
+    def crontab_must_be_valid(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not v.strip():
             raise ValueError("crontab must not be empty")
-        return v.strip() if v is not None else v
+        stripped = v.strip()
+        if not croniter.is_valid(stripped):
+            raise ValueError(f"Invalid cron expression: {stripped!r}")
+        return stripped
 
 
 class UpdateReportResponse(BaseModel):

--- a/superset/mcp_service/report/schemas.py
+++ b/superset/mcp_service/report/schemas.py
@@ -1,0 +1,195 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class RecipientConfig(BaseModel):
+    """Configuration for a single report recipient."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: str = Field(
+        ...,
+        description=(
+            "Recipient channel type. One of: 'Email', 'Slack', 'SlackV2', 'Webhook'."
+        ),
+    )
+    target: str = Field(
+        ...,
+        description=(
+            "Destination for the notification. "
+            "For Email: an email address. "
+            "For Slack/SlackV2: a channel name or ID. "
+            "For Webhook: the URL."
+        ),
+    )
+
+    @field_validator("type")
+    @classmethod
+    def type_must_be_valid(cls, v: str) -> str:
+        if v not in (valid_types := {"Email", "Slack", "SlackV2", "Webhook"}):
+            raise ValueError(
+                f"Invalid recipient type {v!r}. Must be one of: {sorted(valid_types)}"
+            )
+        return v
+
+    @field_validator("target")
+    @classmethod
+    def target_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("target must not be empty")
+        return v.strip()
+
+
+class CreateReportRequest(BaseModel):
+    """Request schema for create_report."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=150,
+        description="Name for the new report or alert schedule.",
+    )
+    type: str = Field(
+        ...,
+        description=(
+            "Schedule type: 'Report' to deliver a snapshot, "
+            "'Alert' to notify on a SQL condition."
+        ),
+    )
+    crontab: str = Field(
+        ...,
+        description=(
+            "Cron expression defining the execution schedule. "
+            "Examples: '0 9 * * 1' (every Monday at 9 AM), "
+            "'0 8 * * 1-5' (weekdays at 8 AM)."
+        ),
+    )
+    description: str | None = Field(
+        None,
+        description="Optional human-readable description of the schedule.",
+    )
+    active: bool = Field(
+        True,
+        description="Whether the schedule is active immediately after creation.",
+    )
+    timezone: str | None = Field(
+        None,
+        description=(
+            "Timezone for interpreting the cron schedule "
+            "(e.g., 'America/New_York', 'UTC'). Defaults to server timezone."
+        ),
+    )
+    recipients: list[RecipientConfig] = Field(
+        default_factory=list,
+        description=(
+            "List of notification recipients. "
+            "For reports/alerts created via this tool, provide at least one recipient. "
+            "Example: [{'type': 'Email', 'target': 'user@example.com'}]"
+        ),
+    )
+    dashboard_id: int | None = Field(
+        None,
+        description=(
+            "ID of the dashboard to attach this report to. "
+            "Use list_dashboards to find valid IDs. "
+            "Provide either dashboard_id or chart_id, not both."
+        ),
+    )
+    chart_id: int | None = Field(
+        None,
+        description=(
+            "ID of the chart to attach this report to. "
+            "Use list_charts to find valid IDs. "
+            "Provide either chart_id or dashboard_id, not both."
+        ),
+    )
+    database_id: int | None = Field(
+        None,
+        description=(
+            "ID of the database connection for evaluating the alert condition. "
+            "Required when type is 'Alert'. Use list_databases to find valid IDs."
+        ),
+    )
+    sql: str | None = Field(
+        None,
+        description=(
+            "SQL query whose result is evaluated as the alert condition. "
+            "Used when type is 'Alert'."
+        ),
+    )
+
+    @field_validator("type")
+    @classmethod
+    def type_must_be_valid(cls, v: str) -> str:
+        if v not in (valid_types := {"Report", "Alert"}):
+            raise ValueError(
+                f"Invalid type {v!r}. Must be one of: {sorted(valid_types)}"
+            )
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def name_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("name must not be empty")
+        return v.strip()
+
+    @field_validator("crontab")
+    @classmethod
+    def crontab_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("crontab must not be empty")
+        return v.strip()
+
+
+class CreateReportResponse(BaseModel):
+    """Response schema for create_report."""
+
+    id: int | None = Field(
+        None,
+        description="ID of the created report schedule. None if creation failed.",
+    )
+    name: str | None = Field(
+        None,
+        description="Name of the created schedule.",
+    )
+    type: str | None = Field(
+        None,
+        description="Type of the schedule ('Report' or 'Alert').",
+    )
+    crontab: str | None = Field(
+        None,
+        description="Cron expression for the schedule.",
+    )
+    active: bool | None = Field(
+        None,
+        description="Whether the schedule is active.",
+    )
+    url: str | None = Field(
+        None,
+        description=(
+            "URL to manage the report schedule in Superset. None if creation failed."
+        ),
+    )
+    error: str | None = Field(
+        None,
+        description="Error message if creation failed, otherwise null.",
+    )

--- a/superset/mcp_service/report/schemas.py
+++ b/superset/mcp_service/report/schemas.py
@@ -19,6 +19,7 @@ import re
 
 from croniter import croniter
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pytz import all_timezones
 
 _EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 
@@ -116,10 +117,9 @@ class CreateReportRequest(BaseModel):
         ),
     )
     recipients: list[RecipientConfig] = Field(
-        default_factory=list,
+        min_length=1,
         description=(
-            "List of notification recipients. "
-            "For reports/alerts created via this tool, provide at least one recipient. "
+            "List of notification recipients. At least one recipient is required. "
             "Example: [{'type': 'Email', 'target': 'user@example.com'}]"
         ),
     )
@@ -179,6 +179,15 @@ class CreateReportRequest(BaseModel):
         if not croniter.is_valid(stripped):
             raise ValueError(f"Invalid cron expression: {stripped!r}")
         return stripped
+
+    @field_validator("timezone")
+    @classmethod
+    def timezone_must_be_valid(cls, v: str | None) -> str | None:
+        if v is not None and v not in all_timezones:
+            raise ValueError(
+                f"Invalid timezone {v!r}. Must be a valid IANA timezone string."
+            )
+        return v
 
 
 class CreateReportResponse(BaseModel):
@@ -329,6 +338,15 @@ class UpdateReportRequest(BaseModel):
         if not croniter.is_valid(stripped):
             raise ValueError(f"Invalid cron expression: {stripped!r}")
         return stripped
+
+    @field_validator("timezone")
+    @classmethod
+    def timezone_must_be_valid(cls, v: str | None) -> str | None:
+        if v is not None and v not in all_timezones:
+            raise ValueError(
+                f"Invalid timezone {v!r}. Must be a valid IANA timezone string."
+            )
+        return v
 
 
 class UpdateReportResponse(BaseModel):

--- a/superset/mcp_service/report/tool/__init__.py
+++ b/superset/mcp_service/report/tool/__init__.py
@@ -16,5 +16,6 @@
 # under the License.
 
 from .create_report import create_report
+from .update_report import update_report
 
-__all__ = ["create_report"]
+__all__ = ["create_report", "update_report"]

--- a/superset/mcp_service/report/tool/__init__.py
+++ b/superset/mcp_service/report/tool/__init__.py
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from .create_report import create_report
+
+__all__ = ["create_report"]

--- a/superset/mcp_service/report/tool/create_report.py
+++ b/superset/mcp_service/report/tool/create_report.py
@@ -61,6 +61,7 @@ async def create_report(
     )
 
     try:
+        # Deferred to avoid circular imports with the @tool decorator initialization
         from superset.commands.report.create import CreateReportScheduleCommand
         from superset.commands.report.exceptions import (
             ReportScheduleCreateFailedError,
@@ -79,20 +80,19 @@ async def create_report(
             else ReportScheduleType.REPORT
         )
 
-        recipients: list[dict[str, Any]] = []
-        for recipient in request.recipients:
-            recipient_type_map = {
-                "Email": ReportRecipientType.EMAIL,
-                "Slack": ReportRecipientType.SLACK,
-                "SlackV2": ReportRecipientType.SLACKV2,
-                "Webhook": ReportRecipientType.WEBHOOK,
+        recipient_type_map = {
+            "Email": ReportRecipientType.EMAIL,
+            "Slack": ReportRecipientType.SLACK,
+            "SlackV2": ReportRecipientType.SLACKV2,
+            "Webhook": ReportRecipientType.WEBHOOK,
+        }
+        recipients: list[dict[str, Any]] = [
+            {
+                "type": recipient_type_map[r.type],
+                "recipient_config_json": {"target": r.target},
             }
-            recipients.append(
-                {
-                    "type": recipient_type_map[recipient.type],
-                    "recipient_config_json": {"target": recipient.target},
-                }
-            )
+            for r in request.recipients
+        ]
 
         properties: dict[str, Any] = {
             "name": request.name,
@@ -116,10 +116,7 @@ async def create_report(
         with event_logger.log_context(action="mcp.create_report.create"):
             schedule = CreateReportScheduleCommand(properties).run()
 
-        report_url = (
-            f"{get_superset_base_url()}/report/list/"
-            f"?filters=%5B%7B%22id%22%3A%22{schedule.id}%22%7D%5D"
-        )
+        report_url = f"{get_superset_base_url()}/report/list/"
 
         await ctx.info(
             "Report schedule created: id=%s, name=%r, type=%s"

--- a/superset/mcp_service/report/tool/create_report.py
+++ b/superset/mcp_service/report/tool/create_report.py
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.report.schemas import (
+    CreateReportRequest,
+    CreateReportResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="ReportSchedule",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Create a scheduled report or alert",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_report(
+    request: CreateReportRequest, ctx: Context
+) -> CreateReportResponse:
+    """Create a new scheduled report or alert in Superset.
+
+    Use this tool when the user wants to:
+    - Email a dashboard or chart snapshot on a recurring schedule (type='Report')
+    - Trigger a notification when a SQL query result meets a threshold (type='Alert')
+
+    Workflow:
+    1. Get dashboard_id from list_dashboards or chart_id from list_charts
+    2. For alerts, also get database_id from list_databases
+    3. Call this tool with the schedule config and at least one recipient
+    4. The returned id can be referenced when managing schedules
+    """
+    await ctx.info(
+        "Creating report schedule: name=%r, type=%s, crontab=%r"
+        % (request.name, request.type, request.crontab)
+    )
+
+    try:
+        from superset.commands.report.create import CreateReportScheduleCommand
+        from superset.commands.report.exceptions import (
+            ReportScheduleCreateFailedError,
+            ReportScheduleInvalidError,
+        )
+        from superset.mcp_service.utils.url_utils import get_superset_base_url
+        from superset.reports.models import (
+            ReportCreationMethod,
+            ReportRecipientType,
+            ReportScheduleType,
+        )
+
+        schedule_type = (
+            ReportScheduleType.ALERT
+            if request.type == "Alert"
+            else ReportScheduleType.REPORT
+        )
+
+        recipients: list[dict[str, Any]] = []
+        for recipient in request.recipients:
+            recipient_type_map = {
+                "Email": ReportRecipientType.EMAIL,
+                "Slack": ReportRecipientType.SLACK,
+                "SlackV2": ReportRecipientType.SLACKV2,
+                "Webhook": ReportRecipientType.WEBHOOK,
+            }
+            recipients.append(
+                {
+                    "type": recipient_type_map[recipient.type],
+                    "recipient_config_json": {"target": recipient.target},
+                }
+            )
+
+        properties: dict[str, Any] = {
+            "name": request.name,
+            "type": schedule_type,
+            "crontab": request.crontab,
+            "active": request.active,
+            "creation_method": ReportCreationMethod.ALERTS_REPORTS,
+            "recipients": recipients,
+        }
+
+        optional: dict[str, Any] = {
+            "description": request.description,
+            "timezone": request.timezone,
+            "dashboard": request.dashboard_id,
+            "chart": request.chart_id,
+            "database": request.database_id,
+            "sql": request.sql,
+        }
+        properties.update({k: v for k, v in optional.items() if v is not None})
+
+        with event_logger.log_context(action="mcp.create_report.create"):
+            schedule = CreateReportScheduleCommand(properties).run()
+
+        report_url = (
+            f"{get_superset_base_url()}/report/list/"
+            f"?filters=%5B%7B%22id%22%3A%22{schedule.id}%22%7D%5D"
+        )
+
+        await ctx.info(
+            "Report schedule created: id=%s, name=%r, type=%s"
+            % (schedule.id, schedule.name, schedule.type)
+        )
+
+        return CreateReportResponse(
+            id=schedule.id,
+            name=schedule.name,
+            type=schedule.type,
+            crontab=schedule.crontab,
+            active=schedule.active,
+            url=report_url,
+        )
+
+    except ReportScheduleInvalidError as exc:
+        messages = exc.normalized_messages()
+        await ctx.warning("Report schedule validation failed: %s" % (messages,))
+        return CreateReportResponse(
+            id=None,
+            name=request.name,
+            type=request.type,
+            crontab=request.crontab,
+            active=request.active,
+            url=None,
+            error=str(messages),
+        )
+    except ReportScheduleCreateFailedError as exc:
+        await ctx.error("Report schedule creation failed: %s" % (str(exc),))
+        return CreateReportResponse(
+            id=None,
+            name=request.name,
+            type=request.type,
+            crontab=request.crontab,
+            active=request.active,
+            url=None,
+            error=f"Failed to create report schedule: {exc}",
+        )
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error creating report schedule: %s: %s"
+            % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/report/tool/create_report.py
+++ b/superset/mcp_service/report/tool/create_report.py
@@ -62,6 +62,19 @@ async def create_report(
 
     try:
         # Deferred to avoid circular imports with the @tool decorator initialization
+        from superset import is_feature_enabled
+
+        if not is_feature_enabled("ALERT_REPORTS"):
+            return CreateReportResponse(
+                id=None,
+                name=request.name,
+                type=request.type,
+                crontab=request.crontab,
+                active=request.active,
+                url=None,
+                error="The ALERT_REPORTS feature is not enabled on this instance.",
+            )
+
         from superset.commands.report.create import CreateReportScheduleCommand
         from superset.commands.report.exceptions import (
             ReportScheduleCreateFailedError,

--- a/superset/mcp_service/report/tool/update_report.py
+++ b/superset/mcp_service/report/tool/update_report.py
@@ -1,0 +1,158 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.report.schemas import (
+    UpdateReportRequest,
+    UpdateReportResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="ReportSchedule",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Update a scheduled report or alert",
+        readOnlyHint=False,
+        destructiveHint=True,
+    ),
+)
+async def update_report(
+    request: UpdateReportRequest, ctx: Context
+) -> UpdateReportResponse:
+    """Update an existing scheduled report or alert in Superset.
+
+    Use this tool when the user wants to:
+    - Change the name, schedule, or recipients of an existing report or alert
+    - Enable or disable a schedule without deleting it
+    - Update the SQL condition or database for an existing alert
+
+    Only fields explicitly provided in the request are changed;
+    all omitted fields retain their current values.
+
+    Workflow:
+    1. Get the report id from a previous create_report call or from the Superset UI
+    2. Call this tool with the id and only the fields to change
+    3. The returned id confirms which schedule was updated
+    """
+    await ctx.info("Updating report schedule: id=%s" % (request.id,))
+
+    try:
+        # Deferred to avoid circular imports with the @tool decorator initialization
+        from superset.commands.report.exceptions import (
+            ReportScheduleInvalidError,
+            ReportScheduleNotFoundError,
+            ReportScheduleUpdateFailedError,
+        )
+        from superset.commands.report.update import UpdateReportScheduleCommand
+        from superset.mcp_service.utils.url_utils import get_superset_base_url
+        from superset.reports.models import (
+            ReportRecipientType,
+            ReportScheduleType,
+        )
+
+        recipient_type_map = {
+            "Email": ReportRecipientType.EMAIL,
+            "Slack": ReportRecipientType.SLACK,
+            "SlackV2": ReportRecipientType.SLACKV2,
+            "Webhook": ReportRecipientType.WEBHOOK,
+        }
+
+        recipients = None
+        if request.recipients is not None:
+            recipients = [
+                {
+                    "type": recipient_type_map[r.type],
+                    "recipient_config_json": {"target": r.target},
+                }
+                for r in request.recipients
+            ]
+
+        all_props: dict[str, Any] = {
+            "name": request.name,
+            "crontab": request.crontab,
+            "active": request.active,
+            "description": request.description,
+            "timezone": request.timezone,
+            "dashboard": request.dashboard_id,
+            "chart": request.chart_id,
+            "database": request.database_id,
+            "sql": request.sql,
+        }
+        if request.type is not None:
+            all_props["type"] = (
+                ReportScheduleType.ALERT
+                if request.type == "Alert"
+                else ReportScheduleType.REPORT
+            )
+        if recipients is not None:
+            all_props["recipients"] = recipients
+        properties = {k: v for k, v in all_props.items() if v is not None}
+
+        with event_logger.log_context(action="mcp.update_report.update"):
+            schedule = UpdateReportScheduleCommand(request.id, properties).run()
+
+        report_url = f"{get_superset_base_url()}/report/list/"
+
+        await ctx.info(
+            "Report schedule updated: id=%s, name=%r, type=%s"
+            % (schedule.id, schedule.name, schedule.type)
+        )
+
+        return UpdateReportResponse(
+            id=schedule.id,
+            name=schedule.name,
+            type=schedule.type,
+            crontab=schedule.crontab,
+            active=schedule.active,
+            url=report_url,
+        )
+
+    except ReportScheduleNotFoundError:
+        await ctx.warning("Report schedule not found: id=%s" % (request.id,))
+        return UpdateReportResponse(
+            id=None,
+            error=f"Report schedule with id={request.id} not found.",
+        )
+    except ReportScheduleInvalidError as exc:
+        messages = exc.normalized_messages()
+        await ctx.warning("Report schedule validation failed: %s" % (messages,))
+        return UpdateReportResponse(
+            id=None,
+            error=str(messages),
+        )
+    except ReportScheduleUpdateFailedError as exc:
+        await ctx.error("Report schedule update failed: %s" % (str(exc),))
+        return UpdateReportResponse(
+            id=None,
+            error=f"Failed to update report schedule: {exc}",
+        )
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error updating report schedule: %s: %s"
+            % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/report/tool/update_report.py
+++ b/superset/mcp_service/report/tool/update_report.py
@@ -62,7 +62,16 @@ async def update_report(
 
     try:
         # Deferred to avoid circular imports with the @tool decorator initialization
+        from superset import is_feature_enabled
+
+        if not is_feature_enabled("ALERT_REPORTS"):
+            return UpdateReportResponse(
+                id=None,
+                error="The ALERT_REPORTS feature is not enabled on this instance.",
+            )
+
         from superset.commands.report.exceptions import (
+            ReportScheduleForbiddenError,
             ReportScheduleInvalidError,
             ReportScheduleNotFoundError,
             ReportScheduleUpdateFailedError,
@@ -91,6 +100,21 @@ async def update_report(
                 for r in request.recipients
             ]
 
+        # Track which fields the caller explicitly provided (including intentional
+        # None values so callers can clear nullable fields like database_id).
+        explicitly_set = request.model_fields_set - {"id"}
+
+        _prop_to_field: dict[str, str] = {
+            "name": "name",
+            "crontab": "crontab",
+            "active": "active",
+            "description": "description",
+            "timezone": "timezone",
+            "dashboard": "dashboard_id",
+            "chart": "chart_id",
+            "database": "database_id",
+            "sql": "sql",
+        }
         all_props: dict[str, Any] = {
             "name": request.name,
             "crontab": request.crontab,
@@ -102,15 +126,17 @@ async def update_report(
             "database": request.database_id,
             "sql": request.sql,
         }
-        if request.type is not None:
-            all_props["type"] = (
+        properties: dict[str, Any] = {
+            k: v for k, v in all_props.items() if _prop_to_field[k] in explicitly_set
+        }
+        if "type" in explicitly_set and request.type is not None:
+            properties["type"] = (
                 ReportScheduleType.ALERT
                 if request.type == "Alert"
                 else ReportScheduleType.REPORT
             )
-        if recipients is not None:
-            all_props["recipients"] = recipients
-        properties = {k: v for k, v in all_props.items() if v is not None}
+        if "recipients" in explicitly_set and recipients is not None:
+            properties["recipients"] = recipients
 
         with event_logger.log_context(action="mcp.update_report.update"):
             schedule = UpdateReportScheduleCommand(request.id, properties).run()
@@ -136,6 +162,16 @@ async def update_report(
         return UpdateReportResponse(
             id=None,
             error=f"Report schedule with id={request.id} not found.",
+        )
+    except ReportScheduleForbiddenError:
+        await ctx.warning(
+            "Forbidden: caller does not own report schedule id=%s" % (request.id,)
+        )
+        return UpdateReportResponse(
+            id=None,
+            error=(
+                f"You do not have permission to update report schedule id={request.id}."
+            ),
         )
     except ReportScheduleInvalidError as exc:
         messages = exc.normalized_messages()

--- a/tests/unit_tests/mcp_service/report/__init__.py
+++ b/tests/unit_tests/mcp_service/report/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/mcp_service/report/tool/__init__.py
+++ b/tests/unit_tests/mcp_service/report/tool/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/mcp_service/report/tool/test_create_report.py
+++ b/tests/unit_tests/mcp_service/report/tool/test_create_report.py
@@ -144,6 +144,42 @@ def test_recipient_config_empty_target_fails() -> None:
         RecipientConfig(type="Email", target="   ")
 
 
+def test_create_report_request_empty_recipients_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="at least 1"):
+        CreateReportRequest(
+            name="Test",
+            type="Report",
+            crontab="0 9 * * 1",
+            recipients=[],
+        )
+
+
+def test_create_report_request_invalid_timezone_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Invalid timezone"):
+        CreateReportRequest(
+            name="Test",
+            type="Report",
+            crontab="0 9 * * 1",
+            timezone="Not/A/Real/Timezone",
+            recipients=[RecipientConfig(type="Email", target="user@example.com")],
+        )
+
+
+def test_create_report_request_valid_timezone() -> None:
+    req = CreateReportRequest(
+        name="Test",
+        type="Report",
+        crontab="0 9 * * 1",
+        timezone="America/New_York",
+        recipients=[RecipientConfig(type="Email", target="user@example.com")],
+    )
+    assert req.timezone == "America/New_York"
+
+
 # --- Tool logic tests ---
 
 

--- a/tests/unit_tests/mcp_service/report/tool/test_create_report.py
+++ b/tests/unit_tests/mcp_service/report/tool/test_create_report.py
@@ -1,0 +1,258 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.report.schemas import CreateReportRequest, RecipientConfig
+from superset.utils import json
+
+
+@pytest.fixture
+def mcp_server():
+    return mcp
+
+
+def _make_mock_schedule(
+    id: int = 1,
+    name: str = "Weekly Report",
+    schedule_type: str = "Report",
+    crontab: str = "0 9 * * 1",
+    active: bool = True,
+) -> MagicMock:
+    schedule = MagicMock()
+    schedule.id = id
+    schedule.name = name
+    schedule.type = schedule_type
+    schedule.crontab = crontab
+    schedule.active = active
+    return schedule
+
+
+# --- Schema tests ---
+
+
+def test_create_report_request_valid() -> None:
+    req = CreateReportRequest(
+        name="Weekly Dashboard",
+        type="Report",
+        crontab="0 9 * * 1",
+        dashboard_id=1,
+        recipients=[RecipientConfig(type="Email", target="user@example.com")],
+    )
+    assert req.name == "Weekly Dashboard"
+    assert req.type == "Report"
+    assert req.active is True
+    assert req.dashboard_id == 1
+
+
+def test_create_report_request_invalid_type() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Invalid type"):
+        CreateReportRequest(
+            name="Test",
+            type="Unknown",
+            crontab="0 9 * * 1",
+        )
+
+
+def test_create_report_request_empty_name_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="name must not be empty"):
+        CreateReportRequest(
+            name="   ",
+            type="Report",
+            crontab="0 9 * * 1",
+        )
+
+
+def test_create_report_request_empty_crontab_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="crontab must not be empty"):
+        CreateReportRequest(
+            name="Test",
+            type="Report",
+            crontab="   ",
+        )
+
+
+def test_recipient_config_invalid_type() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Invalid recipient type"):
+        RecipientConfig(type="Telegram", target="@channel")
+
+
+def test_recipient_config_empty_target_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="target must not be empty"):
+        RecipientConfig(type="Email", target="   ")
+
+
+# --- Tool logic tests ---
+
+
+@pytest.mark.asyncio
+async def test_create_report_success(mcp_server: object) -> None:
+    """Happy path: report created, id and url returned."""
+    mock_schedule = _make_mock_schedule(id=42, name="Weekly Report")
+    mock_command = MagicMock()
+    mock_command.run.return_value = mock_schedule
+
+    with (
+        patch(
+            "superset.commands.report.create.CreateReportScheduleCommand",
+            return_value=mock_command,
+        ),
+        patch(
+            "superset.mcp_service.utils.url_utils.get_superset_base_url",
+            return_value="http://localhost:8088",
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            request = CreateReportRequest(
+                name="Weekly Report",
+                type="Report",
+                crontab="0 9 * * 1",
+                dashboard_id=1,
+                recipients=[RecipientConfig(type="Email", target="user@example.com")],
+            )
+            result = await client.call_tool(
+                "create_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 42
+    assert data["name"] == "Weekly Report"
+    assert data["error"] is None
+    assert data["url"] is not None
+    assert "report/list" in data["url"]
+
+
+@pytest.mark.asyncio
+async def test_create_report_validation_error(mcp_server: object) -> None:
+    """ReportScheduleInvalidError is caught and returned as an error response."""
+    from marshmallow.exceptions import ValidationError as MarshmallowValidationError
+
+    from superset.commands.report.exceptions import ReportScheduleInvalidError
+
+    invalid_exc = ReportScheduleInvalidError()
+    invalid_exc.append(
+        MarshmallowValidationError({"name": ["A report with this name already exists"]})
+    )
+    mock_command = MagicMock()
+    mock_command.run.side_effect = invalid_exc
+
+    with patch(
+        "superset.commands.report.create.CreateReportScheduleCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = CreateReportRequest(
+                name="Duplicate Report",
+                type="Report",
+                crontab="0 9 * * 1",
+                dashboard_id=1,
+                recipients=[RecipientConfig(type="Email", target="user@example.com")],
+            )
+            result = await client.call_tool(
+                "create_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_report_create_failed_error(mcp_server: object) -> None:
+    """ReportScheduleCreateFailedError is caught and returned as an error response."""
+    from superset.commands.report.exceptions import ReportScheduleCreateFailedError
+
+    mock_command = MagicMock()
+    mock_command.run.side_effect = ReportScheduleCreateFailedError()
+
+    with patch(
+        "superset.commands.report.create.CreateReportScheduleCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = CreateReportRequest(
+                name="Test Report",
+                type="Report",
+                crontab="0 9 * * 1",
+                dashboard_id=1,
+                recipients=[RecipientConfig(type="Email", target="user@example.com")],
+            )
+            result = await client.call_tool(
+                "create_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "Failed to create report schedule" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_report_alert_type(mcp_server: object) -> None:
+    """Alert type schedules are created with database_id and sql."""
+    mock_schedule = _make_mock_schedule(
+        id=7, name="High Revenue Alert", schedule_type="Alert"
+    )
+    mock_command = MagicMock()
+    mock_command.run.return_value = mock_schedule
+
+    with (
+        patch(
+            "superset.commands.report.create.CreateReportScheduleCommand",
+            return_value=mock_command,
+        ) as mock_cmd_cls,
+        patch(
+            "superset.mcp_service.utils.url_utils.get_superset_base_url",
+            return_value="http://localhost:8088",
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            request = CreateReportRequest(
+                name="High Revenue Alert",
+                type="Alert",
+                crontab="0 * * * *",
+                chart_id=5,
+                database_id=2,
+                sql="SELECT SUM(revenue) FROM orders",
+                recipients=[RecipientConfig(type="Slack", target="#alerts")],
+            )
+            result = await client.call_tool(
+                "create_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 7
+    assert data["error"] is None
+    # Verify the command received the correct properties
+    call_args = mock_cmd_cls.call_args[0][0]
+    assert call_args["chart"] == 5
+    assert call_args["database"] == 2
+    assert call_args["sql"] == "SELECT SUM(revenue) FROM orders"

--- a/tests/unit_tests/mcp_service/report/tool/test_create_report.py
+++ b/tests/unit_tests/mcp_service/report/tool/test_create_report.py
@@ -107,6 +107,29 @@ def test_create_report_request_empty_crontab_fails() -> None:
         )
 
 
+def test_create_report_request_invalid_crontab_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Invalid cron expression"):
+        CreateReportRequest(
+            name="Test",
+            type="Report",
+            crontab="not-a-valid-cron",
+        )
+
+
+def test_recipient_config_invalid_email() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Invalid email address"):
+        RecipientConfig(type="Email", target="not-an-email")
+
+
+def test_recipient_config_valid_email() -> None:
+    r = RecipientConfig(type="Email", target="user@example.com")
+    assert r.target == "user@example.com"
+
+
 def test_recipient_config_invalid_type() -> None:
     from pydantic import ValidationError
 
@@ -224,6 +247,28 @@ async def test_create_report_create_failed_error(mcp_server: object) -> None:
     assert data["id"] is None
     assert data["error"] is not None
     assert "Failed to create report schedule" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_report_alert_reports_flag_disabled(mcp_server: object) -> None:
+    """When ALERT_REPORTS is disabled the tool returns an error."""
+    with patch("superset.is_feature_enabled", return_value=False):
+        async with Client(mcp_server) as client:
+            request = CreateReportRequest(
+                name="Test Report",
+                type="Report",
+                crontab="0 9 * * 1",
+                dashboard_id=1,
+                recipients=[RecipientConfig(type="Email", target="user@example.com")],
+            )
+            result = await client.call_tool(
+                "create_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "ALERT_REPORTS" in data["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/report/tool/test_create_report.py
+++ b/tests/unit_tests/mcp_service/report/tool/test_create_report.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from fastmcp import Client
@@ -28,6 +28,17 @@ from superset.utils import json
 @pytest.fixture
 def mcp_server():
     return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication for all tests in this module."""
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_user.username = "admin"
+        mock_get_user.return_value = mock_user
+        yield mock_get_user
 
 
 def _make_mock_schedule(

--- a/tests/unit_tests/mcp_service/report/tool/test_update_report.py
+++ b/tests/unit_tests/mcp_service/report/tool/test_update_report.py
@@ -112,6 +112,13 @@ def test_update_report_request_empty_crontab_fails() -> None:
         UpdateReportRequest(id=1, crontab="   ")
 
 
+def test_update_report_request_invalid_crontab_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Invalid cron expression"):
+        UpdateReportRequest(id=1, crontab="not-a-valid-cron")
+
+
 def test_update_report_response_defaults() -> None:
     resp = UpdateReportResponse()
     assert resp.id is None
@@ -141,7 +148,7 @@ async def test_update_report_success(mcp_server: object) -> None:
         async with Client(mcp_server) as client:
             request = UpdateReportRequest(id=42, name="Updated Report", active=False)
             result = await client.call_tool(
-                "update_report", {"request": request.model_dump()}
+                "update_report", {"request": request.model_dump(exclude_unset=True)}
             )
             data = json.loads(result.content[0].text)
 
@@ -167,7 +174,7 @@ async def test_update_report_not_found(mcp_server: object) -> None:
         async with Client(mcp_server) as client:
             request = UpdateReportRequest(id=999)
             result = await client.call_tool(
-                "update_report", {"request": request.model_dump()}
+                "update_report", {"request": request.model_dump(exclude_unset=True)}
             )
             data = json.loads(result.content[0].text)
 
@@ -197,7 +204,7 @@ async def test_update_report_validation_error(mcp_server: object) -> None:
         async with Client(mcp_server) as client:
             request = UpdateReportRequest(id=1, name="Duplicate Name")
             result = await client.call_tool(
-                "update_report", {"request": request.model_dump()}
+                "update_report", {"request": request.model_dump(exclude_unset=True)}
             )
             data = json.loads(result.content[0].text)
 
@@ -220,7 +227,7 @@ async def test_update_report_update_failed_error(mcp_server: object) -> None:
         async with Client(mcp_server) as client:
             request = UpdateReportRequest(id=1, crontab="0 9 * * 1")
             result = await client.call_tool(
-                "update_report", {"request": request.model_dump()}
+                "update_report", {"request": request.model_dump(exclude_unset=True)}
             )
             data = json.loads(result.content[0].text)
 
@@ -252,7 +259,7 @@ async def test_update_report_partial_fields_only_sends_provided(
             # Only updating crontab; name/type/etc. all omitted
             request = UpdateReportRequest(id=10, crontab="0 8 * * 5")
             result = await client.call_tool(
-                "update_report", {"request": request.model_dump()}
+                "update_report", {"request": request.model_dump(exclude_unset=True)}
             )
             data = json.loads(result.content[0].text)
 
@@ -263,6 +270,77 @@ async def test_update_report_partial_fields_only_sends_provided(
     assert "name" not in call_props
     assert "type" not in call_props
     assert "dashboard" not in call_props
+
+
+@pytest.mark.asyncio
+async def test_update_report_alert_reports_flag_disabled(mcp_server: object) -> None:
+    """When ALERT_REPORTS is disabled the tool returns an error."""
+    with patch("superset.is_feature_enabled", return_value=False):
+        async with Client(mcp_server) as client:
+            request = UpdateReportRequest(id=1, name="Updated")
+            result = await client.call_tool(
+                "update_report", {"request": request.model_dump(exclude_unset=True)}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "ALERT_REPORTS" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_report_forbidden_error(mcp_server: object) -> None:
+    """ReportScheduleForbiddenError is caught and returned as a structured error."""
+    from superset.commands.report.exceptions import ReportScheduleForbiddenError
+
+    mock_command = MagicMock()
+    mock_command.run.side_effect = ReportScheduleForbiddenError()
+
+    with patch(
+        "superset.commands.report.update.UpdateReportScheduleCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateReportRequest(id=7, name="Someone Else's Report")
+            result = await client.call_tool(
+                "update_report", {"request": request.model_dump(exclude_unset=True)}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "permission" in data["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_update_report_explicit_null_clears_field(mcp_server: object) -> None:
+    """An explicitly null database_id is passed to the command to clear the field."""
+    mock_schedule = _make_mock_schedule(id=3, name="Report")
+    mock_command = MagicMock()
+    mock_command.run.return_value = mock_schedule
+
+    with (
+        patch(
+            "superset.commands.report.update.UpdateReportScheduleCommand",
+            return_value=mock_command,
+        ) as mock_cmd_cls,
+        patch(
+            "superset.mcp_service.utils.url_utils.get_superset_base_url",
+            return_value="http://localhost:8088",
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            # Explicit database_id=None should clear the field, not be dropped
+            result = await client.call_tool(
+                "update_report",
+                {"request": {"id": 3, "database_id": None}},
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 3
+    call_props = mock_cmd_cls.call_args[0][1]
+    assert "database" in call_props
+    assert call_props["database"] is None
 
 
 @pytest.mark.asyncio
@@ -288,7 +366,7 @@ async def test_update_report_recipients_replaced(mcp_server: object) -> None:
                 recipients=[RecipientConfig(type="Slack", target="#new-channel")],
             )
             result = await client.call_tool(
-                "update_report", {"request": request.model_dump()}
+                "update_report", {"request": request.model_dump(exclude_unset=True)}
             )
             data = json.loads(result.content[0].text)
 

--- a/tests/unit_tests/mcp_service/report/tool/test_update_report.py
+++ b/tests/unit_tests/mcp_service/report/tool/test_update_report.py
@@ -125,6 +125,18 @@ def test_update_report_response_defaults() -> None:
     assert resp.error is None
 
 
+def test_update_report_request_invalid_timezone_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Invalid timezone"):
+        UpdateReportRequest(id=1, timezone="Not/A/Real/Timezone")
+
+
+def test_update_report_request_valid_timezone() -> None:
+    req = UpdateReportRequest(id=1, timezone="Europe/London")
+    assert req.timezone == "Europe/London"
+
+
 # --- Tool logic tests ---
 
 

--- a/tests/unit_tests/mcp_service/report/tool/test_update_report.py
+++ b/tests/unit_tests/mcp_service/report/tool/test_update_report.py
@@ -1,0 +1,298 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastmcp import Client
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.report.schemas import (
+    RecipientConfig,
+    UpdateReportRequest,
+    UpdateReportResponse,
+)
+from superset.utils import json
+
+
+@pytest.fixture
+def mcp_server():
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication for all tests in this module."""
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_user.username = "admin"
+        mock_get_user.return_value = mock_user
+        yield mock_get_user
+
+
+def _make_mock_schedule(
+    id: int = 1,
+    name: str = "Weekly Report",
+    schedule_type: str = "Report",
+    crontab: str = "0 9 * * 1",
+    active: bool = True,
+) -> MagicMock:
+    schedule = MagicMock()
+    schedule.id = id
+    schedule.name = name
+    schedule.type = schedule_type
+    schedule.crontab = crontab
+    schedule.active = active
+    return schedule
+
+
+# --- Schema tests ---
+
+
+def test_update_report_request_valid_id_only() -> None:
+    req = UpdateReportRequest(id=5)
+    assert req.id == 5
+    assert req.name is None
+    assert req.type is None
+    assert req.crontab is None
+    assert req.active is None
+    assert req.recipients is None
+
+
+def test_update_report_request_with_all_fields() -> None:
+    req = UpdateReportRequest(
+        id=5,
+        name="Updated Report",
+        type="Report",
+        crontab="0 10 * * 2",
+        active=False,
+        recipients=[RecipientConfig(type="Email", target="new@example.com")],
+        dashboard_id=3,
+    )
+    assert req.id == 5
+    assert req.name == "Updated Report"
+    assert req.active is False
+    assert req.dashboard_id == 3
+    assert len(req.recipients) == 1  # type: ignore[arg-type]
+
+
+def test_update_report_request_invalid_type() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Invalid type"):
+        UpdateReportRequest(id=1, type="Unknown")
+
+
+def test_update_report_request_empty_name_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="name must not be empty"):
+        UpdateReportRequest(id=1, name="   ")
+
+
+def test_update_report_request_empty_crontab_fails() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="crontab must not be empty"):
+        UpdateReportRequest(id=1, crontab="   ")
+
+
+def test_update_report_response_defaults() -> None:
+    resp = UpdateReportResponse()
+    assert resp.id is None
+    assert resp.error is None
+
+
+# --- Tool logic tests ---
+
+
+@pytest.mark.asyncio
+async def test_update_report_success(mcp_server: object) -> None:
+    """Happy path: schedule updated, id and url returned."""
+    mock_schedule = _make_mock_schedule(id=42, name="Updated Report")
+    mock_command = MagicMock()
+    mock_command.run.return_value = mock_schedule
+
+    with (
+        patch(
+            "superset.commands.report.update.UpdateReportScheduleCommand",
+            return_value=mock_command,
+        ),
+        patch(
+            "superset.mcp_service.utils.url_utils.get_superset_base_url",
+            return_value="http://localhost:8088",
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateReportRequest(id=42, name="Updated Report", active=False)
+            result = await client.call_tool(
+                "update_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 42
+    assert data["name"] == "Updated Report"
+    assert data["error"] is None
+    assert data["url"] is not None
+    assert "report/list" in data["url"]
+
+
+@pytest.mark.asyncio
+async def test_update_report_not_found(mcp_server: object) -> None:
+    """ReportScheduleNotFoundError is caught and returned as error response."""
+    from superset.commands.report.exceptions import ReportScheduleNotFoundError
+
+    mock_command = MagicMock()
+    mock_command.run.side_effect = ReportScheduleNotFoundError()
+
+    with patch(
+        "superset.commands.report.update.UpdateReportScheduleCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateReportRequest(id=999)
+            result = await client.call_tool(
+                "update_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "999" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_report_validation_error(mcp_server: object) -> None:
+    """ReportScheduleInvalidError is caught and returned as error response."""
+    from marshmallow.exceptions import ValidationError as MarshmallowValidationError
+
+    from superset.commands.report.exceptions import ReportScheduleInvalidError
+
+    invalid_exc = ReportScheduleInvalidError()
+    invalid_exc.append(
+        MarshmallowValidationError({"name": ["A report with this name already exists"]})
+    )
+    mock_command = MagicMock()
+    mock_command.run.side_effect = invalid_exc
+
+    with patch(
+        "superset.commands.report.update.UpdateReportScheduleCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateReportRequest(id=1, name="Duplicate Name")
+            result = await client.call_tool(
+                "update_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+
+
+@pytest.mark.asyncio
+async def test_update_report_update_failed_error(mcp_server: object) -> None:
+    """ReportScheduleUpdateFailedError is caught and returned as error response."""
+    from superset.commands.report.exceptions import ReportScheduleUpdateFailedError
+
+    mock_command = MagicMock()
+    mock_command.run.side_effect = ReportScheduleUpdateFailedError()
+
+    with patch(
+        "superset.commands.report.update.UpdateReportScheduleCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateReportRequest(id=1, crontab="0 9 * * 1")
+            result = await client.call_tool(
+                "update_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert data["error"] is not None
+    assert "Failed to update report schedule" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_report_partial_fields_only_sends_provided(
+    mcp_server: object,
+) -> None:
+    """Only the fields that are provided are passed to the command."""
+    mock_schedule = _make_mock_schedule(id=10, name="My Report", crontab="0 8 * * 5")
+    mock_command = MagicMock()
+    mock_command.run.return_value = mock_schedule
+
+    with (
+        patch(
+            "superset.commands.report.update.UpdateReportScheduleCommand",
+            return_value=mock_command,
+        ) as mock_cmd_cls,
+        patch(
+            "superset.mcp_service.utils.url_utils.get_superset_base_url",
+            return_value="http://localhost:8088",
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            # Only updating crontab; name/type/etc. all omitted
+            request = UpdateReportRequest(id=10, crontab="0 8 * * 5")
+            result = await client.call_tool(
+                "update_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 10
+    # Verify properties dict passed to command only has crontab (no None values)
+    call_props = mock_cmd_cls.call_args[0][1]
+    assert "crontab" in call_props
+    assert "name" not in call_props
+    assert "type" not in call_props
+    assert "dashboard" not in call_props
+
+
+@pytest.mark.asyncio
+async def test_update_report_recipients_replaced(mcp_server: object) -> None:
+    """When recipients are provided, they are included in the properties."""
+    mock_schedule = _make_mock_schedule(id=5, name="Alert")
+    mock_command = MagicMock()
+    mock_command.run.return_value = mock_schedule
+
+    with (
+        patch(
+            "superset.commands.report.update.UpdateReportScheduleCommand",
+            return_value=mock_command,
+        ) as mock_cmd_cls,
+        patch(
+            "superset.mcp_service.utils.url_utils.get_superset_base_url",
+            return_value="http://localhost:8088",
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            request = UpdateReportRequest(
+                id=5,
+                recipients=[RecipientConfig(type="Slack", target="#new-channel")],
+            )
+            result = await client.call_tool(
+                "update_report", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] == 5
+    call_props = mock_cmd_cls.call_args[0][1]
+    assert "recipients" in call_props
+    assert len(call_props["recipients"]) == 1


### PR DESCRIPTION
## Summary

- Adds `create_report` MCP mutation tool wrapping `CreateReportScheduleCommand`: creates scheduled reports (snapshot delivery) and alerts (SQL-condition notifications) with Email, Slack, SlackV2, and Webhook recipient support
- Adds `update_report` MCP mutation tool wrapping `UpdateReportScheduleCommand`: partial-update semantics — only explicitly-provided fields are forwarded to the command; omitted fields retain their current values
- Both tools include Pydantic request/response schemas, `event_logger` instrumentation, deferred imports to avoid circular-import issues, and structured error handling for `NotFound`, `Invalid`, and `CreateFailed`/`UpdateFailed` exceptions

## Test plan

- [ ] Unit tests pass for `create_report`: schema validation, success, `ReportScheduleInvalidError`, `ReportScheduleCreateFailedError`, Alert type with database/SQL
- [ ] Unit tests pass for `update_report`: schema validation, success, `ReportScheduleNotFoundError`, `ReportScheduleInvalidError`, `ReportScheduleUpdateFailedError`, partial-field filtering, recipient replacement
- [ ] `pytest tests/unit_tests/mcp_service/report/` passes locally on all Python versions
- [ ] Pre-commit (ruff, mypy, pylint) passes

## Additional information

- `create_report` uses `ReportCreationMethod.ALERTS_REPORTS` so caller-specified recipients are respected (unlike `CHARTS`/`DASHBOARDS` which force-override with the user's own email)
- `update_report` correctly passes `active=False` through the `is not None` filter, enabling schedule deactivation
- Both tools are registered in `superset/mcp_service/app.py` and exported from `superset/mcp_service/report/tool/__init__.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)