### PR TITLE
fix(jinja): apply consistent escaping to url_param values from request args

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -288,11 +288,13 @@ class ExtraCache:
         from superset.views.utils import get_form_data
 
         if has_request_context() and request.args.get(param):
-            return request.args.get(param, default)
-
-        form_data, _ = get_form_data()
-        url_params = form_data.get("url_params") or {}
-        result = url_params.get(param, default)
+            result = request.args.get(param, default)
+        else:
+            form_data, _ = get_form_data()
+            url_params = form_data.get("url_params") or {}
+            result = url_params.get(param, default)
+        # Escape the value regardless of its source (request args or form
+        # data); both are interpolated into the rendered SQL.
         if result and escape_result and self.dialect:
             # use the dialect specific quoting logic to escape string
             result = String().literal_processor(dialect=self.dialect)(value=result)[

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -438,6 +438,25 @@ def test_url_param_unescaped_default_form_data() -> None:
         assert cache.url_param("bar", "O'Malley", escape_result=False) == "O'Malley"
 
 
+def test_url_param_escaped_request_args() -> None:
+    """
+    Values read from the request query string are escaped the same way as
+    values from ``form_data`` (both are interpolated into the rendered SQL).
+    """
+    with current_app.test_request_context(query_string={"foo": "O'Brien"}):
+        cache = ExtraCache(dialect=dialect())
+        assert cache.url_param("foo") == "O''Brien"
+
+
+def test_url_param_unescaped_request_args() -> None:
+    """
+    ``escape_result=False`` still opts out of escaping for request-args values.
+    """
+    with current_app.test_request_context(query_string={"foo": "O'Brien"}):
+        cache = ExtraCache(dialect=dialect())
+        assert cache.url_param("foo", escape_result=False) == "O'Brien"
+
+
 def test_safe_proxy_primitive() -> None:
     """
     Test the ``safe_proxy`` helper with a function returning a ``str``.


### PR DESCRIPTION
### SUMMARY

`ExtraCache.url_param()` escapes values that come from `form_data["url_params"]` using the dialect's literal processor, but values read from the request query string took an **early return that skipped that escaping**. Both sources are interpolated into the rendered SQL, so this routes them through the same escaping path (still honoring `escape_result=False` for callers that opt out). It also means request-args values now consistently participate in the cache key.

### BEFORE / AFTER
`url_param('foo')` with `?foo=O'Brien` on a dialect that doubles quotes:
- **Before:** `O'Brien` (raw, from the request-args early return)
- **After:** `O''Brien` (escaped, same as the form-data path)

### TESTING INSTRUCTIONS
```bash
pytest tests/unit_tests/jinja_context_test.py -k url_param
```
Adds `test_url_param_escaped_request_args` and `test_url_param_unescaped_request_args` (12/12 url_param tests pass).

### ADDITIONAL INFORMATION
- [ ] Has associated issue: n/a
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)