### PR TITLE
fix(plugin-chart-ag-grid-table): enforce numeric bounds for range (BETWEEN) filters

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
@@ -165,6 +165,21 @@ function escapeSQLString(value: string): string {
   return value.replace(/'/g, "''");
 }
 
+/**
+ * Coerce a range-filter bound to a finite number, or null if it is not a valid
+ * numeric value. Unlike a bare Number() call, empty and whitespace-only strings
+ * are rejected (Number('') === 0), so they never get interpolated into SQL.
+ * @param value - Raw bound value from the AG Grid filter model
+ * @returns The finite number, or null if the value is not numeric
+ */
+function toFiniteNumber(value: FilterValue): number | null {
+  if (typeof value === 'string' && value.trim() === '') {
+    return null;
+  }
+  const coerced = Number(value);
+  return Number.isFinite(coerced) ? coerced : null;
+}
+
 // Maximum column name length - conservative upper bound that exceeds all common
 // database identifier limits (MySQL: 64, PostgreSQL: 63, SQL Server: 128, Oracle: 128)
 const MAX_COLUMN_NAME_LENGTH = 255;
@@ -381,10 +396,11 @@ function simpleFilterToWhereClause(
   if (type === FILTER_OPERATORS.IN_RANGE && filterTo !== undefined) {
     // Range bounds are interpolated into the clause without quoting, so they
     // must be finite numbers. Coerce both ends and skip the clause entirely
-    // if either is not numeric.
-    const lowerBound = Number(value);
-    const upperBound = Number(filterTo);
-    if (!Number.isFinite(lowerBound) || !Number.isFinite(upperBound)) {
+    // if either is not numeric. Empty/whitespace-only strings coerce to 0 via
+    // Number(), so reject them explicitly before coercing.
+    const lowerBound = toFiniteNumber(value);
+    const upperBound = toFiniteNumber(filterTo);
+    if (lowerBound === null || upperBound === null) {
       return '';
     }
     return `${columnName} ${SQL_OPERATORS.BETWEEN} ${lowerBound} AND ${upperBound}`;

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
@@ -172,7 +172,12 @@ function escapeSQLString(value: string): string {
  * @param value - Raw bound value from the AG Grid filter model
  * @returns The finite number, or null if the value is not numeric
  */
-function toFiniteNumber(value: FilterValue): number | null {
+function toFiniteNumber(value: FilterValue | undefined): number | null {
+  // Number(null) and Number('') both coerce to 0 and pass Number.isFinite,
+  // so reject nullish and empty/whitespace-only strings before coercing.
+  if (value === null || value === undefined) {
+    return null;
+  }
   if (typeof value === 'string' && value.trim() === '') {
     return null;
   }
@@ -393,11 +398,11 @@ function simpleFilterToWhereClause(
     return '';
   }
 
-  if (type === FILTER_OPERATORS.IN_RANGE && filterTo !== undefined) {
-    // Range bounds are interpolated into the clause without quoting, so they
-    // must be finite numbers. Coerce both ends and skip the clause entirely
-    // if either is not numeric. Empty/whitespace-only strings coerce to 0 via
-    // Number(), so reject them explicitly before coercing.
+  // Handle IN_RANGE unconditionally so a missing/cleared upper bound can never
+  // fall through to the generic clause below and emit an invalid single-operand
+  // BETWEEN. Range bounds are interpolated into the clause without quoting, so
+  // both ends must coerce to finite numbers; otherwise the clause is dropped.
+  if (type === FILTER_OPERATORS.IN_RANGE) {
     const lowerBound = toFiniteNumber(value);
     const upperBound = toFiniteNumber(filterTo);
     if (lowerBound === null || upperBound === null) {

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
@@ -379,7 +379,15 @@ function simpleFilterToWhereClause(
   }
 
   if (type === FILTER_OPERATORS.IN_RANGE && filterTo !== undefined) {
-    return `${columnName} ${SQL_OPERATORS.BETWEEN} ${value} AND ${filterTo}`;
+    // Range bounds are interpolated into the clause without quoting, so they
+    // must be finite numbers. Coerce both ends and skip the clause entirely
+    // if either is not numeric.
+    const lowerBound = Number(value);
+    const upperBound = Number(filterTo);
+    if (!Number.isFinite(lowerBound) || !Number.isFinite(upperBound)) {
+      return '';
+    }
+    return `${columnName} ${SQL_OPERATORS.BETWEEN} ${lowerBound} AND ${upperBound}`;
   }
 
   const formattedValue = formatValueForOperator(type, value!);

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
@@ -284,6 +284,38 @@ describe('agGridFilterConverter', () => {
         val: 18,
       });
     });
+
+    test('should emit a numeric BETWEEN clause for a metric range filter', () => {
+      const filterModel: AgGridFilterModel = {
+        revenue: {
+          filterType: 'number',
+          type: 'inRange',
+          filter: 10,
+          filterTo: 20,
+        },
+      };
+
+      // revenue is a metric, so the range filter renders as a HAVING clause
+      const result = convertAgGridFiltersToSQL(filterModel, ['revenue']);
+
+      expect(result.havingClause).toContain('BETWEEN 10 AND 20');
+    });
+
+    test('should drop a metric range filter whose bounds are not numeric', () => {
+      const filterModel = {
+        revenue: {
+          filterType: 'number',
+          type: 'inRange',
+          filter: '0',
+          filterTo: '100 OR 1=1',
+        },
+      } as unknown as AgGridFilterModel;
+
+      const result = convertAgGridFiltersToSQL(filterModel, ['revenue']);
+
+      // a non-numeric bound must never be interpolated into the clause
+      expect(result.havingClause).toBeUndefined();
+    });
   });
 
   describe('Null/blank filters', () => {

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
@@ -325,7 +325,9 @@ describe('agGridFilterConverter', () => {
         },
       } as unknown as AgGridFilterModel;
 
-      const result2 = convertAgGridFiltersToSQL(emptyBoundFilterModel, ['revenue']);
+      const result2 = convertAgGridFiltersToSQL(emptyBoundFilterModel, [
+        'revenue',
+      ]);
       expect(result2.havingClause).toBeUndefined();
     });
   });

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
@@ -329,6 +329,21 @@ describe('agGridFilterConverter', () => {
         'revenue',
       ]);
       expect(result2.havingClause).toBeUndefined();
+
+      // A missing upper bound must drop the clause rather than fall through
+      // to a generic single-operand BETWEEN.
+      const missingBoundFilterModel = {
+        revenue: {
+          filterType: 'number',
+          type: 'inRange',
+          filter: '0',
+        },
+      } as unknown as AgGridFilterModel;
+
+      const result3 = convertAgGridFiltersToSQL(missingBoundFilterModel, [
+        'revenue',
+      ]);
+      expect(result3.havingClause).toBeUndefined();
     });
   });
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
@@ -315,6 +315,18 @@ describe('agGridFilterConverter', () => {
 
       // a non-numeric bound must never be interpolated into the clause
       expect(result.havingClause).toBeUndefined();
+
+      const emptyBoundFilterModel = {
+        revenue: {
+          filterType: 'number',
+          type: 'inRange',
+          filter: '0',
+          filterTo: '',
+        },
+      } as unknown as AgGridFilterModel;
+
+      const result2 = convertAgGridFiltersToSQL(emptyBoundFilterModel, ['revenue']);
+      expect(result2.havingClause).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
### SUMMARY

In the AG Grid table plugin's filter converter, range (`IN_RANGE` → `BETWEEN`) filter operands are interpolated into the generated clause **without quoting**, so they need to be finite numbers. Previously the raw `filter`/`filterTo` values were passed straight through, even though the filter value path accepts strings — which could produce a malformed clause if the operands weren't numeric.

This coerces both bounds with `Number()` and **skips the clause entirely when either is not a finite number**, so only well-formed numeric ranges are emitted. Valid numeric ranges are unchanged.

### BEFORE / AFTER
For a metric range filter, the generated `HAVING`:
- **Before:** `revenue BETWEEN <raw> AND <raw>` (operands passed through as-is)
- **After:** emitted only when both bounds coerce to finite numbers (`revenue BETWEEN 10 AND 20`); otherwise no clause is generated.

### TESTING INSTRUCTIONS
```bash
cd superset-frontend && npx jest plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
```
Adds two regression tests (numeric bounds → BETWEEN clause; non-numeric bound → no clause). Full file: 47/47 pass.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)