### PR TITLE
fix(SafeMarkdown): block script-executing link protocols regardless of EscapeMarkdownHtml

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -43,13 +43,15 @@ const DANGEROUS_LINK_PROTOCOLS = ['javascript', 'vbscript', 'data'];
  * untouched. Applied regardless of the EscapeMarkdownHtml feature flag.
  */
 export function transformLinkUri(uri: string): string {
-  // Per the WHATWG URL parser, browsers strip leading and trailing C0 control
+  // Per the WHATWG URL parser, browsers strip leading C0 control
   // characters (\x00-\x1f) and space before resolving the scheme, so e.g.
   // "\x01javascript:alert(1)" executes on click. Strip them here too,
   // otherwise the blocklist check below could be bypassed with a leading
-  // control character. (This also subsumes the previous .trim().)
+  // control character. The pattern is anchored at the start so it runs in
+  // linear time; trailing whitespace does not affect the scheme and is
+  // left for the renderer to handle.
   // eslint-disable-next-line no-control-regex
-  const url = (uri || '').replace(/^[\u0000-\u0020]+|[\u0000-\u0020]+$/g, '');
+  const url = (uri || '').replace(/^[\u0000-\u0020]+/, '');
   const first = url.charAt(0);
   // Anchors and absolute/relative paths have no protocol.
   if (first === '#' || first === '/') {

--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -31,6 +31,43 @@ interface SafeMarkdownProps {
   htmlSchemaOverrides?: typeof defaultSchema;
 }
 
+// Link protocols that can execute script when used as an href.
+const DANGEROUS_LINK_PROTOCOLS = ['javascript', 'vbscript', 'data'];
+
+/**
+ * Sanitize link hrefs without using react-markdown's default protocol
+ * allowlist, which would strip the custom link schemes that Superset markdown
+ * is expected to support (see #26211). Instead of allowlisting known-safe
+ * protocols, this blocks the protocols that enable script execution and leaves
+ * everything else (http(s), mailto, relative URLs, anchors and custom schemes)
+ * untouched. Applied regardless of the EscapeMarkdownHtml feature flag.
+ */
+export function transformLinkUri(uri: string): string {
+  const url = (uri || '').trim();
+  const first = url.charAt(0);
+  // Anchors and absolute/relative paths have no protocol.
+  if (first === '#' || first === '/') {
+    return url;
+  }
+  const colon = url.indexOf(':');
+  if (colon === -1) {
+    return url;
+  }
+  // A ':' after a '?' or '#' belongs to the query/fragment, not a scheme.
+  const queryIndex = url.indexOf('?');
+  if (queryIndex !== -1 && colon > queryIndex) {
+    return url;
+  }
+  const hashIndex = url.indexOf('#');
+  if (hashIndex !== -1 && colon > hashIndex) {
+    return url;
+  }
+  // Whitespace inside the scheme (e.g. "java\tscript:") is ignored by browsers,
+  // so strip it before comparing against the blocklist.
+  const scheme = url.slice(0, colon).replace(/\s/g, '').toLowerCase();
+  return DANGEROUS_LINK_PROTOCOLS.includes(scheme) ? '' : url;
+}
+
 export function getOverrideHtmlSchema(
   originalSchema: typeof defaultSchema,
   htmlSchemaOverrides: SafeMarkdownProps['htmlSchemaOverrides'],
@@ -82,7 +119,7 @@ export function SafeMarkdown({
       rehypePlugins={rehypePlugins}
       remarkPlugins={[remarkGfm]}
       skipHtml={false}
-      transformLinkUri={null}
+      transformLinkUri={transformLinkUri}
     >
       {source}
     </ReactMarkdown>

--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -43,7 +43,13 @@ const DANGEROUS_LINK_PROTOCOLS = ['javascript', 'vbscript', 'data'];
  * untouched. Applied regardless of the EscapeMarkdownHtml feature flag.
  */
 export function transformLinkUri(uri: string): string {
-  const url = (uri || '').trim();
+  // Per the WHATWG URL parser, browsers strip leading and trailing C0 control
+  // characters (\x00-\x1f) and space before resolving the scheme, so e.g.
+  // "\x01javascript:alert(1)" executes on click. Strip them here too,
+  // otherwise the blocklist check below could be bypassed with a leading
+  // control character. (This also subsumes the previous .trim().)
+  // eslint-disable-next-line no-control-regex
+  const url = (uri || '').replace(/^[\u0000-\u0020]+|[\u0000-\u0020]+$/g, '');
   const first = url.charAt(0);
   // Anchors and absolute/relative paths have no protocol.
   if (first === '#' || first === '/') {
@@ -62,9 +68,11 @@ export function transformLinkUri(uri: string): string {
   if (hashIndex !== -1 && colon > hashIndex) {
     return url;
   }
-  // Whitespace inside the scheme (e.g. "java\tscript:") is ignored by browsers,
-  // so strip it before comparing against the blocklist.
-  const scheme = url.slice(0, colon).replace(/\s/g, '').toLowerCase();
+  // Whitespace and C0 control characters inside the scheme (e.g.
+  // "java\tscript:" or "java\x01script:") are ignored by browsers, so strip
+  // them before comparing against the blocklist.
+  // eslint-disable-next-line no-control-regex
+  const scheme = url.slice(0, colon).replace(/[\u0000-\u0020]/g, '').toLowerCase();
   return DANGEROUS_LINK_PROTOCOLS.includes(scheme) ? '' : url;
 }
 

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -64,6 +64,13 @@ describe('transformLinkUri', () => {
     `Java${'Script'}:alert(1)`,
     `  ${js}:alert(document.cookie)`,
     `java\t${'script'}:alert(1)`,
+    // Leading C0 control characters are stripped by the WHATWG URL parser
+    // before the scheme is resolved, so they must not bypass the blocklist.
+    `\x01${js}:alert(1)`,
+    `\x00${js}:alert(1)`,
+    `\x1F${js}:alert(1)`,
+    // C0 control characters inside the scheme are ignored by browsers too.
+    `java\x01${'script'}:alert(1)`,
     `${vbs}:msgbox(1)`,
     'data:text/html,<script>alert(1)</script>',
   ])('blocks the script-executing protocol in %p', uri => {

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -20,6 +20,7 @@ import { render } from '@testing-library/react';
 import {
   getOverrideHtmlSchema,
   SafeMarkdown,
+  transformLinkUri,
 } from '../../src/components/SafeMarkdown/SafeMarkdown';
 
 /**
@@ -49,6 +50,48 @@ describe('getOverrideHtmlSchema', () => {
     expect(result.clobberPrefix).toEqual('custom-prefix');
     expect(result.attributes).toEqual({ '*': ['size', 'src'], h1: ['style'] });
     expect(result.tagNames).toEqual(['h1', 'h2', 'h3', 'iframe']);
+  });
+});
+
+describe('transformLinkUri', () => {
+  // Build script-executing protocols via concatenation so the literal URLs
+  // don't trip the no-script-url lint rule.
+  const js = `java${'script'}`;
+  const vbs = `vb${'script'}`;
+
+  test.each([
+    `${js}:alert(1)`,
+    `Java${'Script'}:alert(1)`,
+    `  ${js}:alert(document.cookie)`,
+    `java\t${'script'}:alert(1)`,
+    `${vbs}:msgbox(1)`,
+    'data:text/html,<script>alert(1)</script>',
+  ])('blocks the script-executing protocol in %p', uri => {
+    expect(transformLinkUri(uri)).toBe('');
+  });
+
+  test.each([
+    'https://superset.apache.org',
+    'http://example.com/path?q=1',
+    'mailto:someone@example.com',
+    '/relative/path',
+    '#section',
+  ])('keeps the safe URL %p unchanged', uri => {
+    expect(transformLinkUri(uri)).toBe(uri);
+  });
+
+  test.each([
+    'custom-scheme://open/thing',
+    'slack://channel?id=1',
+    `foo:bar?${js}:alert(1)`,
+  ])('preserves custom link scheme %p (see #26211)', uri => {
+    expect(transformLinkUri(uri)).toBe(uri);
+  });
+
+  test('handles empty and nullish input', () => {
+    expect(transformLinkUri('')).toBe('');
+    // @ts-expect-error -- guarding runtime nullish input
+    expect(transformLinkUri(undefined)).toBe('');
   });
 });
 

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
@@ -59,23 +59,31 @@ describe('transformLinkUri', () => {
   const js = `java${'script'}`;
   const vbs = `vb${'script'}`;
 
+  // Cases are [label, uri] pairs: the raw URIs contain C0 control characters
+  // (\x00, \x01, \x1F) that are invalid in XML, so they must not be
+  // interpolated into the test name (the HTML/JUnit reporters serialize names
+  // to XML and would crash). The label keeps the reported name printable while
+  // the uri is exercised in the body.
   test.each([
-    `${js}:alert(1)`,
-    `Java${'Script'}:alert(1)`,
-    `  ${js}:alert(document.cookie)`,
-    `java\t${'script'}:alert(1)`,
+    ['javascript', `${js}:alert(1)`],
+    ['mixed-case JavaScript', `Java${'Script'}:alert(1)`],
+    ['leading whitespace', `  ${js}:alert(document.cookie)`],
+    ['tab inside scheme', `java\t${'script'}:alert(1)`],
     // Leading C0 control characters are stripped by the WHATWG URL parser
     // before the scheme is resolved, so they must not bypass the blocklist.
-    `\x01${js}:alert(1)`,
-    `\x00${js}:alert(1)`,
-    `\x1F${js}:alert(1)`,
+    ['leading 0x01 control', `\x01${js}:alert(1)`],
+    ['leading NUL (0x00)', `\x00${js}:alert(1)`],
+    ['leading 0x1F control', `\x1F${js}:alert(1)`],
     // C0 control characters inside the scheme are ignored by browsers too.
-    `java\x01${'script'}:alert(1)`,
-    `${vbs}:msgbox(1)`,
-    'data:text/html,<script>alert(1)</script>',
-  ])('blocks the script-executing protocol in %p', uri => {
-    expect(transformLinkUri(uri)).toBe('');
-  });
+    ['0x01 control inside scheme', `java\x01${'script'}:alert(1)`],
+    ['vbscript', `${vbs}:msgbox(1)`],
+    ['data: text/html', 'data:text/html,<script>alert(1)</script>'],
+  ])(
+    'blocks the script-executing protocol (%s)',
+    (_label: string, uri: string) => {
+      expect(transformLinkUri(uri)).toBe('');
+    },
+  );
 
   test.each([
     'https://superset.apache.org',


### PR DESCRIPTION
### SUMMARY

`SafeMarkdown` passed `transformLinkUri={null}` to react-markdown (v8). That `null` explicitly **disables** react-markdown's built-in link-protocol filtering (its default `uriTransformer`). It was set intentionally in #26211 to support custom link schemes in markdown — but as a side effect it also lets `javascript:`, `vbscript:` and `data:` links render.

This is most impactful when the `EscapeMarkdownHtml` feature flag is enabled: in that branch `rehypePlugins` is empty (no `rehype-sanitize`), so **nothing** filtered link `href`s — even though the flag's name implies stronger sanitization. (When the flag is off, `rehype-sanitize`'s `defaultSchema` happened to filter href protocols, masking the gap.)

Rather than restoring react-markdown's allowlist (which would re-break the custom schemes from #26211), this adds a **blocklist** transformer:

- Blocks the protocols that can execute script (`javascript`, `vbscript`, `data`), including case- and whitespace-obfuscated variants (e.g. `java\tscript:`).
- Leaves everything else untouched: `http(s)`, `mailto`, relative URLs, anchors, and arbitrary custom schemes (preserving #26211).
- Applied **unconditionally**, independent of the `EscapeMarkdownHtml` flag.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — link filtering; legitimate links are unaffected.

### TESTING INSTRUCTIONS

```
cd superset-frontend
npm run test -- packages/superset-ui-core/test/components/SafeMarkdown.test.tsx
```

Added a `transformLinkUri` unit-test suite: blocks dangerous protocols (with case/whitespace obfuscation), keeps safe URLs (`https`, `mailto`, relative, anchors), and preserves custom schemes. (react-markdown is globally mocked in the jest shim, so link handling is unit-tested on the exported transformer directly; the transformer is wired unconditionally so it applies in both feature-flag states.)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
