### PR TITLE
fix(explore): tighten popover title-to-tabs spacing to 12px

### DIFF
--- a/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-core/src/theme/GlobalStyles.tsx
@@ -115,6 +115,21 @@ export const GlobalStyles = () => {
           display: flex;
           margin-top: ${theme.marginXS}px;
         }
+
+        .superset-explore-popover.ant-popover
+          .ant-popover-inner:has(.ant-popover-title) {
+          padding-top: 0;
+        }
+        .superset-explore-popover.ant-popover .ant-popover-title {
+          padding-top: ${theme.paddingXS}px;
+          margin-bottom: ${theme.paddingSM}px;
+          line-height: 1;
+        }
+        .superset-explore-popover.ant-popover
+          .ant-popover-inner:has(.ant-popover-title)
+          .ant-tabs-tab {
+          padding-top: 0;
+        }
       `}
     />
   );

--- a/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
@@ -202,6 +202,7 @@ const ControlPopover: FC<PopoverProps> = ({
       getPopupContainer={handleGetPopupContainer}
       destroyOnHidden={destroyOnHidden}
       afterOpenChange={handleAfterOpenChange}
+      rootClassName="superset-explore-popover"
     />
   );
 };


### PR DESCRIPTION
### SUMMARY
In the explore view, control popovers (metric editor, column selector, filter editor) have too much vertical space between the popover title and the tab bar (Saved / Simple / Custom SQL).

The total gap between the bottom of the title text and the top of the tab bar should be 12px. Currently it is visibly larger.

**Approach** (scoped to explore popovers only):

  1. **`ControlPopover.tsx`** — pass `rootClassName="superset-explore-popover"` to antd Popover so we can target all explore control popovers from CSS without touching unrelated popovers across the app.
  2. **`GlobalStyles.tsx`** — three scoped rules behind `:has(.ant-popover-title)` so popovers *without* a title (e.g. filter editor) keep antd defaults:
     - `.ant-popover-inner` → `padding-top: 0` (removes 12px dead space above title)
     - `.ant-popover-title` → `padding-top: 8px` (breathing room), `margin-bottom: 12px` (exact gap to tab bar), `line-height: 1` (collapses font leading so the visible 12px gap actually matches the spec)
     - `.ant-tabs-tab` → `padding-top: 0` (removes the hidden ~14px inside the tab bar that made the gap visibly larger than 12px)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE:
<img width="448" height="375" alt="Screenshot 2026-05-24 at 22 36 27" src="https://github.com/user-attachments/assets/815629ed-b94b-4eb5-a2c9-85bb575e3336" />

AFTER:
<img width="379" height="349" alt="Screenshot 2026-05-24 at 22 36 54" src="https://github.com/user-attachments/assets/650c816e-d5b0-4694-b439-8b82fa47704d" />

### TESTING INSTRUCTIONS
1. Open the explore view for any chart (e.g. a Table chart)
2. **Metric editor**: click a metric chip (`COUNT(*)`) — verify the gap between the title `COUNT(*)` and the tab bar (`Saved / Simple / Custom SQL`) is visibly tighter (~12px), not the previous loose spacing
3. **Column selector**: click a column chip in Dimensions (`school_degree`) — same verification; the `g` descender should not be visually clipped
4. **Filter editor (no title)**: click a filter chip (`is_software_dev = 0`) — verify nothing changed; tabs (`Simple / Custom SQL`) should sit at the antd-default position
5. **Other popovers** (date filter, annotation layers, time series column): open one of each and confirm visual consistency

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
