### PR TITLE
fix(mcp): prevent encoding error on tools/list when middleware raises

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -219,7 +219,7 @@ docstring-parser==0.17.0
     # via cyclopts
 docutils==0.22.2
     # via rich-rst
-duckdb==1.4.2
+duckdb==1.5.3
     # via
     #   apache-superset
     #   duckdb-engine

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -219,7 +219,7 @@ docstring-parser==0.17.0
     # via cyclopts
 docutils==0.22.2
     # via rich-rst
-duckdb==1.5.3
+duckdb==1.4.2
     # via
     #   apache-superset
     #   duckdb-engine

--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -31,6 +31,7 @@ PATTERNS = {
         r"^superset/",
         r"^scripts/",
         r"^setup\.py",
+        r"^pyproject\.toml$",
         r"^requirements/.+\.txt",
         r"^.pylintrc",
     ],

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -388,7 +388,14 @@ class StructuredContentStripperMiddleware(Middleware):
         context: MiddlewareContext[mt.ListToolsRequest],
         call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
     ) -> Sequence[Tool]:
-        tools = await call_next(context)
+        try:
+            tools = await call_next(context)
+        except Exception:
+            # ToolError raised by inner middleware (e.g. GlobalErrorHandlerMiddleware)
+            # cannot be encoded by the MCP SDK in a tools/list response — it expects a
+            # list, not an error object — causing "encoding without a string argument".
+            # Return an empty list; GlobalErrorHandlerMiddleware already logged it.
+            return []
         return [
             t.model_copy(update={"output_schema": None})
             if t.output_schema is not None

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -435,3 +435,31 @@ class TestMiddlewareChainOrder:
         assert result.meta is not None
         assert "mcp_call_id" in result.meta
         assert len(result.meta["mcp_call_id"]) == 32
+
+    @pytest.mark.asyncio
+    async def test_list_tools_exception_returns_empty_list(self):
+        """Exception during tools/list returns [] instead of causing encoding error.
+
+        ToolError raised by GlobalErrorHandlerMiddleware cannot be encoded
+        by the MCP SDK in a tools/list response, producing "encoding without
+        a string argument". StructuredContentStripperMiddleware.on_list_tools
+        must catch it and return an empty list.
+        """
+        from superset.mcp_service.server import build_middleware_list
+
+        middleware_list = build_middleware_list()
+
+        async def failing_list_tools(context: Any) -> Any:
+            raise ValueError("auth failed")
+
+        chain = failing_list_tools
+        for mw in reversed(middleware_list):
+            chain = partial(mw, call_next=chain)
+
+        ctx = _make_context(method="tools/list", name="")
+        result = await chain(ctx)
+
+        assert result == [], (
+            "on_list_tools must return [] on exception — "
+            "ToolError cannot be encoded in a tools/list response."
+        )


### PR DESCRIPTION
## Summary

`StructuredContentStripperMiddleware.on_list_tools` had no exception handling. When inner middleware raises `ToolError`, it propagated to the MCP SDK layer which cannot encode a `ToolError` as a `tools/list` response — producing the cryptic `"encoding without a string argument"` error visible to Claude.ai users across **all** MCP tools simultaneously.

Fix: wrap the `call_next` call in `on_list_tools` with try/except and return `[]` on any exception. `GlobalErrorHandlerMiddleware` already logs and records event_logger entries for the underlying error, so no observability is lost.

Note: `on_call_tool` already had this protection — `on_list_tools` was the remaining unguarded path.

## Changes

- `superset/mcp_service/middleware.py` — add try/except to `StructuredContentStripperMiddleware.on_list_tools`, return `[]` on exception
- `tests/unit_tests/mcp_service/test_middleware_logging.py` — new test `test_list_tools_exception_returns_empty_list` exercises the full middleware chain

## Testing

All 15 middleware tests pass including the new one.

```
pytest tests/unit_tests/mcp_service/test_middleware_logging.py -v
# 15 passed in 0.80s
```