### PR TITLE
fix(databases): do not render existing encrypted field value in edit mode

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
@@ -161,21 +161,42 @@ describe('EncryptedField', () => {
 
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Parameter Value Processing', () => {
-    const testCases = [
+    // In edit mode the existing credential value must never be rendered into
+    // the field, regardless of how it was returned from the backend.
+    const editModeInputs = [
+      {
+        input: { key: 'value', nested: { data: 'test' } },
+        description: 'objects',
+      },
+      { input: true, description: 'booleans' },
+      { input: false, description: 'false booleans' },
+      { input: 'test-string', description: 'strings' },
+      { input: 123, description: 'numbers' },
+    ];
+
+    test.each(editModeInputs)(
+      'does not render existing $description in edit mode',
+      ({ input }) => {
+        const mockDb = createMockDb('gsheets', {
+          service_account_info: input,
+        });
+        const props = { ...defaultProps, db: mockDb, isEditMode: true };
+
+        const { container } = render(<EncryptedField {...props} />);
+        const textarea = container.querySelector('textarea');
+
+        expect(textarea?.value).toBe('');
+      },
+    );
+
+    // The copy/paste (create) flow is controlled by the parent, which echoes
+    // typed content back through `db.parameters`. Verify that values are still
+    // serialized for display when not in edit mode.
+    const createModeCases = [
       {
         input: { key: 'value', nested: { data: 'test' } },
         expected: '{"key":"value","nested":{"data":"test"}}',
         description: 'objects to JSON strings',
-      },
-      {
-        input: true,
-        expected: 'true',
-        description: 'booleans to strings',
-      },
-      {
-        input: false,
-        expected: 'false',
-        description: 'false booleans to strings',
       },
       {
         input: 'test-string',
@@ -189,13 +210,18 @@ describe('EncryptedField', () => {
       },
     ];
 
-    test.each(testCases)(
-      'processes $description correctly',
+    test.each(createModeCases)(
+      'processes $description correctly in create mode',
       ({ input, expected }) => {
         const mockDb = createMockDb('gsheets', {
           service_account_info: input,
         });
-        const props = { ...defaultProps, db: mockDb, isEditMode: true };
+        const props = {
+          ...defaultProps,
+          db: mockDb,
+          isEditMode: false,
+          editNewDb: true,
+        };
 
         const { container } = render(<EncryptedField {...props} />);
         const textarea = container.querySelector('textarea');

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
@@ -208,6 +208,16 @@ describe('EncryptedField', () => {
         expected: '123',
         description: 'numbers to strings',
       },
+      {
+        input: true,
+        expected: 'true',
+        description: 'true booleans to strings',
+      },
+      {
+        input: false,
+        expected: 'false',
+        description: 'false booleans to strings',
+      },
     ];
 
     test.each(createModeCases)(

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx
@@ -67,10 +67,16 @@ export const EncryptedField = ({
     encryptedCredentialsMap[db.engine as keyof typeof encryptedCredentialsMap];
   const paramValue =
     db?.parameters?.[encryptedField as keyof DatabaseParameters];
+  // In edit mode the backend may return the existing (masked) credential in
+  // the parameters. Do not surface any pre-existing value in the field; the
+  // user must re-enter credentials to change them. This also matches the
+  // mount effect below, which resets the parameter to an empty string.
   const encryptedValue =
-    paramValue && typeof paramValue === 'object'
-      ? JSON.stringify(paramValue)
-      : paramValue;
+    isEditMode || !paramValue
+      ? ''
+      : typeof paramValue === 'object'
+        ? JSON.stringify(paramValue)
+        : paramValue;
 
   const handlePublicToggle = (value: string) => {
     const nextIsPublic = value === 'true';

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx
@@ -72,7 +72,7 @@ export const EncryptedField = ({
   // user must re-enter credentials to change them. This also matches the
   // mount effect below, which resets the parameter to an empty string.
   const encryptedValue =
-    isEditMode || !paramValue
+    isEditMode || paramValue == null
       ? ''
       : typeof paramValue === 'object'
         ? JSON.stringify(paramValue)


### PR DESCRIPTION
### SUMMARY

The `EncryptedField` component in the Database connection modal handles engine-specific encrypted credentials (e.g. `service_account_info` for gsheets, `credentials_info` for bigquery/datastore).

In edit mode, the backend may return the existing credential for these fields via `db.parameters`. The component derived its displayed value directly from that parameter, so the value was placed into the DOM on the first render — before the mount `useEffect` reset the parameter to an empty string. The reset relies on an effect that runs after the initial render, leaving a brief window where an existing value could appear in the field.

This change initializes the displayed value to an empty string whenever the form is in edit mode, so a pre-existing credential is never rendered. Users must re-enter credentials to change them, which is consistent with the existing clear-on-mount behavior. The create / copy-paste flow continues to serialize and display typed values exactly as before.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

- `npx jest src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx`
- Tests assert: edit mode never renders an existing value (for object/boolean/string/number inputs), and the create flow still serializes and displays typed values.
- Manual: edit a gsheets/bigquery database with stored credentials — the Service Account field should be empty rather than pre-filled.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)