### PR TITLE
fix(daos): lazy-import SoftDeleteMixin to fix pytest collection error

### DIFF
--- a/superset/constants.py
+++ b/superset/constants.py
@@ -30,6 +30,8 @@ EMPTY_STRING = "<empty string>"
 CHANGE_ME_SECRET_KEY = "CHANGE_ME_TO_A_COMPLEX_RANDOM_SECRET"  # noqa: S105
 CHANGE_ME_GUEST_TOKEN_JWT_SECRET = "test-guest-secret-change-me"  # noqa: S105
 
+SKIP_VISIBILITY_FILTER_CLASSES = "_skip_visibility_filter_classes"
+
 # UUID for the examples database
 EXAMPLES_DB_UUID = "a2dc77af-e654-49bb-b321-40f6b559a1ee"
 

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -44,15 +44,11 @@ from sqlalchemy.orm import ColumnProperty, joinedload, Query, RelationshipProper
 from superset_core.common.daos import BaseDAO as CoreBaseDAO
 from superset_core.common.models import CoreModel
 
+from superset.constants import SKIP_VISIBILITY_FILTER_CLASSES
 from superset.daos.exceptions import (
     DAOFindFailedError,
 )
 from superset.extensions import db
-
-# Defined locally to avoid importing superset.models.helpers at module level,
-# which triggers superset/models/__init__.py → core.py → encrypted_field_factory
-# before the Flask app is initialized (breaks pytest collection).
-SKIP_VISIBILITY_FILTER_CLASSES = "_skip_visibility_filter_classes"
 
 T = TypeVar("T", bound=CoreModel)
 

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -48,7 +48,11 @@ from superset.daos.exceptions import (
     DAOFindFailedError,
 )
 from superset.extensions import db
-from superset.models.helpers import SKIP_VISIBILITY_FILTER_CLASSES, SoftDeleteMixin
+
+# Defined locally to avoid importing superset.models.helpers at module level,
+# which triggers superset/models/__init__.py → core.py → encrypted_field_factory
+# before the Flask app is initialized (breaks pytest collection).
+SKIP_VISIBILITY_FILTER_CLASSES = "_skip_visibility_filter_classes"
 
 T = TypeVar("T", bound=CoreModel)
 
@@ -505,6 +509,10 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
 
         :param items: The items to delete
         """
+        from superset.models.helpers import (
+            SoftDeleteMixin,  # pylint: disable=import-outside-toplevel
+        )
+
         if cls.model_cls is not None and issubclass(cls.model_cls, SoftDeleteMixin):
             cls.soft_delete(items)
         else:

--- a/superset/daos/database.py
+++ b/superset/daos/database.py
@@ -24,13 +24,12 @@ from sqlalchemy.orm import joinedload
 from superset import is_feature_enabled
 from superset.commands.database.ssh_tunnel.exceptions import SSHTunnelingNotEnabledError
 from superset.connectors.sqla.models import SqlaTable
-from superset.daos.base import BaseDAO
+from superset.daos.base import BaseDAO, SKIP_VISIBILITY_FILTER_CLASSES
 from superset.databases.filters import DatabaseFilter
 from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.extensions import db
 from superset.models.core import Database, DatabaseUserOAuth2Tokens
 from superset.models.dashboard import Dashboard
-from superset.models.helpers import SKIP_VISIBILITY_FILTER_CLASSES
 from superset.models.slice import Slice
 from superset.models.sql_lab import TabState
 from superset.utils.core import DatasourceType

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -75,7 +75,13 @@ from superset.common.utils.time_range_utils import (
     get_since_until_from_query_object,
     get_since_until_from_time_range,
 )
-from superset.constants import CacheRegion, EMPTY_STRING, NULL_STRING, TimeGrain
+from superset.constants import (
+    CacheRegion,
+    EMPTY_STRING,
+    NULL_STRING,
+    SKIP_VISIBILITY_FILTER_CLASSES,
+    TimeGrain,
+)
 from superset.db_engine_specs.base import TimestampExpression
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
@@ -660,8 +666,6 @@ class AuditMixinNullable(AuditMixin):
     def modified(self) -> Markup:
         return Markup(f'<span class="no-wrap">{self.changed_on_humanized}</span>')  # noqa: S704
 
-
-SKIP_VISIBILITY_FILTER_CLASSES = "_skip_visibility_filter_classes"
 
 # Shared sentinel for "no bypass requested" — returned by
 # ``_collect_bypass_classes`` on the common path so every primary SELECT


### PR DESCRIPTION
## SUMMARY

Commit \`b2320820b4\` (\`feat(core): SoftDeleteMixin and restore infrastructure\`) added a module-level import in \`superset/daos/base.py\`:

\`\`\`python
from superset.models.helpers import SKIP_VISIBILITY_FILTER_CLASSES, SoftDeleteMixin
\`\`\`

Importing \`superset.models.helpers\` triggers \`superset/models/__init__.py\`, which eagerly imports \`superset/models/core.py\`. At class-definition time, \`core.py\` calls \`encrypted_field_factory.create(String(1024))\`, raising \`Exception: App not initialized yet. Please call init_app first\` whenever a test file is collected before the Flask app is created.

This broke pytest collection for any test that imports from \`superset.daos\` before a Flask app context exists, causing CI failures in downstream consumers.

**Fix (2 commits):**

1. **Lazy import + break the import chain** — Move \`SoftDeleteMixin\` import inside \`BaseDAO.delete()\` where it is used at runtime (\`# pylint: disable=import-outside-toplevel\`). \`database.py\` updated to import \`SKIP_VISIBILITY_FILTER_CLASSES\` from \`superset.daos.base\` instead of \`superset.models.helpers\`.

2. **DRY: move \`SKIP_VISIBILITY_FILTER_CLASSES\` to \`superset/constants.py\`** — The constant was defined independently in both \`superset/models/helpers.py\` (line 664) and \`superset/daos/base.py\` (as a workaround). Canonical home is now \`superset/constants.py\`. \`helpers.py\` imports and re-exports it so all existing callers (\`views/filters.py\`, \`commands/importers/v1/utils.py\`, \`security/manager.py\`) remain unchanged.

## BEFORE/AFTER

**Before:** importing \`superset.daos.base\` or \`superset.daos.database\` before \`create_app()\` raises \`App not initialized yet\`.

**After:** both modules import cleanly without a Flask app context. Single definition of \`SKIP_VISIBILITY_FILTER_CLASSES\` in \`superset/constants.py\`.

## TESTING INSTRUCTIONS

- [ ] \`pytest tests/unit_tests/\` — collection no longer fails with \`App not initialized yet\`
- [ ] Functional smoke: \`BaseDAO.delete()\` still routes to \`soft_delete\` for \`SoftDeleteMixin\` models and \`hard_delete\` for others
- [ ] \`SKIP_VISIBILITY_FILTER_CLASSES\` value is identical (\`"_skip_visibility_filter_classes"\`) — no behavior change to query execution options