### PR TITLE
chore(deps): bump ws to 8.20.1 in docs

### DIFF
--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -15134,9 +15134,9 @@ ws@^7.3.1:
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.18.0, ws@^8.2.3:
-  version "8.18.3"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+  version "8.20.1"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 wsl-utils@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
### SUMMARY

Bumps `ws` from 8.18.3 to 8.20.1 in `docs/yarn.lock`, picking up an upstream fix flagged by Dependabot. `ws` is a transitive dependency requested by `@storybook/core` and `webpack-dev-server` (both `^8.x`).

The patched `8.20.1` satisfies the existing `^8.18.0` / `^8.2.3` ranges, so the shared 8.x lockfile entry is updated directly — **no `resolutions` override needed**. The separate `ws@^7.3.1` entry (used by `webpack-bundle-analyzer`) is intentionally left untouched: it's a different major line and outside the affected range.

Verified with `cd docs && yarn install --immutable` (clean no-op, lockfile is canonical).

### TESTING INSTRUCTIONS

- [ ] CI passes
- [ ] `cd docs && yarn install --immutable` succeeds with no lockfile changes

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
