### PR TITLE
fix(point-cluster-map): guard invalid point radii

### DIFF
--- a/superset-frontend/plugins/plugin-chart-point-cluster-map/src/components/ScatterPlotOverlay.tsx
+++ b/superset-frontend/plugins/plugin-chart-point-cluster-map/src/components/ScatterPlotOverlay.tsx
@@ -26,6 +26,9 @@ import luminanceFromRGB from '../utils/luminanceFromRGB';
 export const MIN_CLUSTER_RADIUS_RATIO = 1 / 6;
 export const MAX_POINT_RADIUS_RATIO = 1 / 3;
 
+const isValidCanvasRadius = (value: number) =>
+  Number.isFinite(value) && value > 0;
+
 interface GeoJSONLocation {
   geometry: {
     coordinates: [number, number];
@@ -352,8 +355,11 @@ function ScatterPlotOverlay({
                   : String(pointMetric);
               }
 
-              if (!pointRadius) {
+              if (!isValidCanvasRadius(pointRadius)) {
                 pointRadius = defaultRadius;
+                if (pointMetric === null) {
+                  pointLabel = undefined;
+                }
               }
 
               ctx.arc(

--- a/superset-frontend/plugins/plugin-chart-point-cluster-map/src/components/ScatterPlotOverlay.tsx
+++ b/superset-frontend/plugins/plugin-chart-point-cluster-map/src/components/ScatterPlotOverlay.tsx
@@ -26,7 +26,7 @@ import luminanceFromRGB from '../utils/luminanceFromRGB';
 export const MIN_CLUSTER_RADIUS_RATIO = 1 / 6;
 export const MAX_POINT_RADIUS_RATIO = 1 / 3;
 
-const isValidCanvasRadius = (value: number) =>
+export const isValidCanvasRadius = (value: number) =>
   Number.isFinite(value) && value > 0;
 
 interface GeoJSONLocation {

--- a/superset-frontend/plugins/plugin-chart-point-cluster-map/test/ScatterPlotOverlay.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-point-cluster-map/test/ScatterPlotOverlay.test.tsx
@@ -373,6 +373,37 @@ test('renders map with Miles mode', () => {
   }).not.toThrow();
 });
 
+test.each(['Kilometers', 'Miles'])(
+  'falls back to default radius for non-positive %s values',
+  pointRadiusUnit => {
+    const locations = [
+      createLocation([100, 50], { radius: -5, cluster: false }),
+      createLocation([200, 50], { radius: 0, cluster: false }),
+      createLocation([300, 50], { radius: 10, cluster: false }),
+    ];
+
+    render(
+      <ScatterPlotOverlay
+        {...defaultProps}
+        locations={locations}
+        pointRadiusUnit={pointRadiusUnit}
+        zoom={10}
+      />,
+    );
+    const redrawParams = triggerRedraw();
+
+    const arcCalls = redrawParams.ctx.arc.mock.calls;
+
+    arcCalls.forEach(call => {
+      expect(Number.isFinite(call[2])).toBe(true);
+      expect(call[2]).toBeGreaterThan(0);
+    });
+    expect(arcCalls[0][2]).toBe(MIN_VISIBLE_POINT_RADIUS);
+    expect(arcCalls[1][2]).toBe(MIN_VISIBLE_POINT_RADIUS);
+    expect(arcCalls[2][2]).toBeGreaterThan(MIN_VISIBLE_POINT_RADIUS);
+  },
+);
+
 test('displays metric property labels on points', () => {
   const locations = [
     createLocation([100, 100], { radius: 50, metric: 123.456, cluster: false }),

--- a/superset-frontend/plugins/plugin-chart-point-cluster-map/test/ScatterPlotOverlay.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-point-cluster-map/test/ScatterPlotOverlay.test.tsx
@@ -18,8 +18,8 @@
  */
 
 import { render } from '@testing-library/react';
-import ScatterPlotOverlay from '../src/components/ScatterPlotOverlay';
-import {
+import ScatterPlotOverlay, {
+  isValidCanvasRadius,
   MIN_CLUSTER_RADIUS_RATIO,
   MAX_POINT_RADIUS_RATIO,
 } from '../src/components/ScatterPlotOverlay';
@@ -157,6 +157,18 @@ const MIN_VISIBLE_POINT_RADIUS =
   defaultProps.dotRadius * MIN_CLUSTER_RADIUS_RATIO;
 const MAX_VISIBLE_POINT_RADIUS =
   defaultProps.dotRadius * MAX_POINT_RADIUS_RATIO;
+
+test.each([
+  [1, true],
+  [0.1, true],
+  [0, false],
+  [-1, false],
+  [NaN, false],
+  [Infinity, false],
+  [-Infinity, false],
+])('validates canvas radius value %p', (value, expected) => {
+  expect(isValidCanvasRadius(value)).toBe(expected);
+});
 
 test('renders map with varying radius values in Pixels mode', () => {
   const locations = [
@@ -401,6 +413,11 @@ test.each(['Kilometers', 'Miles'])(
     expect(arcCalls[0][2]).toBe(MIN_VISIBLE_POINT_RADIUS);
     expect(arcCalls[1][2]).toBe(MIN_VISIBLE_POINT_RADIUS);
     expect(arcCalls[2][2]).toBeGreaterThan(MIN_VISIBLE_POINT_RADIUS);
+
+    const expectedLabel = pointRadiusUnit === 'Miles' ? '10mi' : '10km';
+    expect(redrawParams.ctx.fillText.mock.calls.map(call => call[0])).toEqual([
+      expectedLabel,
+    ]);
   },
 );
 


### PR DESCRIPTION
### SUMMARY
Guard point-cluster map rendering against invalid point radii after Miles/Kilometers conversion. Non-positive or non-finite radii now fall back to the default point radius before calling `ctx.arc()`.

Fixes #34398

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable.

### TESTING INSTRUCTIONS
Added regression coverage for Miles and Kilometers point radius units with non-positive radius values.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #34398
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
