### PR TITLE
chore(ci): limit /app/prefix matrix variant to master merges

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         parallel_id: [0, 1, 2, 3, 4, 5]
         browser: ["chrome"]
-        app_root: ["", "/app/prefix"]
+        app_root: ${{ github.event_name == 'push' && fromJSON('["", "/app/prefix"]') || fromJSON('[""]') }}
     env:
       SUPERSET_ENV: development
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         browser: ["chromium"]
-        app_root: ["", "/app/prefix"]
+        app_root: ${{ github.event_name == 'push' && fromJSON('["", "/app/prefix"]') || fromJSON('[""]') }}
     env:
       SUPERSET_ENV: development
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config


### PR DESCRIPTION
### SUMMARY

Running both `app_root` variants (`""` and `"/app/prefix"`) on every PR doubles the number of E2E jobs (12 Cypress + 4 Playwright) for a check that is primarily relevant at integration time. This restricts the `/app/prefix` variant to `push` events (master merges), halving PR E2E compute while preserving full coverage on merged code.

The change uses GitHub Actions' `fromJSON()` expression in the matrix definition so the value is a proper array at runtime:

```yaml
app_root: ${{ github.event_name == 'push' && fromJSON('["", "/app/prefix"]') || fromJSON('[""]') }}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI-only change, no UI impact.

### TESTING INSTRUCTIONS

- CI on this PR will show **6 Cypress + 2 Playwright jobs** (PR-time count — only `app_root: ""`).
- A master merge will still trigger the full **12 Cypress + 4 Playwright jobs** (both `app_root` variants).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

No functional code changes — CI workflow only.