### PR TITLE
fix(ci): grant security-events write to GHA validator workflow

### DIFF
--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -16,6 +16,11 @@ jobs:
 
   validate-all-ghas:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      # Required for the zizmor action to upload its SARIF results to
+      # GitHub code scanning (advanced-security is enabled by default).
+      security-events: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### SUMMARY

The `Validate All GitHub Actions` workflow (`github-action-validator.yml`, added in #40510) is failing on `master`. The failure is **not** a real security finding — the zizmor audit itself passes (exit code 0). The job fails on the SARIF-upload step:

```
##[error]Resource not accessible by integration
```

The `zizmor-action` runs with `advanced-security: true` (its default), which uploads results to GitHub code scanning via `github/codeql-action/upload-sarif`. That upload requires `security-events: write`, but the job only granted `contents: read`.

This adds a job-scoped `security-events: write` permission, matching the pattern already used by `codeql-analysis.yml`.

### BEFORE

`validate-all-ghas` job fails on `master` push at the "Check for security issues on GHA workflows" step with `Resource not accessible by integration` when uploading SARIF.

### AFTER

The SARIF upload has the permission it needs; zizmor findings flow to the Security tab and the job passes.

### TESTING INSTRUCTIONS

- [ ] The `Validate All GitHub Actions` check passes on this PR
- [ ] zizmor SARIF results upload without the permission error

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a (regression from #40510)
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
