### PR TITLE
chore(deps): bump urllib3, Mako, and python-multipart for high-severity CVEs

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -208,7 +208,7 @@ kombu==5.5.3
     # via celery
 limits==5.1.0
     # via flask-limiter
-mako==1.3.11
+mako==1.3.12
     # via
     #   -r requirements/base.in
     #   apache-superset (pyproject.toml)
@@ -451,7 +451,7 @@ tzdata==2025.2
     #   pandas
 url-normalize==2.2.1
     # via requests-cache
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.in
     #   requests

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -506,7 +506,7 @@ limits==5.1.0
     # via
     #   -c requirements/base-constraint.txt
     #   flask-limiter
-mako==1.3.11
+mako==1.3.12
     # via
     #   -c requirements/base-constraint.txt
     #   alembic
@@ -1071,7 +1071,7 @@ url-normalize==2.2.1
     # via
     #   -c requirements/base-constraint.txt
     #   requests-cache
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/base-constraint.txt
     #   botocore

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -839,7 +839,7 @@ python-dotenv==1.2.2
     #   pydantic-settings
 python-ldap==3.4.4
     # via apache-superset
-python-multipart==0.0.20
+python-multipart==0.0.29
     # via mcp
 pytz==2025.2
     # via


### PR DESCRIPTION
### SUMMARY

Bumps three Python dependencies to resolve high-severity Dependabot alerts. Grouped into a single PR since each is a low-risk version bump to the exact patched release.

| Package | Bump | Manifest | Fixes |
|---------|------|----------|-------|
| `urllib3` | 2.6.3 → 2.7.0 | `base.txt`, `development.txt` | Decompression-bomb safeguard bypass (GHSA-mf9v-mfxr-j63j); sensitive headers forwarded across origins in proxied low-level redirects (GHSA-qccp-gfcp-xxvc) |
| `Mako` | 1.3.11 → 1.3.12 | `base.txt`, `development.txt` | Path traversal via backslash URI on Windows in `TemplateLookup` (GHSA-2h4p-vjrc-8xpq) |
| `python-multipart` | 0.0.20 → 0.0.29 | `development.txt` | Arbitrary file write / path traversal (GHSA-wp53-j4wj-2cfg); DoS via unbounded multipart part headers (GHSA-pp6c-gr5w-3c5g) |

**Risk notes:**
- `urllib3` and `Mako` are direct production dependencies (`requirements/base.in`) bumped to the exact patched release, which is also the latest available. Both are patch/minor bumps with no new sub-dependencies.
- `python-multipart` is a development-only dependency pulled in transitively via `mcp`; Superset uses Werkzeug's own multipart parser at runtime and does not configure `UPLOAD_KEEP_FILENAME=True`, so there is no runtime exposure. Bumped as a precautionary alignment with the patched release.

### TESTING INSTRUCTIONS

- [ ] CI passes (no runtime behavior changes)

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
