### PR TITLE
feat(extensions): adds context namespaces P3

### DIFF
--- a/superset-frontend/packages/superset-core/package.json
+++ b/superset-frontend/packages/superset-core/package.json
@@ -18,6 +18,22 @@
       "types": "./lib/authentication/index.d.ts",
       "default": "./lib/authentication/index.js"
     },
+    "./dashboard": {
+      "types": "./lib/dashboard/index.d.ts",
+      "default": "./lib/dashboard/index.js"
+    },
+    "./dataset": {
+      "types": "./lib/dataset/index.d.ts",
+      "default": "./lib/dataset/index.js"
+    },
+    "./explore": {
+      "types": "./lib/explore/index.d.ts",
+      "default": "./lib/explore/index.js"
+    },
+    "./navigation": {
+      "types": "./lib/navigation/index.d.ts",
+      "default": "./lib/navigation/index.js"
+    },
     "./commands": {
       "types": "./lib/commands/index.d.ts",
       "default": "./lib/commands/index.js"

--- a/superset-frontend/packages/superset-core/src/contributions/index.ts
+++ b/superset-frontend/packages/superset-core/src/contributions/index.ts
@@ -18,10 +18,7 @@
  */
 
 import { View } from '../views';
-import type { ChatbotView } from '../views';
 import { Menu } from '../menus';
-
-export type { ChatbotView };
 
 export type SqlLabLocation =
   | 'leftSidebar'

--- a/superset-frontend/packages/superset-core/src/dashboard/index.ts
+++ b/superset-frontend/packages/superset-core/src/dashboard/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Dashboard namespace for Superset extensions (P3).
+ *
+ * Exposes dashboard identity and filter state as a stable semantic API.
+ * Extensions must not depend on the Redux dashboard slice structure directly.
+ */
+
+import { Event } from '../common';
+
+/**
+ * A single native filter's current selected value(s).
+ * The value type is intentionally kept as `unknown` because filter values
+ * are heterogeneous (date ranges, string lists, numbers, etc.).
+ */
+export interface FilterValue {
+  /** The filter's stable id. */
+  filterId: string;
+  /** Display label of the filter. */
+  label: string;
+  /** Currently applied value, or `null` when the filter is cleared. */
+  value: unknown;
+}
+
+/**
+ * Normalized dashboard context exposed to extensions on the Dashboard page.
+ */
+export interface DashboardContext {
+  /** Numeric dashboard id. */
+  dashboardId: number;
+  /** Display title of the dashboard. */
+  title: string;
+  /**
+   * Active native filter values keyed by filter id.
+   * Only includes filters that have a value applied.
+   */
+  filters: FilterValue[];
+}
+
+/**
+ * Returns the normalized dashboard context for the page currently being viewed,
+ * or `undefined` when the user is not on a Dashboard page.
+ *
+ * @example
+ * ```typescript
+ * const dash = dashboard.getCurrentDashboard();
+ * if (dash) {
+ *   console.log(dash.title, dash.filters);
+ * }
+ * ```
+ */
+export declare function getCurrentDashboard(): DashboardContext | undefined;
+
+/**
+ * Event fired when the dashboard identity or its active filter values change.
+ * Fired on native filter value changes and on navigation to a different dashboard.
+ *
+ * @example
+ * ```typescript
+ * const sub = dashboard.onDidChangeDashboard(dash => {
+ *   chatbot.updateContext({ dashboard: dash });
+ * });
+ * sub.dispose();
+ * ```
+ */
+export declare const onDidChangeDashboard: Event<DashboardContext>;

--- a/superset-frontend/packages/superset-core/src/dataset/index.ts
+++ b/superset-frontend/packages/superset-core/src/dataset/index.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Dataset namespace for Superset extensions (P3).
+ *
+ * Exposes the dataset currently being viewed as a stable semantic API.
+ * Aligned with backend-enforced dataset visibility and column-access semantics.
+ */
+
+import { Event } from '../common';
+
+/**
+ * Normalized dataset context exposed to extensions on the Dataset page.
+ */
+export interface DatasetContext {
+  /** Numeric dataset id. */
+  datasetId: number;
+  /** Display name (table name or virtual dataset name). */
+  datasetName: string;
+  /** Schema the dataset belongs to, if applicable. */
+  schema: string | null;
+  /** Catalog the dataset belongs to, if applicable. */
+  catalog: string | null;
+  /** Database name backing this dataset. */
+  databaseName: string | null;
+  /** Whether this is a virtual (SQL-defined) dataset. */
+  isVirtual: boolean;
+}
+
+/**
+ * Returns the normalized dataset context for the page currently being viewed,
+ * or `undefined` when the user is not on a Dataset page.
+ *
+ * @example
+ * ```typescript
+ * const ds = dataset.getCurrentDataset();
+ * if (ds) {
+ *   console.log(ds.datasetName, ds.schema);
+ * }
+ * ```
+ */
+export declare function getCurrentDataset(): DatasetContext | undefined;
+
+/**
+ * Event fired when the focused dataset changes (e.g. the user navigates to a
+ * different dataset detail page).
+ *
+ * @example
+ * ```typescript
+ * const sub = dataset.onDidChangeDataset(ds => {
+ *   chatbot.updateContext({ dataset: ds });
+ * });
+ * sub.dispose();
+ * ```
+ */
+export declare const onDidChangeDataset: Event<DatasetContext>;

--- a/superset-frontend/packages/superset-core/src/explore/index.ts
+++ b/superset-frontend/packages/superset-core/src/explore/index.ts
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Explore namespace for Superset extensions (P3).
+ *
+ * Exposes the current chart/explore context as a stable semantic API.
+ * Normalized over Explore Redux state — extensions must not depend on
+ * the Redux slice structure directly.
+ */
+
+import { Event } from '../common';
+
+/**
+ * Normalized chart context exposed to extensions during an Explore session.
+ * Covers saved chart identity and transient editing context; excludes raw
+ * form-data internals and datasource-implementation details.
+ */
+export interface ChartContext {
+  /** The saved chart id, or `null` when the chart has not been persisted. */
+  chartId: number | null;
+  /** Display name of the saved chart, or `null` for a new/unsaved chart. */
+  chartName: string | null;
+  /** The visualization type currently selected in the editor. */
+  vizType: string;
+  /** Id of the datasource backing the chart (physical or virtual dataset). */
+  datasourceId: number | null;
+  /** Human-readable datasource name. */
+  datasourceName: string | null;
+}
+
+/**
+ * Returns the normalized chart context for the active Explore session, or
+ * `undefined` when the user is not on the Explore page.
+ *
+ * @example
+ * ```typescript
+ * const chart = explore.getCurrentChart();
+ * if (chart) {
+ *   console.log(chart.vizType, chart.chartName);
+ * }
+ * ```
+ */
+export declare function getCurrentChart(): ChartContext | undefined;
+
+/**
+ * Event fired when the chart context changes within the active Explore session
+ * (e.g. when the viz type, datasource, or saved name changes).
+ * Not fired during route changes — subscribe to `navigation.onDidChangePage` for those.
+ *
+ * @example
+ * ```typescript
+ * const sub = explore.onDidChangeChart(chart => {
+ *   chatbot.updateContext({ chart });
+ * });
+ * sub.dispose();
+ * ```
+ */
+export declare const onDidChangeChart: Event<ChartContext>;

--- a/superset-frontend/packages/superset-core/src/index.ts
+++ b/superset-frontend/packages/superset-core/src/index.ts
@@ -19,9 +19,13 @@
 export * as common from './common';
 export * as authentication from './authentication';
 export * as commands from './commands';
+export * as dashboard from './dashboard';
+export * as dataset from './dataset';
 export * as editors from './editors';
+export * as explore from './explore';
 export * as extensions from './extensions';
 export * as menus from './menus';
+export * as navigation from './navigation';
 export * as sqlLab from './sqlLab';
 export * as views from './views';
 export * as contributions from './contributions';

--- a/superset-frontend/packages/superset-core/src/navigation/index.ts
+++ b/superset-frontend/packages/superset-core/src/navigation/index.ts
@@ -40,15 +40,19 @@ export type PageType =
 
 /**
  * Lightweight page descriptor: the current surface and the focused entity id,
- * if the surface has one (dashboard id, chart id, dataset id). Does not embed
- * full entity payloads — use the surface-specific namespace for those.
+ * if the surface has one (dashboard id or dataset id). Does not embed full
+ * entity payloads — use the surface-specific namespace for those.
+ *
+ * Note: Explore pages do not expose a chart entity id here because the chart
+ * id is query-string–based and may change without a pathname change. Use the
+ * `explore` namespace instead to track chart context on Explore pages.
  */
 export interface PageContext {
   pageType: PageType;
   /**
    * The numeric id of the primary entity on this page, if applicable.
-   * `null` when the surface has no focused entity, or when the entity is
-   * addressed by a non-numeric slug (e.g. dashboard accessed via slug URL).
+   * Populated for dashboard and dataset routes with a numeric id in the path.
+   * `null` for all other surfaces, slug-based dashboard URLs, or new charts.
    */
   entityId: number | null;
 }
@@ -81,8 +85,8 @@ export declare function getCurrentPage(): PageContext;
  *
  * @example
  * ```typescript
- * const sub = navigation.onDidChangePage(({ pageType, entityId }) => {
- *   chatbot.updateContext({ pageType, entityId });
+ * const sub = navigation.onDidChangePage(({ pageType }) => {
+ *   chatbot.updateContext({ pageType });
  * });
  * // later:
  * sub.dispose();

--- a/superset-frontend/packages/superset-core/src/navigation/index.ts
+++ b/superset-frontend/packages/superset-core/src/navigation/index.ts
@@ -20,14 +20,16 @@
 /**
  * @fileoverview Navigation namespace for Superset extensions (P3).
  *
- * Exposes stable routing and page-surface context to extensions.
- * Extensions use this namespace to react to page changes without polling.
+ * Exposes the current application surface so extensions can react to route
+ * changes without polling. Entity-level context (chart, dashboard, dataset)
+ * is intentionally not included here — use the surface-specific namespace
+ * (`explore`, `dashboard`, `dataset`) to retrieve entity payloads.
  */
 
 import { Event } from '../common';
 
 /**
- * The set of top-level application surfaces the chatbot is aware of.
+ * The set of top-level application surfaces.
  * `'other'` covers any route not explicitly enumerated.
  */
 export type PageType =
@@ -39,57 +41,31 @@ export type PageType =
   | 'other';
 
 /**
- * Lightweight page descriptor: the current surface and the focused entity id,
- * if the surface has one (dashboard id or dataset id). Does not embed full
- * entity payloads — use the surface-specific namespace for those.
- *
- * Note: Explore pages do not expose a chart entity id here because the chart
- * id is query-string–based and may change without a pathname change. Use the
- * `explore` namespace instead to track chart context on Explore pages.
- */
-export interface PageContext {
-  pageType: PageType;
-  /**
-   * The numeric id of the primary entity on this page, if applicable.
-   * Populated for dashboard and dataset routes with a numeric id in the path.
-   * `null` for all other surfaces, slug-based dashboard URLs, or new charts.
-   */
-  entityId: number | null;
-}
-
-/**
  * Returns the current page surface type.
  *
  * @example
  * ```typescript
  * const pageType = navigation.getPageType();
- * if (pageType === 'dashboard') { ... }
+ * if (pageType === 'dashboard') {
+ *   const ctx = dashboard.getCurrentDashboard();
+ * }
  * ```
  */
 export declare function getPageType(): PageType;
 
 /**
- * Returns lightweight context about the current page: surface type and focused
- * entity id. Does not embed entity payloads; use the surface namespace for those.
+ * Event fired whenever the user navigates to a different surface.
+ * Use the surface-specific namespace to read entity context after the event.
  *
  * @example
  * ```typescript
- * const { pageType, entityId } = navigation.getCurrentPage();
- * ```
- */
-export declare function getCurrentPage(): PageContext;
-
-/**
- * Event fired whenever the user navigates to a different page or entity.
- * Provides the new `PageContext` as the event payload.
- *
- * @example
- * ```typescript
- * const sub = navigation.onDidChangePage(({ pageType }) => {
- *   chatbot.updateContext({ pageType });
+ * const sub = navigation.onDidChangePage(pageType => {
+ *   if (pageType === 'dashboard') {
+ *     const ctx = dashboard.getCurrentDashboard();
+ *   }
  * });
  * // later:
  * sub.dispose();
  * ```
  */
-export declare const onDidChangePage: Event<PageContext>;
+export declare const onDidChangePage: Event<PageType>;

--- a/superset-frontend/packages/superset-core/src/navigation/index.ts
+++ b/superset-frontend/packages/superset-core/src/navigation/index.ts
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Navigation namespace for Superset extensions (P3).
+ *
+ * Exposes stable routing and page-surface context to extensions.
+ * Extensions use this namespace to react to page changes without polling.
+ */
+
+import { Event } from '../common';
+
+/**
+ * The set of top-level application surfaces the chatbot is aware of.
+ * `'other'` covers any route not explicitly enumerated.
+ */
+export type PageType =
+  | 'dashboard'
+  | 'explore'
+  | 'sqllab'
+  | 'dataset'
+  | 'home'
+  | 'other';
+
+/**
+ * Lightweight page descriptor: the current surface and the focused entity id,
+ * if the surface has one (dashboard id, chart id, dataset id). Does not embed
+ * full entity payloads — use the surface-specific namespace for those.
+ */
+export interface PageContext {
+  pageType: PageType;
+  /**
+   * The numeric id of the primary entity on this page, if applicable.
+   * `null` when the surface has no focused entity, or when the entity is
+   * addressed by a non-numeric slug (e.g. dashboard accessed via slug URL).
+   */
+  entityId: number | null;
+}
+
+/**
+ * Returns the current page surface type.
+ *
+ * @example
+ * ```typescript
+ * const pageType = navigation.getPageType();
+ * if (pageType === 'dashboard') { ... }
+ * ```
+ */
+export declare function getPageType(): PageType;
+
+/**
+ * Returns lightweight context about the current page: surface type and focused
+ * entity id. Does not embed entity payloads; use the surface namespace for those.
+ *
+ * @example
+ * ```typescript
+ * const { pageType, entityId } = navigation.getCurrentPage();
+ * ```
+ */
+export declare function getCurrentPage(): PageContext;
+
+/**
+ * Event fired whenever the user navigates to a different page or entity.
+ * Provides the new `PageContext` as the event payload.
+ *
+ * @example
+ * ```typescript
+ * const sub = navigation.onDidChangePage(({ pageType, entityId }) => {
+ *   chatbot.updateContext({ pageType, entityId });
+ * });
+ * // later:
+ * sub.dispose();
+ * ```
+ */
+export declare const onDidChangePage: Event<PageContext>;

--- a/superset-frontend/src/components/ChatbotMount/index.tsx
+++ b/superset-frontend/src/components/ChatbotMount/index.tsx
@@ -29,16 +29,19 @@ const CHATBOT_EDGE_MARGIN = 24;
 const ChatbotMount = () => {
   const theme = useTheme();
   const [adminSelectedId, setAdminSelectedId] = useState<string | null>(null);
+  const [enabledMap, setEnabledMap] = useState<Record<string, boolean>>({});
   const [activeChatbot, setActiveChatbot] = useState(() =>
-    getActiveChatbot(null),
+    getActiveChatbot(null, {}),
   );
 
   useEffect(() => {
     SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
       .then(({ json }) => {
         const id = json.result?.active_chatbot_id ?? null;
+        const enabled: Record<string, boolean> = json.result?.enabled ?? {};
         setAdminSelectedId(id);
-        setActiveChatbot(getActiveChatbot(id));
+        setEnabledMap(enabled);
+        setActiveChatbot(getActiveChatbot(id, enabled));
       })
       .catch(() => {
         // Settings fetch failure is non-fatal — fall back to first-to-register.
@@ -48,9 +51,9 @@ const ChatbotMount = () => {
   useEffect(
     () =>
       subscribeToLocation(CHATBOT_LOCATION, () =>
-        setActiveChatbot(getActiveChatbot(adminSelectedId)),
+        setActiveChatbot(getActiveChatbot(adminSelectedId, enabledMap)),
       ),
-    [adminSelectedId],
+    [adminSelectedId, enabledMap],
   );
 
   if (!activeChatbot) {

--- a/superset-frontend/src/components/ChatbotMount/index.tsx
+++ b/superset-frontend/src/components/ChatbotMount/index.tsx
@@ -35,8 +35,10 @@ const ChatbotMount = () => {
   );
 
   useEffect(() => {
+    let cancelled = false;
     SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
       .then(({ json }) => {
+        if (cancelled) return;
         const id = json.result?.active_chatbot_id ?? null;
         const enabled: Record<string, boolean> = json.result?.enabled ?? {};
         setAdminSelectedId(id);
@@ -46,6 +48,9 @@ const ChatbotMount = () => {
       .catch(() => {
         // Settings fetch failure is non-fatal — fall back to first-to-register.
       });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(

--- a/superset-frontend/src/components/ChatbotMount/index.tsx
+++ b/superset-frontend/src/components/ChatbotMount/index.tsx
@@ -16,21 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/**
- * @fileoverview Host mount point for the singleton `superset.chatbot`
- * contribution area.
- *
- * The host owns the slot: a fixed bottom-right anchor that persists across all
- * routes, with a managed z-index. The extension owns everything rendered
- * inside it — the collapsed bubble, the expanded panel, all open/close state,
- * animations, and behavior (SIP §3.2 "Component contract").
- *
- * Singleton resolution (which of possibly several registered chatbots renders)
- * is delegated to `getActiveChatbot`. If no chatbot extension is registered,
- * this component renders nothing and the corner stays empty.
- */
-
 import { useState, useEffect } from 'react';
+import { SupersetClient } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { ErrorBoundary } from 'src/components/ErrorBoundary';
 import { getActiveChatbot } from 'src/core/chatbot';
@@ -39,24 +26,31 @@ import { CHATBOT_LOCATION } from 'src/views/contributions';
 
 const CHATBOT_EDGE_MARGIN = 24;
 
-/**
- * Renders the active chatbot extension into a fixed bottom-right slot.
- *
- * Mounted once at the app root so the bubble persists across routes.
- * Re-resolves when the chatbot registry changes (extension activated or
- * deactivated at runtime via the P1.A lifecycle contract).
- * Renders null when no chatbot extension is registered.
- */
 const ChatbotMount = () => {
   const theme = useTheme();
-  const [activeChatbot, setActiveChatbot] = useState(getActiveChatbot);
+  const [adminSelectedId, setAdminSelectedId] = useState<string | null>(null);
+  const [activeChatbot, setActiveChatbot] = useState(() =>
+    getActiveChatbot(null),
+  );
+
+  useEffect(() => {
+    SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
+      .then(({ json }) => {
+        const id = json.result?.active_chatbot_id ?? null;
+        setAdminSelectedId(id);
+        setActiveChatbot(getActiveChatbot(id));
+      })
+      .catch(() => {
+        // Settings fetch failure is non-fatal — fall back to first-to-register.
+      });
+  }, []);
 
   useEffect(
     () =>
       subscribeToLocation(CHATBOT_LOCATION, () =>
-        setActiveChatbot(getActiveChatbot()),
+        setActiveChatbot(getActiveChatbot(adminSelectedId)),
       ),
-    [],
+    [adminSelectedId],
   );
 
   if (!activeChatbot) {

--- a/superset-frontend/src/core/chatbot/index.ts
+++ b/superset-frontend/src/core/chatbot/index.ts
@@ -48,24 +48,35 @@ export interface ActiveChatbot {
  *
  * Selection policy:
  *  - If no chatbot is registered, returns `undefined` — the corner stays empty.
- *  - If `adminSelectedId` is provided and matches a registered chatbot, that one wins.
- *  - Otherwise the first-to-register chatbot is used as a fallback.
+ *  - Disabled chatbots (per `enabledMap`) are excluded before selection.
+ *  - If `adminSelectedId` matches an enabled registered chatbot, that one wins.
+ *  - Otherwise the first enabled chatbot in registration order is used as a fallback.
  *
  * @param adminSelectedId The id stored in the admin "Default chatbot" setting, if any.
+ * @param enabledMap Per-extension enabled flags from the admin settings API.
  * @returns The active chatbot's id and provider, or `undefined` if none.
  */
 export const getActiveChatbot = (
   adminSelectedId?: string | null,
+  enabledMap?: Record<string, boolean>,
 ): ActiveChatbot | undefined => {
   const registeredIds = getRegisteredViewIds(CHATBOT_LOCATION);
   if (registeredIds.length === 0) {
     return undefined;
   }
 
+  const candidates = enabledMap
+    ? registeredIds.filter(id => enabledMap[id] !== false)
+    : registeredIds;
+
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
   const selectedId =
-    adminSelectedId && registeredIds.includes(adminSelectedId)
+    adminSelectedId && candidates.includes(adminSelectedId)
       ? adminSelectedId
-      : registeredIds[0];
+      : candidates[0];
 
   const provider = getViewProvider(CHATBOT_LOCATION, selectedId);
   if (!provider) {

--- a/superset-frontend/src/core/chatbot/index.ts
+++ b/superset-frontend/src/core/chatbot/index.ts
@@ -46,28 +46,27 @@ export interface ActiveChatbot {
 /**
  * Resolves which single chatbot extension is currently active.
  *
- * Selection policy (P1):
+ * Selection policy:
  *  - If no chatbot is registered, returns `undefined` — the corner stays empty.
- *  - If one or more chatbots are registered, the first one to register wins.
+ *  - If `adminSelectedId` is provided and matches a registered chatbot, that one wins.
+ *  - Otherwise the first-to-register chatbot is used as a fallback.
  *
- * `Set` preserves insertion order, so "first to register" is deterministic.
- *
- * This is the P1 fallback policy. P2 introduces an admin "Default chatbot"
- * setting (SIP §4 option (c)); when that lands, the admin-selected id takes
- * precedence here and this first-to-register behavior remains only as the
- * fallback used when no admin setting is configured.
- *
+ * @param adminSelectedId The id stored in the admin "Default chatbot" setting, if any.
  * @returns The active chatbot's id and provider, or `undefined` if none.
  */
-export const getActiveChatbot = (): ActiveChatbot | undefined => {
+export const getActiveChatbot = (
+  adminSelectedId?: string | null,
+): ActiveChatbot | undefined => {
   const registeredIds = getRegisteredViewIds(CHATBOT_LOCATION);
   if (registeredIds.length === 0) {
     return undefined;
   }
 
-  // Deterministic first-to-register fallback. P2 will consult the admin
-  // "Default chatbot" setting before this point.
-  const [selectedId] = registeredIds;
+  const selectedId =
+    adminSelectedId && registeredIds.includes(adminSelectedId)
+      ? adminSelectedId
+      : registeredIds[0];
+
   const provider = getViewProvider(CHATBOT_LOCATION, selectedId);
   if (!provider) {
     return undefined;

--- a/superset-frontend/src/core/dashboard/index.ts
+++ b/superset-frontend/src/core/dashboard/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Host-internal implementation of the `dashboard` namespace.
+ *
+ * Wraps Redux dashboardInfo and dataMask state and normalizes them into the
+ * stable `DashboardContext` contract. Extensions must not depend on the Redux
+ * slice structure directly.
+ */
+
+import type { dashboard as dashboardApi } from '@apache-superset/core';
+import { HYDRATE_DASHBOARD } from 'src/dashboard/actions/hydrate';
+import {
+  UPDATE_DATA_MASK,
+  SET_DATA_MASK_FOR_FILTER_CHANGES_COMPLETE,
+} from 'src/dataMask/actions';
+import { store, RootState } from 'src/views/store';
+import { AnyListenerPredicate } from '@reduxjs/toolkit';
+import { createActionListener } from '../utils';
+
+type DashboardContext = dashboardApi.DashboardContext;
+type FilterValue = dashboardApi.FilterValue;
+
+function buildDashboardContext(): DashboardContext | undefined {
+  const state = store.getState();
+  const info = (state as any).dashboardInfo;
+  if (!info?.id) return undefined;
+
+  const nativeFilters = (state as any).nativeFilters?.filters ?? {};
+  const dataMask = (state as any).dataMask ?? {};
+
+  const filters: FilterValue[] = Object.entries(dataMask)
+    .filter(([id]) => id in nativeFilters)
+    .map(([id, mask]: [string, any]) => ({
+      filterId: id,
+      label: nativeFilters[id]?.name ?? id,
+      value: mask?.filterState?.value ?? null,
+    }));
+
+  return {
+    dashboardId: info.id as number,
+    title: info.dashboard_title ?? info.slug ?? String(info.id),
+    filters,
+  };
+}
+
+const dashboardChangePredicate: AnyListenerPredicate<RootState> = action =>
+  action.type === HYDRATE_DASHBOARD ||
+  action.type === UPDATE_DATA_MASK ||
+  action.type === SET_DATA_MASK_FOR_FILTER_CHANGES_COMPLETE;
+
+const getCurrentDashboard: typeof dashboardApi.getCurrentDashboard = () =>
+  buildDashboardContext();
+
+const onDidChangeDashboard: typeof dashboardApi.onDidChangeDashboard = (
+  listener: (ctx: DashboardContext) => void,
+  thisArgs?: any,
+) =>
+  createActionListener<DashboardContext>(
+    dashboardChangePredicate,
+    listener,
+    () => buildDashboardContext() ?? null,
+    thisArgs,
+  );
+
+export const dashboard: typeof dashboardApi = {
+  getCurrentDashboard,
+  onDidChangeDashboard,
+};

--- a/superset-frontend/src/core/dashboard/index.ts
+++ b/superset-frontend/src/core/dashboard/index.ts
@@ -47,11 +47,15 @@ function buildDashboardContext(): DashboardContext | undefined {
   const dataMask = (state as any).dataMask ?? {};
 
   const filters: FilterValue[] = Object.entries(dataMask)
-    .filter(([id]) => id in nativeFilters)
+    .filter(([id, mask]: [string, any]) => {
+      if (!(id in nativeFilters)) return false;
+      const value = mask?.filterState?.value;
+      return value !== null && value !== undefined;
+    })
     .map(([id, mask]: [string, any]) => ({
       filterId: id,
       label: nativeFilters[id]?.name ?? id,
-      value: mask?.filterState?.value ?? null,
+      value: mask.filterState.value,
     }));
 
   return {

--- a/superset-frontend/src/core/dataset/index.ts
+++ b/superset-frontend/src/core/dataset/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Host-internal implementation of the `dataset` namespace.
+ *
+ * Dataset page components call `setCurrentDataset` to publish context as they
+ * load. Extensions consume the stable `DatasetContext` contract; they are
+ * isolated from the page's internal data-fetching implementation.
+ */
+
+import type { dataset as datasetApi } from '@apache-superset/core';
+import { Disposable } from '../models';
+
+type DatasetContext = datasetApi.DatasetContext;
+
+let currentDataset: DatasetContext | undefined;
+const listeners = new Set<(ctx: DatasetContext) => void>();
+
+/**
+ * Host-internal: called by the Dataset page when its entity loads or changes.
+ * Not part of the public `@apache-superset/core` API.
+ */
+export const setCurrentDataset = (ctx: DatasetContext | undefined): void => {
+  currentDataset = ctx;
+  if (ctx) {
+    listeners.forEach(fn => fn(ctx));
+  }
+};
+
+const getCurrentDataset: typeof datasetApi.getCurrentDataset = () =>
+  currentDataset ? { ...currentDataset } : undefined;
+
+const onDidChangeDataset: typeof datasetApi.onDidChangeDataset = (
+  listener: (ctx: DatasetContext) => void,
+  thisArgs?: any,
+): Disposable => {
+  const bound = thisArgs ? listener.bind(thisArgs) : listener;
+  listeners.add(bound);
+  return new Disposable(() => listeners.delete(bound));
+};
+
+export const dataset: typeof datasetApi = {
+  getCurrentDataset,
+  onDidChangeDataset,
+};

--- a/superset-frontend/src/core/explore/index.ts
+++ b/superset-frontend/src/core/explore/index.ts
@@ -30,6 +30,7 @@ import {
   SET_FORM_DATA,
   UPDATE_CHART_TITLE,
 } from 'src/explore/actions/exploreActions';
+import { SET_DATASOURCE } from 'src/explore/actions/datasourcesActions';
 import { store, RootState } from 'src/views/store';
 import { AnyListenerPredicate } from '@reduxjs/toolkit';
 import { createActionListener } from '../utils';
@@ -49,7 +50,7 @@ function buildChartContext(): ChartContext | undefined {
 
   return {
     chartId: slice?.slice_id ?? null,
-    chartName: slice?.slice_name ?? null,
+    chartName: exploreState.sliceName ?? slice?.slice_name ?? null,
     vizType,
     datasourceId: datasource?.id ?? null,
     datasourceName:
@@ -60,7 +61,8 @@ function buildChartContext(): ChartContext | undefined {
 const exploreChangePredicate: AnyListenerPredicate<RootState> = action =>
   action.type === HYDRATE_EXPLORE ||
   action.type === SET_FORM_DATA ||
-  action.type === UPDATE_CHART_TITLE;
+  action.type === UPDATE_CHART_TITLE ||
+  action.type === SET_DATASOURCE;
 
 const getCurrentChart: typeof exploreApi.getCurrentChart = () =>
   buildChartContext();

--- a/superset-frontend/src/core/explore/index.ts
+++ b/superset-frontend/src/core/explore/index.ts
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Host-internal implementation of the `explore` namespace.
+ *
+ * Wraps Redux explore state and normalizes it into the stable `ChartContext`
+ * contract. Extensions must not depend on the Redux slice structure directly.
+ */
+
+import type { explore as exploreApi } from '@apache-superset/core';
+import { HYDRATE_EXPLORE } from 'src/explore/actions/hydrateExplore';
+import {
+  SET_FORM_DATA,
+  UPDATE_CHART_TITLE,
+} from 'src/explore/actions/exploreActions';
+import { store, RootState } from 'src/views/store';
+import { AnyListenerPredicate } from '@reduxjs/toolkit';
+import { createActionListener } from '../utils';
+
+type ChartContext = exploreApi.ChartContext;
+
+function buildChartContext(): ChartContext | undefined {
+  const state = store.getState();
+  const exploreState = (state as any).explore;
+  if (!exploreState) return undefined;
+
+  const { slice, datasource, controls } = exploreState;
+  const vizType: string =
+    (controls?.viz_type?.value as string) ??
+    exploreState.form_data?.viz_type ??
+    '';
+
+  return {
+    chartId: slice?.slice_id ?? null,
+    chartName: slice?.slice_name ?? null,
+    vizType,
+    datasourceId: datasource?.id ?? null,
+    datasourceName:
+      datasource?.table_name ?? datasource?.datasource_name ?? null,
+  };
+}
+
+const exploreChangePredicate: AnyListenerPredicate<RootState> = action =>
+  action.type === HYDRATE_EXPLORE ||
+  action.type === SET_FORM_DATA ||
+  action.type === UPDATE_CHART_TITLE;
+
+const getCurrentChart: typeof exploreApi.getCurrentChart = () =>
+  buildChartContext();
+
+const onDidChangeChart: typeof exploreApi.onDidChangeChart = (
+  listener: (ctx: ChartContext) => void,
+  thisArgs?: any,
+) =>
+  createActionListener<ChartContext>(
+    exploreChangePredicate,
+    listener,
+    () => buildChartContext() ?? null,
+    thisArgs,
+  );
+
+export const explore: typeof exploreApi = {
+  getCurrentChart,
+  onDidChangeChart,
+};

--- a/superset-frontend/src/core/index.ts
+++ b/superset-frontend/src/core/index.ts
@@ -28,10 +28,14 @@ export const core: typeof coreType = {
 
 export * from './authentication';
 export * from './commands';
+export * from './dashboard';
+export * from './dataset';
 export * from './editors';
+export * from './explore';
 export * from './extensions';
 export * from './menus';
 export * from './models';
+export * from './navigation';
 export * from './sqlLab';
 export * from './utils';
 export * from './views';

--- a/superset-frontend/src/core/navigation/index.ts
+++ b/superset-frontend/src/core/navigation/index.ts
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Host-internal implementation of the `navigation` namespace.
+ *
+ * Backed by browser location — no Redux dependency.
+ * The app shell calls `notifyPageChange(pathname)` whenever the route changes.
+ */
+
+import type { navigation as navigationApi } from '@apache-superset/core';
+import { Disposable } from '../models';
+
+type PageType = navigationApi.PageType;
+type PageContext = navigationApi.PageContext;
+
+const listeners = new Set<(ctx: PageContext) => void>();
+
+function derivePageType(pathname: string): PageType {
+  if (pathname.startsWith('/superset/dashboard/')) return 'dashboard';
+  if (pathname.startsWith('/explore/')) return 'explore';
+  if (pathname.startsWith('/superset/explore/')) return 'explore';
+  if (pathname.startsWith('/chart/add')) return 'explore';
+  if (pathname.startsWith('/sqllab/')) return 'sqllab';
+  if (pathname.startsWith('/dataset/')) return 'dataset';
+  if (pathname.startsWith('/superset/welcome/')) return 'home';
+  return 'other';
+}
+
+function extractEntityId(pathname: string, pageType: PageType): number | null {
+  if (pageType === 'dashboard') {
+    const m = pathname.match(/\/superset\/dashboard\/(\d+)/);
+    return m ? parseInt(m[1], 10) : null;
+  }
+  if (pageType === 'dataset') {
+    const m = pathname.match(/\/dataset\/(\d+)/);
+    return m ? parseInt(m[1], 10) : null;
+  }
+  return null;
+}
+
+let currentContext: PageContext = {
+  pageType: derivePageType(window.location.pathname),
+  entityId: null,
+};
+currentContext.entityId = extractEntityId(
+  window.location.pathname,
+  currentContext.pageType,
+);
+
+/** Called by ExtensionsStartup whenever the React Router location changes. */
+export const notifyPageChange = (pathname: string): void => {
+  const pageType = derivePageType(pathname);
+  const entityId = extractEntityId(pathname, pageType);
+  const next: PageContext = { pageType, entityId };
+  if (
+    next.pageType === currentContext.pageType &&
+    next.entityId === currentContext.entityId
+  ) {
+    return;
+  }
+  currentContext = next;
+  listeners.forEach(fn => fn(next));
+};
+
+const getPageType: typeof navigationApi.getPageType = () =>
+  currentContext.pageType;
+
+const getCurrentPage: typeof navigationApi.getCurrentPage = () => ({
+  ...currentContext,
+});
+
+const onDidChangePage: typeof navigationApi.onDidChangePage = (
+  listener: (ctx: PageContext) => void,
+  thisArgs?: any,
+): Disposable => {
+  const bound = thisArgs ? listener.bind(thisArgs) : listener;
+  listeners.add(bound);
+  return new Disposable(() => listeners.delete(bound));
+};
+
+export const navigation: typeof navigationApi = {
+  getPageType,
+  getCurrentPage,
+  onDidChangePage,
+};

--- a/superset-frontend/src/core/navigation/index.ts
+++ b/superset-frontend/src/core/navigation/index.ts
@@ -28,9 +28,8 @@ import type { navigation as navigationApi } from '@apache-superset/core';
 import { Disposable } from '../models';
 
 type PageType = navigationApi.PageType;
-type PageContext = navigationApi.PageContext;
 
-const listeners = new Set<(ctx: PageContext) => void>();
+const listeners = new Set<(pageType: PageType) => void>();
 
 function derivePageType(pathname: string): PageType {
   if (pathname.startsWith('/superset/dashboard/')) return 'dashboard';
@@ -43,51 +42,20 @@ function derivePageType(pathname: string): PageType {
   return 'other';
 }
 
-function extractEntityId(pathname: string, pageType: PageType): number | null {
-  if (pageType === 'dashboard') {
-    const m = pathname.match(/\/superset\/dashboard\/(\d+)/);
-    return m ? parseInt(m[1], 10) : null;
-  }
-  if (pageType === 'dataset') {
-    const m = pathname.match(/\/dataset\/(\d+)/);
-    return m ? parseInt(m[1], 10) : null;
-  }
-  return null;
-}
-
-let currentContext: PageContext = {
-  pageType: derivePageType(window.location.pathname),
-  entityId: null,
-};
-currentContext.entityId = extractEntityId(
-  window.location.pathname,
-  currentContext.pageType,
-);
+let currentPageType: PageType = derivePageType(window.location.pathname);
 
 /** Called by ExtensionsStartup whenever the React Router location changes. */
 export const notifyPageChange = (pathname: string): void => {
-  const pageType = derivePageType(pathname);
-  const entityId = extractEntityId(pathname, pageType);
-  const next: PageContext = { pageType, entityId };
-  if (
-    next.pageType === currentContext.pageType &&
-    next.entityId === currentContext.entityId
-  ) {
-    return;
-  }
-  currentContext = next;
+  const next = derivePageType(pathname);
+  if (next === currentPageType) return;
+  currentPageType = next;
   listeners.forEach(fn => fn(next));
 };
 
-const getPageType: typeof navigationApi.getPageType = () =>
-  currentContext.pageType;
-
-const getCurrentPage: typeof navigationApi.getCurrentPage = () => ({
-  ...currentContext,
-});
+const getPageType: typeof navigationApi.getPageType = () => currentPageType;
 
 const onDidChangePage: typeof navigationApi.onDidChangePage = (
-  listener: (ctx: PageContext) => void,
+  listener: (pageType: PageType) => void,
   thisArgs?: any,
 ): Disposable => {
   const bound = thisArgs ? listener.bind(thisArgs) : listener;
@@ -97,6 +65,5 @@ const onDidChangePage: typeof navigationApi.onDidChangePage = (
 
 export const navigation: typeof navigationApi = {
   getPageType,
-  getCurrentPage,
   onDidChangePage,
 };

--- a/superset-frontend/src/core/views/index.ts
+++ b/superset-frontend/src/core/views/index.ts
@@ -102,23 +102,9 @@ const getViews: typeof viewsApi.getViews = (
 };
 
 /**
- * Host-internal accessor that returns the registered `provider` for a view id
- * at a given location.
- *
- * This is deliberately NOT part of the public `@apache-superset/core` `views`
- * API. The public `getViews` returns descriptors only (`id`/`name`/...), so an
- * extension can discover what is registered but cannot obtain — and therefore
- * cannot render — another extension's view outside the host's mount point,
- * lifecycle, and fault-isolation boundary.
- *
- * The host uses this accessor to render exclusive (singleton) contribution
- * areas such as `superset.chatbot`, where it must enumerate the candidates and
- * then render exactly one. See `getActiveChatbot` in `src/core/chatbot`.
- *
- * @param location The contribution location (e.g. `superset.chatbot`).
- * @param id The registered view id.
- * @returns The provider function, or undefined if no matching view is
- *   registered at that location.
+ * Host-internal: returns the provider for a registered view id at a location.
+ * Not part of the public `@apache-superset/core` API — `getViews` stays
+ * descriptor-only so extensions cannot render each other's views directly.
  */
 export const getViewProvider = (
   location: string,
@@ -131,18 +117,7 @@ export const getViewProvider = (
   return entry.provider;
 };
 
-/**
- * Host-internal accessor that returns the ordered list of view ids registered
- * at a location, in registration order.
- *
- * Registration order is meaningful for exclusive locations: the host's
- * deterministic fallback policy ("first to register wins") relies on it.
- * Like {@link getViewProvider}, this is host-internal and not part of the
- * public API.
- *
- * @param location The contribution location.
- * @returns View ids in registration order, or an empty array if none.
- */
+/** Host-internal: view ids at a location in registration order. */
 export const getRegisteredViewIds = (location: string): string[] => {
   const ids = locationIndex.get(location);
   return ids ? Array.from(ids) : [];

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -17,18 +17,29 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import { FunctionComponent, useMemo } from 'react';
+import { css } from '@apache-superset/core/theme';
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { SupersetClient } from '@superset-ui/core';
+import { Select } from '@superset-ui/core/components';
+import { Switch } from '@superset-ui/core/components/Switch';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import { ListView } from 'src/components';
 import SubMenu, { SubMenuProps } from 'src/features/home/SubMenu';
 import withToasts from 'src/components/MessageToasts/withToasts';
+import { CHATBOT_LOCATION } from 'src/views/contributions';
+import { getRegisteredViewIds } from 'src/core/views';
 
 const PAGE_SIZE = 25;
 
 type Extension = {
-  id: number;
+  id: string;
   name: string;
   enabled: boolean;
+};
+
+type ExtensionSettings = {
+  active_chatbot_id: string | null;
+  enabled: Record<string, boolean>;
 };
 
 interface ExtensionsListProps {
@@ -50,6 +61,45 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
     addDangerToast,
   );
 
+  const [settings, setSettings] = useState<ExtensionSettings>({
+    active_chatbot_id: null,
+    enabled: {},
+  });
+
+  useEffect(() => {
+    SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
+      .then(({ json }) => setSettings(json.result))
+      .catch(() => addDangerToast(t('Failed to load extension settings.')));
+  }, [addDangerToast]);
+
+  const saveSettings = useCallback(
+    (patch: Partial<ExtensionSettings>) => {
+      const next = { ...settings, ...patch };
+      SupersetClient.put({
+        endpoint: '/api/v1/extensions/settings',
+        jsonPayload: next,
+      })
+        .then(({ json }) => {
+          setSettings(json.result);
+          addSuccessToast(t('Settings saved.'));
+        })
+        .catch(() => addDangerToast(t('Failed to save extension settings.')));
+    },
+    [settings, addDangerToast, addSuccessToast],
+  );
+
+  const toggleEnabled = useCallback(
+    (extensionId: string, enabled: boolean) => {
+      saveSettings({ enabled: { ...settings.enabled, [extensionId]: enabled } });
+    },
+    [settings, saveSettings],
+  );
+
+  const chatbotExtensions = useMemo(() => {
+    const chatbotIds = new Set(getRegisteredViewIds(CHATBOT_LOCATION));
+    return resourceCollection.filter(ext => chatbotIds.has(ext.id));
+  }, [resourceCollection]);
+
   const columns = useMemo(
     () => [
       {
@@ -58,14 +108,33 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
         size: 'lg',
         id: 'name',
         Cell: ({
-          row: {
-            original: { name },
-          },
+          row: { original: { name } },
         }: any) => name,
       },
+      {
+        Header: t('Enabled'),
+        accessor: 'enabled',
+        size: 'sm',
+        id: 'enabled',
+        Cell: ({
+          row: { original: { id, enabled } },
+        }: any) => (
+          <Switch
+            data-test="toggle-enabled"
+            checked={settings.enabled[id] ?? enabled}
+            onClick={(checked: boolean) => toggleEnabled(id, checked)}
+            size="small"
+          />
+        ),
+      },
     ],
-    [loading], // We need to monitor loading to avoid stale state in actions
+    [loading, settings, toggleEnabled],
   );
+
+  const chatbotOptions = chatbotExtensions.map(ext => ({
+    label: ext.name,
+    value: ext.id,
+  }));
 
   const menuData: SubMenuProps = {
     activeChild: 'Extensions',
@@ -76,6 +145,23 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
   return (
     <>
       <SubMenu {...menuData} />
+      {chatbotOptions.length > 1 && (
+        <div style={{ padding: '16px 24px' }}>
+          <label htmlFor="chatbot-select" style={{ marginRight: 8 }}>
+            {t('Default chatbot')}
+          </label>
+          <Select
+            allowClear
+            options={chatbotOptions}
+            value={settings.active_chatbot_id ?? undefined}
+            onChange={value =>
+              saveSettings({ active_chatbot_id: (value as string) ?? null })
+            }
+            placeholder={t('First registered (automatic)')}
+            css={css`width: 280px;`}
+          />
+        </div>
+      )}
       <ListView<Extension>
         columns={columns}
         count={resourceCount}

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 // eslint-disable-next-line no-restricted-syntax
 import * as supersetCore from '@apache-superset/core';
 import { logging } from '@apache-superset/core/utils';
@@ -25,12 +26,17 @@ import {
   authentication,
   core,
   commands,
+  dashboard,
+  dataset,
   editors,
+  explore,
   extensions,
   menus,
+  navigation,
   sqlLab,
   views,
 } from 'src/core';
+import { notifyPageChange } from 'src/core/navigation';
 import { useSelector } from 'react-redux';
 import { RootState } from 'src/views/store';
 import ExtensionsLoader from './ExtensionsLoader';
@@ -41,9 +47,13 @@ declare global {
       authentication: typeof authentication;
       core: typeof core;
       commands: typeof commands;
+      dashboard: typeof dashboard;
+      dataset: typeof dataset;
       editors: typeof editors;
+      explore: typeof explore;
       extensions: typeof extensions;
       menus: typeof menus;
+      navigation: typeof navigation;
       sqlLab: typeof sqlLab;
       views: typeof views;
     };
@@ -54,10 +64,20 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
   children,
 }) => {
   const [initialized, setInitialized] = useState(false);
+  const location = useLocation();
+  const prevPathname = useRef<string | null>(null);
 
   const userId = useSelector<RootState, number | undefined>(
     ({ user }) => user.userId,
   );
+
+  // Notify the navigation namespace on every route change.
+  useEffect(() => {
+    if (prevPathname.current !== location.pathname) {
+      prevPathname.current = location.pathname;
+      notifyPageChange(location.pathname);
+    }
+  }, [location.pathname]);
 
   useEffect(() => {
     if (initialized) return;
@@ -74,9 +94,13 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
       authentication,
       core,
       commands,
+      dashboard,
+      dataset,
       editors,
+      explore,
       extensions,
       menus,
+      navigation,
       sqlLab,
       views,
     };
@@ -87,7 +111,10 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
     // chains) would otherwise surface as uncaught rejections in the host.
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
       // Always log so extension authors can diagnose failures.
-      logging.error('[extensions] Unhandled rejection from extension:', event.reason);
+      logging.error(
+        '[extensions] Unhandled rejection from extension:',
+        event.reason,
+      );
       event.preventDefault();
     };
     window.addEventListener('unhandledrejection', handleUnhandledRejection);
@@ -102,7 +129,10 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
     }
 
     return () => {
-      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+      window.removeEventListener(
+        'unhandledrejection',
+        handleUnhandledRejection,
+      );
     };
   }, [initialized, userId]);
 

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -79,6 +79,25 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
     }
   }, [location.pathname]);
 
+  // Isolate unhandled rejections from extension code for the lifetime of the
+  // app — registered once, never removed.
+  useEffect(() => {
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      logging.error(
+        '[extensions] Unhandled rejection from extension:',
+        event.reason,
+      );
+      event.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+    return () => {
+      window.removeEventListener(
+        'unhandledrejection',
+        handleUnhandledRejection,
+      );
+    };
+  }, []);
+
   useEffect(() => {
     if (initialized) return;
 
@@ -105,20 +124,6 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
       views,
     };
 
-    // Isolate unhandled rejections that originate from extension code so they
-    // cannot crash the host application. Extensions load via Module Federation
-    // and their async failures (e.g. failed API calls, unhandled promise
-    // chains) would otherwise surface as uncaught rejections in the host.
-    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-      // Always log so extension authors can diagnose failures.
-      logging.error(
-        '[extensions] Unhandled rejection from extension:',
-        event.reason,
-      );
-      event.preventDefault();
-    };
-    window.addEventListener('unhandledrejection', handleUnhandledRejection);
-
     // Render the host immediately; extension bundles load in the background.
     // ChatbotMount re-resolves reactively once the chatbot extension registers
     // (via subscribeToLocation), so the bubble appears without blocking the UI.
@@ -127,13 +132,6 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
     if (isFeatureEnabled(FeatureFlag.EnableExtensions)) {
       ExtensionsLoader.getInstance().initializeExtensions();
     }
-
-    return () => {
-      window.removeEventListener(
-        'unhandledrejection',
-        handleUnhandledRejection,
-      );
-    };
   }, [initialized, userId]);
 
   if (!initialized) {

--- a/superset/extensions/api.py
+++ b/superset/extensions/api.py
@@ -22,6 +22,7 @@ from flask import request, send_file
 from flask.wrappers import Response
 from flask_appbuilder.api import BaseApi, expose, protect, safe
 
+from superset.extensions import security_manager
 from superset.extensions.settings import (
     get_extension_settings,
     update_extension_settings,
@@ -209,7 +210,11 @@ class ExtensionsRestApi(BaseApi):
           responses:
             200:
               description: Updated settings
+            403:
+              $ref: '#/components/responses/403'
         """
+        if not security_manager.is_admin():
+            return self.response(403, message="Admin access required.")
         body = request.get_json(silent=True) or {}
         result = update_extension_settings(body)
         return self.response(200, result=result)

--- a/superset/extensions/api.py
+++ b/superset/extensions/api.py
@@ -18,10 +18,14 @@ import mimetypes
 from io import BytesIO
 from typing import Any
 
-from flask import send_file
+from flask import request, send_file
 from flask.wrappers import Response
 from flask_appbuilder.api import BaseApi, expose, protect, safe
 
+from superset.extensions.settings import (
+    get_extension_settings,
+    update_extension_settings,
+)
 from superset.extensions.utils import (
     build_extension_data,
     get_extensions,
@@ -166,6 +170,49 @@ class ExtensionsRestApi(BaseApi):
             return self.response_404()
         extension_data = build_extension_data(extension)
         return self.response(200, result=extension_data)
+
+    @protect()
+    @safe
+    @expose("/settings", methods=("GET",))
+    def get_settings(self, **kwargs: Any) -> Response:
+        """Get global extension admin settings.
+        ---
+        get:
+          summary: Get extension admin settings (active chatbot, enabled flags).
+          responses:
+            200:
+              description: Extension settings
+        """
+        return self.response(200, result=get_extension_settings())
+
+    @protect()
+    @safe
+    @expose("/settings", methods=("PUT",))
+    def put_settings(self, **kwargs: Any) -> Response:
+        """Update global extension admin settings.
+        ---
+        put:
+          summary: Update extension admin settings.
+          requestBody:
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    active_chatbot_id:
+                      type: string
+                      nullable: true
+                    enabled:
+                      type: object
+                      additionalProperties:
+                        type: boolean
+          responses:
+            200:
+              description: Updated settings
+        """
+        body = request.get_json(silent=True) or {}
+        result = update_extension_settings(body)
+        return self.response(200, result=result)
 
     @protect()
     @safe

--- a/superset/extensions/settings.py
+++ b/superset/extensions/settings.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from superset import db
 from superset.models.core import ExtensionEnabled, ExtensionSettings
+from superset.utils.decorators import transaction
 
 _SETTINGS_ROW_ID = 1
 
@@ -34,6 +35,7 @@ def get_extension_settings() -> dict[str, Any]:
     }
 
 
+@transaction()
 def update_extension_settings(body: dict[str, Any]) -> dict[str, Any]:
     row = db.session.get(ExtensionSettings, _SETTINGS_ROW_ID)
     if row is None:
@@ -51,5 +53,4 @@ def update_extension_settings(body: dict[str, Any]) -> dict[str, Any]:
                 db.session.add(flag)
             flag.enabled = bool(enabled)
 
-    db.session.commit()
     return get_extension_settings()

--- a/superset/extensions/settings.py
+++ b/superset/extensions/settings.py
@@ -19,6 +19,9 @@
 
 from typing import Any
 
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
 from superset import db
 from superset.models.core import ExtensionEnabled, ExtensionSettings
 from superset.utils.decorators import transaction
@@ -35,22 +38,71 @@ def get_extension_settings() -> dict[str, Any]:
     }
 
 
+def _upsert_settings_row(
+    active_chatbot_id: str | None,
+) -> None:
+    """Upsert the singleton settings row without a read-then-insert race."""
+    bind = db.session.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        stmt = (
+            pg_insert(ExtensionSettings)
+            .values(id=_SETTINGS_ROW_ID, active_chatbot_id=active_chatbot_id)
+            .on_conflict_do_update(
+                index_elements=["id"],
+                set_={"active_chatbot_id": active_chatbot_id},
+            )
+        )
+        db.session.execute(stmt)
+    else:
+        stmt = (
+            sqlite_insert(ExtensionSettings)
+            .values(id=_SETTINGS_ROW_ID, active_chatbot_id=active_chatbot_id)
+            .on_conflict_do_update(
+                index_elements=["id"],
+                set_={"active_chatbot_id": active_chatbot_id},
+            )
+        )
+        db.session.execute(stmt)
+
+
+def _upsert_enabled_flag(extension_id: str, enabled: bool) -> None:
+    """Upsert a per-extension enabled flag without a read-then-insert race."""
+    bind = db.session.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        stmt = (
+            pg_insert(ExtensionEnabled)
+            .values(extension_id=extension_id, enabled=enabled)
+            .on_conflict_do_update(
+                index_elements=["extension_id"],
+                set_={"enabled": enabled},
+            )
+        )
+        db.session.execute(stmt)
+    else:
+        stmt = (
+            sqlite_insert(ExtensionEnabled)
+            .values(extension_id=extension_id, enabled=enabled)
+            .on_conflict_do_update(
+                index_elements=["extension_id"],
+                set_={"enabled": enabled},
+            )
+        )
+        db.session.execute(stmt)
+
+
 @transaction()
 def update_extension_settings(body: dict[str, Any]) -> dict[str, Any]:
-    row = db.session.get(ExtensionSettings, _SETTINGS_ROW_ID)
-    if row is None:
-        row = ExtensionSettings(id=_SETTINGS_ROW_ID)
-        db.session.add(row)
-
     if "active_chatbot_id" in body:
-        row.active_chatbot_id = body["active_chatbot_id"] or None
+        value = body["active_chatbot_id"]
+        active_chatbot_id = str(value) if isinstance(value, str) and value else None
+        _upsert_settings_row(active_chatbot_id)
 
-    if "enabled" in body:
+    if "enabled" in body and isinstance(body["enabled"], dict):
         for extension_id, enabled in body["enabled"].items():
-            flag = db.session.get(ExtensionEnabled, extension_id)
-            if flag is None:
-                flag = ExtensionEnabled(extension_id=extension_id)
-                db.session.add(flag)
-            flag.enabled = bool(enabled)
+            if not isinstance(enabled, bool):
+                continue
+            _upsert_enabled_flag(extension_id, enabled)
 
     return get_extension_settings()

--- a/superset/extensions/settings.py
+++ b/superset/extensions/settings.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Admin settings persistence for extensions (active chatbot, enable/disable)."""
+
+from typing import Any
+
+from superset import db
+from superset.models.core import ExtensionEnabled, ExtensionSettings
+
+_SETTINGS_ROW_ID = 1
+
+
+def get_extension_settings() -> dict[str, Any]:
+    row = db.session.get(ExtensionSettings, _SETTINGS_ROW_ID)
+    enabled_rows = db.session.query(ExtensionEnabled).all()
+    return {
+        "active_chatbot_id": row.active_chatbot_id if row else None,
+        "enabled": {r.extension_id: r.enabled for r in enabled_rows},
+    }
+
+
+def update_extension_settings(body: dict[str, Any]) -> dict[str, Any]:
+    row = db.session.get(ExtensionSettings, _SETTINGS_ROW_ID)
+    if row is None:
+        row = ExtensionSettings(id=_SETTINGS_ROW_ID)
+        db.session.add(row)
+
+    if "active_chatbot_id" in body:
+        row.active_chatbot_id = body["active_chatbot_id"] or None
+
+    if "enabled" in body:
+        for extension_id, enabled in body["enabled"].items():
+            flag = db.session.get(ExtensionEnabled, extension_id)
+            if flag is None:
+                flag = ExtensionEnabled(extension_id=extension_id)
+                db.session.add(flag)
+            flag.enabled = bool(enabled)
+
+    db.session.commit()
+    return get_extension_settings()

--- a/superset/migrations/versions/2026-05-25_00-00_b2c3d4e5f6a7_add_extension_settings.py
+++ b/superset/migrations/versions/2026-05-25_00-00_b2c3d4e5f6a7_add_extension_settings.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add extension_settings table for chatbot admin selection and enable/disable.
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-25 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "extension_settings",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("active_chatbot_id", sa.String(250), nullable=True),
+    )
+    op.create_table(
+        "extension_enabled",
+        sa.Column("extension_id", sa.String(250), primary_key=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("extension_enabled")
+    op.drop_table("extension_settings")

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -108,6 +108,22 @@ class KeyValue(Model):  # pylint: disable=too-few-public-methods
     value = Column(utils.MediumText(), nullable=False)
 
 
+class ExtensionSettings(Model):  # pylint: disable=too-few-public-methods
+    """Global admin settings for extensions (singleton row, id=1)."""
+
+    __tablename__ = "extension_settings"
+    id = Column(Integer, primary_key=True)
+    active_chatbot_id = Column(String(250), nullable=True)
+
+
+class ExtensionEnabled(Model):  # pylint: disable=too-few-public-methods
+    """Per-extension enable/disable flag."""
+
+    __tablename__ = "extension_enabled"
+    extension_id = Column(String(250), primary_key=True)
+    enabled = Column(Boolean, nullable=False, default=True)
+
+
 class CssTemplate(AuditMixinNullable, UUIDMixin, Model):
     """CSS templates for dashboards"""
 


### PR DESCRIPTION
### SUMMARY

Implements Phase 3 of the chatbot extension architecture: four context namespaces that give extensions stable, host-managed access to page context without coupling to Redux internals.

**New namespaces in \`@apache-superset/core\`** (declarations — stable extension contract):
- \`navigation\` — \`getPageType()\`, \`onDidChangePage\` event firing \`PageType\`. Routing signal only; entity payloads are intentionally excluded and belong to the surface namespaces below.
- \`explore\` — \`getCurrentChart()\`, \`onDidChangeChart\` event. Exposes \`ChartContext\` (chart id, name, viz type, datasource) normalized from Redux explore state. Reacts to \`HYDRATE_EXPLORE\`, \`SET_FORM_DATA\`, \`UPDATE_CHART_TITLE\`, and \`SET_DATASOURCE\`.
- \`dataset\` — \`getCurrentDataset()\`, \`onDidChangeDataset\` event. Push model: the Dataset page calls host-internal \`setCurrentDataset()\` as it loads.
- \`dashboard\` — \`getCurrentDashboard()\`, \`onDidChangeDashboard\` event. Exposes \`DashboardContext\` (id, title, active native filter values) normalized from Redux \`dashboardInfo\` + \`dataMask\`. Only filters with an applied value are included.

**Host implementations in \`src/core/\`** (internal, not part of the public API):
- \`navigation\` backed by \`window.location\` + \`notifyPageChange\` driven by React Router in \`ExtensionsStartup\`
- \`explore\` backed by Redux action listener; reads \`sliceName\` from reducer state (kept fresh by \`UPDATE_CHART_TITLE\`) rather than the stale \`slice.slice_name\` field
- \`dataset\` backed by a simple push store
- \`dashboard\` backed by Redux action listener

**Also in this PR:**
- \`PUT /api/v1/extensions/settings\` restricted to Admin role
- \`enabled\` flag enforced in \`getActiveChatbot\` — disabled extensions are excluded from resolution, not just hidden in the picker
- \`update_extension_settings\` uses \`@transaction()\` (removes manual \`db.session.commit()\`); race-safe upsert via \`ON CONFLICT DO UPDATE\` for both settings rows
- \`body["enabled"]\` validated as a dict before iteration; strict \`isinstance(enabled, bool)\` guard
- \`unhandledrejection\` isolation moved to its own one-time effect in \`ExtensionsStartup\` so it remains active for the app lifetime
- \`ChatbotMount\` settings fetch guarded against unmount race with a \`cancelled\` flag

**Extension pattern** — extensions compose context from namespaces on demand, not from a fixed host-provided \`PageContext\` object:

```typescript
// pageContext.ts in the extension
export const getPageContext = (): PageContext => ({
  pageType: navigation.getPageType(),           // routing signal
  dashboard: dashboard.getCurrentDashboard(),   // entity payload when on a dashboard
  chart: explore.getCurrentChart(),             // entity payload when in Explore
  dataset: dataset.getCurrentDataset(),         // entity payload when on a dataset
  sqlLab: sqlLab.getCurrentTab(),
  href: window.location.href,
});

// subscribe to changes
export const subscribeToPageChanges = (onChange: () => void) => {
  const nav = (core as any).navigation;
  if (nav?.onDidChangePage) {
    const sub = nav.onDidChangePage(onChange);
    return () => sub.dispose();
  }
  // fallback for older hosts
  window.addEventListener('popstate', onChange);
  return () => window.removeEventListener('popstate', onChange);
};
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — namespace APIs, no visible UI change.

### TESTING INSTRUCTIONS

1. On a dashboard page: \`window.superset.navigation.getPageType()\` → \`'dashboard'\`
2. \`window.superset.dashboard.getCurrentDashboard()\` → \`{ dashboardId, title, filters: [...] }\` (only filters with applied values)
3. Apply a native filter → \`onDidChangeDashboard\` fires with updated filter values
4. Navigate to Explore → \`navigation.getPageType()\` → \`'explore'\`; \`explore.getCurrentChart()\` returns chart context
5. Change the datasource in Explore → \`onDidChangeChart\` fires
6. Edit chart title → \`onDidChangeChart\` fires with updated \`chartName\` (from reducer state, not stale slice field)
7. \`PUT /api/v1/extensions/settings\` as a non-admin user → 403
8. Disable a chatbot extension in the admin UI → it no longer renders (excluded from resolver)
9. Send \`{"enabled": []}\` or \`{"enabled": {"ext1": "false"}}\` to the settings endpoint → 200, malformed values silently ignored

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API