### PR TITLE
feat(extensions): eager-load extensions at app-shell startup

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -80,7 +80,7 @@ const restrictedImportsRules = {
   'no-jest-mock-console': {
     name: 'jest-mock-console',
     message: 'Please use native Jest spies, i.e. jest.spyOn(console, "warn")',
-  }
+  },
 };
 
 module.exports = {

--- a/superset-frontend/packages/superset-core/package.json
+++ b/superset-frontend/packages/superset-core/package.json
@@ -18,6 +18,22 @@
       "types": "./lib/authentication/index.d.ts",
       "default": "./lib/authentication/index.js"
     },
+    "./dashboard": {
+      "types": "./lib/dashboard/index.d.ts",
+      "default": "./lib/dashboard/index.js"
+    },
+    "./dataset": {
+      "types": "./lib/dataset/index.d.ts",
+      "default": "./lib/dataset/index.js"
+    },
+    "./explore": {
+      "types": "./lib/explore/index.d.ts",
+      "default": "./lib/explore/index.js"
+    },
+    "./navigation": {
+      "types": "./lib/navigation/index.d.ts",
+      "default": "./lib/navigation/index.js"
+    },
     "./commands": {
       "types": "./lib/commands/index.d.ts",
       "default": "./lib/commands/index.js"

--- a/superset-frontend/packages/superset-core/src/common/index.ts
+++ b/superset-frontend/packages/superset-core/src/common/index.ts
@@ -214,6 +214,55 @@ export declare interface Event<T> {
 }
 
 /**
+ * Context handed to an extension's `activate` function.
+ *
+ * The extension binds the lifetime of everything it registers to this object by
+ * pushing the returned {@link Disposable}s onto `subscriptions`. Because the
+ * context is owned by the extension for as long as it is active, registrations
+ * performed asynchronously (after an `await`, in a timer, or in an event
+ * callback) are tracked just the same as synchronous ones — the host disposes
+ * the whole `subscriptions` array on deactivation.
+ *
+ * @example
+ * ```typescript
+ * export function activate(context: ExtensionContext) {
+ *   context.subscriptions.push(
+ *     commands.registerCommand('my_ext.hello', () => {}),
+ *   );
+ * }
+ * ```
+ */
+export interface ExtensionContext {
+  /**
+   * Disposables to be cleaned up when the extension is deactivated. Push every
+   * {@link Disposable} returned by a `register*` call here.
+   */
+  subscriptions: { dispose(): void }[];
+}
+
+/**
+ * Shape of an extension's entry module (its `./index`).
+ *
+ * Extensions are encouraged to export an `activate(context)` function so that
+ * their registrations are tracked via `context.subscriptions` regardless of
+ * whether they run synchronously or asynchronously. For backward compatibility,
+ * a module may instead register its contributions as top-level side effects when
+ * the module is evaluated; such registrations are only tracked when performed
+ * synchronously during module evaluation.
+ */
+export interface ExtensionModule {
+  /**
+   * Called by the host once the extension module has loaded. May be async; the
+   * host awaits it before considering the extension active.
+   */
+  activate?(context: ExtensionContext): void | Promise<void>;
+  /**
+   * Optional hook called before the host disposes `context.subscriptions`.
+   */
+  deactivate?(): void | Promise<void>;
+}
+
+/**
  * Represents a Superset extension with its metadata.
  * Extensions are modular components that can extend Superset's functionality
  * by registering commands, views, menus, and editors as module-level side effects.

--- a/superset-frontend/packages/superset-core/src/dashboard/index.ts
+++ b/superset-frontend/packages/superset-core/src/dashboard/index.ts
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Dashboard namespace for Superset extensions (P3).
+ *
+ * Exposes dashboard identity and filter state as a stable semantic API.
+ * Extensions must not depend on the Redux dashboard slice structure directly.
+ */
+
+import { Event } from '../common';
+
+/**
+ * A single native filter's current selected value(s).
+ * The value type is intentionally kept as `unknown` because filter values
+ * are heterogeneous (date ranges, string lists, numbers, etc.).
+ */
+export interface FilterValue {
+  /** The filter's stable id. */
+  filterId: string;
+  /** Display label of the filter. */
+  label: string;
+  /** Currently applied value, or `null` when the filter is cleared. */
+  value: unknown;
+}
+
+/**
+ * Summary of a single chart on the active dashboard.
+ *
+ * Exposes the identity, viz type, datasource, and current visibility of a
+ * chart so extensions can answer both "which charts are visible?" and
+ * "find the chart named X" without additional lookups.
+ */
+export interface ChartSummary {
+  /** Numeric chart (slice) id. */
+  chartId: number;
+  /** Display name of the chart. */
+  chartName: string;
+  /** Visualization type key (e.g. `'echarts_timeseries_bar'`). */
+  vizType: string;
+  /** Datasource id, or `null` when not resolvable. */
+  datasourceId: number | null;
+  /** Datasource name, or `null` when not resolvable. */
+  datasourceName: string | null;
+  /** Whether the chart is currently visible (e.g. on the active tab). */
+  isVisible: boolean;
+}
+
+/**
+ * Normalized dashboard context exposed to extensions on the Dashboard page.
+ */
+export interface DashboardContext {
+  /** Numeric dashboard id. */
+  dashboardId: number;
+  /** Display title of the dashboard. */
+  title: string;
+  /**
+   * Active native filter values keyed by filter id.
+   * Only includes filters that have a value applied.
+   */
+  filters: FilterValue[];
+  /**
+   * Summaries of the dashboard's charts, including per-chart visibility.
+   *
+   * Optional: the contract is declared so extensions can compile against the
+   * stable shape, but population is delivered in a later phase (see
+   * CHATBOT_SIP.md §10/§11). The host returns an empty array until then.
+   */
+  charts?: ChartSummary[];
+}
+
+/**
+ * Returns the normalized dashboard context for the page currently being viewed,
+ * or `undefined` when the user is not on a Dashboard page.
+ *
+ * @example
+ * ```typescript
+ * const dash = dashboard.getCurrentDashboard();
+ * if (dash) {
+ *   console.log(dash.title, dash.filters);
+ * }
+ * ```
+ */
+export declare function getCurrentDashboard(): DashboardContext | undefined;
+
+/**
+ * Event fired when the dashboard identity or its active filter values change.
+ * Fired on native filter value changes and on navigation to a different dashboard.
+ *
+ * @example
+ * ```typescript
+ * const sub = dashboard.onDidChangeDashboard(dash => {
+ *   chatbot.updateContext({ dashboard: dash });
+ * });
+ * sub.dispose();
+ * ```
+ */
+export declare const onDidChangeDashboard: Event<DashboardContext>;

--- a/superset-frontend/packages/superset-core/src/dataset/index.ts
+++ b/superset-frontend/packages/superset-core/src/dataset/index.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Dataset namespace for Superset extensions (P3).
+ *
+ * Exposes the dataset currently being viewed as a stable semantic API.
+ * Aligned with backend-enforced dataset visibility and column-access semantics.
+ */
+
+import { Event } from '../common';
+
+/**
+ * Normalized dataset context exposed to extensions on the Dataset page.
+ */
+export interface DatasetContext {
+  /** Numeric dataset id. */
+  datasetId: number;
+  /** Display name (table name or virtual dataset name). */
+  datasetName: string;
+  /** Schema the dataset belongs to, if applicable. */
+  schema: string | null;
+  /** Catalog the dataset belongs to, if applicable. */
+  catalog: string | null;
+  /** Database name backing this dataset. */
+  databaseName: string | null;
+  /** Whether this is a virtual (SQL-defined) dataset. */
+  isVirtual: boolean;
+}
+
+/**
+ * Returns the normalized dataset context for the page currently being viewed,
+ * or `undefined` when the user is not on a Dataset page.
+ *
+ * @example
+ * ```typescript
+ * const ds = dataset.getCurrentDataset();
+ * if (ds) {
+ *   console.log(ds.datasetName, ds.schema);
+ * }
+ * ```
+ */
+export declare function getCurrentDataset(): DatasetContext | undefined;
+
+/**
+ * Event fired when the focused dataset changes (e.g. the user navigates to a
+ * different dataset detail page).
+ *
+ * @example
+ * ```typescript
+ * const sub = dataset.onDidChangeDataset(ds => {
+ *   chatbot.updateContext({ dataset: ds });
+ * });
+ * sub.dispose();
+ * ```
+ */
+export declare const onDidChangeDataset: Event<DatasetContext>;

--- a/superset-frontend/packages/superset-core/src/explore/index.ts
+++ b/superset-frontend/packages/superset-core/src/explore/index.ts
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Explore namespace for Superset extensions (P3).
+ *
+ * Exposes the current chart/explore context as a stable semantic API.
+ * Normalized over Explore Redux state — extensions must not depend on
+ * the Redux slice structure directly.
+ */
+
+import { Event } from '../common';
+
+/**
+ * Normalized chart context exposed to extensions during an Explore session.
+ * Covers saved chart identity and transient editing context; excludes raw
+ * form-data internals and datasource-implementation details.
+ */
+export interface ChartContext {
+  /** The saved chart id, or `null` when the chart has not been persisted. */
+  chartId: number | null;
+  /** Display name of the saved chart, or `null` for a new/unsaved chart. */
+  chartName: string | null;
+  /** The visualization type currently selected in the editor. */
+  vizType: string;
+  /** Id of the datasource backing the chart (physical or virtual dataset). */
+  datasourceId: number | null;
+  /** Human-readable datasource name. */
+  datasourceName: string | null;
+}
+
+/**
+ * Returns the normalized chart context for the active Explore session, or
+ * `undefined` when the user is not on the Explore page.
+ *
+ * @example
+ * ```typescript
+ * const chart = explore.getCurrentChart();
+ * if (chart) {
+ *   console.log(chart.vizType, chart.chartName);
+ * }
+ * ```
+ */
+export declare function getCurrentChart(): ChartContext | undefined;
+
+/**
+ * Event fired when the chart context changes within the active Explore session
+ * (e.g. when the viz type, datasource, or saved name changes).
+ * Not fired during route changes — subscribe to `navigation.onDidChangePage` for those.
+ *
+ * @example
+ * ```typescript
+ * const sub = explore.onDidChangeChart(chart => {
+ *   chatbot.updateContext({ chart });
+ * });
+ * sub.dispose();
+ * ```
+ */
+export declare const onDidChangeChart: Event<ChartContext>;

--- a/superset-frontend/packages/superset-core/src/index.ts
+++ b/superset-frontend/packages/superset-core/src/index.ts
@@ -19,9 +19,13 @@
 export * as common from './common';
 export * as authentication from './authentication';
 export * as commands from './commands';
+export * as dashboard from './dashboard';
+export * as dataset from './dataset';
 export * as editors from './editors';
+export * as explore from './explore';
 export * as extensions from './extensions';
 export * as menus from './menus';
+export * as navigation from './navigation';
 export * as sqlLab from './sqlLab';
 export * as views from './views';
 export * as contributions from './contributions';

--- a/superset-frontend/packages/superset-core/src/navigation/index.ts
+++ b/superset-frontend/packages/superset-core/src/navigation/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Navigation namespace for Superset extensions (P3).
+ *
+ * Exposes the current application surface so extensions can react to route
+ * changes without polling. Entity-level context (chart, dashboard, dataset)
+ * is intentionally not included here — use the surface-specific namespace
+ * (`explore`, `dashboard`, `dataset`) to retrieve entity payloads.
+ */
+
+import { Event } from '../common';
+
+/**
+ * The set of top-level application surfaces.
+ *
+ * `'explore'`, `'dashboard'` and `'dataset'` are the single-entity
+ * editing/viewing surfaces where `explore.getCurrentChart()` /
+ * `dashboard.getCurrentDashboard()` / `dataset.getCurrentDataset()` resolve to a
+ * concrete entity. `'chart_list'`, `'dashboard_list'` and `'dataset_list'` are
+ * the browse/list surfaces, distinct from those because no single entity is
+ * active. `'sqllab'` is the SQL editor where `sqlLab.getCurrentTab()` resolves;
+ * `'query_history'` and `'saved_queries'` are the related SQL Lab browse pages,
+ * which are not the editor. `'other'` covers any route not explicitly enumerated.
+ */
+export type PageType =
+  | 'dashboard'
+  | 'dashboard_list'
+  | 'explore'
+  | 'chart_list'
+  | 'sqllab'
+  | 'query_history'
+  | 'saved_queries'
+  | 'dataset'
+  | 'dataset_list'
+  | 'home'
+  | 'other';
+
+/**
+ * Returns the current page surface type.
+ *
+ * @example
+ * ```typescript
+ * const pageType = navigation.getPageType();
+ * if (pageType === 'dashboard') {
+ *   const ctx = dashboard.getCurrentDashboard();
+ * }
+ * ```
+ */
+export declare function getPageType(): PageType;
+
+/**
+ * Event fired whenever the user navigates to a different surface.
+ * Use the surface-specific namespace to read entity context after the event.
+ *
+ * @example
+ * ```typescript
+ * const sub = navigation.onDidChangePage(pageType => {
+ *   if (pageType === 'dashboard') {
+ *     const ctx = dashboard.getCurrentDashboard();
+ *   }
+ * });
+ * // later:
+ * sub.dispose();
+ * ```
+ */
+export declare const onDidChangePage: Event<PageType>;

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -519,7 +519,8 @@ const Select = forwardRef(
               handleSelectAll();
             }}
           >
-            {t('Select all')} {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.selectable)})`}
+            {t('Select all')}{' '}
+            {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.selectable)})`}
           </Button>
           <Button
             type="link"
@@ -536,7 +537,8 @@ const Select = forwardRef(
               handleDeselectAll();
             }}
           >
-            {t('Clear')} {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.deselectable)})`}
+            {t('Clear')}{' '}
+            {`(${formatNumber('SMART_NUMBER', bulkSelectCounts.deselectable)})`}
           </Button>
         </StyledBulkActionsContainer>
       ),

--- a/superset-frontend/playwright/tests/dashboard/clear-all-filters.spec.ts
+++ b/superset-frontend/playwright/tests/dashboard/clear-all-filters.spec.ts
@@ -182,10 +182,7 @@ testWithAssets(
     // Now track POST /api/v1/chart/data requests around Clear All
     const postsAfterClearAll: string[] = [];
     const handler = (req: any) => {
-      if (
-        req.url().includes('/api/v1/chart/data') &&
-        req.method() === 'POST'
-      ) {
+      if (req.url().includes('/api/v1/chart/data') && req.method() === 'POST') {
         postsAfterClearAll.push(req.url());
       }
     };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
@@ -288,9 +288,7 @@ describe('BigNumberWithTrendline transformProps', () => {
       height: 300,
       queriesData: [
         {
-          data: [
-            { __timestamp: 1, value: 100 },
-          ] as unknown as BigNumberDatum[],
+          data: [{ __timestamp: 1, value: 100 }] as unknown as BigNumberDatum[],
           colnames: ['__timestamp', 'value'],
           coltypes: ['TEMPORAL', 'NUMERIC'],
         },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -284,8 +284,11 @@ function Echart(
       // setOption(notMerge:true) replaces the dataZoom config, dropping any
       // range the user has engaged. Preserve it across the call.
       const previousZoom = notMerge
-        ? (chartRef.current?.getOption() as { dataZoom?: DataZoomComponentOption[] })
-            ?.dataZoom
+        ? (
+            chartRef.current?.getOption() as {
+              dataZoom?: DataZoomComponentOption[];
+            }
+          )?.dataZoom
         : undefined;
       chartRef.current?.setOption(themedEchartOptions, {
         notMerge,

--- a/superset-frontend/src/components/ChatbotMount/ChatbotMount.test.tsx
+++ b/superset-frontend/src/components/ChatbotMount/ChatbotMount.test.tsx
@@ -89,3 +89,19 @@ test('isolates a failing chatbot so it does not crash the host', () => {
   // The host-owned error boundary catches the failure; render does not throw.
   expect(() => render(<ChatbotMount />)).not.toThrow();
 });
+
+test('isolates a chatbot whose provider function itself throws', () => {
+  disposables.push(
+    views.registerView(
+      { id: 'superset.chatbot', name: 'Superset Chatbot' },
+      CHATBOT_LOCATION,
+      () => {
+        throw new Error('provider blew up');
+      },
+    ),
+  );
+
+  // ChatbotRenderer wraps provider() in a component so ErrorBoundary catches
+  // synchronous throws from the provider function, not just from its output.
+  expect(() => render(<ChatbotMount />)).not.toThrow();
+});

--- a/superset-frontend/src/components/ChatbotMount/ChatbotMount.test.tsx
+++ b/superset-frontend/src/components/ChatbotMount/ChatbotMount.test.tsx
@@ -19,10 +19,17 @@
 import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
 import { views } from 'src/core';
+import { setExtensionSettings } from 'src/core/extensions';
 import { CHATBOT_LOCATION } from 'src/views/contributions';
 import ChatbotMount from '.';
 
 const disposables: Array<{ dispose: () => void }> = [];
+
+beforeEach(() => {
+  // The settings store is a module singleton; reset it so resolution starts
+  // from the empty default (no admin pin, all enabled) regardless of run order.
+  setExtensionSettings({ active_chatbot_id: null, enabled: {} });
+});
 
 afterEach(() => {
   disposables.forEach(d => d.dispose());

--- a/superset-frontend/src/components/ChatbotMount/index.tsx
+++ b/superset-frontend/src/components/ChatbotMount/index.tsx
@@ -16,20 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useSyncExternalStore,
-} from 'react';
-import { SupersetClient } from '@superset-ui/core';
+import { type ReactElement, useSyncExternalStore } from 'react';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { ErrorBoundary } from 'src/components/ErrorBoundary';
 import { getActiveChatbot } from 'src/core/chatbot';
 import { subscribeToRegistry, getRegistryVersion } from 'src/core/views';
-import { subscribeToExtensionSettings } from 'src/core/extensions';
 
 const CHATBOT_EDGE_MARGIN = 24;
 
@@ -44,48 +35,15 @@ const ChatbotRenderer = ({ provider }: { provider: () => ReactElement }) =>
 
 const ChatbotMount = () => {
   const theme = useTheme();
-  const [adminSelectedId, setAdminSelectedId] = useState<string | null>(null);
-  const [enabledMap, setEnabledMap] = useState<Record<string, boolean>>({});
 
-  const applySettings = useCallback(
-    (settings: {
-      active_chatbot_id: string | null;
-      enabled: Record<string, boolean>;
-    }) => {
-      setAdminSelectedId(settings.active_chatbot_id ?? null);
-      setEnabledMap(settings.enabled ?? {});
-    },
-    [],
-  );
+  // Subscribing to the registry version re-renders this component whenever a
+  // chatbot view registers or unregisters, so `getActiveChatbot()` below is
+  // re-evaluated against the current registry. Admin-driven selection (default
+  // chatbot, enabled flags) is layered on by the admin settings work later in
+  // the stack; here the single registered chatbot wins.
+  useSyncExternalStore(subscribeToRegistry, getRegistryVersion);
 
-  useEffect(() => {
-    let cancelled = false;
-    SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
-      .then(({ json }) => {
-        if (cancelled) return;
-        applySettings(json.result ?? { active_chatbot_id: null, enabled: {} });
-      })
-      .catch(() => {
-        // Settings fetch failure is non-fatal — fall back to first-to-register.
-        // enabledMap stays {} which getActiveChatbot treats as all-enabled.
-        setAdminSelectedId(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [applySettings]);
-
-  useEffect(() => subscribeToExtensionSettings(applySettings), [applySettings]);
-
-  const registryVersion = useSyncExternalStore(
-    subscribeToRegistry,
-    getRegistryVersion,
-  );
-
-  const activeChatbot = useMemo(
-    () => getActiveChatbot(adminSelectedId, enabledMap),
-    [adminSelectedId, enabledMap, registryVersion],
-  );
+  const activeChatbot = getActiveChatbot();
 
   if (!activeChatbot) {
     return null;

--- a/superset-frontend/src/components/ChatbotMount/index.tsx
+++ b/superset-frontend/src/components/ChatbotMount/index.tsx
@@ -16,41 +16,61 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { ReactElement } from 'react';
 import { SupersetClient } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { ErrorBoundary } from 'src/components/ErrorBoundary';
 import { getActiveChatbot } from 'src/core/chatbot';
 import { subscribeToRegistry, getRegistryVersion } from 'src/core/views';
+import { subscribeToExtensionSettings } from 'src/core/extensions';
 
 const CHATBOT_EDGE_MARGIN = 24;
 
+// Renders the provider as a component so ErrorBoundary catches provider-level throws.
+const ChatbotRenderer = ({ provider }: { provider: () => ReactElement }) =>
+  provider();
+
 const ChatbotMount = () => {
   const theme = useTheme();
-  // undefined = settings not yet loaded; don't render anything until settings arrive.
-  const [adminSelectedId, setAdminSelectedId] = useState<
-    string | null | undefined
-  >(undefined);
+  const [adminSelectedId, setAdminSelectedId] = useState<string | null>(null);
   const [enabledMap, setEnabledMap] = useState<Record<string, boolean>>({});
+
+  const applySettings = useCallback(
+    (settings: {
+      active_chatbot_id: string | null;
+      enabled: Record<string, boolean>;
+    }) => {
+      setAdminSelectedId(settings.active_chatbot_id ?? null);
+      setEnabledMap(settings.enabled ?? {});
+    },
+    [],
+  );
 
   useEffect(() => {
     let cancelled = false;
     SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
       .then(({ json }) => {
         if (cancelled) return;
-        const id = json.result?.active_chatbot_id ?? null;
-        const enabled: Record<string, boolean> = json.result?.enabled ?? {};
-        setAdminSelectedId(id);
-        setEnabledMap(enabled);
+        applySettings(json.result);
       })
       .catch(() => {
         // Settings fetch failure is non-fatal — fall back to first-to-register.
+        // enabledMap stays {} which getActiveChatbot treats as all-enabled.
         setAdminSelectedId(null);
       });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [applySettings]);
+
+  useEffect(() => subscribeToExtensionSettings(applySettings), [applySettings]);
 
   const registryVersion = useSyncExternalStore(
     subscribeToRegistry,
@@ -58,10 +78,7 @@ const ChatbotMount = () => {
   );
 
   const activeChatbot = useMemo(
-    () =>
-      adminSelectedId === undefined
-        ? null
-        : getActiveChatbot(adminSelectedId, enabledMap),
+    () => getActiveChatbot(adminSelectedId, enabledMap),
     [adminSelectedId, enabledMap, registryVersion],
   );
 
@@ -80,7 +97,9 @@ const ChatbotMount = () => {
         z-index: ${theme.zIndexPopupBase + 2};
       `}
     >
-      <ErrorBoundary>{activeChatbot.provider()}</ErrorBoundary>
+      <ErrorBoundary>
+        <ChatbotRenderer provider={activeChatbot.provider} />
+      </ErrorBoundary>
     </div>
   );
 };

--- a/superset-frontend/src/components/ChatbotMount/index.tsx
+++ b/superset-frontend/src/components/ChatbotMount/index.tsx
@@ -17,13 +17,13 @@
  * under the License.
  */
 import {
+  type ReactElement,
   useCallback,
   useEffect,
   useMemo,
   useState,
   useSyncExternalStore,
 } from 'react';
-import { ReactElement } from 'react';
 import { SupersetClient } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { ErrorBoundary } from 'src/components/ErrorBoundary';
@@ -33,7 +33,12 @@ import { subscribeToExtensionSettings } from 'src/core/extensions';
 
 const CHATBOT_EDGE_MARGIN = 24;
 
-// Renders the provider as a component so ErrorBoundary catches provider-level throws.
+/**
+ * Wraps the chatbot provider in a React component so that ErrorBoundary can
+ * catch synchronous throws from the provider function itself. Calling
+ * `provider()` inline (e.g. `{activeChatbot.provider()}`) would throw outside
+ * React's render boundary and crash the host.
+ */
 const ChatbotRenderer = ({ provider }: { provider: () => ReactElement }) =>
   provider();
 
@@ -58,7 +63,7 @@ const ChatbotMount = () => {
     SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
       .then(({ json }) => {
         if (cancelled) return;
-        applySettings(json.result);
+        applySettings(json.result ?? { active_chatbot_id: null, enabled: {} });
       })
       .catch(() => {
         // Settings fetch failure is non-fatal — fall back to first-to-register.

--- a/superset-frontend/src/components/ChatbotMount/index.tsx
+++ b/superset-frontend/src/components/ChatbotMount/index.tsx
@@ -16,25 +16,53 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { SupersetClient } from '@superset-ui/core';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { ErrorBoundary } from 'src/components/ErrorBoundary';
 import { getActiveChatbot } from 'src/core/chatbot';
-import { subscribeToLocation } from 'src/core/views';
-import { CHATBOT_LOCATION } from 'src/views/contributions';
+import { subscribeToRegistry, getRegistryVersion } from 'src/core/views';
 
 const CHATBOT_EDGE_MARGIN = 24;
 
 const ChatbotMount = () => {
   const theme = useTheme();
-  const [activeChatbot, setActiveChatbot] = useState(() => getActiveChatbot());
+  // undefined = settings not yet loaded; don't render anything until settings arrive.
+  const [adminSelectedId, setAdminSelectedId] = useState<
+    string | null | undefined
+  >(undefined);
+  const [enabledMap, setEnabledMap] = useState<Record<string, boolean>>({});
 
-  useEffect(
+  useEffect(() => {
+    let cancelled = false;
+    SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
+      .then(({ json }) => {
+        if (cancelled) return;
+        const id = json.result?.active_chatbot_id ?? null;
+        const enabled: Record<string, boolean> = json.result?.enabled ?? {};
+        setAdminSelectedId(id);
+        setEnabledMap(enabled);
+      })
+      .catch(() => {
+        // Settings fetch failure is non-fatal — fall back to first-to-register.
+        setAdminSelectedId(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const registryVersion = useSyncExternalStore(
+    subscribeToRegistry,
+    getRegistryVersion,
+  );
+
+  const activeChatbot = useMemo(
     () =>
-      subscribeToLocation(CHATBOT_LOCATION, () =>
-        setActiveChatbot(getActiveChatbot()),
-      ),
-    [],
+      adminSelectedId === undefined
+        ? null
+        : getActiveChatbot(adminSelectedId, enabledMap),
+    [adminSelectedId, enabledMap, registryVersion],
   );
 
   if (!activeChatbot) {

--- a/superset-frontend/src/components/ChatbotMount/index.tsx
+++ b/superset-frontend/src/components/ChatbotMount/index.tsx
@@ -16,11 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { type ReactElement, useSyncExternalStore } from 'react';
+import {
+  type ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+import { t } from '@apache-superset/core/translation';
+import { logging } from '@apache-superset/core/utils';
 import { css, useTheme } from '@apache-superset/core/theme';
 import { ErrorBoundary } from 'src/components/ErrorBoundary';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
+import { store } from 'src/views/store';
 import { getActiveChatbot } from 'src/core/chatbot';
 import { subscribeToRegistry, getRegistryVersion } from 'src/core/views';
+import {
+  getExtensionSettingsSnapshot,
+  loadExtensionSettings,
+  subscribeToExtensionSettings,
+} from 'src/core/extensions';
 
 const CHATBOT_EDGE_MARGIN = 24;
 
@@ -35,15 +50,32 @@ const ChatbotRenderer = ({ provider }: { provider: () => ReactElement }) =>
 
 const ChatbotMount = () => {
   const theme = useTheme();
+  // Notify once per mount; a crash can re-render and would otherwise re-toast.
+  const crashNotified = useRef(false);
 
-  // Subscribing to the registry version re-renders this component whenever a
-  // chatbot view registers or unregisters, so `getActiveChatbot()` below is
-  // re-evaluated against the current registry. Admin-driven selection (default
-  // chatbot, enabled flags) is layered on by the admin settings work later in
-  // the stack; here the single registered chatbot wins.
-  useSyncExternalStore(subscribeToRegistry, getRegistryVersion);
+  // The active chatbot is a function of two host-owned stores: the admin
+  // settings (active id + enabled map) and the view registry (which chatbots
+  // are registered). Both are read via useSyncExternalStore so this re-resolves
+  // when either changes — no local copy of the settings state.
+  const settings = useSyncExternalStore(
+    subscribeToExtensionSettings,
+    getExtensionSettingsSnapshot,
+  );
+  const registryVersion = useSyncExternalStore(
+    subscribeToRegistry,
+    getRegistryVersion,
+  );
 
-  const activeChatbot = getActiveChatbot();
+  useEffect(() => {
+    // Settings fetch failure is non-fatal: the store keeps its empty default,
+    // which getActiveChatbot treats as "all enabled, no admin pin".
+    loadExtensionSettings().catch(() => {});
+  }, []);
+
+  const activeChatbot = useMemo(
+    () => getActiveChatbot(settings.active_chatbot_id, settings.enabled),
+    [settings, registryVersion],
+  );
 
   if (!activeChatbot) {
     return null;
@@ -60,7 +92,19 @@ const ChatbotMount = () => {
         z-index: ${theme.zIndexPopupBase + 2};
       `}
     >
-      <ErrorBoundary>
+      <ErrorBoundary
+        showMessage={false}
+        onError={(error: Error) => {
+          // Fault isolation (SIP §4.5): contain the crash, log it, surface a
+          // one-time notification, and leave the corner empty rather than
+          // parking a persistent error card.
+          logging.error('[chatbot] provider crashed', error);
+          if (!crashNotified.current) {
+            crashNotified.current = true;
+            store.dispatch(addDangerToast(t('The chatbot failed to load.')));
+          }
+        }}
+      >
         <ChatbotRenderer provider={activeChatbot.provider} />
       </ErrorBoundary>
     </div>

--- a/superset-frontend/src/core/chatbot/index.test.ts
+++ b/superset-frontend/src/core/chatbot/index.test.ts
@@ -94,3 +94,74 @@ test('getActiveChatbot stops resolving a chatbot once it is disposed', () => {
 
   expect(getActiveChatbot()).toBeUndefined();
 });
+
+test('getActiveChatbot honours the admin-pinned selection', () => {
+  const firstProvider = () => React.createElement('div', null, 'First');
+  const secondProvider = () => React.createElement('div', null, 'Second');
+  disposables.push(
+    views.registerView(
+      { id: 'first.chatbot', name: 'First Chatbot' },
+      CHATBOT_LOCATION,
+      firstProvider,
+    ),
+    views.registerView(
+      { id: 'second.chatbot', name: 'Second Chatbot' },
+      CHATBOT_LOCATION,
+      secondProvider,
+    ),
+  );
+
+  const active = getActiveChatbot('second.chatbot');
+  expect(active?.id).toBe('second.chatbot');
+  expect(active?.provider).toBe(secondProvider);
+});
+
+test('getActiveChatbot falls back to first-registered when pinned id is unknown', () => {
+  const provider = () => React.createElement('div', null, 'First');
+  disposables.push(
+    views.registerView(
+      { id: 'first.chatbot', name: 'First Chatbot' },
+      CHATBOT_LOCATION,
+      provider,
+    ),
+  );
+
+  // 'stale.chatbot' was once the admin pin but is no longer registered.
+  const active = getActiveChatbot('stale.chatbot');
+  expect(active?.id).toBe('first.chatbot');
+});
+
+test('getActiveChatbot excludes disabled extensions before applying admin pin', () => {
+  const firstProvider = () => React.createElement('div', null, 'First');
+  const secondProvider = () => React.createElement('div', null, 'Second');
+  disposables.push(
+    views.registerView(
+      { id: 'first.chatbot', name: 'First Chatbot' },
+      CHATBOT_LOCATION,
+      firstProvider,
+    ),
+    views.registerView(
+      { id: 'second.chatbot', name: 'Second Chatbot' },
+      CHATBOT_LOCATION,
+      secondProvider,
+    ),
+  );
+
+  // Admin pinned second, but second is disabled — should fall back to first.
+  const active = getActiveChatbot('second.chatbot', {
+    'second.chatbot': false,
+  });
+  expect(active?.id).toBe('first.chatbot');
+});
+
+test('getActiveChatbot returns undefined when all candidates are disabled', () => {
+  disposables.push(
+    views.registerView(
+      { id: 'superset.chatbot', name: 'Superset Chatbot' },
+      CHATBOT_LOCATION,
+      () => React.createElement('div', null, 'Chatbot'),
+    ),
+  );
+
+  expect(getActiveChatbot(null, { 'superset.chatbot': false })).toBeUndefined();
+});

--- a/superset-frontend/src/core/chatbot/index.ts
+++ b/superset-frontend/src/core/chatbot/index.ts
@@ -73,15 +73,16 @@ export const getActiveChatbot = (
     return undefined;
   }
 
+  // Mirror SIP §4.3's resolution table directly: when the admin pin names an
+  // enabled candidate, use it; otherwise use the first enabled candidate in
+  // registration order. `getRegisteredViewIds` and `getViewProvider` read the
+  // same synchronous registry maps, so a candidate id always has a live
+  // provider; the final guard is cheap defensiveness, not a fallback path.
   const selectedId =
     adminSelectedId && candidates.includes(adminSelectedId)
       ? adminSelectedId
       : candidates[0];
 
   const provider = getViewProvider(CHATBOT_LOCATION, selectedId);
-  if (!provider) {
-    return undefined;
-  }
-
-  return { id: selectedId, provider };
+  return provider ? { id: selectedId, provider } : undefined;
 };

--- a/superset-frontend/src/core/dashboard/index.test.ts
+++ b/superset-frontend/src/core/dashboard/index.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ---------------------------------------------------------------------------
+// Captured listeners — allows tests to trigger action notifications manually.
+// ---------------------------------------------------------------------------
+type ListenerEntry = {
+  predicate: (action: { type: string }) => boolean;
+  effect: (action: { type: string }) => void;
+};
+
+const capturedListeners: ListenerEntry[] = [];
+
+// Declared before jest.mock so the factory closure can reference it.
+let mockState: Record<string, unknown>;
+
+jest.mock('src/views/store', () => ({
+  store: { getState: () => mockState, dispatch: jest.fn() },
+  listenerMiddleware: {
+    startListening: (opts: {
+      predicate: (action: { type: string }) => boolean;
+      effect: (action: { type: string }) => void;
+    }) => {
+      const entry = { predicate: opts.predicate, effect: opts.effect };
+      capturedListeners.push(entry);
+      return () => {
+        const idx = capturedListeners.indexOf(entry);
+        if (idx !== -1) capturedListeners.splice(idx, 1);
+      };
+    },
+  },
+}));
+
+jest.mock('../navigation', () => ({
+  navigation: { getPageType: jest.fn(() => 'dashboard') },
+}));
+
+function dispatch(actionType: string) {
+  const action = { type: actionType };
+  capturedListeners
+    .filter(e => e.predicate(action))
+    .forEach(e => e.effect(action));
+}
+
+// Imported after mocks
+// eslint-disable-next-line import/first
+import { dashboard } from './index';
+
+function makeState(
+  overrides: Partial<{
+    dashboardInfo: unknown;
+    nativeFilters: unknown;
+    dataMask: unknown;
+    sliceEntities: unknown;
+    dashboardLayout: unknown;
+  }> = {},
+) {
+  return {
+    dashboardInfo: { id: 1, dashboard_title: 'Sales', slug: 'sales' },
+    nativeFilters: { filters: { 'filter-1': { name: 'Region' } } },
+    dataMask: { 'filter-1': { filterState: { value: ['West'] } } },
+    sliceEntities: { slices: {} },
+    dashboardLayout: { present: {} },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockState = makeState();
+});
+
+afterEach(() => {
+  capturedListeners.length = 0;
+  jest.restoreAllMocks();
+});
+
+test('getCurrentDashboard returns undefined when not on dashboard page', () => {
+  const { navigation } = jest.requireMock('../navigation');
+  (navigation.getPageType as jest.Mock).mockReturnValueOnce('explore');
+  expect(dashboard.getCurrentDashboard()).toBeUndefined();
+});
+
+test('getCurrentDashboard returns undefined when dashboardInfo is absent', () => {
+  mockState = makeState({ dashboardInfo: undefined });
+  expect(dashboard.getCurrentDashboard()).toBeUndefined();
+});
+
+test('getCurrentDashboard returns dashboard context with active filters', () => {
+  expect(dashboard.getCurrentDashboard()).toEqual({
+    dashboardId: 1,
+    title: 'Sales',
+    filters: [{ filterId: 'filter-1', label: 'Region', value: ['West'] }],
+    // No charts on the (empty) layout fixture.
+    charts: [],
+  });
+});
+
+test('getCurrentDashboard reports charts placed on the dashboard layout', () => {
+  mockState = makeState({
+    sliceEntities: {
+      slices: {
+        42: {
+          slice_name: 'Revenue by Region',
+          viz_type: 'echarts_timeseries_bar',
+          datasource_id: 7,
+          datasource_name: 'cleaned_sales',
+        },
+      },
+    },
+    dashboardLayout: {
+      present: {
+        'CHART-abc': { id: 'CHART-abc', type: 'CHART', meta: { chartId: 42 } },
+        // A chart id with no matching slice entity still appears, with blanks.
+        'CHART-def': { id: 'CHART-def', type: 'CHART', meta: { chartId: 99 } },
+        // Non-chart components are ignored.
+        'TAB-xyz': { id: 'TAB-xyz', type: 'TAB', meta: {} },
+      },
+    },
+  });
+
+  expect(dashboard.getCurrentDashboard()?.charts).toEqual([
+    {
+      chartId: 42,
+      chartName: 'Revenue by Region',
+      vizType: 'echarts_timeseries_bar',
+      datasourceId: 7,
+      datasourceName: 'cleaned_sales',
+      isVisible: true,
+    },
+    {
+      chartId: 99,
+      chartName: '',
+      vizType: '',
+      datasourceId: null,
+      datasourceName: null,
+      isVisible: true,
+    },
+  ]);
+});
+
+test('getCurrentDashboard excludes filters with null value', () => {
+  mockState = makeState({
+    dataMask: { 'filter-1': { filterState: { value: null } } },
+  });
+  expect(dashboard.getCurrentDashboard()?.filters).toHaveLength(0);
+});
+
+test('getCurrentDashboard excludes dataMask entries not in nativeFilters', () => {
+  mockState = makeState({
+    dataMask: { 'chart-filter': { filterState: { value: 'foo' } } },
+  });
+  expect(dashboard.getCurrentDashboard()?.filters).toHaveLength(0);
+});
+
+test('filter array value is a defensive copy — mutation does not affect Redux state', () => {
+  const ctx = dashboard.getCurrentDashboard();
+  const original = [
+    ...(mockState as any).dataMask['filter-1'].filterState.value,
+  ];
+  (ctx!.filters[0].value as string[]).push('East');
+  expect((mockState as any).dataMask['filter-1'].filterState.value).toEqual(
+    original,
+  );
+});
+
+// Action type strings match the constants in src/dashboard/actions/hydrate
+// and src/dataMask/actions — kept as literals so this test file has no
+// import dependency on those modules.
+test.each([
+  'HYDRATE_DASHBOARD',
+  'UPDATE_DATA_MASK',
+  'SET_DATA_MASK_FOR_FILTER_CHANGES_COMPLETE',
+])('onDidChangeDashboard fires on action type %s', actionType => {
+  const listener = jest.fn();
+  const disposable = dashboard.onDidChangeDashboard(listener);
+
+  dispatch(actionType);
+
+  expect(listener).toHaveBeenCalledWith(
+    expect.objectContaining({ dashboardId: 1, title: 'Sales' }),
+  );
+  disposable.dispose();
+});
+
+test('onDidChangeDashboard does not fire when not on dashboard page', () => {
+  const { navigation } = jest.requireMock('../navigation');
+  (navigation.getPageType as jest.Mock).mockReturnValue('explore');
+
+  const listener = jest.fn();
+  const disposable = dashboard.onDidChangeDashboard(listener);
+  dispatch('HYDRATE_DASHBOARD');
+
+  expect(listener).not.toHaveBeenCalled();
+  (navigation.getPageType as jest.Mock).mockReturnValue('dashboard');
+  disposable.dispose();
+});
+
+test('disposed listener is not called', () => {
+  const listener = jest.fn();
+  const disposable = dashboard.onDidChangeDashboard(listener);
+  disposable.dispose();
+  dispatch('HYDRATE_DASHBOARD');
+  expect(listener).not.toHaveBeenCalled();
+});

--- a/superset-frontend/src/core/dashboard/index.ts
+++ b/superset-frontend/src/core/dashboard/index.ts
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Host-internal implementation of the `dashboard` namespace.
+ *
+ * Wraps Redux dashboardInfo and dataMask state and normalizes them into the
+ * stable `DashboardContext` contract. Extensions must not depend on the Redux
+ * slice structure directly.
+ */
+
+import type { dashboard as dashboardApi } from '@apache-superset/core';
+import type { DataMaskStateWithId } from '@superset-ui/core';
+import { HYDRATE_DASHBOARD } from 'src/dashboard/actions/hydrate';
+import {
+  UPDATE_DATA_MASK,
+  SET_DATA_MASK_FOR_FILTER_CHANGES_COMPLETE,
+} from 'src/dataMask/actions';
+import { store, RootState } from 'src/views/store';
+import { AnyListenerPredicate } from '@reduxjs/toolkit';
+import getChartIdsFromLayout from 'src/dashboard/util/getChartIdsFromLayout';
+import { createActionListener } from '../utils';
+import { navigation } from '../navigation';
+
+type DashboardContext = dashboardApi.DashboardContext;
+type FilterValue = dashboardApi.FilterValue;
+type ChartSummary = NonNullable<DashboardContext['charts']>[number];
+
+function buildChartSummaries(state: RootState): ChartSummary[] {
+  const slices = state.sliceEntities?.slices ?? {};
+  const layout = state.dashboardLayout?.present ?? {};
+
+  // Only charts actually placed on the dashboard layout — `slices` can also
+  // hold entities that are not on the current dashboard.
+  return getChartIdsFromLayout(layout).map(chartId => {
+    const slice = slices[chartId];
+    return {
+      chartId,
+      chartName: slice?.slice_name ?? '',
+      vizType: slice?.viz_type ?? '',
+      datasourceId: slice?.datasource_id ?? null,
+      datasourceName: slice?.datasource_name ?? null,
+      // Tab-accurate visibility is a deferred phase (SIP §10/§11); every chart
+      // on the dashboard is reported visible for now.
+      isVisible: true,
+    };
+  });
+}
+
+function buildDashboardContext(): DashboardContext | undefined {
+  if (navigation.getPageType() !== 'dashboard') return undefined;
+  // `store.getState()` is already typed as RootState, so the slices below are
+  // read with their real types — the host owns this normalization and must
+  // stay type-safe against slice reshapes.
+  const state = store.getState();
+  const info = state.dashboardInfo;
+  if (!info?.id) return undefined;
+
+  const nativeFilters = state.nativeFilters?.filters ?? {};
+  const dataMask: DataMaskStateWithId = state.dataMask ?? {};
+
+  const filters: FilterValue[] = Object.entries(dataMask)
+    .filter(([id, mask]) => {
+      if (!(id in nativeFilters)) return false;
+      const value = mask?.filterState?.value;
+      return value !== null && value !== undefined;
+    })
+    .map(([id, mask]) => {
+      const raw = mask.filterState?.value;
+      return {
+        filterId: id,
+        label: nativeFilters[id]?.name ?? id,
+        value: Array.isArray(raw) ? [...raw] : raw,
+      };
+    });
+
+  return {
+    dashboardId: info.id,
+    title: info.dashboard_title ?? info.slug ?? String(info.id),
+    filters,
+    charts: buildChartSummaries(state),
+  };
+}
+
+const dashboardChangePredicate: AnyListenerPredicate<RootState> = action =>
+  action.type === HYDRATE_DASHBOARD ||
+  action.type === UPDATE_DATA_MASK ||
+  action.type === SET_DATA_MASK_FOR_FILTER_CHANGES_COMPLETE;
+
+const getCurrentDashboard: typeof dashboardApi.getCurrentDashboard = () =>
+  buildDashboardContext();
+
+const onDidChangeDashboard: typeof dashboardApi.onDidChangeDashboard = (
+  listener: (ctx: DashboardContext) => void,
+  thisArgs?: any,
+) =>
+  createActionListener<DashboardContext>(
+    dashboardChangePredicate,
+    listener,
+    () => buildDashboardContext() ?? null,
+    thisArgs,
+  );
+
+export const dashboard: typeof dashboardApi = {
+  getCurrentDashboard,
+  onDidChangeDashboard,
+};

--- a/superset-frontend/src/core/dataset/index.ts
+++ b/superset-frontend/src/core/dataset/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Host-internal implementation of the `dataset` namespace.
+ *
+ * Dataset page components call `setCurrentDataset` to publish context as they
+ * load. Extensions consume the stable `DatasetContext` contract; they are
+ * isolated from the page's internal data-fetching implementation.
+ */
+
+import type { dataset as datasetApi } from '@apache-superset/core';
+import { createEmitter } from '../utils';
+
+type DatasetContext = datasetApi.DatasetContext;
+
+const emitter = createEmitter<DatasetContext | undefined>(undefined);
+
+/**
+ * Host-internal: called by the Dataset page when its entity loads or changes.
+ * Not part of the public `@apache-superset/core` API.
+ */
+export const setCurrentDataset = (ctx: DatasetContext | undefined): void => {
+  emitter.fire(ctx);
+};
+
+const getCurrentDataset: typeof datasetApi.getCurrentDataset = () => {
+  const current = emitter.getCurrent();
+  return current ? { ...current } : undefined;
+};
+
+const onDidChangeDataset: typeof datasetApi.onDidChangeDataset = (
+  listener: (ctx: DatasetContext) => void,
+  thisArgs?: unknown,
+) => {
+  const bound = thisArgs ? listener.bind(thisArgs) : listener;
+  // The public contract only emits a concrete context; skip `undefined` clears
+  // so subscribers are never handed an empty value.
+  return emitter.event(ctx => {
+    if (ctx) bound(ctx);
+  });
+};
+
+export const dataset: typeof datasetApi = {
+  getCurrentDataset,
+  onDidChangeDataset,
+};

--- a/superset-frontend/src/core/explore/index.test.ts
+++ b/superset-frontend/src/core/explore/index.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ---------------------------------------------------------------------------
+// Captured listeners — allows tests to trigger action notifications manually.
+// ---------------------------------------------------------------------------
+type ListenerEntry = {
+  predicate: (action: { type: string }) => boolean;
+  effect: (action: { type: string }) => void;
+};
+
+const capturedListeners: ListenerEntry[] = [];
+
+// Declared before jest.mock so the factory closure can reference it.
+let mockState: Record<string, unknown>;
+
+jest.mock('src/views/store', () => ({
+  store: { getState: () => mockState, dispatch: jest.fn() },
+  listenerMiddleware: {
+    startListening: (opts: {
+      predicate: (action: { type: string }) => boolean;
+      effect: (action: { type: string }) => void;
+    }) => {
+      const entry = { predicate: opts.predicate, effect: opts.effect };
+      capturedListeners.push(entry);
+      return () => {
+        const idx = capturedListeners.indexOf(entry);
+        if (idx !== -1) capturedListeners.splice(idx, 1);
+      };
+    },
+  },
+}));
+
+jest.mock('../navigation', () => ({
+  navigation: { getPageType: jest.fn(() => 'explore') },
+}));
+
+function dispatch(actionType: string) {
+  const action = { type: actionType };
+  capturedListeners
+    .filter(e => e.predicate(action))
+    .forEach(e => e.effect(action));
+}
+
+// Imported after mocks
+// eslint-disable-next-line import/first
+import { explore } from './index';
+
+beforeEach(() => {
+  mockState = {
+    explore: {
+      slice: { slice_id: 42, slice_name: 'My Chart' },
+      datasource: { id: 7, table_name: 'orders' },
+      controls: { viz_type: { value: 'bar' } },
+      sliceName: 'My Chart',
+      form_data: {},
+    },
+  };
+});
+
+afterEach(() => {
+  capturedListeners.length = 0;
+  jest.restoreAllMocks();
+});
+
+test('getCurrentChart returns undefined when not on explore page', () => {
+  const { navigation } = jest.requireMock('../navigation');
+  (navigation.getPageType as jest.Mock).mockReturnValueOnce('dashboard');
+  expect(explore.getCurrentChart()).toBeUndefined();
+});
+
+test('getCurrentChart returns undefined when explore state is absent', () => {
+  mockState = {};
+  expect(explore.getCurrentChart()).toBeUndefined();
+});
+
+test('getCurrentChart returns chart context from Redux state', () => {
+  expect(explore.getCurrentChart()).toEqual({
+    chartId: 42,
+    chartName: 'My Chart',
+    vizType: 'bar',
+    datasourceId: 7,
+    datasourceName: 'orders',
+  });
+});
+
+test('getCurrentChart returns null chartId for unsaved chart', () => {
+  mockState = {
+    explore: {
+      slice: null,
+      datasource: { id: 1, table_name: 'events' },
+      controls: { viz_type: { value: 'line' } },
+      sliceName: null,
+      form_data: { viz_type: 'line' },
+    },
+  };
+  expect(explore.getCurrentChart()?.chartId).toBeNull();
+});
+
+// Action type strings match the constants in src/explore/actions/exploreActions
+// and src/explore/actions/datasourcesActions — kept as literals so this test
+// file has no import dependency on those modules.
+test.each([
+  'HYDRATE_EXPLORE',
+  'UPDATE_FORM_DATA', // SET_FORM_DATA constant resolves to this string
+  'UPDATE_CHART_TITLE',
+  'SET_DATASOURCE',
+  'CREATE_NEW_SLICE',
+  'SLICE_UPDATED',
+])('onDidChangeChart fires on action type %s', actionType => {
+  const listener = jest.fn();
+  const disposable = explore.onDidChangeChart(listener);
+
+  dispatch(actionType);
+
+  expect(listener).toHaveBeenCalledWith(
+    expect.objectContaining({ chartId: 42, vizType: 'bar' }),
+  );
+  disposable.dispose();
+});
+
+test('onDidChangeChart does not fire when page type is not explore', () => {
+  const { navigation } = jest.requireMock('../navigation');
+  (navigation.getPageType as jest.Mock).mockReturnValue('dashboard');
+
+  const listener = jest.fn();
+  const disposable = explore.onDidChangeChart(listener);
+  dispatch('HYDRATE_EXPLORE');
+
+  expect(listener).not.toHaveBeenCalled();
+  (navigation.getPageType as jest.Mock).mockReturnValue('explore');
+  disposable.dispose();
+});
+
+test('disposed listener is not called', () => {
+  const listener = jest.fn();
+  const disposable = explore.onDidChangeChart(listener);
+  disposable.dispose();
+  dispatch('HYDRATE_EXPLORE');
+  expect(listener).not.toHaveBeenCalled();
+});

--- a/superset-frontend/src/core/explore/index.ts
+++ b/superset-frontend/src/core/explore/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Host-internal implementation of the `explore` namespace.
+ *
+ * Wraps Redux explore state and normalizes it into the stable `ChartContext`
+ * contract. Extensions must not depend on the Redux slice structure directly.
+ */
+
+import type { explore as exploreApi } from '@apache-superset/core';
+import { HYDRATE_EXPLORE } from 'src/explore/actions/hydrateExplore';
+import {
+  CREATE_NEW_SLICE,
+  SET_FORM_DATA,
+  SLICE_UPDATED,
+  UPDATE_CHART_TITLE,
+} from 'src/explore/actions/exploreActions';
+import { SET_DATASOURCE } from 'src/explore/actions/datasourcesActions';
+import { store, RootState } from 'src/views/store';
+import { AnyListenerPredicate } from '@reduxjs/toolkit';
+import { createActionListener } from '../utils';
+import { navigation } from '../navigation';
+
+type ChartContext = exploreApi.ChartContext;
+
+function buildChartContext(): ChartContext | undefined {
+  if (navigation.getPageType() !== 'explore') return undefined;
+  // `store.getState()` is already RootState; read the typed `explore` slice
+  // directly rather than casting it away.
+  const state = store.getState();
+  const exploreState = state.explore;
+  if (!exploreState) return undefined;
+
+  const { slice, datasource, controls } = exploreState;
+  const vizType: string =
+    (controls?.viz_type?.value as string) ??
+    exploreState.form_data?.viz_type ??
+    '';
+
+  return {
+    chartId: slice?.slice_id ?? null,
+    chartName: exploreState.sliceName ?? slice?.slice_name ?? null,
+    vizType,
+    datasourceId: datasource?.id ?? null,
+    datasourceName:
+      datasource?.table_name ?? datasource?.datasource_name ?? null,
+  };
+}
+
+const exploreChangePredicate: AnyListenerPredicate<RootState> = action =>
+  action.type === HYDRATE_EXPLORE ||
+  action.type === SET_FORM_DATA ||
+  action.type === UPDATE_CHART_TITLE ||
+  action.type === SET_DATASOURCE ||
+  action.type === CREATE_NEW_SLICE ||
+  action.type === SLICE_UPDATED;
+
+const getCurrentChart: typeof exploreApi.getCurrentChart = () =>
+  buildChartContext();
+
+const onDidChangeChart: typeof exploreApi.onDidChangeChart = (
+  listener: (ctx: ChartContext) => void,
+  thisArgs?: any,
+) =>
+  createActionListener<ChartContext>(
+    exploreChangePredicate,
+    listener,
+    () => buildChartContext() ?? null,
+    thisArgs,
+  );
+
+export const explore: typeof exploreApi = {
+  getCurrentChart,
+  onDidChangeChart,
+};

--- a/superset-frontend/src/core/extensions/index.ts
+++ b/superset-frontend/src/core/extensions/index.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { extensions as extensionsApi } from '@apache-superset/core';
+import { SupersetClient } from '@superset-ui/core';
 import ExtensionsLoader from 'src/extensions/ExtensionsLoader';
 
 const getExtension: typeof extensionsApi.getExtension = id =>
@@ -28,4 +29,85 @@ const getAllExtensions: typeof extensionsApi.getAllExtensions = () =>
 export const extensions: typeof extensionsApi = {
   getExtension,
   getAllExtensions,
+};
+
+/**
+ * Deployment-wide extension admin settings. The keys are snake_case to match
+ * the `/api/v1/extensions/settings` wire shape this store loads and saves.
+ */
+export type ExtensionSettings = {
+  active_chatbot_id: string | null;
+  enabled: Record<string, boolean>;
+};
+
+const SETTINGS_ENDPOINT = '/api/v1/extensions/settings';
+
+const EMPTY_SETTINGS: ExtensionSettings = {
+  active_chatbot_id: null,
+  enabled: {},
+};
+
+/**
+ * Single module-level store for extension admin settings. Both the chatbot
+ * mount and the admin list read this one source via `useSyncExternalStore`,
+ * so a save on the admin page is reflected everywhere without a bespoke
+ * second notification channel.
+ */
+let settings: ExtensionSettings = EMPTY_SETTINGS;
+const settingsListeners = new Set<() => void>();
+
+const emitSettingsChange = (): void => {
+  settingsListeners.forEach(fn => fn());
+};
+
+/** Subscribe to settings changes (for `useSyncExternalStore`). */
+export const subscribeToExtensionSettings = (
+  listener: () => void,
+): (() => void) => {
+  settingsListeners.add(listener);
+  return () => {
+    settingsListeners.delete(listener);
+  };
+};
+
+/** Current settings snapshot (for `useSyncExternalStore`). */
+export const getExtensionSettingsSnapshot = (): ExtensionSettings => settings;
+
+/** Replace the settings snapshot and notify subscribers. */
+export const setExtensionSettings = (next: ExtensionSettings): void => {
+  settings = next;
+  emitSettingsChange();
+};
+
+/**
+ * Fetch settings from the server into the store. Resolves to the loaded value;
+ * on failure the store is left untouched and the error is rethrown so callers
+ * can surface it.
+ */
+export const loadExtensionSettings = async (): Promise<ExtensionSettings> => {
+  const { json } = await SupersetClient.get({ endpoint: SETTINGS_ENDPOINT });
+  setExtensionSettings(json.result ?? EMPTY_SETTINGS);
+  return settings;
+};
+
+/**
+ * Optimistically apply a partial settings update and persist it. On failure the
+ * previous snapshot is restored. Returns a promise that rejects on error so the
+ * caller can toast.
+ */
+export const saveExtensionSettings = async (
+  patch: Partial<ExtensionSettings>,
+): Promise<void> => {
+  const previous = settings;
+  const next = { ...previous, ...patch };
+  setExtensionSettings(next);
+  try {
+    await SupersetClient.put({
+      endpoint: SETTINGS_ENDPOINT,
+      jsonPayload: next,
+    });
+  } catch (error) {
+    setExtensionSettings(previous);
+    throw error;
+  }
 };

--- a/superset-frontend/src/core/index.ts
+++ b/superset-frontend/src/core/index.ts
@@ -28,10 +28,14 @@ export const core: typeof coreType = {
 
 export * from './authentication';
 export * from './commands';
+export * from './dashboard';
+export * from './dataset';
 export * from './editors';
+export * from './explore';
 export * from './extensions';
 export * from './menus';
 export * from './models';
+export * from './navigation';
 export * from './sqlLab';
 export * from './utils';
 export * from './views';

--- a/superset-frontend/src/core/navigation/index.test.ts
+++ b/superset-frontend/src/core/navigation/index.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Reset module state between tests so currentPageType is re-initialized.
+beforeEach(() => {
+  jest.resetModules();
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { pathname: '/' },
+  });
+});
+
+async function importNavigation() {
+  const mod = await import('./index');
+  return mod;
+}
+
+test('getPageType returns "other" for unknown pathname', async () => {
+  const { navigation } = await importNavigation();
+  expect(navigation.getPageType()).toBe('other');
+});
+
+test('getPageType derives page type from window.location.pathname', async () => {
+  window.location.pathname = '/superset/dashboard/42/';
+  const { navigation } = await importNavigation();
+  expect(navigation.getPageType()).toBe('dashboard');
+});
+
+test('notifyPageChange updates the current page type', async () => {
+  const { navigation, notifyPageChange } = await importNavigation();
+  notifyPageChange('/explore/?form_data={}');
+  expect(navigation.getPageType()).toBe('explore');
+});
+
+test('notifyPageChange fires listeners on page type change', async () => {
+  const { navigation, notifyPageChange } = await importNavigation();
+  const listener = jest.fn();
+  const disposable = navigation.onDidChangePage(listener);
+
+  notifyPageChange('/superset/dashboard/1/');
+  expect(listener).toHaveBeenCalledWith('dashboard');
+
+  disposable.dispose();
+});
+
+test('notifyPageChange does not fire listeners when page type is unchanged', async () => {
+  window.location.pathname = '/superset/dashboard/1/';
+  const { navigation, notifyPageChange } = await importNavigation();
+  const listener = jest.fn();
+  navigation.onDidChangePage(listener);
+
+  notifyPageChange('/superset/dashboard/2/');
+  expect(listener).not.toHaveBeenCalled();
+});
+
+test('onDidChangePage listener is removed after dispose', async () => {
+  const { navigation, notifyPageChange } = await importNavigation();
+  const listener = jest.fn();
+  const disposable = navigation.onDidChangePage(listener);
+
+  disposable.dispose();
+  notifyPageChange('/superset/dashboard/1/');
+  expect(listener).not.toHaveBeenCalled();
+});
+
+test('sqllab path is matched with and without trailing slash', async () => {
+  const { notifyPageChange, navigation } = await importNavigation();
+  notifyPageChange('/sqllab');
+  expect(navigation.getPageType()).toBe('sqllab');
+  notifyPageChange('/explore/');
+  notifyPageChange('/sqllab/');
+  expect(navigation.getPageType()).toBe('sqllab');
+});
+
+test('chart and dashboard list pages get their own page types', async () => {
+  const { notifyPageChange, navigation } = await importNavigation();
+  notifyPageChange('/chart/list/');
+  expect(navigation.getPageType()).toBe('chart_list');
+  notifyPageChange('/dashboard/list/');
+  expect(navigation.getPageType()).toBe('dashboard_list');
+});
+
+test('dataset list and single-dataset pages get distinct page types', async () => {
+  const { notifyPageChange, navigation } = await importNavigation();
+  notifyPageChange('/tablemodelview/list/');
+  expect(navigation.getPageType()).toBe('dataset_list');
+  notifyPageChange('/dataset/42');
+  expect(navigation.getPageType()).toBe('dataset');
+});
+
+test('sqllab editor, query history, and saved queries get distinct page types', async () => {
+  const { notifyPageChange, navigation } = await importNavigation();
+  notifyPageChange('/sqllab/');
+  expect(navigation.getPageType()).toBe('sqllab');
+  notifyPageChange('/sqllab/history/');
+  expect(navigation.getPageType()).toBe('query_history');
+  notifyPageChange('/savedqueryview/list/');
+  expect(navigation.getPageType()).toBe('saved_queries');
+});
+
+test('chart/add resolves to explore, not chart_list', async () => {
+  const { notifyPageChange, navigation } = await importNavigation();
+  notifyPageChange('/chart/add');
+  expect(navigation.getPageType()).toBe('explore');
+});

--- a/superset-frontend/src/core/navigation/index.ts
+++ b/superset-frontend/src/core/navigation/index.ts
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Host-internal implementation of the `navigation` namespace.
+ *
+ * Backed by browser location — no Redux dependency.
+ * The app shell calls `notifyPageChange(pathname)` whenever the route changes.
+ */
+
+import type { navigation as navigationApi } from '@apache-superset/core';
+import { Disposable } from '../models';
+
+type PageType = navigationApi.PageType;
+
+const listeners = new Set<(pageType: PageType) => void>();
+
+function derivePageType(pathname: string): PageType {
+  if (pathname.startsWith('/superset/dashboard/')) return 'dashboard';
+  if (pathname.startsWith('/dashboard/list')) return 'dashboard_list';
+  if (pathname.startsWith('/explore/')) return 'explore';
+  if (pathname.startsWith('/superset/explore/')) return 'explore';
+  if (pathname.startsWith('/chart/add')) return 'explore';
+  if (pathname.startsWith('/chart/list')) return 'chart_list';
+  if (pathname.startsWith('/sqllab/history')) return 'query_history';
+  if (pathname.startsWith('/savedqueryview/list')) return 'saved_queries';
+  if (pathname === '/sqllab' || pathname.startsWith('/sqllab/'))
+    return 'sqllab';
+  if (pathname.startsWith('/tablemodelview/list')) return 'dataset_list';
+  if (pathname.startsWith('/dataset/')) return 'dataset';
+  if (pathname.startsWith('/superset/welcome/')) return 'home';
+  return 'other';
+}
+
+let currentPageType: PageType | undefined;
+
+function getOrInitPageType(): PageType {
+  if (currentPageType === undefined) {
+    currentPageType = derivePageType(window.location.pathname);
+  }
+  return currentPageType;
+}
+
+/** Called by ExtensionsStartup whenever the React Router location changes. */
+export const notifyPageChange = (pathname: string): void => {
+  const next = derivePageType(pathname);
+  if (next === getOrInitPageType()) return;
+  currentPageType = next;
+  listeners.forEach(fn => fn(next));
+};
+
+const getPageType: typeof navigationApi.getPageType = () => getOrInitPageType();
+
+const onDidChangePage: typeof navigationApi.onDidChangePage = (
+  listener: (pageType: PageType) => void,
+  thisArgs?: any,
+): Disposable => {
+  const bound = thisArgs ? listener.bind(thisArgs) : listener;
+  listeners.add(bound);
+  return new Disposable(() => listeners.delete(bound));
+};
+
+export const navigation: typeof navigationApi = {
+  getPageType,
+  onDidChangePage,
+};

--- a/superset-frontend/src/core/sqlLab/index.ts
+++ b/superset-frontend/src/core/sqlLab/index.ts
@@ -56,6 +56,7 @@ import {
   QueryResultContext,
   QueryErrorResultContext,
 } from './models';
+import { navigation } from '../navigation';
 
 const { CTASMethod } = sqlLabApi;
 
@@ -301,8 +302,15 @@ function createQueryErrorContext(
   );
 }
 
-const getCurrentTab: typeof sqlLabApi.getCurrentTab = () =>
-  getTab(activeEditorId());
+const getCurrentTab: typeof sqlLabApi.getCurrentTab = () => {
+  // Guard on the page type so the tab does not leak onto non-editor surfaces.
+  // The SQL Lab Redux slice persists after navigating away, so without this
+  // guard `getCurrentTab()` would keep returning the last editor's tab on, e.g.,
+  // a dashboard or list page. Mirrors the page-type guards on
+  // `explore.getCurrentChart()` / `dashboard.getCurrentDashboard()`.
+  if (navigation.getPageType() !== 'sqllab') return undefined;
+  return getTab(activeEditorId());
+};
 
 const getActivePanel: typeof sqlLabApi.getActivePanel = () => {
   const { activeSouthPaneTab } = getSqlLabState();
@@ -452,8 +460,14 @@ const onDidChangeActiveTab: typeof sqlLabApi.onDidChangeActiveTab = (
   createActionListener(
     globalPredicate(SET_ACTIVE_QUERY_EDITOR),
     listener,
-    (action: { type: string; queryEditor: { id: string } }) =>
-      getTab(action.queryEditor.id),
+    // Resolve the now-active tab the same way `getCurrentTab()` does (via the
+    // active-editor / tabHistory state) rather than from the raw action payload.
+    // The action's `queryEditor` carries the base editor without `unsavedQueryEditor`
+    // merged, so its `dbId` can still be undefined at this point, which made
+    // `getTab(action.queryEditor.id)` return undefined and silently swallow the
+    // event. Reading the resolved active tab keeps this event consistent with the
+    // getter and fires on every tab switch.
+    () => getCurrentTab() ?? null,
     thisArgs,
   );
 

--- a/superset-frontend/src/core/sqlLab/sqlLab.test.ts
+++ b/superset-frontend/src/core/sqlLab/sqlLab.test.ts
@@ -119,6 +119,13 @@ jest.mock('src/views/store', () => ({
   setupStore: jest.fn(),
 }));
 
+// The sqlLab namespace guards `getCurrentTab()` on the page type. These tests
+// exercise the editor surface, so report 'sqllab'. Per-test overrides (e.g. to
+// assert the off-surface guard) can change the return value.
+jest.mock('../navigation', () => ({
+  navigation: { getPageType: jest.fn(() => 'sqllab') },
+}));
+
 // Module under test — imported after mocks
 // eslint-disable-next-line import/first
 import { sqlLab } from '.';
@@ -388,6 +395,31 @@ test('onDidChangeActiveTab fires with Tab on SET_ACTIVE_QUERY_EDITOR', () => {
   disposable.dispose();
 });
 
+test('onDidChangeActiveTab carries the newly-activated tab when switching away', () => {
+  // Switching from the first editor to a second one must report the second tab,
+  // not the first. Regression guard: resolving the tab from the live active
+  // editor (via getCurrentTab) instead of the raw action payload.
+  mockStore.dispatch({
+    type: ADD_QUERY_EDITOR,
+    queryEditor: makeSecondEditor(),
+  });
+
+  const listener = jest.fn();
+  const disposable = sqlLab.onDidChangeActiveTab(listener);
+
+  mockStore.dispatch({
+    type: SET_ACTIVE_QUERY_EDITOR,
+    queryEditor: { id: 'editor-2' },
+  });
+
+  expect(listener).toHaveBeenCalledTimes(1);
+  const tab = listener.mock.calls[0][0];
+  expect(tab.id).toBe('editor-2');
+  expect(tab.databaseId).toBe(2);
+
+  disposable.dispose();
+});
+
 test('onDidCreateTab fires with Tab on ADD_QUERY_EDITOR', () => {
   const listener = jest.fn();
   const disposable = sqlLab.onDidCreateTab(listener);
@@ -533,6 +565,13 @@ test('getCurrentTab returns the active tab with correct properties', () => {
   expect(tab!.title).toBe('Untitled Query 1');
   expect(tab!.databaseId).toBe(1);
   expect(tab!.schema).toBe('public');
+});
+
+test('getCurrentTab returns undefined when not on the SQL Lab editor surface', () => {
+  const { navigation } = jest.requireMock('../navigation');
+  (navigation.getPageType as jest.Mock).mockReturnValueOnce('dashboard');
+
+  expect(sqlLab.getCurrentTab()).toBeUndefined();
 });
 
 test('getActivePanel returns the active south pane tab', () => {

--- a/superset-frontend/src/core/utils.ts
+++ b/superset-frontend/src/core/utils.ts
@@ -20,6 +20,56 @@ import type { common as core } from '@apache-superset/core';
 import { AnyAction } from 'redux';
 import { listenerMiddleware, RootState, store } from 'src/views/store';
 import { AnyListenerPredicate } from '@reduxjs/toolkit';
+import { Disposable } from './models';
+
+/**
+ * A typed event subscription matching the public `Event<T>` contract.
+ * Calling it with a listener (and optional `this` arg) subscribes and returns
+ * a {@link Disposable} that unsubscribes.
+ */
+export type EventSubscriber<T> = (
+  listener: (e: T) => void,
+  thisArgs?: unknown,
+) => Disposable;
+
+/**
+ * A minimal host-internal event emitter shared by the producer-backed
+ * namespaces (dataset, navigation, settings, view registry). Each of those
+ * needs the same "publish a value and fan it out to subscribers" primitive;
+ * this collapses the duplicated Set + bind + Disposable boilerplate into one
+ * place.
+ *
+ * `event` is exposed to extensions as the namespace's `onDidChange*`; `fire`
+ * and `getCurrent` stay host-internal.
+ */
+export interface Emitter<T> {
+  /** Subscribe to changes; conforms to the public `Event<T>` shape. */
+  event: EventSubscriber<T>;
+  /** Notify all current subscribers with `value`. */
+  fire: (value: T) => void;
+  /** The most recently fired value (or the initial value). */
+  getCurrent: () => T;
+}
+
+export function createEmitter<T>(initial: T): Emitter<T> {
+  const listeners = new Set<(e: T) => void>();
+  let current = initial;
+
+  return {
+    event: (listener, thisArgs) => {
+      const bound = thisArgs ? listener.bind(thisArgs) : listener;
+      listeners.add(bound);
+      return new Disposable(() => {
+        listeners.delete(bound);
+      });
+    },
+    fire: value => {
+      current = value;
+      listeners.forEach(fn => fn(value));
+    },
+    getCurrent: () => current,
+  };
+}
 
 export function createActionListener<V>(
   predicate: AnyListenerPredicate<RootState>,

--- a/superset-frontend/src/core/views/index.ts
+++ b/superset-frontend/src/core/views/index.ts
@@ -39,26 +39,26 @@ const viewRegistry: Map<
 
 const locationIndex: Map<string, Set<string>> = new Map();
 
-/** Listeners notified whenever a view is registered or unregistered at a location. */
-const locationListeners: Map<string, Set<() => void>> = new Map();
-
-const notifyListeners = (location: string) => {
-  locationListeners.get(location)?.forEach(fn => fn());
-};
-
 /**
- * Subscribe to registration changes at a specific location.
- * Returns an unsubscribe function.
+ * Monotonic version of the view registry. Bumped on every registration or
+ * disposal so consumers can re-derive state via React's `useSyncExternalStore`.
  */
-export const subscribeToLocation = (
-  location: string,
-  listener: () => void,
-): (() => void) => {
-  const listeners = locationListeners.get(location) ?? new Set();
-  listeners.add(listener);
-  locationListeners.set(location, listeners);
-  return () => listeners.delete(listener);
+let registryVersion = 0;
+const registrySubscribers = new Set<() => void>();
+
+const notifyRegistry = () => {
+  registryVersion += 1;
+  registrySubscribers.forEach(fn => fn());
 };
+
+export const subscribeToRegistry = (listener: () => void): (() => void) => {
+  registrySubscribers.add(listener);
+  return () => {
+    registrySubscribers.delete(listener);
+  };
+};
+
+export const getRegistryVersion = () => registryVersion;
 
 const registerView: typeof viewsApi.registerView = (
   view: View,
@@ -70,7 +70,6 @@ const registerView: typeof viewsApi.registerView = (
   const previousLocation = viewRegistry.get(id)?.location;
   if (previousLocation && previousLocation !== location) {
     locationIndex.get(previousLocation)?.delete(id);
-    notifyListeners(previousLocation);
   }
 
   viewRegistry.set(id, { view, location, provider });
@@ -79,13 +78,13 @@ const registerView: typeof viewsApi.registerView = (
   ids.add(id);
   locationIndex.set(location, ids);
 
-  notifyListeners(location);
+  notifyRegistry();
 
   return new Disposable(() => {
     const registeredLocation = viewRegistry.get(id)?.location ?? location;
     viewRegistry.delete(id);
     locationIndex.get(registeredLocation)?.delete(id);
-    notifyListeners(registeredLocation);
+    notifyRegistry();
   });
 };
 

--- a/superset-frontend/src/explore/components/controls/CollectionControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/CollectionControl/index.tsx
@@ -188,7 +188,9 @@ function CollectionControl({
   // Two items can collide when keyAccessor returns falsy and the index
   // fallback is used — breaking dnd-kit reordering and React reconciliation.
   // Assign a stable nanoid per item ref when no key is available.
-  const generatedIdsRef = useRef<WeakMap<CollectionItem, string>>(new WeakMap());
+  const generatedIdsRef = useRef<WeakMap<CollectionItem, string>>(
+    new WeakMap(),
+  );
   const itemIds = useMemo(
     () =>
       value.map(item => {

--- a/superset-frontend/src/extensions/ExtensionsList.test.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.test.tsx
@@ -16,73 +16,304 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, waitFor } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from 'spec/helpers/testing-library';
+import { SupersetClient } from '@superset-ui/core';
 import ExtensionsList from './ExtensionsList';
-import fetchMock from 'fetch-mock';
 
-beforeAll(() => fetchMock.unmockGlobal());
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
 
-// Mock initial state for the store
-const mockInitialState = {
-  extensions: {
-    loading: false,
-    resourceCount: 2,
-    resourceCollection: [
-      {
-        id: 1,
-        name: 'Test Extension 1',
-        enabled: true,
-      },
-      {
-        id: 2,
-        name: 'Test Extension 2',
-        enabled: false,
-      },
-    ],
-    bulkSelectEnabled: false,
+jest.mock('src/views/CRUD/hooks', () => ({
+  useListViewResource: jest.fn(),
+}));
+
+jest.mock('src/components', () => ({
+  ListView: ({ columns, data }: any) => (
+    <table>
+      <tbody>
+        {(data ?? []).map((row: any) =>
+          columns.map((col: any) => (
+            <td key={`${row.id}-${col.id}`}>
+              {col.Cell
+                ? col.Cell({ row: { original: row } })
+                : row[col.accessor]}
+            </td>
+          )),
+        )}
+      </tbody>
+    </table>
+  ),
+}));
+
+// Stub SubMenu so tests aren't coupled to the navigation menu rendering chain.
+jest.mock('src/features/home/SubMenu', () => ({
+  __esModule: true,
+  default: ({ buttons }: any) => (
+    <div data-test="submenu">
+      {(buttons ?? []).map((btn: any, i: number) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <button key={i} type="button" onClick={btn.onClick}>
+          {btn.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+// withToasts is the outermost HOC — pass through so callers can inject toast fns.
+jest.mock('src/components/MessageToasts/withToasts', () => (C: any) => C);
+
+jest.mock('src/views/contributions', () => ({
+  CHATBOT_LOCATION: 'superset.chatbot',
+}));
+
+jest.mock('src/core/views', () => ({
+  getRegisteredViewIds: jest.fn(() => []),
+  subscribeToRegistry: jest.fn(() => () => undefined),
+  getRegistryVersion: jest.fn(() => 0),
+}));
+
+// Stable snapshot reference: useSyncExternalStore requires getSnapshot to
+// return the same object until it actually changes, otherwise it re-renders
+// infinitely.
+const mockSettings = { active_chatbot_id: null, enabled: {} };
+jest.mock('src/core/extensions', () => ({
+  getExtensionSettingsSnapshot: jest.fn(() => mockSettings),
+  setExtensionSettings: jest.fn(),
+  loadExtensionSettings: jest.fn(() => Promise.resolve()),
+  subscribeToExtensionSettings: jest.fn(() => () => undefined),
+}));
+
+jest.mock('@superset-ui/core', () => {
+  const actual = jest.requireActual('@superset-ui/core');
+  return {
+    ...actual,
+    SupersetClient: {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const { useListViewResource } = jest.requireMock('src/views/CRUD/hooks');
+const mockGet = SupersetClient.get as jest.Mock;
+const mockPost = SupersetClient.post as jest.Mock;
+const mockPut = SupersetClient.put as jest.Mock;
+const mockDelete = SupersetClient.delete as jest.Mock;
+
+const EXTENSIONS = [
+  {
+    id: 'acme.chatbot',
+    name: 'chatbot',
+    publisher: 'acme',
+    enabled: true,
+    deletable: true,
   },
-};
+  {
+    id: 'acme.widget',
+    name: 'widget',
+    publisher: 'acme',
+    enabled: true,
+    deletable: false,
+  },
+];
+
+const mockFetchData = jest.fn();
+const mockRefreshData = jest.fn();
+
+function setupHook(extensions = EXTENSIONS) {
+  useListViewResource.mockReturnValue({
+    state: {
+      loading: false,
+      resourceCount: extensions.length,
+      resourceCollection: extensions,
+    },
+    fetchData: mockFetchData,
+    refreshData: mockRefreshData,
+  });
+}
 
 const defaultProps = {
   addDangerToast: jest.fn(),
   addSuccessToast: jest.fn(),
 };
 
-const renderWithStore = (props = {}) =>
-  render(<ExtensionsList {...defaultProps} {...props} />, {
+function renderList(props = {}) {
+  return render(<ExtensionsList {...defaultProps} {...props} />, {
     useRedux: true,
     useQueryParams: true,
     useRouter: true,
     useTheme: true,
-    initialState: mockInitialState,
   });
+}
 
-test('renders extensions list with basic structure', async () => {
-  renderWithStore();
+function uploadFile(input: HTMLInputElement, file: File) {
+  Object.defineProperty(input, 'files', { value: [file], configurable: true });
+  fireEvent.change(input);
+}
 
-  // Check that the component renders
-  expect(document.body).toBeInTheDocument();
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGet.mockResolvedValue({
+    json: { result: { active_chatbot_id: null, enabled: {} } },
+  });
+  setupHook();
 });
 
-test('displays extension names in the list', async () => {
-  renderWithStore();
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('renders the import button in the submenu', () => {
+  renderList();
+  expect(screen.getByTestId('submenu')).toBeInTheDocument();
+});
+
+test('renders extension names in the table', async () => {
+  renderList();
+  await waitFor(() => {
+    expect(screen.getByText('chatbot')).toBeInTheDocument();
+    expect(screen.getByText('widget')).toBeInTheDocument();
+  });
+});
+
+test('renders delete button only for deletable extensions', async () => {
+  renderList();
+  await waitFor(() => {
+    // Only acme.chatbot has deletable: true
+    expect(screen.getAllByTestId('delete-extension')).toHaveLength(1);
+  });
+});
+
+test('clicking delete opens confirmation dialog', async () => {
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
+
+  await userEvent.click(screen.getByTestId('delete-extension'));
 
   await waitFor(() => {
-    // These texts should appear somewhere in the rendered component
-    expect(document.body).toHaveTextContent(/Extensions/);
+    expect(
+      screen.getByText(/are you sure you want to delete/i),
+    ).toBeInTheDocument();
   });
 });
 
-test('calls toast functions when provided', () => {
-  const addDangerToast = jest.fn();
-  const addSuccessToast = jest.fn();
+test('typing DELETE in confirmation modal triggers delete API call', async () => {
+  mockDelete.mockResolvedValue({});
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
 
-  renderWithStore({
-    addDangerToast,
-    addSuccessToast,
+  await userEvent.click(screen.getByTestId('delete-extension'));
+
+  const confirmInput = await screen.findByTestId('delete-modal-input');
+  fireEvent.change(confirmInput, { target: { value: 'DELETE' } });
+
+  const modal = screen.getByRole('dialog');
+  const confirmBtn = within(modal)
+    .getAllByRole('button', { name: /^delete$/i })
+    .pop()!;
+  await userEvent.click(confirmBtn);
+
+  await waitFor(() => {
+    expect(mockDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: '/api/v1/extensions/acme/chatbot' }),
+    );
+    expect(mockRefreshData).toHaveBeenCalled();
+  });
+});
+
+test('star button shown only for extensions registered as chatbot views', async () => {
+  const { getRegisteredViewIds } = jest.requireMock('src/core/views');
+  (getRegisteredViewIds as jest.Mock).mockReturnValue(['acme.chatbot']);
+
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
+
+  expect(screen.getAllByTestId('set-default-chatbot')).toHaveLength(1);
+});
+
+test('clicking star calls PUT settings with the extension id', async () => {
+  const { getRegisteredViewIds } = jest.requireMock('src/core/views');
+  (getRegisteredViewIds as jest.Mock).mockReturnValue(['acme.chatbot']);
+  mockPut.mockResolvedValue({ json: {} });
+
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
+
+  await userEvent.click(screen.getByTestId('set-default-chatbot'));
+
+  await waitFor(() => {
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: '/api/v1/extensions/settings',
+        jsonPayload: expect.objectContaining({
+          active_chatbot_id: 'acme.chatbot',
+        }),
+      }),
+    );
+  });
+});
+
+test('pressing Enter on star span triggers set-default action', async () => {
+  const { getRegisteredViewIds } = jest.requireMock('src/core/views');
+  (getRegisteredViewIds as jest.Mock).mockReturnValue(['acme.chatbot']);
+  mockPut.mockResolvedValue({ json: {} });
+
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
+
+  fireEvent.keyDown(screen.getByTestId('set-default-chatbot'), {
+    key: 'Enter',
   });
 
-  // The component should accept these props without error
-  expect(addDangerToast).toBeDefined();
-  expect(addSuccessToast).toBeDefined();
+  await waitFor(() => {
+    expect(mockPut).toHaveBeenCalled();
+  });
+});
+
+test('uploading a non-.supx file shows danger toast without calling API', async () => {
+  const addDangerToast = jest.fn();
+  renderList({ addDangerToast });
+
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+  uploadFile(input, new File(['x'], 'evil.zip', { type: 'application/zip' }));
+
+  expect(addDangerToast).toHaveBeenCalledWith(expect.stringMatching(/\.supx/i));
+  expect(mockPost).not.toHaveBeenCalled();
+});
+
+test('uploading a .supx file calls POST endpoint and refreshes list', async () => {
+  mockPost.mockResolvedValue({});
+  renderList();
+
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+  uploadFile(
+    input,
+    new File(['PK'], 'my.supx', { type: 'application/octet-stream' }),
+  );
+
+  await waitFor(() => {
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: '/api/v1/extensions/' }),
+    );
+    expect(mockRefreshData).toHaveBeenCalled();
+  });
 });

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -17,18 +17,41 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import { FunctionComponent, useMemo } from 'react';
+import { SupersetClient } from '@superset-ui/core';
+import {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+  useSyncExternalStore,
+} from 'react';
 import { useListViewResource } from 'src/views/CRUD/hooks';
+import { createErrorHandler } from 'src/views/CRUD/utils';
 import { ListView } from 'src/components';
 import SubMenu, { SubMenuProps } from 'src/features/home/SubMenu';
 import withToasts from 'src/components/MessageToasts/withToasts';
+import { ConfirmStatusChange, Tooltip } from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
+import {
+  getExtensionSettingsSnapshot,
+  loadExtensionSettings,
+  setExtensionSettings,
+  subscribeToExtensionSettings,
+} from 'src/core/extensions';
+import { getRegisteredViewIds, subscribeToRegistry } from 'src/core/views';
+
+const CHATBOT_LOCATION = 'superset.chatbot';
 
 const PAGE_SIZE = 25;
 
 type Extension = {
-  id: number;
+  id: string;
   name: string;
+  publisher: string;
   enabled: boolean;
+  deletable: boolean;
 };
 
 interface ExtensionsListProps {
@@ -40,6 +63,21 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
   addDangerToast,
   addSuccessToast,
 }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [chatbotExtensionIds, setChatbotExtensionIds] = useState<Set<string>>(
+    () => new Set(getRegisteredViewIds(CHATBOT_LOCATION)),
+  );
+
+  // The active chatbot lives in the host-owned settings store shared with the
+  // live ChatbotMount, so a change here is reflected there without a second
+  // notification channel.
+  const settings = useSyncExternalStore(
+    subscribeToExtensionSettings,
+    getExtensionSettingsSnapshot,
+  );
+  const activeChatbotId = settings.active_chatbot_id;
+
   const {
     state: { loading, resourceCount, resourceCollection },
     fetchData,
@@ -48,6 +86,111 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
     'extensions',
     t('Extensions'),
     addDangerToast,
+  );
+
+  // Keep chatbotExtensionIds in sync with runtime view registrations
+  useEffect(
+    () =>
+      subscribeToRegistry(() => {
+        setChatbotExtensionIds(new Set(getRegisteredViewIds(CHATBOT_LOCATION)));
+      }),
+    [],
+  );
+
+  // Load settings into the shared store on mount.
+  useEffect(() => {
+    // non-fatal: the store keeps its empty default on failure.
+    loadExtensionSettings().catch(() => {});
+  }, []);
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.name.endsWith('.supx')) {
+      addDangerToast(t('File must have a .supx extension.'));
+      e.target.value = '';
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('bundle', file);
+
+    setUploading(true);
+    SupersetClient.post({
+      endpoint: '/api/v1/extensions/',
+      body: formData,
+      headers: { Accept: 'application/json' },
+    })
+      .then(() => {
+        addSuccessToast(t('Extension installed successfully.'));
+        refreshData();
+      })
+      .catch(
+        createErrorHandler(errMsg =>
+          addDangerToast(
+            t('There was an issue installing the extension: %s', errMsg),
+          ),
+        ),
+      )
+      .finally(() => {
+        setUploading(false);
+        e.target.value = '';
+      });
+  };
+
+  const handleDelete = useCallback(
+    (extension: Extension) => {
+      const { publisher, name } = extension;
+      SupersetClient.delete({
+        endpoint: `/api/v1/extensions/${publisher}/${name}`,
+      }).then(
+        () => {
+          addSuccessToast(t('Deleted: %s', extension.name));
+          refreshData();
+        },
+        createErrorHandler(errMsg =>
+          addDangerToast(
+            t('There was an issue deleting %s: %s', extension.name, errMsg),
+          ),
+        ),
+      );
+    },
+    [addDangerToast, addSuccessToast, refreshData],
+  );
+
+  const handleSetDefaultChatbot = useCallback(
+    (extension: Extension) => {
+      const newId = activeChatbotId === extension.id ? null : extension.id;
+      SupersetClient.put({
+        endpoint: '/api/v1/extensions/settings',
+        jsonPayload: { active_chatbot_id: newId },
+      }).then(
+        () => {
+          // Reflect the change in the shared settings store; the component and
+          // the live ChatbotMount both re-resolve from it immediately.
+          setExtensionSettings({
+            ...getExtensionSettingsSnapshot(),
+            active_chatbot_id: newId,
+          });
+          addSuccessToast(
+            newId
+              ? t('%s set as default chatbot.', extension.name)
+              : t('Default chatbot cleared.'),
+          );
+        },
+        createErrorHandler(errMsg =>
+          addDangerToast(
+            t('There was an issue updating chatbot settings: %s', errMsg),
+          ),
+        ),
+      );
+    },
+    [activeChatbotId, addDangerToast, addSuccessToast],
   );
 
   const columns = useMemo(
@@ -63,18 +206,133 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
           },
         }: any) => name,
       },
+      {
+        Header: t('Publisher'),
+        accessor: 'publisher',
+        id: 'publisher',
+        Cell: ({
+          row: {
+            original: { publisher },
+          },
+        }: any) => publisher,
+      },
+      {
+        Header: t('Actions'),
+        id: 'actions',
+        disableSortBy: true,
+        Cell: ({ row: { original } }: any) => {
+          const isChatbot = chatbotExtensionIds.has(original.id);
+          const isDefault = activeChatbotId === original.id;
+          return (
+            <>
+              {isChatbot && (
+                <Tooltip
+                  id={`set-chatbot-tooltip-${original.id}`}
+                  title={
+                    isDefault
+                      ? t('Clear default chatbot')
+                      : t('Set as default chatbot')
+                  }
+                  placement="bottom"
+                >
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    data-test="set-default-chatbot"
+                    className="action-button"
+                    onClick={() => handleSetDefaultChatbot(original)}
+                    onKeyDown={(e: React.KeyboardEvent) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        handleSetDefaultChatbot(original);
+                      }
+                    }}
+                  >
+                    {isDefault ? (
+                      <Icons.StarFilled iconSize="l" />
+                    ) : (
+                      <Icons.StarOutlined iconSize="l" />
+                    )}
+                  </span>
+                </Tooltip>
+              )}
+              {original.deletable && (
+                <ConfirmStatusChange
+                  title={t('Please confirm')}
+                  description={
+                    <>
+                      {t('Are you sure you want to delete')}{' '}
+                      <b>{original.name}</b>?
+                    </>
+                  }
+                  onConfirm={() => handleDelete(original)}
+                >
+                  {(confirmDelete: () => void) => (
+                    <Tooltip
+                      id={`delete-extension-tooltip-${original.id}`}
+                      title={t('Delete')}
+                      placement="bottom"
+                    >
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        data-test="delete-extension"
+                        className="action-button"
+                        onClick={confirmDelete}
+                        onKeyDown={(e: React.KeyboardEvent) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            confirmDelete();
+                          }
+                        }}
+                      >
+                        <Icons.DeleteOutlined iconSize="l" />
+                      </span>
+                    </Tooltip>
+                  )}
+                </ConfirmStatusChange>
+              )}
+            </>
+          );
+        },
+      },
     ],
-    [loading], // We need to monitor loading to avoid stale state in actions
+    [
+      activeChatbotId,
+      chatbotExtensionIds,
+      handleSetDefaultChatbot,
+      handleDelete,
+    ],
   );
 
   const menuData: SubMenuProps = {
     activeChild: 'Extensions',
     name: t('Extensions'),
-    buttons: [],
+    buttons: [
+      {
+        name: (
+          <Tooltip
+            id="import-extension-tooltip"
+            title={t('Import extension (.supx)')}
+            placement="bottomRight"
+          >
+            <Icons.DownloadOutlined iconSize="l" />
+          </Tooltip>
+        ),
+        buttonStyle: 'link',
+        onClick: handleUploadClick,
+        loading: uploading,
+      },
+    ],
   };
 
   return (
     <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".supx"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
       <SubMenu {...menuData} />
       <ListView<Extension>
         columns={columns}

--- a/superset-frontend/src/extensions/ExtensionsLoader.test.ts
+++ b/superset-frontend/src/extensions/ExtensionsLoader.test.ts
@@ -38,6 +38,13 @@ function createMockExtension(overrides: Partial<Extension> = {}): Extension {
 
 beforeEach(() => {
   (ExtensionsLoader as any).instance = undefined;
+  // Minimal host registry surface the loader wraps during module evaluation.
+  (window as any).superset = {
+    commands: { registerCommand: jest.fn() },
+    menus: { registerMenuItem: jest.fn() },
+    editors: { registerEditor: jest.fn() },
+    views: { registerView: jest.fn() },
+  };
 });
 
 test('creates a singleton instance', () => {
@@ -141,4 +148,101 @@ test('logs error when initializeExtensions fails', async () => {
   );
 
   errorSpy.mockRestore();
+});
+
+/**
+ * Stubs the module-federation machinery `loadModule` depends on so a fake
+ * extension entry module (its `./index` factory) can be loaded in jsdom.
+ * Returns a cleanup function that restores the patched globals.
+ */
+function mockRemoteModule(containerName: string, factory: () => unknown) {
+  const appendChildSpy = jest
+    .spyOn(document.head, 'appendChild')
+    .mockImplementation((element: Node) => {
+      if (element instanceof HTMLScriptElement && element.onload) {
+        setTimeout(() => (element.onload as any)(new Event('load')), 0);
+      }
+      return element;
+    });
+
+  (global as any).__webpack_init_sharing__ = jest
+    .fn()
+    .mockResolvedValue(undefined);
+  (global as any).__webpack_share_scopes__ = { default: {} };
+  (window as any)[containerName] = {
+    init: jest.fn().mockResolvedValue(undefined),
+    get: jest.fn().mockResolvedValue(factory),
+  };
+
+  return () => {
+    appendChildSpy.mockRestore();
+    delete (global as any).__webpack_init_sharing__;
+    delete (global as any).__webpack_share_scopes__;
+    delete (window as any)[containerName];
+  };
+}
+
+const remoteExtension = (overrides: Partial<Extension> = {}) =>
+  createMockExtension({
+    id: 'remote-ext',
+    remoteEntry: 'http://example/remoteEntry.js',
+    ...overrides,
+  });
+
+test('disposes synchronous activation-time registrations on deactivation', async () => {
+  const loader = ExtensionsLoader.getInstance();
+  const dispose = jest.fn();
+  // Legacy side-effect style: register synchronously during module evaluation.
+  const factory = () => {
+    window.superset.views.registerView(
+      { id: 'remote-ext.view', name: 'View' },
+      'sqllab.panels',
+      (() => null) as any,
+    );
+    return undefined;
+  };
+  const registerView = jest
+    .spyOn(window.superset.views, 'registerView')
+    .mockReturnValue({ dispose } as any);
+  const cleanup = mockRemoteModule('remote-ext', factory);
+
+  await loader.initializeExtension(remoteExtension());
+  loader.deactivateExtension('remote-ext');
+
+  expect(dispose).toHaveBeenCalledTimes(1);
+
+  registerView.mockRestore();
+  cleanup();
+});
+
+test('tracks registrations made asynchronously inside activate(context)', async () => {
+  const loader = ExtensionsLoader.getInstance();
+  const dispose = jest.fn();
+  const registerView = jest
+    .spyOn(window.superset.views, 'registerView')
+    .mockReturnValue({ dispose } as any);
+
+  // Modern style: register AFTER an await — the window.superset wrap is already
+  // gone by then, so this is only tracked because activate pushes to context.
+  const factory = () => ({
+    activate: async (context: core.ExtensionContext) => {
+      await Promise.resolve();
+      const disposable = window.superset.views.registerView(
+        { id: 'remote-ext.async-view', name: 'Async View' },
+        'sqllab.panels',
+        (() => null) as any,
+      );
+      context.subscriptions.push(disposable);
+    },
+  });
+  const cleanup = mockRemoteModule('remote-ext', factory);
+
+  await loader.initializeExtension(remoteExtension());
+  loader.deactivateExtension('remote-ext');
+
+  expect(registerView).toHaveBeenCalledTimes(1);
+  expect(dispose).toHaveBeenCalledTimes(1);
+
+  registerView.mockRestore();
+  cleanup();
 });

--- a/superset-frontend/src/extensions/ExtensionsLoader.ts
+++ b/superset-frontend/src/extensions/ExtensionsLoader.ts
@@ -177,17 +177,33 @@ class ExtensionsLoader {
     // collect the Disposables and drive cleanup on deactivation.
     const collected: (() => void)[] = [];
     const originalSuperset = window.superset;
+
+    const wrap = <TArgs extends unknown[]>(
+      fn: (...args: TArgs) => { dispose(): void },
+    ): ((...args: TArgs) => { dispose(): void }) =>
+      (...args: TArgs) => {
+        const disposable = fn(...args);
+        collected.push(() => disposable.dispose());
+        return disposable;
+      };
+
     window.superset = {
       ...originalSuperset,
+      commands: {
+        ...originalSuperset.commands,
+        registerCommand: wrap(originalSuperset.commands.registerCommand),
+      },
+      menus: {
+        ...originalSuperset.menus,
+        registerMenuItem: wrap(originalSuperset.menus.registerMenuItem),
+      },
+      editors: {
+        ...originalSuperset.editors,
+        registerEditor: wrap(originalSuperset.editors.registerEditor),
+      },
       views: {
         ...originalSuperset.views,
-        registerView: (
-          ...args: Parameters<typeof originalSuperset.views.registerView>
-        ) => {
-          const disposable = originalSuperset.views.registerView(...args);
-          collected.push(() => disposable.dispose());
-          return disposable;
-        },
+        registerView: wrap(originalSuperset.views.registerView),
       },
     };
 

--- a/superset-frontend/src/extensions/ExtensionsLoader.ts
+++ b/superset-frontend/src/extensions/ExtensionsLoader.ts
@@ -17,8 +17,11 @@
  * under the License.
  */
 import { SupersetClient } from '@superset-ui/core';
+import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
 import type { common as core } from '@apache-superset/core';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
+import { store } from 'src/views/store';
 
 type Extension = core.Extension;
 
@@ -35,6 +38,9 @@ class ExtensionsLoader {
   private extensionIndex: Map<string, Extension> = new Map();
 
   private initializationPromise: Promise<void> | null = null;
+
+  /** Disposables returned by contribution registrations, keyed by extension id. */
+  private extensionDisposables: Map<string, (() => void)[]> = new Map();
 
   // eslint-disable-next-line no-useless-constructor
   private constructor() {
@@ -88,7 +94,8 @@ class ExtensionsLoader {
   public async initializeExtension(extension: Extension) {
     try {
       if (extension.remoteEntry) {
-        await this.loadModule(extension);
+        const disposables = await this.loadModule(extension);
+        this.extensionDisposables.set(extension.id, disposables);
       }
       this.extensionIndex.set(extension.id, extension);
     } catch (error) {
@@ -96,7 +103,23 @@ class ExtensionsLoader {
         `Failed to initialize extension ${extension.name}\n`,
         error,
       );
+      store.dispatch(
+        addDangerToast(t('Extension "%s" failed to load.', extension.name)),
+      );
     }
+  }
+
+  /**
+   * Deactivates an extension by disposing all of its registered contributions
+   * and removing it from the index.
+   */
+  public deactivateExtension(id: string): void {
+    const disposables = this.extensionDisposables.get(id);
+    if (disposables) {
+      disposables.forEach(dispose => dispose());
+      this.extensionDisposables.delete(id);
+    }
+    this.extensionIndex.delete(id);
   }
 
   /**
@@ -104,7 +127,7 @@ class ExtensionsLoader {
    * The module's top-level side effects fire contribution registrations.
    * @param extension The extension to load.
    */
-  private async loadModule(extension: Extension): Promise<void> {
+  private async loadModule(extension: Extension): Promise<(() => void)[]> {
     const { remoteEntry, id } = extension;
 
     // Load the remote entry script
@@ -149,8 +172,33 @@ class ExtensionsLoader {
     await container.init(__webpack_share_scopes__.default);
 
     const factory = await container.get('./index');
-    // Execute the module factory - side effects fire registrations
-    factory();
+
+    // Intercept contribution registrations during module activation so we can
+    // collect the Disposables and drive cleanup on deactivation.
+    const collected: (() => void)[] = [];
+    const originalSuperset = window.superset;
+    window.superset = {
+      ...originalSuperset,
+      views: {
+        ...originalSuperset.views,
+        registerView: (
+          ...args: Parameters<typeof originalSuperset.views.registerView>
+        ) => {
+          const disposable = originalSuperset.views.registerView(...args);
+          collected.push(() => disposable.dispose());
+          return disposable;
+        },
+      },
+    };
+
+    try {
+      // Execute the module factory — side effects fire contribution registrations
+      factory();
+    } finally {
+      window.superset = originalSuperset;
+    }
+
+    return collected;
   }
 
   /**

--- a/superset-frontend/src/extensions/ExtensionsLoader.ts
+++ b/superset-frontend/src/extensions/ExtensionsLoader.ts
@@ -24,6 +24,8 @@ import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { store } from 'src/views/store';
 
 type Extension = core.Extension;
+type ExtensionContext = core.ExtensionContext;
+type ExtensionModule = core.ExtensionModule;
 
 /**
  * Loads extension modules via webpack module federation.
@@ -39,8 +41,8 @@ class ExtensionsLoader {
 
   private initializationPromise: Promise<void> | null = null;
 
-  /** Disposables returned by contribution registrations, keyed by extension id. */
-  private extensionDisposables: Map<string, (() => void)[]> = new Map();
+  /** Disposables registered by each extension via its context, keyed by extension id. */
+  private extensionDisposables: Map<string, { dispose(): void }[]> = new Map();
 
   // eslint-disable-next-line no-useless-constructor
   private constructor() {
@@ -87,15 +89,16 @@ class ExtensionsLoader {
 
   /**
    * Initializes a single extension.
-   * If the extension has a remote entry, loads the module (which triggers
+   * If the extension has a remote entry, loads the module and runs its
+   * `activate(context)` hook (or, for legacy extensions, its top-level
    * side-effect registrations for commands, views, menus, and editors).
    * @param extension The extension to initialize.
    */
   public async initializeExtension(extension: Extension) {
     try {
       if (extension.remoteEntry) {
-        const disposables = await this.loadModule(extension);
-        this.extensionDisposables.set(extension.id, disposables);
+        const subscriptions = await this.loadModule(extension);
+        this.extensionDisposables.set(extension.id, subscriptions);
       }
       this.extensionIndex.set(extension.id, extension);
     } catch (error) {
@@ -112,22 +115,32 @@ class ExtensionsLoader {
   /**
    * Deactivates an extension by disposing all of its registered contributions
    * and removing it from the index.
+   *
+   * Contributions are disposed from the extension's `context.subscriptions`,
+   * which it populates during `activate(context)`. This tracks registrations
+   * regardless of when they happen — synchronous or asynchronous — so long as
+   * the extension pushes each returned Disposable onto its context. Legacy
+   * extensions that register as top-level side effects are tracked only for the
+   * synchronous module-evaluation window (see `loadModule`).
    */
   public deactivateExtension(id: string): void {
-    const disposables = this.extensionDisposables.get(id);
-    if (disposables) {
-      disposables.forEach(dispose => dispose());
+    const subscriptions = this.extensionDisposables.get(id);
+    if (subscriptions) {
+      subscriptions.forEach(subscription => subscription.dispose());
       this.extensionDisposables.delete(id);
     }
     this.extensionIndex.delete(id);
   }
 
   /**
-   * Loads a single extension module via webpack module federation.
-   * The module's top-level side effects fire contribution registrations.
+   * Loads a single extension module via webpack module federation and runs its
+   * `activate(context)` hook. Returns the Disposables the extension registered
+   * (its `context.subscriptions`) so the loader can dispose them on deactivation.
    * @param extension The extension to load.
    */
-  private async loadModule(extension: Extension): Promise<(() => void)[]> {
+  private async loadModule(
+    extension: Extension,
+  ): Promise<{ dispose(): void }[]> {
     const { remoteEntry, id } = extension;
 
     // Load the remote entry script
@@ -173,17 +186,28 @@ class ExtensionsLoader {
 
     const factory = await container.get('./index');
 
-    // Intercept contribution registrations during module activation so we can
-    // collect the Disposables and drive cleanup on deactivation.
-    const collected: (() => void)[] = [];
+    // The extension binds the lifetime of its registrations to this context by
+    // pushing the returned Disposables onto `subscriptions`. Because the context
+    // object outlives the synchronous module-evaluation window, registrations
+    // performed asynchronously inside `activate` (after an `await`, in a timer,
+    // or in an event callback) are tracked just like synchronous ones.
+    const context: ExtensionContext = { subscriptions: [] };
+
+    // Backward-compatibility path: extensions that register contributions as
+    // top-level side effects (rather than via `activate(context)`) do not push
+    // to `context.subscriptions` themselves. Wrapping the registrars captures
+    // those disposables — but ONLY while they fire synchronously during module
+    // evaluation, since the wrap is removed immediately afterwards. Extensions
+    // that register asynchronously must use `activate(context)` to be tracked.
     const originalSuperset = window.superset;
 
-    const wrap = <TArgs extends unknown[]>(
-      fn: (...args: TArgs) => { dispose(): void },
-    ): ((...args: TArgs) => { dispose(): void }) =>
+    const wrap =
+      <TArgs extends unknown[]>(
+        fn: (...args: TArgs) => { dispose(): void },
+      ): ((...args: TArgs) => { dispose(): void }) =>
       (...args: TArgs) => {
         const disposable = fn(...args);
-        collected.push(() => disposable.dispose());
+        context.subscriptions.push(disposable);
         return disposable;
       };
 
@@ -207,14 +231,26 @@ class ExtensionsLoader {
       },
     };
 
+    let module: ExtensionModule | undefined;
     try {
-      // Execute the module factory — side effects fire contribution registrations
-      factory();
+      // Evaluate the module factory. Legacy extensions fire their contribution
+      // registrations as a synchronous side effect here; modern extensions
+      // return a module exposing `activate`.
+      module = factory() as ExtensionModule | undefined;
     } finally {
+      // Restore the real registrars before `activate` runs so that registrations
+      // are tracked via `context.subscriptions` (which the extension controls and
+      // which survives async boundaries) rather than via the synchronous wrap.
       window.superset = originalSuperset;
     }
 
-    return collected;
+    // Preferred path: hand the extension its context so it can track every
+    // registration it makes, synchronous or asynchronous.
+    if (typeof module?.activate === 'function') {
+      await module.activate(context);
+    }
+
+    return context.subscriptions;
   }
 
   /**

--- a/superset-frontend/src/extensions/ExtensionsLoader.ts
+++ b/superset-frontend/src/extensions/ExtensionsLoader.ts
@@ -22,6 +22,8 @@ import { logging } from '@apache-superset/core/utils';
 import type { common as core } from '@apache-superset/core';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { store } from 'src/views/store';
+// Side-effect import: brings the `window.superset` global augmentation into scope.
+import 'src/extensions/supersetGlobal';
 
 type Extension = core.Extension;
 type ExtensionContext = core.ExtensionContext;

--- a/superset-frontend/src/extensions/ExtensionsStartup.test.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.test.tsx
@@ -72,6 +72,7 @@ afterEach(() => {
 test('renders without crashing', () => {
   render(<ExtensionsStartup />, {
     useRedux: true,
+    useRouter: true,
     initialState: mockInitialState,
   });
 
@@ -88,6 +89,7 @@ test('sets up global superset object when user is logged in', async () => {
 
   render(<ExtensionsStartup />, {
     useRedux: true,
+    useRouter: true,
     initialState: mockInitialState,
   });
 
@@ -109,6 +111,7 @@ test('sets up global superset object when user is logged in', async () => {
 test('does not set up global superset object when user is not logged in', async () => {
   render(<ExtensionsStartup />, {
     useRedux: true,
+    useRouter: true,
     initialState: mockInitialStateNoUser,
   });
 
@@ -127,6 +130,7 @@ test('initializes ExtensionsLoader when user is logged in', async () => {
 
   render(<ExtensionsStartup />, {
     useRedux: true,
+    useRouter: true,
     initialState: mockInitialState,
   });
 
@@ -144,6 +148,7 @@ test('initializes ExtensionsLoader when user is logged in', async () => {
 test('does not initialize ExtensionsLoader when user is not logged in', async () => {
   render(<ExtensionsStartup />, {
     useRedux: true,
+    useRouter: true,
     initialState: mockInitialStateNoUser,
   });
 
@@ -169,6 +174,7 @@ test('only initializes once even with multiple renders', async () => {
 
   const { rerender } = render(<ExtensionsStartup />, {
     useRedux: true,
+    useRouter: true,
     initialState: mockInitialState,
   });
 
@@ -205,6 +211,7 @@ test('initializes ExtensionsLoader when EnableExtensions feature flag is enabled
 
   render(<ExtensionsStartup />, {
     useRedux: true,
+    useRouter: true,
     initialState: mockInitialState,
   });
 
@@ -234,6 +241,7 @@ test('does not initialize ExtensionsLoader when EnableExtensions feature flag is
 
   render(<ExtensionsStartup />, {
     useRedux: true,
+    useRouter: true,
     initialState: mockInitialState,
   });
 
@@ -268,6 +276,7 @@ test('continues rendering children even when ExtensionsLoader initialization fai
     </ExtensionsStartup>,
     {
       useRedux: true,
+      useRouter: true,
       initialState: mockInitialState,
     },
   );

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -84,10 +84,7 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
   // browser's default error surfacing so host error reporting is unaffected.
   useEffect(() => {
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-      logging.error(
-        '[extensions] Unhandled rejection:',
-        event.reason,
-      );
+      logging.error('[extensions] Unhandled rejection:', event.reason);
     };
     window.addEventListener('unhandledrejection', handleUnhandledRejection);
     return () => {
@@ -126,7 +123,8 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
 
     // Render the host immediately; extension bundles load in the background.
     // ChatbotMount re-resolves reactively once the chatbot extension registers
-    // (via subscribeToLocation), so the bubble appears without blocking the UI.
+    // (via subscribeToRegistry / getRegistryVersion), so the bubble appears
+    // without blocking the UI.
     setInitialized(true);
 
     if (isFeatureEnabled(FeatureFlag.EnableExtensions)) {

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 // eslint-disable-next-line no-restricted-syntax
 import * as supersetCore from '@apache-superset/core';
 import { logging } from '@apache-superset/core/utils';
@@ -26,17 +25,12 @@ import {
   authentication,
   core,
   commands,
-  dashboard,
-  dataset,
   editors,
-  explore,
   extensions,
   menus,
-  navigation,
   sqlLab,
   views,
 } from 'src/core';
-import { notifyPageChange } from 'src/core/navigation';
 import { useSelector } from 'react-redux';
 import { RootState } from 'src/views/store';
 import ExtensionsLoader from './ExtensionsLoader';
@@ -47,13 +41,9 @@ declare global {
       authentication: typeof authentication;
       core: typeof core;
       commands: typeof commands;
-      dashboard: typeof dashboard;
-      dataset: typeof dataset;
       editors: typeof editors;
-      explore: typeof explore;
       extensions: typeof extensions;
       menus: typeof menus;
-      navigation: typeof navigation;
       sqlLab: typeof sqlLab;
       views: typeof views;
     };
@@ -64,20 +54,10 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
   children,
 }) => {
   const [initialized, setInitialized] = useState(false);
-  const location = useLocation();
-  const prevPathname = useRef<string | null>(null);
 
   const userId = useSelector<RootState, number | undefined>(
     ({ user }) => user.userId,
   );
-
-  // Notify the navigation namespace on every route change.
-  useEffect(() => {
-    if (prevPathname.current !== location.pathname) {
-      prevPathname.current = location.pathname;
-      notifyPageChange(location.pathname);
-    }
-  }, [location.pathname]);
 
   // Log unhandled rejections that may originate from extension code.
   // Registered once for the lifetime of the app; does not suppress the
@@ -110,13 +90,9 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
       authentication,
       core,
       commands,
-      dashboard,
-      dataset,
       editors,
-      explore,
       extensions,
       menus,
-      navigation,
       sqlLab,
       views,
     };

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -16,20 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 // eslint-disable-next-line no-restricted-syntax
 import * as supersetCore from '@apache-superset/core';
+import { logging } from '@apache-superset/core/utils';
 import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
 import {
   authentication,
   core,
   commands,
+  dashboard,
+  dataset,
   editors,
+  explore,
   extensions,
   menus,
+  navigation,
   sqlLab,
   views,
 } from 'src/core';
+import { notifyPageChange } from 'src/core/navigation';
 import { useSelector } from 'react-redux';
 import { RootState } from 'src/views/store';
 import ExtensionsLoader from './ExtensionsLoader';
@@ -40,9 +47,13 @@ declare global {
       authentication: typeof authentication;
       core: typeof core;
       commands: typeof commands;
+      dashboard: typeof dashboard;
+      dataset: typeof dataset;
       editors: typeof editors;
+      explore: typeof explore;
       extensions: typeof extensions;
       menus: typeof menus;
+      navigation: typeof navigation;
       sqlLab: typeof sqlLab;
       views: typeof views;
     };
@@ -53,10 +64,39 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
   children,
 }) => {
   const [initialized, setInitialized] = useState(false);
+  const location = useLocation();
+  const prevPathname = useRef<string | null>(null);
 
   const userId = useSelector<RootState, number | undefined>(
     ({ user }) => user.userId,
   );
+
+  // Notify the navigation namespace on every route change.
+  useEffect(() => {
+    if (prevPathname.current !== location.pathname) {
+      prevPathname.current = location.pathname;
+      notifyPageChange(location.pathname);
+    }
+  }, [location.pathname]);
+
+  // Log unhandled rejections that may originate from extension code.
+  // Registered once for the lifetime of the app; does not suppress the
+  // browser's default error surfacing so host error reporting is unaffected.
+  useEffect(() => {
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      logging.error(
+        '[extensions] Unhandled rejection:',
+        event.reason,
+      );
+    };
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+    return () => {
+      window.removeEventListener(
+        'unhandledrejection',
+        handleUnhandledRejection,
+      );
+    };
+  }, []);
 
   useEffect(() => {
     if (initialized) return;
@@ -73,21 +113,25 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
       authentication,
       core,
       commands,
+      dashboard,
+      dataset,
       editors,
+      explore,
       extensions,
       menus,
+      navigation,
       sqlLab,
       views,
     };
 
-    const setup = async () => {
-      if (isFeatureEnabled(FeatureFlag.EnableExtensions)) {
-        await ExtensionsLoader.getInstance().initializeExtensions();
-      }
-      setInitialized(true);
-    };
+    // Render the host immediately; extension bundles load in the background.
+    // ChatbotMount re-resolves reactively once the chatbot extension registers
+    // (via subscribeToLocation), so the bubble appears without blocking the UI.
+    setInitialized(true);
 
-    setup();
+    if (isFeatureEnabled(FeatureFlag.EnableExtensions)) {
+      ExtensionsLoader.getInstance().initializeExtensions();
+    }
   }, [initialized, userId]);
 
   if (!initialized) {

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -16,21 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useState } from 'react';
-// eslint-disable-next-line no-restricted-syntax
-import * as supersetCore from '@apache-superset/core';
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { logging } from '@apache-superset/core/utils';
 import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
 import {
   authentication,
   core,
   commands,
+  dashboard,
+  dataset,
   editors,
+  explore,
   extensions,
   menus,
+  navigation,
   sqlLab,
   views,
 } from 'src/core';
+import { notifyPageChange } from 'src/core/navigation';
 import { useSelector } from 'react-redux';
 import { RootState } from 'src/views/store';
 import ExtensionsLoader from './ExtensionsLoader';
@@ -41,10 +45,20 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
   children,
 }) => {
   const [initialized, setInitialized] = useState(false);
+  const location = useLocation();
+  const prevPathname = useRef<string | null>(null);
 
   const userId = useSelector<RootState, number | undefined>(
     ({ user }) => user.userId,
   );
+
+  // Notify the navigation namespace on every route change.
+  useEffect(() => {
+    if (prevPathname.current !== location.pathname) {
+      prevPathname.current = location.pathname;
+      notifyPageChange(location.pathname);
+    }
+  }, [location.pathname]);
 
   // Log unhandled rejections that may originate from extension code.
   // Registered once for the lifetime of the app; does not suppress the
@@ -71,15 +85,20 @@ const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
       return;
     }
 
-    // Provide the implementations for @apache-superset/core
+    // Provide the implementations for @apache-superset/core.
+    // Namespaces are listed explicitly — do not spread the core package here,
+    // as that would leak un-contracted symbols onto window.superset.
     window.superset = {
-      ...supersetCore,
       authentication,
       core,
       commands,
+      dashboard,
+      dataset,
       editors,
+      explore,
       extensions,
       menus,
+      navigation,
       sqlLab,
       views,
     };

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -34,21 +34,8 @@ import {
 import { useSelector } from 'react-redux';
 import { RootState } from 'src/views/store';
 import ExtensionsLoader from './ExtensionsLoader';
-
-declare global {
-  interface Window {
-    superset: {
-      authentication: typeof authentication;
-      core: typeof core;
-      commands: typeof commands;
-      editors: typeof editors;
-      extensions: typeof extensions;
-      menus: typeof menus;
-      sqlLab: typeof sqlLab;
-      views: typeof views;
-    };
-  }
-}
+// Side-effect import: brings the `window.superset` global augmentation into scope.
+import 'src/extensions/supersetGlobal';
 
 const ExtensionsStartup: React.FC<{ children?: React.ReactNode }> = ({
   children,

--- a/superset-frontend/src/extensions/supersetGlobal.ts
+++ b/superset-frontend/src/extensions/supersetGlobal.ts
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Global `window.superset` type augmentation.
+ *
+ * Lives in its own module (rather than inline in ExtensionsStartup) so every
+ * file that reads or writes `window.superset` — notably ExtensionsLoader —
+ * sees the type regardless of how files are batched during compilation. Both
+ * the startup component and the loader import this module for its side effect.
+ */
+
+import type {
+  authentication,
+  commands,
+  core,
+  editors,
+  extensions,
+  menus,
+  sqlLab,
+  views,
+} from 'src/core';
+
+/** The host namespaces exposed to extensions on `window.superset`. */
+export interface SupersetGlobal {
+  authentication: typeof authentication;
+  core: typeof core;
+  commands: typeof commands;
+  editors: typeof editors;
+  extensions: typeof extensions;
+  menus: typeof menus;
+  sqlLab: typeof sqlLab;
+  views: typeof views;
+}
+
+declare global {
+  interface Window {
+    superset: SupersetGlobal;
+  }
+}

--- a/superset-frontend/src/extensions/supersetGlobal.ts
+++ b/superset-frontend/src/extensions/supersetGlobal.ts
@@ -30,9 +30,13 @@ import type {
   authentication,
   commands,
   core,
+  dashboard,
+  dataset,
   editors,
+  explore,
   extensions,
   menus,
+  navigation,
   sqlLab,
   views,
 } from 'src/core';
@@ -42,9 +46,13 @@ export interface SupersetGlobal {
   authentication: typeof authentication;
   core: typeof core;
   commands: typeof commands;
+  dashboard: typeof dashboard;
+  dataset: typeof dataset;
   editors: typeof editors;
+  explore: typeof explore;
   extensions: typeof extensions;
   menus: typeof menus;
+  navigation: typeof navigation;
   sqlLab: typeof sqlLab;
   views: typeof views;
 }

--- a/superset-frontend/src/features/datasets/AddDataset/EditDataset/EditDataset.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/EditDataset/EditDataset.test.tsx
@@ -21,12 +21,18 @@ import { render, screen } from 'spec/helpers/testing-library';
 import EditDataset from './index';
 
 const DATASET_ENDPOINT = 'glob:*api/v1/dataset/1/related_objects';
+// EditPage also fetches the dataset entity itself to publish the `dataset`
+// extension-namespace context (setCurrentDataset).
+const DATASET_RESOURCE_ENDPOINT = 'glob:*api/v1/dataset/1';
 
 const mockedProps = {
   id: '1',
 };
 
 fetchMock.get(DATASET_ENDPOINT, { charts: { results: [], count: 2 } });
+fetchMock.get(DATASET_RESOURCE_ENDPOINT, {
+  result: { id: 1, table_name: 'test_table', schema: 'public' },
+});
 
 test('should render edit dataset view with tabs', async () => {
   render(<EditDataset {...mockedProps} />);

--- a/superset-frontend/src/features/datasets/AddDataset/EditDataset/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/EditDataset/index.tsx
@@ -16,9 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useEffect } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
 import useGetDatasetRelatedCounts from 'src/features/datasets/hooks/useGetDatasetRelatedCounts';
+import { useSingleViewResource } from 'src/views/CRUD/hooks';
+import { setCurrentDataset } from 'src/core/dataset';
 import { Badge } from '@superset-ui/core/components';
 import Tabs from '@superset-ui/core/components/Tabs';
 
@@ -47,6 +50,13 @@ interface EditPageProps {
   id: string;
 }
 
+// Stable no-op error handler so `useSingleViewResource`'s `fetchResource`
+// keeps a stable identity across renders (it lists the handler in its deps).
+// An inline handler would change every render and re-trigger the fetch effect,
+// causing an update loop. Fetch failure is non-fatal here — the dataset
+// context simply stays empty.
+const noopErrorHandler = () => {};
+
 const TRANSLATIONS = {
   USAGE_TEXT: t('Usage'),
   COLUMNS_TEXT: t('Columns'),
@@ -61,6 +71,45 @@ const TABS_KEYS = {
 
 const EditPage = ({ id }: EditPageProps) => {
   const { usageCount } = useGetDatasetRelatedCounts(id);
+
+  // Publish the focused dataset to the `dataset` extension namespace so chatbot
+  // extensions can read which dataset the user is editing. Cleared on unmount.
+  const {
+    state: { resource: datasetResource },
+    fetchResource,
+  } = useSingleViewResource<{
+    id: number;
+    table_name?: string;
+    schema?: string | null;
+    catalog?: string | null;
+    sql?: string | null;
+    is_sqllab_view?: boolean;
+    database?: { database_name?: string };
+  }>('dataset', t('dataset'), noopErrorHandler);
+
+  useEffect(() => {
+    const datasetId = Number(id);
+    if (!Number.isNaN(datasetId)) {
+      fetchResource(datasetId);
+    }
+    // `fetchResource` is stable (noopErrorHandler keeps its identity fixed);
+    // fetch only when the id changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  useEffect(() => {
+    if (!datasetResource) return undefined;
+    setCurrentDataset({
+      datasetId: datasetResource.id,
+      datasetName: datasetResource.table_name ?? String(datasetResource.id),
+      schema: datasetResource.schema ?? null,
+      catalog: datasetResource.catalog ?? null,
+      databaseName: datasetResource.database?.database_name ?? null,
+      isVirtual:
+        Boolean(datasetResource.sql) || !!datasetResource.is_sqllab_view,
+    });
+    return () => setCurrentDataset(undefined);
+  }, [datasetResource]);
 
   const usageTab = (
     <TabStyles>

--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -252,9 +252,7 @@ describe('RoleListEditModal', () => {
     const mockGet = SupersetClient.get as jest.Mock;
     mockGet.mockImplementation(({ endpoint }) => {
       if (
-        endpoint?.includes(
-          `/api/v1/security/roles/${mockRole.id}/permissions/`,
-        )
+        endpoint?.includes(`/api/v1/security/roles/${mockRole.id}/permissions/`)
       ) {
         // Only return permission id=10, not id=20
         return Promise.resolve({
@@ -298,9 +296,7 @@ describe('RoleListEditModal', () => {
     const mockGet = SupersetClient.get as jest.Mock;
     mockGet.mockImplementation(({ endpoint }) => {
       if (
-        endpoint?.includes(
-          `/api/v1/security/roles/${mockRole.id}/permissions/`,
-        )
+        endpoint?.includes(`/api/v1/security/roles/${mockRole.id}/permissions/`)
       ) {
         return Promise.reject(new Error('network error'));
       }
@@ -371,7 +367,9 @@ describe('RoleListEditModal', () => {
     };
 
     mockGet.mockImplementation(({ endpoint }) => {
-      if (endpoint?.includes(`/api/v1/security/roles/${roleA.id}/permissions/`)) {
+      if (
+        endpoint?.includes(`/api/v1/security/roles/${roleA.id}/permissions/`)
+      ) {
         return Promise.resolve({
           json: {
             result: roleA.permission_ids.map(pid => ({
@@ -382,7 +380,9 @@ describe('RoleListEditModal', () => {
           },
         });
       }
-      if (endpoint?.includes(`/api/v1/security/roles/${roleB.id}/permissions/`)) {
+      if (
+        endpoint?.includes(`/api/v1/security/roles/${roleB.id}/permissions/`)
+      ) {
         return Promise.resolve({
           json: {
             result: roleB.permission_ids.map(pid => ({

--- a/superset-frontend/src/middleware/loggerMiddleware.ts
+++ b/superset-frontend/src/middleware/loggerMiddleware.ts
@@ -33,7 +33,12 @@ import { ensureAppRoot } from '../utils/pathUtils';
 import type { DashboardInfo, DashboardLayoutState } from '../dashboard/types';
 import type { QueryEditor } from '../SqlLab/types';
 
-type LogEventSource = 'dashboard' | 'embedded_dashboard' | 'explore' | 'sqlLab' | 'slice';
+type LogEventSource =
+  | 'dashboard'
+  | 'embedded_dashboard'
+  | 'explore'
+  | 'sqlLab'
+  | 'slice';
 
 interface LogEventData {
   source?: LogEventSource;

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -38,6 +38,7 @@ import { Logger, LOG_ACTIONS_SPA_NAVIGATION } from 'src/logger/LogUtils';
 import setupCodeOverrides from 'src/setup/setupCodeOverrides';
 import { logEvent } from 'src/logger/actions';
 import { store } from 'src/views/store';
+import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
 import ExtensionsStartup from 'src/extensions/ExtensionsStartup';
 import ChatbotMount from 'src/components/ChatbotMount';
 import { RootContextProviders } from './RootContextProviders';
@@ -119,7 +120,7 @@ const App = () => (
           loaded and registered, but outside the Switch so the bubble persists
           across route changes (SIP §3.2).
         */}
-        <ChatbotMount />
+        {isFeatureEnabled(FeatureFlag.EnableExtensions) && <ChatbotMount />}
       </ExtensionsStartup>
       <ToastContainer />
     </RootContextProviders>

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -39,6 +39,7 @@ import setupCodeOverrides from 'src/setup/setupCodeOverrides';
 import { logEvent } from 'src/logger/actions';
 import { store } from 'src/views/store';
 import ExtensionsStartup from 'src/extensions/ExtensionsStartup';
+import ChatbotMount from 'src/components/ChatbotMount';
 import { RootContextProviders } from './RootContextProviders';
 import { ScrollToTop } from './ScrollToTop';
 
@@ -112,6 +113,13 @@ const App = () => (
             </Route>
           ))}
         </Switch>
+        {/*
+          The singleton chatbot bubble. Rendered as a sibling of the route
+          Switch — inside ExtensionsStartup so chatbot extensions have been
+          loaded and registered, but outside the Switch so the bubble persists
+          across route changes (SIP §3.2).
+        */}
+        <ChatbotMount />
       </ExtensionsStartup>
       <ToastContainer />
     </RootContextProviders>

--- a/superset/commands/extension/__init__.py
+++ b/superset/commands/extension/__init__.py
@@ -14,6 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset.extensions import models as extensions_models  # noqa: F401
-
-from . import core, dynamic_plugins, sql_lab, user_attributes  # noqa: F401

--- a/superset/commands/extension/settings/__init__.py
+++ b/superset/commands/extension/settings/__init__.py
@@ -14,6 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset.extensions import models as extensions_models  # noqa: F401
-
-from . import core, dynamic_plugins, sql_lab, user_attributes  # noqa: F401

--- a/superset/commands/extension/settings/exceptions.py
+++ b/superset/commands/extension/settings/exceptions.py
@@ -14,6 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset.extensions import models as extensions_models  # noqa: F401
+from flask_babel import lazy_gettext as _
 
-from . import core, dynamic_plugins, sql_lab, user_attributes  # noqa: F401
+from superset.commands.exceptions import CommandInvalidError, UpdateFailedError
+
+
+class ExtensionSettingsInvalidError(CommandInvalidError):
+    message = _("Extension settings parameters are invalid.")
+
+
+class ExtensionSettingsUpdateFailedError(UpdateFailedError):
+    message = _("Extension settings could not be updated.")

--- a/superset/commands/extension/settings/get.py
+++ b/superset/commands/extension/settings/get.py
@@ -14,6 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset.extensions import models as extensions_models  # noqa: F401
+from typing import Any
 
-from . import core, dynamic_plugins, sql_lab, user_attributes  # noqa: F401
+from superset.commands.base import BaseCommand
+from superset.daos.extension import get_extension_settings
+
+
+class GetExtensionSettingsCommand(BaseCommand):
+    def run(self) -> dict[str, Any]:
+        self.validate()
+        return get_extension_settings()
+
+    def validate(self) -> None:
+        return None

--- a/superset/commands/extension/settings/update.py
+++ b/superset/commands/extension/settings/update.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from functools import partial
+from typing import Any
+
+from superset.commands.base import BaseCommand
+from superset.commands.extension.settings.exceptions import (
+    ExtensionSettingsUpdateFailedError,
+)
+from superset.daos.extension import (
+    ExtensionEnabledDAO,
+    ExtensionSettingsDAO,
+    get_extension_settings,
+)
+from superset.utils.decorators import on_error, transaction
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateExtensionSettingsCommand(BaseCommand):
+    """Apply a partial update to global extension admin settings.
+
+    The body is the already-validated output of ``ExtensionSettingsPutSchema``
+    and may contain:
+    * active_chatbot_id: str | None — empty string is normalised to None.
+    * enabled: dict[str, bool] — per-extension toggle map.
+
+    Keys not present in the body are left untouched.
+    """
+
+    def __init__(self, body: dict[str, Any]):
+        self._body = body or {}
+
+    @transaction(
+        on_error=partial(on_error, reraise=ExtensionSettingsUpdateFailedError),
+    )
+    def run(self) -> dict[str, Any]:
+        if "active_chatbot_id" in self._body:
+            value = self._body["active_chatbot_id"]
+            active_chatbot_id = str(value) if value else None
+            ExtensionSettingsDAO.upsert_active_chatbot_id(active_chatbot_id)
+
+        enabled = self._body.get("enabled")
+        if isinstance(enabled, dict):
+            for extension_id, value in enabled.items():
+                ExtensionEnabledDAO.upsert_enabled_flag(extension_id, value)
+
+        return get_extension_settings()
+
+    def validate(self) -> None:
+        # Request-shape validation is handled declaratively by
+        # ExtensionSettingsPutSchema at the route boundary.
+        pass

--- a/superset/daos/extension.py
+++ b/superset/daos/extension.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any
+
+from superset import db
+from superset.daos.base import BaseDAO
+from superset.extensions.models import ExtensionEnabled, ExtensionSettings
+
+# The global extension settings live in a single row; id is fixed so the row
+# can be fetched and upserted without a secondary lookup.
+SETTINGS_ROW_ID = 1
+
+
+class ExtensionSettingsDAO(BaseDAO[ExtensionSettings]):
+    """Persistence for the singleton global extension settings row.
+
+    The row (id=1) holds global admin state such as the active chatbot id.
+    Writes go through a check-then-write upsert that is dialect-agnostic;
+    callers wrap the operation in ``@transaction`` so the read-then-write
+    window is serialised and committed atomically.
+    """
+
+    @staticmethod
+    def get_settings_row() -> ExtensionSettings | None:
+        return db.session.get(ExtensionSettings, SETTINGS_ROW_ID)
+
+    @classmethod
+    def upsert_active_chatbot_id(cls, active_chatbot_id: str | None) -> None:
+        if row := cls.get_settings_row():
+            row.active_chatbot_id = active_chatbot_id
+        else:
+            cls.create(
+                attributes={
+                    "id": SETTINGS_ROW_ID,
+                    "active_chatbot_id": active_chatbot_id,
+                }
+            )
+
+
+class ExtensionEnabledDAO(BaseDAO[ExtensionEnabled]):
+    """Persistence for per-extension enabled flags."""
+
+    id_column_name = "extension_id"
+
+    @classmethod
+    def get_enabled_map(cls) -> dict[str, bool]:
+        return {row.extension_id: row.enabled for row in cls.find_all()}
+
+    @classmethod
+    def upsert_enabled_flag(cls, extension_id: str, enabled: bool) -> None:
+        if row := cls.find_by_id(extension_id):
+            row.enabled = enabled
+        else:
+            cls.create(attributes={"extension_id": extension_id, "enabled": enabled})
+
+
+def get_extension_settings() -> dict[str, Any]:
+    """Read-only view of the combined extension settings."""
+    row = ExtensionSettingsDAO.get_settings_row()
+    return {
+        "active_chatbot_id": row.active_chatbot_id if row else None,
+        "enabled": ExtensionEnabledDAO.get_enabled_map(),
+    }

--- a/superset/extensions/api.py
+++ b/superset/extensions/api.py
@@ -15,34 +15,65 @@
 # specific language governing permissions and limitations
 # under the License.
 import mimetypes
+import re
 from io import BytesIO
+from pathlib import Path
 from typing import Any
+from zipfile import is_zipfile, ZipFile
 
-from flask import send_file
+from flask import current_app, request, send_file
 from flask.wrappers import Response
-from flask_appbuilder.api import BaseApi, expose, protect, safe
+from flask_appbuilder.api import expose, protect, safe
+from marshmallow import ValidationError
 
+from superset.commands.extension.settings.get import GetExtensionSettingsCommand
+from superset.commands.extension.settings.update import (
+    UpdateExtensionSettingsCommand,
+)
+from superset.extensions import security_manager
+from superset.extensions.schemas import ExtensionSettingsPutSchema
 from superset.extensions.utils import (
     build_extension_data,
+    get_bundle_files_from_zip,
     get_extensions,
+    get_loaded_extension,
 )
+from superset.utils.core import check_is_safe_zip
+from superset.views.base_api import BaseSupersetApi
+
+# Allowlist for publisher and name path parameters — alphanumeric, hyphens,
+# underscores only. Rejects path-traversal attempts (../), URL-encoded slashes,
+# and any other characters that could escape EXTENSIONS_PATH.
+_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# Default 10 MB server-side upload limit; can be overridden via config.
+_DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 
 
-class ExtensionsRestApi(BaseApi):
+def _validate_segment(value: str) -> bool:
+    """Return True if *value* is a safe publisher or name segment."""
+    return bool(_SEGMENT_RE.match(value))
+
+
+class ExtensionsRestApi(BaseSupersetApi):
     allow_browser_login = True
     resource_name = "extensions"
-
-    def response(self, status_code: int, **kwargs: Any) -> Response:
-        """Helper method to create JSON responses."""
-        from flask import jsonify
-
-        return jsonify(kwargs), status_code
-
-    def response_404(self) -> Response:
-        """Helper method to create 404 responses."""
-        from flask import jsonify
-
-        return jsonify({"message": "Not found"}), 404
+    # BaseSupersetApi already defaults csrf_exempt to False; kept explicit
+    # because these endpoints use cookie/session auth (allow_browser_login)
+    # and include state-changing routes (settings PUT, upload POST, delete).
+    csrf_exempt = False
+    class_permission_name = "Extensions"
+    base_permissions = [
+        "can_get_list",
+        "can_get",
+        "can_put",
+        "can_post",
+        "can_delete",
+        "can_content",
+        "can_info",
+        "can_get_settings",
+        "can_put_settings",
+    ]
 
     @expose("/_info", methods=("GET",))
     @protect()
@@ -158,7 +189,8 @@ class ExtensionsRestApi(BaseApi):
             500:
               $ref: '#/components/responses/500'
         """
-        # Reconstruct composite ID from publisher and name
+        if not _validate_segment(publisher) or not _validate_segment(name):
+            return self.response(400, message="Invalid publisher or name.")
         composite_id = f"{publisher}.{name}"
         extensions = get_extensions()
         extension = extensions.get(composite_id)
@@ -166,6 +198,259 @@ class ExtensionsRestApi(BaseApi):
             return self.response_404()
         extension_data = build_extension_data(extension)
         return self.response(200, result=extension_data)
+
+    @protect()
+    @safe
+    @expose("/", methods=("POST",))
+    def post(self, **kwargs: Any) -> Response:
+        """Upload and install an extension bundle (.supx file).
+        ---
+        post:
+          summary: Upload a .supx extension bundle.
+          requestBody:
+            required: true
+            content:
+              multipart/form-data:
+                schema:
+                  type: object
+                  properties:
+                    bundle:
+                      type: string
+                      format: binary
+                      description: The .supx extension bundle file.
+          responses:
+            201:
+              description: Extension installed successfully.
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        if not security_manager.is_admin():
+            return self.response(403, message="Admin access required.")
+
+        extensions_path = current_app.config.get("EXTENSIONS_PATH")
+        if not extensions_path:
+            return self.response(
+                400,
+                message=(
+                    "EXTENSIONS_PATH is not configured. Set it in superset_config.py "
+                    "to enable extension uploads."
+                ),
+            )
+
+        upload = request.files.get("bundle")
+        if not upload:
+            return self.response(
+                400, message="No file provided. Send a 'bundle' field."
+            )
+
+        if not upload.filename or not upload.filename.endswith(".supx"):
+            return self.response(400, message="File must have a .supx extension.")
+
+        max_bytes: int = current_app.config.get(
+            "EXTENSIONS_MAX_UPLOAD_SIZE", _DEFAULT_MAX_UPLOAD_BYTES
+        )
+        raw = upload.read(max_bytes + 1)
+        if len(raw) > max_bytes:
+            return self.response(
+                400,
+                message=(
+                    f"File exceeds the maximum allowed size of {max_bytes} bytes."
+                ),
+            )
+
+        stream = BytesIO(raw)
+        if not is_zipfile(stream):
+            return self.response(400, message="File is not a valid ZIP archive.")
+
+        stream.seek(0)
+        try:
+            with ZipFile(stream, "r") as zip_file:
+                check_is_safe_zip(zip_file)
+                files = list(get_bundle_files_from_zip(zip_file))
+                extension = get_loaded_extension(files, source_base_path="upload://")
+        except Exception as ex:  # pylint: disable=broad-except
+            return self.response(400, message=f"Invalid extension bundle: {ex}")
+
+        # Validate the manifest id before using it as a filename component.
+        # The id is publisher.name (e.g. "acme.chatbot"); each segment must pass
+        # _validate_segment so a crafted bundle cannot write outside EXTENSIONS_PATH
+        # even though the admin is trusted — defence-in-depth against third-party
+        # bundles the admin did not author.
+        manifest_id: str = extension.manifest.id
+        id_parts = manifest_id.split(".", 1)
+        if len(id_parts) != 2 or not all(  # noqa: PLR2004
+            _validate_segment(p) for p in id_parts
+        ):
+            return self.response(
+                400,
+                message=(
+                    f"Invalid extension id '{manifest_id}' in manifest. "
+                    "Expected '<publisher>.<name>' with alphanumeric, hyphen, "
+                    "or underscore characters only."
+                ),
+            )
+
+        # Reject bundles whose manifest id collides with a LOCAL_EXTENSIONS entry.
+        local_ids = {
+            Path(p).name for p in current_app.config.get("LOCAL_EXTENSIONS", [])
+        }
+        if manifest_id in local_ids:
+            return self.response(
+                409,
+                message=(
+                    f"Extension '{manifest_id}' is already installed as a "
+                    "local extension. Remove it from LOCAL_EXTENSIONS before uploading."
+                ),
+            )
+
+        # Persist to EXTENSIONS_PATH so the extension survives restarts.
+        # Destination filename is built from the validated manifest id, not from the
+        # uploaded filename, so neither can escape EXTENSIONS_PATH.
+        dest_dir = Path(extensions_path)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest_file = dest_dir / f"{manifest_id}.supx"
+
+        stream.seek(0)
+        dest_file.write_bytes(stream.read())
+
+        return self.response(201, result=build_extension_data(extension))
+
+    @protect()
+    @safe
+    @expose("/<publisher>/<name>", methods=("DELETE",))
+    def delete(self, publisher: str, name: str, **kwargs: Any) -> Response:
+        """Delete an uploaded extension bundle.
+        ---
+        delete:
+          summary: Delete an extension by its publisher and name.
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: publisher
+          - in: path
+            schema:
+              type: string
+            name: name
+          responses:
+            200:
+              description: Extension deleted.
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+        """
+        if not security_manager.is_admin():
+            return self.response(403, message="Admin access required.")
+
+        if not _validate_segment(publisher) or not _validate_segment(name):
+            return self.response(400, message="Invalid publisher or name.")
+
+        composite_id = f"{publisher}.{name}"
+        extensions = get_extensions()
+        extension = extensions.get(composite_id)
+        if not extension:
+            return self.response_404()
+
+        # LOCAL_EXTENSIONS are managed via config — cannot be deleted through the UI.
+        local_paths = {
+            str((Path(p) / "dist").resolve())
+            for p in current_app.config.get("LOCAL_EXTENSIONS", [])
+        }
+        if extension.source_base_path in local_paths:
+            return self.response(
+                400,
+                message=(
+                    "Local extensions configured via LOCAL_EXTENSIONS cannot be "
+                    "deleted through the UI. Remove them from your configuration."
+                ),
+            )
+
+        # Locate and remove the .supx file from EXTENSIONS_PATH.
+        extensions_path = current_app.config.get("EXTENSIONS_PATH")
+        if not extensions_path:
+            return self.response(
+                400,
+                message="EXTENSIONS_PATH is not configured; cannot remove bundle file.",
+            )
+
+        supx_file = Path(extensions_path) / f"{composite_id}.supx"
+        if not supx_file.exists():
+            return self.response_404()
+
+        supx_file.unlink()
+        return self.response(200, message="Extension deleted.")
+
+    @protect()
+    @safe
+    @expose("/settings", methods=("GET",))
+    def get_settings(self, **kwargs: Any) -> Response:
+        """Get global extension admin settings.
+
+        No admin gate here by design: authenticated non-admin users need these
+        settings so the ChatbotMount can read active_chatbot_id on every page.
+        ---
+        get:
+          summary: Get extension admin settings (active chatbot, enabled flags).
+          responses:
+            200:
+              description: Extension settings
+        """
+        return self.response(200, result=GetExtensionSettingsCommand().run())
+
+    @protect()
+    @safe
+    @expose("/settings", methods=("PUT",))
+    def put_settings(self, **kwargs: Any) -> Response:
+        """Update global extension admin settings.
+        ---
+        put:
+          summary: Update extension admin settings.
+          requestBody:
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    active_chatbot_id:
+                      type: string
+                      nullable: true
+                    enabled:
+                      type: object
+                      additionalProperties:
+                        type: boolean
+          responses:
+            200:
+              description: Updated settings
+            400:
+              $ref: '#/components/responses/400'
+            403:
+              $ref: '#/components/responses/403'
+        """
+        if not security_manager.is_admin():
+            return self.response(403, message="Admin access required.")
+        try:
+            body = ExtensionSettingsPutSchema().load(request.json or {})
+        except ValidationError as error:
+            return self.response(400, message=error.messages)
+        return self.response(200, result=UpdateExtensionSettingsCommand(body).run())
 
     @protect()
     @safe
@@ -210,7 +495,8 @@ class ExtensionsRestApi(BaseApi):
             500:
               $ref: '#/components/responses/500'
         """
-        # Reconstruct composite ID from publisher and name
+        if not _validate_segment(publisher) or not _validate_segment(name):
+            return self.response(400, message="Invalid publisher or name.")
         composite_id = f"{publisher}.{name}"
         extensions = get_extensions()
         extension = extensions.get(composite_id)

--- a/superset/extensions/models.py
+++ b/superset/extensions/models.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""SQLAlchemy models for extension settings persistence."""
+
+from flask_appbuilder import Model
+from sqlalchemy import Boolean, Column, Integer, String
+
+# Shared column length for extension/chatbot identifiers; reused by request
+# validation so oversized keys are rejected with a 400 before hitting the DB.
+EXTENSION_ID_MAX_LENGTH = 250
+
+
+class ExtensionSettings(Model):  # pylint: disable=too-few-public-methods
+    """Global admin settings for extensions (singleton row, id=1)."""
+
+    __tablename__ = "extension_settings"
+    id = Column(Integer, primary_key=True)
+    active_chatbot_id = Column(String(EXTENSION_ID_MAX_LENGTH), nullable=True)
+
+
+class ExtensionEnabled(Model):  # pylint: disable=too-few-public-methods
+    """Per-extension enable/disable flag."""
+
+    __tablename__ = "extension_enabled"
+    extension_id = Column(String(EXTENSION_ID_MAX_LENGTH), primary_key=True)
+    enabled = Column(Boolean, nullable=False, default=True)

--- a/superset/extensions/schemas.py
+++ b/superset/extensions/schemas.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Marshmallow schemas for the extensions REST API."""
+
+from marshmallow import fields, Schema
+from marshmallow.validate import Length
+
+from superset.extensions.models import EXTENSION_ID_MAX_LENGTH
+
+
+class ExtensionSettingsPutSchema(Schema):
+    """Validate the partial update body for the extension settings PUT route.
+
+    Both fields are optional so the update is a partial patch: keys absent from
+    the payload are left untouched. An empty-string ``active_chatbot_id`` is a
+    valid "clear" signal that the command normalises to ``None``.
+    """
+
+    active_chatbot_id = fields.String(
+        allow_none=True,
+        validate=Length(max=EXTENSION_ID_MAX_LENGTH),
+        metadata={"description": "Id of the chatbot to render, or null to clear."},
+    )
+    enabled = fields.Dict(
+        keys=fields.String(validate=Length(min=1, max=EXTENSION_ID_MAX_LENGTH)),
+        # Strict booleans: reject non-bool values (e.g. "yes") rather than
+        # coercing them, so a malformed toggle map is a 400, not a silent write.
+        values=fields.Boolean(truthy={True}, falsy={False}),
+        metadata={"description": "Per-extension enabled flags keyed by extension id."},
+    )

--- a/superset/extensions/utils.py
+++ b/superset/extensions/utils.py
@@ -232,12 +232,18 @@ def get_loaded_extension(
 
 def build_extension_data(extension: LoadedExtension) -> dict[str, Any]:
     manifest = extension.manifest
+    local_paths = {
+        str((Path(p) / "dist").resolve())
+        for p in current_app.config.get("LOCAL_EXTENSIONS", [])
+    }
     extension_data: dict[str, Any] = {
         "id": manifest.id,
+        "publisher": manifest.publisher,
         "name": extension.name,
         "version": extension.version,
         "description": manifest.description or "",
         "dependencies": manifest.dependencies,
+        "deletable": extension.source_base_path not in local_paths,
     }
     if manifest.frontend:
         frontend = manifest.frontend

--- a/superset/migrations/versions/2026-05-25_00-00_b2c3d4e5f6a7_add_extension_settings.py
+++ b/superset/migrations/versions/2026-05-25_00-00_b2c3d4e5f6a7_add_extension_settings.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add extension_settings table for chatbot admin selection and enable/disable.
+
+Revision ID: b2c3d4e5f6a7
+Revises: 33d7e0e21daa
+Create Date: 2026-05-25 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b2c3d4e5f6a7"
+down_revision = "33d7e0e21daa"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "extension_settings",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("active_chatbot_id", sa.String(250), nullable=True),
+    )
+    op.create_table(
+        "extension_enabled",
+        sa.Column("extension_id", sa.String(250), primary_key=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("extension_enabled")
+    op.drop_table("extension_settings")

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -118,6 +118,22 @@ class KeyValue(Model):  # pylint: disable=too-few-public-methods
     value = Column(utils.MediumText(), nullable=False)
 
 
+class ExtensionSettings(Model):  # pylint: disable=too-few-public-methods
+    """Global admin settings for extensions (singleton row, id=1)."""
+
+    __tablename__ = "extension_settings"
+    id = Column(Integer, primary_key=True)
+    active_chatbot_id = Column(String(250), nullable=True)
+
+
+class ExtensionEnabled(Model):  # pylint: disable=too-few-public-methods
+    """Per-extension enable/disable flag."""
+
+    __tablename__ = "extension_enabled"
+    extension_id = Column(String(250), primary_key=True)
+    enabled = Column(Boolean, nullable=False, default=True)
+
+
 class CssTemplate(AuditMixinNullable, UUIDMixin, Model):
     """CSS templates for dashboards"""
 

--- a/tests/unit_tests/extensions/test_api.py
+++ b/tests/unit_tests/extensions/test_api.py
@@ -1,0 +1,417 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for the extensions REST API (POST and DELETE endpoints)."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from superset.extensions.api import _validate_segment
+
+# The extension routes are only registered when ENABLE_EXTENSIONS is on at
+# app-init time, so the endpoint tests parametrize the app fixture to enable it
+# (otherwise the route is absent and requests 404).
+_ENABLE_EXTENSIONS = [{"FEATURE_FLAGS": {"ENABLE_EXTENSIONS": True}}]
+
+# ---------------------------------------------------------------------------
+# _validate_segment helper
+# ---------------------------------------------------------------------------
+
+
+def test_validate_segment_accepts_alphanumeric() -> None:
+    assert _validate_segment("acme") is True
+    assert _validate_segment("my-ext") is True
+    assert _validate_segment("my_ext") is True
+    assert _validate_segment("Ext123") is True
+
+
+def test_validate_segment_rejects_traversal() -> None:
+    assert _validate_segment("..") is False
+    assert _validate_segment("../etc") is False
+    assert _validate_segment("acme/bad") is False
+    assert _validate_segment("acme%2Fbad") is False
+    assert _validate_segment("") is False
+
+
+def test_validate_segment_rejects_dots() -> None:
+    assert _validate_segment("acme.corp") is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building fake .supx payloads
+# ---------------------------------------------------------------------------
+
+
+def _make_supx(manifest_id: str = "acme.chatbot") -> bytes:
+    """Return minimal valid .supx (zip) bytes with a manifest."""
+    buf = io.BytesIO()
+    manifest_json = (
+        f'{{"id": "{manifest_id}", "name": "Chatbot", "version": "1.0.0",'
+        f'"publisher": "acme", "description": "test"}}'
+    )
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", manifest_json)
+    return buf.getvalue()
+
+
+def _make_fake_extension(manifest_id: str = "acme.chatbot") -> MagicMock:
+    ext = MagicMock()
+    ext.manifest.id = manifest_id
+    ext.source_base_path = "upload://"
+    ext.frontend = {}
+    ext.backend = {}
+    ext.version = "1.0.0"
+    ext.name = "Chatbot"
+    return ext
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/extensions/ — upload and install
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("app", _ENABLE_EXTENSIONS, indirect=True)
+class TestPostEndpoint:
+    def _post(self, client: Any, data: dict[str, Any], full_api_access: None) -> Any:
+        return client.post(
+            "/api/v1/extensions/",
+            data=data,
+            content_type="multipart/form-data",
+        )
+
+    def test_non_admin_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=False
+        )
+        resp = client.post("/api/v1/extensions/", data={})
+        assert resp.status_code == 403
+
+    def test_missing_extensions_path_returns_400(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict("flask.current_app.config", {"EXTENSIONS_PATH": None})
+        resp = client.post("/api/v1/extensions/", data={})
+        assert resp.status_code == 400
+        assert "EXTENSIONS_PATH" in resp.json["message"]
+
+    def test_missing_bundle_field_returns_400(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config", {"EXTENSIONS_PATH": str(tmp_path)}
+        )
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "bundle" in resp.json["message"]
+
+    def test_wrong_extension_rejected(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config", {"EXTENSIONS_PATH": str(tmp_path)}
+        )
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(b"data"), "evil.zip")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert ".supx" in resp.json["message"]
+
+    def test_oversize_upload_rejected(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"EXTENSIONS_PATH": str(tmp_path), "EXTENSIONS_MAX_UPLOAD_SIZE": 10},
+        )
+        big = io.BytesIO(b"x" * 20)
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (big, "big.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "maximum" in resp.json["message"]
+
+    def test_not_a_zip_returns_400(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config", {"EXTENSIONS_PATH": str(tmp_path)}
+        )
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(b"not a zip"), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "ZIP" in resp.json["message"]
+
+    def test_zip_slip_rejected(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        """check_is_safe_zip raises on path-traversal entries inside the zip."""
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config", {"EXTENSIONS_PATH": str(tmp_path)}
+        )
+        mocker.patch(
+            "superset.extensions.api.check_is_safe_zip",
+            side_effect=Exception("zip-slip detected"),
+        )
+        supx = _make_supx()
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(supx), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "zip-slip" in resp.json["message"]
+
+    def test_local_extensions_collision_returns_409(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {
+                "EXTENSIONS_PATH": str(tmp_path),
+                "LOCAL_EXTENSIONS": ["/opt/superset/ext/acme.chatbot"],
+            },
+        )
+        fake_ext = _make_fake_extension("acme.chatbot")
+        mocker.patch(
+            "superset.extensions.api.get_bundle_files_from_zip", return_value=[]
+        )
+        mocker.patch(
+            "superset.extensions.api.get_loaded_extension", return_value=fake_ext
+        )
+        supx = _make_supx("acme.chatbot")
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(supx), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 409
+        assert "local extension" in resp.json["message"]
+
+    def test_hostile_manifest_id_rejected(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        """A crafted manifest.id with path traversal must not escape EXTENSIONS_PATH."""
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"EXTENSIONS_PATH": str(tmp_path), "LOCAL_EXTENSIONS": []},
+        )
+        fake_ext = _make_fake_extension("../../tmp/evil")
+        mocker.patch(
+            "superset.extensions.api.get_bundle_files_from_zip", return_value=[]
+        )
+        mocker.patch(
+            "superset.extensions.api.get_loaded_extension", return_value=fake_ext
+        )
+        supx = _make_supx("../../tmp/evil")
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(supx), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "Invalid extension id" in resp.json["message"]
+
+    def test_happy_path_returns_201(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"EXTENSIONS_PATH": str(tmp_path), "LOCAL_EXTENSIONS": []},
+        )
+        fake_ext = _make_fake_extension("acme.chatbot")
+        mocker.patch(
+            "superset.extensions.api.get_bundle_files_from_zip", return_value=[]
+        )
+        mocker.patch(
+            "superset.extensions.api.get_loaded_extension", return_value=fake_ext
+        )
+        mocker.patch(
+            "superset.extensions.api.build_extension_data",
+            return_value={"id": "acme.chatbot"},
+        )
+        supx = _make_supx("acme.chatbot")
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(supx), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        assert resp.json["result"]["id"] == "acme.chatbot"
+        assert (tmp_path / "acme.chatbot.supx").exists()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/extensions/<publisher>/<name>
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("app", _ENABLE_EXTENSIONS, indirect=True)
+class TestDeleteEndpoint:
+    def test_non_admin_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=False
+        )
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 403
+
+    def test_path_traversal_publisher_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        # Use percent-encoded dots so Flask routing passes the segment to the
+        # handler as the string ".." — literal slashes in the path would be
+        # intercepted by the router before reaching the view.
+        resp = client.delete("/api/v1/extensions/%2E%2E/passwd")
+        assert resp.status_code == 400
+        assert "Invalid" in resp.json["message"]
+
+    def test_invalid_name_returns_400(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        resp = client.delete("/api/v1/extensions/acme/bad.name")
+        assert resp.status_code == 400
+        assert "Invalid" in resp.json["message"]
+
+    def test_unknown_extension_returns_404(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch("superset.extensions.api.get_extensions", return_value={})
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 404
+
+    def test_local_extension_cannot_be_deleted(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        local_base = str(tmp_path / "local-ext" / "dist")
+        fake_ext = _make_fake_extension("acme.chatbot")
+        fake_ext.source_base_path = local_base
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.get_extensions",
+            return_value={"acme.chatbot": fake_ext},
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"LOCAL_EXTENSIONS": [str(tmp_path / "local-ext")]},
+        )
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 400
+        assert "LOCAL_EXTENSIONS" in resp.json["message"]
+
+    def test_happy_path_deletes_file(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        supx_file = tmp_path / "acme.chatbot.supx"
+        supx_file.write_bytes(b"fake")
+
+        fake_ext = _make_fake_extension("acme.chatbot")
+        fake_ext.source_base_path = "upload://"
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.get_extensions",
+            return_value={"acme.chatbot": fake_ext},
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {
+                "LOCAL_EXTENSIONS": [],
+                "EXTENSIONS_PATH": str(tmp_path),
+            },
+        )
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 200
+        assert not supx_file.exists()
+
+    def test_supx_file_missing_returns_404(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        fake_ext = _make_fake_extension("acme.chatbot")
+        fake_ext.source_base_path = "upload://"
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.get_extensions",
+            return_value={"acme.chatbot": fake_ext},
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"LOCAL_EXTENSIONS": [], "EXTENSIONS_PATH": str(tmp_path)},
+        )
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 404

--- a/tests/unit_tests/extensions/test_settings.py
+++ b/tests/unit_tests/extensions/test_settings.py
@@ -1,0 +1,371 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for extension settings persistence and the settings API endpoints.
+
+Persistence is exercised through the public Command + DAO layer:
+``UpdateExtensionSettingsCommand`` / ``GetExtensionSettingsCommand`` and the
+``ExtensionSettingsDAO`` / ``ExtensionEnabledDAO`` they delegate to.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Settings persistence (Command + DAO) — sqlite-backed round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetExtensionSettings:
+    def test_returns_defaults_when_no_rows(self, app_context: Any) -> None:
+        from superset.commands.extension.settings.get import (
+            GetExtensionSettingsCommand,
+        )
+
+        result = GetExtensionSettingsCommand().run()
+        assert result["active_chatbot_id"] is None
+        assert result["enabled"] == {}
+
+    def test_round_trips_active_chatbot_id(self, app_context: Any) -> None:
+        from superset.commands.extension.settings.get import (
+            GetExtensionSettingsCommand,
+        )
+        from superset.commands.extension.settings.update import (
+            UpdateExtensionSettingsCommand,
+        )
+
+        UpdateExtensionSettingsCommand({"active_chatbot_id": "acme.chatbot"}).run()
+        result = GetExtensionSettingsCommand().run()
+        assert result["active_chatbot_id"] == "acme.chatbot"
+
+    def test_round_trips_enabled_flags(self, app_context: Any) -> None:
+        from superset.commands.extension.settings.get import (
+            GetExtensionSettingsCommand,
+        )
+        from superset.commands.extension.settings.update import (
+            UpdateExtensionSettingsCommand,
+        )
+
+        UpdateExtensionSettingsCommand(
+            {"enabled": {"acme.chatbot": True, "acme.widget": False}}
+        ).run()
+        result = GetExtensionSettingsCommand().run()
+        assert result["enabled"]["acme.chatbot"] is True
+        assert result["enabled"]["acme.widget"] is False
+
+
+class TestUpdateExtensionSettings:
+    def test_empty_string_active_chatbot_id_stored_as_none(
+        self, app_context: Any
+    ) -> None:
+        from superset.commands.extension.settings.get import (
+            GetExtensionSettingsCommand,
+        )
+        from superset.commands.extension.settings.update import (
+            UpdateExtensionSettingsCommand,
+        )
+
+        # First set a value, then clear it via empty string.
+        UpdateExtensionSettingsCommand({"active_chatbot_id": "acme.chatbot"}).run()
+        UpdateExtensionSettingsCommand({"active_chatbot_id": ""}).run()
+        assert GetExtensionSettingsCommand().run()["active_chatbot_id"] is None
+
+    def test_enabled_flags_are_persisted(self, app_context: Any) -> None:
+        from superset.commands.extension.settings.get import (
+            GetExtensionSettingsCommand,
+        )
+        from superset.commands.extension.settings.update import (
+            UpdateExtensionSettingsCommand,
+        )
+
+        # The command trusts already-validated input (request-shape validation
+        # is the schema's job — see TestExtensionSettingsPutSchema), so a bool
+        # value is written through as-is.
+        UpdateExtensionSettingsCommand({"enabled": {"acme.persisted": False}}).run()
+        result = GetExtensionSettingsCommand().run()
+        assert result["enabled"]["acme.persisted"] is False
+
+    def test_upsert_overwrites_existing_chatbot(self, app_context: Any) -> None:
+        from superset.commands.extension.settings.get import (
+            GetExtensionSettingsCommand,
+        )
+        from superset.commands.extension.settings.update import (
+            UpdateExtensionSettingsCommand,
+        )
+
+        UpdateExtensionSettingsCommand({"active_chatbot_id": "acme.chatbot"}).run()
+        UpdateExtensionSettingsCommand({"active_chatbot_id": "vendor.bot"}).run()
+        assert GetExtensionSettingsCommand().run()["active_chatbot_id"] == "vendor.bot"
+
+    def test_upsert_overwrites_existing_enabled_flag(self, app_context: Any) -> None:
+        from superset.commands.extension.settings.get import (
+            GetExtensionSettingsCommand,
+        )
+        from superset.commands.extension.settings.update import (
+            UpdateExtensionSettingsCommand,
+        )
+
+        UpdateExtensionSettingsCommand({"enabled": {"acme.chatbot": True}}).run()
+        UpdateExtensionSettingsCommand({"enabled": {"acme.chatbot": False}}).run()
+        assert GetExtensionSettingsCommand().run()["enabled"]["acme.chatbot"] is False
+
+    def test_partial_update_leaves_other_keys_intact(self, app_context: Any) -> None:
+        from superset.commands.extension.settings.get import (
+            GetExtensionSettingsCommand,
+        )
+        from superset.commands.extension.settings.update import (
+            UpdateExtensionSettingsCommand,
+        )
+
+        UpdateExtensionSettingsCommand(
+            {"active_chatbot_id": "acme.chatbot", "enabled": {"acme.widget": True}}
+        ).run()
+        # Update only enabled — active_chatbot_id must survive.
+        UpdateExtensionSettingsCommand({"enabled": {"acme.widget": False}}).run()
+        result = GetExtensionSettingsCommand().run()
+        assert result["active_chatbot_id"] == "acme.chatbot"
+        assert result["enabled"]["acme.widget"] is False
+
+    def test_returns_current_state(self, app_context: Any) -> None:
+        from superset.commands.extension.settings.update import (
+            UpdateExtensionSettingsCommand,
+        )
+
+        result = UpdateExtensionSettingsCommand(
+            {"active_chatbot_id": "acme.chatbot"}
+        ).run()
+        assert result["active_chatbot_id"] == "acme.chatbot"
+
+
+class TestExtensionSettingsPutSchema:
+    """Request-shape validation now lives in ExtensionSettingsPutSchema."""
+
+    def test_non_string_active_chatbot_id_raises(self, app_context: Any) -> None:
+        from marshmallow import ValidationError
+
+        from superset.extensions.schemas import ExtensionSettingsPutSchema
+
+        with pytest.raises(ValidationError):
+            ExtensionSettingsPutSchema().load({"active_chatbot_id": 123})
+
+    def test_oversized_active_chatbot_id_raises(self, app_context: Any) -> None:
+        from marshmallow import ValidationError
+
+        from superset.extensions.models import EXTENSION_ID_MAX_LENGTH
+        from superset.extensions.schemas import ExtensionSettingsPutSchema
+
+        with pytest.raises(ValidationError):
+            ExtensionSettingsPutSchema().load(
+                {"active_chatbot_id": "x" * (EXTENSION_ID_MAX_LENGTH + 1)}
+            )
+
+    def test_oversized_enabled_key_raises(self, app_context: Any) -> None:
+        from marshmallow import ValidationError
+
+        from superset.extensions.models import EXTENSION_ID_MAX_LENGTH
+        from superset.extensions.schemas import ExtensionSettingsPutSchema
+
+        with pytest.raises(ValidationError):
+            ExtensionSettingsPutSchema().load(
+                {"enabled": {"x" * (EXTENSION_ID_MAX_LENGTH + 1): True}}
+            )
+
+    def test_non_bool_enabled_value_raises(self, app_context: Any) -> None:
+        from marshmallow import ValidationError
+
+        from superset.extensions.schemas import ExtensionSettingsPutSchema
+
+        with pytest.raises(ValidationError):
+            ExtensionSettingsPutSchema().load({"enabled": {"acme.ext": "yes"}})
+
+    def test_null_active_chatbot_id_is_valid(self, app_context: Any) -> None:
+        from superset.extensions.schemas import ExtensionSettingsPutSchema
+
+        loaded = ExtensionSettingsPutSchema().load({"active_chatbot_id": None})
+        assert loaded["active_chatbot_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/extensions/settings
+# ---------------------------------------------------------------------------
+
+# The settings routes are only registered when ENABLE_EXTENSIONS is on at
+# app-init time, so the endpoint tests parametrize the app fixture to enable it
+# (otherwise the route is absent and requests 404).
+_ENABLE_EXTENSIONS = [{"FEATURE_FLAGS": {"ENABLE_EXTENSIONS": True}}]
+
+
+@pytest.mark.parametrize("app", _ENABLE_EXTENSIONS, indirect=True)
+class TestGetSettingsEndpoint:
+    def test_authenticated_user_can_read(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.GetExtensionSettingsCommand.run",
+            return_value={"active_chatbot_id": None, "enabled": {}},
+        )
+        resp = client.get("/api/v1/extensions/settings")
+        assert resp.status_code == 200
+        assert resp.json["result"]["active_chatbot_id"] is None
+
+    def test_returns_active_chatbot_and_enabled_map(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.GetExtensionSettingsCommand.run",
+            return_value={
+                "active_chatbot_id": "acme.chatbot",
+                "enabled": {"acme.chatbot": True},
+            },
+        )
+        resp = client.get("/api/v1/extensions/settings")
+        assert resp.status_code == 200
+        assert resp.json["result"]["active_chatbot_id"] == "acme.chatbot"
+        assert resp.json["result"]["enabled"]["acme.chatbot"] is True
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/v1/extensions/settings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("app", _ENABLE_EXTENSIONS, indirect=True)
+class TestPutSettingsEndpoint:
+    def test_non_admin_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=False
+        )
+        resp = client.put(
+            "/api/v1/extensions/settings",
+            json={"active_chatbot_id": "acme.chatbot"},
+        )
+        assert resp.status_code == 403
+
+    def test_admin_can_update_active_chatbot(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.UpdateExtensionSettingsCommand.run",
+            return_value={"active_chatbot_id": "acme.chatbot", "enabled": {}},
+        )
+        resp = client.put(
+            "/api/v1/extensions/settings",
+            json={"active_chatbot_id": "acme.chatbot"},
+        )
+        assert resp.status_code == 200
+        assert resp.json["result"]["active_chatbot_id"] == "acme.chatbot"
+
+    def test_empty_body_is_accepted(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.UpdateExtensionSettingsCommand.run",
+            return_value={"active_chatbot_id": None, "enabled": {}},
+        )
+        resp = client.put("/api/v1/extensions/settings", json={})
+        assert resp.status_code == 200
+
+    def test_non_object_body_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        run = mocker.patch(
+            "superset.extensions.api.UpdateExtensionSettingsCommand.run",
+        )
+        resp = client.put("/api/v1/extensions/settings", json=["not", "an", "object"])
+        assert resp.status_code == 400
+        run.assert_not_called()
+
+    def test_non_string_active_chatbot_id_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        run = mocker.patch(
+            "superset.extensions.api.UpdateExtensionSettingsCommand.run",
+        )
+        # An int must be rejected with a 400, not silently coerced to null.
+        resp = client.put(
+            "/api/v1/extensions/settings", json={"active_chatbot_id": 123}
+        )
+        assert resp.status_code == 400
+        run.assert_not_called()
+
+    def test_null_active_chatbot_id_is_accepted(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.UpdateExtensionSettingsCommand.run",
+            return_value={"active_chatbot_id": None, "enabled": {}},
+        )
+        resp = client.put(
+            "/api/v1/extensions/settings", json={"active_chatbot_id": None}
+        )
+        assert resp.status_code == 200
+
+    def test_oversized_active_chatbot_id_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        from superset.extensions.models import EXTENSION_ID_MAX_LENGTH
+
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        run = mocker.patch(
+            "superset.extensions.api.UpdateExtensionSettingsCommand.run",
+        )
+        resp = client.put(
+            "/api/v1/extensions/settings",
+            json={"active_chatbot_id": "x" * (EXTENSION_ID_MAX_LENGTH + 1)},
+        )
+        assert resp.status_code == 400
+        run.assert_not_called()
+
+    def test_oversized_enabled_key_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        from superset.extensions.models import EXTENSION_ID_MAX_LENGTH
+
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        run = mocker.patch(
+            "superset.extensions.api.UpdateExtensionSettingsCommand.run",
+        )
+        resp = client.put(
+            "/api/v1/extensions/settings",
+            json={"enabled": {"x" * (EXTENSION_ID_MAX_LENGTH + 1): True}},
+        )
+        assert resp.status_code == 400
+        run.assert_not_called()


### PR DESCRIPTION
### SUMMARY

Wires extension bundles into app-shell startup so contributions register before the user reaches the first route, and defines the host contract for tearing those contributions down.

**What this introduces:**
- `ExtensionsStartup` — mounts at the app-shell root; once the session is confirmed and behind `FeatureFlag.EnableExtensions`, it triggers `ExtensionsLoader.initializeExtensions()` in the background. The host renders immediately; the chatbot mount re-resolves reactively when registrations land (no route change needed).
- `window.superset` is populated on first mount with the host namespaces available at this layer (`authentication`, `core`, `commands`, `editors`, `extensions`, `menus`, `sqlLab`, `views`). The per-surface context namespaces (`dashboard`, `explore`, `navigation`, `dataset`) are added by the context-sharing PR (#40444).
- **Extension lifecycle / teardown contract:** extensions export `activate(context)` and push each contribution's `Disposable` onto `context.subscriptions`; `ExtensionsLoader.deactivateExtension(id)` disposes them all and removes the extension from the index. Because lifetime is bound to the `context` object (not a synchronous window), registrations made asynchronously inside `activate` are tracked too. A legacy fallback wraps the registrars to collect synchronous side-effect registrations.
- On bundle-load failure: a danger toast, the host stays interactive, the chatbot corner stays empty. A global `unhandledrejection` listener logs extension-originated rejections without suppressing the browser default.

**Stack:**
1. [Contribution point](https://github.com/apache/superset/pull/40439)
2. [Host resolution & mount](https://github.com/apache/superset/pull/40440) ← merged first
3. **This PR** — eager loading at startup + lifecycle/teardown
4. [Admin configuration UI](https://github.com/apache/superset/pull/40442)
5. [Backend settings persistence & permissions](https://github.com/apache/superset/pull/40443)
6. [Context sharing namespaces](https://github.com/apache/superset/pull/40444)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — infrastructure only.

### TESTING INSTRUCTIONS

1. Add a chatbot extension URL to the extensions config.
2. Reload the app — the chatbot bubble should appear without a full page reload or manual trigger.
3. Deactivate the extension and verify its contributions are disposed (the bubble unmounts, no leftover registrations).
4. Verify a failed bundle load shows a danger toast and the host stays interactive (corner empty).
5. Verify unhandled rejections from extension code are logged without breaking the host.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
