### PR TITLE
fix: correct Security menu case for MySQL deployments

### DIFF
--- a/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
+++ b/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
@@ -17,7 +17,7 @@
 """fix Security view menu case
 
 Revision ID: b4a3f2e1d0c9
-Revises: 33d7e0e21daa
+Revises: 31dae2559c05
 Create Date: 2026-05-29 00:00:00.000000
 
 On MySQL with the default case-insensitive collation, five Superset views that
@@ -40,7 +40,7 @@ This migration normalises the row:
 
 # revision identifiers, used by Alembic.
 revision = "b4a3f2e1d0c9"
-down_revision = "33d7e0e21daa"
+down_revision = "31dae2559c05"
 
 import logging  # noqa: E402
 

--- a/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
+++ b/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
@@ -40,7 +40,7 @@ This migration normalises the row:
 
 # revision identifiers, used by Alembic.
 revision = "b4a3f2e1d0c9"
-down_revision = "a1b2c3d4e5f6"
+down_revision = "ce6bd21901ab"
 
 import logging  # noqa: E402
 
@@ -91,7 +91,7 @@ def upgrade() -> None:
             .all()
         )
         for pvm in pvms_lower:
-            conflict = (
+            upper_pvm = (
                 session.query(PermissionView)
                 .filter(
                     PermissionView.view_menu_id == security_upper.id,
@@ -99,7 +99,14 @@ def upgrade() -> None:
                 )
                 .one_or_none()
             )
-            if conflict:
+            if upper_pvm:
+                # Transfer role bindings from the duplicate row to the
+                # surviving row before discarding the duplicate, so no
+                # role silently loses a permission.
+                for role in list(pvm.role):
+                    if upper_pvm not in role.permissions:
+                        role.permissions.append(upper_pvm)
+                session.flush()
                 session.delete(pvm)
             else:
                 pvm.view_menu_id = security_upper.id

--- a/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
+++ b/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
@@ -17,7 +17,7 @@
 """fix Security view menu case
 
 Revision ID: b4a3f2e1d0c9
-Revises: a1b2c3d4e5f6
+Revises: 33d7e0e21daa
 Create Date: 2026-05-29 00:00:00.000000
 
 On MySQL with the default case-insensitive collation, five Superset views that
@@ -40,7 +40,7 @@ This migration normalises the row:
 
 # revision identifiers, used by Alembic.
 revision = "b4a3f2e1d0c9"
-down_revision = "ce6bd21901ab"
+down_revision = "33d7e0e21daa"
 
 import logging  # noqa: E402
 

--- a/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
+++ b/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
@@ -17,7 +17,7 @@
 """fix Security view menu case
 
 Revision ID: b4a3f2e1d0c9
-Revises: 2bee73611e32
+Revises: 9e1f3b8c4d2a
 Create Date: 2026-05-29 00:00:00.000000
 
 On MySQL with the default case-insensitive collation, five Superset views that
@@ -40,7 +40,7 @@ This migration normalises the row:
 
 # revision identifiers, used by Alembic.
 revision = "b4a3f2e1d0c9"
-down_revision = "2bee73611e32"
+down_revision = "9e1f3b8c4d2a"
 
 import logging  # noqa: E402
 
@@ -55,10 +55,7 @@ from superset.migrations.shared.security_converge import (  # noqa: E402
 logger = logging.getLogger("alembic.env")
 
 
-def upgrade() -> None:
-    bind = op.get_bind()
-    session = Session(bind=bind)
-
+def do_upgrade(session: Session) -> None:
     # Fetch all view menus and compare in Python (SQL filter_by is
     # case-insensitive on MySQL, so we cannot rely on it here).
     all_vms: list[ViewMenu] = session.query(ViewMenu).all()
@@ -114,6 +111,12 @@ def upgrade() -> None:
         session.delete(security_lower)
 
     session.commit()
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    do_upgrade(session)
 
 
 def downgrade() -> None:

--- a/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
+++ b/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
@@ -17,7 +17,7 @@
 """fix Security view menu case
 
 Revision ID: b4a3f2e1d0c9
-Revises: 31dae2559c05
+Revises: 2bee73611e32
 Create Date: 2026-05-29 00:00:00.000000
 
 On MySQL with the default case-insensitive collation, five Superset views that
@@ -40,7 +40,7 @@ This migration normalises the row:
 
 # revision identifiers, used by Alembic.
 revision = "b4a3f2e1d0c9"
-down_revision = "31dae2559c05"
+down_revision = "2bee73611e32"
 
 import logging  # noqa: E402
 

--- a/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
+++ b/superset/migrations/versions/2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case.py
@@ -1,0 +1,115 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""fix Security view menu case
+
+Revision ID: b4a3f2e1d0c9
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-29 00:00:00.000000
+
+On MySQL with the default case-insensitive collation, five Superset views that
+declare ``class_permission_name = "security"`` (lowercase) cause FAB to look up
+or insert a view-menu entry named ``"security"``.  MySQL's case-insensitive
+``UNIQUE`` constraint means the lookup finds an existing ``"Security"`` row and
+uses it, OR a fresh install stores ``"security"`` because that view is
+registered before the FAB built-in views register ``"Security"``.
+
+Python string comparisons in ``sync_role_definitions`` and the menu-hiding
+logic are case-sensitive, so an all-lowercase ``"security"`` row breaks the
+Security menu for MySQL (and MariaDB) deployments.
+
+This migration normalises the row:
+* If only the lowercase ``"security"`` row exists: rename it to ``"Security"``.
+* If both rows exist (SQLite / PostgreSQL fresh-install with the old code):
+  reassign every ``ab_permission_view`` from the lowercase row to the
+  correctly-cased row, then delete the duplicate.
+"""
+
+# revision identifiers, used by Alembic.
+revision = "b4a3f2e1d0c9"
+down_revision = "a1b2c3d4e5f6"
+
+import logging  # noqa: E402
+
+from alembic import op  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+
+from superset.migrations.shared.security_converge import (  # noqa: E402
+    PermissionView,
+    ViewMenu,
+)
+
+logger = logging.getLogger("alembic.env")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # Fetch all view menus and compare in Python (SQL filter_by is
+    # case-insensitive on MySQL, so we cannot rely on it here).
+    all_vms: list[ViewMenu] = session.query(ViewMenu).all()
+    security_upper = next((vm for vm in all_vms if vm.name == "Security"), None)
+    security_lower = next((vm for vm in all_vms if vm.name == "security"), None)
+
+    if security_lower is None:
+        logger.info("No lowercase 'security' view-menu found; nothing to do.")
+        return
+
+    if security_upper is None:
+        # Simple rename — only the incorrect row exists.
+        logger.info(
+            "Renaming ab_view_menu 'security' -> 'Security' (id=%d)",
+            security_lower.id,
+        )
+        security_lower.name = "Security"
+        session.flush()
+    else:
+        # Both rows exist.  Re-home every permission_view from the lowercase
+        # entry to the correctly-cased entry, then drop the duplicate.
+        logger.info(
+            "Both 'security' (id=%d) and 'Security' (id=%d) found; merging.",
+            security_lower.id,
+            security_upper.id,
+        )
+        pvms_lower: list[PermissionView] = (
+            session.query(PermissionView)
+            .filter(PermissionView.view_menu_id == security_lower.id)
+            .all()
+        )
+        for pvm in pvms_lower:
+            conflict = (
+                session.query(PermissionView)
+                .filter(
+                    PermissionView.view_menu_id == security_upper.id,
+                    PermissionView.permission_id == pvm.permission_id,
+                )
+                .one_or_none()
+            )
+            if conflict:
+                session.delete(pvm)
+            else:
+                pvm.view_menu_id = security_upper.id
+        session.flush()
+        session.delete(security_lower)
+
+    session.commit()
+
+
+def downgrade() -> None:
+    # There is no safe way to determine the original state (whether the row was
+    # lowercase or whether there were two rows), so downgrade is a no-op.
+    pass

--- a/superset/views/groups.py
+++ b/superset/views/groups.py
@@ -25,7 +25,7 @@ from .base import BaseSupersetView
 
 class GroupsListView(BaseSupersetView):
     route_base = "/"
-    class_permission_name = "security"
+    class_permission_name = "Security"
 
     @expose("/list_groups/")
     @has_access

--- a/superset/views/logs.py
+++ b/superset/views/logs.py
@@ -25,7 +25,7 @@ from .base import BaseSupersetView
 
 class ActionLogView(BaseSupersetView):
     route_base = "/"
-    class_permission_name = "security"
+    class_permission_name = "Security"
 
     @expose("/actionlog/list")
     @has_access

--- a/superset/views/roles.py
+++ b/superset/views/roles.py
@@ -25,7 +25,7 @@ from .base import BaseSupersetView
 
 class RolesListView(BaseSupersetView):
     route_base = "/"
-    class_permission_name = "security"
+    class_permission_name = "Security"
 
     @expose("/roles/")
     @has_access

--- a/superset/views/user_registrations.py
+++ b/superset/views/user_registrations.py
@@ -25,7 +25,7 @@ from .base import BaseSupersetView
 
 class UserRegistrationsView(BaseSupersetView):
     route_base = "/"
-    class_permission_name = "security"
+    class_permission_name = "Security"
 
     @expose("/registrations/")
     @has_access

--- a/superset/views/users_list.py
+++ b/superset/views/users_list.py
@@ -25,7 +25,7 @@ from .base import BaseSupersetView
 
 class UsersListView(BaseSupersetView):
     route_base = "/"
-    class_permission_name = "security"
+    class_permission_name = "Security"
 
     @expose("/users/")
     @has_access

--- a/tests/integration_tests/migrations/b4a3f2e1d0c9_fix_security_view_menu_case__tests.py
+++ b/tests/integration_tests/migrations/b4a3f2e1d0c9_fix_security_view_menu_case__tests.py
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from importlib import import_module
+
+import pytest
+
+from superset import db
+from superset.migrations.shared.security_converge import (
+    _add_permission,
+    _add_permission_view,
+    PermissionView,
+    Role,
+    ViewMenu,
+)
+
+migration_module = import_module(
+    "superset.migrations.versions."
+    "2026-05-29_00-00_b4a3f2e1d0c9_fix_security_view_menu_case"
+)
+
+do_upgrade = migration_module.do_upgrade
+
+
+def _clear_security_view_menus() -> None:
+    """
+    Drop any pre-seeded ``security``/``Security`` view menus (and their PVMs) so
+    each test can assert against a state it fully controls. The bootstrapped
+    metadata DB ships with a ``Security`` menu (and, mirroring the MySQL bug,
+    sometimes a lowercase ``security`` one too), which would otherwise collide
+    with the unique constraint on ``ab_view_menu.name``.
+    """
+    vms = (
+        db.session.query(ViewMenu)
+        .filter(ViewMenu.name.in_(["security", "Security"]))
+        .all()
+    )
+    for vm in vms:
+        pvms = (
+            db.session.query(PermissionView)
+            .filter(PermissionView.view_menu_id == vm.id)
+            .all()
+        )
+        for pvm in pvms:
+            for role in list(pvm.role):
+                role.permissions.remove(pvm)
+            db.session.delete(pvm)
+        db.session.flush()
+        db.session.delete(vm)
+    db.session.commit()
+
+
+def _make_view_menu(name: str) -> ViewMenu:
+    vm = ViewMenu(name=name)
+    db.session.add(vm)
+    db.session.flush()
+    return vm
+
+
+_TEST_ROLE_NAMES = ("mysql_security_role", "dup_security_role")
+
+
+def _clear_test_roles() -> None:
+    for name in _TEST_ROLE_NAMES:
+        role = db.session.query(Role).filter_by(name=name).one_or_none()
+        if role is not None:
+            db.session.delete(role)
+    db.session.commit()
+
+
+@pytest.fixture
+def _clean_security():
+    _clear_test_roles()
+    _clear_security_view_menus()
+    yield
+    _clear_test_roles()
+    _clear_security_view_menus()
+
+
+@pytest.mark.usefixtures("app_context", "_clean_security")
+def test_upgrade_renames_lonely_lowercase_row() -> None:
+    # Arrange: only the incorrect lowercase "security" row exists.
+    lower = _make_view_menu("security")
+    permission = _add_permission(db.session, "menu_access")
+    pvm = _add_permission_view(db.session, permission, lower)
+    role = Role(name="mysql_security_role")
+    role.permissions.append(pvm)
+    db.session.add(role)
+    db.session.commit()
+    lower_id = lower.id
+    pvm_id = pvm.id
+
+    # Act
+    do_upgrade(db.session)
+
+    # Assert: the row was renamed in place, so its id and PVM/role are intact.
+    renamed = db.session.query(ViewMenu).filter_by(id=lower_id).one()
+    assert renamed.name == "Security"
+    assert db.session.query(ViewMenu).filter_by(name="security").one_or_none() is None
+    refreshed_role = db.session.query(Role).filter_by(name="mysql_security_role").one()
+    assert pvm_id in {p.id for p in refreshed_role.permissions}
+
+    # Cleanup role (view menu / pvm handled by the fixture teardown).
+    db.session.delete(refreshed_role)
+    db.session.commit()
+
+
+@pytest.mark.usefixtures("app_context", "_clean_security")
+def test_upgrade_merges_duplicate_rows_and_preserves_role_permissions() -> None:
+    # Arrange: both "Security" and "security" exist. The lowercase row carries
+    # one overlapping permission (also on the upper row) and one unique
+    # permission, each bound to a role.
+    upper = _make_view_menu("Security")
+    lower = _make_view_menu("security")
+
+    overlap_perm = _add_permission(db.session, "menu_access")
+    unique_perm = _add_permission(db.session, "can_test_security_case_migration")
+
+    upper_overlap_pvm = _add_permission_view(db.session, overlap_perm, upper)
+    lower_overlap_pvm = _add_permission_view(db.session, overlap_perm, lower)
+    lower_unique_pvm = _add_permission_view(db.session, unique_perm, lower)
+
+    role = Role(name="dup_security_role")
+    role.permissions.append(lower_overlap_pvm)
+    role.permissions.append(lower_unique_pvm)
+    db.session.add(role)
+    db.session.commit()
+
+    upper_id = upper.id
+    upper_overlap_pvm_id = upper_overlap_pvm.id
+
+    # Act
+    do_upgrade(db.session)
+
+    # Assert: the duplicate lowercase row is gone and only "Security" survives.
+    assert db.session.query(ViewMenu).filter_by(name="security").one_or_none() is None
+    assert db.session.query(ViewMenu).filter_by(name="Security").one() is not None
+
+    refreshed_role = db.session.query(Role).filter_by(name="dup_security_role").one()
+    role_pvm_ids = {pvm.id for pvm in refreshed_role.permissions}
+
+    # The overlapping binding was migrated to the surviving upper PVM.
+    assert upper_overlap_pvm_id in role_pvm_ids
+    # The unique PVM was re-homed onto the surviving "Security" row, keeping it.
+    surviving_unique = (
+        db.session.query(PermissionView)
+        .filter_by(permission_id=unique_perm.id, view_menu_id=upper_id)
+        .one()
+    )
+    assert surviving_unique.id in role_pvm_ids
+    # ...and no copy lingers on the deleted lowercase row's id.
+    assert (
+        db.session.query(PermissionView).filter_by(permission_id=unique_perm.id).count()
+        == 1
+    )
+
+    # Cleanup role (view menu / pvm handled by the fixture teardown).
+    db.session.delete(refreshed_role)
+    db.session.commit()
+
+
+@pytest.mark.usefixtures("app_context", "_clean_security")
+def test_upgrade_is_noop_without_lowercase_row() -> None:
+    # A clean install has only the correctly-cased "Security" row.
+    _make_view_menu("Security")
+    db.session.commit()
+
+    do_upgrade(db.session)
+
+    assert db.session.query(ViewMenu).filter_by(name="Security").one() is not None
+    assert db.session.query(ViewMenu).filter_by(name="security").one_or_none() is None

--- a/tests/integration_tests/migrations/b4a3f2e1d0c9_fix_security_view_menu_case__tests.py
+++ b/tests/integration_tests/migrations/b4a3f2e1d0c9_fix_security_view_menu_case__tests.py
@@ -70,6 +70,36 @@ def _make_view_menu(name: str) -> ViewMenu:
     return vm
 
 
+def _security_row_names() -> set[str]:
+    """
+    Exact-case names of any ``security``/``Security`` view-menu rows.
+
+    Compares in Python because a SQL ``name`` filter is case-insensitive on
+    MySQL's default collation (the very behaviour this migration works around),
+    so ``filter_by(name="security")`` would also match ``"Security"``.
+    """
+    return {
+        vm.name
+        for vm in db.session.query(ViewMenu).all()
+        if vm.name in ("security", "Security")
+    }
+
+
+def _skip_if_case_insensitive_unique_key() -> None:
+    """
+    Skip scenarios that require both ``security`` and ``Security`` rows.
+
+    MySQL's default case-insensitive unique key on ``ab_view_menu.name`` cannot
+    hold both spellings at once, so the duplicate-row state (a SQLite/PostgreSQL
+    artifact, per the migration docstring) cannot be arranged there.
+    """
+    if db.session.get_bind().dialect.name == "mysql":
+        pytest.skip(
+            "MySQL's case-insensitive unique key cannot hold both "
+            "'security' and 'Security' rows"
+        )
+
+
 _TEST_ROLE_NAMES = ("mysql_security_role", "dup_security_role")
 
 
@@ -109,7 +139,7 @@ def test_upgrade_renames_lonely_lowercase_row() -> None:
     # Assert: the row was renamed in place, so its id and PVM/role are intact.
     renamed = db.session.query(ViewMenu).filter_by(id=lower_id).one()
     assert renamed.name == "Security"
-    assert db.session.query(ViewMenu).filter_by(name="security").one_or_none() is None
+    assert _security_row_names() == {"Security"}
     refreshed_role = db.session.query(Role).filter_by(name="mysql_security_role").one()
     assert pvm_id in {p.id for p in refreshed_role.permissions}
 
@@ -120,6 +150,7 @@ def test_upgrade_renames_lonely_lowercase_row() -> None:
 
 @pytest.mark.usefixtures("app_context", "_clean_security")
 def test_upgrade_merges_duplicate_rows_and_preserves_role_permissions() -> None:
+    _skip_if_case_insensitive_unique_key()
     # Arrange: both "Security" and "security" exist. The lowercase row carries
     # one overlapping permission (also on the upper row) and one unique
     # permission, each bound to a role.
@@ -146,8 +177,7 @@ def test_upgrade_merges_duplicate_rows_and_preserves_role_permissions() -> None:
     do_upgrade(db.session)
 
     # Assert: the duplicate lowercase row is gone and only "Security" survives.
-    assert db.session.query(ViewMenu).filter_by(name="security").one_or_none() is None
-    assert db.session.query(ViewMenu).filter_by(name="Security").one() is not None
+    assert _security_row_names() == {"Security"}
 
     refreshed_role = db.session.query(Role).filter_by(name="dup_security_role").one()
     role_pvm_ids = {pvm.id for pvm in refreshed_role.permissions}
@@ -180,5 +210,4 @@ def test_upgrade_is_noop_without_lowercase_row() -> None:
 
     do_upgrade(db.session)
 
-    assert db.session.query(ViewMenu).filter_by(name="Security").one() is not None
-    assert db.session.query(ViewMenu).filter_by(name="security").one_or_none() is None
+    assert _security_row_names() == {"Security"}


### PR DESCRIPTION
### SUMMARY

On MySQL (and MariaDB) with the default case-insensitive collation, the **Security** menu — containing *List Users*, *List Roles*, and *List Groups* — disappears for admin users after a fresh install or upgrade.

**Root cause:** Five Superset views (`UsersListView`, `RolesListView`, `GroupsListView`, `ActionLogView`, `UserRegistrationsView`) declared `class_permission_name = "security"` (lowercase). Flask-AppBuilder uses this string as the key to look up or insert a row in the `ab_view_menu` table. On MySQL, `WHERE name = 'security'` matches `'Security'` (case-insensitive), so whichever casing is inserted first wins. The DB ends up with a lowercase `"security"` row, while all of Superset's Python comparisons (`m.name == "Security"`, `ADMIN_ONLY_VIEW_MENUS`, etc.) are case-sensitive — causing them to silently miss the row.

**Fix:**
1. Change `class_permission_name` to `"Security"` in all five view files so FAB registers the correct name from the start.
2. Add migration `b4a3f2e1d0c9` to normalise existing databases:
   - If only `"security"` exists → rename to `"Security"`.
   - If both exist (possible on SQLite/PostgreSQL with old code) → merge `ab_permission_view` rows into the correctly-cased entry and delete the duplicate.

The workaround documented in discussions (`UPDATE ab_view_menu SET name='Security' WHERE name='security'`) is exactly what this migration automates.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

*Not applicable — the Security menu either appears or doesn't; no visual diff available in this environment.*

### TESTING INSTRUCTIONS

**Fresh MySQL install (reproduces the bug):**
```bash
# 1. Point SUPERSET_CONFIG to a MySQL metadata DB
# 2. superset db upgrade
# 3. superset fab create-admin
# 4. superset init
# 5. Log in as admin → Settings menu should show List Users / List Roles / List Groups
```

**Upgrade path (migration):**
```bash
superset db upgrade  # runs migration b4a3f2e1d0c9
# Verify: SELECT name FROM ab_view_menu WHERE LOWER(name)='security';
# Should return exactly one row: 'Security'
```

**Unit test:**
```bash
pytest tests/unit_tests/security/test_security_manager.py -v -k security
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #40330. Closes #33864. Fixes #37097
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Migration notes:** The migration is a simple `UPDATE` (or merge) on `ab_view_menu`. Row count is at most a handful of rows; downtime is zero. Downgrade is a no-op (there is no safe way to restore the original incorrect casing without knowing which state the DB was in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)