### PR TITLE
fix(ci): restrict workflow_run jobs to trusted origins and add zizmor audit

### DIFF
--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -45,7 +45,13 @@ jobs:
           SUPERSET_SITE_BUILD: ${{ (secrets.SUPERSET_SITE_BUILD != '' && secrets.SUPERSET_SITE_BUILD != '') || '' }}
   build-deploy:
     needs: config
-    if: needs.config.outputs.has-secrets
+    # For workflow_run triggers, only deploy when the triggering run originated
+    # from this repository (not a fork), ensuring the checked-out code and any
+    # local actions executed with deploy credentials are trusted.
+    if: >-
+      needs.config.outputs.has-secrets &&
+      (github.event_name != 'workflow_run' ||
+       github.event.workflow_run.head_repository.full_name == github.repository)
     name: Build & Deploy
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -97,7 +97,8 @@ jobs:
     # Only runs if integration tests succeeded
     if: >
       github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     name: Build (after integration tests)
     runs-on: ubuntu-24.04
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,7 +162,6 @@ repos:
         name: zizmor (GHA security audit)
         entry: zizmor
         language: python
-        language_version: python3.10
         additional_dependencies: [zizmor==1.25.2]
         files: ^\.github/
         types: [yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -158,3 +158,15 @@ repos:
         language: system
         files: ^superset/config\.py$
         pass_filenames: false
+      - id: zizmor
+        name: zizmor (GHA security audit)
+        entry: zizmor
+        language: python
+        language_version: python3.10
+        additional_dependencies: [zizmor==1.25.2]
+        files: ^\.github/
+        types: [yaml]
+        pass_filenames: false
+        # Advisory until pre-existing findings are resolved; remove
+        # --no-exit-codes to make this hook blocking.
+        args: [--no-exit-codes, .github/]


### PR DESCRIPTION
### SUMMARY

- Adds a repository-origin guard to two `workflow_run`-triggered jobs so they only proceed when the triggering run came from this repository rather than an external fork.
- Adds [zizmor](https://docs.zizmor.sh) as a local **pre-commit** hook so developers catch this class of issue before pushing (CI coverage was added separately in #40510).

### CHANGES

**`superset-docs-deploy.yml`** — `build-deploy` job

The job's `if` condition now includes:
```yaml
github.event.workflow_run.head_repository.full_name == github.repository
```
When triggered via `workflow_run`, the job is skipped entirely if the triggering run did not originate from `apache/superset`. `push` and `workflow_dispatch` triggers are unaffected.

**`superset-docs-verify.yml`** — `build-after-tests` job

Same guard applied to the `build-after-tests` job, which checks out `workflow_run.head_sha` and runs `yarn install` / `yarn build` from that code. While this job carries no explicit deployment secret, `GITHUB_TOKEN` in a `workflow_run` context has repository write permissions (unlike the read-only token in a fork `pull_request` context).

**`.pre-commit-config.yaml`**

Adds `zizmor v1.25.2` as a local pre-commit hook so the linter also runs on developers' machines before they push. CI coverage was already added in #40510 via `zizmorcore/zizmor-action`. The hook runs in advisory mode (`--no-exit-codes`) to match the current CI posture — remove that flag once the ~35 pre-existing findings elsewhere in `.github/` are addressed.

### TESTING INSTRUCTIONS

- [ ] Verify that a direct `push` to `master` docs paths still triggers a successful docs deployment
- [ ] Verify that `workflow_dispatch` on the docs-deploy workflow still works
- [ ] Verify that an integration test run from `master` still triggers both docs workflows
- [ ] Confirm that a `workflow_run` event from a fork is skipped at the `build-deploy` / `build-after-tests` job level (job shows as skipped, not failed)
- [ ] Confirm the pre-commit hook runs and reports findings locally without blocking commits

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags: none
- [ ] Changes UI: no
- [ ] Includes DB Migration: no
- [ ] Introduces new feature or API: no
- [ ] Removes existing feature or API: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)