### PR TITLE
fix(docs): use absolute URL for docker-builds link in 4.1 release notes

### DIFF
--- a/RELEASING/release-notes-4-1/README.md
+++ b/RELEASING/release-notes-4-1/README.md
@@ -137,4 +137,4 @@ There is now a [metadata bar](https://github.com/apache/superset/pull/27857) add
 
 ## Change to Docker image builds
 
-Starting in 4.1.0, the release's docker image does not ship with drivers needed to operate Superset. Users may need to install a driver for their metadata database (MySQL or Postgres) as well as the driver for their data warehouse. This is a result of changes to the `lean` docker image that official releases come from; see [Docker Build Presets](/docs/installation/docker-builds#build-presets) for more details.
+Starting in 4.1.0, the release's docker image does not ship with drivers needed to operate Superset. Users may need to install a driver for their metadata database (MySQL or Postgres) as well as the driver for their data warehouse. This is a result of changes to the `lean` docker image that official releases come from; see [Docker Build Presets](https://superset.apache.org/docs/installation/docker-builds/#build-presets) for more details.


### PR DESCRIPTION
### SUMMARY

Fixes a relative link in the 4.1 release notes so it resolves correctly when
viewed on GitHub (relative doc-site paths don't resolve outside the docs
site router).

_Retitled/redescribed by a maintainer: the PR's original title and
description described Italian `messages.po` translation work, but this
branch's actual diff only ever touched
`RELEASING/release-notes-4-1/README.md` — a one-line link fix. Title/body
updated to match what's actually here so review reflects the real change._

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — docs link only.

### TESTING INSTRUCTIONS

N/A — link fix only.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API