### PR TITLE
fix(dataset): sort by data type when clicking Datatype column header

### DIFF
--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
@@ -23,6 +23,7 @@ import DatasetPanel, {
   COLUMN_TITLE,
 } from 'src/features/datasets/AddDataset/DatasetPanel/DatasetPanel';
 import { exampleColumns, exampleDataset } from './fixtures';
+import { ITableColumn } from './types';
 import {
   SELECT_MESSAGE,
   CREATE_MESSAGE,
@@ -173,5 +174,27 @@ describe('DatasetPanel', () => {
         /this table already has a dataset associated with it. you can only associate one dataset with a table./i,
       ),
     ).toBeVisible();
+  });
+
+  test('sorts the column list by name when sorting by Column Name', () => {
+    const sorter = tableColumnDefinition[0].sorter as (
+      a: ITableColumn,
+      b: ITableColumn,
+    ) => number;
+    const sorted = [...exampleColumns].sort(sorter);
+    expect(sorted.map(c => c.name)).toEqual([
+      'birth_date',
+      'height_in_inches',
+      'name',
+    ]);
+  });
+
+  test('sorts the column list by type when sorting by Datatype', () => {
+    const sorter = tableColumnDefinition[1].sorter as (
+      a: ITableColumn,
+      b: ITableColumn,
+    ) => number;
+    const sorted = [...exampleColumns].sort(sorter);
+    expect(sorted.map(c => c.type)).toEqual(['DATE', 'NUMBER', 'STRING']);
   });
 });

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -183,7 +183,7 @@ export const tableColumnDefinition: ColumnsType<ITableColumn> = [
     dataIndex: 'type',
     key: 'type',
     width: '100px',
-    sorter: (a: ITableColumn, b: ITableColumn) => a.name.localeCompare(b.name),
+    sorter: (a: ITableColumn, b: ITableColumn) => a.type.localeCompare(b.type),
   },
 ];
 


### PR DESCRIPTION
### SUMMARY
When selecting a table to create a physical dataset, the table columns and data types are displayed in a table. Clicking on the Datatype column header to sort the table sorts it by the column name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="1054" height="382" alt="Screenshot 2026-05-24 at 23 46 00" src="https://github.com/user-attachments/assets/779ec307-19df-43cb-8b8f-4fd7ce8041e6" />

AFTER: 
<img width="1177" height="422" alt="Screenshot 2026-05-24 at 23 46 26" src="https://github.com/user-attachments/assets/aefa07d0-9baf-4df3-8ac7-63d4dce83e9c" />

### TESTING INSTRUCTIONS
1. Access the Workspace.
2. Navigate to Datasets in the top navigation bar.
3. Click on + Dataset.
4. Select a database, schema and table.
5. The table metadata loads. Click on the Datatype column header, to sort the table by data type values.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
