### PR TITLE
fix(cachekey): use data_cache for chart query result invalidation

### DIFF
--- a/superset/cachekeys/api.py
+++ b/superset/cachekeys/api.py
@@ -100,7 +100,10 @@ class CacheRestApi(BaseSupersetModelRestApi):
         )
         cache_keys = [c.cache_key for c in cache_key_objs]
         if cache_key_objs:
-            all_keys_deleted = cache_manager.cache.delete_many(*cache_keys)
+            # Chart query results live in ``data_cache``, not the default
+            # ``cache`` — using the wrong backend silently misses the Redis
+            # keys when ``CACHE_KEY_PREFIX`` differs between the two configs.
+            all_keys_deleted = cache_manager.data_cache.delete_many(*cache_keys)
 
             if not all_keys_deleted:
                 # expected behavior as keys may expire and cache is not a

--- a/tests/integration_tests/cachekeys/api_tests.py
+++ b/tests/integration_tests/cachekeys/api_tests.py
@@ -18,6 +18,7 @@
 """Unit tests for Superset"""
 
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -52,15 +53,41 @@ def test_invalidate_cache(invalidate):
 def test_invalidate_existing_cache(invalidate):
     db.session.add(CacheKey(cache_key="cache_key", datasource_uid="3__table"))
     db.session.commit()
-    cache_manager.cache.set("cache_key", "value")
+    cache_manager.data_cache.set("cache_key", "value")
 
     rv = invalidate({"datasource_uids": ["3__table"]})
 
     assert rv.status_code == 201
-    assert cache_manager.cache.get("cache_key") is None  # noqa: E711
+    assert cache_manager.data_cache.get("cache_key") is None  # noqa: E711
     assert (
         not db.session.query(CacheKey).filter(CacheKey.cache_key == "cache_key").first()
     )
+
+
+def test_invalidate_uses_data_cache_not_default_cache(invalidate):
+    """Regression test for #40489.
+
+    Chart query results are written through ``cache_manager.data_cache``
+    (``DATA_CACHE_CONFIG``). When ``CACHE_CONFIG`` and ``DATA_CACHE_CONFIG``
+    use distinct ``CACHE_KEY_PREFIX`` values, deleting via the default
+    ``cache_manager.cache`` silently misses the underlying Redis keys
+    because flask-caching prepends the wrong prefix to the DEL call.
+    """
+    db.session.add(CacheKey(cache_key="cache_key", datasource_uid="3__table"))
+    db.session.commit()
+
+    with (
+        patch.object(cache_manager.data_cache, "delete_many") as data_delete,
+        patch.object(cache_manager.cache, "delete_many") as default_delete,
+    ):
+        data_delete.return_value = True
+        rv = invalidate({"datasource_uids": ["3__table"]})
+
+    assert rv.status_code == 201
+    # Chart-data cache backend (the one that wrote the keys) must be hit.
+    data_delete.assert_called_once_with("cache_key")
+    # The default cache must NOT be touched — that's the #40489 regression.
+    default_delete.assert_not_called()
 
 
 def test_invalidate_cache_empty_input(invalidate):
@@ -111,10 +138,10 @@ def test_invalidate_existing_caches(invalidate):
     db.session.add(CacheKey(cache_key="cache_keyX", datasource_uid="X__table"))
     db.session.commit()
 
-    cache_manager.cache.set("cache_key1", "value")
-    cache_manager.cache.set("cache_key2", "value")
-    cache_manager.cache.set("cache_key4", "value")
-    cache_manager.cache.set("cache_keyX", "value")
+    cache_manager.data_cache.set("cache_key1", "value")
+    cache_manager.data_cache.set("cache_key2", "value")
+    cache_manager.data_cache.set("cache_key4", "value")
+    cache_manager.data_cache.set("cache_keyX", "value")
 
     rv = invalidate(
         {
@@ -155,10 +182,10 @@ def test_invalidate_existing_caches(invalidate):
     )
 
     assert rv.status_code == 201
-    assert cache_manager.cache.get("cache_key1") is None
-    assert cache_manager.cache.get("cache_key2") is None
-    assert cache_manager.cache.get("cache_key4") is None
-    assert cache_manager.cache.get("cache_keyX") == "value"
+    assert cache_manager.data_cache.get("cache_key1") is None
+    assert cache_manager.data_cache.get("cache_key2") is None
+    assert cache_manager.data_cache.get("cache_key4") is None
+    assert cache_manager.data_cache.get("cache_keyX") == "value"
     assert (
         not db.session.query(CacheKey)
         .filter(CacheKey.cache_key.in_({"cache_key1", "cache_key2", "cache_key4"}))


### PR DESCRIPTION
### SUMMARY

Fixes #40489. `POST /api/v1/cachekey/invalidate` was calling `cache_manager.cache.delete_many(...)` (which uses `CACHE_CONFIG.CACHE_KEY_PREFIX`), but the chart query results tracked by `CacheKey` rows are written via `cache_manager.data_cache` (`DATA_CACHE_CONFIG.CACHE_KEY_PREFIX`).

When a deployment configures the two caches with different prefixes (the recommended multi-cache setup), `delete_many` issues `DEL` against the wrong Redis prefix and silently misses every key. The metadata rows are cleared, but Redis keeps serving stale chart data until TTL expiry. The mismatch is invisible in default-config deployments because both prefixes resolve to the same value.

### Fix

One-line backend change in `superset/cachekeys/api.py`:

```diff
-            all_keys_deleted = cache_manager.cache.delete_many(*cache_keys)
+            all_keys_deleted = cache_manager.data_cache.delete_many(*cache_keys)
```

### TESTING INSTRUCTIONS

```bash
pytest tests/integration_tests/cachekeys/api_tests.py -v
```

- Existing tests updated to write/read via `cache_manager.data_cache` (they previously exercised the buggy path; `cache` and `data_cache` resolve to the same backend in the default test config so the asserts passed anyway).
- New regression test `test_invalidate_uses_data_cache_not_default_cache` patches both `cache_manager.data_cache.delete_many` and `cache_manager.cache.delete_many`, then asserts the API calls the **data** cache and never touches the default cache — this is the precise condition #40489 fails on in production.

### Manual reproduction (per the issue)

```python
CACHE_CONFIG      = {"CACHE_TYPE": "RedisCache", "CACHE_KEY_PREFIX": "superset_", ...}
DATA_CACHE_CONFIG = {"CACHE_TYPE": "RedisCache", "CACHE_KEY_PREFIX": "superset_data_", ...}
```

1. View a chart so it caches a result. `redis-cli EXISTS superset_data_<hash>` → `1`.
2. `POST /api/v1/cachekey/invalidate {"datasource_uids":["<uid>"]}` → `201`.
3. **Before fix:** `redis-cli EXISTS superset_data_<hash>` → still `1` (chart serves stale data).
4. **After fix:** `redis-cli EXISTS superset_data_<hash>` → `0` (chart re-runs fresh query).

### ADDITIONAL INFORMATION

- [x] Has associated issue: #40489
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API