### PR TITLE
fix(mcp): deny deactivated user accounts in MCP authentication

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -512,6 +512,17 @@ def _log_user_resolution_failure(exc: ValueError) -> None:
         logger.error("MCP user resolution failed, denying request: %s", exc)
 
 
+def _reject_if_inactive(user: User | None) -> None:
+    """Raise ``ValueError`` if the resolved user account is deactivated.
+
+    A still-valid JWT or API key must not grant MCP access to a user whose
+    account has been disabled. This mirrors Flask-Login's ``is_active`` check
+    for web sessions, which the MCP auth path does not otherwise go through.
+    """
+    if user is not None and not getattr(user, "is_active", True):
+        raise ValueError("User account is disabled")
+
+
 def _setup_user_context() -> User | None:
     """
     Set up user context for MCP tool execution.
@@ -539,6 +550,7 @@ def _setup_user_context() -> User | None:
     for attempt in range(2):
         try:
             user = get_user_from_request()
+            _reject_if_inactive(user)
 
             # Validate user has necessary relationships loaded.
             # Force access to ensure they're loaded if lazy.

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -519,7 +519,9 @@ def _reject_if_inactive(user: User | None) -> None:
     account has been disabled. This mirrors Flask-Login's ``is_active`` check
     for web sessions, which the MCP auth path does not otherwise go through.
     """
-    if user is not None and not getattr(user, "is_active", True):
+    if user is not None and not (
+        getattr(user, "is_active", True) and getattr(user, "active", True)
+    ):
         raise ValueError("User account is disabled")
 
 

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -535,3 +535,41 @@ def test_setup_user_context_propagates_valueerror(app) -> None:
                 _setup_user_context()
             # g.user should be cleared after ValueError (no misleading audit)
             assert not hasattr(g, "user") or g.user is None
+
+
+def test_setup_user_context_rejects_disabled_user(app) -> None:
+    """A deactivated account must be denied even with a valid token.
+
+    The MCP auth path does not go through Flask-Login's is_active check, so
+    this guards that a disabled user (active=False) cannot authenticate.
+    """
+    from superset.mcp_service.auth import _setup_user_context
+
+    disabled_user = _make_mock_user("disabled_user")
+    disabled_user.is_active = False
+
+    with app.test_request_context():
+        with patch(
+            "superset.mcp_service.auth.get_user_from_request",
+            return_value=disabled_user,
+        ):
+            with pytest.raises(ValueError, match="disabled"):
+                _setup_user_context()
+            assert not hasattr(g, "user") or g.user is None
+
+
+def test_setup_user_context_allows_active_user(app) -> None:
+    """An active account authenticates normally."""
+    from superset.mcp_service.auth import _setup_user_context
+
+    active_user = _make_mock_user("active_user")
+    active_user.is_active = True
+
+    with app.test_request_context():
+        with patch(
+            "superset.mcp_service.auth.get_user_from_request",
+            return_value=active_user,
+        ):
+            result = _setup_user_context()
+            assert result is active_user
+            assert g.user is active_user

--- a/tests/unit_tests/mcp_service/test_auth_user_resolution.py
+++ b/tests/unit_tests/mcp_service/test_auth_user_resolution.py
@@ -547,6 +547,7 @@ def test_setup_user_context_rejects_disabled_user(app) -> None:
 
     disabled_user = _make_mock_user("disabled_user")
     disabled_user.is_active = False
+    disabled_user.active = False
 
     with app.test_request_context():
         with patch(
@@ -564,6 +565,7 @@ def test_setup_user_context_allows_active_user(app) -> None:
 
     active_user = _make_mock_user("active_user")
     active_user.is_active = True
+    active_user.active = True
 
     with app.test_request_context():
         with patch(


### PR DESCRIPTION
### SUMMARY

The MCP service authenticates tool calls via JWT/API key, but its user-resolution path (`_setup_user_context` → `get_user_from_request`) never checked `User.active`. Flask-Login enforces `is_active` for web sessions, but the MCP path bypasses that — so a user whose account had been **deactivated** could keep making MCP tool calls (data queries, chart/dashboard operations, retaining RBAC permissions) for as long as they held a valid token.

This adds an `is_active` check immediately after the user is resolved: an inactive account raises `ValueError`, which the existing fail-closed handler in `_setup_user_context` converts into a denied request (and clears `g.user` so audit logs don't misattribute the denied call). The check is factored into a small `_reject_if_inactive` helper, applied across all resolution paths (JWT, dev-username, `g.user` fallback) at the single choke point.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/mcp_service/test_auth_user_resolution.py
```

New tests:
- `test_setup_user_context_rejects_disabled_user` — a user with `active=False` raises `ValueError` and `g.user` is cleared.
- `test_setup_user_context_allows_active_user` — an active user authenticates normally.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
