### PR TITLE
chore(deps): force serialize-javascript 7.0.5 in docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -132,7 +132,8 @@
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
     "yaml": "1.10.3",
-    "uuid": "11.1.1"
+    "uuid": "11.1.1",
+    "serialize-javascript": "7.0.5"
   },
   "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -13362,12 +13362,10 @@ serialize-error@^8.1.0:
   dependencies:
     type-fest "^0.20.2"
 
-serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.5, serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 serve-handler@^6.1.7:
   version "6.1.7"


### PR DESCRIPTION
### SUMMARY

Forces `serialize-javascript` to **7.0.5** in `docs/yarn.lock` via a yarn `resolutions` override, picking up upstream security fixes flagged by Dependabot. It's a transitive, build-time-only dependency used by `copy-webpack-plugin` and `css-minimizer-webpack-plugin` (both request `^6.x`).

The fixes only land in the 7.x line, which those plugins don't yet request — so Dependabot can't bump it without upstream releases. The 7.x changes are security hardening (function-body sanitization, RegExp/Date handling); there is no API change for the `serialize(obj)` usage these plugins rely on.

`7.0.5` clears both the high-severity and the follow-up medium-severity advisories for this package.

### TESTING INSTRUCTIONS

- [ ] CI passes
- [ ] `cd docs && yarn install --immutable` is a clean no-op
- [x] Full `cd docs && yarn build` succeeds — webpack minification (which uses serialize-javascript) completes and static files are generated

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
