### PR TITLE
fix(i18n): auto-add ASF license header in backfill_po.py

### DIFF
--- a/scripts/translations/backfill_po.py
+++ b/scripts/translations/backfill_po.py
@@ -69,6 +69,24 @@ DEFAULT_INDEX = TRANSLATIONS_DIR / "translation_index.json"
 DEFAULT_MODEL = "claude-sonnet-4-6"
 DEFAULT_BATCH_SIZE = 50
 
+_ASF_LICENSE_HEADER = """\
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+
 # Language names for the prompt, keyed by ISO code
 LANGUAGE_NAMES: dict[str, str] = {
     "ar": "Arabic",
@@ -93,6 +111,14 @@ LANGUAGE_NAMES: dict[str, str] = {
     "zh": "Chinese (Simplified)",
     "zh_TW": "Chinese (Traditional)",
 }
+
+
+def _ensure_license_header(po_path: Path) -> None:
+    """Prepend the ASF license header to the .po file if it is missing."""
+    content = po_path.read_text(encoding="utf-8")
+    if "Licensed to the Apache Software Foundation" not in content:
+        po_path.write_text(_ASF_LICENSE_HEADER + content, encoding="utf-8")
+        print(f"Added ASF license header to {po_path}", file=sys.stderr)
 
 
 def _lang_name(code: str) -> str:
@@ -509,6 +535,8 @@ def backfill(
     print("Loading translation index …", file=sys.stderr)
     with open(index_path, encoding="utf-8") as f:
         index: dict[str, Any] = json.load(f)
+
+    _ensure_license_header(po_path)
 
     print(f"Loading {po_path} …", file=sys.stderr)
     cat = polib.pofile(str(po_path))

--- a/scripts/translations/backfill_po.py
+++ b/scripts/translations/backfill_po.py
@@ -113,12 +113,17 @@ LANGUAGE_NAMES: dict[str, str] = {
 }
 
 
-def _ensure_license_header(po_path: Path) -> None:
+def _ensure_license_header(po_path: Path, *, dry_run: bool = False) -> None:
     """Prepend the ASF license header to the .po file if it is missing."""
     content = po_path.read_text(encoding="utf-8")
     if "Licensed to the Apache Software Foundation" not in content:
-        po_path.write_text(_ASF_LICENSE_HEADER + content, encoding="utf-8")
-        print(f"Added ASF license header to {po_path}", file=sys.stderr)
+        if dry_run:
+            print(
+                f"[dry-run] Would add ASF license header to {po_path}", file=sys.stderr
+            )
+        else:
+            po_path.write_text(_ASF_LICENSE_HEADER + content, encoding="utf-8")
+            print(f"Added ASF license header to {po_path}", file=sys.stderr)
 
 
 def _lang_name(code: str) -> str:
@@ -536,7 +541,7 @@ def backfill(
     with open(index_path, encoding="utf-8") as f:
         index: dict[str, Any] = json.load(f)
 
-    _ensure_license_header(po_path)
+    _ensure_license_header(po_path, dry_run=dry_run)
 
     print(f"Loading {po_path} …", file=sys.stderr)
     cat = polib.pofile(str(po_path))

--- a/tests/unit_tests/scripts/translations/backfill_po_test.py
+++ b/tests/unit_tests/scripts/translations/backfill_po_test.py
@@ -310,3 +310,36 @@ def test_build_prompt_includes_plural_note_when_plural_is_not_first() -> None:
     ]
     prompt = backfill_po.build_prompt("fr", batch, index={})
     assert "provide ALL plural forms" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _ensure_license_header
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_license_header_prepends_when_missing(tmp_path: Path) -> None:
+    """Header is written when the file lacks the ASF copyright notice."""
+    po = tmp_path / "messages.po"
+    po.write_text('msgid ""\nmsgstr ""\n', encoding="utf-8")
+    backfill_po._ensure_license_header(po)
+    content = po.read_text(encoding="utf-8")
+    assert "Licensed to the Apache Software Foundation" in content
+    assert content.startswith("#")
+
+
+def test_ensure_license_header_skips_when_present(tmp_path: Path) -> None:
+    """Header is not duplicated when already present."""
+    po = tmp_path / "messages.po"
+    original = '# Licensed to the Apache Software Foundation\nmsgid ""\n'
+    po.write_text(original, encoding="utf-8")
+    backfill_po._ensure_license_header(po)
+    assert po.read_text(encoding="utf-8") == original
+
+
+def test_ensure_license_header_dry_run_does_not_write(tmp_path: Path) -> None:
+    """Passing dry_run=True prints a notice but leaves the file unchanged."""
+    po = tmp_path / "messages.po"
+    original = 'msgid ""\nmsgstr ""\n'
+    po.write_text(original, encoding="utf-8")
+    backfill_po._ensure_license_header(po, dry_run=True)
+    assert po.read_text(encoding="utf-8") == original


### PR DESCRIPTION
### SUMMARY

Translation `.po` files in Apache Superset require the ASF license header — the same header present in all other `.po` files in the repo (German, Chinese, etc.). Files initialized from the `.pot` template (e.g. via `msginit`) don't inherit this header, causing **License Check** CI failures on any PR that adds a new language.

`backfill_po.py` now automatically prepends the header to any `.po` file that's missing it before beginning translation. This makes the tool self-healing: running it on a freshly-initialized `.po` file will fix the license header as a side effect, with no separate manual step required.

**Related:** Discovered while fixing #40390 (Finnish) and #40391 (Thai) translation PRs that failed License Check.

### TESTING INSTRUCTIONS

```bash
# Create a bare .po file without the header and confirm it gets fixed:
python scripts/translations/backfill_po.py --lang <code> --dry-run
# The script should print "Added ASF license header to ..." before proceeding.
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)