### PR TITLE
fix(dashboard): preserve owner data on removal to avoid undefined display

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -257,10 +257,9 @@ const PropertiesModal = ({
     owners: { value: number; label: string }[],
     options: Record<string, unknown>[],
   ) => {
-    setOwners(prev => {
-      const previousById = new Map(prev.map(o => [o.id, o]));
-      return ensureIsArray(owners).map((o, i) => {
-        const previous = previousById.get(o.value);
+    setOwners(prev =>
+      ensureIsArray(owners).map((o, i) => {
+        const previous = prev.find(p => p.id === o.value);
         if (previous) return previous;
         return {
           id: o.value,
@@ -269,8 +268,8 @@ const PropertiesModal = ({
             (typeof o.label === 'string' ? o.label : ''),
           email: (options?.[i]?.[OWNER_EMAIL_PROP] as string) || '',
         };
-      });
-    });
+      }),
+    );
   };
 
   const handleOnChangeRoles = (roles: { value: number; label: string }[]) => {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -257,14 +257,20 @@ const PropertiesModal = ({
     owners: { value: number; label: string }[],
     options: Record<string, unknown>[],
   ) => {
-    const parsedOwners: Owners = ensureIsArray(owners).map((o, i) => ({
-      id: o.value,
-      full_name:
-        (options?.[i]?.[OWNER_TEXT_LABEL_PROP] as string) ||
-        (typeof o.label === 'string' ? o.label : ''),
-      email: (options?.[i]?.[OWNER_EMAIL_PROP] as string) || '',
-    }));
-    setOwners(parsedOwners);
+    setOwners(prev => {
+      const previousById = new Map(prev.map(o => [o.id, o]));
+      return ensureIsArray(owners).map((o, i) => {
+        const previous = previousById.get(o.value);
+        if (previous) return previous;
+        return {
+          id: o.value,
+          full_name:
+            (options?.[i]?.[OWNER_TEXT_LABEL_PROP] as string) ||
+            (typeof o.label === 'string' ? o.label : ''),
+          email: (options?.[i]?.[OWNER_EMAIL_PROP] as string) || '',
+        };
+      });
+    });
   };
 
   const handleOnChangeRoles = (roles: { value: number; label: string }[]) => {


### PR DESCRIPTION
### SUMMARY
In Dashboard Properties → Access & ownership, removing one owner caused the remaining owner chip(s) to re-render as `undefined undefined` instead of their actual name.

Root cause: `handleOnChangeOwners` rebuilt every owner object from antd's onChange payload, but the option objects passed for already-selected items don't carry the custom `OWNER_TEXT_LABEL_PROP` /
`OWNER_EMAIL_PROP` props. So `full_name` collapsed to `''`, and `getOwnerName` fell back to `` `${first_name} ${last_name}` `` where both were undefined.

Fix: in `handleOnChangeOwners`, look up each owner by id in the previous state and preserve the original object when it already exists. Only newly added owners get derived from the option payload (existing
behavior).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Remaining chip renders as `undefined undefined`.
<img width="539" height="710" alt="Screenshot 2026-05-31 at 23 09 57" src="https://github.com/user-attachments/assets/46b8c293-089a-4c79-8731-e35574c47329" />
<img width="570" height="720" alt="Screenshot 2026-05-31 at 23 10 07" src="https://github.com/user-attachments/assets/c158c0fe-f35b-4c8e-9618-d65e658453e1" />


**After:** Remaining chip keeps the correct name.
<img width="620" height="737" alt="Screenshot 2026-05-31 at 23 08 01" src="https://github.com/user-attachments/assets/156996ff-7d6d-4a71-b95f-4acc9929a927" />
<img width="559" height="735" alt="Screenshot 2026-05-31 at 23 08 13" src="https://github.com/user-attachments/assets/57440030-b188-40f2-b55f-6a1e589eca7d" />

### TESTING INSTRUCTIONS
1. Open a dashboard's Properties modal (you'll need 2+ users in the system).
2. Expand Access & ownership and add a second owner. Save.
3. Reopen Properties → Access & ownership. Click the `x` on one of the owner chips.
4. Confirm the remaining chip still shows the owner's name (not `undefined undefined`).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API