### PR TITLE
fix(dashboard): clear undo history

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.test.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.test.tsx
@@ -26,6 +26,8 @@ import {
 } from 'src/hooks/apiResources';
 import { SupersetClient } from '@superset-ui/core';
 import CrudThemeProvider from 'src/components/CrudThemeProvider';
+import { hydrateDashboard } from 'src/dashboard/actions/hydrate';
+import { clearDashboardHistory } from 'src/dashboard/actions/dashboardLayout';
 import DashboardPage from './DashboardPage';
 
 const mockTheme = {
@@ -62,6 +64,11 @@ jest.mock('src/hooks/apiResources', () => ({
 jest.mock('src/dashboard/actions/hydrate', () => ({
   ...jest.requireActual('src/dashboard/actions/hydrate'),
   hydrateDashboard: jest.fn(() => ({ type: 'MOCK_HYDRATE' })),
+}));
+
+jest.mock('src/dashboard/actions/dashboardLayout', () => ({
+  ...jest.requireActual('src/dashboard/actions/dashboardLayout'),
+  clearDashboardHistory: jest.fn(() => ({ type: 'MOCK_CLEAR_HISTORY' })),
 }));
 
 jest.mock('src/dashboard/actions/datasources', () => ({
@@ -253,4 +260,32 @@ test('passes null theme when Redux dashboardInfo.theme is explicitly null (theme
     expect.objectContaining({ theme: null }),
     expect.anything(),
   );
+});
+
+test('clears undo history after hydrating the dashboard', async () => {
+  render(
+    <Suspense fallback="loading">
+      <DashboardPage idOrSlug="1" />
+    </Suspense>,
+    {
+      useRedux: true,
+      useRouter: true,
+      initialState: {
+        dashboardInfo: { id: 1, metadata: {} },
+        dashboardState: { sliceIds: [] },
+        nativeFilters: { filters: {} },
+        dataMask: {},
+      },
+    },
+  );
+
+  await waitFor(() => {
+    expect(screen.queryByText('loading')).not.toBeInTheDocument();
+  });
+
+  expect(hydrateDashboard).toHaveBeenCalled();
+  expect(clearDashboardHistory).toHaveBeenCalled();
+  const hydrateOrder = (hydrateDashboard as jest.Mock).mock.invocationCallOrder[0];
+  const clearOrder = (clearDashboardHistory as jest.Mock).mock.invocationCallOrder[0];
+  expect(clearOrder).toBeGreaterThan(hydrateOrder);
 });

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -31,6 +31,7 @@ import {
   useDashboardDatasets,
 } from 'src/hooks/apiResources';
 import { hydrateDashboard } from 'src/dashboard/actions/hydrate';
+import { clearDashboardHistory } from 'src/dashboard/actions/dashboardLayout';
 import { setDatasources } from 'src/dashboard/actions/datasources';
 import injectCustomCss from 'src/dashboard/util/injectCustomCss';
 import {
@@ -278,6 +279,7 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
             chartStates: chartStates ?? null,
           } as unknown as Parameters<typeof hydrateDashboard>[0]),
         );
+        dispatch(clearDashboardHistory());
 
         // Scroll to anchor element if specified in permalink state
         if (anchor) {


### PR DESCRIPTION
### SUMMARY
On a brand-new dashboard, the Undo button was incorrectly enabled and crashed with `TypeError: Cannot read properties of undefined (reading 'type')` when clicked.

Root cause: `HYDRATE_DASHBOARD` is in `TRACKED_ACTIONS` for the undoable layout reducer, so the initial hydrate pushes a phantom entry onto `dashboardLayout.past`. The button's existing `disabled={undoLength <
1}` check then resolves to `false`, and clicking Undo restores a pre-hydration empty layout, which crashes `DragDroppable.render`.

Existing dashboards don't hit this because `handleEnterEditMode` already dispatches `clearDashboardHistory()` when the user enters edit mode. New dashboards skip that path (they mount directly with `?edit=true`).

Fix: dispatch `clearDashboardHistory()` immediately after `hydrateDashboard()` in `DashboardPage.tsx`. Same helper, same pattern as the two existing call sites.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** The undo button appears right after create a new dashboard even if nothing was changed. 
<img width="768" height="603" alt="Screenshot 2026-05-31 at 15 13 56" src="https://github.com/user-attachments/assets/dd8662e1-2f09-4dda-bc22-177cd5ab6015" />

**After:** Undo disabled until the first layout change. No crash.
<img width="821" height="601" alt="Screenshot 2026-05-31 at 15 13 21" src="https://github.com/user-attachments/assets/a00f67be-e479-48d9-9d14-77da9d10b3b5" />

### TESTING INSTRUCTIONS
1. Open Superset, go to Dashboards.
2. Click `+ Dashboard`.
3. Without making any edits, confirm the Undo button is disabled (same visual state as Redo).
4. Add a chart via drag-and-drop, confirm Undo becomes enabled and works normally.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: #107306
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API