### PR TITLE
fix(core): restrict allowed CSS properties in sanitized HTML

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -33,6 +33,35 @@ describe('sanitizeHtml', () => {
     const sanitizedString = sanitizeHtml(htmlString);
     expect(sanitizedString).not.toContain('script');
   });
+
+  test('should preserve allowed presentational CSS properties', () => {
+    const htmlString =
+      '<div style="color: red; background-color: blue; font-size: 12px; text-align: center">x</div>';
+    const sanitizedString = sanitizeHtml(htmlString);
+    expect(sanitizedString).toContain('color:red');
+    expect(sanitizedString).toContain('background-color:blue');
+    expect(sanitizedString).toContain('font-size:12px');
+    expect(sanitizedString).toContain('text-align:center');
+  });
+
+  test('should strip layout and positioning CSS properties', () => {
+    const htmlString =
+      '<div style="color: red; position: fixed; z-index: 9999; width: 100%; height: 100%">x</div>';
+    const sanitizedString = sanitizeHtml(htmlString);
+    expect(sanitizedString).toContain('color:red');
+    expect(sanitizedString).not.toContain('position');
+    expect(sanitizedString).not.toContain('z-index');
+    expect(sanitizedString).not.toContain('width');
+    expect(sanitizedString).not.toContain('height');
+  });
+
+  test('should strip unsafe CSS property values', () => {
+    const htmlString =
+      '<div style="background-color: url(javascript:alert(1)); color: blue">x</div>';
+    const sanitizedString = sanitizeHtml(htmlString);
+    expect(sanitizedString).not.toContain('javascript');
+    expect(sanitizedString).not.toContain('url(');
+  });
 });
 
 describe('isProbablyHTML', () => {

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -52,6 +52,11 @@ const allowedCssProperties = {
   'border-width': true,
   'border-radius': true,
   'vertical-align': true,
+  // Needed by ECharts tooltips for row transparency and text truncation.
+  opacity: true,
+  'max-width': true,
+  overflow: true,
+  'text-overflow': true,
 };
 
 const xssFilter = new FilterXSS({

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -19,6 +19,41 @@
 import { FilterXSS, getDefaultWhiteList } from 'xss';
 import { DataRecordValue } from '../types';
 
+// Restrict inline `style` attributes to a small set of presentational CSS
+// properties. Layout/positioning properties (e.g. position, z-index, width,
+// height) are intentionally excluded so that sanitized markup cannot affect
+// surrounding page layout. The `xss` library also validates property values
+// against this allowlist, stripping unsupported constructs such as url()/expression().
+const allowedCssProperties = {
+  color: true,
+  'background-color': true,
+  'text-align': true,
+  'text-decoration': true,
+  'font-family': true,
+  'font-size': true,
+  'font-style': true,
+  'font-weight': true,
+  'line-height': true,
+  'letter-spacing': true,
+  'white-space': true,
+  padding: true,
+  'padding-top': true,
+  'padding-right': true,
+  'padding-bottom': true,
+  'padding-left': true,
+  margin: true,
+  'margin-top': true,
+  'margin-right': true,
+  'margin-bottom': true,
+  'margin-left': true,
+  border: true,
+  'border-color': true,
+  'border-style': true,
+  'border-width': true,
+  'border-radius': true,
+  'vertical-align': true,
+};
+
 const xssFilter = new FilterXSS({
   whiteList: {
     ...getDefaultWhiteList(),
@@ -45,7 +80,7 @@ const xssFilter = new FilterXSS({
     tfoot: ['align', 'valign', 'style'],
   },
   stripIgnoreTag: true,
-  css: false,
+  css: { whiteList: allowedCssProperties },
 });
 
 export function sanitizeHtml(htmlString: string) {

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -20,10 +20,14 @@ import { FilterXSS, getDefaultWhiteList } from 'xss';
 import { DataRecordValue } from '../types';
 
 // Restrict inline `style` attributes to a small set of presentational CSS
-// properties. Layout/positioning properties (e.g. position, z-index, width,
-// height) are intentionally excluded so that sanitized markup cannot affect
-// surrounding page layout. The `xss` library also validates property values
-// against this allowlist, stripping unsupported constructs such as url()/expression().
+// properties. Overlay/positioning properties (e.g. position, z-index, top,
+// left, transform) and sizing properties that could cover the page (e.g.
+// width, height) are intentionally excluded so that sanitized markup cannot
+// escape its container to overlay or obscure the surrounding page. The
+// allowlisted spacing/border properties (margin, padding, border) can still
+// affect layout within the container, which is acceptable. The `xss` library
+// also validates property values against this allowlist, stripping unsupported
+// constructs such as url()/expression().
 const allowedCssProperties = {
   color: true,
   'background-color': true,

--- a/superset-frontend/packages/superset-ui-core/test/utils/tooltip.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/tooltip.test.ts
@@ -161,10 +161,13 @@ test('should preserve table styling after sanitization (fixes ECharts tooltip fo
     </table>
   `;
 
+  // The `xss` CSS filter normalizes declarations, dropping the space after
+  // each colon (e.g. `opacity: 0.8;` becomes `opacity:0.8;`) while preserving
+  // the property/value pairs themselves.
   const sanitized = sanitizeHtml(tableWithStyles);
-  expect(sanitized).toContain('style="opacity: 0.8;"');
-  expect(sanitized).toContain('style="text-align: left; padding-left: 0px;"');
-  expect(sanitized).toContain('style="text-align: right; padding-left: 16px;"');
+  expect(sanitized).toContain('style="opacity:0.8;"');
+  expect(sanitized).toContain('style="text-align:left; padding-left:0px;"');
+  expect(sanitized).toContain('style="text-align:right; padding-left:16px;"');
 
   const data = [
     ['Metric', 'Value'],
@@ -172,10 +175,10 @@ test('should preserve table styling after sanitization (fixes ECharts tooltip fo
   ];
   const html = tooltipHtml(data, 'Test Tooltip');
 
-  expect(html).toContain('style="opacity: 0.8;"');
-  expect(html).toContain('text-align: left');
-  expect(html).toContain('text-align: right');
-  expect(html).toContain('padding-left: 0px');
-  expect(html).toContain('padding-left: 16px');
-  expect(html).toContain('max-width: 300px');
+  expect(html).toContain('style="opacity:0.8;"');
+  expect(html).toContain('text-align:left');
+  expect(html).toContain('text-align:right');
+  expect(html).toContain('padding-left:0px');
+  expect(html).toContain('padding-left:16px');
+  expect(html).toContain('max-width:300px');
 });


### PR DESCRIPTION
### SUMMARY

The shared HTML sanitizer in `superset-ui-core` (`utils/html.tsx`) allows inline `style` attributes on a set of whitelisted elements, but it disabled CSS value validation by setting `css: false` on the `FilterXSS` instance. With validation disabled, any CSS property — including layout and positioning properties such as `position`, `z-index`, `width`, and `height` — passed through untouched.

This change replaces `css: false` with a restrictive CSS property allowlist limited to safe presentational properties (`color`, `background-color`, `font-*`, `text-*`, spacing, borders, etc.). The `xss` library validates declared properties against this allowlist and also validates their values, so unsupported constructs (e.g. `url(...)`, `expression(...)`) are stripped as well.

This sanitizer is reachable when markup is rendered with HTML rendering enabled (e.g. table/pivot cells with `allow_render_html`), so tightening the allowlist hardens that path while keeping ordinary presentational styling intact.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

- `npx jest packages/superset-ui-core/src/utils/html.test.tsx`
- New tests cover: allowed presentational properties are preserved, layout/positioning properties are stripped, and unsafe property values are removed.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)