### PR TITLE
fix(legacy-preset-chart-nvd3): sanitize tooltip HTML built from chart data

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/utils.ts
@@ -162,7 +162,7 @@ export function generateMultiLineTooltipContent(d, xFormatter, yFormatters) {
 
   tooltip += '</tbody></table>';
 
-  return tooltip;
+  return dompurify.sanitize(tooltip);
 }
 
 export function generateTimePivotTooltip(d, xFormatter, yFormatter) {
@@ -223,7 +223,7 @@ export function generateBubbleTooltipContent({
   s += createHTMLRow(getLabel(sizeField), sizeFormatter(point.size));
   s += '</table>';
 
-  return s;
+  return dompurify.sanitize(s);
 }
 
 // shouldRemove indicates whether the nvtooltips should be removed from the DOM
@@ -287,9 +287,11 @@ export function tipFactory(layer) {
         ? layer.descriptionColumns.map(c => d[c])
         : Object.values(d);
 
-      return `<div><strong>${title}</strong></div><br/><div>${body.join(
-        ', ',
-      )}</div>`;
+      return dompurify.sanitize(
+        `<div><strong>${title}</strong></div><br/><div>${body.join(
+          ', ',
+        )}</div>`,
+      );
     });
 }
 

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils.test.ts
@@ -26,6 +26,9 @@ import {
   computeYDomain,
   getTimeOrNumberFormatter,
   formatLabel,
+  generateBubbleTooltipContent,
+  generateMultiLineTooltipContent,
+  tipFactory,
 } from '../src/utils';
 
 const DATA = [
@@ -179,6 +182,63 @@ describe('nvd3/utils', () => {
       expect(computeYDomain(DATA_WITH_DISABLED_SERIES)).toEqual([
         660881033.0, 668526708.0,
       ]);
+    });
+  });
+
+  describe('tooltip HTML sanitization', () => {
+    const identity = (v: unknown) => v;
+
+    test('generateBubbleTooltipContent strips scripts from entity/group', () => {
+      const html = generateBubbleTooltipContent({
+        point: {
+          name: '<img src=x onerror="alert(1)">',
+          group: '<script>alert(2)</script>',
+          color: 'red',
+          x: 1,
+          y: 2,
+          size: 3,
+        },
+        entity: 'name',
+        xField: 'x',
+        yField: 'y',
+        sizeField: 'size',
+        xFormatter: identity,
+        yFormatter: identity,
+        sizeFormatter: identity,
+      });
+
+      expect(html).not.toContain('onerror');
+      expect(html).not.toContain('<script>');
+    });
+
+    test('generateMultiLineTooltipContent strips scripts from series keys', () => {
+      const html = generateMultiLineTooltipContent(
+        {
+          value: 'x',
+          series: [
+            { key: '<img src=x onerror="alert(1)">', color: 'red', value: 1 },
+          ],
+        },
+        identity,
+        [identity],
+      );
+
+      expect(html).not.toContain('onerror');
+    });
+
+    test('tipFactory strips scripts from annotation data values', () => {
+      const tip = tipFactory({
+        titleColumn: 'title',
+        name: 'layer',
+        descriptionColumns: ['desc'],
+      });
+      const html = tip.html()({
+        title: '<img src=x onerror="alert(1)">',
+        desc: '<script>alert(2)</script>',
+      });
+
+      expect(html).not.toContain('onerror');
+      expect(html).not.toContain('<script>');
     });
   });
 });


### PR DESCRIPTION
### SUMMARY

Several tooltip generators in `legacy-preset-chart-nvd3/src/utils.ts` build HTML strings from chart data and return them to be rendered via D3 `.html()`, but — unlike their sibling generators in the same file (`generateCompareTooltipContent`, `generateTimePivotTooltip`) which already call `dompurify.sanitize()` — they returned the HTML unsanitized:

- `generateBubbleTooltipContent` (entity / group / color)
- `generateMultiLineTooltipContent` (series keys)
- `tipFactory` annotation tooltip callback (title / description columns)

This applies `dompurify.sanitize()` to the returned HTML in all three, so data-derived values render as text rather than markup. Consistent with the existing pattern in the file; no change to legitimate tooltip output.

### TESTING INSTRUCTIONS
```bash
cd superset-frontend && npx jest plugins/legacy-preset-chart-nvd3/test/utils.test.ts
```
Adds regression tests asserting that script/handler markup placed in the data-derived fields is stripped from the generated tooltip HTML (12/12 pass).

### ADDITIONAL INFORMATION
- [ ] Has associated issue: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)