### PR TITLE
fix(rbac): widen permissions dropdown in role form

### DIFF
--- a/superset-frontend/src/features/roles/RoleFormItems.tsx
+++ b/superset-frontend/src/features/roles/RoleFormItems.tsx
@@ -60,7 +60,10 @@ export const PermissionsField = ({
         placeholder={t('Select permissions')}
         options={options}
         loading={loading}
-        getPopupContainer={trigger => trigger.closest('.ant-modal-content')}
+        getPopupContainer={trigger =>
+          trigger.closest('.ant-modal-content') || document.body
+        }
+        dropdownStyle={{ minWidth: 480 }}
         data-test="permissions-select"
       />
     </FormItem>

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -341,6 +341,7 @@ export const ChartCreation = ({
                 optionFilterProps={['id', 'table_name']}
                 placeholder={t('Choose a %s', datasetLabelLower())}
                 showSearch
+                oneLine
                 value={datasource}
               />
               {datasetHelpText}


### PR DESCRIPTION
### SUMMARY

Fixes #40430.

This updates the permissions AsyncSelect dropdown in the role create/edit form so long permission names are easier to read.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

- Ran `npm run lint`
- Rebuilt frontend plugin workspaces locally
- Manually verified the Permissions dropdown in:
  - Security → List Roles → Edit Role
  - Security → List Roles → + Role

### ADDITIONAL INFORMATION

- [x] Has associated issue: #40430
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Note: local `npm run type` surfaced unrelated plugin workspace TypeScript issues in `plugin-chart-word-cloud` and `preset-chart-deckgl`, not caused by this change.