### PR TITLE
fix(ci): gate welcome message on first-time contributor association

### DIFF
--- a/.github/workflows/welcome-new-users.yml
+++ b/.github/workflows/welcome-new-users.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   welcome:
     runs-on: ubuntu-24.04
+    if: github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
### SUMMARY

The \"Congrats on your first PR\" workflow fires on **every** PR from returning contributors, including org members.

**Root cause:** `actions/first-interaction@v3` detects first-time contributors by querying the GitHub API for prior PRs, but the job's `permissions` block only grants `pull-requests: write`. That restricted token cannot list the repo's PR history, so the action silently falls back to treating every PR as a first — even from someone with hundreds of merged PRs.

**Fix:** Add a job-level `if` condition gating on `github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'`. GitHub computes `author_association` server-side before the workflow runs, so it's authoritative with no API calls required. The action only runs (and posts the comment) when GitHub itself confirms the author has never had a PR merged here.

The `author_association` values for returning contributors (`MEMBER`, `COLLABORATOR`, `CONTRIBUTOR`) all correctly skip the job.

### TESTING INSTRUCTIONS

- Open a PR as an org member → workflow job skips (condition false), no comment posted ✓
- Open a PR as a brand-new GitHub user with no prior contributions → workflow runs and posts the welcome comment ✓

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)