### PR TITLE
fix(mcp): support dashboard owner filters

### DIFF
--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -50,9 +50,10 @@ logger = logging.getLogger(__name__)
 # Custom filterable fields for dashboards
 DASHBOARD_CUSTOM_FIELDS = {
     "tags": ["eq", "in", "like"],
-    "owners": ["eq", "in"],
+    "owners": ["eq", "in", "rel_m_m"],
     "published": ["eq"],
     "owner": ["eq", "in"],
+    "created_by": ["rel_o_m"],
     "favorite": ["eq"],
 }
 
@@ -63,6 +64,79 @@ class DashboardDAO(BaseDAO[Dashboard]):
     # slug-like identifier can resolve to a dashboard even when its slug
     # field is empty.
     title_column = "dashboard_title"
+
+    @staticmethod
+    def _apply_owner_column_operator(
+        query: Query, column_operator: ColumnOperator
+    ) -> Query:
+        """Apply dashboard owner filters backed by the dashboard/user table."""
+        if column_operator.opr == "rel_m_m":
+            values = (
+                column_operator.value
+                if isinstance(column_operator.value, (list, tuple, set))
+                else [column_operator.value]
+            )
+            owner_filter = dashboard_user.c.user_id.in_(values)
+        else:
+            operator_enum = ColumnOperatorEnum(column_operator.opr)
+            owner_filter = operator_enum.apply(
+                dashboard_user.c.user_id, column_operator.value
+            )
+        subq = select(dashboard_user.c.dashboard_id).where(owner_filter)
+        return query.filter(
+            Dashboard.id.in_(subq)  # type: ignore[attr-defined,unused-ignore]
+        )
+
+    @staticmethod
+    def _apply_created_by_column_operator(
+        query: Query, column_operator: ColumnOperator
+    ) -> Query:
+        """Apply dashboard creator filters matching the REST relationship contract."""
+        if column_operator.opr != "rel_o_m":
+            raise ValueError(
+                f"created_by only supports 'rel_o_m'; got '{column_operator.opr}'"
+            )
+        return query.filter(
+            Dashboard.created_by_fk == column_operator.value  # type: ignore[attr-defined,unused-ignore]
+        )
+
+    @staticmethod
+    def _apply_created_by_or_owner_column_operator(
+        query: Query, column_operator: ColumnOperator
+    ) -> Query:
+        """Apply the current-user-created-or-owned convenience filter."""
+        if column_operator.opr != "eq":
+            raise ValueError(
+                "created_by_fk_or_owner only supports 'eq'; "
+                f"got '{column_operator.opr}'"
+            )
+        owner_subq = select(dashboard_user.c.dashboard_id).where(
+            dashboard_user.c.user_id == column_operator.value
+        )
+        return query.filter(
+            or_(
+                Dashboard.created_by_fk == column_operator.value,  # type: ignore[attr-defined,unused-ignore]
+                Dashboard.id.in_(owner_subq),  # type: ignore[attr-defined,unused-ignore]
+            )
+        )
+
+    @staticmethod
+    def _apply_favorite_column_operator(
+        query: Query, column_operator: ColumnOperator
+    ) -> Query:
+        """Apply dashboard favorite filters for the current user."""
+        user_id = get_user_id()
+        fav_subq = select(FavStar.obj_id).where(
+            FavStar.class_name == FavStarClassName.DASHBOARD,
+            FavStar.user_id == user_id,
+        )
+        if column_operator.value is True or column_operator.value == 1:
+            return query.filter(
+                Dashboard.id.in_(fav_subq)  # type: ignore[attr-defined,unused-ignore]
+            )
+        return query.filter(
+            ~Dashboard.id.in_(fav_subq)  # type: ignore[attr-defined,unused-ignore]
+        )
 
     @classmethod
     def apply_column_operators(
@@ -79,45 +153,18 @@ class DashboardDAO(BaseDAO[Dashboard]):
             return query
 
         remaining_operators: list[ColumnOperator] = []
+        special_operator_handlers = {
+            "owner": cls._apply_owner_column_operator,
+            "owners": cls._apply_owner_column_operator,
+            "created_by": cls._apply_created_by_column_operator,
+            "created_by_fk_or_owner": cls._apply_created_by_or_owner_column_operator,
+            "favorite": cls._apply_favorite_column_operator,
+        }
         for c in column_operators:
             if not isinstance(c, ColumnOperator):
                 c = ColumnOperator.model_validate(c)
-            if c.col == "owner":
-                operator_enum = ColumnOperatorEnum(c.opr)
-                subq = select(dashboard_user.c.dashboard_id).where(
-                    operator_enum.apply(dashboard_user.c.user_id, c.value)
-                )
-                query = query.filter(
-                    Dashboard.id.in_(subq)  # type: ignore[attr-defined,unused-ignore]
-                )
-            elif c.col == "created_by_fk_or_owner":
-                if c.opr != "eq":
-                    raise ValueError(
-                        f"created_by_fk_or_owner only supports 'eq'; got '{c.opr}'"
-                    )
-                owner_subq = select(dashboard_user.c.dashboard_id).where(
-                    dashboard_user.c.user_id == c.value
-                )
-                query = query.filter(
-                    or_(
-                        Dashboard.created_by_fk == c.value,  # type: ignore[attr-defined,unused-ignore]
-                        Dashboard.id.in_(owner_subq),  # type: ignore[attr-defined,unused-ignore]
-                    )
-                )
-            elif c.col == "favorite":
-                user_id = get_user_id()
-                fav_subq = select(FavStar.obj_id).where(
-                    FavStar.class_name == FavStarClassName.DASHBOARD,
-                    FavStar.user_id == user_id,
-                )
-                if c.value is True or c.value == 1:
-                    query = query.filter(
-                        Dashboard.id.in_(fav_subq)  # type: ignore[attr-defined,unused-ignore]
-                    )
-                else:
-                    query = query.filter(
-                        ~Dashboard.id.in_(fav_subq)  # type: ignore[attr-defined,unused-ignore]
-                    )
+            if handler := special_operator_handlers.get(c.col):
+                query = handler(query, c)
             else:
                 remaining_operators.append(c)
 

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -173,6 +173,8 @@ class DashboardFilter(ColumnOperator):
         "dashboard_title",
         "published",
         "favorite",
+        "owners",
+        "created_by",
     ] = Field(
         ...,
         description=(
@@ -180,7 +182,7 @@ class DashboardFilter(ColumnOperator):
             "get_schema(model_type='dashboard') for available filter columns."
         ),
     )
-    opr: ColumnOperatorEnum = Field(
+    opr: ColumnOperatorEnum | Literal["rel_m_m", "rel_o_m"] = Field(  # type: ignore[assignment]
         ...,
         description="Operator to use. Use get_schema(model_type='dashboard') for "
         "available operators.",
@@ -188,6 +190,24 @@ class DashboardFilter(ColumnOperator):
     value: str | int | float | bool | List[str | int | float | bool] = Field(
         ..., description="Value to filter by (type depends on col and opr)"
     )
+
+    @model_validator(mode="after")
+    def validate_relationship_operator_scope(self) -> "DashboardFilter":
+        """Restrict relationship operators to relationship filter columns."""
+        operator = (
+            self.opr.value if isinstance(self.opr, ColumnOperatorEnum) else self.opr
+        )
+        if operator not in {"rel_m_m", "rel_o_m"}:
+            return self
+
+        from superset.daos.dashboard import DASHBOARD_CUSTOM_FIELDS
+
+        if operator not in DASHBOARD_CUSTOM_FIELDS.get(self.col, []):
+            raise ValueError(
+                f"Operator '{operator}' is not supported for dashboard filter "
+                f"column '{self.col}'."
+            )
+        return self
 
 
 class ListDashboardsRequest(OwnedByMeMixin, CreatedByMeMixin, MetadataCacheControl):

--- a/tests/unit_tests/dashboards/dao_tests.py
+++ b/tests/unit_tests/dashboards/dao_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from collections.abc import Iterator
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy.orm.session import Session
@@ -73,3 +74,35 @@ def test_remove_favorite(session: Session) -> None:
 
     DashboardDAO.remove_favorite(dashboard)
     assert len(DashboardDAO.favorited_ids([dashboard])) == 0
+
+
+def test_apply_column_operators_accepts_owners_relationship_operator() -> None:
+    from superset.daos.dashboard import DashboardDAO
+    from superset.mcp_service.dashboard.schemas import DashboardFilter
+
+    query = MagicMock()
+    filtered_query = MagicMock()
+    query.filter.return_value = filtered_query
+
+    result = DashboardDAO.apply_column_operators(
+        query, [DashboardFilter(col="owners", opr="rel_m_m", value=1)]
+    )
+
+    assert result == filtered_query
+    query.filter.assert_called_once()
+
+
+def test_apply_column_operators_accepts_created_by_relationship_operator() -> None:
+    from superset.daos.dashboard import DashboardDAO
+    from superset.mcp_service.dashboard.schemas import DashboardFilter
+
+    query = MagicMock()
+    filtered_query = MagicMock()
+    query.filter.return_value = filtered_query
+
+    result = DashboardDAO.apply_column_operators(
+        query, [DashboardFilter(col="created_by", opr="rel_o_m", value=1)]
+    )
+
+    assert result == filtered_query
+    query.filter.assert_called_once()

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -220,6 +220,46 @@ async def test_list_dashboards_with_string_filters(mock_list, mcp_server):
 
 @patch("superset.daos.dashboard.DashboardDAO.list")
 @pytest.mark.asyncio
+async def test_list_dashboards_accepts_owners_relationship_filter(
+    mock_list, mcp_server
+):
+    mock_list.return_value = ([], 0)
+    async with Client(mcp_server) as client:
+        request = ListDashboardsRequest(
+            filters=[{"col": "owners", "opr": "rel_m_m", "value": 1}]
+        )
+
+        result = await client.call_tool(
+            "list_dashboards", {"request": request.model_dump()}
+        )
+
+    data = json.loads(result.content[0].text)
+    assert data["count"] == 0
+    owner_filter = mock_list.call_args.kwargs["column_operators"][0]
+    assert owner_filter.col == "owners"
+    assert owner_filter.opr == "rel_m_m"
+    assert owner_filter.value == 1
+
+
+def test_list_dashboards_accepts_created_by_relationship_filter():
+    request = ListDashboardsRequest(
+        filters=[{"col": "created_by", "opr": "rel_o_m", "value": 1}]
+    )
+
+    assert request.filters[0].col == "created_by"
+    assert request.filters[0].opr == "rel_o_m"
+    assert request.filters[0].value == 1
+
+
+def test_list_dashboards_rejects_relationship_operator_for_title_filter():
+    with pytest.raises(ValueError, match="dashboard_title"):
+        ListDashboardsRequest(
+            filters=[{"col": "dashboard_title", "opr": "rel_m_m", "value": 1}]
+        )
+
+
+@patch("superset.daos.dashboard.DashboardDAO.list")
+@pytest.mark.asyncio
 async def test_list_dashboards_api_error(mock_list, mcp_server):
     mock_list.side_effect = ToolError("API request failed")
     async with Client(mcp_server) as client:


### PR DESCRIPTION
### SUMMARY

`list_dashboards` accepted only scalar dashboard filters in its MCP request schema, so an owner relationship filter such as `owners` + `rel_m_m` failed Pydantic validation before dashboard listing could run.

#### What Changed

This change:

- Adds `owners` and `created_by` to the dashboard MCP filter schema with their relationship operators.
- Validates relationship operators against the dashboard DAO custom field/operator contract so scalar filters such as `dashboard_title` still reject relationship-only operators.
- Handles owner and creator relationship filters in `superset/daos/dashboard.py` while preserving existing dashboard-specific favorite/current-user handling and generic scalar filter delegation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - backend/MCP request validation change with API-level verification.

#### Reviewer Focus

The main review risk is keeping relationship operators scoped to relationship fields while avoiding a second hard-coded operator table in the MCP schema. The schema checks the dashboard DAO custom field/operator contract, and generic scalar filters continue through the existing base DAO path.

### TESTING INSTRUCTIONS

#### Validation

- Live MCP/API validation in a local Superset compose runtime: started the MCP streamable HTTP server from the Superset API container and posted JSON-RPC `tools/call` requests to `list_dashboards`. The reproduced `owners` + `rel_m_m` request returned HTTP 200 and reached the authentication boundary instead of `Validation error in list_dashboards`, confirming the reported validation rejection is gone.
- Live MCP/API validation in the same local runtime: posted `created_by` + `rel_o_m` to `list_dashboards`; the response also reached the authentication boundary instead of schema rejection, confirming the creator relationship variant is accepted.
- Live MCP/API validation in the same local runtime: posted the adversarial scalar filter `dashboard_title` + `rel_m_m`; the response returned `Validation error in list_dashboards` with an unsupported operator/column message, confirming relationship operators were not broadened to scalar fields.
- Focused regression check: `pytest -q tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py tests/unit_tests/dashboards/dao_tests.py`

### ADDITIONAL INFORMATION

- [ ] Has associated issue: N/A - tracked internally
- [ ] Required feature flags: N/A
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

