### PR TITLE
fix(bigquery): escape apostrophes in string literal filters (#35857)

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -51,7 +51,7 @@ def compile_bind_param_bigquery(element: BindParameter, compiler: Any, **kw: Any
     We override the bind parameter compilation to use \\' instead.
     """
     if kw.get("literal_binds") and isinstance(element.value, str):
-        val = element.value.replace("'", "\\'")
+        val = element.value.replace("\\", "\\\\").replace("'", "\\'")
         return f"'{val}'"
     return compiler.visit_bindparam(element, **kw)
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -39,6 +39,22 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.sql import column as sql_column, select, sqltypes
 from sqlalchemy.sql.expression import table as sql_table
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.elements import BindParameter
+
+
+@compiles(BindParameter, "bigquery")
+def compile_bind_param_bigquery(element: BindParameter, compiler: Any, **kw: Any) -> str:
+    """
+    BigQuery does not support standard SQL '' escaping natively for adjacent string literals,
+    which causes 400 POST syntax errors on filters with apostrophes.
+    We override the bind parameter compilation to use \\' instead.
+    """
+    if kw.get("literal_binds") and isinstance(element.value, str):
+        val = element.value.replace("'", "\\'")
+        return f"'{val}'"
+    return compiler.visit_bindparam(element, **kw)
+
 
 from superset.constants import TimeGrain
 from superset.databases.schemas import encrypted_field_properties, EncryptedString

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -37,24 +37,10 @@ from sqlalchemy.engine.base import Engine
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
-from sqlalchemy.sql import column as sql_column, select, sqltypes
-from sqlalchemy.sql.expression import table as sql_table
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import column as sql_column, select, sqltypes
 from sqlalchemy.sql.elements import BindParameter
-
-
-@compiles(BindParameter, "bigquery")
-def compile_bind_param_bigquery(element: BindParameter, compiler: Any, **kw: Any) -> str:
-    """
-    BigQuery does not support standard SQL '' escaping natively for adjacent string literals,
-    which causes 400 POST syntax errors on filters with apostrophes.
-    We override the bind parameter compilation to use \\' instead.
-    """
-    if kw.get("literal_binds") and isinstance(element.value, str):
-        val = element.value.replace("\\", "\\\\").replace("'", "\\'")
-        return f"'{val}'"
-    return compiler.visit_bindparam(element, **kw)
-
+from sqlalchemy.sql.expression import table as sql_table
 
 from superset.constants import TimeGrain
 from superset.databases.schemas import encrypted_field_properties, EncryptedString
@@ -76,6 +62,22 @@ if TYPE_CHECKING:
     from sqlalchemy.sql.expression import Select
 
 logger = logging.getLogger(__name__)
+
+
+@compiles(BindParameter, "bigquery")
+def compile_bind_param_bigquery(
+    element: BindParameter, compiler: Any, **kw: Any
+) -> str:
+    """
+    BigQuery does not support standard SQL '' escaping natively for adjacent
+    string literals, which causes 400 POST syntax errors on filters with
+    apostrophes. We override the bind parameter compilation to use \\' instead.
+    """
+    if kw.get("literal_binds") and isinstance(element.value, str):
+        val = element.value.replace("\\", "\\\\").replace("'", "\\'")
+        return f"'{val}'"
+    return compiler.visit_bindparam(element, **kw)
+
 
 try:
     import google.auth

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -743,3 +743,47 @@ def test_fetch_data_converts_bigquery_row_objects(mocker: MockerFixture) -> None
 
     assert result == [(1, "a"), (2, "b")]
     assert flask_g.bq_memory_limited is False
+
+def test_compile_bind_param_bigquery_string_literal() -> None:
+    """
+    Test that string literal bind parameters are compiled properly for BigQuery.
+    """
+    from sqlalchemy import select, table, column
+    from sqlalchemy_bigquery import BigQueryDialect
+    
+    # We must import BigQueryEngineSpec to ensure the @compiles decorator is executed
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F401
+
+    t = table("my_table", column("my_col"))
+
+    # 1. Normal string
+    q1 = select(t).where(t.c.my_col == "Normal")
+    compiled1 = q1.compile(
+        dialect=BigQueryDialect(),
+        compile_kwargs={"literal_binds": True},
+    )
+    assert "'Normal'" in str(compiled1)
+
+    # 2. String with apostrophe
+    q2 = select(t).where(t.c.my_col == "O'Donnell")
+    compiled2 = q2.compile(
+        dialect=BigQueryDialect(),
+        compile_kwargs={"literal_binds": True},
+    )
+    assert "'O\\'Donnell'" in str(compiled2)
+
+    # 3. String with backslash
+    q3 = select(t).where(t.c.my_col == "Back\\slash")
+    compiled3 = q3.compile(
+        dialect=BigQueryDialect(),
+        compile_kwargs={"literal_binds": True},
+    )
+    assert "'Back\\\\slash'" in str(compiled3)
+
+    # 4. String with both
+    q4 = select(t).where(t.c.my_col == "Mixed\\'O")
+    compiled4 = q4.compile(
+        dialect=BigQueryDialect(),
+        compile_kwargs={"literal_binds": True},
+    )
+    assert "'Mixed\\\\\\'O'" in str(compiled4)

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -744,13 +744,14 @@ def test_fetch_data_converts_bigquery_row_objects(mocker: MockerFixture) -> None
     assert result == [(1, "a"), (2, "b")]
     assert flask_g.bq_memory_limited is False
 
+
 def test_compile_bind_param_bigquery_string_literal() -> None:
     """
     Test that string literal bind parameters are compiled properly for BigQuery.
     """
-    from sqlalchemy import select, table, column
+    from sqlalchemy import column, select, table
     from sqlalchemy_bigquery import BigQueryDialect
-    
+
     # We must import BigQueryEngineSpec to ensure the @compiles decorator is executed
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec  # noqa: F401
 


### PR DESCRIPTION
Fixes #35857 by overriding BindParameter compilation for bigquery dialect to use backslash escaping for single quotes.

<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes BigQuery string literal apostrophe escaping issue in filters by overriding the `BindParameter` compilation for the BigQuery dialect to use backslash escaping.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!-- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Unit tests verify the correct escaping behavior for the BigQuery dialect.

### ADDITIONAL INFORMATION
<!-- Check any relevant boxes with "x" -->
<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### AI Assistance Disclosure
This PR was developed with the assistance of Antigravity (a Gemini-based AI coding assistant). The contributor has reviewed and validated all changes.