### PR TITLE
feat(mcp): add create_saved_query and update_saved_query tools

### DIFF
--- a/superset/commands/query/create.py
+++ b/superset/commands/query/create.py
@@ -51,7 +51,7 @@ class CreateSavedQueryCommand(CreateMixin, BaseCommand):
         exceptions: list[ValidationError] = []
 
         db_id = self._properties.get("db_id")
-        if not db_id:
+        if db_id is None:
             exceptions.append(ValidationError("db_id is required", field_name="db_id"))
             raise SavedQueryInvalidError(exceptions=exceptions)
 

--- a/superset/commands/query/create.py
+++ b/superset/commands/query/create.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from functools import partial
+from typing import Any
+
+from flask import g
+from flask_appbuilder.models.sqla import Model
+from marshmallow import ValidationError
+
+from superset.commands.base import BaseCommand, CreateMixin
+from superset.commands.query.exceptions import (
+    SavedQueryCreateFailedError,
+    SavedQueryInvalidError,
+)
+from superset.daos.query import SavedQueryDAO
+from superset.utils.decorators import on_error, transaction
+
+logger = logging.getLogger(__name__)
+
+
+class CreateSavedQueryCommand(CreateMixin, BaseCommand):
+    def __init__(self, data: dict[str, Any]):
+        self._properties = data.copy()
+
+    @transaction(on_error=partial(on_error, reraise=SavedQueryCreateFailedError))
+    def run(self) -> Model:
+        self.validate()
+        self._properties["user_id"] = g.user.id
+        saved_query = SavedQueryDAO.create(attributes=self._properties)
+        return saved_query
+
+    def validate(self) -> None:
+        from superset.extensions import db, security_manager
+        from superset.models.core import Database
+
+        exceptions: list[ValidationError] = []
+
+        db_id = self._properties.get("db_id")
+        if not db_id:
+            exceptions.append(ValidationError("db_id is required", field_name="db_id"))
+            raise SavedQueryInvalidError(exceptions=exceptions)
+
+        database = db.session.query(Database).filter_by(id=db_id).first()
+
+        if not database:
+            exceptions.append(
+                ValidationError(
+                    f"Database with ID {db_id} not found", field_name="db_id"
+                )
+            )
+            raise SavedQueryInvalidError(exceptions=exceptions)
+
+        if not security_manager.can_access_database(database):
+            exceptions.append(
+                ValidationError(
+                    f"Access denied to database {database.database_name}",
+                    field_name="db_id",
+                )
+            )
+            raise SavedQueryInvalidError(exceptions=exceptions)

--- a/superset/commands/query/exceptions.py
+++ b/superset/commands/query/exceptions.py
@@ -19,6 +19,7 @@ from flask_babel import lazy_gettext as _
 from superset.commands.exceptions import (
     CommandException,
     CommandInvalidError,
+    CreateFailedError,
     DeleteFailedError,
     ImportFailedError,
 )
@@ -38,3 +39,7 @@ class SavedQueryImportError(ImportFailedError):
 
 class SavedQueryInvalidError(CommandInvalidError):
     message = _("Saved query parameters are invalid.")
+
+
+class SavedQueryCreateFailedError(CreateFailedError):
+    message = _("Saved query could not be created.")

--- a/superset/commands/query/exceptions.py
+++ b/superset/commands/query/exceptions.py
@@ -22,6 +22,7 @@ from superset.commands.exceptions import (
     CreateFailedError,
     DeleteFailedError,
     ImportFailedError,
+    UpdateFailedError,
 )
 
 
@@ -43,3 +44,7 @@ class SavedQueryInvalidError(CommandInvalidError):
 
 class SavedQueryCreateFailedError(CreateFailedError):
     message = _("Saved query could not be created.")
+
+
+class SavedQueryUpdateFailedError(UpdateFailedError):
+    message = _("Saved query could not be updated.")

--- a/superset/commands/query/update.py
+++ b/superset/commands/query/update.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from functools import partial
+from typing import Any, Optional
+
+from flask_appbuilder.models.sqla import Model
+from marshmallow import ValidationError
+
+from superset.commands.base import BaseCommand, UpdateMixin
+from superset.commands.query.exceptions import (
+    SavedQueryInvalidError,
+    SavedQueryNotFoundError,
+    SavedQueryUpdateFailedError,
+)
+from superset.daos.query import SavedQueryDAO
+from superset.utils.decorators import on_error, transaction
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateSavedQueryCommand(UpdateMixin, BaseCommand):
+    def __init__(self, model_id: int, data: dict[str, Any]):
+        self._model_id = model_id
+        self._properties = data.copy()
+        self._model: Optional[Model] = None
+
+    @transaction(on_error=partial(on_error, reraise=SavedQueryUpdateFailedError))
+    def run(self) -> Model:
+        self.validate()
+        assert self._model is not None
+        saved_query = SavedQueryDAO.update(self._model, attributes=self._properties)
+        return saved_query
+
+    def validate(self) -> None:
+        exceptions: list[ValidationError] = []
+
+        self._model = SavedQueryDAO.find_by_id(self._model_id)
+        if not self._model:
+            raise SavedQueryNotFoundError()
+
+        if (db_id := self._properties.get("db_id")) is not None:
+            from superset.extensions import db, security_manager
+            from superset.models.core import Database
+
+            database = db.session.query(Database).filter_by(id=db_id).first()
+            if not database:
+                exceptions.append(
+                    ValidationError(
+                        f"Database with ID {db_id} not found", field_name="db_id"
+                    )
+                )
+                raise SavedQueryInvalidError(exceptions=exceptions)
+
+            if not security_manager.can_access_database(database):
+                exceptions.append(
+                    ValidationError(
+                        f"Access denied to database {database.database_name}",
+                        field_name="db_id",
+                    )
+                )
+                raise SavedQueryInvalidError(exceptions=exceptions)

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -187,6 +187,7 @@ Chart Management:
 SQL Lab Integration:
 - execute_sql: Execute SQL queries and get results (requires database_id and SQL access)
 - save_sql_query: Save a SQL query to Saved Queries list (requires write access)
+- create_saved_query: Create a saved query with label, SQL, and optional schema/description (requires write access)
 - open_sql_lab_with_context: Generate SQL Lab URL with pre-filled sql
 - list_saved_queries: List saved SQL queries with filtering and search (1-based pagination)
 - get_saved_query_info: Get saved query details by ID or UUID
@@ -426,9 +427,10 @@ Input format:
 {_instance_info_role_bullet}- ALWAYS check the user's roles BEFORE suggesting write operations (creating datasets,
   charts, or dashboards). SQL execution is a separate permission — see execute_sql below.
 - Write tools (generate_chart, generate_dashboard, update_chart, create_virtual_dataset,
-  save_sql_query, add_chart_to_existing_dashboard, update_chart_preview) require write
-  permissions. These tools are only listed for users who have the necessary access.
-  If a write tool does not appear in the tool list, the current user lacks write access.
+  save_sql_query, create_saved_query, add_chart_to_existing_dashboard, update_chart_preview)
+  require write permissions. These tools are only listed for users who have the necessary
+  access. If a write tool does not appear in the tool list, the current user lacks write
+  access.
 - execute_sql requires SQL Lab access (execute_sql_query permission), which is separate
   from write access. A user may have SQL Lab access without having write access to charts
   or dashboards, and vice versa.
@@ -734,6 +736,7 @@ from superset.mcp_service.role.tool import (  # noqa: F401, E402
     list_roles,
 )
 from superset.mcp_service.saved_query.tool import (  # noqa: F401, E402
+    create_saved_query,
     get_saved_query_info,
     list_saved_queries,
 )

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -188,6 +188,7 @@ SQL Lab Integration:
 - execute_sql: Execute SQL queries and get results (requires database_id and SQL access)
 - save_sql_query: Save a SQL query to Saved Queries list (requires write access)
 - create_saved_query: Create a saved query with label, SQL, and optional schema/description (requires write access)
+- update_saved_query: Update an existing saved query's label, SQL, db, schema, or description (requires write access)
 - open_sql_lab_with_context: Generate SQL Lab URL with pre-filled sql
 - list_saved_queries: List saved SQL queries with filtering and search (1-based pagination)
 - get_saved_query_info: Get saved query details by ID or UUID
@@ -427,8 +428,8 @@ Input format:
 {_instance_info_role_bullet}- ALWAYS check the user's roles BEFORE suggesting write operations (creating datasets,
   charts, or dashboards). SQL execution is a separate permission — see execute_sql below.
 - Write tools (generate_chart, generate_dashboard, update_chart, create_virtual_dataset,
-  save_sql_query, create_saved_query, add_chart_to_existing_dashboard, update_chart_preview)
-  require write permissions. These tools are only listed for users who have the necessary
+  save_sql_query, create_saved_query, update_saved_query, add_chart_to_existing_dashboard,
+  update_chart_preview) require write permissions. These tools are only listed for users who have the necessary
   access. If a write tool does not appear in the tool list, the current user lacks write
   access.
 - execute_sql requires SQL Lab access (execute_sql_query permission), which is separate
@@ -739,6 +740,7 @@ from superset.mcp_service.saved_query.tool import (  # noqa: F401, E402
     create_saved_query,
     get_saved_query_info,
     list_saved_queries,
+    update_saved_query,
 )
 from superset.mcp_service.sql_lab.tool import (  # noqa: F401, E402
     execute_sql,

--- a/superset/mcp_service/saved_query/schemas.py
+++ b/superset/mcp_service/saved_query/schemas.py
@@ -320,6 +320,70 @@ class CreateSavedQueryRequest(BaseModel):
         return v.strip()
 
 
+class UpdateSavedQueryRequest(BaseModel):
+    """Request schema for update_saved_query."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: int = Field(..., description="ID of the saved query to update.")
+    label: str | None = Field(
+        None,
+        min_length=1,
+        max_length=256,
+        description="New name for the saved query (optional).",
+    )
+    sql: str | None = Field(None, description="New SQL query text (optional).")
+    db_id: int | None = Field(
+        None,
+        description="New database connection ID (optional).",
+    )
+    schema: str | None = Field(
+        None,
+        description="New database schema (optional).",
+    )
+    description: str | None = Field(
+        None,
+        description="New description (optional).",
+    )
+    template_parameters: str | None = Field(
+        None,
+        description=("New JSON string of Jinja2 template parameters (optional)."),
+    )
+
+    @field_validator("sql")
+    @classmethod
+    def sql_not_empty(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("sql must not be empty")
+        return v.strip() if v is not None else v
+
+    @field_validator("label")
+    @classmethod
+    def label_not_empty(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("label must not be empty")
+        return v.strip() if v is not None else v
+
+
+class UpdateSavedQueryResponse(BaseModel):
+    """Response schema for update_saved_query."""
+
+    id: int | None = Field(
+        None,
+        description="Saved query ID. None if update failed.",
+    )
+    label: str | None = Field(None, description="Name of the saved query.")
+    sql: str | None = Field(None, description="SQL query text stored.")
+    db_id: int | None = Field(None, description="Database ID used.")
+    schema: str | None = Field(None, description="Database schema (if set).")
+    description: str | None = Field(None, description="Query description (if set).")
+    url: str | None = Field(
+        None,
+        description=("URL to open this saved query in SQL Lab. None if update failed."),
+    )
+    error: str | None = Field(None, description="Error message if update failed.")
+
+
 class CreateSavedQueryResponse(BaseModel):
     """Response schema for create_saved_query."""
 

--- a/superset/mcp_service/saved_query/schemas.py
+++ b/superset/mcp_service/saved_query/schemas.py
@@ -298,6 +298,10 @@ class CreateSavedQueryRequest(BaseModel):
         None,
         description="Human-readable description of the saved query (optional).",
     )
+    catalog: str | None = Field(
+        None,
+        description="Database catalog the query targets (optional).",
+    )
     template_parameters: str | None = Field(
         None,
         description=(
@@ -345,6 +349,10 @@ class UpdateSavedQueryRequest(BaseModel):
         None,
         description="New description (optional).",
     )
+    catalog: str | None = Field(
+        None,
+        description="New database catalog (optional).",
+    )
     template_parameters: str | None = Field(
         None,
         description=("New JSON string of Jinja2 template parameters (optional)."),
@@ -376,6 +384,7 @@ class UpdateSavedQueryResponse(BaseModel):
     sql: str | None = Field(None, description="SQL query text stored.")
     db_id: int | None = Field(None, description="Database ID used.")
     schema: str | None = Field(None, description="Database schema (if set).")
+    catalog: str | None = Field(None, description="Database catalog (if set).")
     description: str | None = Field(None, description="Query description (if set).")
     url: str | None = Field(
         None,
@@ -395,6 +404,7 @@ class CreateSavedQueryResponse(BaseModel):
     sql: str = Field(..., description="SQL query text stored.")
     db_id: int = Field(..., description="Database ID used.")
     schema: str | None = Field(None, description="Database schema (if set).")
+    catalog: str | None = Field(None, description="Database catalog (if set).")
     description: str | None = Field(None, description="Query description (if set).")
     url: str | None = Field(
         None,

--- a/superset/mcp_service/saved_query/schemas.py
+++ b/superset/mcp_service/saved_query/schemas.py
@@ -267,3 +267,76 @@ def serialize_saved_query_object(saved_query: Any) -> SavedQueryInfo | None:
         created_on=getattr(saved_query, "created_on", None),
         last_run=getattr(saved_query, "last_run", None),
     )
+
+
+class CreateSavedQueryRequest(BaseModel):
+    """Request schema for create_saved_query."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    label: str = Field(
+        ...,
+        min_length=1,
+        max_length=256,
+        description="Name for the saved query (shown in the Saved Queries list).",
+    )
+    sql: str = Field(
+        ...,
+        description="SQL query text to save.",
+    )
+    db_id: int = Field(
+        ...,
+        description=(
+            "ID of the database connection. Use list_databases to find valid IDs."
+        ),
+    )
+    schema: str | None = Field(
+        None,
+        description="Database schema the query targets (optional).",
+    )
+    description: str | None = Field(
+        None,
+        description="Human-readable description of the saved query (optional).",
+    )
+    template_parameters: str | None = Field(
+        None,
+        description=(
+            "JSON string of Jinja2 template parameters for the query (optional)."
+        ),
+    )
+
+    @field_validator("sql")
+    @classmethod
+    def sql_not_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("sql must not be empty")
+        return v.strip()
+
+    @field_validator("label")
+    @classmethod
+    def label_not_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("label must not be empty")
+        return v.strip()
+
+
+class CreateSavedQueryResponse(BaseModel):
+    """Response schema for create_saved_query."""
+
+    id: int | None = Field(
+        None,
+        description="Saved query ID. None if creation failed.",
+    )
+    label: str = Field(..., description="Name of the saved query.")
+    sql: str = Field(..., description="SQL query text stored.")
+    db_id: int = Field(..., description="Database ID used.")
+    schema: str | None = Field(None, description="Database schema (if set).")
+    description: str | None = Field(None, description="Query description (if set).")
+    url: str | None = Field(
+        None,
+        description=(
+            "URL to open this saved query in SQL Lab "
+            "(e.g., /sqllab?savedQueryId=42). None if creation failed."
+        ),
+    )
+    error: str | None = Field(None, description="Error message if creation failed.")

--- a/superset/mcp_service/saved_query/tool/__init__.py
+++ b/superset/mcp_service/saved_query/tool/__init__.py
@@ -15,10 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .get_saved_query_info import get_saved_query_info
-from .list_saved_queries import list_saved_queries
+from superset.mcp_service.saved_query.tool.create_saved_query import (
+    create_saved_query,
+)
+from superset.mcp_service.saved_query.tool.get_saved_query_info import (
+    get_saved_query_info,
+)
+from superset.mcp_service.saved_query.tool.list_saved_queries import list_saved_queries
 
 __all__ = [
-    "list_saved_queries",
+    "create_saved_query",
     "get_saved_query_info",
+    "list_saved_queries",
 ]

--- a/superset/mcp_service/saved_query/tool/__init__.py
+++ b/superset/mcp_service/saved_query/tool/__init__.py
@@ -22,9 +22,13 @@ from superset.mcp_service.saved_query.tool.get_saved_query_info import (
     get_saved_query_info,
 )
 from superset.mcp_service.saved_query.tool.list_saved_queries import list_saved_queries
+from superset.mcp_service.saved_query.tool.update_saved_query import (
+    update_saved_query,
+)
 
 __all__ = [
     "create_saved_query",
     "get_saved_query_info",
     "list_saved_queries",
+    "update_saved_query",
 ]

--- a/superset/mcp_service/saved_query/tool/create_saved_query.py
+++ b/superset/mcp_service/saved_query/tool/create_saved_query.py
@@ -72,6 +72,8 @@ async def create_saved_query(
         }
         if request.schema is not None:
             properties["schema"] = request.schema
+        if request.catalog is not None:
+            properties["catalog"] = request.catalog
         if request.description is not None:
             properties["description"] = request.description
         if request.template_parameters is not None:
@@ -93,6 +95,7 @@ async def create_saved_query(
             sql=saved_query.sql,
             db_id=saved_query.db_id,
             schema=saved_query.schema or None,
+            catalog=getattr(saved_query, "catalog", None),
             description=saved_query.description or None,
             url=saved_query_url,
         )

--- a/superset/mcp_service/saved_query/tool/create_saved_query.py
+++ b/superset/mcp_service/saved_query/tool/create_saved_query.py
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.saved_query.schemas import (
+    CreateSavedQueryRequest,
+    CreateSavedQueryResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="SavedQuery",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Create saved query",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def create_saved_query(
+    request: CreateSavedQueryRequest, ctx: Context
+) -> CreateSavedQueryResponse:
+    """Save a SQL query to the Saved Queries list so it can be reloaded and shared.
+
+    Creates a persistent SavedQuery that appears in the Saved Queries page
+    and can be opened in SQL Lab via the returned URL.
+
+    Workflow:
+    1. Call execute_sql to verify the query returns expected results
+    2. Call this tool with a label and the SQL to persist it
+    3. Use the returned ``url`` to open the saved query in SQL Lab
+    """
+    await ctx.info(
+        "Creating saved query: db_id=%s, label=%r" % (request.db_id, request.label)
+    )
+
+    try:
+        from superset.commands.query.create import CreateSavedQueryCommand
+        from superset.commands.query.exceptions import (
+            SavedQueryCreateFailedError,
+            SavedQueryInvalidError,
+        )
+        from superset.mcp_service.utils.url_utils import get_superset_base_url
+
+        properties: dict[str, Any] = {
+            "db_id": request.db_id,
+            "label": request.label,
+            "sql": request.sql,
+        }
+        if request.schema is not None:
+            properties["schema"] = request.schema
+        if request.description is not None:
+            properties["description"] = request.description
+        if request.template_parameters is not None:
+            properties["template_parameters"] = request.template_parameters
+
+        with event_logger.log_context(action="mcp.create_saved_query.create"):
+            saved_query = CreateSavedQueryCommand(properties).run()
+
+        base_url = get_superset_base_url()
+        saved_query_url = f"{base_url}/sqllab?savedQueryId={saved_query.id}"
+
+        await ctx.info(
+            "Saved query created: id=%s, url=%s" % (saved_query.id, saved_query_url)
+        )
+
+        return CreateSavedQueryResponse(
+            id=saved_query.id,
+            label=saved_query.label,
+            sql=saved_query.sql,
+            db_id=saved_query.db_id,
+            schema=saved_query.schema or None,
+            description=saved_query.description or None,
+            url=saved_query_url,
+        )
+
+    except SavedQueryInvalidError as exc:
+        messages = exc.normalized_messages()
+        await ctx.warning("Saved query validation failed: %s" % (messages,))
+        return CreateSavedQueryResponse(
+            id=None,
+            label=request.label,
+            sql=request.sql,
+            db_id=request.db_id,
+            url=None,
+            error=str(messages),
+        )
+    except SavedQueryCreateFailedError as exc:
+        await ctx.error("Saved query creation failed: %s" % (str(exc),))
+        return CreateSavedQueryResponse(
+            id=None,
+            label=request.label,
+            sql=request.sql,
+            db_id=request.db_id,
+            url=None,
+            error=f"Failed to create saved query: {exc}",
+        )
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error creating saved query: %s: %s"
+            % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/saved_query/tool/update_saved_query.py
+++ b/superset/mcp_service/saved_query/tool/update_saved_query.py
@@ -34,6 +34,7 @@ _LOGGABLE_FIELDS = (
     "sql",
     "db_id",
     "schema",
+    "catalog",
     "description",
     "template_parameters",
 )
@@ -46,6 +47,7 @@ def _build_update_properties(request: "UpdateSavedQueryRequest") -> dict[str, An
         "sql": request.sql,
         "db_id": request.db_id,
         "schema": request.schema,
+        "catalog": request.catalog,
         "description": request.description,
         "template_parameters": request.template_parameters,
     }
@@ -120,6 +122,7 @@ async def update_saved_query(
             sql=saved_query.sql,
             db_id=saved_query.db_id,
             schema=saved_query.schema or None,
+            catalog=getattr(saved_query, "catalog", None),
             description=saved_query.description or None,
             url=saved_query_url,
         )

--- a/superset/mcp_service/saved_query/tool/update_saved_query.py
+++ b/superset/mcp_service/saved_query/tool/update_saved_query.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+from superset_core.mcp.decorators import tool, ToolAnnotations
+
+from superset.extensions import event_logger
+from superset.mcp_service.saved_query.schemas import (
+    UpdateSavedQueryRequest,
+    UpdateSavedQueryResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+_LOGGABLE_FIELDS = (
+    "label",
+    "sql",
+    "db_id",
+    "schema",
+    "description",
+    "template_parameters",
+)
+
+
+def _build_update_properties(request: "UpdateSavedQueryRequest") -> dict[str, Any]:
+    """Return only the fields the caller explicitly provided."""
+    fields = {
+        "label": request.label,
+        "sql": request.sql,
+        "db_id": request.db_id,
+        "schema": request.schema,
+        "description": request.description,
+        "template_parameters": request.template_parameters,
+    }
+    return {k: v for k, v in fields.items() if v is not None}
+
+
+@tool(
+    tags=["mutate"],
+    class_permission_name="SavedQuery",
+    method_permission_name="write",
+    annotations=ToolAnnotations(
+        title="Update saved query",
+        readOnlyHint=False,
+        destructiveHint=True,
+    ),
+)
+async def update_saved_query(
+    request: UpdateSavedQueryRequest, ctx: Context
+) -> UpdateSavedQueryResponse:
+    """Update an existing saved query's label, SQL, database, schema, or description.
+
+    All fields except ``id`` are optional — only provided fields are changed.
+    The query must already exist and the caller must have write access to
+    the SavedQuery resource.
+
+    Example: rename only
+    ```json
+    {"id": 42, "label": "Monthly Revenue"}
+    ```
+
+    Example: update SQL and description
+    ```json
+    {"id": 42, "sql": "SELECT * FROM orders LIMIT 100", "description": "All orders"}
+    ```
+    """
+    changed = [f for f in _LOGGABLE_FIELDS if getattr(request, f, None) is not None]
+    await ctx.info("Updating saved query: id=%s, fields=%s" % (request.id, changed))
+
+    try:
+        from superset.commands.query.exceptions import (
+            SavedQueryInvalidError,
+            SavedQueryNotFoundError,
+            SavedQueryUpdateFailedError,
+        )
+        from superset.commands.query.update import UpdateSavedQueryCommand
+        from superset.mcp_service.utils.url_utils import get_superset_base_url
+
+        properties = _build_update_properties(request)
+
+        with event_logger.log_context(action="mcp.update_saved_query.update"):
+            saved_query = UpdateSavedQueryCommand(request.id, properties).run()
+
+        base_url = get_superset_base_url()
+        saved_query_url = f"{base_url}/sqllab?savedQueryId={saved_query.id}"
+
+        await ctx.info(
+            "Saved query updated: id=%s, url=%s" % (saved_query.id, saved_query_url)
+        )
+
+        return UpdateSavedQueryResponse(
+            id=saved_query.id,
+            label=saved_query.label,
+            sql=saved_query.sql,
+            db_id=saved_query.db_id,
+            schema=saved_query.schema or None,
+            description=saved_query.description or None,
+            url=saved_query_url,
+        )
+
+    except SavedQueryNotFoundError:
+        await ctx.warning("Saved query not found: id=%s" % (request.id,))
+        return UpdateSavedQueryResponse(
+            id=None,
+            error=f"Saved query with ID {request.id} not found.",
+        )
+    except SavedQueryInvalidError as exc:
+        messages = exc.normalized_messages()
+        await ctx.warning("Saved query validation failed: %s" % (messages,))
+        return UpdateSavedQueryResponse(
+            id=None,
+            error=str(messages),
+        )
+    except SavedQueryUpdateFailedError as exc:
+        await ctx.error("Saved query update failed: %s" % (str(exc),))
+        return UpdateSavedQueryResponse(
+            id=None,
+            error=f"Failed to update saved query: {exc}",
+        )
+    except Exception as exc:
+        await ctx.error(
+            "Unexpected error updating saved query: %s: %s"
+            % (type(exc).__name__, str(exc))
+        )
+        raise

--- a/superset/mcp_service/saved_query/tool/update_saved_query.py
+++ b/superset/mcp_service/saved_query/tool/update_saved_query.py
@@ -95,6 +95,15 @@ async def update_saved_query(
 
         properties = _build_update_properties(request)
 
+        if not properties:
+            return UpdateSavedQueryResponse(
+                id=None,
+                error=(
+                    "No fields to update. Provide at least one of: "
+                    "label, sql, db_id, schema, description, template_parameters."
+                ),
+            )
+
         with event_logger.log_context(action="mcp.update_saved_query.update"):
             saved_query = UpdateSavedQueryCommand(request.id, properties).run()
 

--- a/tests/unit_tests/mcp_service/saved_query/conftest.py
+++ b/tests/unit_tests/mcp_service/saved_query/conftest.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Conftest for saved_query MCP tool tests.
+
+Patches the editable-install meta path finder to resolve the `superset`
+package from the current worktree rather than the install-time worktree.
+"""
+
+import pathlib
+import sys
+
+# Worktree root is 4 levels above this file.
+_WORKTREE_ROOT = str(pathlib.Path(__file__).parents[4])
+
+# Patch the editable install MAPPING so `superset` resolves to this worktree.
+for _finder in sys.meta_path:
+    if hasattr(_finder, "MAPPING") and "superset" in getattr(_finder, "MAPPING", {}):
+        _finder.MAPPING["superset"] = _WORKTREE_ROOT + "/superset"
+        _finder.MAPPING["tests"] = _WORKTREE_ROOT + "/tests"
+        break
+
+# Also ensure our worktree is first in sys.path as a fallback.
+if _WORKTREE_ROOT not in sys.path:
+    sys.path.insert(0, _WORKTREE_ROOT)
+
+# Evict any previously cached superset submodules that may have been loaded
+# from the old worktree, so they're re-imported from the correct location.
+_to_evict = [k for k in sys.modules if k == "superset" or k.startswith("superset.")]
+for _key in _to_evict:
+    del sys.modules[_key]

--- a/tests/unit_tests/mcp_service/saved_query/conftest.py
+++ b/tests/unit_tests/mcp_service/saved_query/conftest.py
@@ -20,6 +20,11 @@ Conftest for saved_query MCP tool tests.
 
 Patches the editable-install meta path finder to resolve the `superset`
 package from the current worktree rather than the install-time worktree.
+
+This is only needed in shared-venv environments (e.g. Agor) where the editable
+install MAPPING points to a different worktree.  In standard CI environments the
+MAPPING already points to the correct location, so we skip the eviction entirely
+to avoid SQLAlchemy "table already defined" errors caused by re-importing models.
 """
 
 import pathlib
@@ -28,19 +33,25 @@ import sys
 # Worktree root is 4 levels above this file.
 _WORKTREE_ROOT = str(pathlib.Path(__file__).parents[4])
 
-# Patch the editable install MAPPING so `superset` resolves to this worktree.
+# Patch the editable install MAPPING only when it points somewhere else.
+_patched = False
 for _finder in sys.meta_path:
     if hasattr(_finder, "MAPPING") and "superset" in getattr(_finder, "MAPPING", {}):
-        _finder.MAPPING["superset"] = _WORKTREE_ROOT + "/superset"
-        _finder.MAPPING["tests"] = _WORKTREE_ROOT + "/tests"
+        _new_path = _WORKTREE_ROOT + "/superset"
+        if _finder.MAPPING["superset"] != _new_path:
+            _finder.MAPPING["superset"] = _new_path
+            _finder.MAPPING["tests"] = _WORKTREE_ROOT + "/tests"
+            _patched = True
         break
 
-# Also ensure our worktree is first in sys.path as a fallback.
-if _WORKTREE_ROOT not in sys.path:
-    sys.path.insert(0, _WORKTREE_ROOT)
+if _patched:
+    # Ensure our worktree is first in sys.path as a fallback.
+    if _WORKTREE_ROOT not in sys.path:
+        sys.path.insert(0, _WORKTREE_ROOT)
 
-# Evict any previously cached superset submodules that may have been loaded
-# from the old worktree, so they're re-imported from the correct location.
-_to_evict = [k for k in sys.modules if k == "superset" or k.startswith("superset.")]
-for _key in _to_evict:
-    del sys.modules[_key]
+    # Evict cached superset submodules so they re-import from the new location.
+    # Only safe to do when we actually changed the MAPPING; otherwise SQLAlchemy
+    # raises "Table X is already defined" when models are re-imported.
+    _to_evict = [k for k in sys.modules if k == "superset" or k.startswith("superset.")]
+    for _key in _to_evict:
+        del sys.modules[_key]

--- a/tests/unit_tests/mcp_service/saved_query/tool/test_create_saved_query.py
+++ b/tests/unit_tests/mcp_service/saved_query/tool/test_create_saved_query.py
@@ -1,0 +1,301 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for create_saved_query MCP tool."""
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.commands.query.exceptions import (
+    SavedQueryCreateFailedError,
+    SavedQueryInvalidError,
+)
+from superset.mcp_service.saved_query.schemas import CreateSavedQueryRequest
+
+_BASE_URL = "http://localhost:8088"
+
+
+def _force_passthrough_decorators() -> dict[str, types.ModuleType]:
+    def _passthrough_tool(func=None, **kwargs):
+        if func is not None:
+            return func
+        return lambda f: f
+
+    mock_mcp = MagicMock()
+    mock_mcp.tool = _passthrough_tool
+    mock_decorators = MagicMock()
+    mock_decorators.tool = _passthrough_tool
+    mock_api = MagicMock()
+    mock_api.mcp = mock_mcp
+
+    # Keys we will override — save originals so _restore_modules can put them back.
+    override_keys = [
+        "superset_core.api",
+        "superset_core.api.mcp",
+        "superset_core.api.types",
+        "superset_core.mcp",
+        "superset_core.mcp.decorators",
+        "superset.extensions",
+        "superset.mcp_service.utils",
+        "superset.mcp_service.utils.url_utils",
+    ]
+    saved: dict[str, types.ModuleType] = {}
+    for key in override_keys:
+        if key in sys.modules:
+            saved[key] = sys.modules[key]
+
+    sys.modules["superset_core.api"] = mock_api
+    sys.modules["superset_core.api.mcp"] = mock_mcp
+    sys.modules["superset_core.mcp"] = mock_mcp
+    sys.modules["superset_core.mcp.decorators"] = mock_decorators
+    sys.modules.setdefault("superset_core.api.types", MagicMock())
+
+    # Stub extensions so `from superset.extensions import event_logger` succeeds.
+    sys.modules["superset.extensions"] = MagicMock()
+
+    # Stub url_utils to avoid importing nh3 (a PyO3 module that can't be
+    # re-initialized in the same process).
+    mock_url_utils = MagicMock()
+    mock_url_utils.get_superset_base_url.return_value = _BASE_URL
+    sys.modules["superset.mcp_service.utils"] = MagicMock()
+    sys.modules["superset.mcp_service.utils.url_utils"] = mock_url_utils
+
+    return saved
+
+
+def _restore_modules(saved: dict[str, types.ModuleType]) -> None:
+    evict_prefixes = (
+        "superset_core.api",
+        "superset_core.mcp",
+        "superset.mcp_service.saved_query.tool",
+        "superset.mcp_service.utils",
+        "superset.extensions",
+    )
+    for key in list(sys.modules.keys()):
+        if any(key == p or key.startswith(p + ".") for p in evict_prefixes):
+            del sys.modules[key]
+    sys.modules.update(saved)
+
+
+def _get_tool_module():
+    saved = _force_passthrough_decorators()
+    mod_name = "superset.mcp_service.saved_query.tool.create_saved_query"
+    for key in list(sys.modules.keys()):
+        if key.startswith("superset.mcp_service.saved_query.tool"):
+            saved[key] = sys.modules.pop(key)
+    mod = importlib.import_module(mod_name)
+    return mod, saved
+
+
+def _make_mock_ctx():
+    async def _noop(*args, **kwargs):
+        pass
+
+    ctx = MagicMock()
+    ctx.info = _noop
+    ctx.error = _noop
+    ctx.warning = _noop
+    return ctx
+
+
+def _mock_create_module(sq=None, exception=None):
+    """Return a mock superset.commands.query.create module."""
+    mod = MagicMock()
+    if exception is not None:
+        mod.CreateSavedQueryCommand.return_value.run.side_effect = exception
+    elif sq is not None:
+        mod.CreateSavedQueryCommand.return_value.run.return_value = sq
+    return mod
+
+
+def _mock_exceptions_module():
+    """Return a mock superset.commands.query.exceptions module with real classes."""
+    mod = MagicMock()
+    mod.SavedQueryInvalidError = SavedQueryInvalidError
+    mod.SavedQueryCreateFailedError = SavedQueryCreateFailedError
+    return mod
+
+
+class TestCreateSavedQuerySchemas:
+    def test_valid_request(self) -> None:
+        req = CreateSavedQueryRequest(db_id=1, label="My Query", sql="SELECT 1")
+        assert req.db_id == 1
+        assert req.label == "My Query"
+        assert req.sql == "SELECT 1"
+
+    def test_optional_fields(self) -> None:
+        req = CreateSavedQueryRequest(
+            db_id=1,
+            label="My Query",
+            sql="SELECT 1",
+            schema="public",
+            description="A test",
+            template_parameters='{"limit": 100}',
+        )
+        assert req.schema == "public"
+        assert req.description == "A test"
+        assert req.template_parameters == '{"limit": 100}'
+
+    def test_empty_sql_fails(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="sql must not be empty"):
+            CreateSavedQueryRequest(db_id=1, label="test", sql="  ")
+
+    def test_empty_label_fails(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="label must not be empty"):
+            CreateSavedQueryRequest(db_id=1, label="  ", sql="SELECT 1")
+
+    def test_sql_is_stripped(self) -> None:
+        req = CreateSavedQueryRequest(db_id=1, label="test", sql="  SELECT 1  ")
+        assert req.sql == "SELECT 1"
+
+    def test_label_is_stripped(self) -> None:
+        req = CreateSavedQueryRequest(db_id=1, label="  My Query  ", sql="SELECT 1")
+        assert req.label == "My Query"
+
+
+class TestCreateSavedQueryToolLogic:
+    @pytest.mark.anyio
+    async def test_create_success(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            mock_sq = MagicMock()
+            mock_sq.id = 42
+            mock_sq.label = "My Query"
+            mock_sq.sql = "SELECT 1"
+            mock_sq.db_id = 1
+            mock_sq.schema = None
+            mock_sq.description = None
+
+            request = CreateSavedQueryRequest(db_id=1, label="My Query", sql="SELECT 1")
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.create": _mock_create_module(sq=mock_sq),
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.create_saved_query(request, _make_mock_ctx())
+
+            assert result.id == 42
+            assert result.label == "My Query"
+            assert result.error is None
+            assert "savedQueryId=42" in result.url
+            assert _BASE_URL in result.url
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_create_invalid_db(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            from marshmallow import ValidationError as MarshmallowValidationError
+
+            exc = SavedQueryInvalidError(
+                exceptions=[
+                    MarshmallowValidationError("db_id is required", field_name="db_id")
+                ]
+            )
+            request = CreateSavedQueryRequest(db_id=1, label="Test", sql="SELECT 1")
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.create": _mock_create_module(
+                        exception=exc
+                    ),
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.create_saved_query(request, _make_mock_ctx())
+
+            assert result.id is None
+            assert result.error is not None
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_create_command_failed(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            exc = SavedQueryCreateFailedError()
+            request = CreateSavedQueryRequest(db_id=1, label="Test", sql="SELECT 1")
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.create": _mock_create_module(
+                        exception=exc
+                    ),
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.create_saved_query(request, _make_mock_ctx())
+
+            assert result.id is None
+            assert result.error is not None
+            assert "Failed to create" in result.error
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_create_with_optional_fields(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            mock_sq = MagicMock()
+            mock_sq.id = 10
+            mock_sq.label = "Test"
+            mock_sq.sql = "SELECT 1"
+            mock_sq.db_id = 2
+            mock_sq.schema = "analytics"
+            mock_sq.description = "My desc"
+
+            request = CreateSavedQueryRequest(
+                db_id=2,
+                label="Test",
+                sql="SELECT 1",
+                schema="analytics",
+                description="My desc",
+                template_parameters='{"x": 1}',
+            )
+
+            mock_create_mod = _mock_create_module(sq=mock_sq)
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.create": mock_create_mod,
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.create_saved_query(request, _make_mock_ctx())
+
+            assert result.id == 10
+            called_with = mock_create_mod.CreateSavedQueryCommand.call_args[0][0]
+            assert called_with["schema"] == "analytics"
+            assert called_with["description"] == "My desc"
+            assert called_with["template_parameters"] == '{"x": 1}'
+        finally:
+            _restore_modules(saved)

--- a/tests/unit_tests/mcp_service/saved_query/tool/test_create_saved_query.py
+++ b/tests/unit_tests/mcp_service/saved_query/tool/test_create_saved_query.py
@@ -147,10 +147,12 @@ class TestCreateSavedQuerySchemas:
             label="My Query",
             sql="SELECT 1",
             schema="public",
+            catalog="main",
             description="A test",
             template_parameters='{"limit": 100}',
         )
         assert req.schema == "public"
+        assert req.catalog == "main"
         assert req.description == "A test"
         assert req.template_parameters == '{"limit": 100}'
 
@@ -186,6 +188,7 @@ class TestCreateSavedQueryToolLogic:
             mock_sq.sql = "SELECT 1"
             mock_sq.db_id = 1
             mock_sq.schema = None
+            mock_sq.catalog = None
             mock_sq.description = None
 
             request = CreateSavedQueryRequest(db_id=1, label="My Query", sql="SELECT 1")
@@ -270,6 +273,7 @@ class TestCreateSavedQueryToolLogic:
             mock_sq.sql = "SELECT 1"
             mock_sq.db_id = 2
             mock_sq.schema = "analytics"
+            mock_sq.catalog = None
             mock_sq.description = "My desc"
 
             request = CreateSavedQueryRequest(
@@ -297,5 +301,44 @@ class TestCreateSavedQueryToolLogic:
             assert called_with["schema"] == "analytics"
             assert called_with["description"] == "My desc"
             assert called_with["template_parameters"] == '{"x": 1}'
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_create_with_catalog(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            mock_sq = MagicMock()
+            mock_sq.id = 55
+            mock_sq.label = "Catalog Query"
+            mock_sq.sql = "SELECT 1"
+            mock_sq.db_id = 3
+            mock_sq.schema = "dbo"
+            mock_sq.catalog = "main"
+            mock_sq.description = None
+
+            request = CreateSavedQueryRequest(
+                db_id=3,
+                label="Catalog Query",
+                sql="SELECT 1",
+                schema="dbo",
+                catalog="main",
+            )
+
+            mock_create_mod = _mock_create_module(sq=mock_sq)
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.create": mock_create_mod,
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.create_saved_query(request, _make_mock_ctx())
+
+            assert result.id == 55
+            assert result.catalog == "main"
+            called_with = mock_create_mod.CreateSavedQueryCommand.call_args[0][0]
+            assert called_with["catalog"] == "main"
         finally:
             _restore_modules(saved)

--- a/tests/unit_tests/mcp_service/saved_query/tool/test_update_saved_query.py
+++ b/tests/unit_tests/mcp_service/saved_query/tool/test_update_saved_query.py
@@ -172,6 +172,7 @@ class TestUpdateSavedQueryToolLogic:
             mock_sq.sql = "SELECT 1"
             mock_sq.db_id = 1
             mock_sq.schema = None
+            mock_sq.catalog = None
             mock_sq.description = None
 
             request = UpdateSavedQueryRequest(id=42, label="Renamed")
@@ -292,5 +293,38 @@ class TestUpdateSavedQueryToolLogic:
             assert result.id is None
             assert result.error is not None
             assert "Failed to update" in result.error
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_update_with_catalog(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            mock_sq = MagicMock()
+            mock_sq.id = 7
+            mock_sq.label = "Cat Query"
+            mock_sq.sql = "SELECT 1"
+            mock_sq.db_id = 2
+            mock_sq.schema = "dbo"
+            mock_sq.catalog = "main"
+            mock_sq.description = None
+
+            request = UpdateSavedQueryRequest(id=7, catalog="main")
+
+            mock_update_mod = _mock_update_module(sq=mock_sq)
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.update": mock_update_mod,
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.update_saved_query(request, _make_mock_ctx())
+
+            assert result.id == 7
+            assert result.catalog == "main"
+            called_props = mock_update_mod.UpdateSavedQueryCommand.call_args[0][1]
+            assert called_props["catalog"] == "main"
         finally:
             _restore_modules(saved)

--- a/tests/unit_tests/mcp_service/saved_query/tool/test_update_saved_query.py
+++ b/tests/unit_tests/mcp_service/saved_query/tool/test_update_saved_query.py
@@ -1,0 +1,296 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for update_saved_query MCP tool."""
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.commands.query.exceptions import (
+    SavedQueryInvalidError,
+    SavedQueryNotFoundError,
+    SavedQueryUpdateFailedError,
+)
+from superset.mcp_service.saved_query.schemas import UpdateSavedQueryRequest
+
+_BASE_URL = "http://localhost:8088"
+
+
+def _force_passthrough_decorators() -> dict[str, types.ModuleType]:
+    def _passthrough_tool(func=None, **kwargs):
+        if func is not None:
+            return func
+        return lambda f: f
+
+    mock_mcp = MagicMock()
+    mock_mcp.tool = _passthrough_tool
+    mock_decorators = MagicMock()
+    mock_decorators.tool = _passthrough_tool
+    mock_api = MagicMock()
+    mock_api.mcp = mock_mcp
+
+    override_keys = [
+        "superset_core.api",
+        "superset_core.api.mcp",
+        "superset_core.api.types",
+        "superset_core.mcp",
+        "superset_core.mcp.decorators",
+        "superset.extensions",
+        "superset.mcp_service.utils",
+        "superset.mcp_service.utils.url_utils",
+    ]
+    saved: dict[str, types.ModuleType] = {}
+    for key in override_keys:
+        if key in sys.modules:
+            saved[key] = sys.modules[key]
+
+    sys.modules["superset_core.api"] = mock_api
+    sys.modules["superset_core.api.mcp"] = mock_mcp
+    sys.modules["superset_core.mcp"] = mock_mcp
+    sys.modules["superset_core.mcp.decorators"] = mock_decorators
+    sys.modules.setdefault("superset_core.api.types", MagicMock())
+
+    sys.modules["superset.extensions"] = MagicMock()
+
+    mock_url_utils = MagicMock()
+    mock_url_utils.get_superset_base_url.return_value = _BASE_URL
+    sys.modules["superset.mcp_service.utils"] = MagicMock()
+    sys.modules["superset.mcp_service.utils.url_utils"] = mock_url_utils
+
+    return saved
+
+
+def _restore_modules(saved: dict[str, types.ModuleType]) -> None:
+    evict_prefixes = (
+        "superset_core.api",
+        "superset_core.mcp",
+        "superset.mcp_service.saved_query.tool",
+        "superset.mcp_service.utils",
+        "superset.extensions",
+    )
+    for key in list(sys.modules.keys()):
+        if any(key == p or key.startswith(p + ".") for p in evict_prefixes):
+            del sys.modules[key]
+    sys.modules.update(saved)
+
+
+def _get_tool_module():
+    saved = _force_passthrough_decorators()
+    mod_name = "superset.mcp_service.saved_query.tool.update_saved_query"
+    for key in list(sys.modules.keys()):
+        if key.startswith("superset.mcp_service.saved_query.tool"):
+            saved[key] = sys.modules.pop(key)
+    mod = importlib.import_module(mod_name)
+    return mod, saved
+
+
+def _make_mock_ctx():
+    async def _noop(*args, **kwargs):
+        pass
+
+    ctx = MagicMock()
+    ctx.info = _noop
+    ctx.error = _noop
+    ctx.warning = _noop
+    return ctx
+
+
+def _mock_update_module(sq=None, exception=None):
+    """Return a mock superset.commands.query.update module."""
+    mod = MagicMock()
+    if exception is not None:
+        mod.UpdateSavedQueryCommand.return_value.run.side_effect = exception
+    elif sq is not None:
+        mod.UpdateSavedQueryCommand.return_value.run.return_value = sq
+    return mod
+
+
+def _mock_exceptions_module():
+    """Return a mock superset.commands.query.exceptions module with real classes."""
+    mod = MagicMock()
+    mod.SavedQueryInvalidError = SavedQueryInvalidError
+    mod.SavedQueryNotFoundError = SavedQueryNotFoundError
+    mod.SavedQueryUpdateFailedError = SavedQueryUpdateFailedError
+    return mod
+
+
+class TestUpdateSavedQuerySchemas:
+    def test_valid_request_with_label(self) -> None:
+        req = UpdateSavedQueryRequest(id=1, label="New Name")
+        assert req.id == 1
+        assert req.label == "New Name"
+
+    def test_id_only_is_valid(self) -> None:
+        req = UpdateSavedQueryRequest(id=5)
+        assert req.id == 5
+        assert req.label is None
+        assert req.sql is None
+
+    def test_empty_sql_fails(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="sql must not be empty"):
+            UpdateSavedQueryRequest(id=1, sql="  ")
+
+    def test_empty_label_fails(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="label must not be empty"):
+            UpdateSavedQueryRequest(id=1, label="  ")
+
+    def test_sql_is_stripped(self) -> None:
+        req = UpdateSavedQueryRequest(id=1, sql="  SELECT 1  ")
+        assert req.sql == "SELECT 1"
+
+
+class TestUpdateSavedQueryToolLogic:
+    @pytest.mark.anyio
+    async def test_update_success(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            mock_sq = MagicMock()
+            mock_sq.id = 42
+            mock_sq.label = "Renamed"
+            mock_sq.sql = "SELECT 1"
+            mock_sq.db_id = 1
+            mock_sq.schema = None
+            mock_sq.description = None
+
+            request = UpdateSavedQueryRequest(id=42, label="Renamed")
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.update": _mock_update_module(sq=mock_sq),
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.update_saved_query(request, _make_mock_ctx())
+
+            assert result.id == 42
+            assert result.label == "Renamed"
+            assert result.error is None
+            assert "savedQueryId=42" in result.url
+            assert _BASE_URL in result.url
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_update_no_fields_returns_error(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            request = UpdateSavedQueryRequest(id=42)
+
+            # The tool still performs lazy imports before the no-op check,
+            # so we must stub the command modules to avoid transitive failures.
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.update": _mock_update_module(),
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.update_saved_query(request, _make_mock_ctx())
+
+            assert result.id is None
+            assert result.error is not None
+            assert "No fields to update" in result.error
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_update_not_found(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            exc = SavedQueryNotFoundError()
+            request = UpdateSavedQueryRequest(id=999, label="Ghost")
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.update": _mock_update_module(
+                        exception=exc
+                    ),
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.update_saved_query(request, _make_mock_ctx())
+
+            assert result.id is None
+            assert result.error is not None
+            assert "999" in result.error
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_update_invalid_db(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            from marshmallow import ValidationError as MarshmallowValidationError
+
+            exc = SavedQueryInvalidError(
+                exceptions=[
+                    MarshmallowValidationError(
+                        "Database with ID 999 not found", field_name="db_id"
+                    )
+                ]
+            )
+            request = UpdateSavedQueryRequest(id=1, db_id=999)
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.update": _mock_update_module(
+                        exception=exc
+                    ),
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.update_saved_query(request, _make_mock_ctx())
+
+            assert result.id is None
+            assert result.error is not None
+        finally:
+            _restore_modules(saved)
+
+    @pytest.mark.anyio
+    async def test_update_command_failed(self) -> None:
+        mod, saved = _get_tool_module()
+        try:
+            exc = SavedQueryUpdateFailedError()
+            request = UpdateSavedQueryRequest(id=1, sql="SELECT 2")
+
+            with patch.dict(
+                sys.modules,
+                {
+                    "superset.commands.query.update": _mock_update_module(
+                        exception=exc
+                    ),
+                    "superset.commands.query.exceptions": _mock_exceptions_module(),
+                },
+            ):
+                result = await mod.update_saved_query(request, _make_mock_ctx())
+
+            assert result.id is None
+            assert result.error is not None
+            assert "Failed to update" in result.error
+        finally:
+            _restore_modules(saved)


### PR DESCRIPTION
### SUMMARY

Adds two new MCP tools for managing saved queries in SQL Lab:

- **`create_saved_query`**: Creates a new saved query with required fields (`label`, `sql`, `db_id`) and optional fields (`schema`, `description`, `template_parameters`).
- **`update_saved_query`**: Updates an existing saved query by ID. All fields except `id` are optional — only provided fields are changed.

Both tools:
- Require `SavedQuery` write permission (`tags=["mutate"]`, `readOnlyHint=False`)
- Return a URL to open the query in SQL Lab (e.g. `/sqllab?savedQueryId=42`)
- Handle validation errors (invalid db_id, not found) with structured error responses

New files:
- `superset/commands/query/create.py` — `CreateSavedQueryCommand`
- `superset/commands/query/update.py` — `UpdateSavedQueryCommand`
- `superset/mcp_service/saved_query/tool/create_saved_query.py`
- `superset/mcp_service/saved_query/tool/update_saved_query.py`
- `superset/mcp_service/saved_query/schemas.py`

Modified:
- `superset/commands/query/exceptions.py` — added `SavedQueryCreateFailedError`, `SavedQueryUpdateFailedError`
- `superset/mcp_service/app.py` — registered both tools

### BEFORE/AFTER SCREENSHOTS (N/A)

No UI changes — MCP tools only.

### TESTING INSTRUCTIONS

```python
# Via MCP client
await client.call_tool("create_saved_query", {
    "request": {"label": "My query", "sql": "SELECT 1", "db_id": 1}
})
# Returns: {"id": 42, "label": "My query", "sql": "SELECT 1", "db_id": 1, "url": "/sqllab?savedQueryId=42"}

await client.call_tool("update_saved_query", {
    "request": {"id": 42, "label": "Renamed query"}
})
# Returns: {"id": 42, "label": "Renamed query", ...}
```

### ADDITIONAL INFORMATION

- Follows the same mutation tool pattern as `create_virtual_dataset` and `update_chart`
- `update_saved_query` uses partial update: only explicitly provided fields are written
- `destructiveHint=True` on `update_saved_query` (modifies existing data)