### PR TITLE
fix(ci): repair Python version extraction in uv-pip-compile.sh

### DIFF
--- a/scripts/uv-pip-compile.sh
+++ b/scripts/uv-pip-compile.sh
@@ -22,7 +22,12 @@ set -e
 # If not already running in Docker, run this script inside Docker
 if [ -z "$RUNNING_IN_DOCKER" ]; then
   # Extract "current" Python version from CI config (single source of truth)
-  PYTHON_VERSION=$(grep -A 1 'if.*"current"' .github/actions/setup-backend/action.yml | grep 'PYTHON_VERSION=' | sed 's/.*PYTHON_VERSION=\([0-9.]*\).*/\1/')
+  PYTHON_VERSION=$(grep -A 1 'if.*"current"' .github/actions/setup-backend/action.yml | grep 'RESOLVED_VERSION=' | sed 's/.*RESOLVED_VERSION="\([0-9.]*\)".*/\1/')
+
+  if [ -z "$PYTHON_VERSION" ]; then
+    echo "Failed to determine Python version from .github/actions/setup-backend/action.yml" >&2
+    exit 1
+  fi
 
   echo "Running in Docker (Python ${PYTHON_VERSION} on Linux)..."
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Regression introduced by #40556, which hardened `.github/actions/setup-backend/action.yml` and in the process renamed its Python version variable from `PYTHON_VERSION` to `RESOLVED_VERSION`.

`./scripts/uv-pip-compile.sh` derives its Docker image (`python:${PYTHON_VERSION}-slim`) by grepping that action file for a `PYTHON_VERSION=` assignment. After the rename the grep matches nothing, `PYTHON_VERSION` is empty, and the image becomes the invalid `python:-slim`, so the script fails immediately with:

```
Running in Docker (Python  on Linux)...
docker: invalid reference format
```

This updates the extraction to read `RESOLVED_VERSION` and adds a guard that fails loudly
if the version can't be parsed.

### TESTING INSTRUCTIONS

With the fix, running `./scripts/uv-pip-compile.sh` we get:

```
Running in Docker (Python 3.11 on Linux)...
Unable to find image 'python:3.11-slim' locally
3.11-slim: Pulling from library/python
cda3d70ae7d7: Pull complete
5eab6366d324: Pull complete
b2c22afaf507: Pull complete
31b290acbac4: Pull complete
Digest: sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
Status: Downloaded newer image for python:3.11-slim
Collecting uv
...
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
