### PR TITLE
chore(deps): migrate MCP service JWT errors from authlib.jose to joserfc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ exasol = ["sqlalchemy-exasol >= 2.4.0, < 8.0"]
 excel = ["xlrd>=1.2.0, <1.3"]
 fastmcp = [
     "fastmcp>=3.2.4,<4.0",
+    "joserfc>=1.0.0,<2.0",
     # tiktoken backs the response-size-guard token estimator. Without
     # it, the middleware falls back to a coarser character-based
     # heuristic that under-counts JSON-heavy MCP responses.

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -471,6 +471,8 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
+joserfc==1.6.8
+    # via apache-superset
 jsonpath-ng==1.7.0
     # via
     #   -c requirements/base-constraint.txt

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -183,6 +183,7 @@ cryptography==46.0.7
     #   -c requirements/base-constraint.txt
     #   apache-superset
     #   authlib
+    #   joserfc
     #   paramiko
     #   pyjwt
     #   pyopenssl

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -33,14 +33,14 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, cast
 
-from authlib.jose.errors import (
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from joserfc.errors import (
     BadSignatureError,
     DecodeError,
     ExpiredTokenError,
     JoseError,
 )
-from fastmcp.server.auth.auth import AccessToken
-from fastmcp.server.auth.providers.jwt import JWTVerifier
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend
 from starlette.authentication import AuthenticationError

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -684,7 +684,7 @@ async def test_expired_token_during_decode(hs256_verifier):
     with patch.object(
         hs256_verifier.jwt,
         "decode",
-        side_effect=ExpiredTokenError(),
+        side_effect=ExpiredTokenError("exp"),
     ):
         result = await hs256_verifier.load_access_token(token)
 

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -23,7 +23,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from authlib.jose.errors import BadSignatureError, DecodeError, ExpiredTokenError
+from joserfc.errors import BadSignatureError, DecodeError, ExpiredTokenError
 
 from superset.mcp_service.jwt_verifier import (
     _auth_error_handler,
@@ -108,7 +108,7 @@ async def test_signature_verification_failed(hs256_verifier):
     with patch.object(
         hs256_verifier.jwt,
         "decode",
-        side_effect=BadSignatureError(result=None),
+        side_effect=BadSignatureError(),
     ):
         result = await hs256_verifier.load_access_token(token)
 


### PR DESCRIPTION
### SUMMARY

Replaces `authlib.jose.errors` imports in the MCP service JWT verifier with the equivalent `joserfc.errors` classes. `joserfc` is a dedicated standalone JOSE library with the same error class names, and is the preferred dependency for JWT error handling going forward.

Changes:
- `superset/mcp_service/jwt_verifier.py`: `from authlib.jose.errors import ...` → `from joserfc.errors import ...`
- `tests/unit_tests/mcp_service/test_jwt_verifier.py`: same import swap; updated `BadSignatureError(result=None)` → `BadSignatureError()` since joserfc errors don't accept a `result` kwarg
- `pyproject.toml`: added `joserfc>=1.0.0,<2.0` to the `fastmcp` extras
- `requirements/development.txt`: pinned `joserfc==1.6.8`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no UI changes.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/mcp_service/test_jwt_verifier.py -v
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API