### PR TITLE
fix(extensions-cli): constrain backend include patterns to the backend directory

### DIFF
--- a/superset-extensions-cli/src/superset_extensions_cli/cli.py
+++ b/superset-extensions-cli/src/superset_extensions_cli/cli.py
@@ -244,7 +244,7 @@ def copy_backend_files(cwd: Path) -> None:
         # parent ("..") components before handing them to glob().
         pattern_parts = Path(pattern).parts
         if Path(pattern).is_absolute() or ".." in pattern_parts:
-            raise ValueError(
+            raise click.ClickException(
                 f"Invalid include pattern {pattern!r}: patterns must be "
                 "relative to the backend directory and may not contain '..'."
             )
@@ -256,7 +256,7 @@ def copy_backend_files(cwd: Path) -> None:
             # inside the backend directory before copying it into the bundle.
             resolved = f.resolve()
             if not resolved.is_relative_to(backend_dir):
-                raise ValueError(
+                raise click.ClickException(
                     f"Refusing to copy {f}: resolved path is outside the "
                     f"backend directory {backend_dir}."
                 )

--- a/superset-extensions-cli/src/superset_extensions_cli/cli.py
+++ b/superset-extensions-cli/src/superset_extensions_cli/cli.py
@@ -226,7 +226,7 @@ def copy_frontend_dist(cwd: Path) -> str:
 def copy_backend_files(cwd: Path) -> None:
     """Copy backend files based on pyproject.toml build configuration (validation already passed)."""
     dist_dir = cwd / "dist"
-    backend_dir = cwd / "backend"
+    backend_dir = (cwd / "backend").resolve()
 
     # Read build config from pyproject.toml
     pyproject = read_toml(backend_dir / "pyproject.toml")
@@ -239,12 +239,30 @@ def copy_backend_files(cwd: Path) -> None:
 
     # Process include patterns
     for pattern in include_patterns:
+        # Include patterns are only meant to select files within the backend
+        # directory. Reject absolute patterns or ones that walk outside it via
+        # parent ("..") components before handing them to glob().
+        pattern_parts = Path(pattern).parts
+        if Path(pattern).is_absolute() or ".." in pattern_parts:
+            raise ValueError(
+                f"Invalid include pattern {pattern!r}: patterns must be "
+                "relative to the backend directory and may not contain '..'."
+            )
         for f in backend_dir.glob(pattern):
             if not f.is_file():
                 continue
 
+            # Defense in depth: confirm the matched file resolves to a location
+            # inside the backend directory before copying it into the bundle.
+            resolved = f.resolve()
+            if not resolved.is_relative_to(backend_dir):
+                raise ValueError(
+                    f"Refusing to copy {f}: resolved path is outside the "
+                    f"backend directory {backend_dir}."
+                )
+
             # Check exclude patterns
-            relative_path = f.relative_to(backend_dir)
+            relative_path = resolved.relative_to(backend_dir)
             should_exclude = any(
                 relative_path.match(excl_pattern) for excl_pattern in exclude_patterns
             )

--- a/superset-extensions-cli/src/superset_extensions_cli/cli.py
+++ b/superset-extensions-cli/src/superset_extensions_cli/cli.py
@@ -261,8 +261,10 @@ def copy_backend_files(cwd: Path) -> None:
                     f"backend directory {backend_dir}."
                 )
 
-            # Check exclude patterns
-            relative_path = resolved.relative_to(backend_dir)
+            # Use the matched path (not the resolved target) for the bundle
+            # layout and exclude evaluation so symlinked files are staged at
+            # their configured path rather than their symlink target.
+            relative_path = f.relative_to(backend_dir)
             should_exclude = any(
                 relative_path.match(excl_pattern) for excl_pattern in exclude_patterns
             )

--- a/superset-extensions-cli/tests/test_cli_build.py
+++ b/superset-extensions-cli/tests/test_cli_build.py
@@ -625,6 +625,109 @@ exclude = []
     )
 
 
+@pytest.mark.unit
+def test_copy_backend_files_supports_legitimate_nested_patterns(isolated_filesystem):
+    """Test copy_backend_files copies deeply nested files via recursive globs."""
+    backend_dir = isolated_filesystem / "backend"
+    nested = backend_dir / "src" / "test_org" / "test_ext" / "deep" / "deeper"
+    nested.mkdir(parents=True)
+    (nested / "module.py").write_text("# nested module")
+
+    pyproject_content = """[project]
+name = "test_org-test_ext"
+version = "1.0.0"
+license = "Apache-2.0"
+
+[tool.apache_superset_extensions.build]
+include = [
+    "src/test_org/test_ext/**/*.py",
+]
+exclude = []
+"""
+    (backend_dir / "pyproject.toml").write_text(pyproject_content)
+
+    extension_data = {
+        "publisher": "test-org",
+        "name": "test-ext",
+        "displayName": "Test Extension",
+        "version": "1.0.0",
+        "permissions": [],
+    }
+    (isolated_filesystem / "extension.json").write_text(json.dumps(extension_data))
+
+    clean_dist(isolated_filesystem)
+    copy_backend_files(isolated_filesystem)
+
+    dist_dir = isolated_filesystem / "dist"
+    assert_file_exists(
+        dist_dir
+        / "backend"
+        / "src"
+        / "test_org"
+        / "test_ext"
+        / "deep"
+        / "deeper"
+        / "module.py"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_pattern",
+    [
+        "../../.ssh/*",
+        "../config",
+        "src/../../secret.txt",
+        "/etc/passwd",
+    ],
+)
+def test_copy_backend_files_rejects_patterns_escaping_backend_dir(
+    isolated_filesystem, bad_pattern
+):
+    """Test copy_backend_files refuses include patterns that escape backend_dir."""
+    # Create a sensitive file outside the backend directory.
+    (isolated_filesystem / "secret.txt").write_text("SECRET")
+    (isolated_filesystem / "config").write_text("SECRET")
+
+    backend_dir = isolated_filesystem / "backend"
+    backend_src = backend_dir / "src" / "test_org" / "test_ext"
+    backend_src.mkdir(parents=True)
+    (backend_src / "__init__.py").write_text("# init")
+
+    pyproject_content = f"""[project]
+name = "test_org-test_ext"
+version = "1.0.0"
+license = "Apache-2.0"
+
+[tool.apache_superset_extensions.build]
+include = [
+    "{bad_pattern}",
+]
+exclude = []
+"""
+    (backend_dir / "pyproject.toml").write_text(pyproject_content)
+
+    extension_data = {
+        "publisher": "test-org",
+        "name": "test-ext",
+        "displayName": "Test Extension",
+        "version": "1.0.0",
+        "permissions": [],
+    }
+    (isolated_filesystem / "extension.json").write_text(json.dumps(extension_data))
+
+    clean_dist(isolated_filesystem)
+
+    with pytest.raises(ValueError):
+        copy_backend_files(isolated_filesystem)
+
+    # Nothing outside the backend directory should have been staged into dist,
+    # including paths reachable via ".." from inside dist/backend.
+    dist_dir = isolated_filesystem / "dist"
+    assert not (dist_dir / "secret.txt").exists()
+    assert not (dist_dir / "config").exists()
+
+
 # Removed obsolete tests:
 # - test_copy_backend_files_handles_no_backend_config: This scenario can't happen since copy_backend_files is only called when backend exists
 # - test_copy_backend_files_exits_when_extension_json_missing: Validation catches this before copy_backend_files is called

--- a/superset-extensions-cli/tests/test_cli_build.py
+++ b/superset-extensions-cli/tests/test_cli_build.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 from unittest.mock import Mock, patch
 
+import click
 import pytest
 from superset_extensions_cli.cli import (
     app,
@@ -718,7 +719,7 @@ exclude = []
 
     clean_dist(isolated_filesystem)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         copy_backend_files(isolated_filesystem)
 
     # Nothing outside the backend directory should have been staged into dist,

--- a/superset-extensions-cli/tests/test_cli_build.py
+++ b/superset-extensions-cli/tests/test_cli_build.py
@@ -729,6 +729,52 @@ exclude = []
     assert not (dist_dir / "config").exists()
 
 
+@pytest.mark.unit
+def test_copy_backend_files_stages_symlink_at_matched_path(isolated_filesystem):
+    """Symlinked files inside backend are staged at the matched path, not the target."""
+    backend_dir = isolated_filesystem / "backend"
+    target_dir = backend_dir / "src" / "common"
+    target_dir.mkdir(parents=True)
+    (target_dir / "module.py").write_text("# shared module")
+
+    link_dir = backend_dir / "src" / "test_org" / "test_ext" / "common"
+    link_dir.mkdir(parents=True)
+    link = link_dir / "module.py"
+    link.symlink_to(target_dir / "module.py")
+
+    pyproject_content = """[project]
+name = "test_org-test_ext"
+version = "1.0.0"
+license = "Apache-2.0"
+
+[tool.apache_superset_extensions.build]
+include = [
+    "src/test_org/test_ext/**/*.py",
+]
+exclude = []
+"""
+    (backend_dir / "pyproject.toml").write_text(pyproject_content)
+
+    extension_data = {
+        "publisher": "test-org",
+        "name": "test-ext",
+        "displayName": "Test Extension",
+        "version": "1.0.0",
+        "permissions": [],
+    }
+    (isolated_filesystem / "extension.json").write_text(json.dumps(extension_data))
+
+    clean_dist(isolated_filesystem)
+    copy_backend_files(isolated_filesystem)
+
+    dist_dir = isolated_filesystem / "dist"
+    # Staged at the configured (symlink) path, not the resolved target path.
+    assert_file_exists(
+        dist_dir / "backend" / "src" / "test_org" / "test_ext" / "common" / "module.py"
+    )
+    assert not (dist_dir / "backend" / "src" / "common" / "module.py").exists()
+
+
 # Removed obsolete tests:
 # - test_copy_backend_files_handles_no_backend_config: This scenario can't happen since copy_backend_files is only called when backend exists
 # - test_copy_backend_files_exits_when_extension_json_missing: Validation catches this before copy_backend_files is called


### PR DESCRIPTION
### SUMMARY

The Superset Extensions CLI `build`/`bundle` step copies backend files into the distributable bundle based on the `include` glob patterns declared in an extension's `backend/pyproject.toml` (`[tool.apache_superset_extensions.build]`).

Previously those patterns were passed directly to `Path.glob()` and every match was copied without confirming it actually lived under the `backend/` directory. Because `Path.glob()` happily evaluates patterns with parent (`..`) components and `Path.relative_to()` compares lexically (it does not resolve `..`), a pattern could select files from outside the intended `backend/` root and stage them into the build output.

This change tightens the input handling in `copy_backend_files`:

- **Reject** absolute include patterns and any pattern containing `..` path components before they reach `glob()`.
- **Boundary-check** every matched file: resolve it and confirm it is inside the (resolved) backend directory before copying. This is defense-in-depth that also covers symlink-based escapes.

Both checks raise a clear `ValueError` so a misconfigured or hostile build config fails loudly instead of silently bundling unintended files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CLI behavior change.

### TESTING INSTRUCTIONS

```
cd superset-extensions-cli
pip install -e ".[test]"
pytest tests/test_cli_build.py
```

New tests:
- `test_copy_backend_files_rejects_patterns_escaping_backend_dir` — parametrized over patterns that try to escape the backend dir; asserts a `ValueError` and that nothing was staged into `dist/`.
- `test_copy_backend_files_supports_legitimate_nested_patterns` — confirms ordinary recursive globs (e.g. `src/**/*.py`) still resolve and copy deeply nested files.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
