### PR TITLE
chore(deps): force uuid 11.1.1 in docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -131,7 +131,8 @@
     "swagger-client": "3.37.3",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "yaml": "1.10.3"
+    "yaml": "1.10.3",
+    "uuid": "11.1.1"
   },
   "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -14721,15 +14721,10 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@8.3.2, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-"uuid@^11.1.0 || ^12 || ^13 || ^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
-  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
+uuid@11.1.1, uuid@8.3.2, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 uvu@^0.5.0:
   version "0.5.6"


### PR DESCRIPTION
### SUMMARY

Forces `uuid` to **11.1.1** in `docs/yarn.lock` via a yarn `resolutions` override, picking up an upstream fix flagged by Dependabot.

The vulnerable `8.3.2` was pulled in transitively by:
- `postman-collection` (exact `8.3.2`, via the OpenAPI docs generation)
- `sockjs` (`^8.3.2`, webpack-dev-server's websocket fallback)

The fix only lands in the 11.x line, so Dependabot can't bump it without upstream releases. The override forces every `uuid` request to `11.1.1`. `mermaid` (`^11.1.0 || ^12 || ^13 || ^14.0.0`) is unaffected — `11.1.1` satisfies its range.

**Breaking-change review:** uuid v9 removed the default export, but both consumers use the named `.v4()` API, which is unchanged across 8.x → 11.x. So the override is API-safe for the actual usage.

### TESTING INSTRUCTIONS

- [ ] CI passes
- [ ] `cd docs && yarn install --immutable` is a clean no-op
- [x] Full `cd docs && yarn build` succeeds (exercises the postman-collection / OpenAPI-docs path); static files generated

> ⚠️ **Coverage note:** `sockjs` is only used by `docusaurus start` (the dev server), **not** the production build, so its `uuid` path is validated by changelog review (named `.v4()` usage) rather than by the build. Functionally low-risk, but flagging for transparency.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
