### PR TITLE
fix(cli): encrypt sqlalchemy_uri password on import_datasources (#31983)

### DIFF
--- a/superset/commands/dataset/importers/v0.py
+++ b/superset/commands/dataset/importers/v0.py
@@ -211,7 +211,13 @@ def import_from_dict(data: dict[str, Any], sync: Optional[list[str]] = None) -> 
     if isinstance(data, dict):
         logger.info("Importing %d %s", len(data.get(DATABASES_KEY, [])), DATABASES_KEY)
         for database in data.get(DATABASES_KEY, []):
-            Database.import_from_dict(database, sync=sync)
+            db_obj = Database.import_from_dict(database, sync=sync)
+            # ``import_from_dict`` sets fields via setattr, bypassing
+            # ``set_sqlalchemy_uri``.  Call it explicitly so that any plaintext
+            # password in the URI is extracted into the encrypted ``password``
+            # column and replaced with the password mask in ``sqlalchemy_uri``.
+            if db_obj is not None:
+                db_obj.set_sqlalchemy_uri(db_obj.sqlalchemy_uri)
     else:
         logger.info("Supplied object is not a dictionary.")
 

--- a/superset/commands/dataset/importers/v0.py
+++ b/superset/commands/dataset/importers/v0.py
@@ -32,6 +32,8 @@ from superset.connectors.sqla.models import (
     SqlMetric,
     TableColumn,
 )
+from superset.constants import PASSWORD_MASK
+from superset.databases.utils import make_url_safe
 from superset.models.core import Database
 from superset.utils import json
 from superset.utils.decorators import transaction
@@ -217,7 +219,15 @@ def import_from_dict(data: dict[str, Any], sync: Optional[list[str]] = None) -> 
             # password in the URI is extracted into the encrypted ``password``
             # column and replaced with the password mask in ``sqlalchemy_uri``.
             if db_obj is not None:
-                db_obj.set_sqlalchemy_uri(db_obj.sqlalchemy_uri)
+                # Only call set_sqlalchemy_uri when the imported URI carries a real
+                # password (non-empty and not the password mask).  If the URI has no
+                # password segment — common when users keep secrets out of YAML and
+                # rely on the encrypted ``password`` column from a prior run —
+                # calling set_sqlalchemy_uri would set ``password = None`` and break
+                # existing connections.
+                parsed = make_url_safe(db_obj.sqlalchemy_uri)
+                if parsed.password and parsed.password != PASSWORD_MASK:
+                    db_obj.set_sqlalchemy_uri(db_obj.sqlalchemy_uri)
     else:
         logger.info("Supplied object is not a dictionary.")
 

--- a/tests/unit_tests/databases/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/databases/commands/importers/v1/import_test.py
@@ -373,3 +373,81 @@ def test_import_database_oauth2_redirect_is_nonfatal(
 
     assert database.database_name == "imported_database"
     mock_add_perms.assert_called_once_with(database)
+
+
+def test_import_datasources_cli_encrypts_password(
+    mocker: MockerFixture,
+    session: Session,
+) -> None:
+    """
+    Regression for #31983: import_datasources must encrypt sqlalchemy_uri passwords,
+    not store them as cleartext.
+
+    The ``superset import_datasources -p file.yaml`` CLI command uses the legacy v0
+    YAML format (a dict with a top-level ``databases`` key).  Internally it calls
+    ``Database.import_from_dict``, which historically set ``sqlalchemy_uri`` directly
+    on the model — bypassing ``set_sqlalchemy_uri`` and leaving the plaintext password
+    stored in the DB.
+
+    After the fix, the stored ``sqlalchemy_uri`` must contain the password mask
+    (``XXXXXXXXXX``) rather than the cleartext secret, and ``database.password``
+    must hold the real credential so that connections still work.
+    """
+    from superset import db
+    from superset.commands.dataset.importers.v0 import import_from_dict
+    from superset.constants import PASSWORD_MASK
+    from superset.models.core import Database
+
+    engine = db.session.get_bind()
+    Database.metadata.create_all(engine)  # pylint: disable=no-member
+
+    plaintext_password = "secret-password"  # noqa: S105
+    plaintext_uri = (
+        f"postgresql://user:{plaintext_password}@db.example.org:5432/superset_data"
+    )
+
+    # This is the exact YAML structure produced by the Helm chart / docs example
+    # referenced in issue #31983.
+    data: dict[str, list[dict[str, object]]] = {
+        "databases": [
+            {
+                "database_name": "issue_31983_regression",
+                "sqlalchemy_uri": plaintext_uri,
+                "expose_in_sqllab": True,
+                "allow_run_async": False,
+                "allow_ctas": False,
+                "allow_cvas": False,
+                "allow_dml": False,
+                "allow_file_upload": False,
+                "tables": [],
+            }
+        ]
+    }
+
+    import_from_dict(data)
+    db.session.flush()
+
+    database = (
+        db.session.query(Database)
+        .filter_by(database_name="issue_31983_regression")
+        .one()
+    )
+
+    # The stored URI must NOT contain the plaintext password.
+    assert plaintext_password not in database.sqlalchemy_uri, (
+        f"Bug #31983: plaintext password found in sqlalchemy_uri: "
+        f"{database.sqlalchemy_uri!r}"
+    )
+
+    # The stored URI must contain the password mask (same behaviour as the REST API).
+    assert PASSWORD_MASK in database.sqlalchemy_uri, (
+        f"Bug #31983: expected password mask {PASSWORD_MASK!r} in "
+        f"sqlalchemy_uri, got: {database.sqlalchemy_uri!r}"
+    )
+
+    # The real password must be recoverable via the encrypted ``password`` column
+    # so that existing connections continue to work after import.
+    assert database.password == plaintext_password, (  # noqa: S105
+        f"Bug #31983: expected real password to be stored in the encrypted "
+        f"``password`` column, got: {database.password!r}"
+    )

--- a/tests/unit_tests/databases/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/databases/commands/importers/v1/import_test.py
@@ -451,3 +451,75 @@ def test_import_datasources_cli_encrypts_password(
         f"Bug #31983: expected real password to be stored in the encrypted "
         f"``password`` column, got: {database.password!r}"
     )
+
+
+def test_import_datasources_cli_no_password_does_not_clobber_existing(
+    mocker: MockerFixture,
+    session: Session,
+) -> None:
+    """
+    Guard against the Copilot-identified regression: importing a URI that has no
+    password segment must not overwrite an existing encrypted ``password`` value.
+
+    Users commonly keep secrets out of YAML and rely on the ``password`` column
+    populated during a prior import.  Before the guard, calling
+    ``set_sqlalchemy_uri`` on a password-less URI would set ``password = None``
+    and break existing connections.
+    """
+    from superset import db
+    from superset.commands.dataset.importers.v0 import import_from_dict
+    from superset.models.core import Database
+
+    engine = db.session.get_bind()
+    Database.metadata.create_all(engine)  # pylint: disable=no-member
+
+    # URI with no password segment — this is the "secret kept out of YAML" pattern.
+    no_password_uri = "postgresql://user@db.example.org:5432/superset_data"  # noqa: S105
+
+    data: dict[str, list[dict[str, object]]] = {
+        "databases": [
+            {
+                "database_name": "no_password_uri_test",
+                "sqlalchemy_uri": no_password_uri,
+                "expose_in_sqllab": True,
+                "allow_run_async": False,
+                "allow_ctas": False,
+                "allow_cvas": False,
+                "allow_dml": False,
+                "allow_file_upload": False,
+                "tables": [],
+            }
+        ]
+    }
+
+    import_from_dict(data)
+    db.session.flush()
+
+    database = (
+        db.session.query(Database).filter_by(database_name="no_password_uri_test").one()
+    )
+
+    # The ``password`` column must not have been set to None by
+    # set_sqlalchemy_uri — it should remain at whatever value import_from_dict
+    # left it (None for a brand-new record with no password in the URI).
+    # The critical invariant is that a subsequent import of the same no-password
+    # URI does not overwrite a password that was stored by a prior import.
+    assert database.password is None
+
+    # Simulate a prior import having stored an encrypted password (e.g. from a
+    # previous import run that included the password in the URI).
+    stored_password = "previously-stored-secret"  # noqa: S105
+    database.password = stored_password
+    db.session.flush()
+
+    # Re-import with the same no-password URI — must not clobber the stored value.
+    import_from_dict(data)
+    db.session.flush()
+
+    database = (
+        db.session.query(Database).filter_by(database_name="no_password_uri_test").one()
+    )
+    assert database.password == stored_password, (
+        "Importing a URI with no password segment must not overwrite an "
+        f"existing encrypted password; got: {database.password!r}"
+    )


### PR DESCRIPTION
### SUMMARY

Fixes #31983.

`superset import_datasources` stored `sqlalchemy_uri` as cleartext (including the password) instead of encrypting it. A workaround using the REST API to re-save connections post-import existed, but the CLI should handle this transparently.

**Root cause:**
The `superset import_datasources -p file.yaml` CLI command dispatches to the legacy v0 `ImportDatasetsCommand`, which calls `Database.import_from_dict(database, sync=sync)`. The generic `import_from_dict` helper in `superset/models/helpers.py` sets `sqlalchemy_uri` directly on the model via `setattr`, bypassing `Database.set_sqlalchemy_uri()`. That method is the only place that extracts the password, stores it in the encrypted `password` column, and replaces the password in the URI with `XXXXXXXXXX`.

**Fix:**
After calling `Database.import_from_dict`, immediately call `db_obj.set_sqlalchemy_uri(db_obj.sqlalchemy_uri)` on the returned object. This re-runs the password-extraction and masking logic, matching the behaviour of the v1 ZIP import path (`ImportDatabasesCommand`) in `superset/commands/database/importers/v1/utils.py`.

The v1 ZIP import path is **not affected** — it already calls `database.set_sqlalchemy_uri(sqlalchemy_uri)` explicitly.

### BEFORE / AFTER

**Before:** `database.sqlalchemy_uri` stored `postgresql://user:secret-password@host/db` — plaintext password visible in the metadata DB.

**After:** `database.sqlalchemy_uri` stores `postgresql://user:XXXXXXXXXX@host/db` and `database.password` (encrypted column) holds the real credential so connections continue to work.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/databases/commands/importers/v1/import_test.py::test_import_datasources_cli_encrypts_password -v
```

The test was introduced as a TDD regression test on this same branch. It previously failed (confirming the bug), and passes after the fix.

### ADDITIONAL INFORMATION

- [x] Has associated issue: closes #31983
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API