### PR TITLE
chore(deps): bump protobuf to 5.29.6 and google-cloud-bigquery-storage to 2.26.0

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -346,6 +346,7 @@ google-auth==2.43.0
     #   google-api-core
     #   google-auth-oauthlib
     #   google-cloud-bigquery
+    #   google-cloud-bigquery-storage
     #   google-cloud-core
     #   pandas-gbq
     #   pydata-google-auth
@@ -360,7 +361,7 @@ google-cloud-bigquery==3.27.0
     #   apache-superset
     #   pandas-gbq
     #   sqlalchemy-bigquery
-google-cloud-bigquery-storage==2.19.1
+google-cloud-bigquery-storage==2.26.0
     # via pandas-gbq
 google-cloud-core==2.4.1
     # via google-cloud-bigquery
@@ -701,7 +702,7 @@ proto-plus==1.25.0
     # via
     #   google-api-core
     #   google-cloud-bigquery-storage
-protobuf==4.25.8
+protobuf==5.29.6
     # via
     #   google-api-core
     #   google-cloud-bigquery-storage


### PR DESCRIPTION
### SUMMARY

Bumps `protobuf` from 4.25.8 to 5.29.6 (a development-only dependency, via the BigQuery / google-cloud stack) to pick up an upstream security fix flagged by Dependabot.

**Why this needs a coupled bump:** `protobuf` is a transitive dependency, and it was held on the 4.x line by `google-cloud-bigquery-storage 2.19.1`, which requires `protobuf <5.0.0dev`. Moving protobuf forward therefore also requires moving that package.

**Fix:** bump `google-cloud-bigquery-storage` to `2.26.0` — the first release that relaxes its pin to `protobuf <6.0.0dev` — which allows `protobuf 5.29.6`. All other protobuf consumers already permit 5.x:

| Consumer | protobuf constraint |
|----------|---------------------|
| `google-api-core 2.23.0` | `<6.0.0.dev0,>=3.19.5` ✅ |
| `googleapis-common-protos 1.66.0` | `<6.0.0.dev0,>=3.20.2` ✅ |
| `grpcio-status 1.60.1` | `>=4.21.6` ✅ |
| `proto-plus 1.25.0` | `<6.0.0dev,>=3.19.0` ✅ |
| `google-cloud-bigquery-storage` | `<5.0.0dev` → bumped to 2.26.0 (`<6.0.0dev`) ✅ |

The lockfile was regenerated with `./scripts/uv-pip-compile.sh -P protobuf==5.29.6 -P google-cloud-bigquery-storage==2.26.0` (canonical Python version, existing pins preserved), yielding a minimal diff. `google-cloud-bigquery-storage 2.26.0` introduces no new transitive dependencies.

`protobuf` is a development-only dependency (BigQuery DB engine) and is not present in `requirements/base.txt`.

### TESTING INSTRUCTIONS

- [ ] CI passes
- [ ] BigQuery DB engine tests pass with protobuf 5.x

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
