### PR TITLE
fix(chart): load viz_type from request params when creating chart via API

### DIFF
--- a/superset/commands/chart/create.py
+++ b/superset/commands/chart/create.py
@@ -43,6 +43,16 @@ class CreateChartCommand(CreateMixin, BaseCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
+        # Extract viz_type from params if it exists
+        if 'params' in self._properties:
+            try:
+                import json
+                params = json.loads(self._properties['params'])
+                if 'viz_type' in params:
+                    self._properties['viz_type'] = params['viz_type']
+            except json.JSONDecodeError as ex:
+                exceptions.append(ex)
+
     @transaction(on_error=partial(on_error, reraise=ChartCreateFailedError))
     def run(self) -> Model:
         self.validate()

--- a/superset/commands/chart/create.py
+++ b/superset/commands/chart/create.py
@@ -43,15 +43,14 @@ class CreateChartCommand(CreateMixin, BaseCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
-        # Extract viz_type from params if it exists
-        if 'params' in self._properties:
+        if self._properties.get('params'):
             try:
                 import json
                 params = json.loads(self._properties['params'])
                 if 'viz_type' in params:
                     self._properties['viz_type'] = params['viz_type']
             except json.JSONDecodeError as ex:
-                exceptions.append(ex)
+                raise ex
 
     @transaction(on_error=partial(on_error, reraise=ChartCreateFailedError))
     def run(self) -> Model:

--- a/superset/commands/chart/create.py
+++ b/superset/commands/chart/create.py
@@ -47,7 +47,9 @@ class CreateChartCommand(CreateMixin, BaseCommand):
         if params_str := self._properties.get("params"):
             params = json.loads(params_str)
             if isinstance(params, dict) and "viz_type" in params:
-                self._properties["viz_type"] = params["viz_type"]
+                # Only fall back to params when no top-level viz_type was supplied;
+                # an explicit top-level field takes precedence.
+                self._properties.setdefault("viz_type", params["viz_type"])
 
     @transaction(on_error=partial(on_error, reraise=ChartCreateFailedError))
     def run(self) -> Model:

--- a/superset/commands/chart/create.py
+++ b/superset/commands/chart/create.py
@@ -34,6 +34,7 @@ from superset.commands.chart.exceptions import (
 from superset.commands.utils import get_datasource_by_id
 from superset.daos.chart import ChartDAO
 from superset.daos.dashboard import DashboardDAO
+from superset.utils import json
 from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
@@ -43,14 +44,10 @@ class CreateChartCommand(CreateMixin, BaseCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
-        if self._properties.get('params'):
-            try:
-                import json
-                params = json.loads(self._properties['params'])
-                if 'viz_type' in params:
-                    self._properties['viz_type'] = params['viz_type']
-            except json.JSONDecodeError as ex:
-                raise ex
+        if params_str := self._properties.get("params"):
+            params = json.loads(params_str)
+            if isinstance(params, dict) and "viz_type" in params:
+                self._properties["viz_type"] = params["viz_type"]
 
     @transaction(on_error=partial(on_error, reraise=ChartCreateFailedError))
     def run(self) -> Model:


### PR DESCRIPTION
### SUMMARY

Adopts and fixes #31929 (originally by @hdahme, whose fork was subsequently archived).

When creating a chart via the API, the `viz_type` field was not being extracted from the JSON-encoded `params` string. This meant that charts created programmatically with `params` set (but without an explicit top-level `viz_type`) ended up with a blank/wrong chart type.

**Changes in `superset/commands/chart/create.py`:**
- In `CreateChartCommand.__init__`, if `params` is present, parse it and copy `viz_type` into the top-level properties so the model gets the correct chart type.
- Moved `import json` to module level using `from superset.utils import json` (project convention).
- Removed the vacuous `try/except JSONDecodeError as ex: raise ex` antipattern — let the exception propagate naturally.
- Added `isinstance(params, dict)` guard to prevent `TypeError` when the `params` JSON is not an object (e.g. an array or scalar).

### TESTING INSTRUCTIONS

```bash
pytest tests/integration_tests/charts/commands_tests.py -k "viz_type" -v
```

The integration test at `tests/integration_tests/charts/commands_tests.py` already covers the expected behaviour: a chart created with `params={"viz_type": "new_viz_type"}` should have `chart.viz_type == "new_viz_type"`.

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #31929 (adopts abandoned PR)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)