### PR TITLE
chore(deps): pin lodash, lodash-es, and yaml in docs to patched releases

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -128,7 +128,10 @@
     "react-redux": "^9.2.0",
     "@reduxjs/toolkit": "^2.5.0",
     "baseline-browser-mapping": "^2.9.19",
-    "swagger-client": "3.37.3"
+    "swagger-client": "3.37.3",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
+    "yaml": "1.10.3"
   },
   "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -9676,10 +9676,10 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+lodash-es@4.18.1, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.debounce@^4, lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -9701,12 +9701,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.18.1:
+lodash@4.17.21, lodash@4.18.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.18.1:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -15209,12 +15204,7 @@ yaml-ast-parser@0.0.43:
   resolved "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz"
   integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
 
-yaml@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@^1.10.0:
+yaml@1.10.2, yaml@1.10.3, yaml@^1.10.0:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
   integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==


### PR DESCRIPTION
### SUMMARY

Pins three transitively-bundled packages in `docs/yarn.lock` to their patched releases, picking up upstream fixes flagged by Dependabot:

| Package | Bump |
|---------|------|
| `lodash` | 4.17.21 → **4.18.1** |
| `lodash-es` | 4.17.21 → **4.18.1** |
| `yaml` | 1.10.2 → **1.10.3** |

**Why Dependabot couldn't do these:** all three are transitive dependencies that were held below the patched release by intermediate packages — either exact-pinned (e.g. Postman packages pin `lodash` and `yaml` to exact versions) or simply resolved to an older version that still satisfied a caret range. Dependabot can't move them without upstream releases from those parents.

**Fix:** add yarn `resolutions` overrides forcing every request for these packages to the patched version. The lockfile collapses the duplicate/old entries and passes `yarn install --frozen-lockfile`.

Note: `lodash` and `lodash-es` are distinct packages, so each needs its own resolution.

### BEFORE/AFTER

`docs/yarn.lock` previously resolved `lodash`/`lodash-es` to 4.17.21 and the exact `yaml@1.10.2` descriptor to 1.10.2; after this change they resolve to 4.18.1 and 1.10.3 respectively, with no older copies remaining.

### TESTING INSTRUCTIONS

- [ ] CI passes
- [ ] `cd docs && yarn install --frozen-lockfile` succeeds
- [ ] Docs build succeeds (patch/minor bumps, no behavior change)

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
