### PR TITLE
fix: guard dynamic dispatch and bound a regex quantifier

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/boxplotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/boxplotOperator.ts
@@ -25,7 +25,7 @@ import {
 } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
 
-const PERCENTILE_REGEX = /(\d+)\/(\d+) percentiles/;
+const PERCENTILE_REGEX = /(\d{1,3})\/(\d{1,3}) percentiles/;
 
 export const boxplotOperator: PostProcessingFactory<PostProcessingBoxplot> = (
   formData,

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -143,7 +143,12 @@ const setLastId = (asyncEvent: AsyncEvent) => {
 export const processEvents = async (events: AsyncEvent[]) => {
   events.forEach((asyncEvent: AsyncEvent) => {
     const jobId = asyncEvent.job_id;
-    const listener = listenersByJobId[jobId];
+    const listener = Object.prototype.hasOwnProperty.call(
+      listenersByJobId,
+      jobId,
+    )
+      ? listenersByJobId[jobId]
+      : undefined;
     if (listener) {
       listener(asyncEvent);
       delete retriesByJobId[jobId];


### PR DESCRIPTION
### SUMMARY

Resolves the remaining two findings:

- **Dynamic dispatch (`asyncEvent.ts`):** the async-event middleware looked up a listener by a server-supplied job id and invoked it. Now the dynamic property access is guarded with an own-property check, so the lookup can only resolve to a listener the app actually registered (not an inherited object method).
- **Regex backtracking (`boxplotOperator.ts`):** the boxplot percentile pattern used unbounded digit quantifiers. Since these values are always in the 0–100 range, the quantifiers are now bounded, removing the backtracking risk while preserving matching behavior.

Both are minimal, behavior-preserving changes.

### TESTING INSTRUCTIONS

- [ ] CI passes (frontend lint / type-check / unit tests)
- [ ] Boxplot "X/Y percentiles" whisker option still parses correctly
- [ ] Async event listeners still fire for registered job ids
- [ ] The relevant CodeQL alerts no longer appear after the next scan

### ADDITIONAL INFORMATION

- [ ] Has associated issue: addresses code-scanning alerts
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
