### PR TITLE
fix(plugin-chart-ag-grid-table): validate filter values/operators in state converter

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/stateConversion.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/stateConversion.ts
@@ -216,7 +216,13 @@ function convertFilterToSQL(
     if (conditions.length === 0) return null;
     if (conditions.length === 1) return conditions[0];
 
-    return `(${conditions.join(` ${filter.operator} `)})`;
+    // The join operator is interpolated into raw SQL, so only allow the two
+    // boolean connectors AG Grid produces.
+    const joinOperator = String(filter.operator).toUpperCase();
+    if (joinOperator !== 'AND' && joinOperator !== 'OR') {
+      return null;
+    }
+    return `(${conditions.join(` ${joinOperator} `)})`;
   }
 
   // Handle blank/notBlank operators for all filter types
@@ -263,20 +269,26 @@ function convertFilterToSQL(
     filter.filter !== undefined &&
     filter.type
   ) {
+    // Number values are interpolated into the clause without quoting, so they
+    // must be finite numbers. Coerce and skip the filter if it is not numeric.
+    const numericValue = Number(filter.filter);
+    if (!Number.isFinite(numericValue)) {
+      return null;
+    }
     // Map number filter types to SQL operators
     switch (filter.type) {
       case FILTER_OPERATORS.EQUALS:
-        return `${colId} ${SQL_OPERATORS.EQUALS} ${filter.filter}`;
+        return `${colId} ${SQL_OPERATORS.EQUALS} ${numericValue}`;
       case FILTER_OPERATORS.NOT_EQUAL:
-        return `${colId} ${SQL_OPERATORS.NOT_EQUALS} ${filter.filter}`;
+        return `${colId} ${SQL_OPERATORS.NOT_EQUALS} ${numericValue}`;
       case FILTER_OPERATORS.LESS_THAN:
-        return `${colId} ${SQL_OPERATORS.LESS_THAN} ${filter.filter}`;
+        return `${colId} ${SQL_OPERATORS.LESS_THAN} ${numericValue}`;
       case FILTER_OPERATORS.LESS_THAN_OR_EQUAL:
-        return `${colId} ${SQL_OPERATORS.LESS_THAN_OR_EQUAL} ${filter.filter}`;
+        return `${colId} ${SQL_OPERATORS.LESS_THAN_OR_EQUAL} ${numericValue}`;
       case FILTER_OPERATORS.GREATER_THAN:
-        return `${colId} ${SQL_OPERATORS.GREATER_THAN} ${filter.filter}`;
+        return `${colId} ${SQL_OPERATORS.GREATER_THAN} ${numericValue}`;
       case FILTER_OPERATORS.GREATER_THAN_OR_EQUAL:
-        return `${colId} ${SQL_OPERATORS.GREATER_THAN_OR_EQUAL} ${filter.filter}`;
+        return `${colId} ${SQL_OPERATORS.GREATER_THAN_OR_EQUAL} ${numericValue}`;
       default:
         return null;
     }
@@ -314,7 +326,9 @@ export function convertFilterModel(
     return undefined;
   }
 
-  const sqlClauses: Record<string, string> = {};
+  // Null-prototype object: column ids come from the (user-influenced) filter
+  // model and are used as keys here, so avoid prototype-chain keys.
+  const sqlClauses: Record<string, string> = Object.create(null);
 
   Object.entries(filterModel).forEach(([colId, filter]) => {
     const sqlClause = convertFilterToSQL(colId, filter);

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/stateConversion.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/stateConversion.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { convertFilterModel } from '../src/stateConversion';
+
+describe('convertFilterModel', () => {
+  test('emits a clause for a valid numeric comparison filter', () => {
+    const result = convertFilterModel({
+      revenue: { filterType: 'number', type: 'greaterThan', filter: 100 },
+    } as any);
+
+    expect(result?.sqlClauses?.revenue).toBe('revenue > 100');
+  });
+
+  test('drops a number filter whose value is not numeric', () => {
+    const result = convertFilterModel({
+      revenue: { filterType: 'number', type: 'equals', filter: '1 OR 1=1' },
+    } as any);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('joins conditions with a valid boolean operator', () => {
+    const result = convertFilterModel({
+      revenue: {
+        filterType: 'number',
+        operator: 'AND',
+        condition1: { filterType: 'number', type: 'greaterThan', filter: 1 },
+        condition2: { filterType: 'number', type: 'lessThan', filter: 9 },
+      },
+    } as any);
+
+    expect(result?.sqlClauses?.revenue).toBe('(revenue > 1 AND revenue < 9)');
+  });
+
+  test('drops a compound filter whose join operator is not AND/OR', () => {
+    const result = convertFilterModel({
+      revenue: {
+        filterType: 'number',
+        operator: 'AND 1=1) OR (1=1',
+        condition1: { filterType: 'number', type: 'greaterThan', filter: 1 },
+        condition2: { filterType: 'number', type: 'lessThan', filter: 9 },
+      },
+    } as any);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('stores clauses on a null-prototype map (prototype-safe column ids)', () => {
+    const result = convertFilterModel({
+      constructor: { filterType: 'number', type: 'equals', filter: 5 },
+    } as any);
+
+    // The map has no prototype, so a column id like "constructor" is just data.
+    expect(Object.getPrototypeOf(result?.sqlClauses)).toBeNull();
+    expect(result?.sqlClauses?.constructor).toBe('constructor = 5');
+  });
+});


### PR DESCRIPTION
### SUMMARY

`stateConversion.ts` is the chart-state → ownState converter for the AG Grid table (registered via `registerChartStateConverter`, used on dashboards/Explore/embedded). It builds SQL filter clauses that are interpolated **without quoting**, so the inputs need validation. This hardens three spots:

- **Number filter values** are coerced with `Number()` and the filter is **skipped when the value is not finite** (they were previously interpolated as-is, unlike the text branch which already escapes).
- **Compound join operators** are restricted to `AND`/`OR` (normalized to upper case); any other value skips the clause (previously `filter.operator` was interpolated raw into the join).
- The **column-id-keyed clause map** is created with `Object.create(null)` so user-influenced column ids can't reach prototype keys.

This converter previously had **no test coverage**; this adds the first tests for `convertFilterModel` covering numeric validation, the operator allowlist, and the null-prototype map.

### TESTING INSTRUCTIONS
```bash
cd superset-frontend && npx jest plugins/plugin-chart-ag-grid-table/test/stateConversion.test.ts
```
5/5 pass.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)