### PR TITLE
fix(dataset): validate catalog against allow_multi_catalog on import

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,12 @@ assists people when migrating to a new version.
 
 ## Next
 
+### Dataset import validates catalog against the target connection
+
+Importing a dataset now validates the `catalog` field against the target database connection. When the connection has multi-catalog disabled (`allow_multi_catalog` off) and the dataset's catalog is not the connection's default catalog, the import fails instead of silently persisting the non-default catalog. This matches the validation already enforced on the dataset update path and prevents imported datasets from querying an unintended database.
+
+If you relied on importing datasets with a non-default catalog, enable "Allow changing catalogs" on the target connection, or set the dataset's catalog to the connection's default before importing.
+
 ### Granular Export Controls
 
 A new feature flag `GRANULAR_EXPORT_CONTROLS` introduces three fine-grained permissions that replace the legacy `can_csv` permission:

--- a/superset/commands/dataset/importers/v1/__init__.py
+++ b/superset/commands/dataset/importers/v1/__init__.py
@@ -21,8 +21,12 @@ from marshmallow import Schema
 from sqlalchemy.orm import Session  # noqa: F401
 
 from superset.commands.database.importers.v1.utils import import_database
-from superset.commands.dataset.exceptions import DatasetImportError
+from superset.commands.dataset.exceptions import (
+    DatasetImportError,
+    MultiCatalogDisabledValidationError,
+)
 from superset.commands.dataset.importers.v1.utils import import_dataset
+from superset.commands.exceptions import CommandInvalidError
 from superset.commands.importers.v1 import ImportModelsCommand
 from superset.daos.dataset import DatasetDAO
 from superset.databases.schemas import ImportV1DatabaseSchema
@@ -69,4 +73,11 @@ class ImportDatasetsCommand(ImportModelsCommand):
                 and config["database_uuid"] in database_ids
             ):
                 config["database_id"] = database_ids[config["database_uuid"]]
-                import_dataset(config, overwrite=overwrite)
+                try:
+                    import_dataset(config, overwrite=overwrite)
+                except MultiCatalogDisabledValidationError as ex:
+                    # surface as a 422 validation error instead of a generic 500
+                    raise CommandInvalidError(
+                        "; ".join(str(message) for message in ex.messages),
+                        [ex],
+                    ) from ex

--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -161,7 +161,10 @@ def import_dataset(  # noqa: C901
             "Dataset doesn't exist and user doesn't have permission to create datasets"
         )
 
-    validate_catalog(config)
+    # Trusted imports (e.g. example loading) carry curated configs; only
+    # untrusted user imports validate the catalog, like the access checks below.
+    if not ignore_permissions:
+        validate_catalog(config)
 
     # TODO (betodealmeida): move this logic to import_from_dict
     config = config.copy()

--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -30,6 +30,7 @@ from superset import db, security_manager
 from superset.commands.dataset.exceptions import (
     DatasetAccessDeniedError,
     DatasetForbiddenDataURI,
+    MultiCatalogDisabledValidationError,
 )
 from superset.commands.exceptions import ImportFailedError
 from superset.connectors.sqla.models import SqlaTable
@@ -106,6 +107,32 @@ def validate_data_uri(data_uri: str) -> None:
     raise DatasetForbiddenDataURI()
 
 
+def validate_catalog(config: dict[str, Any]) -> None:
+    """
+    Reject a non-default catalog when the target database has multi-catalog
+    disabled, matching the dataset update validation so an import can't silently
+    bind a dataset to an unintended catalog (and route queries to it).
+    """
+    catalog = config.get("catalog")
+    database_id = config.get("database_id")
+    if not catalog or database_id is None:
+        return
+
+    database = db.session.query(Database).filter_by(id=database_id).first()
+    if database is None or not database.db_engine_spec.supports_catalog:
+        return
+
+    # Only validate when the connection has a known default catalog to compare
+    # against; without one there is no "non-default" catalog to reject.
+    default_catalog = database.get_default_catalog()
+    if (
+        default_catalog is not None
+        and not database.allow_multi_catalog
+        and catalog != default_catalog
+    ):
+        raise MultiCatalogDisabledValidationError()
+
+
 def import_dataset(  # noqa: C901
     config: dict[str, Any],
     overwrite: bool = False,
@@ -133,6 +160,8 @@ def import_dataset(  # noqa: C901
         raise ImportFailedError(
             "Dataset doesn't exist and user doesn't have permission to create datasets"
         )
+
+    validate_catalog(config)
 
     # TODO (betodealmeida): move this logic to import_from_dict
     config = config.copy()

--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -33,6 +33,7 @@ from superset import db, security_manager
 from superset.commands.dataset.exceptions import (
     DatasetAccessDeniedError,
     DatasetForbiddenDataURI,
+    MultiCatalogDisabledValidationError,
 )
 from superset.commands.dataset.importers.v1.utils import (
     import_dataset,
@@ -45,6 +46,7 @@ from superset.models.core import Database
 from superset.utils import json
 from superset.utils.core import override_user
 from tests.integration_tests.fixtures.importexport import (
+    database_config,
     dataset_config as dataset_fixture,
 )
 
@@ -320,6 +322,200 @@ def test_import_dataset_no_folder(mocker: MockerFixture, session: Session) -> No
 
     sqla_table = import_dataset(config)
     assert sqla_table.folders is None
+
+
+def test_import_dataset_rejects_non_default_catalog_when_multi_catalog_disabled(
+    mocker: MockerFixture, session: Session
+) -> None:
+    """
+    Importing a non-default catalog must fail when the target database has
+    multi-catalog disabled, matching the dataset update validation so an import
+    can't silently bind a dataset to an unintended catalog.
+    """
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+
+    engine = db.session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    db.session.add(database)
+    db.session.flush()
+
+    # the connection supports catalogs, defaults to "primary", multi-catalog off
+    engine_spec = database.db_engine_spec
+    mocker.patch.object(engine_spec, "supports_catalog", True)
+    mocker.patch.object(engine_spec, "get_default_catalog", return_value="primary")
+
+    config = {
+        "table_name": "my_table",
+        "schema": "my_schema",
+        "catalog": "other_catalog",
+        "uuid": uuid.uuid4(),
+        "metrics": [],
+        "columns": [],
+        "database_uuid": database.uuid,
+        "database_id": database.id,
+    }
+
+    with pytest.raises(MultiCatalogDisabledValidationError):
+        import_dataset(config)
+
+
+def test_import_command_surfaces_non_default_catalog_as_validation_error(
+    mocker: MockerFixture, session: Session
+) -> None:
+    """
+    The dataset import command surfaces a disallowed catalog as a 422
+    CommandInvalidError carrying the catalog message, instead of a generic 500.
+    """
+    from superset.commands.dataset.importers.v1 import ImportDatasetsCommand
+    from superset.commands.exceptions import CommandInvalidError
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+
+    engine = db.session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    db_config = copy.deepcopy(database_config)
+    # a URI with a database gives PostgresEngineSpec a non-None default catalog
+    db_config["sqlalchemy_uri"] = "postgresql://user:pass@host1/primary"
+
+    ds_config = copy.deepcopy(dataset_fixture)
+    ds_config["catalog"] = "other_catalog"
+
+    configs = {
+        "databases/imported_database.yaml": db_config,
+        "datasets/imported_dataset.yaml": ds_config,
+    }
+
+    with pytest.raises(CommandInvalidError) as excinfo:
+        ImportDatasetsCommand._import(configs, overwrite=False)
+
+    assert "Only the default catalog is supported for this connection" in str(
+        excinfo.value
+    )
+
+
+def test_import_dataset_overwrite_cannot_flip_to_non_default_catalog(
+    mocker: MockerFixture, session: Session
+) -> None:
+    """
+    Overwriting an existing dataset with a non-default catalog must fail when
+    multi-catalog is disabled, so a UUID-matched import can't flip a
+    correctly-bound dataset onto an unintended catalog.
+    """
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+
+    engine = db.session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    db.session.add(database)
+    db.session.flush()
+
+    engine_spec = database.db_engine_spec
+    mocker.patch.object(engine_spec, "supports_catalog", True)
+    mocker.patch.object(engine_spec, "get_default_catalog", return_value="primary")
+
+    dataset_uuid = uuid.uuid4()
+    existing = SqlaTable(
+        uuid=dataset_uuid,
+        table_name="my_table",
+        catalog="primary",
+        database_id=database.id,
+    )
+    db.session.add(existing)
+    db.session.flush()
+
+    config = {
+        "table_name": "my_table",
+        "schema": "my_schema",
+        "catalog": "other_catalog",
+        "uuid": dataset_uuid,
+        "metrics": [],
+        "columns": [],
+        "database_uuid": database.uuid,
+        "database_id": database.id,
+    }
+
+    with pytest.raises(MultiCatalogDisabledValidationError):
+        import_dataset(config, overwrite=True)
+
+    assert existing.catalog == "primary"
+
+
+def test_import_dataset_allows_non_default_catalog_when_multi_catalog_enabled(
+    mocker: MockerFixture, session: Session
+) -> None:
+    """
+    A non-default catalog imports cleanly when the target database has
+    multi-catalog enabled.
+    """
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+
+    engine = db.session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(
+        database_name="my_database",
+        sqlalchemy_uri="sqlite://",
+        extra=json.dumps({"allow_multi_catalog": True}),
+    )
+    db.session.add(database)
+    db.session.flush()
+
+    engine_spec = database.db_engine_spec
+    mocker.patch.object(engine_spec, "supports_catalog", True)
+    mocker.patch.object(engine_spec, "get_default_catalog", return_value="primary")
+
+    config = {
+        "table_name": "my_table",
+        "schema": "my_schema",
+        "catalog": "other_catalog",
+        "uuid": uuid.uuid4(),
+        "metrics": [],
+        "columns": [],
+        "database_uuid": database.uuid,
+        "database_id": database.id,
+    }
+
+    sqla_table = import_dataset(config)
+    assert sqla_table.catalog == "other_catalog"
+
+
+def test_import_dataset_allows_default_catalog_when_multi_catalog_disabled(
+    mocker: MockerFixture, session: Session
+) -> None:
+    """
+    Re-importing the connection's default catalog is allowed even with
+    multi-catalog disabled.
+    """
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+
+    engine = db.session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    db.session.add(database)
+    db.session.flush()
+
+    engine_spec = database.db_engine_spec
+    mocker.patch.object(engine_spec, "supports_catalog", True)
+    mocker.patch.object(engine_spec, "get_default_catalog", return_value="primary")
+
+    config = {
+        "table_name": "my_table",
+        "schema": "my_schema",
+        "catalog": "primary",
+        "uuid": uuid.uuid4(),
+        "metrics": [],
+        "columns": [],
+        "database_uuid": database.uuid,
+        "database_id": database.id,
+    }
+
+    sqla_table = import_dataset(config)
+    assert sqla_table.catalog == "primary"
 
 
 def test_import_dataset_duplicate_column(

--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -361,6 +361,41 @@ def test_import_dataset_rejects_non_default_catalog_when_multi_catalog_disabled(
         import_dataset(config)
 
 
+def test_import_dataset_skips_catalog_validation_for_trusted_imports(
+    mocker: MockerFixture, session: Session
+) -> None:
+    """
+    Trusted imports (ignore_permissions=True, e.g. example loading) bypass
+    catalog validation, so a non-default catalog does not abort the import even
+    when the target database has multi-catalog disabled.
+    """
+    engine = db.session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    db.session.add(database)
+    db.session.flush()
+
+    # the connection supports catalogs, defaults to "primary", multi-catalog off
+    engine_spec = database.db_engine_spec
+    mocker.patch.object(engine_spec, "supports_catalog", True)
+    mocker.patch.object(engine_spec, "get_default_catalog", return_value="primary")
+
+    config = {
+        "table_name": "my_table",
+        "schema": "my_schema",
+        "catalog": "other_catalog",
+        "uuid": uuid.uuid4(),
+        "metrics": [],
+        "columns": [],
+        "database_uuid": database.uuid,
+        "database_id": database.id,
+    }
+
+    sqla_table = import_dataset(config, ignore_permissions=True)
+    assert sqla_table.catalog == "other_catalog"
+
+
 def test_import_command_surfaces_non_default_catalog_as_validation_error(
     mocker: MockerFixture, session: Session
 ) -> None:


### PR DESCRIPTION
### SUMMARY

The v1 dataset importer persisted a dataset's `catalog` without validating it against the target database connection, unlike the dataset update path. When the connection has multi-catalog disabled (`allow_multi_catalog` off) and the imported catalog is not the connection's default catalog, the import succeeded and the dataset then executed queries against a different physical database. When the source and target databases live on the same server, this silently routes queries to the wrong database and shows incorrect data in charts and dashboards. With overwrite enabled, a UUID-matched import could flip an existing, correctly-bound dataset into this state.

`import_dataset` now validates the catalog and raises the same `MultiCatalogDisabledValidationError` the update command uses. The import command converts it to a `CommandInvalidError` so the API returns a 422 with the catalog message ("Only the default catalog is supported for this connection") instead of a generic failure.

Validation only triggers when the target database supports catalogs and has a known default catalog. Databases without catalog support, and a `None`/absent catalog (which resolves to the connection's default at query time), are left unaffected, so existing imports keep working.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Repro: import a dataset whose YAML `catalog` differs from the target connection's default catalog, onto a catalog-supporting connection (e.g. Postgres) with "Allow changing catalogs" off.

Before: the import is accepted and the dataset is silently created bound to the non-default catalog, so it then queries a different physical database.

![before](https://files.catbox.moe/iw9yf6.png)

After: the same import is rejected.

![after](https://files.catbox.moe/jho53o.png)

### TESTING INSTRUCTIONS

Unit tests:

```
pytest tests/unit_tests/datasets/commands/importers/v1/import_test.py
```

Coverage added: a non-default catalog with multi-catalog off raises; the import command surfaces it as a validation error; overwrite cannot flip an existing dataset's catalog; a non-default catalog is allowed when multi-catalog is on; the default catalog is allowed when multi-catalog is off.

Manual:

1. On a catalog-supporting connection (e.g. Postgres) with "Allow changing catalogs" off, create a dataset and export it.
2. Edit `catalog:` in the dataset YAML to a non-default catalog and re-zip.
3. Import with Overwrite enabled. The import now fails with "Only the default catalog is supported for this connection" instead of silently persisting the non-default catalog.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API