### PR TITLE
fix(dashboard): handle missing chart metadata in dashboard export

### DIFF
--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -51,15 +51,20 @@ def find_native_filter_datasets(metadata: dict[str, Any]) -> set[str]:
 
 
 def build_uuid_to_id_map(position: dict[str, Any]) -> dict[str, int]:
-    return {
-        child["meta"]["uuid"]: child["meta"]["chartId"]
-        for child in position.values()
-        if (
-            isinstance(child, dict)
-            and child["type"] == "CHART"
-            and "uuid" in child["meta"]
-        )
-    }
+    result: dict[str, int] = {}
+    for child in position.values():
+        if not isinstance(child, dict):
+            continue
+        if child.get("type") != "CHART":
+            continue
+        meta = child.get("meta")
+        if not isinstance(meta, dict):
+            continue
+        uuid = meta.get("uuid")
+        chart_id = meta.get("chartId")
+        if uuid is not None and chart_id is not None:
+            result[uuid] = chart_id
+    return result
 
 
 def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
@@ -81,7 +86,9 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
     metadata = fixed.get("metadata", {})
     if "timed_refresh_immune_slices" in metadata:
         metadata["timed_refresh_immune_slices"] = [
-            id_map[old_id] for old_id in metadata["timed_refresh_immune_slices"]
+            id_map[old_id]
+            for old_id in metadata["timed_refresh_immune_slices"]
+            if old_id in id_map
         ]
 
     if "filter_scopes" in metadata:
@@ -106,6 +113,7 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
         metadata["expanded_slices"] = {
             str(id_map[int(old_id)]): value
             for old_id, value in metadata["expanded_slices"].items()
+            if int(old_id) in id_map
         }
 
     if "default_filters" in metadata:
@@ -121,13 +129,15 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
     # fix position
     position = fixed.get("position", {})
     for child in position.values():
-        if (
-            isinstance(child, dict)
-            and child["type"] == "CHART"
-            and "uuid" in child["meta"]
-            and child["meta"]["uuid"] in chart_ids
-        ):
-            child["meta"]["chartId"] = chart_ids[child["meta"]["uuid"]]
+        if not isinstance(child, dict):
+            continue
+        if child.get("type") != "CHART":
+            continue
+        meta = child.get("meta")
+        if not isinstance(meta, dict):
+            continue
+        if "uuid" in meta and meta["uuid"] in chart_ids:
+            meta["chartId"] = chart_ids[meta["uuid"]]
 
     # fix native filter references
     native_filter_configuration = fixed.get("metadata", {}).get(

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -840,3 +840,150 @@ def test_update_id_refs_cross_filter_charts_in_scope() -> None:
     # Check global_chart_configuration chartsInScope is updated
     assert metadata["global_chart_configuration"]["chartsInScope"] == [1, 2, 3]
     assert metadata["global_chart_configuration"]["scope"]["excluded"] == [3]
+
+
+def test_build_uuid_to_id_map_missing_meta():
+    """Charts with missing or non-dict ``meta`` should be silently skipped."""
+    from superset.commands.dashboard.importers.v1.utils import build_uuid_to_id_map
+
+    position: dict[str, Any] = {
+        "CHART-OK": {
+            "type": "CHART",
+            "meta": {"uuid": "uuid1", "chartId": 1},
+        },
+        "CHART-NO-META": {
+            "type": "CHART",
+            # meta key is completely absent
+        },
+        "CHART-NULL-META": {
+            "type": "CHART",
+            "meta": None,
+        },
+        "CHART-STRING-META": {
+            "type": "CHART",
+            "meta": "corrupt",
+        },
+        "ROW-NORMAL": {
+            "type": "ROW",
+            "meta": {},
+        },
+        "DASHBOARD_VERSION_KEY": "v2",
+    }
+
+    result = build_uuid_to_id_map(position)
+    assert result == {"uuid1": 1}
+
+
+def test_build_uuid_to_id_map_missing_type():
+    """Position entries without a ``type`` key should be skipped."""
+    from superset.commands.dashboard.importers.v1.utils import build_uuid_to_id_map
+
+    position: dict[str, Any] = {
+        "CHART-NO-TYPE": {
+            "meta": {"uuid": "uuid1", "chartId": 1},
+        },
+        "CHART-OK": {
+            "type": "CHART",
+            "meta": {"uuid": "uuid2", "chartId": 2},
+        },
+    }
+
+    result = build_uuid_to_id_map(position)
+    assert result == {"uuid2": 2}
+
+
+def test_find_chart_uuids_missing_meta():
+    """``find_chart_uuids`` should not raise when chart meta is missing."""
+    from superset.commands.dashboard.importers.v1.utils import find_chart_uuids
+
+    position: dict[str, Any] = {
+        "CHART-OK": {
+            "type": "CHART",
+            "meta": {"uuid": "uuid1", "chartId": 1},
+        },
+        "CHART-BROKEN": {
+            "type": "CHART",
+            # no meta
+        },
+    }
+
+    result = find_chart_uuids(position)
+    assert result == {"uuid1"}
+
+
+def test_update_id_refs_position_missing_meta():
+    """Position entries with missing meta should be skipped during ID remapping."""
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART-OK": {
+                "type": "CHART",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+            },
+            "CHART-NO-META": {
+                "type": "CHART",
+            },
+            "CHART-NULL-META": {
+                "type": "CHART",
+                "meta": None,
+            },
+        },
+        "metadata": {"native_filter_configuration": []},
+    }
+    chart_ids = {"uuid1": 1}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    assert fixed["position"]["CHART-OK"]["meta"]["chartId"] == 1
+    assert "meta" not in fixed["position"]["CHART-NO-META"]
+    assert fixed["position"]["CHART-NULL-META"]["meta"] is None
+
+
+def test_update_id_refs_timed_refresh_immune_missing_ids():
+    """Stale IDs in ``timed_refresh_immune_slices`` should be dropped."""
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "type": "CHART",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+            },
+        },
+        "metadata": {
+            "timed_refresh_immune_slices": [101, 999],
+            "native_filter_configuration": [],
+        },
+    }
+    chart_ids = {"uuid1": 1}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    assert fixed["metadata"]["timed_refresh_immune_slices"] == [1]
+
+
+def test_update_id_refs_expanded_slices_missing_ids():
+    """Stale IDs in ``expanded_slices`` should be dropped."""
+    from superset.commands.dashboard.importers.v1.utils import update_id_refs
+
+    config: dict[str, Any] = {
+        "position": {
+            "CHART1": {
+                "type": "CHART",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+            },
+        },
+        "metadata": {
+            "expanded_slices": {"101": "details", "999": "stale"},
+            "native_filter_configuration": [],
+        },
+    }
+    chart_ids = {"uuid1": 1}
+    dataset_info: dict[str, dict[str, Any]] = {}
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+
+    assert fixed["metadata"]["expanded_slices"] == {"1": "details"}


### PR DESCRIPTION
Guard against KeyError when position entries have missing or corrupt 'type', 'meta', or 'chartId' keys in build_uuid_to_id_map() and the update_id_refs() position loop. Also add id_map membership checks in timed_refresh_immune_slices and expanded_slices to drop stale IDs.

Closes #3

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
