### PR TITLE
fix(ci): stop cancelling Hold Label Check runs

### DIFF
--- a/.github/workflows/no-hold-label.yml
+++ b/.github/workflows/no-hold-label.yml
@@ -7,10 +7,13 @@ on:
 permissions:
   pull-requests: read
 
-# cancel previous workflow jobs for PRs
+# Let each label event run to completion. Cancelling in-progress runs leaves
+# CANCELLED entries in the PR's check-suite rollup, which poisons GitHub's
+# `status:success` search filter even though all real CI passed. The job is
+# a tiny no-op github-script call, so the wasted compute is negligible.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-hold-label:


### PR DESCRIPTION
### SUMMARY

`Hold Label Check` re-fires on every PR label event (`labeled`, `unlabeled`, `opened`, `reopened`, `synchronize`) with `cancel-in-progress: true`. When a PR gets multiple labels in quick succession — Dependabot PRs are a great example, picking up `dependencies`, the scope label, language tags, etc. — earlier runs are killed and end up as **CANCELLED** entries in the PR's check-suite rollup.

GitHub's PR search filter `status:success` treats CANCELLED as a non-success terminal state (unlike `SKIPPED` or `NEUTRAL`), so PRs end up excluded from queries like [`is:pr is:open author:dependabot[bot] status:success`](https://github.com/apache/superset/pulls?q=is%3Apr+is%3Aopen+author%3Adependabot%5Bbot%5D+status%3Asuccess+) even though every real CI check passed.

Example: #40372 has 73 SUCCESS, 3 NEUTRAL, 1 SKIPPED, and **3 CANCELLED** `check-hold-label` runs from rapid-fire labeling.

### Fix

Flip `cancel-in-progress` to `false`. Each label event runs to completion (the job is a ~5s `github-script` no-op), so:
- The rollup stays clean → `status:success` works as intended.
- The hold-label gate still re-evaluates on every label change.
- Wasted compute is negligible (no checkout, no install).

### BEFORE/AFTER

**Before:** `is:open status:success` filter silently drops PRs that had >1 hold-label run.
**After:** all green dependabot PRs surface correctly in maintainer review queues.

### TESTING INSTRUCTIONS

Land it, then poke a label on any PR a couple of times — the prior `check-hold-label` runs should complete normally rather than show as cancelled.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)