### PR TITLE
chore: guard recursive merge keys and invoke subprocess without a shell

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.ts
@@ -4005,6 +4005,10 @@ function mergeRecursive(obj1, obj2) {
 
   /*jshint forin:false */
   for (var p in obj2) {
+    // Skip keys that could pollute the object prototype.
+    if (p === '__proto__' || p === 'constructor' || p === 'prototype') {
+      continue;
+    }
     try {
       // Property in destination object set; update its value.
       if (obj2[p].constructor === Object) {

--- a/superset/mcp_service/bin/superset-mcp.js
+++ b/superset/mcp_service/bin/superset-mcp.js
@@ -59,7 +59,7 @@
  * 4. Run npm publish with appropriate access rights
  */
 
-const { spawn, execSync } = require('child_process');
+const { spawn, execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -176,7 +176,7 @@ function checkEnvironment() {
 
     // Check if Superset is installed
     try {
-        execSync(`${python} -c "import superset"`, {
+        execFileSync(python, ['-c', 'import superset'], {
             env: { ...process.env, PYTHONPATH: supersetRoot },
             stdio: 'ignore'
         });


### PR DESCRIPTION
### SUMMARY

Two small code-quality hardening tweaks surfaced by static analysis. No behavior change for normal inputs.

- **`legacy-plugin-chart-calendar` vendored `cal-heatmap` helper** — `mergeRecursive` now skips `__proto__`, `constructor`, and `prototype` keys when copying properties from the source object, so a merge source can't reach the destination object's prototype.
- **`superset-mcp.js` dev launcher** — the "is Superset importable" check now uses `execFileSync(python, ['-c', 'import superset'])` instead of assembling a shell command string. This matches how the server process is already launched (`spawn(python, args)`), so no shell parsing is involved.

### TESTING INSTRUCTIONS

- [x] Reviewed both call sites; argument shape unchanged for normal inputs
- [ ] CI green

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)