### PR TITLE
fix(tasks): gate exception_type in task properties behind SHOW_STACKTRACE

### DIFF
--- a/superset/tasks/schemas.py
+++ b/superset/tasks/schemas.py
@@ -123,14 +123,21 @@ class TaskResponseSchema(Schema):
         return obj.payload_dict  # type: ignore[attr-defined]
 
     def get_properties(self, obj: object) -> dict[str, object]:
-        """Get properties dict, filtering stack_trace if SHOW_STACKTRACE is disabled."""
+        """Get properties dict, filtering debugging details when SHOW_STACKTRACE
+        is disabled."""
         from flask import current_app
 
         properties = dict(obj.properties_dict)  # type: ignore[attr-defined]
 
-        # Remove stack_trace unless SHOW_STACKTRACE is enabled
+        # Remove internal debugging details unless SHOW_STACKTRACE is enabled.
+        # The full traceback and the raw exception class name disclose internal
+        # file paths, library versions, and architecture details (CWE-209), so
+        # they are gated behind the same flag that controls stack traces
+        # elsewhere in Superset. ``error_message`` is left in place as the
+        # consumer-facing failure reason.
         if not current_app.config.get("SHOW_STACKTRACE", False):
             properties.pop("stack_trace", None)
+            properties.pop("exception_type", None)
 
         return properties
 

--- a/superset/tasks/schemas.py
+++ b/superset/tasks/schemas.py
@@ -134,7 +134,7 @@ class TaskResponseSchema(Schema):
         # they are gated behind the same flag that controls stack traces
         # elsewhere in Superset. ``error_message`` is left in place as the
         # consumer-facing failure reason.
-        if not current_app.config.get("SHOW_STACKTRACE", False):
+        if not current_app.config["SHOW_STACKTRACE"]:
             properties.pop("stack_trace", None)
             properties.pop("exception_type", None)
 

--- a/superset/tasks/schemas.py
+++ b/superset/tasks/schemas.py
@@ -46,8 +46,8 @@ user_id_description = "ID of the user context for task execution"
 payload_description = "Task-specific data in JSON format"
 properties_description = (
     "Runtime state and execution config. Contains: is_abortable, progress_percent, "
-    "progress_current, progress_total, error_message, exception_type, stack_trace, "
-    "timeout"
+    "progress_current, progress_total, error_message, timeout. Also includes "
+    "exception_type and stack_trace, but only when SHOW_STACKTRACE is enabled"
 )
 duration_seconds_description = (
     "Duration in seconds - for finished tasks: execution time, "
@@ -123,8 +123,7 @@ class TaskResponseSchema(Schema):
         return obj.payload_dict  # type: ignore[attr-defined]
 
     def get_properties(self, obj: object) -> dict[str, object]:
-        """Get properties dict, filtering debugging details when SHOW_STACKTRACE
-        is disabled."""
+        """Get properties dict, filtering debug fields unless SHOW_STACKTRACE."""
         from flask import current_app
 
         properties = dict(obj.properties_dict)  # type: ignore[attr-defined]

--- a/tests/unit_tests/tasks/test_schemas.py
+++ b/tests/unit_tests/tasks/test_schemas.py
@@ -62,4 +62,4 @@ def test_get_properties_exposes_debug_fields_when_show_stacktrace(
     properties = TaskResponseSchema().get_properties(_task_with_error_properties())
 
     assert properties["exception_type"] == "KeyError"
-    assert properties["stack_trace"].startswith("Traceback")
+    assert str(properties["stack_trace"]).startswith("Traceback")

--- a/tests/unit_tests/tasks/test_schemas.py
+++ b/tests/unit_tests/tasks/test_schemas.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from types import SimpleNamespace
+
+from flask import current_app
+from pytest_mock import MockerFixture
+
+from superset.tasks.schemas import TaskResponseSchema
+
+
+def _task_with_error_properties() -> SimpleNamespace:
+    return SimpleNamespace(
+        properties_dict={
+            "is_abortable": True,
+            "progress_percent": 1.0,
+            "error_message": "boom",
+            "exception_type": "KeyError",
+            "stack_trace": 'Traceback (most recent call last):\n  File "/app/x.py"',
+        }
+    )
+
+
+def test_get_properties_hides_debug_fields_by_default(app_context: None) -> None:
+    """
+    By default (SHOW_STACKTRACE disabled) the serialized task properties must
+    not disclose the stack trace or the raw exception class name (CWE-209),
+    while still returning consumer-safe fields like error_message.
+    """
+    properties = TaskResponseSchema().get_properties(_task_with_error_properties())
+
+    assert "stack_trace" not in properties
+    assert "exception_type" not in properties
+    # consumer-safe fields are preserved
+    assert properties["error_message"] == "boom"
+    assert properties["is_abortable"] is True
+    assert properties["progress_percent"] == 1.0
+
+
+def test_get_properties_exposes_debug_fields_when_show_stacktrace(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    """
+    When SHOW_STACKTRACE is explicitly enabled, the debugging fields are
+    returned (parity with how Superset surfaces stack traces elsewhere).
+    """
+    mocker.patch.dict(current_app.config, {"SHOW_STACKTRACE": True})
+
+    properties = TaskResponseSchema().get_properties(_task_with_error_properties())
+
+    assert properties["exception_type"] == "KeyError"
+    assert properties["stack_trace"].startswith("Traceback")

--- a/tests/unit_tests/tasks/test_schemas.py
+++ b/tests/unit_tests/tasks/test_schemas.py
@@ -34,12 +34,16 @@ def _task_with_error_properties() -> SimpleNamespace:
     )
 
 
-def test_get_properties_hides_debug_fields_by_default(app_context: None) -> None:
+def test_get_properties_hides_debug_fields_by_default(
+    app_context: None, mocker: MockerFixture
+) -> None:
     """
     By default (SHOW_STACKTRACE disabled) the serialized task properties must
     not disclose the stack trace or the raw exception class name (CWE-209),
     while still returning consumer-safe fields like error_message.
     """
+    mocker.patch.dict(current_app.config, {"SHOW_STACKTRACE": False})
+
     properties = TaskResponseSchema().get_properties(_task_with_error_properties())
 
     assert "stack_trace" not in properties


### PR DESCRIPTION
### SUMMARY

The task REST API (`TaskRestApi`, scoped per-user) returns the full task `properties` dict via `TaskResponseSchema`. That schema already stripped `stack_trace` unless `SHOW_STACKTRACE` is enabled, but **`exception_type`** (the raw exception class name, e.g. `OperationalError`) was returned unconditionally — disclosing internal library/architecture details in consumer-facing responses (CWE-209 / ASVS 16.5.1).

This change filters `exception_type` alongside `stack_trace`, behind the same `SHOW_STACKTRACE` flag Superset already uses to gate traceback exposure. `error_message` is intentionally left in place — it is the consumer-facing failure reason shown in the UI.

### Investigation / scope

I traced every place task `properties` is serialized to confirm this is the only consumer-facing exposure:
- **`TaskResponseSchema.get_properties`** (REST API show/list) — the affected path. **Fixed here.**
- **`superset/mcp_service/task/schemas.py` (`TaskInfo`)** — does not expose `properties` at all. No change needed.
- **`TaskManager.publish_completion` / `publish_abort`** (Redis pub/sub) — only send `uuid` + `status`. No change needed.
- **`Task.to_dict()`** — returns properties unfiltered, but has **no callers** in the codebase. Left as-is; worth keeping in mind if it is ever wired to an endpoint.

### BEFORE / AFTER

`GET /api/v1/task/<uuid>` → `properties` for a failed task:
- **Before:** includes `exception_type` (and `error_message`); `stack_trace` already hidden.
- **After:** `exception_type` and `stack_trace` hidden by default; `error_message` retained. Both reappear when `SHOW_STACKTRACE=True`.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/tasks/test_schemas.py -v
```
Adds coverage for both the default-hidden and `SHOW_STACKTRACE`-enabled paths.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: n/a (security scan finding, CWE-209)
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)