### PR TITLE
fix(chart-echarts): drop white textBorder from Funnel segment labels

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -239,8 +239,6 @@ export default function transformProps(
     formatter,
     show: showLabels,
     color: theme.colorText,
-    textBorderColor: theme.colorBgBase,
-    textBorderWidth: 1,
   };
   const legendData = keys.sort((a: string, b: string) => {
     if (!legendSort) return 0;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
@@ -72,6 +72,15 @@ describe('Funnel transformProps', () => {
       }),
     );
   });
+
+  test('does not apply a text border to segment labels', () => {
+    // A white textBorder washes out the dark text on light-colored segments.
+    const result = transformProps(chartProps as EchartsFunnelChartProps);
+    const { label } = (result.echartOptions.series as any)[0];
+    expect(label.color).toBe(supersetTheme.colorText);
+    expect(label.textBorderColor).toBeUndefined();
+    expect(label.textBorderWidth).toBeUndefined();
+  });
 });
 
 describe('formatFunnelLabel', () => {


### PR DESCRIPTION
### SUMMARY

Funnel Chart segment labels currently apply a 1px white `textBorder`, added by #31590 (Ant Design v5 overhaul) when the label color moved from `theme.colors.grayscale.dark2` to `theme.colorText`. On lighter segments the white outline overwhelms the thin dark text and labels are nearly illegible. This PR drops the `textBorder` so the theme-provided text color stands on its own against the segment fill.

```diff
   const defaultLabel = {
     formatter,
     show: showLabels,
     color: theme.colorText,
-    textBorderColor: theme.colorBgBase,
-    textBorderWidth: 1,
   };
```

Pixel-sampled the rendered canvas to confirm the perceived "white" labels are actually dark text (`rgba(0,0,0,0.88)`) surrounded by a white 1px outline that wins the local contrast on yellow / light segments.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Funnel Chart on `cleaned_sales_data` with `product_line` + `SUM(sales)`, row limit 10.

| Before | After |
|---|---|
| ![before](https://files.catbox.moe/vbndk4.png) | ![after](https://files.catbox.moe/oezj1x.png) |

### TESTING INSTRUCTIONS

1. Open a Funnel Chart in Explore with a string dimension and a numeric metric (e.g. `product_line` + `SUM(sales)` on `cleaned_sales_data`).
2. Configure categories that produce a mix of light- and dark-colored segments.
3. Verify each segment label is readable against its background, including yellow / light-colored segments.

Unit coverage: `plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts` adds a test asserting `defaultLabel` does not set `textBorderColor` / `textBorderWidth`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API