### PR TITLE
fix: replace native prompt() with styled modal for SQL Lab tab rename

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -133,15 +133,20 @@ describe('SqlEditorTabHeader', () => {
       );
     });
 
-    test('should dispatch queryEditorSetTitle action', async () => {
+    test('should dispatch queryEditorSetTitle action via modal confirm', async () => {
       await waitFor(() =>
-        expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
       );
       const expectedTitle = 'typed text';
-      const mockPrompt = jest
-        .spyOn(window, 'prompt')
-        .mockImplementation(() => expectedTitle);
+
       fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: expectedTitle } });
+
+      fireEvent.click(screen.getByTestId('rename-tab-confirm'));
 
       const actions = store.getActions();
       await waitFor(() =>
@@ -153,7 +158,88 @@ describe('SqlEditorTabHeader', () => {
           }),
         }),
       );
-      mockPrompt.mockClear();
+    });
+
+    test('should dispatch queryEditorSetTitle action when pressing Enter', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+      const expectedTitle = 'enter key title';
+
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: expectedTitle } });
+      fireEvent.keyDown(input, {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        charCode: 13,
+      });
+
+      const actions = store.getActions();
+      await waitFor(() =>
+        expect(actions[0]).toEqual({
+          type: QUERY_EDITOR_SET_TITLE,
+          name: expectedTitle,
+          queryEditor: expect.objectContaining({
+            id: defaultQueryEditor.id,
+          }),
+        }),
+      );
+    });
+
+    test('cancel button closes modal without dispatching', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: 'discarded' } });
+
+      fireEvent.click(screen.getByTestId('rename-tab-cancel'));
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('rename-tab-input')).not.toBeInTheDocument(),
+      );
+      expect(
+        store
+          .getActions()
+          .some(action => action.type === QUERY_EDITOR_SET_TITLE),
+      ).toBe(false);
+    });
+
+    test('confirm with empty input does not dispatch and keeps modal open', async () => {
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('rename-tab-menu-option'),
+        ).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByTestId('rename-tab-menu-option'));
+
+      const input = await screen.findByTestId('rename-tab-input');
+      fireEvent.change(input, { target: { value: '   ' } });
+      fireEvent.keyDown(input, {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        charCode: 13,
+      });
+
+      // Modal is still open and no rename action was dispatched.
+      expect(screen.getByTestId('rename-tab-input')).toBeInTheDocument();
+      expect(
+        store
+          .getActions()
+          .some(action => action.type === QUERY_EDITOR_SET_TITLE),
+      ).toBe(false);
     });
 
     test('should dispatch removeAllOtherQueryEditors action', async () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -234,7 +234,10 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
         onHide={() => setShowRenameModal(false)}
         footer={
           <>
-            <Button onClick={() => setShowRenameModal(false)}>
+            <Button
+              onClick={() => setShowRenameModal(false)}
+              data-test="rename-tab-cancel"
+            >
               {t('Cancel')}
             </Button>
             <Button
@@ -250,9 +253,10 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
       >
         <span>{t('Enter a new title for the tab')}</span>
         <Input
+          autoFocus
           value={newTitle}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setNewTitle(e.target.value)
+            setNewTitle(e.target.value.trim())
           }
           onPressEnter={handleRenameConfirm}
           data-test="rename-tab-input"

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -117,9 +117,10 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
   }
 
   function handleRenameConfirm() {
-    if (newTitle.trim()) {
-      actions.queryEditorSetTitle(qe, newTitle.trim(), qe.id);
+    if (!newTitle.trim()) {
+      return;
     }
+    actions.queryEditorSetTitle(qe, newTitle.trim(), qe.id);
     setShowRenameModal(false);
   }
   const getStatusColor = (state: QueryState, theme: SupersetTheme): string => {

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, FC } from 'react';
+import { useMemo, useState, FC } from 'react';
 
 import { bindActionCreators } from 'redux';
 import { useSelector, shallowEqual } from 'react-redux';
@@ -40,6 +40,7 @@ import {
 } from 'src/SqlLab/actions/sqlLab';
 import { QueryEditor, SqlLabRootState } from 'src/SqlLab/types';
 import { Icons, type IconType } from '@superset-ui/core/components/Icons';
+import { Modal, Input, Button } from '@superset-ui/core/components';
 
 const TabTitleWrapper = styled.div`
   display: flex;
@@ -107,13 +108,19 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
     [dispatch],
   );
 
-  function renameTab() {
-    // TODO: Replace native prompt with a proper modal dialog
-    // eslint-disable-next-line no-alert
-    const newTitle = prompt(t('Enter a new title for the tab'));
-    if (newTitle) {
-      actions.queryEditorSetTitle(qe, newTitle, qe.id);
+  const [showRenameModal, setShowRenameModal] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+
+  function openRenameModal() {
+    setNewTitle(qe.name);
+    setShowRenameModal(true);
+  }
+
+  function handleRenameConfirm() {
+    if (newTitle.trim()) {
+      actions.queryEditorSetTitle(qe, newTitle.trim(), qe.id);
     }
+    setShowRenameModal(false);
   }
   const getStatusColor = (state: QueryState, theme: SupersetTheme): string => {
     const statusColors: Record<QueryState, string> = {
@@ -158,7 +165,7 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
               } as MenuItemType,
               {
                 key: '2',
-                onClick: renameTab,
+                onClick: openRenameModal,
                 'data-test': 'rename-tab-menu-option',
                 label: (
                   <>
@@ -220,6 +227,36 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
         iconSize="m"
         iconColor={getStatusColor(queryState, theme)}
       />{' '}
+      <Modal
+        show={showRenameModal}
+        title={t('Rename tab')}
+        onHide={() => setShowRenameModal(false)}
+        footer={
+          <>
+            <Button onClick={() => setShowRenameModal(false)}>
+              {t('Cancel')}
+            </Button>
+            <Button
+              buttonStyle="primary"
+              disabled={!newTitle.trim()}
+              onClick={handleRenameConfirm}
+              data-test="rename-tab-confirm"
+            >
+              {t('Rename')}
+            </Button>
+          </>
+        }
+      >
+        <span>{t('Enter a new title for the tab')}</span>
+        <Input
+          value={newTitle}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setNewTitle(e.target.value)
+          }
+          onPressEnter={handleRenameConfirm}
+          data-test="rename-tab-input"
+        />
+      </Modal>
     </TabTitleWrapper>
   );
 };


### PR DESCRIPTION
## What this does

Fixes #40401

Replaces the native browser `prompt()` dialog with a styled Superset Modal for the SQL Lab tab rename feature.

**Before:** Native browser `prompt()` dialog (unstyled, blocked in some environments)
**After:** Superset-styled Modal with Input field, consistent with the rest of the UI

## Changes

- `SqlEditorTabHeader/index.tsx`: Replaced `prompt()` call with a controlled `Modal` component containing an `Input` field
- Added `useState` for modal visibility and title state
- Modal pre-fills the current tab name
- Rename button disabled when input is empty
- Supports Enter key to confirm
- Follows the same Modal pattern used by `CREATE TABLE/VIEW AS` in `SqlEditor/index.tsx`

## How it works

Clicking "Rename tab" in the context menu now opens a styled Modal dialog instead of the browser's native prompt. The modal includes:
- A text input pre-filled with the current tab name
- Cancel and Rename buttons (Rename is disabled when input is empty)
- Enter key support for quick confirmation
