### PR TITLE
refactor(nvd3): extract testable generateAnnotationTooltipContent helper

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/utils.ts
@@ -275,29 +275,29 @@ export function wrapTooltip(chart) {
   });
 }
 
+// Builds the sanitized HTML for an annotation layer's tooltip. Title and
+// description values come from the annotation data source, so the output is
+// run through dompurify before being inserted into the DOM by d3-tip.
+export function generateAnnotationTooltipContent(layer, d) {
+  const title =
+    d[layer.titleColumn] && d[layer.titleColumn].length > 0
+      ? `${d[layer.titleColumn]} - ${layer.name}`
+      : layer.name;
+  const body = Array.isArray(layer.descriptionColumns)
+    ? layer.descriptionColumns.map(c => d[c])
+    : Object.values(d);
+
+  return dompurify.sanitize(
+    `<div><strong>${title}</strong></div><br/><div>${body.join(', ')}</div>`,
+  );
+}
+
 export function tipFactory(layer) {
   return d3tip()
     .attr('class', `d3-tip ${layer.annotationTipClass || ''}`)
     .direction('n')
     .offset([-5, 0])
-    .html(d => {
-      if (!d) {
-        return '';
-      }
-      const rawTitle =
-        d[layer.titleColumn] && d[layer.titleColumn].length > 0
-          ? `${d[layer.titleColumn]} - ${layer.name}`
-          : layer.name;
-      const rawBody = Array.isArray(layer.descriptionColumns)
-        ? layer.descriptionColumns.map(c => d[c])
-        : Object.values(d);
-
-      return dompurify.sanitize(
-        `<div><strong>${rawTitle}</strong></div><br/><div>${rawBody.join(
-          ', ',
-        )}</div>`,
-      );
-    });
+    .html(d => (d ? generateAnnotationTooltipContent(layer, d) : ''));
 }
 
 export function getMaxLabelSize(svg, axisClass) {

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils.test.ts
@@ -24,6 +24,7 @@ import {
 
 import {
   computeYDomain,
+  generateAnnotationTooltipContent,
   generateBubbleTooltipContent,
   generateMultiLineTooltipContent,
   getTimeOrNumberFormatter,
@@ -274,6 +275,48 @@ describe('nvd3/utils', () => {
       const html = tip.html()(datum);
       expect(html).not.toMatch(/<script/i);
       expect(html).toContain('payload');
+    });
+  });
+
+  describe('generateAnnotationTooltipContent()', () => {
+    const layer = {
+      name: 'My annotations',
+      titleColumn: 'title',
+      descriptionColumns: ['description'],
+    };
+
+    test('renders the annotation title and description', () => {
+      const html = generateAnnotationTooltipContent(layer, {
+        title: 'Release',
+        description: 'Shipped v1',
+      });
+      expect(html).toContain('Release - My annotations');
+      expect(html).toContain('Shipped v1');
+    });
+
+    test('falls back to the layer name when the title column is empty', () => {
+      const html = generateAnnotationTooltipContent(layer, {
+        title: '',
+        description: 'Shipped v1',
+      });
+      expect(html).toContain('My annotations');
+    });
+
+    test('strips an event-handler payload from the title column', () => {
+      const html = generateAnnotationTooltipContent(layer, {
+        title: '<img src=x onerror="alert(1)">',
+        description: 'ok',
+      });
+      expect(html).not.toContain('onerror');
+      expect(html).not.toContain('alert(1)');
+    });
+
+    test('strips a script payload from a description column', () => {
+      const html = generateAnnotationTooltipContent(layer, {
+        title: 'Release',
+        description: '<script>alert(document.cookie)</script>',
+      });
+      expect(html).not.toContain('<script>');
     });
   });
 });


### PR DESCRIPTION
### SUMMARY

The annotation-tooltip XSS fix this PR originally proposed **already landed in #40502**, which wrapped `tipFactory`'s annotation HTML (along with the other nvd3 tooltip sinks) in `dompurify.sanitize`. Rather than close this as a duplicate, I've trimmed it to the part that adds value on top of #40502:

- **Refactor:** extract the annotation-tooltip HTML construction out of `tipFactory`'s inline `.html()` callback into a pure, exported `generateAnnotationTooltipContent(layer, d)` helper. This matches the file's existing pattern of standalone tooltip-content helpers (`generateCompareTooltipContent`, `generateMultiLineTooltipContent`, etc.) and makes the annotation path independently unit-testable without standing up d3-tip.
- **Tests #40502 doesn't have:** title + description rendering, fallback to the layer name when the title column is empty, and an explicit **title-column** XSS strip (#40502 only covers the description column).

No behavior change — the output is still run through `dompurify.sanitize` before d3-tip inserts it via `.html()`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no visual change.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend && npx jest plugins/legacy-preset-chart-nvd3/test/utils.test.ts
```

17/17 pass (master's 13 + 4 net-new annotation-path tests).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)