### PR TITLE
chore(deps): force d3-color 3.1.0 in docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -133,7 +133,8 @@
     "lodash-es": "4.18.1",
     "yaml": "1.10.3",
     "uuid": "11.1.1",
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "d3-color": "3.1.0"
   },
   "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6538,14 +6538,9 @@ d3-chord@3:
   dependencies:
     d3-path "1 - 3"
 
-"d3-color@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz"
-  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
-
-"d3-color@1 - 3", d3-color@3:
+"d3-color@1 - 2", "d3-color@1 - 3", d3-color@3, d3-color@3.1.0:
   version "3.1.0"
-  resolved "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 d3-contour@4:


### PR DESCRIPTION
### SUMMARY

Forces `d3-color` to **3.1.0** in `docs/yarn.lock` via a yarn `resolutions` override, picking up an upstream fix flagged by Dependabot.

The vulnerable copy (`2.0.0`) was pulled in by an older `d3-interpolate@1.2.0 - 2` requesting the `1 - 2` range, while the rest of the d3 stack (d3-interpolate 3.x, d3-scale-chromatic, d3-transition, d3@^7.9.0) already resolved to the patched `3.1.0`. Dependabot can't bump the `1 - 2` copy because it falls outside that range.

The override unifies every `d3-color` request to `3.1.0`. d3-color 3.0.0's only breaking change was adopting `type: module` (Node 12+) — there are **no API changes** from the 2.x line — and the docs build runs Node 20 through webpack, so the ESM form is fine.

### TESTING INSTRUCTIONS

- [ ] CI passes
- [ ] `cd docs && yarn install --immutable` is a clean no-op
- [x] Full `cd docs && yarn build` succeeds (d3 stack is exercised in chart components); static files generated

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
