### PR TITLE
fix(ci): consolidate docs-deploy triggers to push and workflow_dispatch

### DIFF
--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -1,13 +1,10 @@
 name: Docs Deployment
 
 on:
-  # Deploy after integration tests complete on master
-  workflow_run:
-    workflows: ["Python-Integration"]
-    types: [completed]
-    branches: [master]
-
-  # Also allow manual trigger and direct pushes to docs
+  # Deploy on direct pushes to docs and via manual dispatch. Both
+  # triggers run with `github.sha` resolved against the default
+  # branch's HEAD, so the deploy job and its repository-local action
+  # always execute from a trusted tree.
   push:
     paths:
       - "docs/**"
@@ -49,10 +46,10 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-24.04
     steps:
-      - name: "Checkout ${{ github.event.workflow_run.head_sha || github.sha }}"
+      - name: "Checkout ${{ github.sha }}"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
           submodules: recursive
       - name: Set up Node.js
@@ -78,17 +75,7 @@ jobs:
         working-directory: docs
         run: |
           yarn install --check-cache
-      - name: Download database diagnostics (if triggered by integration tests)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        continue-on-error: true
-        with:
-          workflow: superset-python-integrationtest.yml
-          run_id: ${{ github.event.workflow_run.id }}
-          name: database-diagnostics
-          path: docs/src/data/
-      - name: Try to download latest diagnostics (for push/dispatch triggers)
-        if: github.event_name != 'workflow_run'
+      - name: Try to download latest diagnostics from master
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         continue-on-error: true
         with:
@@ -120,5 +107,5 @@ jobs:
           destination-github-username: "apache"
           destination-repository-name: "superset-site"
           target-branch: "asf-site"
-          commit-message: "deploying docs: ${{ github.event.head_commit.message || 'triggered by integration tests' }} (apache/superset@${{ github.event.workflow_run.head_sha || github.sha }})"
+          commit-message: "deploying docs: ${{ github.event.head_commit.message || 'manual dispatch' }} (apache/superset@${{ github.sha }})"
           user-email: dev@superset.apache.org


### PR DESCRIPTION
### SUMMARY

Removes the `workflow_run` trigger and the two `if`-gated artifact-download branches that depended on it. The remaining `push` (`docs/**` and `README.md` on `master`) and `workflow_dispatch` triggers both resolve `github.sha` against the default branch's HEAD, so the deploy job and its repository-local action always execute from a trusted tree.

### Changes

- `on:` block: drop `workflow_run` (deploy after `Python-Integration` completes). `push` (docs/** and README on master) and `workflow_dispatch` are retained.
- Diagnostics-artifact download: collapse the two `if`-gated branches into a single step that always uses the `branch: master, search_artifacts: true, if_no_artifact_found: warn` fallback. The previous `workflow_run`-only branch read the same artifact via `run_id: ${{ github.event.workflow_run.id }}`, which is no longer reachable.
- Checkout `ref:` simplified from `${{ github.event.workflow_run.head_sha || github.sha }}` to plain `${{ github.sha }}` since `workflow_run.head_sha` is no longer reachable.
- `commit-message` template fallback changes from `triggered by integration tests` to `manual dispatch` to match the remaining trigger set.

### Behaviour after this change

| Trigger | Before | After |
|---|---|---|
| Push to `docs/**` or `README.md` on master | Deploy | Deploy (unchanged) |
| `workflow_dispatch` | Deploy | Deploy (unchanged) |
| Python-Integration completes on master | Deploy | No deploy |
| Push to non-docs file on master | No deploy | No deploy (unchanged) |

Every docs change merged to master goes through one of the two retained triggers, so the published docs site continues to update on every merge that touches `docs/**` or `README.md`. The `workflow_run` path was redundant: it re-ran the same build after the Python-Integration job finished, but the same content had already been built and deployed by the `push` trigger.

### Testing instructions

- Trigger a deploy via the Actions UI ("Run workflow" on `superset-docs-deploy.yml`); confirm the workflow runs and deploys the docs site as before.
- Push a no-op change to `docs/README.md` on a branch, merge to master; confirm the `push` trigger fires and deploys.
- Inspect a recent run's "Try to download latest diagnostics" step; confirm it still finds the latest `database-diagnostics` artifact on master via the existing fallback.

### Additional information

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Includes CI/workflow changes