### PR TITLE
feat(mcp): add sql_expression to ColumnRef for calculated metrics

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -488,10 +488,27 @@ def create_metric_object(col: ColumnRef) -> Dict[str, Any] | str:
 
     For saved metrics, returns the metric name as a plain string which
     Superset's query engine resolves via its metrics_by_name lookup.
+    For SQL-expression metrics, returns a SQL expression dict.
     For ad-hoc metrics, returns a SIMPLE expression dict.
     """
     if col.saved_metric:
         return col.name
+
+    if col.sql_expression:
+        # SQL-expression metric: arbitrary calculation, no single column.
+        # Useful for ratios (SUM(profit)/NULLIF(SUM(sales),0)),
+        # growth rates, conversion percentages, etc.
+        label = col.label or col.name
+        return {
+            "expressionType": "SQL",
+            "sqlExpression": col.sql_expression,
+            "label": label,
+            "optionName": f"metric_{col.name}",
+            "hasCustomLabel": bool(col.label),
+            "aggregate": None,
+            "column": None,
+            "datasourceWarning": False,
+        }
 
     # Ensure aggregate is valid - default to SUM if not specified or invalid
     valid_aggregates = {

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -700,18 +700,59 @@ class ColumnRef(BaseModel):
         "(use get_dataset_info to see available metrics). "
         "When set, 'aggregate' is ignored.",
     )
+    sql_expression: str | None = Field(
+        None,
+        max_length=2000,
+        description=(
+            "Inline SQL expression for a calculated metric, e.g. "
+            "'SUM(profit) / NULLIF(SUM(sales), 0)'. Use for ratios, "
+            "growth rates, conversion percentages, and other formulas "
+            "that don't reduce to a single column + aggregate. When set, "
+            "'aggregate' is ignored; 'name' is used as the metric label."
+        ),
+    )
 
     @property
     def is_metric(self) -> bool:
-        """Whether this ref acts as a metric (has aggregate or is a saved metric)."""
-        return bool(self.aggregate) or self.saved_metric
+        """Whether this ref acts as a metric."""
+        return bool(self.aggregate) or self.saved_metric or bool(self.sql_expression)
 
     @model_validator(mode="after")
     def clear_aggregate_for_saved_metric(self) -> "ColumnRef":
-        """Clear aggregate when saved_metric is True since it's ignored."""
-        if self.saved_metric and self.aggregate is not None:
+        """Clear aggregate when saved_metric or sql_expression takes over."""
+        if (self.saved_metric or self.sql_expression) and self.aggregate is not None:
             self.aggregate = None
         return self
+
+    @model_validator(mode="after")
+    def disallow_saved_and_sql(self) -> "ColumnRef":
+        """saved_metric and sql_expression are mutually exclusive paths."""
+        if self.saved_metric and self.sql_expression:
+            raise ValueError(
+                "saved_metric and sql_expression are mutually exclusive — "
+                "pick one. saved_metric references a stored metric by name; "
+                "sql_expression embeds a calculation inline."
+            )
+        return self
+
+    @field_validator("sql_expression")
+    @classmethod
+    def strip_and_reject_blank_sql_expression(cls, v: str | None) -> str | None:
+        """Strip whitespace and reject blank-or-whitespace-only expressions.
+
+        Without this, ``sql_expression='   '`` would slip past the
+        ``is_metric`` check and fail later with a database SQL syntax
+        error. Failing here gives the caller a clear validation error.
+        """
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError(
+                "sql_expression must contain a non-empty SQL fragment "
+                "(e.g. 'SUM(profit) / NULLIF(SUM(sales), 0)')."
+            )
+        return stripped
 
     @field_validator("name")
     @classmethod

--- a/superset/mcp_service/chart/validation/dataset_validator.py
+++ b/superset/mcp_service/chart/validation/dataset_validator.py
@@ -87,6 +87,12 @@ class DatasetValidator:
         # Collect all column references
         column_refs = DatasetValidator._extract_column_references(config)
 
+        # Identify which refs are in metric positions. Only those refs may
+        # legitimately carry a sql_expression — a sql_expression on an
+        # x_axis / dimension / group_by is invalid (those positions need
+        # a real column name).
+        metric_ref_ids = DatasetValidator._get_metric_ref_ids(config)
+
         # Validate saved metrics exist in dataset metrics specifically
         invalid_saved = DatasetValidator._validate_saved_metrics(
             column_refs, dataset_context
@@ -96,7 +102,7 @@ class DatasetValidator:
 
         # Validate columns exist (skip saved metrics — already validated above)
         column_error = DatasetValidator._validate_columns_exist(
-            column_refs, dataset_context
+            column_refs, dataset_context, metric_ref_ids
         )
         if column_error:
             return False, column_error
@@ -116,7 +122,9 @@ class DatasetValidator:
 
     @staticmethod
     def _validate_columns_exist(
-        column_refs: List[ColumnRef], dataset_context: DatasetContext
+        column_refs: List[ColumnRef],
+        dataset_context: DatasetContext,
+        metric_ref_ids: set[int] | None = None,
     ) -> ChartGenerationError | None:
         """Validate that non-saved-metric column refs exist in the dataset.
 
@@ -126,7 +134,15 @@ class DatasetValidator:
         ``saved_metric=true``) would slip through and downstream code would
         emit ``SUM(sum_boys)`` as an ad-hoc SIMPLE metric, producing the
         broken-SQL pattern this validator is meant to prevent.
+
+        ``metric_ref_ids`` is the set of ``id(ref)`` values for refs in
+        metric positions. SQL-expression refs are only valid in metric
+        positions; if a ref carries ``sql_expression`` but isn't in a
+        metric slot (e.g., used as x_axis or group_by), it's flagged as
+        invalid here so the caller learns at Tier-1 instead of getting
+        a generic DB error later.
         """
+        metric_ref_ids = metric_ref_ids or set()
         column_names_lower = {
             col["name"].lower() for col in dataset_context.available_columns
         }
@@ -138,6 +154,17 @@ class DatasetValidator:
         saved_metric_typo: List[ColumnRef] = []
         for col_ref in column_refs:
             if col_ref.saved_metric:
+                continue
+            if col_ref.sql_expression:
+                # SQL-expression refs are only valid in metric positions.
+                # In a metric slot, the inline expression carries its own
+                # column references — skip dataset-column lookup. In a
+                # non-metric slot (x_axis, group_by, dimensions, etc.) the
+                # position needs a real column name, so flag as invalid
+                # at Tier 1 instead of failing later with a DB error.
+                if id(col_ref) in metric_ref_ids:
+                    continue
+                invalid_columns.append(col_ref)
                 continue
             name_lower = col_ref.name.lower()
             if name_lower in column_names_lower:
@@ -313,6 +340,48 @@ class DatasetValidator:
                 refs.append(ColumnRef(name=filter_config.column))
 
         return refs
+
+    @staticmethod
+    def _get_metric_ref_ids(config: Any) -> set[int]:  # noqa: C901
+        """Return ``id(ref)`` values for ColumnRefs sitting in metric slots.
+
+        A ``sql_expression`` only makes sense on a metric-bearing field
+        (XY ``y``, Pie ``metric``, BigNumber ``metric``, etc.). Used by
+        ``_validate_columns_exist`` to distinguish "metric carrying an
+        inline calc" from "x-axis/dimension carrying nonsense".
+
+        Identity comparison via ``id()`` is sufficient because the
+        validator runs on a single config instance per call — no aliasing
+        across configs to worry about.
+        """
+        ids: set[int] = set()
+
+        if isinstance(config, XYChartConfig):
+            for ref in config.y:
+                ids.add(id(ref))
+        elif isinstance(config, PieChartConfig):
+            ids.add(id(config.metric))
+        elif isinstance(config, PivotTableChartConfig):
+            for ref in config.metrics:
+                ids.add(id(ref))
+        elif isinstance(config, MixedTimeseriesChartConfig):
+            for ref in config.y:
+                ids.add(id(ref))
+            for ref in config.y_secondary:
+                ids.add(id(ref))
+        elif isinstance(config, HandlebarsChartConfig):
+            if config.metrics:
+                for ref in config.metrics:
+                    ids.add(id(ref))
+        elif isinstance(config, BigNumberChartConfig):
+            ids.add(id(config.metric))
+        elif isinstance(config, TableChartConfig):
+            # In a table, any column with an aggregate is acting as a metric.
+            for ref in config.columns:
+                if ref.aggregate or ref.saved_metric or ref.sql_expression:
+                    ids.add(id(ref))
+
+        return ids
 
     @staticmethod
     def _column_exists(column_name: str, dataset_context: DatasetContext) -> bool:

--- a/superset/mcp_service/chart/validation/schema_validator.py
+++ b/superset/mcp_service/chart/validation/schema_validator.py
@@ -392,18 +392,32 @@ class SchemaValidator:
                 ],
                 error_code="INVALID_BIG_NUMBER_METRIC_TYPE",
             )
-        if not metric.get("aggregate") and not metric.get("saved_metric"):
+        sql_expression = metric.get("sql_expression")
+        if isinstance(sql_expression, str) and not sql_expression.strip():
+            # Treat whitespace-only as missing so the error message below
+            # surfaces the same way a missing-aggregate would, rather than
+            # letting the empty string slip through to fail at query time.
+            sql_expression = None
+
+        if (
+            not metric.get("aggregate")
+            and not metric.get("saved_metric")
+            and not sql_expression
+        ):
             return False, ChartGenerationError(
                 error_type="missing_metric_aggregate",
-                message="Big Number metric must include an aggregate function "
-                "or reference a saved metric",
-                details="The metric must have an 'aggregate' field "
-                "or 'saved_metric': true",
+                message="Big Number metric must include an aggregate function, "
+                "reference a saved metric, or provide a SQL expression",
+                details="The metric must have an 'aggregate' field, "
+                "'saved_metric': true, or 'sql_expression' set",
                 suggestions=[
                     "Add 'aggregate' to your metric: "
                     "{'name': 'col', 'aggregate': 'SUM'}",
                     "Or use a saved metric: "
                     "{'name': 'total_sales', 'saved_metric': true}",
+                    "Or use a SQL expression for calculated metrics: "
+                    "{'name': 'profit_ratio', "
+                    "'sql_expression': 'SUM(profit)/NULLIF(SUM(sales),0)'}",
                     "Valid aggregates: SUM, COUNT, AVG, MIN, MAX",
                 ],
                 error_code="MISSING_BIG_NUMBER_AGGREGATE",

--- a/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_big_number_chart.py
@@ -94,6 +94,45 @@ class TestBigNumberChartConfig:
         assert is_valid is True
         assert error is None
 
+    def test_sql_expression_metric_accepted(self) -> None:
+        """SQL-expression metrics satisfy the big-number is_metric requirement."""
+        config = BigNumberChartConfig(
+            chart_type="big_number",
+            metric=ColumnRef(
+                name="profit_ratio",
+                sql_expression="SUM(profit) / NULLIF(SUM(sales), 0)",
+                label="Profit Ratio",
+            ),
+        )
+        assert config.metric.sql_expression == (
+            "SUM(profit) / NULLIF(SUM(sales), 0)"
+        )
+        assert config.metric.is_metric is True
+
+    def test_sql_expression_passes_pre_validation(self) -> None:
+        """SQL-expression metrics pass the schema_validator big-number guard."""
+        data = {
+            "chart_type": "big_number",
+            "metric": {
+                "name": "profit_ratio",
+                "sql_expression": "SUM(profit) / NULLIF(SUM(sales), 0)",
+            },
+        }
+        is_valid, error = SchemaValidator._pre_validate_big_number_config(data)
+        assert is_valid is True
+        assert error is None
+
+    def test_metric_without_aggregate_or_sql_or_saved_rejected(self) -> None:
+        """Bare ColumnRef (no aggregate, no sql_expression, no saved_metric)
+        is still rejected by the big_number guard."""
+        data = {
+            "chart_type": "big_number",
+            "metric": {"name": "revenue"},
+        }
+        is_valid, error = SchemaValidator._pre_validate_big_number_config(data)
+        assert is_valid is False
+        assert error.error_code == "MISSING_BIG_NUMBER_AGGREGATE"
+
     def test_with_subheader(self) -> None:
         config = BigNumberChartConfig(
             chart_type="big_number",

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -727,6 +727,89 @@ class TestColumnRefSavedMetric:
             )
 
 
+class TestColumnRefSqlExpression:
+    """Test ColumnRef sql_expression support for calculated metrics."""
+
+    def test_sql_expression_defaults_to_none(self) -> None:
+        """A ColumnRef without an explicit sql_expression defaults to None,
+        leaving the existing SIMPLE / saved_metric paths unaffected."""
+        col = ColumnRef(name="revenue", aggregate="SUM")
+        assert col.sql_expression is None
+
+    def test_sql_expression_accepted(self) -> None:
+        """A ColumnRef accepts an inline SQL expression for calculated
+        metrics, preserving the supplied expression and label verbatim."""
+        col = ColumnRef(
+            name="profit_ratio",
+            sql_expression="SUM(profit) / NULLIF(SUM(sales), 0)",
+            label="Profit Ratio",
+        )
+        assert col.sql_expression == "SUM(profit) / NULLIF(SUM(sales), 0)"
+        assert col.label == "Profit Ratio"
+
+    def test_sql_expression_clears_aggregate(self) -> None:
+        """sql_expression takes over from aggregate, matching saved_metric behavior."""
+        col = ColumnRef(
+            name="profit_ratio",
+            sql_expression="SUM(profit) / SUM(sales)",
+            aggregate="SUM",
+        )
+        assert col.sql_expression == "SUM(profit) / SUM(sales)"
+        assert col.aggregate is None
+
+    def test_sql_expression_marks_as_metric(self) -> None:
+        """A ref with sql_expression set is treated as a valid metric ref by
+        the is_metric property, even without aggregate or saved_metric."""
+        col = ColumnRef(name="ratio", sql_expression="SUM(a)/SUM(b)")
+        assert col.is_metric is True
+
+    def test_sql_expression_and_saved_metric_are_mutually_exclusive(self) -> None:
+        """A ColumnRef can't be both a saved-metric reference AND a SQL calc."""
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            ColumnRef(
+                name="profit_ratio",
+                sql_expression="SUM(profit)/SUM(sales)",
+                saved_metric=True,
+            )
+
+    def test_sql_expression_in_xy_config(self) -> None:
+        """SQL-expression metrics work as the y-axis of an xy chart."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="order_date"),
+            y=[
+                ColumnRef(
+                    name="margin",
+                    sql_expression="SUM(profit) / NULLIF(SUM(sales), 0)",
+                    label="Margin",
+                )
+            ],
+        )
+        assert len(config.y) == 1
+        assert config.y[0].sql_expression == (
+            "SUM(profit) / NULLIF(SUM(sales), 0)"
+        )
+
+    def test_sql_expression_max_length_enforced(self) -> None:
+        """Enforce the 2000-char cap so callers can't slip arbitrarily
+        large SQL blobs through the metric field."""
+        with pytest.raises(ValidationError, match="at most 2000"):
+            ColumnRef(name="x", sql_expression="x" * 2001)
+
+    def test_sql_expression_whitespace_only_rejected(self) -> None:
+        """Blank-or-whitespace-only sql_expression is rejected at schema
+        validation time so it can't slip past is_metric and fail with a
+        cryptic SQL syntax error at query time."""
+        with pytest.raises(ValidationError, match="non-empty SQL fragment"):
+            ColumnRef(name="x", sql_expression="   ")
+
+    def test_sql_expression_is_stripped(self) -> None:
+        """Surrounding whitespace is trimmed so the stored expression is
+        always canonical, matching the REST API's behavior."""
+        col = ColumnRef(name="x", sql_expression="  SUM(a)/SUM(b)  ")
+        assert col.sql_expression == "SUM(a)/SUM(b)"
+
+
 class TestChartConfigValidation:
     """Tests for ChartConfig discriminated union validation via Pydantic."""
 

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -114,6 +114,38 @@ class TestCreateMetricObject:
         # saved_metric validator clears aggregate, result is plain string
         assert result == "total_revenue"
 
+    def test_create_metric_object_sql_expression_emits_sql_form(self) -> None:
+        """SQL-expression metrics emit Superset's SQL form_data shape."""
+        col = ColumnRef(
+            name="profit_ratio",
+            sql_expression="SUM(profit) / NULLIF(SUM(sales), 0)",
+            label="Profit Ratio",
+        )
+        result = create_metric_object(col)
+
+        assert isinstance(result, dict)
+        assert result["expressionType"] == "SQL"
+        assert result["sqlExpression"] == "SUM(profit) / NULLIF(SUM(sales), 0)"
+        assert result["label"] == "Profit Ratio"
+        assert result["optionName"] == "metric_profit_ratio"
+        assert result["hasCustomLabel"] is True
+        # SQL metrics don't carry an aggregate or a column reference
+        assert result["aggregate"] is None
+        assert result["column"] is None
+
+    def test_create_metric_object_sql_expression_uses_name_as_label_fallback(
+        self,
+    ) -> None:
+        """When no label is supplied, the SQL metric falls back to name."""
+        col = ColumnRef(
+            name="margin",
+            sql_expression="SUM(profit) / SUM(sales)",
+        )
+        result = create_metric_object(col)
+
+        assert result["label"] == "margin"
+        assert result["hasCustomLabel"] is False
+
 
 class TestMapFilterOperator:
     """Test map_filter_operator function"""

--- a/tests/unit_tests/mcp_service/chart/validation/test_sql_expression_scoping.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_sql_expression_scoping.py
@@ -1,0 +1,186 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests that ``sql_expression`` on a ``ColumnRef`` is only valid in metric
+positions.
+
+The ``ColumnRef`` schema is shared across config fields — it shows up as
+x_axis (XYChartConfig.x), dimensions (PieChartConfig.dimension),
+group-bys (XYChartConfig.group_by), pivot rows, table columns, and as
+the actual metric. ``sql_expression`` is only meaningful in the last of
+those — an x_axis carrying a SQL fragment doesn't compile to anything
+useful.
+
+The dataset validator distinguishes by collecting metric-slot
+``id(ref)`` values and only skipping column-existence checks for those.
+A sql_expression in a non-metric slot is reported as an invalid column
+at Tier-1, instead of silently passing through and failing later with
+a generic DB error.
+"""
+
+from superset.mcp_service.chart.schemas import (
+    BigNumberChartConfig,
+    ColumnRef,
+    MixedTimeseriesChartConfig,
+    PieChartConfig,
+    PivotTableChartConfig,
+    TableChartConfig,
+    XYChartConfig,
+)
+from superset.mcp_service.chart.validation.dataset_validator import (
+    DatasetValidator,
+)
+
+
+class TestGetMetricRefIds:
+    """``_get_metric_ref_ids`` returns ``id(ref)`` values for refs that
+    occupy a metric slot in a given config. Used by the dataset validator
+    to scope the sql_expression skip to metric positions only."""
+
+    def test_xy_config_y_is_metric_x_is_not(self) -> None:
+        """In an XY chart, the y-axis refs are metrics; the x-axis ref isn't."""
+        x_ref = ColumnRef(name="order_date")
+        y_ref = ColumnRef(name="sales", aggregate="SUM")
+        config = XYChartConfig(chart_type="xy", x=x_ref, y=[y_ref])
+        ids = DatasetValidator._get_metric_ref_ids(config)
+        assert id(y_ref) in ids
+        assert id(x_ref) not in ids
+
+    def test_pie_metric_is_metric_dimension_is_not(self) -> None:
+        """Pie chart's dimension is categorical, not a metric."""
+        dim_ref = ColumnRef(name="category")
+        metric_ref = ColumnRef(name="sales", aggregate="SUM")
+        config = PieChartConfig(
+            chart_type="pie", dimension=dim_ref, metric=metric_ref
+        )
+        ids = DatasetValidator._get_metric_ref_ids(config)
+        assert id(metric_ref) in ids
+        assert id(dim_ref) not in ids
+
+    def test_big_number_metric_is_metric(self) -> None:
+        """The single metric ref on a BigNumber config is identified."""
+        metric_ref = ColumnRef(name="sales", aggregate="SUM")
+        config = BigNumberChartConfig(chart_type="big_number", metric=metric_ref)
+        ids = DatasetValidator._get_metric_ref_ids(config)
+        assert id(metric_ref) in ids
+
+    def test_pivot_metrics_only(self) -> None:
+        """In a pivot table, rows and columns are dimensions; metrics are
+        the only metric-position refs."""
+        row_ref = ColumnRef(name="region")
+        col_ref = ColumnRef(name="category")
+        m_ref = ColumnRef(name="sales", aggregate="SUM")
+        config = PivotTableChartConfig(
+            chart_type="pivot_table",
+            rows=[row_ref],
+            columns=[col_ref],
+            metrics=[m_ref],
+        )
+        ids = DatasetValidator._get_metric_ref_ids(config)
+        assert id(m_ref) in ids
+        assert id(row_ref) not in ids
+        assert id(col_ref) not in ids
+
+    def test_mixed_timeseries_both_y_lists(self) -> None:
+        """MixedTimeseries has y AND y_secondary; both are metric positions."""
+        x = ColumnRef(name="ds")
+        y1 = ColumnRef(name="sales", aggregate="SUM")
+        y2 = ColumnRef(name="profit", aggregate="SUM")
+        config = MixedTimeseriesChartConfig(
+            chart_type="mixed_timeseries", x=x, y=[y1], y_secondary=[y2]
+        )
+        ids = DatasetValidator._get_metric_ref_ids(config)
+        assert id(y1) in ids
+        assert id(y2) in ids
+        assert id(x) not in ids
+
+    def test_table_aggregated_columns_are_metrics(self) -> None:
+        """In a table, any column with an aggregate (or saved_metric, or
+        sql_expression) is acting as a metric."""
+        dim_ref = ColumnRef(name="category")
+        agg_ref = ColumnRef(name="sales", aggregate="SUM")
+        sql_ref = ColumnRef(
+            name="margin", sql_expression="SUM(profit)/SUM(sales)"
+        )
+        config = TableChartConfig(
+            chart_type="table", columns=[dim_ref, agg_ref, sql_ref]
+        )
+        ids = DatasetValidator._get_metric_ref_ids(config)
+        assert id(agg_ref) in ids
+        assert id(sql_ref) in ids
+        assert id(dim_ref) not in ids
+
+
+class TestSqlExpressionInNonMetricPositionRejected:
+    """A ColumnRef with sql_expression in a non-metric slot is reported
+    as invalid by ``_validate_columns_exist`` instead of being silently
+    skipped."""
+
+    def _ctx(self, columns: list[str], metrics: list[str] | None = None):
+        """Build a minimal DatasetContext with given column + metric names."""
+        from superset.mcp_service.common.error_schemas import DatasetContext
+
+        return DatasetContext(
+            id=1,
+            table_name="test_table",
+            database_name="test_db",
+            available_columns=[
+                {"name": c, "type_generic": "STRING"} for c in columns
+            ],
+            available_metrics=[{"name": m} for m in (metrics or [])],
+        )
+
+    def test_sql_expression_in_metric_slot_passes(self) -> None:
+        """A sql_expression on the y-axis of an XY chart is valid."""
+        ref = ColumnRef(
+            name="margin",
+            sql_expression="SUM(profit) / NULLIF(SUM(sales), 0)",
+            label="Margin",
+        )
+        config = XYChartConfig(
+            chart_type="xy", x=ColumnRef(name="ds"), y=[ref]
+        )
+        ctx = self._ctx(["ds"])
+        metric_ids = DatasetValidator._get_metric_ref_ids(config)
+        # When the validator runs, all extracted refs are passed in.
+        all_refs = DatasetValidator._extract_column_references(config)
+        err = DatasetValidator._validate_columns_exist(
+            all_refs, ctx, metric_ids
+        )
+        assert err is None
+
+    def test_sql_expression_in_x_axis_slot_flagged(self) -> None:
+        """A sql_expression on x_axis is invalid — x_axis needs a real
+        column name. Validator reports it as an invalid column."""
+        bad_ref = ColumnRef(
+            name="not_a_real_column",
+            sql_expression="SUM(profit)",  # nonsensical here
+        )
+        config = XYChartConfig(
+            chart_type="xy",
+            x=bad_ref,
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+        )
+        ctx = self._ctx(["sales"])  # x_axis "not_a_real_column" doesn't exist
+        metric_ids = DatasetValidator._get_metric_ref_ids(config)
+        all_refs = DatasetValidator._extract_column_references(config)
+        err = DatasetValidator._validate_columns_exist(
+            all_refs, ctx, metric_ids
+        )
+        # The validator should report an invalid-column error rather than
+        # silently passing through.
+        assert err is not None


### PR DESCRIPTION
### SUMMARY

`ColumnRef` (the metric/column reference used in `generate_chart` configs) previously offered two modes for defining a metric:

- **SIMPLE**: `{name, aggregate}` — e.g. `SUM(sales)`
- **saved_metric**: `{name, saved_metric: true}` — reference a stored dataset metric by name

This left **calculated metrics** — ratios, growth rates, conversion percentages — unreachable from MCP unless the dataset already had a saved metric defined. There's no MCP tool to add saved metrics to an existing dataset, so an LLM trying to build a "Profit Ratio" KPI is stuck:

```
big_number's metric only accepts ColumnRef (name + aggregate)
↳ No SQL expression slot
↳ saved_metric requires manually editing the dataset (no MCP path)
↳ Fallback: use `update_chart` to patch raw form_data
   — defeats the typed-config story
```

This PR adds a third mode:
- **SQL**: `{name, sql_expression}` — e.g. `SUM(profit) / NULLIF(SUM(sales), 0)`

`name` becomes the metric's label; `sql_expression` carries the formula.

### BEFORE/AFTER

**Before** — `generate_chart` rejects calculated metrics:

```
generate_chart({
  config: {
    chart_type: "big_number",
    metric: {name: "profit_ratio", sql_expression: "SUM(profit)/SUM(sales)"},
  }
})
→ Error: ColumnRef has no field 'sql_expression'
```

**After** — calculated metric works in a single call:

```
generate_chart({
  config: {
    chart_type: "big_number",
    metric: {
      name: "profit_ratio",
      sql_expression: "SUM(profit) / NULLIF(SUM(sales), 0)",
      label: "Profit Ratio",
    },
    y_axis_format: ".2%",
  }
})
→ Chart created. get_chart_data returns {'Profit Ratio': 0.15063…}
```

### CHANGES

Four files touched:

1. **`superset/mcp_service/chart/schemas.py`**
   - Add `sql_expression: str | None` field to `ColumnRef` with description geared at LLM consumers (mentions ratios, growth rates, conversion percentages).
   - Extend `is_metric` to recognize sql_expression as valid.
   - Extend `clear_aggregate_for_saved_metric` so sql_expression also takes over from aggregate (matching saved_metric semantics).
   - Add `disallow_saved_and_sql` validator — saved_metric and sql_expression are mutually exclusive paths.

2. **`superset/mcp_service/chart/chart_utils.py`**
   - Extend `create_metric_object` to emit Superset's SQL form_data shape when sql_expression is set.

3. **`superset/mcp_service/chart/validation/schema_validator.py`**
   - Update the big_number metric guard to accept sql_expression alongside aggregate and saved_metric. Updated error message + suggestions teach the LLM the new path.

4. **`superset/mcp_service/chart/validation/dataset_validator.py`**
   - Skip the dataset-column-existence check for sql_expression metrics — their column references live inline in the expression, not as the ColumnRef.name.

The REST API has supported this shape via adhoc form_data metrics forever (chart `params.metric = {expressionType: "SQL", sqlExpression, label}`). This PR exposes the same capability through the typed MCP schema so an LLM can construct `big_number`, `xy`, `table`, `pivot_table`, and `mixed_timeseries` charts with calculated metrics in one round-trip.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/mcp_service/chart/test_chart_schemas.py::TestColumnRefSqlExpression
pytest tests/unit_tests/mcp_service/chart/test_chart_utils.py::TestCreateMetricObject
pytest tests/unit_tests/mcp_service/chart/test_big_number_chart.py
```

New tests:
- `TestColumnRefSqlExpression` — 7 tests covering field defaults, acceptance, aggregate-clearing, is_metric, mutual exclusion with saved_metric, use in XYChartConfig, max-length enforcement.
- `TestCreateMetricObject` (2 added) — SQL emission shape + label fallback.
- `TestBigNumberChartConfig` (3 added) — config acceptance, SchemaValidator pre-validation guard, and that bare ColumnRef (no aggregate/sql/saved) is still rejected.

**306 tests pass across the four touched modules; zero regressions.**

### ADDITIONAL INFORMATION

- [ ] Has associated issue: _(filing alongside, will link)_
- [ ] Required feature flags: _none_
- [x] Changes UI: _no_
- [x] Includes DB Migration: _no_
- [x] Includes packaged template files: _no_
- [x] Introduces new feature or API: _adds `sql_expression` field to the `ColumnRef` schema used by `generate_chart` and related MCP tools_
- [x] Removes existing feature or API: _no_