### PR TITLE
fix(dataset-api): disambiguate get_or_create by schema

### DIFF
--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -425,7 +425,7 @@ class DatasetDAO(BaseDAO[SqlaTable]):
         )
 
     @staticmethod
-    def get_table_by_schema_and_name(
+    def get_table_by_catalog_schema_and_name(
         database_id: int,
         schema: str | None,
         table_name: str,

--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -424,6 +424,18 @@ class DatasetDAO(BaseDAO[SqlaTable]):
             .one_or_none()
         )
 
+    @staticmethod
+    def get_table_by_schema_and_name(
+        database_id: int, schema: str | None, table_name: str
+    ) -> SqlaTable | None:
+        # Filter by schema as well so callers can disambiguate datasets that
+        # share a ``table_name`` across schemas (#30377).
+        return (
+            db.session.query(SqlaTable)
+            .filter_by(database_id=database_id, schema=schema, table_name=table_name)
+            .one_or_none()
+        )
+
     @classmethod
     def get_filterable_columns_and_operators(cls) -> Dict[str, List[str]]:
         filterable = super().get_filterable_columns_and_operators()

--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -426,13 +426,22 @@ class DatasetDAO(BaseDAO[SqlaTable]):
 
     @staticmethod
     def get_table_by_schema_and_name(
-        database_id: int, schema: str | None, table_name: str
+        database_id: int,
+        schema: str | None,
+        table_name: str,
+        catalog: str | None = None,
     ) -> SqlaTable | None:
-        # Filter by schema as well so callers can disambiguate datasets that
-        # share a ``table_name`` across schemas (#30377).
+        # Filter by the full ``(database_id, catalog, schema, table_name)``
+        # uniqueness key so callers can disambiguate datasets that share a
+        # ``table_name`` across schemas or catalogs (#30377).
         return (
             db.session.query(SqlaTable)
-            .filter_by(database_id=database_id, schema=schema, table_name=table_name)
+            .filter_by(
+                database_id=database_id,
+                catalog=catalog,
+                schema=schema,
+                table_name=table_name,
+            )
             .one_or_none()
         )
 

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -712,8 +712,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        ".detect_datetime_formats",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.detect_datetime_formats"
+        ),
         log_to_statsd=False,
     )
     def detect_datetime_formats(self, pk: int) -> Response:
@@ -794,8 +795,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".related_objects",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.related_objects"
+        ),
         log_to_statsd=False,
     )
     def related_objects(self, id_or_uuid: str) -> Response:
@@ -1053,8 +1055,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".get_or_create_dataset",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.get_or_create_dataset"
+        ),
         log_to_statsd=False,
     )
     def get_or_create_dataset(self) -> Response:
@@ -1096,7 +1099,14 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             return self.response(400, message=ex.messages)
         table_name = body["table_name"]
         database_id = body["database_id"]
-        if table := DatasetDAO.get_table_by_name(database_id, table_name):
+        # Honour the request's ``schema`` so we don't (a) raise 500 on
+        # ``MultipleResultsFound`` when datasets share a ``table_name`` across
+        # schemas, or (b) silently return an existing dataset from the wrong
+        # schema as a false positive (#30377).
+        schema = body.get("schema")
+        if table := DatasetDAO.get_table_by_schema_and_name(
+            database_id, schema, table_name
+        ):
             return self.response(200, result={"table_id": table.id})
 
         body["database"] = database_id
@@ -1274,9 +1284,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.get_drill_info",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.get_drill_info"
+        ),
         log_to_statsd=False,
     )
     def get_drill_info(self, pk: int, **kwargs: Any) -> Response:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1103,15 +1103,14 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         # uniqueness key so we don't (a) raise 500 on ``MultipleResultsFound``
         # when datasets share a ``table_name`` across schemas/catalogs, or
         # (b) silently return an existing dataset from the wrong schema as a
-        # false positive (#30377). Empty-string schema/catalog are normalised
-        # to ``None`` to match how the rest of Superset treats them; catalog
-        # falls back to the database's default when not supplied, mirroring
-        # ``DatasetDAO.validate_uniqueness``.
+        # false positive (#30377). Empty-string schema/catalog normalise to
+        # ``None`` so blank request values match datasets stored with NULL.
+        # We pass the request's catalog literally rather than falling back to
+        # ``database.get_default_catalog()`` because existing datasets created
+        # before multi-catalog support landed are stored with ``catalog=None``
+        # — applying the default would miss them.
         schema = body.get("schema") or None
-        database = DatasetDAO.get_database_by_id(database_id)
-        catalog = body.get("catalog") or (
-            database.get_default_catalog() if database else None
-        )
+        catalog = body.get("catalog") or None
         if table := DatasetDAO.get_table_by_schema_and_name(
             database_id, schema, table_name, catalog=catalog
         ):

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1111,7 +1111,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         # — applying the default would miss them.
         schema = body.get("schema") or None
         catalog = body.get("catalog") or None
-        if table := DatasetDAO.get_table_by_schema_and_name(
+        if table := DatasetDAO.get_table_by_catalog_schema_and_name(
             database_id, schema, table_name, catalog=catalog
         ):
             return self.response(200, result={"table_id": table.id})

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -31,6 +31,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from jinja2.exceptions import TemplateSyntaxError
 from marshmallow import ValidationError
+from sqlalchemy.orm.exc import MultipleResultsFound
 
 from superset import event_logger, is_feature_enabled, security_manager
 from superset.commands.dataset.create import CreateDatasetCommand
@@ -1099,21 +1100,39 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             return self.response(400, message=ex.messages)
         table_name = body["table_name"]
         database_id = body["database_id"]
-        # Look up using the full ``(database_id, catalog, schema, table_name)``
-        # uniqueness key so we don't (a) raise 500 on ``MultipleResultsFound``
-        # when datasets share a ``table_name`` across schemas/catalogs, or
-        # (b) silently return an existing dataset from the wrong schema as a
-        # false positive (#30377). Empty-string schema/catalog normalise to
-        # ``None`` so blank request values match datasets stored with NULL.
-        # We pass the request's catalog literally rather than falling back to
-        # ``database.get_default_catalog()`` because existing datasets created
-        # before multi-catalog support landed are stored with ``catalog=None``
-        # — applying the default would miss them.
+        # Dual-path lookup. When the caller specifies ``schema``, query the
+        # full ``(database_id, catalog, schema, table_name)`` uniqueness key
+        # — this is the path that fixes #30377 by disambiguating datasets
+        # that share a ``table_name`` across schemas/catalogs. When the
+        # caller omits ``schema``, fall back to the legacy schema-agnostic
+        # ``get_table_by_name`` so external callers that relied on
+        # schema-blind matching still find their dataset (typically a
+        # physical Postgres/MySQL table stored with a non-NULL schema).
+        # If two datasets share the ``table_name`` across schemas and the
+        # caller omits ``schema``, surface a 400 with an actionable message
+        # instead of the original 500 ``MultipleResultsFound``.
+        # Catalog follows the same literal-pass rule: existing datasets
+        # created before multi-catalog support landed are stored with
+        # ``catalog=None``, so applying ``database.get_default_catalog()``
+        # would miss them.
         schema = body.get("schema") or None
         catalog = body.get("catalog") or None
-        if table := DatasetDAO.get_table_by_catalog_schema_and_name(
-            database_id, schema, table_name, catalog=catalog
-        ):
+        if schema:
+            table = DatasetDAO.get_table_by_catalog_schema_and_name(
+                database_id, schema, table_name, catalog=catalog
+            )
+        else:
+            try:
+                table = DatasetDAO.get_table_by_name(database_id, table_name)
+            except MultipleResultsFound:
+                return self.response_400(
+                    message=(
+                        f"Multiple datasets named '{table_name}' exist in this "
+                        "database across different schemas. Specify the "
+                        "'schema' field to disambiguate."
+                    )
+                )
+        if table:
             return self.response(200, result={"table_id": table.id})
 
         body["database"] = database_id

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1099,13 +1099,21 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             return self.response(400, message=ex.messages)
         table_name = body["table_name"]
         database_id = body["database_id"]
-        # Honour the request's ``schema`` so we don't (a) raise 500 on
-        # ``MultipleResultsFound`` when datasets share a ``table_name`` across
-        # schemas, or (b) silently return an existing dataset from the wrong
-        # schema as a false positive (#30377).
-        schema = body.get("schema")
+        # Look up using the full ``(database_id, catalog, schema, table_name)``
+        # uniqueness key so we don't (a) raise 500 on ``MultipleResultsFound``
+        # when datasets share a ``table_name`` across schemas/catalogs, or
+        # (b) silently return an existing dataset from the wrong schema as a
+        # false positive (#30377). Empty-string schema/catalog are normalised
+        # to ``None`` to match how the rest of Superset treats them; catalog
+        # falls back to the database's default when not supplied, mirroring
+        # ``DatasetDAO.validate_uniqueness``.
+        schema = body.get("schema") or None
+        database = DatasetDAO.get_database_by_id(database_id)
+        catalog = body.get("catalog") or (
+            database.get_default_catalog() if database else None
+        )
         if table := DatasetDAO.get_table_by_schema_and_name(
-            database_id, schema, table_name
+            database_id, schema, table_name, catalog=catalog
         ):
             return self.response(200, result={"table_id": table.id})
 

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3001,7 +3001,11 @@ class TestDatasetApi(SupersetTestCase):
         # datasets that share a ``table_name`` fails at INSERT regardless of
         # schema. Postgres and MySQL behave correctly.
         if get_main_database().backend == "sqlite":
-            return
+            pytest.skip(
+                "SQLite has a legacy single-column unique constraint on "
+                "table_name that prevents seeding two same-name datasets in "
+                "different schemas"
+            )
 
         self.login(ADMIN_USERNAME)
         admin_id = self.get_user("admin").id
@@ -3025,6 +3029,9 @@ class TestDatasetApi(SupersetTestCase):
             schema="schema_b",
             fetch_metadata=False,
         )
+        # Hand the seed rows to teardown before any assertion can fail, so a
+        # mid-test failure can't leak them into subsequent tests.
+        self.items_to_delete = [ds_schema_a, ds_schema_b]
 
         # Case 1: ask for an existing schema — must return that exact dataset,
         # not raise MultipleResultsFound.
@@ -3053,10 +3060,6 @@ class TestDatasetApi(SupersetTestCase):
         assert json.loads(rv.data.decode("utf-8"))["result"] == {
             "table_id": ds_schema_b.id
         }
-
-        # Cleanup the seed rows; the "new schema" path creates an additional
-        # dataset that the test_client owns — also handed off to teardown.
-        self.items_to_delete = [ds_schema_a, ds_schema_b]
 
     @pytest.mark.usefixtures(
         "load_energy_table_with_slice", "load_birth_names_dashboard_with_slices"

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3000,11 +3000,22 @@ class TestDatasetApi(SupersetTestCase):
         examples_db = get_example_database()
         table_name = "test_get_or_create_schema_disambiguation"
 
+        # ``fetch_metadata=False`` so the helper doesn't try to introspect
+        # ``schema_a`` / ``schema_b`` against the real example DB — those
+        # schemas only need to exist as metadata rows for this test.
         ds_schema_a = self.insert_dataset(
-            table_name, [admin_id], examples_db, schema="schema_a"
+            table_name,
+            [admin_id],
+            examples_db,
+            schema="schema_a",
+            fetch_metadata=False,
         )
         ds_schema_b = self.insert_dataset(
-            table_name, [admin_id], examples_db, schema="schema_b"
+            table_name,
+            [admin_id],
+            examples_db,
+            schema="schema_b",
+            fetch_metadata=False,
         )
 
         # Case 1: ask for an existing schema — must return that exact dataset,

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3061,6 +3061,87 @@ class TestDatasetApi(SupersetTestCase):
             "table_id": ds_schema_b.id
         }
 
+    def test_get_or_create_dataset_no_schema_finds_existing_with_schema(self):
+        """
+        Dataset API: regression for #30377 review feedback.
+
+        A caller that omits ``schema`` in the request must still find an
+        existing dataset stored with a non-NULL schema (the legacy
+        schema-blind matching behaviour). Without this, schema-unaware
+        callers would silently hit the create path and duplicate the
+        dataset.
+        """
+        if get_main_database().backend == "sqlite":
+            pytest.skip(
+                "SQLite has a legacy single-column unique constraint on "
+                "table_name that prevents seeding a non-NULL-schema row "
+                "with the same name elsewhere"
+            )
+
+        self.login(ADMIN_USERNAME)
+        admin_id = self.get_user("admin").id
+        examples_db = get_example_database()
+        table_name = "test_get_or_create_schema_blind"
+
+        ds = self.insert_dataset(
+            table_name,
+            [admin_id],
+            examples_db,
+            schema="some_schema",
+            fetch_metadata=False,
+        )
+        self.items_to_delete = [ds]
+
+        rv = self.client.post(
+            "api/v1/dataset/get_or_create/",
+            json={"table_name": table_name, "database_id": examples_db.id},
+        )
+        assert rv.status_code == 200
+        assert json.loads(rv.data.decode("utf-8"))["result"] == {"table_id": ds.id}
+
+    def test_get_or_create_dataset_no_schema_returns_400_when_ambiguous(self):
+        """
+        Dataset API: regression for #30377 review feedback.
+
+        When two datasets share a ``table_name`` across different schemas
+        and the caller omits ``schema``, the API must return a 400 with an
+        actionable message rather than 500-ing on ``MultipleResultsFound``.
+        """
+        if get_main_database().backend == "sqlite":
+            pytest.skip(
+                "SQLite has a legacy single-column unique constraint on "
+                "table_name that prevents seeding two same-name datasets in "
+                "different schemas"
+            )
+
+        self.login(ADMIN_USERNAME)
+        admin_id = self.get_user("admin").id
+        examples_db = get_example_database()
+        table_name = "test_get_or_create_ambiguous"
+
+        ds_a = self.insert_dataset(
+            table_name,
+            [admin_id],
+            examples_db,
+            schema="schema_a",
+            fetch_metadata=False,
+        )
+        ds_b = self.insert_dataset(
+            table_name,
+            [admin_id],
+            examples_db,
+            schema="schema_b",
+            fetch_metadata=False,
+        )
+        self.items_to_delete = [ds_a, ds_b]
+
+        rv = self.client.post(
+            "api/v1/dataset/get_or_create/",
+            json={"table_name": table_name, "database_id": examples_db.id},
+        )
+        assert rv.status_code == 400
+        assert "Specify the 'schema' field" in rv.data.decode("utf-8")
+
     @pytest.mark.usefixtures(
         "load_energy_table_with_slice", "load_birth_names_dashboard_with_slices"
     )

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -2995,6 +2995,14 @@ class TestDatasetApi(SupersetTestCase):
         - A single existing dataset in schema A is wrongly returned when the
           caller asks for the same ``table_name`` in schema B (false positive).
         """
+        # SQLite's test schema carries a legacy single-column unique constraint
+        # on ``tables.table_name`` that contradicts the modern composite
+        # ``(database_id, catalog, schema, table_name)`` key, so inserting two
+        # datasets that share a ``table_name`` fails at INSERT regardless of
+        # schema. Postgres and MySQL behave correctly.
+        if get_main_database().backend == "sqlite":
+            return
+
         self.login(ADMIN_USERNAME)
         admin_id = self.get_user("admin").id
         examples_db = get_example_database()

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -2983,6 +2983,62 @@ class TestDatasetApi(SupersetTestCase):
         with examples_db.get_sqla_engine() as engine:
             engine.execute("DROP TABLE test_create_sqla_table_api")
 
+    def test_get_or_create_dataset_disambiguates_by_schema(self):
+        """
+        Dataset API: Regression test for #30377.
+
+        ``get_or_create`` must filter on ``schema`` as well as ``table_name``.
+        Otherwise:
+
+        - Two pre-existing datasets sharing a ``table_name`` across different
+          schemas make ``one_or_none()`` raise ``MultipleResultsFound`` → 500.
+        - A single existing dataset in schema A is wrongly returned when the
+          caller asks for the same ``table_name`` in schema B (false positive).
+        """
+        self.login(ADMIN_USERNAME)
+        admin_id = self.get_user("admin").id
+        examples_db = get_example_database()
+        table_name = "test_get_or_create_schema_disambiguation"
+
+        ds_schema_a = self.insert_dataset(
+            table_name, [admin_id], examples_db, schema="schema_a"
+        )
+        ds_schema_b = self.insert_dataset(
+            table_name, [admin_id], examples_db, schema="schema_b"
+        )
+
+        # Case 1: ask for an existing schema — must return that exact dataset,
+        # not raise MultipleResultsFound.
+        rv = self.client.post(
+            "api/v1/dataset/get_or_create/",
+            json={
+                "table_name": table_name,
+                "schema": "schema_a",
+                "database_id": examples_db.id,
+            },
+        )
+        assert rv.status_code == 200
+        assert json.loads(rv.data.decode("utf-8"))["result"] == {
+            "table_id": ds_schema_a.id
+        }
+
+        rv = self.client.post(
+            "api/v1/dataset/get_or_create/",
+            json={
+                "table_name": table_name,
+                "schema": "schema_b",
+                "database_id": examples_db.id,
+            },
+        )
+        assert rv.status_code == 200
+        assert json.loads(rv.data.decode("utf-8"))["result"] == {
+            "table_id": ds_schema_b.id
+        }
+
+        # Cleanup the seed rows; the "new schema" path creates an additional
+        # dataset that the test_client owns — also handed off to teardown.
+        self.items_to_delete = [ds_schema_a, ds_schema_b]
+
     @pytest.mark.usefixtures(
         "load_energy_table_with_slice", "load_birth_names_dashboard_with_slices"
     )


### PR DESCRIPTION
### SUMMARY

Fixes #30377. Adopts the approach from the stale PR #30379 by @luizcapu (credited below).

`POST /api/v1/dataset/get_or_create/` accepts a `schema` field in the request body but ignores it during the existence check, calling `DatasetDAO.get_table_by_name(database_id, table_name)`. This produces two failures:

- **500 (MultipleResultsFound)** — when two or more datasets already exist with the same `table_name` across different schemas, `one_or_none()` raises.
- **False-positive 200** — when one dataset exists in schema A and the caller asks for the same `table_name` in schema B, the API returns the schema-A dataset and never creates the schema-B one.

The mismatch is invisible in default deployments because most installs only ever have one dataset per `table_name`.

### Fix

- Adds `DatasetDAO.get_table_by_schema_and_name(database_id, schema, table_name)`.
- `get_or_create_dataset` now reads `body.get("schema")` and uses the schema-aware lookup, matching the contract the request schema already advertises.

### TESTING INSTRUCTIONS

```bash
pytest tests/integration_tests/datasets/api_tests.py::DatasetApiTests::test_get_or_create_dataset_disambiguates_by_schema -v
```

Regression test seeds two datasets with the same `table_name` in different schemas, then asserts both lookups (`schema=schema_a` and `schema=schema_b`) return the correct dataset id without raising.

### Credit

This PR adopts the approach from #30379 by @luizcapu (Pinterest), which sat without review for ~1 year. @rusackas invited adoption on the issue thread three times in 2025-2026. I left a courtesy ping on the issue and proceeded.

Modern union syntax (`str | None`) is used throughout; the original PR's `Optional[str]` reverts are not included per Superset's Python style.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #30377
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API