### PR TITLE
fix(websocket): validate last_id query param format

### DIFF
--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -152,6 +152,43 @@ describe('server', () => {
     });
   });
 
+  describe('getLastId', () => {
+    const requestWithUrl = (url: string): http.IncomingMessage => {
+      const request = new http.IncomingMessage(new net.Socket());
+      request.url = url;
+      return request;
+    };
+
+    test('returns null when last_id is absent', () => {
+      expect(server.getLastId(requestWithUrl('http://localhost'))).toBeNull();
+    });
+
+    test('returns a well-formed Redis stream ID', () => {
+      expect(
+        server.getLastId(
+          requestWithUrl('http://localhost?last_id=1607477697866-0'),
+        ),
+      ).toEqual('1607477697866-0');
+    });
+
+    test.each([
+      'abc-xyz',
+      '1607477697866',
+      '1607477697866-',
+      '-0',
+      '1607477697866-0; DROP TABLE',
+      '1607477697866-0-0',
+    ])('returns null for malformed last_id %p', value => {
+      expect(
+        server.getLastId(
+          requestWithUrl(
+            `http://localhost?last_id=${encodeURIComponent(value)}`,
+          ),
+        ),
+      ).toBeNull();
+    });
+  });
+
   describe('redisUrlFromConfig', () => {
     test('it builds a valid Redis URL from defaults', () => {
       expect(
@@ -391,6 +428,23 @@ describe('server', () => {
       );
       expect(fetchRangeFromStreamSpy).not.toHaveBeenCalled();
       expect(wsEventMock).toHaveBeenCalledWith('pong', expect.any(Function));
+    });
+
+    test('valid JWT, malformed lastId is ignored', async () => {
+      const validToken = jwt.sign({ channel: channelId }, config.jwtSecret);
+      const request = getRequest(
+        validToken,
+        'http://localhost?last_id=abc-xyz',
+      );
+
+      server.wsConnection(ws, request);
+
+      expect(trackClientSpy).toHaveBeenCalledWith(
+        channelId,
+        socketInstanceExpected,
+      );
+      // Malformed last_id must not trigger a stream range fetch.
+      expect(fetchRangeFromStreamSpy).not.toHaveBeenCalled();
     });
 
     test('valid JWT, with lastId', async () => {

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -300,13 +300,24 @@ const readChannelId = (request: http.IncomingMessage): string => {
   return channelId;
 };
 
+// Redis stream IDs have the form '<millisecondsTime>-<sequenceNumber>',
+// e.g. '1607477697866-0'.
+const REDIS_STREAM_ID_REGEX = /^\d{1,15}-\d{1,10}$/;
+
 /**
- * Extracts the `last_id` query param value from an HTTP request
+ * Extracts the `last_id` query param value from an HTTP request, returning it
+ * only when it is a well-formed Redis stream ID. Malformed values are ignored
+ * (returns null) rather than being passed through to incrementId / Redis.
  */
-const getLastId = (request: http.IncomingMessage): string | null => {
+export const getLastId = (request: http.IncomingMessage): string | null => {
   const url = new URL(String(request.url), 'http://0.0.0.0');
-  const queryParams = url.searchParams;
-  return queryParams.get('last_id');
+  const lastId = url.searchParams.get('last_id');
+  if (lastId === null) return null;
+  if (!REDIS_STREAM_ID_REGEX.test(lastId)) {
+    logger.warn(`Ignoring malformed last_id query param: ${lastId}`);
+    return null;
+  }
+  return lastId;
 };
 
 /**


### PR DESCRIPTION
### SUMMARY

In `superset-websocket`, `getLastId` returned the raw `last_id` query parameter, which is then passed to `incrementId` and used as the start of a Redis stream range read during the client reconnection flow. Malformed values like `last_id=abc-xyz` produced ids such as `abc-NaN`. Redis handles these gracefully and a client can only read its own channel's stream, so the impact is limited — but no positive validation enforced the expected format.

This adds validation: `last_id` must match the Redis stream ID format `/^\d{1,15}-\d{1,10}$/` (`<millisecondsTime>-<sequence>`); anything else is ignored (returns `null`), so malformed input is no longer processed.

### TESTING INSTRUCTIONS

```
cd superset-websocket
npm ci
npm test
```

New tests:
- `getLastId`: returns `null` when absent, returns well-formed IDs, and returns `null` for a range of malformed inputs (`abc-xyz`, missing parts, injection-like suffixes, extra segments).
- `wsConnection`: a malformed `last_id` does not trigger a stream range fetch.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
