### PR TITLE
ci: preserve PR translation updates during regression checks

### DIFF
--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -113,13 +113,9 @@ jobs:
             --translations-dir /tmp/base-worktree/superset/translations \
             > /tmp/before.json
 
-      # Reset the PR worktree's translations to the pristine BASE state so
-      # both babel_update runs start from the same .po files. The only
-      # difference between the runs is the source code.
-      - name: Reset PR worktree translations to pristine BASE
-        if: steps.check.outputs.python == 'true' || steps.check.outputs.frontend == 'true'
-        run: git checkout FETCH_HEAD -- superset/translations/
-
+      # Run babel_update against the PR source and PR translations. This keeps
+      # committed .po fixes in play while the base babel_update above still
+      # cancels out translation drift already present on the base branch.
       - name: Run babel_update against PR source
         if: steps.check.outputs.python == 'true' || steps.check.outputs.frontend == 'true'
         run: ./scripts/translations/babel_update.sh

--- a/scripts/translations/check_translation_regression.py
+++ b/scripts/translations/check_translation_regression.py
@@ -44,13 +44,14 @@ Typical CI workflow
 1. Create a base-branch worktree alongside the PR worktree
 2. Run babel_update.sh in the base worktree (extract from BASE source)
 3. Record baseline:  python ... --count --translations-dir BASE_TREE > before.json
-4. Run babel_update.sh in the PR worktree (extract from PR source) starting
-   from the same pristine BASE translations
+4. Run babel_update.sh in the PR worktree (extract from PR source and keep
+   any committed PR .po updates)
 5. Compare:  python ... --compare before.json [--report report.md]
 
-Comparing two babel_update outputs that started from the same BASE .po files
-isolates regressions caused by the PR's source diff from any pre-existing
-drift on the base branch.
+Running babel_update on the base branch first isolates regressions caused by
+the PR's source diff from any pre-existing drift on the base branch, while the
+PR worktree run still allows committed .po updates to restore lost
+translations.
 """
 
 import argparse


### PR DESCRIPTION
### SUMMARY

Updates the translation regression workflow introduced in #39443 so committed PR `.po` updates are preserved when checking for translation regressions.

Currently, the workflow reset `superset/translations/` back to the base branch immediately before running `babel_update.sh` against PR source. That meant any translation fixes committed in the PR were discarded, so the regression checker could still fail even when the PR included updated translations.

This keeps the base-branch `babel_update.sh` baseline, but runs the PR-side update against the PR worktree as-is.

### BEFORE/AFTER

Before:
- Baseline counts were produced from base source + base translations.
- PR counts were produced from PR source + base translations.
- Committed PR `.po` fixes could not affect the check.

After:
- Baseline counts are still produced from base source + base translations.
- PR counts are produced from PR source + PR translations.
- Committed PR `.po` fixes can restore translated counts.

### TESTING INSTRUCTIONS

- `python -m py_compile scripts/translations/check_translation_regression.py`
- `pre-commit run ruff --files scripts/translations/check_translation_regression.py`
- `pre-commit run check-yaml --files .github/workflows/superset-translations.yml`
- `pre-commit run trailing-whitespace --files .github/workflows/superset-translations.yml scripts/translations/check_translation_regression.py`
- `pre-commit run end-of-file-fixer --files .github/workflows/superset-translations.yml scripts/translations/check_translation_regression.py`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
