### PR TITLE
chore(i18n): lint + dev warning for eager t() in controlPanel configs

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -149,6 +149,7 @@ module.exports = {
     'theme-colors/no-literal-colors': 'error',
     'icons/no-fa-icons-usage': 'error',
     'i18n-strings/no-template-vars': 'error',
+    'i18n-strings/no-eager-t-in-config': 'off', // enabled only for controlPanel files via overrides below
 
     // Core ESLint overrides for Superset
     'no-console': 'warn',
@@ -262,6 +263,19 @@ module.exports = {
     ],
   },
   overrides: [
+    // Eager t()/tn() in `label`/`description` config props is captured at
+    // module-load time, before i18n initializes — labels stay in the fallback
+    // language even after the user switches. Surfaced as a warning (with
+    // autofix to `() => t(...)`) wherever this is a real foot-gun:
+    // controlPanel files. Many pre-existing call sites need conversion;
+    // run `eslint --fix` on a controlPanel file to sweep it. Promote to
+    // `'error'` once the codebase is clean.
+    {
+      files: ['**/controlPanel.{ts,tsx,js,jsx}'],
+      rules: {
+        'i18n-strings/no-eager-t-in-config': 'warn',
+      },
+    },
     // Ban JavaScript files in src/ - all new code must be TypeScript
     {
       files: ['src/**/*.js', 'src/**/*.jsx'],

--- a/superset-frontend/eslint-rules/eslint-plugin-i18n-strings/index.ts
+++ b/superset-frontend/eslint-rules/eslint-plugin-i18n-strings/index.ts
@@ -65,6 +65,86 @@ const plugin: { rules: Record<string, Rule.RuleModule> } = {
         };
       },
     },
+    'no-eager-t-in-config': {
+      meta: {
+        type: 'problem',
+        fixable: 'code',
+        docs: {
+          description:
+            'Disallow eager t()/tn() calls for `label` and `description` in config objects evaluated at module load (e.g., controlPanel files). The translation is captured at module-evaluation time, before i18n has loaded, and never updates when the user switches language. Wrap the call in an arrow function so it is evaluated at render time.',
+        },
+        schema: [
+          {
+            type: 'object',
+            properties: {
+              properties: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+            additionalProperties: false,
+          },
+        ],
+        messages: {
+          eager:
+            'Eager `{{property}}: t(...)` is evaluated at module load, before i18n is initialized. Wrap in an arrow function: `{{property}}: () => t(...)`.',
+        },
+      },
+      create(context: Rule.RuleContext): Rule.RuleListener {
+        const watchedProps: string[] = context.options[0]?.properties ?? [
+          'label',
+          'description',
+        ];
+        const TRANSLATE_FNS = new Set(['t', 'tn']);
+
+        function handler(node: Node): void {
+          const prop = node as Node & {
+            key: { type: string; name?: string; value?: string };
+            value: Node & {
+              type: string;
+              callee?: { type: string; name?: string };
+            };
+            shorthand?: boolean;
+            computed?: boolean;
+          };
+          if (prop.shorthand || prop.computed) return;
+
+          const keyName =
+            prop.key.type === 'Identifier'
+              ? prop.key.name
+              : prop.key.type === 'Literal'
+                ? prop.key.value
+                : undefined;
+          if (typeof keyName !== 'string' || !watchedProps.includes(keyName)) {
+            return;
+          }
+
+          const callee = prop.value;
+          if (
+            callee.type !== 'CallExpression' ||
+            callee.callee?.type !== 'Identifier' ||
+            !callee.callee.name ||
+            !TRANSLATE_FNS.has(callee.callee.name)
+          ) {
+            return;
+          }
+
+          context.report({
+            node: prop.value,
+            messageId: 'eager',
+            data: { property: keyName },
+            fix(fixer) {
+              const source = context.getSourceCode().getText(prop.value);
+              return fixer.replaceText(prop.value, `() => ${source}`);
+            },
+          });
+        }
+
+        return {
+          Property: handler,
+        };
+      },
+    },
     'sentence-case-buttons': {
       meta: {
         type: 'suggestion',

--- a/superset-frontend/eslint-rules/eslint-plugin-i18n-strings/index.ts
+++ b/superset-frontend/eslint-rules/eslint-plugin-i18n-strings/index.ts
@@ -87,7 +87,7 @@ const plugin: { rules: Record<string, Rule.RuleModule> } = {
         ],
         messages: {
           eager:
-            'Eager `{{property}}: t(...)` is evaluated at module load, before i18n is initialized. Wrap in an arrow function: `{{property}}: () => t(...)`.',
+            'Eager `{{property}}: {{fn}}(...)` is evaluated at module load, before i18n is initialized. Wrap in an arrow function: `{{property}}: () => {{fn}}(...)`.',
         },
       },
       create(context: Rule.RuleContext): Rule.RuleListener {
@@ -132,7 +132,7 @@ const plugin: { rules: Record<string, Rule.RuleModule> } = {
           context.report({
             node: prop.value,
             messageId: 'eager',
-            data: { property: keyName },
+            data: { property: keyName, fn: callee.callee.name },
             fix(fixer) {
               const source = context.getSourceCode().getText(prop.value);
               return fixer.replaceText(prop.value, `() => ${source}`);

--- a/superset-frontend/eslint-rules/eslint-plugin-i18n-strings/no-eager-t-in-config.test.ts
+++ b/superset-frontend/eslint-rules/eslint-plugin-i18n-strings/no-eager-t-in-config.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { Rule } from 'eslint';
+
+const { RuleTester } = require('eslint');
+const plugin: { rules: Record<string, Rule.RuleModule> } = require('.');
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+});
+const rule: Rule.RuleModule = plugin.rules['no-eager-t-in-config'];
+
+ruleTester.run('no-eager-t-in-config', rule, {
+  valid: [
+    // Lazy form — the recommended pattern
+    "const c = { label: () => t('Foo') };",
+    "const c = { description: () => t('Foo') };",
+    "const c = { label: () => tn('one', 'many', n) };",
+    // Static strings — no translation, no issue
+    "const c = { label: 'Foo' };",
+    // Other property names — unaffected
+    "const c = { name: t('Foo') };",
+    "const c = { title: t('Foo') };",
+    // Computed keys are too dynamic to lint usefully
+    "const c = { [labelKey]: t('Foo') };",
+    // Shorthand: `{ label }` — no value to inspect
+    'const label = t("Foo"); const c = { label };',
+    // t() called inside a function body — already lazy
+    "const c = { label: state => t('Foo') };",
+    // Non-t() call expressions are fine
+    "const c = { label: someOtherFn('Foo') };",
+  ],
+  invalid: [
+    {
+      code: "const c = { label: t('Foo') };",
+      output: "const c = { label: () => t('Foo') };",
+      errors: [{ messageId: 'eager' }],
+    },
+    {
+      code: "const c = { description: t('Foo bar') };",
+      output: "const c = { description: () => t('Foo bar') };",
+      errors: [{ messageId: 'eager' }],
+    },
+    {
+      code: "const c = { label: tn('one', 'many', 2) };",
+      output: "const c = { label: () => tn('one', 'many', 2) };",
+      errors: [{ messageId: 'eager' }],
+    },
+    // String-literal keys are equivalent to identifier keys
+    {
+      code: "const c = { 'label': t('Foo') };",
+      output: "const c = { 'label': () => t('Foo') };",
+      errors: [{ messageId: 'eager' }],
+    },
+    // Custom watched-property list via rule option
+    {
+      code: "const c = { headerTitle: t('Foo') };",
+      output: "const c = { headerTitle: () => t('Foo') };",
+      options: [{ properties: ['headerTitle'] }],
+      errors: [{ messageId: 'eager' }],
+    },
+    // Nested config — fires per occurrence
+    {
+      code: "const c = { foo: { label: t('A'), description: t('B') } };",
+      output:
+        "const c = { foo: { label: () => t('A'), description: () => t('B') } };",
+      errors: [{ messageId: 'eager' }, { messageId: 'eager' }],
+    },
+  ],
+});

--- a/superset-frontend/packages/superset-core/src/translation/TranslatorSingleton.test.ts
+++ b/superset-frontend/packages/superset-core/src/translation/TranslatorSingleton.test.ts
@@ -26,7 +26,7 @@ test('t() warns and creates a default translator when called before configure', 
     const { t } = require('./TranslatorSingleton');
     const result = t('hello');
     expect(consoleSpy).toHaveBeenCalledWith(
-      'You should call configure(...) before calling other methods',
+      expect.stringMatching(/was called before configure\(\)/),
     );
     expect(result).toBe('hello');
     consoleSpy.mockRestore();
@@ -54,7 +54,7 @@ test('resetTranslation resets the configured singleton', () => {
     // After reset, calling t() should warn again
     t('hello');
     expect(consoleSpy).toHaveBeenCalledWith(
-      'You should call configure(...) before calling other methods',
+      expect.stringMatching(/was called before configure\(\)/),
     );
     consoleSpy.mockRestore();
   });
@@ -96,6 +96,65 @@ test('tn() calls translateWithNumber on the singleton', () => {
   });
 });
 
+test('pre-configure warning fires once per unique key', () => {
+  jest.isolateModules(() => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { t } = require('./TranslatorSingleton');
+    t('apple');
+    t('apple');
+    t('apple');
+    t('banana');
+    expect(consoleSpy).toHaveBeenCalledTimes(2);
+    expect(consoleSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('"apple"'),
+    );
+    expect(consoleSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('"banana"'),
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+test('pre-configure warning suggests the lazy-function fix', () => {
+  jest.isolateModules(() => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { t } = require('./TranslatorSingleton');
+    t('Sort ascending');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('() => t("Sort ascending")'),
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+test('pre-configure warning is suppressed in production', () => {
+  jest.isolateModules(() => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { t } = require('./TranslatorSingleton');
+    t('hello');
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+    process.env.NODE_ENV = originalEnv;
+  });
+});
+
+test('resetTranslation clears the warned-keys dedupe set', () => {
+  jest.isolateModules(() => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { t, resetTranslation } = require('./TranslatorSingleton');
+    t('hello');
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    resetTranslation();
+    t('hello');
+    expect(consoleSpy).toHaveBeenCalledTimes(2);
+    consoleSpy.mockRestore();
+  });
+});
+
 test('resetTranslation does nothing when not yet configured', () => {
   jest.isolateModules(() => {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -105,7 +164,7 @@ test('resetTranslation does nothing when not yet configured', () => {
     // The singleton is still unconfigured, so t() warns
     t('hello');
     expect(consoleSpy).toHaveBeenCalledWith(
-      'You should call configure(...) before calling other methods',
+      expect.stringMatching(/was called before configure\(\)/),
     );
     consoleSpy.mockRestore();
   });

--- a/superset-frontend/packages/superset-core/src/translation/TranslatorSingleton.test.ts
+++ b/superset-frontend/packages/superset-core/src/translation/TranslatorSingleton.test.ts
@@ -138,7 +138,11 @@ test('pre-configure warning is suppressed in production', () => {
     t('hello');
     expect(consoleSpy).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
-    process.env.NODE_ENV = originalEnv;
+    if (originalEnv !== undefined) {
+      process.env.NODE_ENV = originalEnv;
+    } else {
+      delete process.env.NODE_ENV;
+    }
   });
 });
 

--- a/superset-frontend/packages/superset-core/src/translation/TranslatorSingleton.ts
+++ b/superset-frontend/packages/superset-core/src/translation/TranslatorSingleton.ts
@@ -25,6 +25,10 @@ import { TranslatorConfig, Translations, LocaleData } from './types';
 let singleton: Translator | undefined;
 let isConfigured = false;
 
+// Tracks which keys have already triggered a pre-configure warning so the
+// logs don't drown in repeated calls from large module-load fan-outs.
+const warnedPreConfigureKeys = new Set<string>();
+
 function configure(config?: TranslatorConfig) {
   singleton = new Translator(config);
   isConfigured = true;
@@ -33,10 +37,6 @@ function configure(config?: TranslatorConfig) {
 }
 
 function getInstance() {
-  if (!isConfigured) {
-    console.warn('You should call configure(...) before calling other methods');
-  }
-
   if (typeof singleton === 'undefined') {
     singleton = new Translator();
   }
@@ -44,11 +44,32 @@ function getInstance() {
   return singleton;
 }
 
+function warnPreConfigure(key: string) {
+  // Only warn in non-production builds — production callers may legitimately
+  // tolerate the fallback, and the noise isn't useful at runtime.
+  if (
+    typeof process !== 'undefined' &&
+    process.env?.NODE_ENV === 'production'
+  ) {
+    return;
+  }
+  if (warnedPreConfigureKeys.has(key)) return;
+  warnedPreConfigureKeys.add(key);
+  console.warn(
+    `[i18n] t(${JSON.stringify(key)}) was called before configure() — ` +
+      `the result is the fallback language and will not update when the ` +
+      `user switches language. If this call is at module load (e.g., a ` +
+      `controlPanel \`label\`/\`description\`), wrap it in an arrow ` +
+      `function: \`() => t(${JSON.stringify(key)})\`.`,
+  );
+}
+
 function resetTranslation() {
   if (isConfigured) {
     isConfigured = false;
     singleton = undefined;
   }
+  warnedPreConfigureKeys.clear();
 }
 
 function addTranslation(key: string, translations: string[]) {
@@ -64,10 +85,12 @@ function addLocaleData(data: LocaleData) {
 }
 
 function t(input: string, ...args: unknown[]) {
+  if (!isConfigured) warnPreConfigure(input);
   return getInstance().translate(input, ...args);
 }
 
 function tn(key: string, ...args: unknown[]) {
+  if (!isConfigured) warnPreConfigure(key);
   return getInstance().translateWithNumber(key, ...args);
 }
 

--- a/superset-frontend/packages/superset-core/src/translation/TranslatorSingleton.ts
+++ b/superset-frontend/packages/superset-core/src/translation/TranslatorSingleton.ts
@@ -44,7 +44,7 @@ function getInstance() {
   return singleton;
 }
 
-function warnPreConfigure(key: string) {
+function warnPreConfigure(fn: 't' | 'tn', key: string) {
   // Only warn in non-production builds — production callers may legitimately
   // tolerate the fallback, and the noise isn't useful at runtime.
   if (
@@ -56,11 +56,11 @@ function warnPreConfigure(key: string) {
   if (warnedPreConfigureKeys.has(key)) return;
   warnedPreConfigureKeys.add(key);
   console.warn(
-    `[i18n] t(${JSON.stringify(key)}) was called before configure() — ` +
+    `[i18n] ${fn}(${JSON.stringify(key)}) was called before configure() — ` +
       `the result is the fallback language and will not update when the ` +
       `user switches language. If this call is at module load (e.g., a ` +
       `controlPanel \`label\`/\`description\`), wrap it in an arrow ` +
-      `function: \`() => t(${JSON.stringify(key)})\`.`,
+      `function: \`() => ${fn}(${JSON.stringify(key)})\`.`,
   );
 }
 
@@ -85,12 +85,12 @@ function addLocaleData(data: LocaleData) {
 }
 
 function t(input: string, ...args: unknown[]) {
-  if (!isConfigured) warnPreConfigure(input);
+  if (!isConfigured) warnPreConfigure('t', input);
   return getInstance().translate(input, ...args);
 }
 
 function tn(key: string, ...args: unknown[]) {
-  if (!isConfigured) warnPreConfigure(key);
+  if (!isConfigured) warnPreConfigure('tn', key);
   return getInstance().translateWithNumber(key, ...args);
 }
 

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -204,8 +204,14 @@ export type TabOverride = 'data' | 'customize' | 'matrixify' | boolean;
  * these configs will be passed to the UI component for control as props.
  *
  * - type: the control type, referencing a React component of the same name
- * - label: the label as shown in the control's header
- * - description: shown in the info tooltip of the control's header
+ * - label: the label as shown in the control's header. When the value involves
+ *   `t()`/`tn()`, prefer the arrow-function form (`label: () => t('Foo')`) so
+ *   the lookup runs at render time rather than at module load — eager
+ *   `label: t('Foo')` captures the fallback language before i18n initializes
+ *   and does not update on runtime language change. The
+ *   `i18n-strings/no-eager-t-in-config` lint rule autofixes this.
+ * - description: shown in the info tooltip of the control's header. Same
+ *   lazy-form guidance as `label`.
  * - default: the default value when opening a new chart, or changing visualization type
  * - renderTrigger: a bool that defines whether the visualization should be re-rendered
  *    when changed. This should `true` for controls that only affect the rendering (client side)

--- a/superset-frontend/scripts/check-custom-rules.js
+++ b/superset-frontend/scripts/check-custom-rules.js
@@ -198,6 +198,62 @@ function checkI18nTemplates(ast, filepath) {
 }
 
 /**
+ * Check for eager t()/tn() calls in `label` / `description` properties of
+ * config objects evaluated at module load (e.g., controlPanel files). The
+ * translation is captured at module-evaluation time, before i18n has loaded,
+ * and never updates when the user switches language. The fix is to wrap the
+ * call in an arrow function: `label: () => t('Foo')`.
+ *
+ * Limited to controlPanel files because that's where this pattern is
+ * problematic at scale; t() inside JSX or component bodies is evaluated at
+ * render time and works fine.
+ */
+const EAGER_T_WATCHED_PROPS = new Set(['label', 'description']);
+
+function checkEagerTranslationsInConfig(ast, filepath) {
+  if (!/controlPanel\.(ts|tsx|js|jsx)$/.test(filepath)) return;
+
+  traverse(ast, {
+    ObjectProperty(path) {
+      const { node } = path;
+      if (node.computed || node.shorthand) return;
+
+      const keyName =
+        node.key.type === 'Identifier'
+          ? node.key.name
+          : node.key.type === 'StringLiteral'
+            ? node.key.value
+            : null;
+      if (!keyName || !EAGER_T_WATCHED_PROPS.has(keyName)) return;
+
+      const { value } = node;
+      if (
+        value.type !== 'CallExpression' ||
+        value.callee.type !== 'Identifier' ||
+        (value.callee.name !== 't' && value.callee.name !== 'tn')
+      ) {
+        return;
+      }
+
+      if (hasEslintDisable(path, 'i18n-strings/no-eager-t-in-config')) return;
+
+      // Warn (not error) because there are many pre-existing violations.
+      // The ESLint plugin provides an autofix so authors can sweep files
+      // as they touch them. Promote to error once the codebase is clean.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `${YELLOW}⚠${RESET} ${filepath}:${node.loc?.start.line ?? '?'}: ` +
+          `Eager \`${keyName}: ${value.callee.name}(...)\` is evaluated at ` +
+          `module load, before i18n is initialized. Wrap in an arrow ` +
+          `function: \`${keyName}: () => ${value.callee.name}(...)\`. ` +
+          `Run \`eslint --fix\` to autofix.`,
+      );
+      warningCount += 1;
+    },
+  });
+}
+
+/**
  * Props that should contain translated strings
  */
 const TRANSLATABLE_PROPS = new Set([
@@ -565,6 +621,7 @@ function processFile(filepath) {
     checkNoLiteralColors(ast, filepath);
     checkNoFaIcons(ast, filepath);
     checkI18nTemplates(ast, filepath);
+    checkEagerTranslationsInConfig(ast, filepath);
     checkUntranslatedStrings(ast, filepath);
   } catch (error) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
### SUMMARY

Follow-up to #40229. That PR fixed a class of bugs where chart-control labels stayed in the English fallback even after switching language — root cause was `label: t('Foo')` at module-load time, evaluated before i18n initialization. The fix in that PR converted call sites to the arrow form `label: () => t('Foo')` so the lookup happens at render time.

This PR doesn't change runtime behavior — instead it adds **three guard rails** against future regressions of the same bug class:

1. **ESLint rule `i18n-strings/no-eager-t-in-config`** (autofixable). Flags `label: t(...)` / `description: t(...)` and rewrites to the arrow form. Wired as `'warn'` for `**/controlPanel.{ts,tsx,js,jsx}` files so authors can sweep files with `eslint --fix` as they touch them, without breaking CI on the ~1055 pre-existing call sites. Promote to `'error'` once the codebase is clean.

2. **`check-custom-rules.js` parallel check**. ESLint isn't run in CI/pre-commit (that path uses `oxlint` + the babel-traverse `check-custom-rules.js`), so this mirrors the rule there as a warning. Same shape as the existing `checkI18nTemplates` check.

3. **`t()` / `tn()` dev-mode warning**. When called before `configure()`, emits a once-per-key console warning that names the key and suggests the arrow-function fix. Replaces the previous noisy per-call generic warning. Suppressed when `NODE_ENV === 'production'`.

Also adds a brief note to `BaseControlConfig`'s docstring (`packages/superset-ui-chart-controls/src/types.ts`) so the lazy-form convention is documented where authors actually look.

### Why these specific guards (and not others)

I considered a few alternatives in [this thread](https://github.com/apache/superset/pull/40229) — Proxy returns, blocking i18n init at bootstrap, tag-template syntax. All have wider blast radius (break \`typeof === 'string'\`, JSON serialization, Redux DevTools, etc.) or only fix the initial-load case while leaving runtime language switches broken. The lazy-function pattern is already what the framework supports throughout (`ControlPanelsContainer`, `ExploreViewContainer`, `getControlItemsMap`, etc. all handle `typeof label === 'function'`), so the cheapest durable fix is to *enforce the pattern* via lint and surface its absence at dev runtime.

### Why warn-only initially

There are ~1055 pre-existing call sites across ~65 controlPanel files. Most are safe to mass-autofix (the framework already handles the function form), but a few custom renderers (e.g., `plugin-chart-handlebars`'s own ControlHeader) currently fall through to `null` on function-valued labels. So the conservative path is: ship the rule, sweep files gradually as people touch them, fix renderer edge cases in parallel, then promote to `'error'`.

### TESTING INSTRUCTIONS

**ESLint plugin rule** (verified locally):
- Drop a fresh `controlPanel.ts` with `const c = { label: t('Foo'), description: t('Bar') };` into `src/`.
- \`npx eslint <path>\` → 2 warnings: `Eager \`label: t(...)\` is evaluated at module load... Wrap in an arrow function: \`label: () => t(...)\``.
- \`npx eslint --fix <path>\` → rewrites to `() => t('Foo')` / `() => t('Bar')`.

**`check-custom-rules.js`** (verified locally):
- `node scripts/check-custom-rules.js src/chartCustomizations/components/DynamicGroupBy/controlPanel.ts` → 4 warnings (the section-level labels + a description still eager in that file).
- `node scripts/check-custom-rules.js src/explore/components/ControlHeader.tsx` → 0 warnings (non-controlPanel files are untouched).

**`t()` dev warning** (unit-tested):
- Call `t('apple')` three times before `configure()` → exactly 1 warning containing `"apple"` and `() => t("apple")`.
- Call with `NODE_ENV=production` → no warning.
- `resetTranslation()` clears the dedupe set.
- See `TranslatorSingleton.test.ts` — 12 tests pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: follow-up to #40229
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)