### PR TITLE
fix(ag-grid-table): validate numeric bounds in IN_RANGE filter clause

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
@@ -379,7 +379,16 @@ function simpleFilterToWhereClause(
   }
 
   if (type === FILTER_OPERATORS.IN_RANGE && filterTo !== undefined) {
-    return `${columnName} ${SQL_OPERATORS.BETWEEN} ${value} AND ${filterTo}`;
+    // BETWEEN bounds are interpolated directly into the WHERE clause, so only
+    // accept finite numeric bounds (date ranges are handled separately above).
+    // Numeric strings from serialized filter state are coerced; anything that
+    // isn't a finite number is dropped rather than concatenated as raw SQL.
+    const from = Number(value);
+    const to = Number(filterTo);
+    if (!Number.isFinite(from) || !Number.isFinite(to)) {
+      return '';
+    }
+    return `${columnName} ${SQL_OPERATORS.BETWEEN} ${from} AND ${to}`;
   }
 
   const formattedValue = formatValueForOperator(type, value!);

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts
@@ -383,6 +383,13 @@ function simpleFilterToWhereClause(
     // accept finite numeric bounds (date ranges are handled separately above).
     // Numeric strings from serialized filter state are coerced; anything that
     // isn't a finite number is dropped rather than concatenated as raw SQL.
+    // Reject null/empty bounds explicitly: Number(null) and Number('') both
+    // coerce to 0, which would otherwise produce a misleading BETWEEN ... AND 0.
+    const isCoercibleBound = (bound: FilterValue): boolean =>
+      (typeof bound === 'number' || typeof bound === 'string') && bound !== '';
+    if (!isCoercibleBound(value) || !isCoercibleBound(filterTo)) {
+      return '';
+    }
     const from = Number(value);
     const to = Number(filterTo);
     if (!Number.isFinite(from) || !Number.isFinite(to)) {

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
@@ -794,9 +794,10 @@ describe('agGridFilterConverter', () => {
       const result = convertAgGridFiltersToSQL(filterModel);
 
       // The malicious range condition is dropped, so its payload never reaches
-      // the WHERE clause; the sibling numeric condition is unaffected.
+      // the WHERE clause; the sibling numeric condition survives unchanged.
       expect(result.complexWhere ?? '').not.toContain('1=1');
       expect(result.complexWhere ?? '').not.toContain('BETWEEN');
+      expect(result.complexWhere).toBe('age > 5');
     });
 
     test('should keep numeric inRange bounds (including numeric strings)', () => {
@@ -820,7 +821,9 @@ describe('agGridFilterConverter', () => {
 
       const result = convertAgGridFiltersToSQL(filterModel);
 
-      expect(result.complexWhere).toContain('BETWEEN 18 AND 65');
+      // Assert the full compound clause so the upper bound and the sibling
+      // condition are both validated, not just the BETWEEN fragment.
+      expect(result.complexWhere).toBe('(age BETWEEN 18 AND 65 AND age < 100)');
     });
   });
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
@@ -771,6 +771,57 @@ describe('agGridFilterConverter', () => {
       // Should reject column names longer than 255 characters
       expect(result.simpleFilters).toHaveLength(0);
     });
+
+    test('should drop inRange bounds that are not numeric', () => {
+      const filterModel: AgGridFilterModel = {
+        age: {
+          filterType: 'number',
+          operator: 'AND',
+          condition1: {
+            filterType: 'number',
+            type: 'inRange',
+            filter: '0 AND 1=1--',
+            filterTo: '100',
+          },
+          condition2: {
+            filterType: 'number',
+            type: 'greaterThan',
+            filter: 5,
+          },
+        } as AgGridCompoundFilter,
+      };
+
+      const result = convertAgGridFiltersToSQL(filterModel);
+
+      // The malicious range condition is dropped, so its payload never reaches
+      // the WHERE clause; the sibling numeric condition is unaffected.
+      expect(result.complexWhere ?? '').not.toContain('1=1');
+      expect(result.complexWhere ?? '').not.toContain('BETWEEN');
+    });
+
+    test('should keep numeric inRange bounds (including numeric strings)', () => {
+      const filterModel: AgGridFilterModel = {
+        age: {
+          filterType: 'number',
+          operator: 'AND',
+          condition1: {
+            filterType: 'number',
+            type: 'inRange',
+            filter: '18',
+            filterTo: 65,
+          },
+          condition2: {
+            filterType: 'number',
+            type: 'lessThan',
+            filter: 100,
+          },
+        } as AgGridCompoundFilter,
+      };
+
+      const result = convertAgGridFiltersToSQL(filterModel);
+
+      expect(result.complexWhere).toContain('BETWEEN 18 AND 65');
+    });
   });
 
   describe('Edge cases', () => {


### PR DESCRIPTION
### SUMMARY

`simpleFilterToWhereClause` in `plugins/plugin-chart-ag-grid-table/src/utils/agGridFilterConverter.ts` builds WHERE-clause fragments from the AG Grid filter model. The `IN_RANGE` (`BETWEEN`) branch interpolated both bounds **directly** into the SQL string:

```ts
return `${columnName} ${SQL_OPERATORS.BETWEEN} ${value} AND ${filterTo}`;
```

This is inconsistent with the other branches (ILIKE / string comparisons) which escape via `escapeSQLString`. The bounds come from the filter model, which is client-controlled and serialized into the query (it feeds the raw `extras.where` path), and `filterTo` was never passed through `validateFilterValue` at all — so a manipulated filter model could inject SQL fragments through the range bounds. Practical exploitability is limited because the normal AG Grid number UI produces numeric values, but it's a real gap in the escaping coverage.

Fix: coerce both bounds with `Number()` and emit the `BETWEEN` clause only when both are finite; otherwise drop the condition. Numeric strings from serialized filter state still work, and non-numeric input can no longer be concatenated as raw SQL. Date ranges are unaffected — they're handled separately in `dateFilterToWhereClause` and normalized through `Date.toISOString()`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — WHERE-clause generation.

### TESTING INSTRUCTIONS

```
cd superset-frontend
npm run test -- plugins/plugin-chart-ag-grid-table/test/utils/agGridFilterConverter.test.ts
```

Added to the existing "SQL injection prevention" suite:
- a compound `inRange` filter with a SQL payload in the bounds is dropped (payload never reaches `complexWhere`),
- numeric and numeric-string bounds still produce the expected `BETWEEN 18 AND 65` clause.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
