### PR TITLE
ci(docs): skip Netlify docs preview on PRs that don't touch docs

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -25,9 +25,17 @@
   command = "yarn install && yarn build"
   # Output directory (relative to base)
   publish = "build"
-  # Skip builds when no docs changes (exit 0 = skip, exit 1 = build)
-  # Checks for changes in docs/ and README.md (which gets pulled into docs)
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- . ../README.md"
+  # Skip builds when no docs changes (exit 0 = skip, non-zero = build).
+  # Checks for changes in docs/ and README.md (which gets pulled into docs).
+  #
+  # $CACHED_COMMIT_REF is the last *deployed* commit. On a PR's first build it
+  # is empty, so the original `git diff` errored and Netlify fell back to
+  # building -- which is why every PR built a docs preview once even with no
+  # docs changes. When it is empty we instead diff the whole branch against its
+  # merge-base with master, so non-docs PRs are skipped from the very first
+  # build. Subsequent builds (and the master production build) keep the cheaper
+  # incremental $CACHED_COMMIT_REF diff. Any failure exits non-zero -> build.
+  ignore = 'if [ -n "$CACHED_COMMIT_REF" ]; then git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- . ../README.md; else git fetch origin master --depth=100 >/dev/null 2>&1; git diff --quiet "$(git merge-base origin/master "$COMMIT_REF" 2>/dev/null || echo origin/master)" "$COMMIT_REF" -- . ../README.md; fi'
 
 [build.environment]
   # Node version matching docs/.nvmrc


### PR DESCRIPTION
### SUMMARY

The docs Netlify build already has a path-based `ignore` command, but it only worked for *some* builds. It diffed against `$CACHED_COMMIT_REF` — the last **deployed** commit of that preview context — and on a PR's **first** build that variable is empty. With it empty, `git diff --quiet "" $COMMIT_REF` errors, and Netlify treats a non-zero exit from the ignore command as "build" — so **every PR built a full docs preview at least once, even with zero docs changes** (e.g. #40587, a backend-only change, deployed a docs preview).

This change keeps the cheap incremental diff when `$CACHED_COMMIT_REF` is available (subsequent PR builds + the master production deploy), and **falls back to diffing the branch against its merge-base with `master`** when it's empty — so non-docs PRs are skipped from the very first build:

```sh
if [ -n "$CACHED_COMMIT_REF" ]; then
  git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- . ../README.md
else
  git fetch origin master --depth=100 >/dev/null 2>&1
  git diff --quiet "$(git merge-base origin/master "$COMMIT_REF" 2>/dev/null || echo origin/master)" "$COMMIT_REF" -- . ../README.md
fi
```

Any failure (fetch/merge-base errors, shallow-clone edge cases) exits non-zero, preserving the existing safe "build when unsure" behavior — it can never *skip* a build it should have run.

### Notes
- The `master` production deploy is unaffected: it has a populated `$CACHED_COMMIT_REF`, so it stays on the incremental path and still rebuilds whenever a docs change lands on master.
- This PR touches `docs/netlify.toml`, so its **own** preview will (correctly) build — a live confirmation that docs-touching PRs still deploy.
- Validated: the file parses as TOML and the `ignore` command is valid `bash -n`.

### TESTING INSTRUCTIONS
N/A — CI config. Behavior is observable on this PR (docs preview builds, since it edits docs/) and on the next non-docs PR (no preview build).

### ADDITIONAL INFORMATION
- [ ] Has associated issue: n/a
- [ ] Required feature flags: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)