### PR TITLE
fix(mcp): add select_columns lean defaults to get_dashboard_info, get_chart_info, get_dataset_info

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -249,6 +249,29 @@ class VersionedResponse(BaseModel):
     api_version: str = Field("v1", description="MCP API version")
 
 
+DEFAULT_GET_CHART_INFO_COLUMNS: List[str] = [
+    "id",
+    "slice_name",
+    "viz_type",
+    "datasource_name",
+    "datasource_type",
+    "url",
+    "description",
+    "cache_timeout",
+    "changed_on",
+    "changed_on_humanized",
+    "created_on",
+    "created_on_humanized",
+    "certified_by",
+    "certification_details",
+    "uuid",
+    "tags",
+    "filters",
+    "form_data_key",
+    "is_unsaved_state",
+]
+
+
 class GetChartInfoRequest(BaseModel):
     """Request schema for get_chart_info with support for ID, UUID, or form_data_key.
 
@@ -289,6 +312,17 @@ class GetChartInfoRequest(BaseModel):
             "and the caller to have dashboard access."
         ),
     )
+    select_columns: Annotated[
+        List[str],
+        Field(
+            default_factory=lambda: list(DEFAULT_GET_CHART_INFO_COLUMNS),
+            description=(
+                "Top-level fields to include in the response. Defaults to a lean "
+                "set that excludes 'form_data' (the full chart config, can be 50KB+). "
+                "Add 'form_data' explicitly when you need the raw chart configuration."
+            ),
+        ),
+    ]
 
     @model_validator(mode="after")
     def validate_identifier_or_form_data_key(self) -> "GetChartInfoRequest":
@@ -297,6 +331,15 @@ class GetChartInfoRequest(BaseModel):
                 "At least one of 'identifier' or 'form_data_key' must be provided."
             )
         return self
+
+    @field_validator("select_columns", mode="before")
+    @classmethod
+    def _parse_select_columns(cls, value: Any) -> Any:
+        from superset.mcp_service.utils.schema_utils import parse_json_or_list
+
+        if value is None:
+            return list(DEFAULT_GET_CHART_INFO_COLUMNS)
+        return parse_json_or_list(value, "select_columns")
 
 
 def extract_filters_from_form_data(

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -339,7 +339,8 @@ class GetChartInfoRequest(BaseModel):
 
         if value is None:
             return list(DEFAULT_GET_CHART_INFO_COLUMNS)
-        return parse_json_or_list(value, "select_columns")
+        parsed = parse_json_or_list(value, "select_columns")
+        return parsed if parsed else list(DEFAULT_GET_CHART_INFO_COLUMNS)
 
 
 def extract_filters_from_form_data(

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -278,6 +278,8 @@ async def get_chart_info(
                 "form_data_key=%s" % (request.form_data_key,)
             )
             result = _build_unsaved_chart_info(request.form_data_key)
+            if isinstance(result, ChartError):
+                return result
             if not can_view_data_model_metadata:
                 result = redact_chart_data_model_fields(result)
             return result.model_dump(

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -20,6 +20,7 @@ MCP tool: get_chart_info
 """
 
 import logging
+from typing import Any
 
 from fastmcp import Context
 from sqlalchemy.orm import subqueryload
@@ -213,7 +214,7 @@ def _apply_unsaved_state_override(result: ChartInfo, form_data_key: str) -> None
 )
 async def get_chart_info(
     request: GetChartInfoRequest, ctx: Context
-) -> ChartInfo | ChartError:
+) -> dict[str, Any] | ChartError:
     """Get chart metadata by ID or UUID.
 
     IMPORTANT FOR LLM CLIENTS:
@@ -333,6 +334,11 @@ async def get_chart_info(
             error = await _attach_dashboard_filters(result, request.dashboard_id, ctx)
             if error is not None:
                 return error
+
+        return result.model_dump(
+            mode="json",
+            context={"select_columns": request.select_columns},
+        )
     else:
         await ctx.warning("Chart retrieval failed: error=%s" % (str(result),))
 

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -279,8 +279,11 @@ async def get_chart_info(
             )
             result = _build_unsaved_chart_info(request.form_data_key)
             if not can_view_data_model_metadata:
-                return redact_chart_data_model_fields(result)
-            return result
+                result = redact_chart_data_model_fields(result)
+            return result.model_dump(
+                mode="json",
+                context={"select_columns": request.select_columns},
+            )
 
     # At this point identifier must be set (validator ensures at least one
     # of identifier/form_data_key is provided, and the form_data_key-only

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -311,7 +311,6 @@ DEFAULT_GET_DASHBOARD_INFO_COLUMNS: List[str] = [
     "cross_filters_enabled",
     "is_permalink_state",
     "permalink_key",
-    "filter_state",
 ]
 
 
@@ -360,7 +359,8 @@ class GetDashboardInfoRequest(MetadataCacheControl):
 
         if value is None:
             return list(DEFAULT_GET_DASHBOARD_INFO_COLUMNS)
-        return parse_json_or_list(value, "select_columns")
+        parsed = parse_json_or_list(value, "select_columns")
+        return parsed if parsed else list(DEFAULT_GET_DASHBOARD_INFO_COLUMNS)
 
 
 class GetDashboardLayoutRequest(BaseModel):

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -310,6 +310,8 @@ DEFAULT_GET_DASHBOARD_INFO_COLUMNS: List[str] = [
     "native_filters",
     "cross_filters_enabled",
     "is_permalink_state",
+    "permalink_key",
+    "filter_state",
 ]
 
 

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -288,6 +288,31 @@ class ListDashboardsRequest(OwnedByMeMixin, CreatedByMeMixin, MetadataCacheContr
         return self
 
 
+DEFAULT_GET_DASHBOARD_INFO_COLUMNS: List[str] = [
+    "id",
+    "dashboard_title",
+    "slug",
+    "description",
+    "certified_by",
+    "certification_details",
+    "published",
+    "is_managed_externally",
+    "external_url",
+    "created_on",
+    "changed_on",
+    "uuid",
+    "url",
+    "created_on_humanized",
+    "changed_on_humanized",
+    "chart_count",
+    "tags",
+    "charts",
+    "native_filters",
+    "cross_filters_enabled",
+    "is_permalink_state",
+]
+
+
 class GetDashboardInfoRequest(MetadataCacheControl):
     """Request schema for get_dashboard_info with support for ID, UUID, or slug.
 
@@ -312,6 +337,28 @@ class GetDashboardInfoRequest(MetadataCacheControl):
             "from that permalink."
         ),
     )
+    select_columns: Annotated[
+        List[str],
+        Field(
+            default_factory=lambda: list(DEFAULT_GET_DASHBOARD_INFO_COLUMNS),
+            description=(
+                "Top-level fields to include in the response. Defaults to a lean "
+                "set that excludes 'css' (raw CSS, can be many KB) and 'filter_state' "
+                "(only relevant when permalink_key is provided). Pass an explicit list "
+                "to override, e.g. ['id','dashboard_title','charts'] for minimal "
+                "output, or add 'css' to include raw dashboard CSS."
+            ),
+        ),
+    ]
+
+    @field_validator("select_columns", mode="before")
+    @classmethod
+    def _parse_select_columns(cls, value: Any) -> Any:
+        from superset.mcp_service.utils.schema_utils import parse_json_or_list
+
+        if value is None:
+            return list(DEFAULT_GET_DASHBOARD_INFO_COLUMNS)
+        return parse_json_or_list(value, "select_columns")
 
 
 class GetDashboardLayoutRequest(BaseModel):

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -39,6 +39,7 @@ from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
     DashboardError,
     DashboardInfo,
+    DEFAULT_GET_DASHBOARD_INFO_COLUMNS,
     GetDashboardInfoRequest,
     redact_filter_state_data_model_metadata,
 )
@@ -248,9 +249,20 @@ async def get_dashboard_info(
                     result.is_permalink_state,
                 )
             )
+            # When permalink_key is supplied and the caller did not explicitly
+            # override select_columns, ensure filter_state is present so the
+            # caller gets the data they came for.
+            effective_select_columns = list(request.select_columns)
+            if (
+                request.permalink_key
+                and effective_select_columns == list(DEFAULT_GET_DASHBOARD_INFO_COLUMNS)
+                and "filter_state" not in effective_select_columns
+            ):
+                effective_select_columns.append("filter_state")
+
             return result.model_dump(
                 mode="json",
-                context={"select_columns": request.select_columns},
+                context={"select_columns": effective_select_columns},
             )
         else:
             await ctx.warning(

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -253,10 +253,8 @@ async def get_dashboard_info(
             # override select_columns, ensure filter_state is present so the
             # caller gets the data they came for.
             effective_select_columns = list(request.select_columns)
-            if (
-                request.permalink_key
-                and effective_select_columns == list(DEFAULT_GET_DASHBOARD_INFO_COLUMNS)
-                and "filter_state" not in effective_select_columns
+            if request.permalink_key and effective_select_columns == list(
+                DEFAULT_GET_DASHBOARD_INFO_COLUMNS
             ):
                 effective_select_columns.append("filter_state")
 

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -24,6 +24,7 @@ about a specific dashboard.
 
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 from fastmcp import Context
 from flask import g, has_request_context
@@ -114,7 +115,7 @@ def _get_permalink_state(permalink_key: str) -> DashboardPermalinkValue | None:
 )
 async def get_dashboard_info(
     request: GetDashboardInfoRequest, ctx: Context
-) -> DashboardInfo | DashboardError:
+) -> dict[str, Any] | DashboardError:
     """
     Get dashboard metadata by ID, UUID, or slug.
 
@@ -246,6 +247,10 @@ async def get_dashboard_info(
                     result.published,
                     result.is_permalink_state,
                 )
+            )
+            return result.model_dump(
+                mode="json",
+                context={"select_columns": request.select_columns},
             )
         else:
             await ctx.warning(

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -110,7 +110,7 @@ class TableColumnInfo(BaseModel):
         data = serializer(self)
         if info.context and isinstance(info.context, dict):
             column_fields = info.context.get("column_fields")
-            if column_fields:
+            if column_fields is not None:
                 requested = set(column_fields)
                 requested.add("column_name")
                 return {k: v for k, v in data.items() if k in requested}
@@ -404,10 +404,10 @@ class GetDatasetInfoRequest(MetadataCacheControl):
     def _parse_column_fields(cls, value: Any) -> Any:
         from superset.mcp_service.utils.schema_utils import parse_json_or_list
 
-        if value is None:
+        if value is None or value == "":
             return list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
         parsed = parse_json_or_list(value, "column_fields")
-        return parsed if parsed else list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
+        return parsed
 
 
 class CreateVirtualDatasetRequest(BaseModel):

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -396,7 +396,8 @@ class GetDatasetInfoRequest(MetadataCacheControl):
 
         if value is None:
             return list(DEFAULT_GET_DATASET_INFO_COLUMNS)
-        return parse_json_or_list(value, "select_columns")
+        parsed = parse_json_or_list(value, "select_columns")
+        return parsed if parsed else list(DEFAULT_GET_DATASET_INFO_COLUMNS)
 
     @field_validator("column_fields", mode="before")
     @classmethod
@@ -405,7 +406,8 @@ class GetDatasetInfoRequest(MetadataCacheControl):
 
         if value is None:
             return list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
-        return parse_json_or_list(value, "column_fields")
+        parsed = parse_json_or_list(value, "column_fields")
+        return parsed if parsed else list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
 
 
 class CreateVirtualDatasetRequest(BaseModel):

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -97,6 +97,25 @@ class TableColumnInfo(BaseModel):
     filterable: bool | None = Field(None, description="Is filterable")
     description: str | None = Field(None, description="Column description")
 
+    @model_serializer(mode="wrap")
+    def _filter_column_fields_by_context(
+        self, serializer: Any, info: Any
+    ) -> Dict[str, Any]:
+        """Filter column fields based on serialization context.
+
+        If context contains 'column_fields', only include those fields plus
+        column_name (always required). Keeps wide datasets small when the
+        caller only needs column_name + type.
+        """
+        data = serializer(self)
+        if info.context and isinstance(info.context, dict):
+            column_fields = info.context.get("column_fields")
+            if column_fields:
+                requested = set(column_fields)
+                requested.add("column_name")
+                return {k: v for k, v in data.items() if k in requested}
+        return data
+
 
 class SqlMetricInfo(BaseModel):
     metric_name: str = Field(
@@ -315,6 +334,29 @@ class DatasetError(BaseModel):
         )
 
 
+DEFAULT_GET_DATASET_INFO_COLUMNS: List[str] = [
+    "id",
+    "table_name",
+    "schema",
+    "database_name",
+    "database_id",
+    "uuid",
+    "is_virtual",
+    "description",
+    "main_dttm_col",
+    "sql",
+    "url",
+    "columns",
+    "metrics",
+]
+
+DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS: List[str] = [
+    "column_name",
+    "type",
+    "is_dttm",
+]
+
+
 class GetDatasetInfoRequest(MetadataCacheControl):
     """Request schema for get_dataset_info with support for ID or UUID."""
 
@@ -322,6 +364,48 @@ class GetDatasetInfoRequest(MetadataCacheControl):
         int | str,
         Field(description="Dataset identifier - can be numeric ID or UUID string"),
     ]
+    select_columns: Annotated[
+        List[str],
+        Field(
+            default_factory=lambda: list(DEFAULT_GET_DATASET_INFO_COLUMNS),
+            description=(
+                "Top-level fields to include in the response. Defaults to a lean "
+                "set that excludes verbose fields like params, template_params, "
+                "extra, tags, certification_details. Pass an explicit list to "
+                "override (e.g. ['id','table_name','columns'] for minimal output)."
+            ),
+        ),
+    ]
+    column_fields: Annotated[
+        List[str],
+        Field(
+            default_factory=lambda: list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS),
+            description=(
+                "Per-column fields to include for entries in 'columns'. Defaults "
+                "to ['column_name','type','is_dttm']. Pass a wider list to "
+                "include 'verbose_name','groupby','filterable','description' "
+                "when needed."
+            ),
+        ),
+    ]
+
+    @field_validator("select_columns", mode="before")
+    @classmethod
+    def _parse_select_columns(cls, value: Any) -> Any:
+        from superset.mcp_service.utils.schema_utils import parse_json_or_list
+
+        if value is None:
+            return list(DEFAULT_GET_DATASET_INFO_COLUMNS)
+        return parse_json_or_list(value, "select_columns")
+
+    @field_validator("column_fields", mode="before")
+    @classmethod
+    def _parse_column_fields(cls, value: Any) -> Any:
+        from superset.mcp_service.utils.schema_utils import parse_json_or_list
+
+        if value is None:
+            return list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
+        return parse_json_or_list(value, "column_fields")
 
 
 class CreateVirtualDatasetRequest(BaseModel):

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -24,6 +24,7 @@ about a specific dataset.
 
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 from fastmcp import Context
 from sqlalchemy.orm import joinedload, subqueryload
@@ -58,7 +59,7 @@ logger = logging.getLogger(__name__)
 @requires_data_model_metadata_access
 async def get_dataset_info(
     request: GetDatasetInfoRequest, ctx: Context
-) -> DatasetInfo | DatasetError:
+) -> dict[str, Any] | DatasetError:
     """Get dataset metadata by ID or UUID.
 
     Returns columns, metrics, and schema details.
@@ -144,6 +145,19 @@ async def get_dataset_info(
                     len(result.metrics) if result.metrics else 0,
                 )
             )
+            await ctx.debug(
+                "Filtering response: select_columns=%s, column_fields=%s"
+                % (request.select_columns, request.column_fields)
+            )
+            with event_logger.log_context(action="mcp.get_dataset_info.serialization"):
+                return result.model_dump(
+                    mode="json",
+                    by_alias=True,
+                    context={
+                        "select_columns": request.select_columns,
+                        "column_fields": request.column_fields,
+                    },
+                )
         else:
             await ctx.warning(
                 "Dataset retrieval failed: error_type=%s, error=%s"

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
@@ -492,4 +492,57 @@ class TestGetChartInfoPrivacy:
         assert result["datasource_name"] is None
         assert result["datasource_type"] is None
         assert result["filters"] is None
-        assert result["form_data"] is None
+        # form_data is excluded from default select_columns, so it won't
+        # appear in the response at all — which is even more restrictive than None.
+        assert "form_data" not in result
+
+    @pytest.mark.asyncio
+    async def test_unsaved_chart_select_columns_filters_response(
+        self, mcp_server
+    ) -> None:
+        """Unsaved-chart path (form_data_key without identifier) must apply
+        select_columns filtering just like the saved-chart path does."""
+        cached_form_data = (
+            '{"viz_type":"bar","datasource_name":"sales",'
+            '"datasource_type":"table","metrics":["revenue"]}'
+        )
+
+        with (
+            patch.object(
+                get_chart_info_module.event_logger,
+                "log_context",
+                return_value=nullcontext(),
+            ),
+            patch.object(
+                get_chart_info_module,
+                "user_can_view_data_model_metadata",
+                return_value=True,
+                create=True,
+            ),
+            patch.object(
+                get_chart_info_module,
+                "get_cached_form_data",
+                return_value=cached_form_data,
+            ),
+            patch("superset.mcp_service.auth.check_tool_permission", return_value=True),
+        ):
+            async with Client(mcp_server) as client:
+                # Explicit select_columns: only id and slice_name
+                response = await client.call_tool(
+                    "get_chart_info",
+                    {
+                        "request": GetChartInfoRequest(
+                            form_data_key="cached-key",
+                            select_columns=["id", "slice_name", "viz_type"],
+                        ).model_dump()
+                    },
+                )
+
+        result = json.loads(response.content[0].text)
+        # Only requested fields must be present
+        assert "id" in result
+        assert "slice_name" in result
+        assert "viz_type" in result
+        # Fields NOT in select_columns must be absent
+        assert "form_data" not in result
+        assert "datasource_name" not in result

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
@@ -23,7 +23,7 @@ privacy behavior.
 import importlib
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from fastmcp import Client
@@ -36,6 +36,7 @@ from superset.mcp_service.chart.chart_helpers import (
     ChartNotOnDashboardError,
 )
 from superset.mcp_service.chart.schemas import (
+    ChartError,
     ChartInfo,
     extract_filters_from_form_data,
     GetChartInfoRequest,
@@ -546,3 +547,33 @@ class TestGetChartInfoPrivacy:
         # Fields NOT in select_columns must be absent
         assert "form_data" not in result
         assert "datasource_name" not in result
+
+    @pytest.mark.asyncio
+    async def test_unsaved_chart_error_returned_unchanged(self) -> None:
+        """ChartError results should not be serialized as success dictionaries."""
+        error = ChartError(error="Missing cached chart data", error_type="NotFound")
+
+        with (
+            patch.object(
+                get_chart_info_module.event_logger,
+                "log_context",
+                return_value=nullcontext(),
+            ),
+            patch.object(
+                get_chart_info_module,
+                "user_can_view_data_model_metadata",
+                return_value=True,
+                create=True,
+            ),
+            patch.object(
+                get_chart_info_module,
+                "_build_unsaved_chart_info",
+                return_value=error,
+            ),
+        ):
+            result = await get_chart_info_module.get_chart_info(
+                request=GetChartInfoRequest(form_data_key="missing-key"),
+                ctx=SimpleNamespace(info=AsyncMock()),
+            )
+
+        assert result is error

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
@@ -365,7 +365,8 @@ class TestGetChartInfoPrivacy:
         assert result["datasource_name"] is None
         assert result["datasource_type"] is None
         assert result["filters"] is None
-        assert result["form_data"] is None
+        # form_data is excluded from default select_columns, so it won't be in result
+        assert "form_data" not in result
 
     def test_form_data_override_does_not_double_sanitize(self) -> None:
         """Saved chart fields stay single-wrapped after unsaved overrides."""

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -489,6 +489,78 @@ async def test_get_dashboard_info_permalink_does_not_double_sanitize(
     assert result.data["filter_state"]["activeTabs"][0] == _wrapped("TAB-1")
 
 
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_permalink_key_includes_filter_state(
+    mock_info, mcp_server
+):
+    """When permalink_key is provided without explicit select_columns, filter_state
+    must be present in the response."""
+    dashboard = Mock()
+    dashboard.id = 42
+    dashboard.dashboard_title = "Sales Dashboard"
+    dashboard.slug = "sales"
+    dashboard.description = None
+    dashboard.css = None
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = None
+    dashboard.published = True
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.created_on = None
+    dashboard.changed_on = None
+    dashboard.created_by = None
+    dashboard.changed_by = None
+    dashboard.uuid = "dashboard-uuid-42"
+    dashboard.url = "/dashboard/42"
+    dashboard.thumbnail_url = None
+    dashboard.created_on_humanized = None
+    dashboard.changed_on_humanized = None
+    dashboard.slices = []
+    dashboard.owners = []
+    dashboard.tags = []
+    dashboard.roles = []
+    dashboard.charts = []
+    mock_info.return_value = dashboard
+
+    permalink_value = {
+        "dashboardId": "42",
+        "state": {
+            "dataMask": {},
+            "activeTabs": ["TAB-A"],
+        },
+    }
+
+    with (
+        patch(
+            "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
+            return_value=True,
+        ),
+        patch.object(
+            get_dashboard_info_module,
+            "user_can_view_data_model_metadata",
+            return_value=True,
+        ),
+        patch.object(
+            get_dashboard_info_module,
+            "_get_permalink_state",
+            return_value=permalink_value,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            # No explicit select_columns — tool should use its default which
+            # includes filter_state when permalink_key is supplied.
+            result = await client.call_tool(
+                "get_dashboard_info",
+                {"request": {"identifier": 42, "permalink_key": "some-key"}},
+            )
+
+    assert "filter_state" in result.data
+    assert result.data["is_permalink_state"] is True
+    assert result.data["permalink_key"] == "some-key"
+
+
 def test_refresh_request_user_for_permalink_access(
     app,
 ):

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -1654,16 +1654,30 @@ class TestGetDatasetInfoRequestValidators:
         )
         assert request.column_fields == ["column_name", "type"]
 
-    def test_column_fields_empty_list_falls_back_to_default(self):
-        """An explicit empty list for column_fields falls back to the default so that
-        filtering is not accidentally disabled by an empty column list."""
-        from superset.mcp_service.dataset.schemas import (
-            DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS,
-            GetDatasetInfoRequest,
-        )
+    def test_column_fields_empty_list_stays_empty(self):
+        """An explicit empty list for column_fields is preserved as-is."""
+        from superset.mcp_service.dataset.schemas import GetDatasetInfoRequest
 
         request = GetDatasetInfoRequest(identifier=1, column_fields=[])
-        assert request.column_fields == list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
+        assert request.column_fields == []
+
+    def test_column_fields_empty_list_serializes_column_name_only(self):
+        """An explicit empty list still includes the required column_name field."""
+        from superset.mcp_service.dataset.schemas import TableColumnInfo
+
+        column = TableColumnInfo(
+            column_name="region",
+            verbose_name="Region",
+            type="VARCHAR",
+            is_dttm=False,
+            groupby=True,
+            filterable=True,
+            description="Region dimension",
+        )
+
+        assert column.model_dump(context={"column_fields": []}) == {
+            "column_name": "region"
+        }
 
     def test_column_fields_none_falls_back_to_default(self):
         """When column_fields is None (not provided), the default columns are used."""

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -1654,12 +1654,16 @@ class TestGetDatasetInfoRequestValidators:
         )
         assert request.column_fields == ["column_name", "type"]
 
-    def test_column_fields_empty_list_stays_empty(self):
-        """An explicit empty list for column_fields is preserved as-is."""
-        from superset.mcp_service.dataset.schemas import GetDatasetInfoRequest
+    def test_column_fields_empty_list_falls_back_to_default(self):
+        """An explicit empty list for column_fields falls back to the default so that
+        filtering is not accidentally disabled by an empty column list."""
+        from superset.mcp_service.dataset.schemas import (
+            DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS,
+            GetDatasetInfoRequest,
+        )
 
         request = GetDatasetInfoRequest(identifier=1, column_fields=[])
-        assert request.column_fields == []
+        assert request.column_fields == list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
 
     def test_column_fields_none_falls_back_to_default(self):
         """When column_fields is None (not provided), the default columns are used."""

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -1641,6 +1641,47 @@ class TestDatasetDefaultColumnFiltering:
                 )
 
 
+class TestGetDatasetInfoRequestValidators:
+    """Unit tests for GetDatasetInfoRequest field validators."""
+
+    def test_column_fields_json_string_parses_to_list(self):
+        """JSON string input for column_fields is decoded into a list."""
+        from superset.mcp_service.dataset.schemas import GetDatasetInfoRequest
+
+        request = GetDatasetInfoRequest(
+            identifier=1,
+            column_fields='["column_name","type"]',
+        )
+        assert request.column_fields == ["column_name", "type"]
+
+    def test_column_fields_empty_list_stays_empty(self):
+        """An explicit empty list for column_fields is preserved as-is."""
+        from superset.mcp_service.dataset.schemas import GetDatasetInfoRequest
+
+        request = GetDatasetInfoRequest(identifier=1, column_fields=[])
+        assert request.column_fields == []
+
+    def test_column_fields_none_falls_back_to_default(self):
+        """When column_fields is None (not provided), the default columns are used."""
+        from superset.mcp_service.dataset.schemas import (
+            DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS,
+            GetDatasetInfoRequest,
+        )
+
+        request = GetDatasetInfoRequest(identifier=1, column_fields=None)
+        assert request.column_fields == list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
+
+    def test_column_fields_default_when_omitted(self):
+        """When column_fields is omitted entirely, the default columns are used."""
+        from superset.mcp_service.dataset.schemas import (
+            DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS,
+            GetDatasetInfoRequest,
+        )
+
+        request = GetDatasetInfoRequest(identifier=1)
+        assert request.column_fields == list(DEFAULT_GET_DATASET_INFO_COLUMN_FIELDS)
+
+
 class TestDatasetSortableColumns:
     """Test sortable columns configuration for dataset tools."""
 


### PR DESCRIPTION
## Summary

The three `*_info` tools (`get_dashboard_info`, `get_chart_info`, `get_dataset_info`) could return responses exceeding 91KB for large resources, causing `ResponseSizeGuardMiddleware` to truncate responses into an unusable state for MCP clients.

Root cause: `DashboardInfo`, `ChartInfo`, and `DatasetInfo` already have `_filter_fields_by_context` model serializers that support context-based field filtering, but none of their request schemas exposed a `select_columns` parameter — so the filtering was never invoked.

### Changes

- **`get_dashboard_info`**: adds `select_columns` to `GetDashboardInfoRequest` with a lean default that excludes `css` (raw CSS, can be many KB) and `filter_state` (only relevant with `permalink_key`).

- **`get_chart_info`**: adds `select_columns` to `GetChartInfoRequest` with a lean default that excludes `form_data` (full chart config dict, can be 50KB+). Callers that need the raw config can add `'form_data'` explicitly.

- **`get_dataset_info`**: adds `select_columns` (lean top-level field set) and `column_fields` (per-column field set, defaults to `column_name/type/is_dttm`) to `GetDatasetInfoRequest`. Adds `_filter_column_fields_by_context` to `TableColumnInfo` so per-column filtering applies during serialization.

All three tools now call `result.model_dump(context={"select_columns": ...})` so filtering fires on every call. Default response size for a large dashboard drops from ~91KB to a few KB. Callers can opt in to wider responses by passing explicit `select_columns` lists.

## Testing

- Existing tests for all three tools continue to pass
- Default response for large dashboards stays within the MCP token limit
- Explicit `select_columns` override returns only the requested fields