### PR TITLE
fix(time-comparison): shift offset filter when X-axis is adhoc Custom SQL

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1787,9 +1787,12 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     # If it IS a datetime series, we still need to clear conflicts
                     query_object_clone.filter = copy.deepcopy(query_object_clone.filter)
 
-                    # For relative offsets with datetime series, ensure the temporal
-                    # filter matches our range
-                    temporal_col = query_object_clone.granularity or x_axis_label
+                    # Match against the column of the existing TEMPORAL_RANGE
+                    # filter rather than the X-axis label so adhoc Custom SQL
+                    # x-axes (label != underlying time column) still get shifted.
+                    temporal_col = self._get_temporal_column_for_filter(
+                        query_object, x_axis_label
+                    )
 
                     # Update any existing temporal filters to match our shifted range
                     for flt in query_object_clone.filter:

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -927,6 +927,101 @@ def test_processing_time_offsets_falls_back_to_config_row_limit(processor):
     assert captured[0]["row_offset"] == 0
 
 
+def test_processing_time_offsets_updates_temporal_filter_with_adhoc_x_axis(processor):
+    """Offset query's TEMPORAL_RANGE filter must be shifted when the X-axis is
+    an adhoc Custom SQL column whose label differs from the underlying time
+    column. Previously the filter was matched against the X-axis label, which
+    never equals the dataset column, so the filter stayed at the original
+    range and the offset query AND'd both ranges together (empty intersection).
+    """
+    from superset.common.query_object import QueryObject
+    from superset.models.helpers import ExploreMixin
+
+    processor._qc_datasource.processing_time_offsets = (
+        ExploreMixin.processing_time_offsets.__get__(processor._qc_datasource)
+    )
+
+    df = pd.DataFrame(
+        {
+            "wedding_date_cast": pd.to_datetime(["2025-01-01", "2025-02-01"]),
+            "SUM(revenue)": [110, 120],
+        }
+    )
+
+    adhoc_x_axis = {
+        "label": "wedding_date_cast",
+        "sqlExpression": "CAST(wedding_date AS TIMESTAMP)",
+        "expressionType": "SQL",
+        "columnType": "BASE_AXIS",
+        "timeGrain": "P1M",
+    }
+
+    query_object = QueryObject(
+        datasource=MagicMock(),
+        granularity=None,
+        columns=[adhoc_x_axis],
+        metrics=["SUM(revenue)"],
+        is_timeseries=True,
+        row_limit=10000,
+        time_offsets=["1 year ago"],
+        filters=[
+            {
+                "col": "wedding_date",
+                "op": "TEMPORAL_RANGE",
+                "val": "2025-01-01 : 2026-06-01",
+            }
+        ],
+    )
+
+    captured: list[dict[str, Any]] = []
+
+    def fake_query(dct: dict[str, Any]) -> MagicMock:
+        captured.append(dct)
+        result = MagicMock()
+        result.df = pd.DataFrame()
+        result.query = "SELECT 1"
+        return result
+
+    processor._qc_datasource.query = fake_query
+    processor._qc_datasource.normalize_df = MagicMock(return_value=pd.DataFrame())
+
+    with (
+        patch(
+            "superset.models.helpers.get_since_until_from_query_object",
+            return_value=(pd.Timestamp("2025-01-01"), pd.Timestamp("2026-06-01")),
+        ),
+        patch(
+            "superset.common.utils.query_cache_manager.QueryCacheManager"
+        ) as mock_cache_manager,
+        patch.object(
+            processor._qc_datasource,
+            "get_time_grain",
+            return_value="P1M",
+        ),
+        patch.object(
+            processor._qc_datasource,
+            "join_offset_dfs",
+            return_value=df,
+        ),
+    ):
+        mock_cache = MagicMock()
+        mock_cache.is_loaded = False
+        mock_cache_manager.get.return_value = mock_cache
+
+        processor._qc_datasource.processing_time_offsets(
+            df, query_object, None, None, False
+        )
+
+    assert len(captured) == 1
+    temporal_filters = [
+        flt for flt in captured[0]["filter"] if flt.get("op") == "TEMPORAL_RANGE"
+    ]
+    assert len(temporal_filters) == 1
+    val = temporal_filters[0]["val"]
+    assert "2024-01-01" in val, f"Expected shifted-from-dttm in val, got: {val!r}"
+    assert "2025-06-01" in val, f"Expected shifted-to-dttm in val, got: {val!r}"
+
+
 def test_ensure_totals_available_updates_cache_values():
     """
     Test that ensure_totals_available() updates the query objects AND


### PR DESCRIPTION
### SUMMARY

When a chart with a Custom SQL X-axis (adhoc column whose label differs from the underlying time column) uses a relative time comparison like "1 year ago", the offset query's temporal filter never gets shifted. The original time range and the granularity-derived shifted range both end up in the WHERE clause, AND'd together. The intersection covers only the overlap of the two ranges, so the comparison series shows values for just that overlap (e.g. last ~4 months of the requested window) instead of the full range.

In `processing_time_offsets` (relative-offset, datetime-series branch), the existing TEMPORAL_RANGE filter was matched against `query_object_clone.granularity or x_axis_label`. For an adhoc Custom SQL X-axis the label is the user's column label (e.g. `wedding_date_cast`), not the dataset column the filter is on (`wedding_date`), so the match fails and the filter's `val` stays at the original range.

The fix uses `_get_temporal_column_for_filter`, which is already used by the date-range-offset branch. It prefers the column from an existing TEMPORAL_RANGE filter over the X-axis label.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Same chart, same X-axis Custom SQL, time range 2025-01-01 to 2026-06-01, "1 year ago" comparison. Dataset has year-dependent revenue (2024 baseline + 80/year) so the comparison line is visually offset from the main line.

Before — `1 year ago` series (purple) only renders for the last ~4 months of the range (the overlap of original and shifted windows):

![](https://files.catbox.moe/to1hp6.png)

After — `1 year ago` series plots across the full range, ~80 below the main `SUM(revenue)` line (as expected from the dataset formula):

![](https://files.catbox.moe/yl9ti0.png)

Offset query WHERE clause before/after:

Before (offset has impossible intersection of original + shifted ranges):

```sql
WHERE wedding_date >= '2024-01-01' AND wedding_date < '2025-06-01'
  AND wedding_date >= '2025-01-01' AND wedding_date < '2026-06-01'
```

After (offset uses the shifted range only):

```sql
WHERE wedding_date >= '2024-01-01' AND wedding_date < '2025-06-01'
  AND wedding_date >= '2024-01-01' AND wedding_date < '2025-06-01'
```

### TESTING INSTRUCTIONS

1. Create a virtual dataset with a temporal column (e.g. `wedding_date`).
2. Create a Mixed/Line/Bar chart on that dataset.
3. Set X-axis to Custom SQL with a Jinja expression like:
   ```
   {% set tc = time_column if time_column else 'wedding_date' %} CAST({{ tc }} AS TIMESTAMP)
   ```
4. Add a SUM metric, a TEMPORAL_RANGE filter on `wedding_date`, time grain Month.
5. Enable a relative time comparison such as "1 year ago".
6. Confirm the comparison line plots values across the full range rather than only the trailing overlap.

Unit test: `test_processing_time_offsets_updates_temporal_filter_with_adhoc_x_axis`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
