### PR TITLE
feat(websocket): validate WebSocket upgrade Origin against an allowlist

### DIFF
--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -67,6 +67,25 @@ Copy `config.example.json` to `config.json` and adjust the values for your envir
 
 Configuration via environment variables is also supported which can be helpful in certain contexts, e.g., deployment. `src/config.ts` can be consulted to see the full list of supported values.
 
+### Restricting WebSocket origins
+
+To mitigate Cross-Site WebSocket Hijacking, set `allowedOrigins` (or the
+`ALLOWED_ORIGINS` environment variable, comma-separated) to the list of origins
+permitted to open WebSocket connections, e.g. the origin Superset is served
+from:
+
+```json
+{
+  "allowedOrigins": ["https://superset.example.com"]
+}
+```
+
+The `Origin` header of each upgrade request must exactly match one of the
+configured values. When `allowedOrigins` is empty (the default) the check is
+skipped and any origin is accepted; a single `"*"` entry explicitly allows any
+origin. Setting this is recommended for production deployments, especially when
+the JWT cookie uses `SameSite=None`.
+
 ## Superset Configuration
 
 Configure the Superset Flask app to enable global async queries (in `superset_config.py`):

--- a/superset-websocket/config.example.json
+++ b/superset-websocket/config.example.json
@@ -18,5 +18,6 @@
   "redisStreamPrefix": "async-events-",
   "jwtAlgorithms": ["HS256"],
   "jwtSecret": "CHANGE-ME",
-  "jwtCookieName": "async-token"
+  "jwtCookieName": "async-token",
+  "allowedOrigins": []
 }

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -493,6 +493,105 @@ describe('server', () => {
       expect(socketDestroySpy).not.toHaveBeenCalled();
       expect(wssUpgradeSpy).toHaveBeenCalled();
     });
+
+    describe('origin validation', () => {
+      afterEach(() => {
+        server.opts.allowedOrigins = [];
+      });
+
+      const getRequestWithOrigin = (
+        token: string,
+        origin?: string,
+      ): http.IncomingMessage => {
+        const request = new http.IncomingMessage(new net.Socket());
+        request.method = 'GET';
+        request.headers = { cookie: `${config.jwtCookieName}=${token}` };
+        if (origin) request.headers.origin = origin;
+        request.url = 'http://localhost';
+        return request;
+      };
+
+      test('rejects upgrade from a disallowed origin', () => {
+        server.opts.allowedOrigins = ['https://superset.example.com'];
+        const validToken = jwt.sign({ channel: channelId }, config.jwtSecret);
+        const request = getRequestWithOrigin(
+          validToken,
+          'https://evil.example',
+        );
+
+        server.httpUpgrade(request, socket, Buffer.alloc(5));
+
+        expect(socketDestroySpy).toHaveBeenCalled();
+        expect(wssUpgradeSpy).not.toHaveBeenCalled();
+      });
+
+      test('rejects upgrade with no origin when an allowlist is set', () => {
+        server.opts.allowedOrigins = ['https://superset.example.com'];
+        const validToken = jwt.sign({ channel: channelId }, config.jwtSecret);
+        const request = getRequestWithOrigin(validToken);
+
+        server.httpUpgrade(request, socket, Buffer.alloc(5));
+
+        expect(socketDestroySpy).toHaveBeenCalled();
+        expect(wssUpgradeSpy).not.toHaveBeenCalled();
+      });
+
+      test('allows upgrade from an allowed origin', () => {
+        server.opts.allowedOrigins = ['https://superset.example.com'];
+        const validToken = jwt.sign({ channel: channelId }, config.jwtSecret);
+        const request = getRequestWithOrigin(
+          validToken,
+          'https://superset.example.com',
+        );
+
+        server.httpUpgrade(request, socket, Buffer.alloc(5));
+
+        expect(socketDestroySpy).not.toHaveBeenCalled();
+        expect(wssUpgradeSpy).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('isOriginAllowed', () => {
+    const makeRequest = (origin?: string): http.IncomingMessage => {
+      const request = new http.IncomingMessage(new net.Socket());
+      if (origin) request.headers.origin = origin;
+      return request;
+    };
+
+    afterEach(() => {
+      server.opts.allowedOrigins = [];
+    });
+
+    test('allows any origin when allowlist is empty', () => {
+      server.opts.allowedOrigins = [];
+      expect(server.isOriginAllowed(makeRequest('https://anything'))).toBe(
+        true,
+      );
+      expect(server.isOriginAllowed(makeRequest())).toBe(true);
+    });
+
+    test('allows any origin when allowlist contains a wildcard', () => {
+      server.opts.allowedOrigins = ['*'];
+      expect(server.isOriginAllowed(makeRequest('https://anything'))).toBe(
+        true,
+      );
+    });
+
+    test('allows an exact-match origin', () => {
+      server.opts.allowedOrigins = ['https://a.example', 'https://b.example'];
+      expect(server.isOriginAllowed(makeRequest('https://b.example'))).toBe(
+        true,
+      );
+    });
+
+    test('rejects a non-matching or missing origin', () => {
+      server.opts.allowedOrigins = ['https://a.example'];
+      expect(server.isOriginAllowed(makeRequest('https://evil.example'))).toBe(
+        false,
+      );
+      expect(server.isOriginAllowed(makeRequest())).toBe(false);
+    });
   });
 
   const setReadyState = (ws: WebSocket, value: typeof ws.readyState) => {

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -101,7 +101,11 @@ function configFromFile(): Partial<ConfigType> {
 const isPresent = (s: string) => /\S+/.test(s);
 const toNumber = Number;
 const toBoolean = (s: string) => s.toLowerCase() === 'true';
-const toStringArray = (s: string) => s.split(',');
+const toStringArray = (s: string) =>
+  s
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0);
 
 function applyEnvOverrides(config: ConfigType): ConfigType {
   const envVarConfigSetter: { [envVar: string]: (val: string) => void } = {

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -47,6 +47,7 @@ type ConfigType = {
   jwtSecret: string;
   jwtCookieName: string;
   jwtChannelIdKey: string;
+  allowedOrigins: string[];
   socketResponseTimeoutMs: number;
   pingSocketsIntervalMs: number;
   gcChannelsIntervalMs: number;
@@ -65,6 +66,7 @@ function defaultConfig(): ConfigType {
     jwtSecret: '',
     jwtCookieName: 'async-token',
     jwtChannelIdKey: 'channel',
+    allowedOrigins: [],
     socketResponseTimeoutMs: 60 * 1000,
     pingSocketsIntervalMs: 20 * 1000,
     gcChannelsIntervalMs: 120 * 1000,
@@ -114,6 +116,7 @@ function applyEnvOverrides(config: ConfigType): ConfigType {
       (config.redisStreamReadBlockMs = toNumber(val)),
     JWT_SECRET: val => (config.jwtSecret = val),
     JWT_COOKIE_NAME: val => (config.jwtCookieName = val),
+    ALLOWED_ORIGINS: val => (config.allowedOrigins = toStringArray(val)),
     SOCKET_RESPONSE_TIMEOUT_MS: val =>
       (config.socketResponseTimeoutMs = toNumber(val)),
     PING_SOCKETS_INTERVAL_MS: val =>

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -379,6 +379,31 @@ export const httpRequest = (
 };
 
 /**
+ * Validates the `Origin` header of a WebSocket upgrade request against the
+ * configured `allowedOrigins` list, mitigating Cross-Site WebSocket Hijacking.
+ *
+ * When `allowedOrigins` is empty the check is skipped (preserving existing
+ * behavior); a single `'*'` entry explicitly allows any origin. Otherwise the
+ * request's `Origin` must exactly match one of the configured origins.
+ */
+export const isOriginAllowed = (request: http.IncomingMessage): boolean => {
+  const { allowedOrigins } = opts;
+
+  if (!allowedOrigins || allowedOrigins.length === 0) {
+    return true;
+  }
+  if (allowedOrigins.includes('*')) {
+    return true;
+  }
+
+  const origin = request.headers.origin;
+  if (!origin) {
+    return false;
+  }
+  return allowedOrigins.includes(origin);
+};
+
+/**
  * HTTP `upgrade` event handler, called via httpServer
  */
 export const httpUpgrade = (
@@ -386,6 +411,16 @@ export const httpUpgrade = (
   socket: net.Socket,
   head: Buffer,
 ) => {
+  if (!isOriginAllowed(request)) {
+    logger.error(
+      `Rejecting WebSocket upgrade from disallowed origin: ${
+        request.headers.origin || '(none)'
+      }`,
+    );
+    socket.destroy();
+    return;
+  }
+
   try {
     readChannelId(request);
   } catch (err) {

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -396,8 +396,10 @@ export const isOriginAllowed = (request: http.IncomingMessage): boolean => {
     return true;
   }
 
+  // `origin` is typed as `string | string[] | undefined`; only a single,
+  // unambiguous string header is acceptable for an exact-match comparison.
   const origin = request.headers.origin;
-  if (!origin) {
+  if (typeof origin !== 'string') {
     return false;
   }
   return allowedOrigins.includes(origin);


### PR DESCRIPTION
### SUMMARY

The async-queries WebSocket server (`superset-websocket`) authenticated upgrade requests via the JWT cookie but never validated the request `Origin`. Browsers attach cookies to cross-site WebSocket handshakes when the cookie's `SameSite` policy permits — notably when a deployment sets `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_SAMESITE = "None"` (common for embedded dashboards). In that configuration a malicious page visited by an authenticated user could open a WebSocket on the victim's channel and receive their async query result events (Cross-Site WebSocket Hijacking).

This adds an optional origin allowlist:

- New `allowedOrigins` config option and `ALLOWED_ORIGINS` env var (comma-separated).
- The upgrade handler now rejects (destroys the socket) when the request `Origin` is not in the list.
- **Backward compatible:** an empty list (the default) skips the check and accepts any origin, preserving today's behavior. A single `"*"` entry explicitly allows any origin.

Operators are encouraged to set `allowedOrigins` to the origin Superset is served from. Documented in the README and `config.example.json`.

### TESTING INSTRUCTIONS

```
cd superset-websocket
npm ci
npm test
```

New tests:
- `isOriginAllowed`: empty list → allow; `"*"` → allow; exact match → allow; non-match / missing origin → reject.
- `httpUpgrade` origin validation: disallowed origin and missing origin are rejected (socket destroyed, no upgrade); allowed origin proceeds.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
