### PR TITLE
chore(mcp): return a generic error from the webdriver pool-stats endpoint

### DIFF
--- a/superset/mcp_service/screenshot/webdriver_config.py
+++ b/superset/mcp_service/screenshot/webdriver_config.py
@@ -19,7 +19,10 @@
 WebDriver pool configuration defaults for Superset MCP service
 """
 
+import logging
 from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
 
 # Default WebDriver pool configuration
 DEFAULT_WEBDRIVER_POOL_CONFIG = {
@@ -80,10 +83,13 @@ def get_pool_stats_endpoint() -> Any:
             stats = pool.get_stats()
 
             return jsonify({"webdriver_pool": stats, "status": "healthy"})
-        except Exception as e:
+        except Exception:
             from flask import jsonify
 
-            return jsonify({"error": str(e), "status": "error"}), 500
+            logger.exception("Failed to retrieve webdriver pool stats")
+            return jsonify(
+                {"error": "Failed to retrieve pool stats", "status": "error"}
+            ), 500
 
     return pool_stats
 

--- a/superset/mcp_service/screenshot/webdriver_config.py
+++ b/superset/mcp_service/screenshot/webdriver_config.py
@@ -72,9 +72,9 @@ def get_pool_stats_endpoint() -> Any:
     """
 
     def pool_stats() -> Any:
-        try:
-            from flask import jsonify
+        from flask import jsonify
 
+        try:
             from superset.mcp_service.screenshot.webdriver_pool import (
                 get_webdriver_pool,
             )
@@ -84,8 +84,6 @@ def get_pool_stats_endpoint() -> Any:
 
             return jsonify({"webdriver_pool": stats, "status": "healthy"})
         except Exception:
-            from flask import jsonify
-
             logger.exception("Failed to retrieve webdriver pool stats")
             return jsonify(
                 {"error": "Failed to retrieve pool stats", "status": "error"}


### PR DESCRIPTION
### SUMMARY

The MCP webdriver pool-stats debug endpoint previously returned the raw exception string to the caller (`{"error": str(e)}`). It now logs the exception server-side via `logger.exception(...)` and returns a fixed, generic error message instead. Surfaced by static analysis as a code-quality improvement.

### BEFORE
```python
except Exception as e:
    return jsonify({"error": str(e), "status": "error"}), 500
```

### AFTER
```python
except Exception:
    logger.exception("Failed to retrieve webdriver pool stats")
    return jsonify({"error": "Failed to retrieve pool stats", "status": "error"}), 500
```

### TESTING INSTRUCTIONS

- [x] Syntax-checked; error path still returns HTTP 500
- [ ] CI green

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)