### PR TITLE
chore(ci): update GHA actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Set up QEMU
       if: ${{ inputs.build == 'true' }}
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       with:
         # Pin the binfmt image to a specific QEMU release. The default
         # (`tonistiigi/binfmt:latest`) is a moving target, and drift across
@@ -39,12 +39,12 @@ runs:
 
     - name: Set up Docker Buildx
       if: ${{ inputs.build == 'true' }}
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Try to login to DockerHub
       if: ${{ inputs.login-to-dockerhub == 'true' }}
       continue-on-error: true
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         username: ${{ inputs.dockerhub-user }}
         password: ${{ inputs.dockerhub-token }}

--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
 
     - name: Setup Node Env
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
 
@@ -21,7 +21,7 @@ runs:
 
     - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
       if: ${{ inputs.from-npm == 'false' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: apache-superset/supersetbot
         path: supersetbot

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,7 +95,11 @@ jobs:
       # in the context of push (using multi-platform build), we need to pull the image locally
       - name: Docker pull
         if: github.event_name == 'push' && (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker)
-        run:  docker pull $IMAGE_TAG
+        run: |
+          for i in 1 2 3; do
+            docker pull $IMAGE_TAG && break
+            [ $i -lt 3 ] && sleep 30
+          done
 
       - name: Print docker stats
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker


### PR DESCRIPTION
### SUMMARY

GitHub is forcing Node.js 24 as the default GitHub Actions runtime starting **June 2nd, 2026** (6 days away). Four actions in our docker build workflow are annotated as running on the deprecated Node.js 20 runtime.

This PR updates them to their v4 major releases (which ship Node.js 24 as their internal runtime) and also fixes a related transient failure:

| Action | Before | After |
|--------|--------|-------|
| `docker/setup-qemu-action` | v3.6.0 | v4.1.0 |
| `docker/setup-buildx-action` | v3.12.0 | v4.1.0 |
| `docker/login-action` | v3.7.0 | v4.2.0 |
| `actions/setup-node` | v4 (unpinned) | v6.4.0 (pinned hash) |

Also:
- Updates the unpinned `actions/checkout@v4` in `setup-supersetbot/action.yml` to the pinned `v6.0.2` hash already used elsewhere in the repo (consistency + security).
- Adds a 3-attempt retry loop to the `docker pull` step to handle the transient DockerHub `connection reset by peer` errors that caused `docker-build (dev)` to fail in recent master pushes (e.g. run [26542517324](https://github.com/apache/superset/actions/runs/26542517324)).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI workflow changes only.

### TESTING INSTRUCTIONS

1. Merge and observe the next master push run — the Node.js 20 deprecation annotations should be gone from the docker-build jobs.
2. The `docker pull` step will retry up to 3×30s if DockerHub is flaky, rather than failing immediately.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)