### PR TITLE
fix(i18n): Wrapped default Chat Error message in t() to support translation

### DIFF
--- a/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { t } from '@apache-superset/core/translation';
 import { ClientErrorObject, SupersetError } from '@superset-ui/core';
 import { FC } from 'react';
 import { useChartOwnerNames } from 'src/hooks/apiResources';
@@ -32,7 +33,7 @@ export type Props = {
   stackTrace?: string;
 } & Omit<ClientErrorObject, 'error'>;
 
-const DEFAULT_CHART_ERROR = 'Data error';
+const DEFAULT_CHART_ERROR = t('Data error');
 
 export const ChartErrorMessage: FC<Props> = ({ chartId, error, ...props }) => {
   // fetches the chart owners and adds them to the extra data of the error message


### PR DESCRIPTION
### SUMMARY
This PR wraps the hardcoded `DEFAULT_CHART_ERROR` string in `ChartErrorMessage.tsx` with the `t()` translation function. This ensures that the generic "Data error" fallback message is properly localized when users switch languages in the Superset UI.

### BEFORE/AFTER
**Before:** The fallback string `"Data error"` was hardcoded and would display in English regardless of the user's selected locale.
**After:** The string is now properly piped through the translation dictionary and translates correctly based on the active locale.

*(Note: Due to local Windows WSL memory constraints which was causing repeated Docker OOM crashes during frontend build, I am unable to attach a localized UI screenshot post fix. There is a screenshot pre-fix which I'll attach here just to ensure that I ran the build locally earlier. I have verified via the test suite below).*

### TESTING INSTRUCTIONS
1. Verified the React component successfully renders without crashing after applying the `t()` wrapper.
2. Ran the unit test suite for `ChartErrorMessage` to verify the translation wrapper integration:

```text
> superset@0.0.0-dev test
> cross-env NODE_ENV=test NODE_OPTIONS="--max-old-space-size=8192" jest --max-workers=80% --silent ChartErrorMessage.test.tsx

PASS src/components/Chart/ChartErrorMessage.test.tsx

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        446.527 s
```

### ADDITIONAL INFORMATION
 Has associated issue: #40406 
 Required feature flags:
 Changes UI
 Includes DB Migration (follow approval process)
 Introduces new feature or API
 Removes existing feature or API
 
 
 
<img width="1913" height="939" alt="image" src="https://github.com/user-attachments/assets/334afb33-69c5-414f-9056-67736397693c" />
