### PR TITLE
test(model): roll back uncommitted ds_col mutations in timestamp-expression tests

### DIFF
--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -395,47 +395,66 @@ class TestSqlaTableModel(SupersetTestCase):
     def test_get_timestamp_expression(self):
         tbl = self.get_table(name="birth_names")
         ds_col = tbl.get_column("ds")
-        sqla_literal = ds_col.get_timestamp_expression(None)
-        assert str(sqla_literal.compile()) == "ds"
+        try:
+            sqla_literal = ds_col.get_timestamp_expression(None)
+            assert str(sqla_literal.compile()) == "ds"
 
-        sqla_literal = ds_col.get_timestamp_expression("P1D")
-        compiled = f"{sqla_literal.compile()}"
-        if tbl.database.backend == "mysql":
-            assert compiled == "DATE(ds)"
+            sqla_literal = ds_col.get_timestamp_expression("P1D")
+            compiled = f"{sqla_literal.compile()}"
+            if tbl.database.backend == "mysql":
+                assert compiled == "DATE(ds)"
 
-        prev_ds_expr = ds_col.expression
-        ds_col.expression = "DATE_ADD(ds, 1)"
-        sqla_literal = ds_col.get_timestamp_expression("P1D")
-        compiled = f"{sqla_literal.compile()}"
-        if tbl.database.backend == "mysql":
-            assert compiled == "DATE(DATE_ADD(ds, 1))"
-        ds_col.expression = prev_ds_expr
+            prev_ds_expr = ds_col.expression
+            ds_col.expression = "DATE_ADD(ds, 1)"
+            sqla_literal = ds_col.get_timestamp_expression("P1D")
+            compiled = f"{sqla_literal.compile()}"
+            if tbl.database.backend == "mysql":
+                assert compiled == "DATE(DATE_ADD(ds, 1))"
+            ds_col.expression = prev_ds_expr
+        finally:
+            # Discard the in-memory attribute history so the next session
+            # autoflush doesn't see this row as dirty. The test only
+            # exercises the in-memory compile path; any persisted write
+            # would be accidental. ``rollback`` rather than ``expire`` —
+            # the latter doesn't reliably clear SA's per-attribute history
+            # tracking for already-loaded objects.
+            metadata_db.session.rollback()
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_get_timestamp_expression_epoch(self):
         tbl = self.get_table(name="birth_names")
         ds_col = tbl.get_column("ds")
 
-        ds_col.expression = None
-        ds_col.python_date_format = "epoch_s"
-        sqla_literal = ds_col.get_timestamp_expression(None)
-        compiled = f"{sqla_literal.compile()}"
-        if tbl.database.backend == "mysql":
-            assert compiled == "from_unixtime(ds)"
+        try:
+            ds_col.expression = None
+            ds_col.python_date_format = "epoch_s"
+            sqla_literal = ds_col.get_timestamp_expression(None)
+            compiled = f"{sqla_literal.compile()}"
+            if tbl.database.backend == "mysql":
+                assert compiled == "from_unixtime(ds)"
 
-        ds_col.python_date_format = "epoch_s"
-        sqla_literal = ds_col.get_timestamp_expression("P1D")
-        compiled = f"{sqla_literal.compile()}"
-        if tbl.database.backend == "mysql":
-            assert compiled == "DATE(from_unixtime(ds))"
+            ds_col.python_date_format = "epoch_s"
+            sqla_literal = ds_col.get_timestamp_expression("P1D")
+            compiled = f"{sqla_literal.compile()}"
+            if tbl.database.backend == "mysql":
+                assert compiled == "DATE(from_unixtime(ds))"
 
-        prev_ds_expr = ds_col.expression
-        ds_col.expression = "DATE_ADD(ds, 1)"
-        sqla_literal = ds_col.get_timestamp_expression("P1D")
-        compiled = f"{sqla_literal.compile()}"
-        if tbl.database.backend == "mysql":
-            assert compiled == "DATE(from_unixtime(DATE_ADD(ds, 1)))"
-        ds_col.expression = prev_ds_expr
+            prev_ds_expr = ds_col.expression
+            ds_col.expression = "DATE_ADD(ds, 1)"
+            sqla_literal = ds_col.get_timestamp_expression("P1D")
+            compiled = f"{sqla_literal.compile()}"
+            if tbl.database.backend == "mysql":
+                assert compiled == "DATE(from_unixtime(DATE_ADD(ds, 1)))"
+            ds_col.expression = prev_ds_expr
+        finally:
+            # Discard the in-memory attribute history so the next session
+            # autoflush doesn't see this row as dirty —
+            # ``python_date_format`` isn't restored above and the test
+            # never commits, so the mutation would otherwise leak.
+            # ``rollback`` rather than ``expire`` — the latter doesn't
+            # reliably clear SA's per-attribute history tracking for
+            # already-loaded objects.
+            metadata_db.session.rollback()
 
     def query_with_expr_helper(self, is_timeseries, inner_join=True):
         tbl = self.get_table(name="birth_names")


### PR DESCRIPTION
### SUMMARY

`tests/integration_tests/model_tests.py::TestSqlaTableModel::test_get_timestamp_expression` and `::test_get_timestamp_expression_epoch` directly mutate `birth_names.ds_col.expression` (and, in the `_epoch` variant, `ds_col.python_date_format`) to exercise the `get_timestamp_expression` compile path. `expression` is restored at the end of each test; `python_date_format` is not. Neither test commits nor rolls back, so the `TableColumn` row stays in `session.dirty` for the next autoflush.

This is harmless on master today because nothing inspects `TableColumn` for dirty state at flush time. It becomes load-bearing the moment any code adds a SQLAlchemy listener that walks dirty rows — concretely, the `__versioned__` (sqlalchemy-continuum) instrumentation from the in-flight entity-versioning work ([#39603](https://github.com/apache/superset/pull/39603)). With that instrumentation applied, the next autoflush captures the uncommitted mutation, writes a `table_columns_version` shadow row for `ds_col`, and corrupts `birth_names`' version timeline.

The polluter mechanism is plain SQLAlchemy session-dirty + autoflush, not anything backend-specific — so the cascade reproduces on **all three backends**:

| CI job | `test_restore_applies_scalar_field` (downstream of `birth_names` version-history) | `test_rls_filter_applies_to_virtual_dataset` (+ `_with_join`) |
|---|---|---|
| `test-sqlite` | fails (422 "Dataset could not be updated") | passes |
| `test-mysql` | fails (422) | passes |
| `test-postgres (current/next/previous)` | fails (422) | fails (empty RLS clauses in rendered SQL) |

The virtual-dataset-RLS-cascade Postgres-only symptom appears to involve an additional Postgres path through the composite-PK `rls_filter_tables` M2M (not fully root-caused; out of scope here). The dataset-restore cascade is uniform across backends.

Fix: wrap each test body in `try` / `finally` with `metadata_db.session.rollback()` in the `finally` to discard the dirty attribute history. Behaviour on master is unchanged; the fix removes a latent footgun for anyone adding flush-time listeners to `TableColumn`.

### TESTING INSTRUCTIONS

The fix is hygiene-only on vanilla master — the two affected tests pass before and after:

```bash
pytest tests/integration_tests/model_tests.py::TestSqlaTableModel::test_get_timestamp_expression \
       tests/integration_tests/model_tests.py::TestSqlaTableModel::test_get_timestamp_expression_epoch
```

To verify the latent bug this prevents, apply any SQLAlchemy `__versioned__` listener to `TableColumn` (e.g. via `sqlalchemy-continuum`) and run the full integration suite. Before this fix: 3 downstream tests fail in CI's full-suite ordering (1 on each backend; Postgres also picks up the two RLS virtual-dataset failures). After: clean run.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Preset internal ticket sc-107618
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API