### PR TITLE
fix(ci): correct first-interaction inputs in welcome workflow

### DIFF
--- a/.github/workflows/welcome-new-users.yml
+++ b/.github/workflows/welcome-new-users.yml
@@ -13,10 +13,15 @@ jobs:
     steps:
       - name: Welcome Message
         uses: actions/first-interaction@v3
-        continue-on-error: true
         with:
-          repo-token: ${{ github.token }}
-          pr-message: |-
+          repo_token: ${{ github.token }}
+          issue_message: |-
+            Congrats on opening your first issue and thank you for contributing to Superset! :tada: :heart:
+
+            Please read our [New Contributor Welcome & Expectations](https://github.com/apache/superset/wiki/New-Contributor-Welcome-&-Expectations) guide.
+          pr_message: |-
             Congrats on making your first PR and thank you for contributing to Superset! :tada: :heart:
+
+            Please read our [New Contributor Welcome & Expectations](https://github.com/apache/superset/wiki/New-Contributor-Welcome-&-Expectations) guide.
 
             We hope to see you in our [Slack](https://apache-superset.slack.com/) community too! Not signed up? Use our [Slack App](http://bit.ly/join-superset-slack) to self-register.


### PR DESCRIPTION
### SUMMARY
Fixes the "Welcome New Contributor" GitHub Action by updating `actions/first-interaction@v3` inputs from v2-style names to v3 names (`repo_token`, `pr_message`), adding the required `issue_message`, including a link to the New Contributor Welcome wiki, and removing `continue-on-error` so failures are visible.

Fixes #40505

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: Action reported success but failed with `Input required and not supplied: issue_message` and no welcome comment was posted.

After: Action completes successfully and posts a welcome comment on first-time contributor PRs.

### TESTING INSTRUCTIONS
This change updates GitHub Actions workflow inputs only; I have not been able to fully verify end-to-end locally.

Suggested verification after merge:
1. Open a PR from a first-time contributor account.
2. Confirm the "Welcome New Contributor / welcome" check passes.
3. Confirm a welcome comment is posted with the wiki link.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #40505
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API