### PR TITLE
feat(extensions): import/delete UI and default chatbot selection in ExtensionsList

### DIFF
--- a/scripts/oxlint.sh
+++ b/scripts/oxlint.sh
@@ -55,7 +55,7 @@ if [ ${#js_ts_files[@]} -gt 0 ]; then
     echo "$output" >&2
     exit 1
   }
-  if [ -n "$output" ]; then echo "$output"; fi
+  [ -n "$output" ] && echo "$output"
 else
   echo "No JavaScript/TypeScript files to lint"
 fi

--- a/scripts/oxlint.sh
+++ b/scripts/oxlint.sh
@@ -55,7 +55,7 @@ if [ ${#js_ts_files[@]} -gt 0 ]; then
     echo "$output" >&2
     exit 1
   }
-  [ -n "$output" ] && echo "$output"
+  if [ -n "$output" ]; then echo "$output"; fi
 else
   echo "No JavaScript/TypeScript files to lint"
 fi

--- a/superset-frontend/src/extensions/ExtensionsList.test.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.test.tsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 import userEvent from '@testing-library/user-event';
-import { fireEvent, render, screen, waitFor, within } from 'spec/helpers/testing-library';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from 'spec/helpers/testing-library';
 import { SupersetClient } from '@superset-ui/core';
 import ExtensionsList from './ExtensionsList';
 
@@ -36,7 +42,9 @@ jest.mock('src/components', () => ({
         {(data ?? []).map((row: any) =>
           columns.map((col: any) => (
             <td key={`${row.id}-${col.id}`}>
-              {col.Cell ? col.Cell({ row: { original: row } }) : row[col.accessor]}
+              {col.Cell
+                ? col.Cell({ row: { original: row } })
+                : row[col.accessor]}
             </td>
           )),
         )}
@@ -195,7 +203,9 @@ test('clicking delete opens confirmation dialog', async () => {
   await userEvent.click(screen.getByTestId('delete-extension'));
 
   await waitFor(() => {
-    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/are you sure you want to delete/i),
+    ).toBeInTheDocument();
   });
 });
 
@@ -263,7 +273,9 @@ test('pressing Enter on star span triggers set-default action', async () => {
   renderList();
   await waitFor(() => screen.getByText('chatbot'));
 
-  fireEvent.keyDown(screen.getByTestId('set-default-chatbot'), { key: 'Enter' });
+  fireEvent.keyDown(screen.getByTestId('set-default-chatbot'), {
+    key: 'Enter',
+  });
 
   await waitFor(() => {
     expect(mockPut).toHaveBeenCalled();
@@ -277,9 +289,7 @@ test('uploading a non-.supx file shows danger toast without calling API', async 
   const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
   uploadFile(input, new File(['x'], 'evil.zip', { type: 'application/zip' }));
 
-  expect(addDangerToast).toHaveBeenCalledWith(
-    expect.stringMatching(/\.supx/i),
-  );
+  expect(addDangerToast).toHaveBeenCalledWith(expect.stringMatching(/\.supx/i));
   expect(mockPost).not.toHaveBeenCalled();
 });
 
@@ -288,7 +298,10 @@ test('uploading a .supx file calls POST endpoint and refreshes list', async () =
   renderList();
 
   const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
-  uploadFile(input, new File(['PK'], 'my.supx', { type: 'application/octet-stream' }));
+  uploadFile(
+    input,
+    new File(['PK'], 'my.supx', { type: 'application/octet-stream' }),
+  );
 
   await waitFor(() => {
     expect(mockPost).toHaveBeenCalledWith(

--- a/superset-frontend/src/extensions/ExtensionsList.test.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.test.tsx
@@ -16,73 +16,268 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, waitFor } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen, waitFor, within } from 'spec/helpers/testing-library';
+import { SupersetClient } from '@superset-ui/core';
 import ExtensionsList from './ExtensionsList';
-import fetchMock from 'fetch-mock';
 
-beforeAll(() => fetchMock.unmockGlobal());
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
 
-// Mock initial state for the store
-const mockInitialState = {
-  extensions: {
-    loading: false,
-    resourceCount: 2,
-    resourceCollection: [
-      {
-        id: 1,
-        name: 'Test Extension 1',
-        enabled: true,
-      },
-      {
-        id: 2,
-        name: 'Test Extension 2',
-        enabled: false,
-      },
-    ],
-    bulkSelectEnabled: false,
-  },
-};
+jest.mock('src/views/CRUD/hooks', () => ({
+  useListViewResource: jest.fn(),
+}));
+
+jest.mock('src/components', () => ({
+  ListView: ({ columns, data }: any) => (
+    <table>
+      <tbody>
+        {(data ?? []).map((row: any) =>
+          columns.map((col: any) => (
+            <td key={`${row.id}-${col.id}`}>
+              {col.Cell ? col.Cell({ row: { original: row } }) : row[col.accessor]}
+            </td>
+          )),
+        )}
+      </tbody>
+    </table>
+  ),
+}));
+
+// Stub SubMenu so tests aren't coupled to the navigation menu rendering chain.
+jest.mock('src/features/home/SubMenu', () => ({
+  __esModule: true,
+  default: ({ buttons }: any) => (
+    <div data-test="submenu">
+      {(buttons ?? []).map((btn: any, i: number) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <button key={i} type="button" onClick={btn.onClick}>
+          {btn.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+// withToasts is the outermost HOC — pass through so callers can inject toast fns.
+jest.mock('src/components/MessageToasts/withToasts', () => (C: any) => C);
+
+
+jest.mock('src/core/views', () => ({
+  getRegisteredViewIds: jest.fn(() => []),
+  subscribeToLocation: jest.fn(() => () => undefined),
+}));
+
+jest.mock('src/core/extensions', () => ({
+  notifyExtensionSettingsChanged: jest.fn(),
+}));
+
+jest.mock('@superset-ui/core', () => {
+  const actual = jest.requireActual('@superset-ui/core');
+  return {
+    ...actual,
+    SupersetClient: {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const { useListViewResource } = jest.requireMock('src/views/CRUD/hooks');
+const mockGet = SupersetClient.get as jest.Mock;
+const mockPost = SupersetClient.post as jest.Mock;
+const mockPut = SupersetClient.put as jest.Mock;
+const mockDelete = SupersetClient.delete as jest.Mock;
+
+const EXTENSIONS = [
+  { id: 'acme.chatbot', name: 'chatbot', publisher: 'acme', enabled: true },
+  { id: 'acme.widget', name: 'widget', publisher: 'acme', enabled: true },
+];
+
+const mockFetchData = jest.fn();
+const mockRefreshData = jest.fn();
+
+function setupHook(extensions = EXTENSIONS) {
+  useListViewResource.mockReturnValue({
+    state: {
+      loading: false,
+      resourceCount: extensions.length,
+      resourceCollection: extensions,
+    },
+    fetchData: mockFetchData,
+    refreshData: mockRefreshData,
+  });
+}
 
 const defaultProps = {
   addDangerToast: jest.fn(),
   addSuccessToast: jest.fn(),
 };
 
-const renderWithStore = (props = {}) =>
-  render(<ExtensionsList {...defaultProps} {...props} />, {
+function renderList(props = {}) {
+  return render(<ExtensionsList {...defaultProps} {...props} />, {
     useRedux: true,
     useQueryParams: true,
     useRouter: true,
     useTheme: true,
-    initialState: mockInitialState,
   });
+}
 
-test('renders extensions list with basic structure', async () => {
-  renderWithStore();
+function uploadFile(input: HTMLInputElement, file: File) {
+  Object.defineProperty(input, 'files', { value: [file], configurable: true });
+  fireEvent.change(input);
+}
 
-  // Check that the component renders
-  expect(document.body).toBeInTheDocument();
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGet.mockResolvedValue({ json: { result: { active_chatbot_id: null } } });
+  setupHook();
 });
 
-test('displays extension names in the list', async () => {
-  renderWithStore();
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('renders the import button in the submenu', () => {
+  renderList();
+  // SubMenu stub renders each button's `name` node — the button wraps the icon tooltip
+  expect(screen.getByTestId('submenu')).toBeInTheDocument();
+});
+
+test('renders extension names in the table', async () => {
+  renderList();
+  await waitFor(() => {
+    expect(screen.getByText('chatbot')).toBeInTheDocument();
+    expect(screen.getByText('widget')).toBeInTheDocument();
+  });
+});
+
+test('renders a delete button for each extension', async () => {
+  renderList();
+  await waitFor(() => {
+    expect(screen.getAllByTestId('delete-extension')).toHaveLength(
+      EXTENSIONS.length,
+    );
+  });
+});
+
+test('clicking delete opens confirmation dialog', async () => {
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
+
+  await userEvent.click(screen.getAllByTestId('delete-extension')[0]);
 
   await waitFor(() => {
-    // These texts should appear somewhere in the rendered component
-    expect(document.body).toHaveTextContent(/Extensions/);
+    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
   });
 });
 
-test('calls toast functions when provided', () => {
-  const addDangerToast = jest.fn();
-  const addSuccessToast = jest.fn();
+test('typing DELETE in confirmation modal triggers delete API call', async () => {
+  mockDelete.mockResolvedValue({});
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
 
-  renderWithStore({
-    addDangerToast,
-    addSuccessToast,
+  await userEvent.click(screen.getAllByTestId('delete-extension')[0]);
+
+  const confirmInput = await screen.findByTestId('delete-modal-input');
+  fireEvent.change(confirmInput, { target: { value: 'DELETE' } });
+
+  // The DeleteModal confirm button is labelled "Delete" and sits in a dialog.
+  const modal = screen.getByRole('dialog');
+  const confirmBtn = within(modal)
+    .getAllByRole('button', { name: /^delete$/i })
+    .pop()!;
+  await userEvent.click(confirmBtn);
+
+  await waitFor(() => {
+    expect(mockDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: '/api/v1/extensions/acme/chatbot' }),
+    );
+    expect(mockRefreshData).toHaveBeenCalled();
   });
+});
 
-  // The component should accept these props without error
-  expect(addDangerToast).toBeDefined();
-  expect(addSuccessToast).toBeDefined();
+test('star button shown only for extensions registered as chatbot views', async () => {
+  const { getRegisteredViewIds } = jest.requireMock('src/core/views');
+  (getRegisteredViewIds as jest.Mock).mockReturnValue(['acme.chatbot']);
+
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
+
+  // Only acme.chatbot is a chatbot — only one star button should appear
+  expect(screen.getAllByTestId('set-default-chatbot')).toHaveLength(1);
+});
+
+test('clicking star calls PUT settings with the extension id', async () => {
+  const { getRegisteredViewIds } = jest.requireMock('src/core/views');
+  (getRegisteredViewIds as jest.Mock).mockReturnValue(['acme.chatbot']);
+  mockPut.mockResolvedValue({ json: {} });
+
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
+
+  await userEvent.click(screen.getByTestId('set-default-chatbot'));
+
+  await waitFor(() => {
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: '/api/v1/extensions/settings',
+        jsonPayload: { active_chatbot_id: 'acme.chatbot' },
+      }),
+    );
+  });
+});
+
+test('pressing Enter on star span triggers set-default action', async () => {
+  const { getRegisteredViewIds } = jest.requireMock('src/core/views');
+  (getRegisteredViewIds as jest.Mock).mockReturnValue(['acme.chatbot']);
+  mockPut.mockResolvedValue({ json: {} });
+
+  renderList();
+  await waitFor(() => screen.getByText('chatbot'));
+
+  fireEvent.keyDown(screen.getByTestId('set-default-chatbot'), { key: 'Enter' });
+
+  await waitFor(() => {
+    expect(mockPut).toHaveBeenCalled();
+  });
+});
+
+test('uploading a non-.supx file shows danger toast without calling API', async () => {
+  const addDangerToast = jest.fn();
+  renderList({ addDangerToast });
+
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+  uploadFile(input, new File(['x'], 'evil.zip', { type: 'application/zip' }));
+
+  expect(addDangerToast).toHaveBeenCalledWith(
+    expect.stringMatching(/\.supx/i),
+  );
+  expect(mockPost).not.toHaveBeenCalled();
+});
+
+test('uploading a .supx file calls POST endpoint and refreshes list', async () => {
+  mockPost.mockResolvedValue({});
+  renderList();
+
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+  uploadFile(input, new File(['PK'], 'my.supx', { type: 'application/octet-stream' }));
+
+  await waitFor(() => {
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: '/api/v1/extensions/' }),
+    );
+    expect(mockRefreshData).toHaveBeenCalled();
+  });
 });

--- a/superset-frontend/src/extensions/ExtensionsList.test.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.test.tsx
@@ -63,10 +63,14 @@ jest.mock('src/features/home/SubMenu', () => ({
 // withToasts is the outermost HOC — pass through so callers can inject toast fns.
 jest.mock('src/components/MessageToasts/withToasts', () => (C: any) => C);
 
+jest.mock('src/views/contributions', () => ({
+  CHATBOT_LOCATION: 'superset.chatbot',
+}));
 
 jest.mock('src/core/views', () => ({
   getRegisteredViewIds: jest.fn(() => []),
-  subscribeToLocation: jest.fn(() => () => undefined),
+  subscribeToRegistry: jest.fn(() => () => undefined),
+  getRegistryVersion: jest.fn(() => 0),
 }));
 
 jest.mock('src/core/extensions', () => ({
@@ -97,8 +101,20 @@ const mockPut = SupersetClient.put as jest.Mock;
 const mockDelete = SupersetClient.delete as jest.Mock;
 
 const EXTENSIONS = [
-  { id: 'acme.chatbot', name: 'chatbot', publisher: 'acme', enabled: true },
-  { id: 'acme.widget', name: 'widget', publisher: 'acme', enabled: true },
+  {
+    id: 'acme.chatbot',
+    name: 'chatbot',
+    publisher: 'acme',
+    enabled: true,
+    deletable: true,
+  },
+  {
+    id: 'acme.widget',
+    name: 'widget',
+    publisher: 'acme',
+    enabled: true,
+    deletable: false,
+  },
 ];
 
 const mockFetchData = jest.fn();
@@ -141,7 +157,9 @@ function uploadFile(input: HTMLInputElement, file: File) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockGet.mockResolvedValue({ json: { result: { active_chatbot_id: null } } });
+  mockGet.mockResolvedValue({
+    json: { result: { active_chatbot_id: null, enabled: {} } },
+  });
   setupHook();
 });
 
@@ -151,7 +169,6 @@ beforeEach(() => {
 
 test('renders the import button in the submenu', () => {
   renderList();
-  // SubMenu stub renders each button's `name` node — the button wraps the icon tooltip
   expect(screen.getByTestId('submenu')).toBeInTheDocument();
 });
 
@@ -163,12 +180,11 @@ test('renders extension names in the table', async () => {
   });
 });
 
-test('renders a delete button for each extension', async () => {
+test('renders delete button only for deletable extensions', async () => {
   renderList();
   await waitFor(() => {
-    expect(screen.getAllByTestId('delete-extension')).toHaveLength(
-      EXTENSIONS.length,
-    );
+    // Only acme.chatbot has deletable: true
+    expect(screen.getAllByTestId('delete-extension')).toHaveLength(1);
   });
 });
 
@@ -176,7 +192,7 @@ test('clicking delete opens confirmation dialog', async () => {
   renderList();
   await waitFor(() => screen.getByText('chatbot'));
 
-  await userEvent.click(screen.getAllByTestId('delete-extension')[0]);
+  await userEvent.click(screen.getByTestId('delete-extension'));
 
   await waitFor(() => {
     expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
@@ -188,12 +204,11 @@ test('typing DELETE in confirmation modal triggers delete API call', async () =>
   renderList();
   await waitFor(() => screen.getByText('chatbot'));
 
-  await userEvent.click(screen.getAllByTestId('delete-extension')[0]);
+  await userEvent.click(screen.getByTestId('delete-extension'));
 
   const confirmInput = await screen.findByTestId('delete-modal-input');
   fireEvent.change(confirmInput, { target: { value: 'DELETE' } });
 
-  // The DeleteModal confirm button is labelled "Delete" and sits in a dialog.
   const modal = screen.getByRole('dialog');
   const confirmBtn = within(modal)
     .getAllByRole('button', { name: /^delete$/i })
@@ -215,7 +230,6 @@ test('star button shown only for extensions registered as chatbot views', async 
   renderList();
   await waitFor(() => screen.getByText('chatbot'));
 
-  // Only acme.chatbot is a chatbot — only one star button should appear
   expect(screen.getAllByTestId('set-default-chatbot')).toHaveLength(1);
 });
 
@@ -233,7 +247,9 @@ test('clicking star calls PUT settings with the extension id', async () => {
     expect(mockPut).toHaveBeenCalledWith(
       expect.objectContaining({
         endpoint: '/api/v1/extensions/settings',
-        jsonPayload: { active_chatbot_id: 'acme.chatbot' },
+        jsonPayload: expect.objectContaining({
+          active_chatbot_id: 'acme.chatbot',
+        }),
       }),
     );
   });

--- a/superset-frontend/src/extensions/ExtensionsList.test.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.test.tsx
@@ -82,7 +82,11 @@ jest.mock('src/core/views', () => ({
 }));
 
 jest.mock('src/core/extensions', () => ({
-  notifyExtensionSettingsChanged: jest.fn(),
+  getExtensionSettingsSnapshot: jest.fn(() => ({
+    active_chatbot_id: null,
+    enabled: {},
+  })),
+  setExtensionSettings: jest.fn(),
 }));
 
 jest.mock('@superset-ui/core', () => {

--- a/superset-frontend/src/extensions/ExtensionsList.test.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.test.tsx
@@ -81,12 +81,15 @@ jest.mock('src/core/views', () => ({
   getRegistryVersion: jest.fn(() => 0),
 }));
 
+// Stable snapshot reference: useSyncExternalStore requires getSnapshot to
+// return the same object until it actually changes, otherwise it re-renders
+// infinitely.
+const mockSettings = { active_chatbot_id: null, enabled: {} };
 jest.mock('src/core/extensions', () => ({
-  getExtensionSettingsSnapshot: jest.fn(() => ({
-    active_chatbot_id: null,
-    enabled: {},
-  })),
+  getExtensionSettingsSnapshot: jest.fn(() => mockSettings),
   setExtensionSettings: jest.fn(),
+  loadExtensionSettings: jest.fn(() => Promise.resolve()),
+  subscribeToExtensionSettings: jest.fn(() => () => undefined),
 }));
 
 jest.mock('@superset-ui/core', () => {

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -25,6 +25,7 @@ import {
   useRef,
   useState,
   useMemo,
+  useSyncExternalStore,
 } from 'react';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import { createErrorHandler } from 'src/views/CRUD/utils';
@@ -35,7 +36,9 @@ import { ConfirmStatusChange, Tooltip } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 import {
   getExtensionSettingsSnapshot,
+  loadExtensionSettings,
   setExtensionSettings,
+  subscribeToExtensionSettings,
 } from 'src/core/extensions';
 import { getRegisteredViewIds, subscribeToRegistry } from 'src/core/views';
 
@@ -62,10 +65,18 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
-  const [activeChatbotId, setActiveChatbotId] = useState<string | null>(null);
   const [chatbotExtensionIds, setChatbotExtensionIds] = useState<Set<string>>(
     () => new Set(getRegisteredViewIds(CHATBOT_LOCATION)),
   );
+
+  // The active chatbot lives in the host-owned settings store shared with the
+  // live ChatbotMount, so a change here is reflected there without a second
+  // notification channel.
+  const settings = useSyncExternalStore(
+    subscribeToExtensionSettings,
+    getExtensionSettingsSnapshot,
+  );
+  const activeChatbotId = settings.active_chatbot_id;
 
   const {
     state: { loading, resourceCount, resourceCollection },
@@ -86,15 +97,10 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
     [],
   );
 
-  // Load current active chatbot from settings on mount
+  // Load settings into the shared store on mount.
   useEffect(() => {
-    SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
-      .then(({ json }) => {
-        setActiveChatbotId(json?.result?.active_chatbot_id ?? null);
-      })
-      .catch(() => {
-        // non-fatal: leave activeChatbotId as null
-      });
+    // non-fatal: the store keeps its empty default on failure.
+    loadExtensionSettings().catch(() => {});
   }, []);
 
   const handleUploadClick = () => {
@@ -165,9 +171,8 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
         jsonPayload: { active_chatbot_id: newId },
       }).then(
         () => {
-          setActiveChatbotId(newId);
-          // Reflect the change in the shared settings store so the live
-          // ChatbotMount re-resolves the active chatbot immediately.
+          // Reflect the change in the shared settings store; the component and
+          // the live ChatbotMount both re-resolve from it immediately.
           setExtensionSettings({
             ...getExtensionSettingsSnapshot(),
             active_chatbot_id: newId,

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -37,7 +37,7 @@ import {
   getExtensionSettingsSnapshot,
   setExtensionSettings,
 } from 'src/core/extensions';
-import { getRegisteredViewIds, subscribeToLocation } from 'src/core/views';
+import { getRegisteredViewIds, subscribeToRegistry } from 'src/core/views';
 
 const CHATBOT_LOCATION = 'superset.chatbot';
 
@@ -79,7 +79,7 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
   // Keep chatbotExtensionIds in sync with runtime view registrations
   useEffect(
     () =>
-      subscribeToLocation(CHATBOT_LOCATION, () => {
+      subscribeToRegistry(() => {
         setChatbotExtensionIds(new Set(getRegisteredViewIds(CHATBOT_LOCATION)));
       }),
     [],
@@ -287,7 +287,12 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
         },
       },
     ],
-    [activeChatbotId, chatbotExtensionIds, handleSetDefaultChatbot, handleDelete],
+    [
+      activeChatbotId,
+      chatbotExtensionIds,
+      handleSetDefaultChatbot,
+      handleDelete,
+    ],
   );
 
   const menuData: SubMenuProps = {

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -48,6 +48,7 @@ type Extension = {
   name: string;
   publisher: string;
   enabled: boolean;
+  deletable: boolean;
 };
 
 interface ExtensionsListProps {
@@ -249,39 +250,41 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
                   </span>
                 </Tooltip>
               )}
-              <ConfirmStatusChange
-                title={t('Please confirm')}
-                description={
-                  <>
-                    {t('Are you sure you want to delete')}{' '}
-                    <b>{original.name}</b>?
-                  </>
-                }
-                onConfirm={() => handleDelete(original)}
-              >
-                {(confirmDelete: () => void) => (
-                  <Tooltip
-                    id={`delete-extension-tooltip-${original.id}`}
-                    title={t('Delete')}
-                    placement="bottom"
-                  >
-                    <span
-                      role="button"
-                      tabIndex={0}
-                      data-test="delete-extension"
-                      className="action-button"
-                      onClick={confirmDelete}
-                      onKeyDown={(e: React.KeyboardEvent) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          confirmDelete();
-                        }
-                      }}
+              {original.deletable && (
+                <ConfirmStatusChange
+                  title={t('Please confirm')}
+                  description={
+                    <>
+                      {t('Are you sure you want to delete')}{' '}
+                      <b>{original.name}</b>?
+                    </>
+                  }
+                  onConfirm={() => handleDelete(original)}
+                >
+                  {(confirmDelete: () => void) => (
+                    <Tooltip
+                      id={`delete-extension-tooltip-${original.id}`}
+                      title={t('Delete')}
+                      placement="bottom"
                     >
-                      <Icons.DeleteOutlined iconSize="l" />
-                    </span>
-                  </Tooltip>
-                )}
-              </ConfirmStatusChange>
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        data-test="delete-extension"
+                        className="action-button"
+                        onClick={confirmDelete}
+                        onKeyDown={(e: React.KeyboardEvent) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            confirmDelete();
+                          }
+                        }}
+                      >
+                        <Icons.DeleteOutlined iconSize="l" />
+                      </span>
+                    </Tooltip>
+                  )}
+                </ConfirmStatusChange>
+              )}
             </>
           );
         },

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -136,22 +136,25 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
       });
   };
 
-  const handleDelete = (extension: Extension) => {
-    const { publisher, name } = extension;
-    SupersetClient.delete({
-      endpoint: `/api/v1/extensions/${publisher}/${name}`,
-    }).then(
-      () => {
-        addSuccessToast(t('Deleted: %s', extension.name));
-        refreshData();
-      },
-      createErrorHandler(errMsg =>
-        addDangerToast(
-          t('There was an issue deleting %s: %s', extension.name, errMsg),
+  const handleDelete = useCallback(
+    (extension: Extension) => {
+      const { publisher, name } = extension;
+      SupersetClient.delete({
+        endpoint: `/api/v1/extensions/${publisher}/${name}`,
+      }).then(
+        () => {
+          addSuccessToast(t('Deleted: %s', extension.name));
+          refreshData();
+        },
+        createErrorHandler(errMsg =>
+          addDangerToast(
+            t('There was an issue deleting %s: %s', extension.name, errMsg),
+          ),
         ),
-      ),
-    );
-  };
+      );
+    },
+    [addDangerToast, addSuccessToast, refreshData],
+  );
 
   const handleSetDefaultChatbot = useCallback(
     (extension: Extension) => {
@@ -284,7 +287,7 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
         },
       },
     ],
-    [activeChatbotId, chatbotExtensionIds, handleSetDefaultChatbot],
+    [activeChatbotId, chatbotExtensionIds, handleSetDefaultChatbot, handleDelete],
   );
 
   const menuData: SubMenuProps = {

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -17,40 +17,34 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import { css } from '@apache-superset/core/theme';
+import { SupersetClient } from '@superset-ui/core';
 import {
   FunctionComponent,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
+  useMemo,
 } from 'react';
-import { SupersetClient } from '@superset-ui/core';
-import { Select, Switch } from '@superset-ui/core/components';
 import { useListViewResource } from 'src/views/CRUD/hooks';
+import { createErrorHandler } from 'src/views/CRUD/utils';
 import { ListView } from 'src/components';
 import SubMenu, { SubMenuProps } from 'src/features/home/SubMenu';
 import withToasts from 'src/components/MessageToasts/withToasts';
-import { CHATBOT_LOCATION } from 'src/views/contributions';
+import { ConfirmStatusChange, Tooltip } from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
 import {
-  getRegisteredViewIds,
-  subscribeToRegistry,
-  getRegistryVersion,
-} from 'src/core/views';
+  getExtensionSettingsSnapshot,
+  setExtensionSettings,
+} from 'src/core/extensions';
 
 const PAGE_SIZE = 25;
 
 type Extension = {
   id: string;
   name: string;
+  publisher: string;
   enabled: boolean;
-};
-
-type ExtensionSettings = {
-  active_chatbot_id: string | null;
-  enabled: Record<string, boolean>;
 };
 
 interface ExtensionsListProps {
@@ -62,6 +56,10 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
   addDangerToast,
   addSuccessToast,
 }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [activeChatbotId, setActiveChatbotId] = useState<string | null>(null);
+
   const {
     state: { loading, resourceCount, resourceCollection },
     fetchData,
@@ -72,64 +70,104 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
     addDangerToast,
   );
 
-  const [settings, setSettings] = useState<ExtensionSettings>({
-    active_chatbot_id: null,
-    enabled: {},
-  });
-  // Always holds the latest settings value so saveSettings never closes over
-  // a stale snapshot when rapid toggles race against each other.
-  const settingsRef = useRef(settings);
-  settingsRef.current = settings;
-
-  // Re-evaluate the chatbot rows whenever a view registers or unregisters.
-  const chatbotRegistryVersion = useSyncExternalStore(
-    subscribeToRegistry,
-    getRegistryVersion,
-  );
-
+  // Load current active chatbot from settings on mount
   useEffect(() => {
     SupersetClient.get({ endpoint: '/api/v1/extensions/settings' })
-      .then(({ json }) => setSettings(json.result))
-      .catch(() => addDangerToast(t('Failed to load extension settings.')));
-  }, [addDangerToast]);
+      .then(({ json }) => {
+        setActiveChatbotId(json?.result?.active_chatbot_id ?? null);
+      })
+      .catch(() => {
+        // non-fatal: leave activeChatbotId as null
+      });
+  }, []);
 
-  const saveSettings = useCallback(
-    (patch: Partial<ExtensionSettings>) => {
-      const previous = settingsRef.current;
-      const next = { ...previous, ...patch };
-      setSettings(next);
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.name.endsWith('.supx')) {
+      addDangerToast(t('File must have a .supx extension.'));
+      e.target.value = '';
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('bundle', file);
+
+    setUploading(true);
+    SupersetClient.post({
+      endpoint: '/api/v1/extensions/',
+      body: formData,
+      headers: { Accept: 'application/json' },
+    })
+      .then(() => {
+        addSuccessToast(t('Extension installed successfully.'));
+        refreshData();
+      })
+      .catch(
+        createErrorHandler(errMsg =>
+          addDangerToast(
+            t('There was an issue installing the extension: %s', errMsg),
+          ),
+        ),
+      )
+      .finally(() => {
+        setUploading(false);
+        e.target.value = '';
+      });
+  };
+
+  const handleDelete = (extension: Extension) => {
+    const { publisher, name } = extension;
+    SupersetClient.delete({
+      endpoint: `/api/v1/extensions/${publisher}/${name}`,
+    }).then(
+      () => {
+        addSuccessToast(t('Deleted: %s', extension.name));
+        refreshData();
+      },
+      createErrorHandler(errMsg =>
+        addDangerToast(
+          t('There was an issue deleting %s: %s', extension.name, errMsg),
+        ),
+      ),
+    );
+  };
+
+  const handleSetDefaultChatbot = useCallback(
+    (extension: Extension) => {
+      const newId = activeChatbotId === extension.id ? null : extension.id;
       SupersetClient.put({
         endpoint: '/api/v1/extensions/settings',
-        jsonPayload: next,
-      })
-        .then(() => {
-          addSuccessToast(t('Settings saved.'));
-        })
-        .catch(() => {
-          // Rollback optimistic update so UI stays consistent with server state.
-          setSettings(previous);
-          addDangerToast(t('Failed to save extension settings.'));
-        });
+        jsonPayload: { active_chatbot_id: newId },
+      }).then(
+        () => {
+          setActiveChatbotId(newId);
+          // Reflect the change in the shared settings store so the live
+          // ChatbotMount re-resolves the active chatbot immediately.
+          setExtensionSettings({
+            ...getExtensionSettingsSnapshot(),
+            active_chatbot_id: newId,
+          });
+          addSuccessToast(
+            newId
+              ? t('%s set as default chatbot.', extension.name)
+              : t('Default chatbot cleared.'),
+          );
+        },
+        createErrorHandler(errMsg =>
+          addDangerToast(
+            t('There was an issue updating chatbot settings: %s', errMsg),
+          ),
+        ),
+      );
     },
-    [addDangerToast, addSuccessToast],
+    [activeChatbotId, addDangerToast, addSuccessToast],
   );
-
-  const toggleEnabled = useCallback(
-    (extensionId: string, enabled: boolean) => {
-      saveSettings({
-        enabled: { ...settingsRef.current.enabled, [extensionId]: enabled },
-      });
-    },
-    [saveSettings],
-  );
-
-  const chatbotExtensions = useMemo(() => {
-    const chatbotIds = new Set(getRegisteredViewIds(CHATBOT_LOCATION));
-    return resourceCollection.filter(ext => chatbotIds.has(ext.id));
-    // chatbotRegistryVersion is intentionally in deps to re-evaluate when
-    // chatbot views register or deregister.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resourceCollection, chatbotRegistryVersion]);
 
   const columns = useMemo(
     () => [
@@ -145,60 +183,111 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
         }: any) => name,
       },
       {
-        Header: t('Enabled'),
-        accessor: 'enabled',
-        size: 'sm',
-        id: 'enabled',
+        Header: t('Publisher'),
+        accessor: 'publisher',
+        id: 'publisher',
         Cell: ({
           row: {
-            original: { id },
+            original: { publisher },
           },
-        }: any) => (
-          <Switch
-            data-test="toggle-enabled"
-            checked={settings.enabled[id] ?? true}
-            onChange={(checked: boolean) => toggleEnabled(id, checked)}
-            size="small"
-          />
-        ),
+        }: any) => publisher,
+      },
+      {
+        Header: t('Actions'),
+        id: 'actions',
+        disableSortBy: true,
+        Cell: ({ row: { original } }: any) => {
+          const isDefault = activeChatbotId === original.id;
+          return (
+            <>
+              <Tooltip
+                id="set-chatbot-tooltip"
+                title={
+                  isDefault
+                    ? t('Clear default chatbot')
+                    : t('Set as default chatbot')
+                }
+                placement="bottom"
+              >
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="action-button"
+                  onClick={() => handleSetDefaultChatbot(original)}
+                >
+                  {isDefault ? (
+                    <Icons.StarFilled iconSize="l" />
+                  ) : (
+                    <Icons.StarOutlined iconSize="l" />
+                  )}
+                </span>
+              </Tooltip>
+              <ConfirmStatusChange
+                title={t('Please confirm')}
+                description={
+                  <>
+                    {t('Are you sure you want to delete')}{' '}
+                    <b>{original.name}</b>?
+                  </>
+                }
+                onConfirm={() => handleDelete(original)}
+              >
+                {(confirmDelete: () => void) => (
+                  <Tooltip
+                    id="delete-extension-tooltip"
+                    title={t('Delete')}
+                    placement="bottom"
+                  >
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      className="action-button"
+                      onClick={confirmDelete}
+                    >
+                      <Icons.DeleteOutlined iconSize="l" />
+                    </span>
+                  </Tooltip>
+                )}
+              </ConfirmStatusChange>
+            </>
+          );
+        },
       },
     ],
-    [settings, toggleEnabled],
+    [loading, activeChatbotId, handleSetDefaultChatbot],
   );
-
-  const chatbotOptions = chatbotExtensions.map(ext => ({
-    label: ext.name,
-    value: ext.id,
-  }));
 
   const menuData: SubMenuProps = {
     activeChild: 'Extensions',
     name: t('Extensions'),
-    buttons: [],
+    buttons: [
+      {
+        name: (
+          <Tooltip
+            id="import-extension-tooltip"
+            title={t('Import extension (.supx)')}
+            placement="bottomRight"
+          >
+            <Icons.DownloadOutlined iconSize="l" />
+          </Tooltip>
+        ),
+        buttonStyle: 'link',
+        onClick: handleUploadClick,
+        loading: uploading,
+      },
+    ],
   };
 
   return (
     <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".supx"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
       <SubMenu {...menuData} />
-      {chatbotOptions.length > 1 && (
-        <div style={{ padding: '16px 24px' }}>
-          <label htmlFor="chatbot-select" style={{ marginRight: 8 }}>
-            {t('Default chatbot')}
-          </label>
-          <Select
-            allowClear
-            options={chatbotOptions}
-            value={settings.active_chatbot_id ?? undefined}
-            onChange={value =>
-              saveSettings({ active_chatbot_id: (value as string) ?? null })
-            }
-            placeholder={t('First registered (automatic)')}
-            css={css`
-              width: 280px;
-            `}
-          />
-        </div>
-      )}
       <ListView<Extension>
         columns={columns}
         count={resourceCount}

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -218,7 +218,7 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
             <>
               {isChatbot && (
                 <Tooltip
-                  id="set-chatbot-tooltip"
+                  id={`set-chatbot-tooltip-${original.id}`}
                   title={
                     isDefault
                       ? t('Clear default chatbot')
@@ -229,8 +229,14 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
                   <span
                     role="button"
                     tabIndex={0}
+                    data-test="set-default-chatbot"
                     className="action-button"
                     onClick={() => handleSetDefaultChatbot(original)}
+                    onKeyDown={(e: React.KeyboardEvent) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        handleSetDefaultChatbot(original);
+                      }
+                    }}
                   >
                     {isDefault ? (
                       <Icons.StarFilled iconSize="l" />
@@ -252,15 +258,21 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
               >
                 {(confirmDelete: () => void) => (
                   <Tooltip
-                    id="delete-extension-tooltip"
+                    id={`delete-extension-tooltip-${original.id}`}
                     title={t('Delete')}
                     placement="bottom"
                   >
                     <span
                       role="button"
                       tabIndex={0}
+                      data-test="delete-extension"
                       className="action-button"
                       onClick={confirmDelete}
+                      onKeyDown={(e: React.KeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          confirmDelete();
+                        }
+                      }}
                     >
                       <Icons.DeleteOutlined iconSize="l" />
                     </span>
@@ -272,7 +284,7 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
         },
       },
     ],
-    [loading, activeChatbotId, chatbotExtensionIds, handleSetDefaultChatbot],
+    [activeChatbotId, chatbotExtensionIds, handleSetDefaultChatbot],
   );
 
   const menuData: SubMenuProps = {

--- a/superset-frontend/src/extensions/ExtensionsList.tsx
+++ b/superset-frontend/src/extensions/ExtensionsList.tsx
@@ -37,6 +37,9 @@ import {
   getExtensionSettingsSnapshot,
   setExtensionSettings,
 } from 'src/core/extensions';
+import { getRegisteredViewIds, subscribeToLocation } from 'src/core/views';
+
+const CHATBOT_LOCATION = 'superset.chatbot';
 
 const PAGE_SIZE = 25;
 
@@ -59,6 +62,9 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [activeChatbotId, setActiveChatbotId] = useState<string | null>(null);
+  const [chatbotExtensionIds, setChatbotExtensionIds] = useState<Set<string>>(
+    () => new Set(getRegisteredViewIds(CHATBOT_LOCATION)),
+  );
 
   const {
     state: { loading, resourceCount, resourceCollection },
@@ -68,6 +74,15 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
     'extensions',
     t('Extensions'),
     addDangerToast,
+  );
+
+  // Keep chatbotExtensionIds in sync with runtime view registrations
+  useEffect(
+    () =>
+      subscribeToLocation(CHATBOT_LOCATION, () => {
+        setChatbotExtensionIds(new Set(getRegisteredViewIds(CHATBOT_LOCATION)));
+      }),
+    [],
   );
 
   // Load current active chatbot from settings on mount
@@ -197,31 +212,34 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
         id: 'actions',
         disableSortBy: true,
         Cell: ({ row: { original } }: any) => {
+          const isChatbot = chatbotExtensionIds.has(original.id);
           const isDefault = activeChatbotId === original.id;
           return (
             <>
-              <Tooltip
-                id="set-chatbot-tooltip"
-                title={
-                  isDefault
-                    ? t('Clear default chatbot')
-                    : t('Set as default chatbot')
-                }
-                placement="bottom"
-              >
-                <span
-                  role="button"
-                  tabIndex={0}
-                  className="action-button"
-                  onClick={() => handleSetDefaultChatbot(original)}
+              {isChatbot && (
+                <Tooltip
+                  id="set-chatbot-tooltip"
+                  title={
+                    isDefault
+                      ? t('Clear default chatbot')
+                      : t('Set as default chatbot')
+                  }
+                  placement="bottom"
                 >
-                  {isDefault ? (
-                    <Icons.StarFilled iconSize="l" />
-                  ) : (
-                    <Icons.StarOutlined iconSize="l" />
-                  )}
-                </span>
-              </Tooltip>
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    className="action-button"
+                    onClick={() => handleSetDefaultChatbot(original)}
+                  >
+                    {isDefault ? (
+                      <Icons.StarFilled iconSize="l" />
+                    ) : (
+                      <Icons.StarOutlined iconSize="l" />
+                    )}
+                  </span>
+                </Tooltip>
+              )}
               <ConfirmStatusChange
                 title={t('Please confirm')}
                 description={
@@ -254,7 +272,7 @@ const ExtensionsList: FunctionComponent<ExtensionsListProps> = ({
         },
       },
     ],
-    [loading, activeChatbotId, handleSetDefaultChatbot],
+    [loading, activeChatbotId, chatbotExtensionIds, handleSetDefaultChatbot],
   );
 
   const menuData: SubMenuProps = {

--- a/superset/extensions/api.py
+++ b/superset/extensions/api.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import mimetypes
+import re
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -39,6 +40,19 @@ from superset.extensions.utils import (
 )
 from superset.utils.core import check_is_safe_zip
 from superset.views.base_api import BaseSupersetApi
+
+# Allowlist for publisher and name path parameters — alphanumeric, hyphens,
+# underscores only. Rejects path-traversal attempts (../), URL-encoded slashes,
+# and any other characters that could escape EXTENSIONS_PATH.
+_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# Default 10 MB server-side upload limit; can be overridden via config.
+_DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+
+def _validate_segment(value: str) -> bool:
+    """Return True if *value* is a safe publisher or name segment."""
+    return bool(_SEGMENT_RE.match(value))
 
 
 class ExtensionsRestApi(BaseSupersetApi):
@@ -175,7 +189,8 @@ class ExtensionsRestApi(BaseSupersetApi):
             500:
               $ref: '#/components/responses/500'
         """
-        # Reconstruct composite ID from publisher and name
+        if not _validate_segment(publisher) or not _validate_segment(name):
+            return self.response(400, message="Invalid publisher or name.")
         composite_id = f"{publisher}.{name}"
         extensions = get_extensions()
         extension = extensions.get(composite_id)
@@ -244,7 +259,19 @@ class ExtensionsRestApi(BaseSupersetApi):
         if not upload.filename or not upload.filename.endswith(".supx"):
             return self.response(400, message="File must have a .supx extension.")
 
-        stream = BytesIO(upload.read())
+        max_bytes: int = current_app.config.get(
+            "EXTENSIONS_MAX_UPLOAD_SIZE", _DEFAULT_MAX_UPLOAD_BYTES
+        )
+        raw = upload.read(max_bytes + 1)
+        if len(raw) > max_bytes:
+            return self.response(
+                400,
+                message=(
+                    f"File exceeds the maximum allowed size of {max_bytes} bytes."
+                ),
+            )
+
+        stream = BytesIO(raw)
         if not is_zipfile(stream):
             return self.response(400, message="File is not a valid ZIP archive.")
 
@@ -257,7 +284,22 @@ class ExtensionsRestApi(BaseSupersetApi):
         except Exception as ex:  # pylint: disable=broad-except
             return self.response(400, message=f"Invalid extension bundle: {ex}")
 
+        # Reject bundles whose manifest id collides with a LOCAL_EXTENSIONS entry.
+        local_ids = {
+            Path(p).name for p in current_app.config.get("LOCAL_EXTENSIONS", [])
+        }
+        if extension.manifest.id in local_ids:
+            return self.response(
+                409,
+                message=(
+                    f"Extension '{extension.manifest.id}' is already installed as a "
+                    "local extension. Remove it from LOCAL_EXTENSIONS before uploading."
+                ),
+            )
+
         # Persist to EXTENSIONS_PATH so the extension survives restarts.
+        # Destination path is derived from the validated manifest id, not the
+        # uploaded filename, so the upload filename cannot escape EXTENSIONS_PATH.
         dest_dir = Path(extensions_path)
         dest_dir.mkdir(parents=True, exist_ok=True)
         dest_file = dest_dir / f"{extension.manifest.id}.supx"
@@ -298,6 +340,9 @@ class ExtensionsRestApi(BaseSupersetApi):
         """
         if not security_manager.is_admin():
             return self.response(403, message="Admin access required.")
+
+        if not _validate_segment(publisher) or not _validate_segment(name):
+            return self.response(400, message="Invalid publisher or name.")
 
         composite_id = f"{publisher}.{name}"
         extensions = get_extensions()
@@ -428,7 +473,8 @@ class ExtensionsRestApi(BaseSupersetApi):
             500:
               $ref: '#/components/responses/500'
         """
-        # Reconstruct composite ID from publisher and name
+        if not _validate_segment(publisher) or not _validate_segment(name):
+            return self.response(400, message="Invalid publisher or name.")
         composite_id = f"{publisher}.{name}"
         extensions = get_extensions()
         extension = extensions.get(composite_id)

--- a/superset/extensions/api.py
+++ b/superset/extensions/api.py
@@ -16,9 +16,11 @@
 # under the License.
 import mimetypes
 from io import BytesIO
+from pathlib import Path
 from typing import Any
+from zipfile import is_zipfile, ZipFile
 
-from flask import request, send_file
+from flask import current_app, request, send_file
 from flask.wrappers import Response
 from flask_appbuilder.api import expose, protect, safe
 from marshmallow import ValidationError
@@ -31,8 +33,11 @@ from superset.extensions import security_manager
 from superset.extensions.schemas import ExtensionSettingsPutSchema
 from superset.extensions.utils import (
     build_extension_data,
+    get_bundle_files_from_zip,
     get_extensions,
+    get_loaded_extension,
 )
+from superset.utils.core import check_is_safe_zip
 from superset.views.base_api import BaseSupersetApi
 
 
@@ -43,6 +48,18 @@ class ExtensionsRestApi(BaseSupersetApi):
     # because these endpoints use cookie/session auth (allow_browser_login)
     # and include state-changing routes (settings PUT, upload POST, delete).
     csrf_exempt = False
+    class_permission_name = "Extensions"
+    base_permissions = [
+        "can_get_list",
+        "can_get",
+        "can_put",
+        "can_post",
+        "can_delete",
+        "can_content",
+        "can_info",
+        "can_get_settings",
+        "can_put_settings",
+    ]
 
     @expose("/_info", methods=("GET",))
     @protect()
@@ -166,6 +183,156 @@ class ExtensionsRestApi(BaseSupersetApi):
             return self.response_404()
         extension_data = build_extension_data(extension)
         return self.response(200, result=extension_data)
+
+    @protect()
+    @safe
+    @expose("/", methods=("POST",))
+    def post(self, **kwargs: Any) -> Response:
+        """Upload and install an extension bundle (.supx file).
+        ---
+        post:
+          summary: Upload a .supx extension bundle.
+          requestBody:
+            required: true
+            content:
+              multipart/form-data:
+                schema:
+                  type: object
+                  properties:
+                    bundle:
+                      type: string
+                      format: binary
+                      description: The .supx extension bundle file.
+          responses:
+            201:
+              description: Extension installed successfully.
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        if not security_manager.is_admin():
+            return self.response(403, message="Admin access required.")
+
+        extensions_path = current_app.config.get("EXTENSIONS_PATH")
+        if not extensions_path:
+            return self.response(
+                400,
+                message=(
+                    "EXTENSIONS_PATH is not configured. Set it in superset_config.py "
+                    "to enable extension uploads."
+                ),
+            )
+
+        upload = request.files.get("bundle")
+        if not upload:
+            return self.response(
+                400, message="No file provided. Send a 'bundle' field."
+            )
+
+        if not upload.filename or not upload.filename.endswith(".supx"):
+            return self.response(400, message="File must have a .supx extension.")
+
+        stream = BytesIO(upload.read())
+        if not is_zipfile(stream):
+            return self.response(400, message="File is not a valid ZIP archive.")
+
+        stream.seek(0)
+        try:
+            with ZipFile(stream, "r") as zip_file:
+                check_is_safe_zip(zip_file)
+                files = list(get_bundle_files_from_zip(zip_file))
+                extension = get_loaded_extension(files, source_base_path="upload://")
+        except Exception as ex:  # pylint: disable=broad-except
+            return self.response(400, message=f"Invalid extension bundle: {ex}")
+
+        # Persist to EXTENSIONS_PATH so the extension survives restarts.
+        dest_dir = Path(extensions_path)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest_file = dest_dir / f"{extension.manifest.id}.supx"
+
+        stream.seek(0)
+        dest_file.write_bytes(stream.read())
+
+        return self.response(201, result=build_extension_data(extension))
+
+    @protect()
+    @safe
+    @expose("/<publisher>/<name>", methods=("DELETE",))
+    def delete(self, publisher: str, name: str, **kwargs: Any) -> Response:
+        """Delete an uploaded extension bundle.
+        ---
+        delete:
+          summary: Delete an extension by its publisher and name.
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: publisher
+          - in: path
+            schema:
+              type: string
+            name: name
+          responses:
+            200:
+              description: Extension deleted.
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+        """
+        if not security_manager.is_admin():
+            return self.response(403, message="Admin access required.")
+
+        composite_id = f"{publisher}.{name}"
+        extensions = get_extensions()
+        extension = extensions.get(composite_id)
+        if not extension:
+            return self.response_404()
+
+        # LOCAL_EXTENSIONS are managed via config — cannot be deleted through the UI.
+        local_paths = {
+            str((Path(p) / "dist").resolve())
+            for p in current_app.config.get("LOCAL_EXTENSIONS", [])
+        }
+        if extension.source_base_path in local_paths:
+            return self.response(
+                400,
+                message=(
+                    "Local extensions configured via LOCAL_EXTENSIONS cannot be "
+                    "deleted through the UI. Remove them from your configuration."
+                ),
+            )
+
+        # Locate and remove the .supx file from EXTENSIONS_PATH.
+        extensions_path = current_app.config.get("EXTENSIONS_PATH")
+        if not extensions_path:
+            return self.response(
+                400,
+                message="EXTENSIONS_PATH is not configured; cannot remove bundle file.",
+            )
+
+        supx_file = Path(extensions_path) / f"{composite_id}.supx"
+        if not supx_file.exists():
+            return self.response_404()
+
+        supx_file.unlink()
+        return self.response(200, message="Extension deleted.")
 
     @protect()
     @safe

--- a/superset/extensions/api.py
+++ b/superset/extensions/api.py
@@ -284,25 +284,44 @@ class ExtensionsRestApi(BaseSupersetApi):
         except Exception as ex:  # pylint: disable=broad-except
             return self.response(400, message=f"Invalid extension bundle: {ex}")
 
+        # Validate the manifest id before using it as a filename component.
+        # The id is publisher.name (e.g. "acme.chatbot"); each segment must pass
+        # _validate_segment so a crafted bundle cannot write outside EXTENSIONS_PATH
+        # even though the admin is trusted — defence-in-depth against third-party
+        # bundles the admin did not author.
+        manifest_id: str = extension.manifest.id
+        id_parts = manifest_id.split(".", 1)
+        if len(id_parts) != 2 or not all(  # noqa: PLR2004
+            _validate_segment(p) for p in id_parts
+        ):
+            return self.response(
+                400,
+                message=(
+                    f"Invalid extension id '{manifest_id}' in manifest. "
+                    "Expected '<publisher>.<name>' with alphanumeric, hyphen, "
+                    "or underscore characters only."
+                ),
+            )
+
         # Reject bundles whose manifest id collides with a LOCAL_EXTENSIONS entry.
         local_ids = {
             Path(p).name for p in current_app.config.get("LOCAL_EXTENSIONS", [])
         }
-        if extension.manifest.id in local_ids:
+        if manifest_id in local_ids:
             return self.response(
                 409,
                 message=(
-                    f"Extension '{extension.manifest.id}' is already installed as a "
+                    f"Extension '{manifest_id}' is already installed as a "
                     "local extension. Remove it from LOCAL_EXTENSIONS before uploading."
                 ),
             )
 
         # Persist to EXTENSIONS_PATH so the extension survives restarts.
-        # Destination path is derived from the validated manifest id, not the
-        # uploaded filename, so the upload filename cannot escape EXTENSIONS_PATH.
+        # Destination filename is built from the validated manifest id, not from the
+        # uploaded filename, so neither can escape EXTENSIONS_PATH.
         dest_dir = Path(extensions_path)
         dest_dir.mkdir(parents=True, exist_ok=True)
-        dest_file = dest_dir / f"{extension.manifest.id}.supx"
+        dest_file = dest_dir / f"{manifest_id}.supx"
 
         stream.seek(0)
         dest_file.write_bytes(stream.read())
@@ -384,6 +403,9 @@ class ExtensionsRestApi(BaseSupersetApi):
     @expose("/settings", methods=("GET",))
     def get_settings(self, **kwargs: Any) -> Response:
         """Get global extension admin settings.
+
+        No admin gate here by design: authenticated non-admin users need these
+        settings so the ChatbotMount can read active_chatbot_id on every page.
         ---
         get:
           summary: Get extension admin settings (active chatbot, enabled flags).

--- a/superset/extensions/utils.py
+++ b/superset/extensions/utils.py
@@ -232,6 +232,10 @@ def get_loaded_extension(
 
 def build_extension_data(extension: LoadedExtension) -> dict[str, Any]:
     manifest = extension.manifest
+    local_paths = {
+        str((Path(p) / "dist").resolve())
+        for p in current_app.config.get("LOCAL_EXTENSIONS", [])
+    }
     extension_data: dict[str, Any] = {
         "id": manifest.id,
         "publisher": manifest.publisher,
@@ -239,6 +243,7 @@ def build_extension_data(extension: LoadedExtension) -> dict[str, Any]:
         "version": extension.version,
         "description": manifest.description or "",
         "dependencies": manifest.dependencies,
+        "deletable": extension.source_base_path not in local_paths,
     }
     if manifest.frontend:
         frontend = manifest.frontend

--- a/superset/extensions/utils.py
+++ b/superset/extensions/utils.py
@@ -234,6 +234,7 @@ def build_extension_data(extension: LoadedExtension) -> dict[str, Any]:
     manifest = extension.manifest
     extension_data: dict[str, Any] = {
         "id": manifest.id,
+        "publisher": manifest.publisher,
         "name": extension.name,
         "version": extension.version,
         "description": manifest.description or "",

--- a/superset/migrations/versions/2026-05-25_00-00_b2c3d4e5f6a7_add_extension_settings.py
+++ b/superset/migrations/versions/2026-05-25_00-00_b2c3d4e5f6a7_add_extension_settings.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Add extension_settings and extension_enabled tables.
+"""Add extension_settings table for chatbot admin selection and enable/disable.
 
 Revision ID: b2c3d4e5f6a7
 Revises: 33d7e0e21daa
@@ -38,7 +38,7 @@ def upgrade() -> None:
     op.create_table(
         "extension_enabled",
         sa.Column("extension_id", sa.String(250), primary_key=True),
-        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="1"),
     )
 
 

--- a/tests/unit_tests/extensions/test_api.py
+++ b/tests/unit_tests/extensions/test_api.py
@@ -234,6 +234,33 @@ class TestPostEndpoint:
         assert resp.status_code == 409
         assert "local extension" in resp.json["message"]
 
+    def test_hostile_manifest_id_rejected(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        """A crafted manifest.id with path traversal must not escape EXTENSIONS_PATH."""
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"EXTENSIONS_PATH": str(tmp_path), "LOCAL_EXTENSIONS": []},
+        )
+        fake_ext = _make_fake_extension("../../tmp/evil")
+        mocker.patch(
+            "superset.extensions.api.get_bundle_files_from_zip", return_value=[]
+        )
+        mocker.patch(
+            "superset.extensions.api.get_loaded_extension", return_value=fake_ext
+        )
+        supx = _make_supx("../../tmp/evil")
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(supx), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "Invalid extension id" in resp.json["message"]
+
     def test_happy_path_returns_201(
         self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
     ) -> None:

--- a/tests/unit_tests/extensions/test_api.py
+++ b/tests/unit_tests/extensions/test_api.py
@@ -1,0 +1,381 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for the extensions REST API (POST and DELETE endpoints)."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from superset.extensions.api import _validate_segment
+
+# ---------------------------------------------------------------------------
+# _validate_segment helper
+# ---------------------------------------------------------------------------
+
+
+def test_validate_segment_accepts_alphanumeric() -> None:
+    assert _validate_segment("acme") is True
+    assert _validate_segment("my-ext") is True
+    assert _validate_segment("my_ext") is True
+    assert _validate_segment("Ext123") is True
+
+
+def test_validate_segment_rejects_traversal() -> None:
+    assert _validate_segment("..") is False
+    assert _validate_segment("../etc") is False
+    assert _validate_segment("acme/bad") is False
+    assert _validate_segment("acme%2Fbad") is False
+    assert _validate_segment("") is False
+
+
+def test_validate_segment_rejects_dots() -> None:
+    assert _validate_segment("acme.corp") is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building fake .supx payloads
+# ---------------------------------------------------------------------------
+
+
+def _make_supx(manifest_id: str = "acme.chatbot") -> bytes:
+    """Return minimal valid .supx (zip) bytes with a manifest."""
+    buf = io.BytesIO()
+    manifest_json = (
+        f'{{"id": "{manifest_id}", "name": "Chatbot", "version": "1.0.0",'
+        f'"publisher": "acme", "description": "test"}}'
+    )
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", manifest_json)
+    return buf.getvalue()
+
+
+def _make_fake_extension(manifest_id: str = "acme.chatbot") -> MagicMock:
+    ext = MagicMock()
+    ext.manifest.id = manifest_id
+    ext.source_base_path = "upload://"
+    ext.frontend = {}
+    ext.backend = {}
+    ext.version = "1.0.0"
+    ext.name = "Chatbot"
+    return ext
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/extensions/ — upload and install
+# ---------------------------------------------------------------------------
+
+
+class TestPostEndpoint:
+    def _post(self, client: Any, data: dict[str, Any], full_api_access: None) -> Any:
+        return client.post(
+            "/api/v1/extensions/",
+            data=data,
+            content_type="multipart/form-data",
+        )
+
+    def test_non_admin_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=False
+        )
+        resp = client.post("/api/v1/extensions/", data={})
+        assert resp.status_code == 403
+
+    def test_missing_extensions_path_returns_400(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict("flask.current_app.config", {"EXTENSIONS_PATH": None})
+        resp = client.post("/api/v1/extensions/", data={})
+        assert resp.status_code == 400
+        assert "EXTENSIONS_PATH" in resp.json["message"]
+
+    def test_missing_bundle_field_returns_400(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config", {"EXTENSIONS_PATH": str(tmp_path)}
+        )
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "bundle" in resp.json["message"]
+
+    def test_wrong_extension_rejected(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config", {"EXTENSIONS_PATH": str(tmp_path)}
+        )
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(b"data"), "evil.zip")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert ".supx" in resp.json["message"]
+
+    def test_oversize_upload_rejected(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"EXTENSIONS_PATH": str(tmp_path), "EXTENSIONS_MAX_UPLOAD_SIZE": 10},
+        )
+        big = io.BytesIO(b"x" * 20)
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (big, "big.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "maximum" in resp.json["message"]
+
+    def test_not_a_zip_returns_400(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config", {"EXTENSIONS_PATH": str(tmp_path)}
+        )
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(b"not a zip"), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "ZIP" in resp.json["message"]
+
+    def test_zip_slip_rejected(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        """check_is_safe_zip raises on path-traversal entries inside the zip."""
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config", {"EXTENSIONS_PATH": str(tmp_path)}
+        )
+        mocker.patch(
+            "superset.extensions.api.check_is_safe_zip",
+            side_effect=Exception("zip-slip detected"),
+        )
+        supx = _make_supx()
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(supx), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "zip-slip" in resp.json["message"]
+
+    def test_local_extensions_collision_returns_409(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {
+                "EXTENSIONS_PATH": str(tmp_path),
+                "LOCAL_EXTENSIONS": ["/opt/superset/ext/acme.chatbot"],
+            },
+        )
+        fake_ext = _make_fake_extension("acme.chatbot")
+        mocker.patch(
+            "superset.extensions.api.get_bundle_files_from_zip", return_value=[]
+        )
+        mocker.patch(
+            "superset.extensions.api.get_loaded_extension", return_value=fake_ext
+        )
+        supx = _make_supx("acme.chatbot")
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(supx), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 409
+        assert "local extension" in resp.json["message"]
+
+    def test_happy_path_returns_201(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"EXTENSIONS_PATH": str(tmp_path), "LOCAL_EXTENSIONS": []},
+        )
+        fake_ext = _make_fake_extension("acme.chatbot")
+        mocker.patch(
+            "superset.extensions.api.get_bundle_files_from_zip", return_value=[]
+        )
+        mocker.patch(
+            "superset.extensions.api.get_loaded_extension", return_value=fake_ext
+        )
+        mocker.patch(
+            "superset.extensions.api.build_extension_data",
+            return_value={"id": "acme.chatbot"},
+        )
+        supx = _make_supx("acme.chatbot")
+        resp = client.post(
+            "/api/v1/extensions/",
+            data={"bundle": (io.BytesIO(supx), "ext.supx")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 201
+        assert resp.json["result"]["id"] == "acme.chatbot"
+        assert (tmp_path / "acme.chatbot.supx").exists()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/extensions/<publisher>/<name>
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteEndpoint:
+    def test_non_admin_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=False
+        )
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 403
+
+    def test_path_traversal_publisher_rejected(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        # Use percent-encoded dots so Flask routing passes the segment to the
+        # handler as the string ".." — literal slashes in the path would be
+        # intercepted by the router before reaching the view.
+        resp = client.delete("/api/v1/extensions/%2E%2E/passwd")
+        assert resp.status_code == 400
+        assert "Invalid" in resp.json["message"]
+
+    def test_invalid_name_returns_400(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        resp = client.delete("/api/v1/extensions/acme/bad.name")
+        assert resp.status_code == 400
+        assert "Invalid" in resp.json["message"]
+
+    def test_unknown_extension_returns_404(
+        self, client: Any, full_api_access: None, mocker: Any
+    ) -> None:
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch("superset.extensions.api.get_extensions", return_value={})
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 404
+
+    def test_local_extension_cannot_be_deleted(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        local_base = str(tmp_path / "local-ext" / "dist")
+        fake_ext = _make_fake_extension("acme.chatbot")
+        fake_ext.source_base_path = local_base
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.get_extensions",
+            return_value={"acme.chatbot": fake_ext},
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"LOCAL_EXTENSIONS": [str(tmp_path / "local-ext")]},
+        )
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 400
+        assert "LOCAL_EXTENSIONS" in resp.json["message"]
+
+    def test_happy_path_deletes_file(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        supx_file = tmp_path / "acme.chatbot.supx"
+        supx_file.write_bytes(b"fake")
+
+        fake_ext = _make_fake_extension("acme.chatbot")
+        fake_ext.source_base_path = "upload://"
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.get_extensions",
+            return_value={"acme.chatbot": fake_ext},
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {
+                "LOCAL_EXTENSIONS": [],
+                "EXTENSIONS_PATH": str(tmp_path),
+            },
+        )
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 200
+        assert not supx_file.exists()
+
+    def test_supx_file_missing_returns_404(
+        self, client: Any, full_api_access: None, mocker: Any, tmp_path: Path
+    ) -> None:
+        fake_ext = _make_fake_extension("acme.chatbot")
+        fake_ext.source_base_path = "upload://"
+        mocker.patch(
+            "superset.extensions.api.security_manager.is_admin", return_value=True
+        )
+        mocker.patch(
+            "superset.extensions.api.get_extensions",
+            return_value={"acme.chatbot": fake_ext},
+        )
+        mocker.patch.dict(
+            "flask.current_app.config",
+            {"LOCAL_EXTENSIONS": [], "EXTENSIONS_PATH": str(tmp_path)},
+        )
+        resp = client.delete("/api/v1/extensions/acme/chatbot")
+        assert resp.status_code == 404

--- a/tests/unit_tests/extensions/test_api.py
+++ b/tests/unit_tests/extensions/test_api.py
@@ -25,7 +25,14 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from superset.extensions.api import _validate_segment
+
+# The extension routes are only registered when ENABLE_EXTENSIONS is on at
+# app-init time, so the endpoint tests parametrize the app fixture to enable it
+# (otherwise the route is absent and requests 404).
+_ENABLE_EXTENSIONS = [{"FEATURE_FLAGS": {"ENABLE_EXTENSIONS": True}}]
 
 # ---------------------------------------------------------------------------
 # _validate_segment helper
@@ -84,6 +91,7 @@ def _make_fake_extension(manifest_id: str = "acme.chatbot") -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("app", _ENABLE_EXTENSIONS, indirect=True)
 class TestPostEndpoint:
     def _post(self, client: Any, data: dict[str, Any], full_api_access: None) -> Any:
         return client.post(
@@ -298,6 +306,7 @@ class TestPostEndpoint:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("app", _ENABLE_EXTENSIONS, indirect=True)
 class TestDeleteEndpoint:
     def test_non_admin_rejected(
         self, client: Any, full_api_access: None, mocker: Any


### PR DESCRIPTION
### SUMMARY

Adds three new capabilities to the Extensions management page:

1. **Import extension** — a download icon button in the SubMenu opens a file picker restricted to `.supx` files. On selection, the file is uploaded via `POST /api/v1/extensions/` (new endpoint), validated (zip integrity + safe-zip check), and persisted to `EXTENSIONS_PATH`. The list refreshes automatically.

2. **Delete extension** — a trash icon in the Actions column (with confirmation dialog) calls `DELETE /api/v1/extensions/<publisher>/<name>` (new endpoint); uploaded `.supx` files are removed from `EXTENSIONS_PATH`. The button is shown only for deletable extensions: the API's `build_extension_data` now returns a `deletable` flag (false for locally-developed extensions under `LOCAL_EXTENSIONS`), and the UI gates the trash icon on it — so local extensions have no delete button rather than erroring on click.

3. **Set default chatbot** — a star icon in the Actions column calls `PUT /api/v1/extensions/settings` with the selected extension's ID as `active_chatbot_id`. The filled star indicates the current active chatbot. Clicking the filled star clears the selection. The change is propagated immediately via `notifyExtensionSettingsChanged()` so `ChatbotMount` updates without a page reload.

Also includes:
- Settings pub/sub (`notifyExtensionSettingsChanged` / `subscribeToExtensionSettings`) in `src/core/extensions` so components can react to admin setting changes without Redux or a page reload.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Extensions list shows only extension names with no actions.
<img width="2338" height="870" alt="Screenshot 2026-05-26 211801" src="https://github.com/user-attachments/assets/18f2e927-3071-4862-a80e-abd935fb1c8b" />
**After:** Extensions list has a Publisher column, an import button in the header, and per-row star (default chatbot) and trash (delete) action buttons.
<img width="1626" height="1153" alt="Screenshot 2026-05-26 214818" src="https://github.com/user-attachments/assets/0b6c9e7a-2fa9-4a8d-b8d8-9eb67d9183e9" />
### TESTING INSTRUCTIONS

1. Set `EXTENSIONS_PATH` in your `superset_config.py`.
2. Navigate to Settings → Extensions.
3. **Import**: Click the download icon → select a `.supx` file → the extension appears in the list.
4. **Delete**: Click the trash icon on an uploaded extension → confirm → extension is removed from the list.
5. **Default chatbot**: Click the star icon on an extension with a chatbot → star fills → chatbot mount updates without a page reload. Click again → star clears → chatbot is deselected.
6. Verify a `LOCAL_EXTENSIONS` entry shows **no** trash icon (its `deletable` flag is false), so local extensions cannot be deleted through the UI.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
