### PR TITLE
chore(deps): bump idna, Authlib, fontTools, python-ldap, virtualenv

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -176,7 +176,7 @@ holidays==0.82
     # via apache-superset (pyproject.toml)
 humanize==4.12.3
     # via apache-superset (pyproject.toml)
-idna==3.10
+idna==3.15
     # via
     #   email-validator
     #   requests

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -52,7 +52,7 @@ attrs==25.3.0
     #   referencing
     #   requests-cache
     #   trio
-authlib==1.6.9
+authlib==1.6.12
     # via fastmcp
 babel==2.17.0
     # via
@@ -317,7 +317,7 @@ flask-wtf==1.2.2
     #   -c requirements/base-constraint.txt
     #   apache-superset
     #   flask-appbuilder
-fonttools==4.55.0
+fonttools==4.60.2
     # via matplotlib
 freezegun==1.5.1
     # via apache-superset
@@ -422,7 +422,7 @@ humanize==4.12.3
     #   apache-superset
 identify==2.5.36
     # via pre-commit
-idna==3.10
+idna==3.15
     # via
     #   -c requirements/base-constraint.txt
     #   anyio
@@ -838,7 +838,7 @@ python-dotenv==1.2.2
     #   apache-superset
     #   fastmcp
     #   pydantic-settings
-python-ldap==3.4.4
+python-ldap==3.4.5
     # via apache-superset
 python-multipart==0.0.29
     # via mcp
@@ -1090,7 +1090,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.2
+virtualenv==20.36.1
     # via pre-commit
 watchdog==6.0.0
     # via


### PR DESCRIPTION
### SUMMARY

Bumps several pinned Python dependencies to releases that address open security advisories surfaced by Dependabot. Grouped because they are all low-risk leaf or patch/minor bumps in the `requirements/` lockfiles.

| Package | From | To | Lockfile(s) |
|---|---|---|---|
| idna | 3.10 | 3.15 | base.txt + development.txt |
| Authlib | 1.6.9 | 1.6.12 | development.txt |
| fontTools | 4.55.0 | 4.60.2 | development.txt |
| python-ldap | 3.4.4 | 3.4.5 | development.txt |
| virtualenv | 20.29.2 | 20.36.1 | development.txt |

The existing transitive pins (cryptography 46.0.7, distlib 0.3.8, filelock 3.20.3, platformdirs 4.3.8, pyasn1 0.6.3) already satisfy the new packages' requirements, so no lockfile regeneration was needed — these are line-level pin edits matching the repo's Dependabot convention. `idna` is kept in sync across `base.txt` and `development.txt`.

### TESTING INSTRUCTIONS

- [x] Verified the target version set resolves cleanly with `uv pip compile`
- [x] Confirmed each bumped package's declared requirements are met by existing transitive pins
- [x] CI green

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)