### PR TITLE
chore(i18n): update french po file to match latest pot file version

### DIFF
--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -115,8 +115,8 @@ msgid ""
 " Set the opacity to 0 if you do not want to override the color specified "
 "in the GeoJSON"
 msgstr ""
-" Réglez l’opacité à 0 si vous ne voulez pas remplacer la couleur "
-"spécifiée dans le GeoJSON"
+"Réglez l'opacité à 0 si vous ne voulez pas remplacer la couleur spécifiée "
+"dans le GeoJSON"
 
 msgid " a dashboard OR "
 msgstr " un tableau de bord OU "
@@ -180,8 +180,8 @@ msgstr " pour marquer une colonne comme colonne temporelle"
 
 msgid " to open SQL Lab. From there you can save the query as a dataset."
 msgstr ""
-" pour ouvrir SQL Lab. À partir de là, vous pouvez enregistrer la requête "
-"sous forme d'ensemble de données."
+"pour ouvrir SQL Lab. À partir de là, vous pouvez enregistrer la requête "
+"sous forme de jeu de données."
 
 msgid " to see details."
 msgstr " pour voir les détails"
@@ -328,7 +328,7 @@ msgstr "%s %s"
 
 #, python-format
 msgid "%s ENCRYPTED EXTRA"
-msgstr "%s EXTRA CRYPTE"
+msgstr "%s CHIFFREMENT SUPPLEMENTAIRE"
 
 #, python-format
 msgid "%s Error"
@@ -360,7 +360,7 @@ msgstr "%s Sélectionné"
 
 #, python-format
 msgid "%s Selected (%s)"
-msgstr "%s Sélectionné"
+msgstr "%s Sélectionné (%s)"
 
 #, python-format
 msgid "%s Selected (Physical)"
@@ -491,14 +491,14 @@ msgstr "%s destinataires"
 #, python-format
 msgid "%s record..."
 msgid_plural "%s records..."
-msgstr[0] "%s enregistrement"
-msgstr[1] "%s enregistrements"
+msgstr[0] "%s enregistrement..."
+msgstr[1] "%s enregistrements..."
 
 #, python-format
 msgid "%s row"
 msgid_plural "%s rows"
-msgstr[0] "%s rangée"
-msgstr[1] "%s rangées"
+msgstr[0] "%s ligne"
+msgstr[1] "%s lignes"
 
 #, python-format
 msgid "%s s ago"
@@ -607,11 +607,11 @@ msgstr ""
 
 #, python-format
 msgid "... and %d more"
-msgstr "... et %s de plus"
+msgstr "... et %d autres"
 
 #, python-format
 msgid "... and %s more records"
-msgstr "... et %s enregistrement en plus"
+msgstr "... et %s autres enregistrements"
 
 #, python-format
 msgid "... and %s others"
@@ -621,7 +621,7 @@ msgid "0 Selected"
 msgstr "0 sélectionné"
 
 msgid "1 calendar day frequency"
-msgstr "Fréquence d’un jour civil"
+msgstr "Fréquence d'un jour civil"
 
 msgid "1 day"
 msgstr "1 jour"
@@ -669,10 +669,10 @@ msgid "1 year ago"
 msgstr "Il y a 1 an"
 
 msgid "1 year end frequency"
-msgstr "Fréquence de fin d’année"
+msgstr "Fréquence de fin d'année"
 
 msgid "1 year start frequency"
-msgstr "Fréquence de début d’année"
+msgstr "Fréquence de début d'année"
 
 msgid "10 minute"
 msgstr "10 minutes"
@@ -844,7 +844,7 @@ msgid "<new metric>"
 msgstr "<nouvelle mesure>"
 
 msgid "<new spatial>"
-msgstr "<nouvel element spatial>"
+msgstr "<new spatial>"
 
 msgid "<no type>"
 msgstr "<pas de type>"
@@ -883,8 +883,7 @@ msgstr "Liste de Colonnes séparée par des virgules à traiter comme des dates"
 
 msgid "A comma-separated list of schemas that files are allowed to upload to."
 msgstr ""
-"Une liste de schémas séparés par des virgules autorisés pour le "
-"téléchargement."
+"Une liste de schémas séparés par des virgules autorisés pour le chargement."
 
 msgid "A database port is required when connecting via SSH Tunnel."
 msgstr "Un port de base de donnée est requis lors de la connexion en SSH."
@@ -894,7 +893,7 @@ msgstr "Une base de données avec le même nom existe déjà."
 
 msgid "A date is required when using custom date shift"
 msgstr ""
-"Une date est requise lors de l’utilisation d’un décalage de date "
+"Une date est requise lors de l'utilisation d'un décalage de date "
 "personnalisé"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
@@ -930,7 +929,7 @@ msgid ""
 "empty will allow embedding from any domain."
 msgstr ""
 "Une liste de noms de domaine qui peuvent intégrer ce tableau de bord. "
-"Laisser ce champ vide permettra l’intégration à partir de n’importe quel "
+"Laisser ce champ vide permettra l'intégration à partir de n'importe quel "
 "domaine."
 
 msgid "A list of subjects who can alter the chart. Searchable by name."
@@ -984,9 +983,9 @@ msgid ""
 "angle, and the value represented by any wedge is illustrated by its area,"
 " rather than its radius or sweep angle."
 msgstr ""
-"Un tableau de coordonnées polaires où le cercle est divisé en coins "
-"d’angle égal et où la valeur représentée par n’importe quel coin est "
-"illustrée par sa zone, plutôt que par son rayon ou son angle de balayage."
+"Un tableau de coordonnées polaires où le cercle est divisé en coins d'angle "
+"égal et où la valeur représentée par n'importe quel coin est illustrée par "
+"sa zone, plutôt que par son rayon ou son angle de balayage."
 
 msgid "A readable URL for your dashboard"
 msgstr "Une URL lisible pour votre tableau de bord"
@@ -999,7 +998,7 @@ msgid "A report named \"%(name)s\" already exists"
 msgstr "Un rapport nommé \"%(name)s\" existe déjà"
 
 msgid "A reusable dataset will be saved with your chart."
-msgstr "Un ensemble de données réutilisable sera enregistré avec votre graphique."
+msgstr "Un jeu de données réutilisable sera enregistré avec votre graphique."
 
 msgid ""
 "A set of parameters that become available in the query using Jinja "
@@ -1071,26 +1070,27 @@ msgid "AND"
 msgstr "ET"
 
 msgid "API Key Created"
-msgstr "Clé d'API créée"
+msgstr "Clé API créée"
 
 msgid "API Keys"
-msgstr "Clé d'API"
+msgstr "Clés API"
 
 msgid "API key created successfully"
-msgstr "Clé d'API créée avec succès"
+msgstr "Clé API créée avec succès"
 
 msgid "API key name is required"
-msgstr "Un nom est nécessaire pour la clé d'API"
+msgstr "Le nom de la clé API est obligatoire"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
 # sr_Latn]
 msgid "API key revoked successfully"
-msgstr "Clé API révoquée avec succès"
+msgstr "La clé API a été révoquée avec succès."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
 # sr_Latn]
 msgid "API keys allow scoped programmatic access to Superset."
-msgstr "Les clés API permettent un accès programmatique limité à Superset."
+msgstr ""
+"Les clés API permettent un accès avec un périmètre restreint à Superset."
 
 msgid "APR"
 msgstr "APR"
@@ -1114,7 +1114,7 @@ msgid "Access"
 msgstr "Accès"
 
 msgid "Access token"
-msgstr "Jeton d’accès"
+msgstr "Jeton d'accès"
 
 msgid "Account"
 msgstr "Compte"
@@ -1237,13 +1237,13 @@ msgstr "Ajouter une autre méthode de notification"
 
 msgid "Add calculated columns to dataset in \"Edit datasource\" modal"
 msgstr ""
-"Ajouter des colonnes calculées au ensemble de données dans le modal « "
-"Modifier la source de données »"
+"Ajouter des colonnes calculées au jeu de données dans le modal « Modifier "
+"la source de données »"
 
 msgid "Add calculated temporal columns to dataset in \"Edit datasource\" modal"
 msgstr ""
-"Ajouter des colonnes temporelles calculées au ensemble de données dans le"
-" modal « Modifier la source de données »"
+"Ajouter des colonnes temporelles calculées au jeu de données dans le modal "
+"« Modifier la source de données »"
 
 msgid "Add certification details for this dashboard"
 msgstr "Ajouter des détails de certification pour ce tableau de bord"
@@ -1324,8 +1324,8 @@ msgstr "Ajouter une mesure"
 
 msgid "Add metrics to dataset in \"Edit datasource\" modal"
 msgstr ""
-"Ajouter des mesures au ensemble de données dans le modal « Modifier la "
-"source de données »"
+"Ajouter des mesures au jeu de données dans le modal « Modifier la source de "
+"données »"
 
 msgid "Add new color formatter"
 msgstr "Ajouter un nouveau formateur de couleur"
@@ -1334,7 +1334,7 @@ msgid "Add new formatter"
 msgstr "Ajouter un nouveau formateur"
 
 msgid "Add numbered column"
-msgstr "Ajouter une colonne numérotée"
+msgstr "Ajouter le numéro de la colonne"
 
 msgid "Add or edit display controls"
 msgstr "Ajouter ou modifier les contrôles d'affichage"
@@ -1389,7 +1389,7 @@ msgstr[1] "%s nouvelles colonnes ajoutées au jeu de données virtuel"
 #, python-format
 msgid "Added to 1 dashboard"
 msgid_plural "Added to %s dashboards"
-msgstr[0] "Ajouté à 1 tableau de bord"
+msgstr[0] "Ajouté à %s tableau de bord"
 msgstr[1] "Ajouté à %s tableaux de bord"
 
 msgid "Additional Parameters"
@@ -1544,17 +1544,17 @@ msgid "Alert on grace period"
 msgstr "Alerte sur la période de grace"
 
 msgid "Alert query returned a non-number value."
-msgstr "La requête d’alerte a retourné une valeur non numérique."
+msgstr "La requête d'alerte a retourné une valeur non numérique."
 
 msgid "Alert query returned more than one column."
-msgstr "La requête d’alerte a retourné plus d'une colonne."
+msgstr "La requête d'alerte a retourné plus d'une colonne."
 
 #, python-format
 msgid "Alert query returned more than one column. %(num_cols)s columns returned"
 msgstr "La requête a retourné plus d'une colonne. %(num_cols)s colonnes retournées"
 
 msgid "Alert query returned more than one row."
-msgstr "La requête d’alerte a retourné plus d'une rangée."
+msgstr "La requête d'alerte a retourné plus d'une ligne."
 
 #, python-format
 msgid "Alert query returned more than one row. %(num_rows)s rows returned"
@@ -1658,7 +1658,7 @@ msgstr ""
 "persisteront pas la prochaine fois qu’ils ouvriront le tableau."
 
 msgid "Allow file uploads to database"
-msgstr "Autoriser des téléchargements de fichier vers la base de donnée"
+msgstr "Autoriser le chargement de fichier vers la base de donnée"
 
 msgid "Allow node selections"
 msgstr "Autoriser les sélections multiples"
@@ -1737,7 +1737,7 @@ msgid "An error occurred"
 msgstr "Un erreur s'est produite"
 
 msgid "An error occurred saving dataset"
-msgstr "Une erreur s'est produite durant la sauvegarde du ensemble de données"
+msgstr "Une erreur s'est produite durant la sauvegarde du jeu de données"
 
 msgid "An error occurred when running alert query"
 msgstr "Une erreur s'est produite lors de l'exécution de la requête d'alerte"
@@ -1752,7 +1752,7 @@ msgid "An error occurred while accessing the value."
 msgstr "Une erreur s'est produite lors de l'accès à la valeur."
 
 msgid "An error occurred while adding semantic views"
-msgstr ""
+msgstr "Une erreur s'est produite lors de la sauvegarde de la vue sémantique"
 
 msgid ""
 "An error occurred while collapsing the table schema. Please contact your "
@@ -1784,7 +1784,7 @@ msgid "An error occurred while deleting the extension."
 msgstr "Une erreur s'est produite lors de la suppression de l'extension."
 
 msgid "An error occurred while deleting the value."
-msgstr "Une erreur s'est produite durant la suppression de la valeur."
+msgstr "Une erreur s'est produite lors de la suppression de la valeur."
 
 msgid ""
 "An error occurred while expanding the table schema. Please contact your "
@@ -1795,7 +1795,8 @@ msgstr ""
 
 #, python-format
 msgid "An error occurred while fetching %s"
-msgstr "Une erreur s'est produite durant la récupération de %s"
+msgstr ""
+"Une erreur s'est produite lors de la récupération des informations: %s"
 
 #, python-format
 msgid "An error occurred while fetching %s info: %s"
@@ -1809,11 +1810,12 @@ msgstr ""
 
 #, python-format
 msgid "An error occurred while fetching %s values: %s"
-msgstr "Une erreur s'est produite lors de la récupération des %s valeurs : %s"
+msgstr "Une erreur s'est produite lors de l'extraction de %s valeurs : %s"
 
 #, python-format
 msgid "An error occurred while fetching %s: %s"
-msgstr "Une erreur s'est produite durant la récupération de %s : %s"
+msgstr ""
+"Une erreur s'est produite durant la récupération des informations %s : %s"
 
 #, python-format
 msgid "An error occurred while fetching %ss: %s"
@@ -1829,6 +1831,7 @@ msgstr "Une erreur s'est produite lors de la récupération des thèmes disponib
 
 msgid "An error occurred while fetching available views"
 msgstr ""
+"Une erreur s'est produite lors de la récupération des vues disponibles"
 
 #, python-format
 msgid "An error occurred while fetching chart editor values: %s"
@@ -1843,7 +1846,7 @@ msgstr ""
 "du graphique : %s"
 
 msgid "An error occurred while fetching connections"
-msgstr "Une erreur s'est produite lors de la récupération des connexions"
+msgstr "Une erreur s'est produite lors de la récupération des connections."
 
 #, python-format
 msgid "An error occurred while fetching created by values: %s"
@@ -1885,8 +1888,8 @@ msgstr ""
 #, python-format
 msgid "An error occurred while fetching dataset datasource values: %s"
 msgstr ""
-"Une erreur s'est produite lors de la récupération des valeurs des sources"
-" de données : %s"
+"Une erreur s'est produite lors de la récupération du jeu de données "
+"relatives à la source de données : %s"
 
 #, python-format
 msgid "An error occurred while fetching dataset editor values: %s"
@@ -1897,8 +1900,8 @@ msgstr ""
 #, python-format
 msgid "An error occurred while fetching dataset related data: %s"
 msgstr ""
-"Une erreur s'est produite lors de la récupération des données relatives "
-"au ensemble de données : %s"
+"Une erreur s'est produite lors de la récupération des données relatives au "
+"jeu de données : %s"
 
 #, python-format
 msgid "An error occurred while fetching editor values: %s"
@@ -1923,7 +1926,7 @@ msgstr ""
 
 msgid "An error occurred while fetching semantic layer types"
 msgstr ""
-"Une erreur s'est produite lors de la récupération des type de couches "
+"Une erreur s'est produite lors de la récupération des types de couches "
 "sémantiques"
 
 msgid "An error occurred while fetching semantic layers"
@@ -1935,22 +1938,25 @@ msgstr "Une erreur s'est produite lors de la récupération de l'état de l'ongl
 #, python-format
 msgid "An error occurred while fetching table metadata for %s"
 msgstr ""
-"Une erreur s'est produite lors de la récupération des métadonnées du "
-"tableau pour %s"
+"Une erreur s'est produite lors de l'extraction des métadonnées de la table "
+"pour %s"
 
 msgid "An error occurred while fetching the configuration schema"
-msgstr "Une erreur s'est produite lors de la recherche des noms de fonctions."
+msgstr ""
+"Une erreur s'est produite lors de la récupération des schémas de "
+"configuration."
 
 msgid "An error occurred while fetching the runtime schema"
-msgstr "Une erreur s'est produite lors de la récupération du schema d'exécution"
+msgstr ""
+"Une erreur s'est produite lors de la récupération des schéma d'exécution."
 
 msgid "An error occurred while fetching the semantic layer"
 msgstr "Une erreur s'est produite lors de la récupération de la couche sémantique"
 
 msgid "An error occurred while fetching the semantic view structure"
 msgstr ""
-"Une erreur s'est produite lors de la récupération de la structure de "
-"lavue sémantique"
+"Une erreur s'est produite lors de la récupération de la structure de la vue "
+"sémantique"
 
 #, python-format
 msgid "An error occurred while fetching theme datasource values: %s"
@@ -1984,8 +1990,8 @@ msgid ""
 "An error occurred while loading SQL Lab. This may be caused by a "
 "corrupted query state."
 msgstr ""
-"Une erreur s'est produite lors du chargement de SQL Lab. Cela peut être "
-"dû à un état de requête corrompu."
+"Une erreur s'est produite lors du chargement du SQL Lab. Cela peut être dû "
+"à un état de requête corrompu."
 
 msgid "An error occurred while loading dashboard information."
 msgstr ""
@@ -2006,7 +2012,7 @@ msgstr "Une erreur s'est produite lors de la suppression des journaux "
 
 msgid "An error occurred while refreshing the configuration schema"
 msgstr ""
-"Une erreur s'est produite pendant la rafraîchissement du schema de "
+"Une erreur s'est produite lors de l'actualisation du schéma de "
 "configuration"
 
 msgid "An error occurred while removing query. Please contact your administrator."
@@ -2036,10 +2042,9 @@ msgid ""
 "losing your changes, please save your query using the \"Save Query\" "
 "button."
 msgstr ""
-"Une erreur s'est produite lors de l'enregistrement de votre requête dans "
-"le programme dorsal. Pour éviter de perdre vos modifications, veuillez "
-"enregistrer votre requête en utilisant le bouton « Enregistrer la requête"
-" »."
+"Une erreur s'est produite lors de l'enregistrement de votre requête dans le "
+"serveur. Pour éviter de perdre vos modifications, veuillez enregistrer "
+"votre requête en utilisant le bouton « Enregistrer la requête »."
 
 #, python-format
 msgid "An error occurred while syncing permissions for %s: %s"
@@ -2052,7 +2057,8 @@ msgid "An error occurred while updating the extension."
 msgstr "Une erreur s'est produite lors de la mise à jour de l'extension."
 
 msgid "An error occurred while updating the semantic layer"
-msgstr "Une erreur s'est produite durant la mise à jour de la vue sémantique."
+msgstr ""
+"Une erreur s'est produite durant la mise à jour de la couche sémantique."
 
 msgid "An error occurred while updating the value."
 msgstr "Une erreur s'est produite durant la mise à jour de la valeur."
@@ -2195,7 +2201,8 @@ msgid "Any"
 msgstr "Tout"
 
 msgid "Any additional detail to show in the certification tooltip."
-msgstr "Tout détail supplémentaire à afficher dans l’infobulle de certification."
+msgstr ""
+"Tout détail supplémentaire à afficher dans l'infobulle de certification."
 
 msgid ""
 "Any color palette selected here will override the colors applied to this "
@@ -2260,9 +2267,9 @@ msgid ""
 " the histogram columns is displayed if the \"Show cell bars\" flag is "
 "enabled."
 msgstr ""
-"S'applique uniquement lorsque le formatage « Barres de cellule » est "
-"sélectionné : l'arrière-plan des colonnes de l'histogramme est affiché si"
-" l'option « Afficher les barres de cellule » est activée."
+"S'applique uniquement lorsque le formatage « Barres de cellule » est "
+"sélectionné : l'arrière-plan des colonnes de l'histogramme est affiché si "
+"l'option « Afficher les barres de cellule » est activée."
 
 msgid "Apply"
 msgstr "Appliquer"
@@ -2287,7 +2294,7 @@ msgid ""
 "to target specific components."
 msgstr ""
 "Appliquez du CSS personnalisé au tableau de bord. Utilisez des noms de "
-"classes ou des sélecteurs d’éléments pour cibler des composants "
+"classes ou des sélecteurs d'éléments pour cibler des composants "
 "spécifiques."
 
 msgid "Apply filters"
@@ -2413,8 +2420,8 @@ msgid ""
 "Are you sure you want to revoke this API key? This action cannot be "
 "undone."
 msgstr ""
-"Voulez-vous vraiment supprimer cette clé d'API ? Cette action est "
-"irréversible."
+"Voulez-vous vraiment révoquer cette clé API ? Cette action ne peut pas être "
+"annulée."
 
 msgid "Are you sure you want to save and apply changes?"
 msgstr "Voulez-vous vraiment sauvegarder et appliquer les changements?"
@@ -2504,7 +2511,7 @@ msgstr ""
 
 #, python-format
 msgid "Auto refresh set to %s seconds"
-msgstr "Fréquence de rafraîchissement définie à %s secondes"
+msgstr "La fréquence de rafraîchissement définie à %s secondes"
 
 msgid "Auto-detect"
 msgstr "Auto détection"
@@ -2551,7 +2558,7 @@ msgid "Average value"
 msgstr "Valeur moyenne"
 
 msgid "Awaiting filter selection"
-msgstr "En attente de sélection du filtre"
+msgstr "En attente de la sélection d'un filtre"
 
 msgid "Axis"
 msgstr "Axe"
@@ -2563,7 +2570,7 @@ msgid "Axis Format"
 msgstr "Format de l'axe"
 
 msgid "Axis Title"
-msgstr "Titre de l’axe"
+msgstr "Titre de l'axe"
 
 msgid "Axis ascending"
 msgstr "Axe ascendant"
@@ -2590,7 +2597,7 @@ msgid "Back to all"
 msgstr "Retour à tout"
 
 msgid "Backend"
-msgstr "Programme dorsal"
+msgstr "Serveur"
 
 msgid "Background Color"
 msgstr "Couleur d'arrière plan"
@@ -2631,20 +2638,19 @@ msgid "Base height"
 msgstr "Hauteur de base"
 
 msgid "Base layer map style. Accepts a MapLibre-compatible style URL."
-msgstr "Style de la couche de base de la carte. Accepte une URL de style MapLibre"
+msgstr ""
+"Style de la couche de base de la carte. Accepte une URL compatible Maplibre"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Base layer map style. Accepts a Mapbox style URL (mapbox://styles/...)."
 msgstr ""
-"Style de carte de la couche de base. Accepte une URL de style Mapbox "
-"(mapbox://styles/...)."
+"Style de la couche de base de la carte. Accepte une URL compatible Mapbox"
 
 #, python-format
 msgid "Base layer map style. See MapLibre documentation: %s"
 msgstr ""
-"Style de la couche de base de la carte. Voir la documentation MapLibre : "
-"%s"
+"Style de la couche de base de la carte. Voir la documentation MapLibre : %s"
 
 msgid "Base slope"
 msgstr "Pente de base"
@@ -2716,8 +2722,8 @@ msgstr "En bas à gauche"
 
 msgid "Bottom margin, in pixels, allowing for more room for axis labels"
 msgstr ""
-"Marge inférieure, en pixels, offrant plus d’espace pour les étiquettes "
-"d’axe"
+"Marge inférieure, en pixels, offrant plus d'espace pour les étiquettes "
+"d'axe"
 
 msgid "Bottom right"
 msgstr "En bas à droite"
@@ -2754,10 +2760,10 @@ msgid ""
 "defined based on the min/max of the data. Note that this feature will "
 "only expand the axis range. It won't narrow the data's extent."
 msgstr ""
-"Limites de l'axe des ordonnées. Lorsqu'elles sont laissées vides, les "
-"limites sont définies dynamiquement sur la base des valeurs min/max des "
-"données. Notez que cette fonction ne fait qu'étendre la plage de l'axe. "
-"Elle ne réduira pas l'étendue des données."
+"Limites de l'axe Y. Lorsqu'elles sont laissées vides, les limites sont "
+"définies dynamiquement sur la base des valeurs min/max des données. Notez "
+"que cette fonction ne fait qu'étendre la plage de l'axe. Elle ne réduira "
+"pas l'étendue des données."
 
 msgid ""
 "Bounds for the axis. When left empty, the bounds are dynamically defined "
@@ -2775,10 +2781,10 @@ msgid ""
 "feature will only expand the axis range. It won't narrow the data's "
 "extent."
 msgstr ""
-"Limites de l'axe des ordonnées principal. Lorsqu'elles sont laissées "
-"vides, les limites sont définies dynamiquement sur la base des valeurs "
-"min/max des données. Notez que cette fonction ne fait qu'étendre la plage"
-" de l'axe. Elle ne réduira pas l'étendue des données."
+"Limites de l'axe Y principal. Lorsqu'elles sont laissées vides, les limites "
+"sont définies dynamiquement sur la base des valeurs min/max des données. "
+"Notez que cette fonction ne fait qu'étendre la plage de l'axe. Elle ne "
+"réduira pas l'étendue des données."
 
 msgid ""
 "Bounds for the secondary Y-axis. Only works when Independent Y-axis\n"
@@ -2788,11 +2794,11 @@ msgid ""
 "will only expand\n"
 "                the axis range. It won't narrow the data's extent."
 msgstr ""
-"Limites de l'axe secondaire des ordonnées. Ne fonctionne que si les "
-"limites de l'axe Y indépendant sont activées. Si cette option n'est pas "
-"activée, les limites sont définies dynamiquement sur la base des valeurs "
-"min/max des données. Notez que cette fonction ne fait qu'étendre la plage"
-" de l'axe. Elle ne réduira pas l'étendue des données."
+"Limites de l'axe Y secondaire. Ne fonctionne que si les limites de l'axe Y "
+"indépendant sont activées. Si cette option n'est pas activée, les limites "
+"sont définies dynamiquement sur la base des valeurs min/max des données. "
+"Notez que cette fonction ne fait qu'étendre la plage de l'axe. Elle ne "
+"réduira pas l'étendue des données."
 
 msgid "Box Plot"
 msgstr "Diagramme de quartiles"
@@ -2801,7 +2807,7 @@ msgid "Breakdowns"
 msgstr "Ventilations"
 
 msgid "Breakpoint Metric"
-msgstr "Métrique de point de rupture"
+msgstr "Point de rupture de la mesure"
 
 msgid ""
 "Breaks down the series by the category specified in this control.\n"
@@ -2837,7 +2843,7 @@ msgid "Bucket break points"
 msgstr "Points de rupture du seau"
 
 msgid "Bulk select"
-msgstr "Sélectionner plusieurs"
+msgstr "Sélection multiple"
 
 msgid "Bulk tag"
 msgstr "Étiquetage en lot"
@@ -2864,7 +2870,7 @@ msgid "By key: use column names as sorting key"
 msgstr "Par clé : utilisez les noms de colonne comme clé de tri"
 
 msgid "By key: use row names as sorting key"
-msgstr "Par clé : utilisez les noms de rangée comme clé de tri"
+msgstr "Par clé : utilisez les noms de ligne comme clé de tri"
 
 msgid "By value: use metric values as sorting key"
 msgstr "Par valeur : utilisez les valeurs mesures comme clé de tri"
@@ -2906,9 +2912,10 @@ msgid ""
 " not applying, ask your Superset administrator to adjust the HTML "
 "sanitization configuration."
 msgstr ""
-"Les styles CSS peuvent être supprimés par l'assainissement HTML côté "
-"serveur. Si les styles ne s'appliquent pas, demandez à votre "
-"administrateur Superset d'ajuster la configuration d'assainissement HTML."
+"Les styles CSS peuvent être supprimés par le nettoyage HTML réalisé par le "
+"serveur. Si les styles ne sont pas appliqués, contacter votre "
+"adminsitrateur Superset pour ajuster la configuration du nettoyage HTML "
+"(HTML sanitization)."
 
 msgid "CSS template"
 msgstr "Modèles CSS"
@@ -2929,7 +2936,7 @@ msgid "CSV file downloaded successfully"
 msgstr "Le fichier CSV a été téléchargé avec succès."
 
 msgid "CSV upload"
-msgstr "Téléversement CSV"
+msgstr "Charger un CSV"
 
 msgid "CTAS & CVAS SCHEMA"
 msgstr "SCHÉMA CTAS ET CVAS"
@@ -2968,9 +2975,9 @@ msgid ""
 "Cache data separately for each user based on their data access roles and "
 "permissions. When disabled, a single cache will be used for all users."
 msgstr ""
-"Mettre en cache les données séparément pour chaque utilisateur en "
-"fonction de ses rôles et permissions d'accès aux données. Lorsque "
-"désactivé, un cache unique sera utilisé pour tous les utilisateurs."
+"Conserver les données en cache pour chaque utilisateur en se basant sur "
+"leurs roles et leurs permissions. Si désactivée, un seul cache sera utilisé "
+"pour tous les utilisateurs"
 
 msgid "Cache timeout"
 msgstr "Délai d'inactivité et reprise du cache"
@@ -3038,7 +3045,7 @@ msgstr "Impossible d'accéder à la requête"
 msgid "Cannot delete a database that has datasets attached"
 msgstr ""
 "Impossible de supprimer une base de données à laquelle sont attachés des "
-"ensembles de données"
+"jeux de données"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 msgid ""
@@ -3082,7 +3089,7 @@ msgstr "Impossible de modifier les thèmes système."
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Cannot nest folders in default folders"
-msgstr "Impossible d'imbriquer des dossiers dans les dossiers par défaut"
+msgstr "Impossible d'imbriquer les dossiers dans les dossiers par défaut."
 
 #, python-format
 msgid "Cannot parse time string [%(human_readable)s]"
@@ -3145,7 +3152,7 @@ msgstr "Contenu de cellule"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Cell layout & styling"
-msgstr "Mise en page et style des cellules"
+msgstr "Format et disposition de la cellule"
 
 msgid "Cell limit"
 msgstr "Limite de la cellule"
@@ -3179,10 +3186,10 @@ msgid "Certified by %s"
 msgstr "Certifié par %s"
 
 msgid "Change order of columns."
-msgstr "Modifier l’ordre des colonnes."
+msgstr "Modifier l'ordre des colonnes."
 
 msgid "Change order of rows."
-msgstr "Modifier l’ordre des rangées."
+msgstr "Modifier l'ordre des lignes."
 
 msgid "Changed by"
 msgstr "Modifié par"
@@ -3203,17 +3210,17 @@ msgid ""
 "Changing the dataset may break the chart if the chart relies on columns "
 "or metadata that does not exist in the target dataset"
 msgstr ""
-"La modification de l'ensemble de données peut briser le graphique si "
-"celui-ci repose sur des colonnes ou des métadonnées qui n'existent pas "
-"dans l'ensemble de données cible"
+"La modification du jeu de données peut briser le graphique si celui-ci "
+"repose sur des colonnes ou des métadonnées qui n'existent pas dans le jeu "
+"de données cible"
 
 msgid ""
 "Changing these settings will affect all charts using this dataset, "
 "including charts owned by other people."
 msgstr ""
 "La modification de ces paramètres affectera tous les graphiques qui "
-"utilisent cet ensemble de données, y compris les graphiques qui "
-"appartiennent à d'autres personnes."
+"utilisent ce jeu de données, y compris les graphiques qui appartiennent à "
+"d'autres personnes."
 
 msgid "Changing this Dashboard is forbidden"
 msgstr "Modifier ce tableau de bord est interdit"
@@ -3225,10 +3232,10 @@ msgid "Changing this control takes effect instantly"
 msgstr "Modifier ce contrôle prend effet instantanément"
 
 msgid "Changing this dataset is forbidden"
-msgstr "Modifier cet ensemble de données est interdit"
+msgstr "Modifier ce jeu de données est interdit"
 
 msgid "Changing this dataset is forbidden."
-msgstr "Modifier cet ensemble de données est interdit."
+msgstr "Modifier ce jeu de données est interdit."
 
 msgid "Changing this datasource is forbidden"
 msgstr "Modifier cette source de données est interdit"
@@ -3237,7 +3244,7 @@ msgid "Changing this report is forbidden"
 msgstr "Modifier ce rapport est interdit"
 
 msgid "Changing this semantic layer is forbidden"
-msgstr "Modifier cette couche est interdit"
+msgstr "Modifier cette couche sémantique est interdit"
 
 msgid "Changing this semantic view is forbidden"
 msgstr "Modifier cette vue sémantique est interdit"
@@ -3323,7 +3330,7 @@ msgstr "Le graphique n'a pas pu être mis à jour."
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Chart customization to control deck.gl layer visibility"
 msgstr ""
-"Personnalisation du graphique pour contrôler la visibilité des couches "
+"Personnalisation du graphique pour contrôler la couche de visibilité "
 "deck.gl"
 
 msgid "Chart customization value is required"
@@ -3380,7 +3387,7 @@ msgid "Chart type"
 msgstr "Type de graphique"
 
 msgid "Chart type requires a dataset"
-msgstr "Le type de graphique nécessite un ensemble de données"
+msgstr "Le type de graphique nécessite un jeu de données"
 
 msgid "Chart was saved but could not be added to the selected tab."
 msgstr ""
@@ -3424,7 +3431,7 @@ msgstr ""
 "hauteur"
 
 msgid "Child label position"
-msgstr "Position de l’étiquette enfant"
+msgstr "Position de l'étiquette enfant"
 
 msgid "Choice of [Label] must be present in [Group By]"
 msgstr "Le choix de [Étiquette] doit être présent dans [Grouper par]"
@@ -3461,7 +3468,7 @@ msgid "Choose a target"
 msgstr "Choisissez une cible"
 
 msgid "Choose already exists"
-msgstr "Choisissez 'existe déjà'"
+msgstr "La sélection existe déjà"
 
 msgid "Choose chart type"
 msgstr "Choisissez un type de graphique"
@@ -3478,8 +3485,8 @@ msgid ""
 "Choose from existing dashboard filters and select a value to refine your "
 "report results."
 msgstr ""
-"Choisissez parmi les filtres de tableau de bord existants et sélectionnez"
-" une valeur pour affiner les résultats de votre rapport."
+"Choisir depuis les filtres existant d'un tableau de bord et sélectionner "
+"une valeur pour préciser vos résultats."
 
 msgid "Choose how many X-Axis labels to show"
 msgstr "Choisir combien d'étiquettes afficher sur l'axe X"
@@ -3493,8 +3500,8 @@ msgid ""
 "Choose layers to hide from all deck.gl Multiple Layer charts in this "
 "dashboard."
 msgstr ""
-"Choisissez les couches à masquer dans tous les graphiques à couches "
-"multiples deck.gl de ce tableau de bord."
+"Choisir les calques à masquer de tous graphiques avec des calques multiples "
+"dans ce tableau de bord."
 
 msgid "Choose notification method and recipients."
 msgstr "Choisissez la méthode de notification et les destinataires."
@@ -3505,11 +3512,12 @@ msgstr "choisir une valeur comprise entre %(min)spx et %(max)spx"
 
 msgid "Choose one of the available databases from the panel on the left."
 msgstr ""
-"Choisissez l’une des bases de données disponibles dans le panneau de "
+"Choisissez l'une des bases de données disponibles dans le panneau de "
 "gauche."
 
 msgid "Choose one of the available databases on the left panel."
-msgstr "Choisir l’une des bases de données disponibles dans le panneau de gauche."
+msgstr ""
+"Choisir l'une des bases de données disponibles dans le panneau de gauche."
 
 msgid "Choose sheet name"
 msgstr "Choisir le nom de la feuille"
@@ -3530,8 +3538,8 @@ msgid ""
 "Choose values that should be treated as null. Warning: Hive database "
 "supports only a single value"
 msgstr ""
-"Liste des valeurs qui doivent être traitées comme nulles. Attention : La "
-"base de données Hive ne prend en charge qu'une seule valeur"
+"Liste Json des valeurs qui doivent être traitées comme nulles. Attention : "
+"La base de données Hive ne prend en charge qu'une seule valeur"
 
 msgid ""
 "Choose whether a country should be shaded by the metric, or assigned a "
@@ -3569,9 +3577,9 @@ msgid ""
 "Classic row-by-column spreadsheet like view of a dataset. Use tables to "
 "showcase a view into the underlying data or to show aggregated metrics."
 msgstr ""
-"Vue classique d'un ensemble de données, rangée par colonne, à la manière "
-"d'une feuille de calcul. Utilisez les tableaux pour présenter une vue des"
-" données sous-jacentes ou pour montrer des mesures agrégées."
+"Vue classique d'un jeu de données, ligne par colonne, à la manière d'une "
+"feuille de calcul. Utilisez les tableaux pour présenter une vue des données "
+"sous-jacentes ou pour montrer des mesures agrégées."
 
 msgid "Clause"
 msgstr "Clause"
@@ -3581,7 +3589,7 @@ msgstr "Effacer"
 
 #, python-format
 msgid "Clear %s filter"
-msgstr "Supprimer le filtre %s"
+msgstr "Reinitialiser %s filtre(s)"
 
 msgid "Clear Sort"
 msgstr "Effacer le tri"
@@ -3671,7 +3679,7 @@ msgid "Click to edit chart."
 msgstr "Cliquer pour modifier le graphique."
 
 msgid "Click to edit label"
-msgstr "Cliquer pour éditer le l’étiquette"
+msgstr "Cliquer pour éditer l'étiquette"
 
 msgid "Click to favorite/unfavorite"
 msgstr "Cliquez pour favori ou non"
@@ -3701,7 +3709,7 @@ msgid "Close all other tabs"
 msgstr "Fermer tous les autres onglets"
 
 msgid "Close color breakpoint editor"
-msgstr "Fermer l’éditeur de points d'arrêt de couleur"
+msgstr "Fermer l'éditeur de points d'arrêt de couleur"
 
 msgid "Close tab"
 msgstr "Fermer l'onglet"
@@ -3719,7 +3727,7 @@ msgid "Code Copied!"
 msgstr "Code copié!"
 
 msgid "Collapse"
-msgstr "Replier"
+msgstr "Réduire"
 
 msgid "Collapse All"
 msgstr "Tout réduire"
@@ -3746,13 +3754,13 @@ msgid "Color +/-"
 msgstr "Couleur +/-"
 
 msgid "Color By X-Axis"
-msgstr "Couleur pas axe X"
+msgstr "Colorer par axe X"
 
 msgid "Color By Y-Axis"
-msgstr "Couleur par axe Y"
+msgstr "Colorer par axe Y"
 
 msgid "Color Metric"
-msgstr "Mesure de couleur"
+msgstr "Couleur de la mesure"
 
 msgid "Color Range End"
 msgstr ""
@@ -3772,12 +3780,12 @@ msgstr "Étapes de couleur"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Color bars by x-axis"
-msgstr "Colorer les barres par axe x"
+msgstr "Couleur de l'axe X"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Color bars by y-axis"
-msgstr "Colorer les barres par axe y"
+msgstr "Couleur de l'axe Y"
 
 msgid "Color bounds"
 msgstr "Limites de couleur"
@@ -3796,10 +3804,10 @@ msgstr ""
 "g, b)'"
 
 msgid "Color for breakpoint"
-msgstr "Couleur pour point de rupture"
+msgstr "Couleur pour les points de rupture"
 
 msgid "Color metric"
-msgstr "Mesure de couleur"
+msgstr "Couleur de la mesure"
 
 msgid "Color of the source location"
 msgstr "Couleur de l'emplacement de la source"
@@ -3881,14 +3889,14 @@ msgid ""
 "Column to use as the index of the dataframe. If None is given, Index "
 "label is used."
 msgstr ""
-"Colonne à utiliser pour l'index de dataframe. Si laissé vide, l'étiquette"
-" d'index est utilisée."
+"Colonne à utiliser en tant qu'index des données. Laissez vide s'il n'y a "
+"pas de colonne d'index."
 
 msgid "Column type"
 msgstr "Type de données de la colonne"
 
 msgid "Columnar upload"
-msgstr "Fichier en colonnes"
+msgstr "Charger un fichier column (parquet)"
 
 msgid "Columns"
 msgstr "Colonnes"
@@ -3904,12 +3912,12 @@ msgid "Columns and metrics"
 msgstr "Colonnes et mesures"
 
 msgid "Columns and metrics should be inside folders"
-msgstr " Colonnes et métriques devraient être dans des dossiers"
+msgstr " Colonnes et mesures doivent être dans le dossier"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Columns folder can only contain column items"
-msgstr "Le dossier de colonnes ne peut contenir que des éléments de colonne"
+msgstr "Le dossier column ne peut contenir que des éléments colonnes"
 
 #, python-format
 msgid "Columns missing in dataset: %(invalid_columns)s"
@@ -3922,7 +3930,7 @@ msgstr "Colonnes absentes de la source de données : %(invalid_columns)s"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
 # sr_Latn]
 msgid "Columns should be inside folders"
-msgstr "Les colonnes doivent être à l'intérieur des dossiers"
+msgstr "Les colonnes doivent être à l'intérieur d'un dossier"
 
 msgid "Columns subtotal position"
 msgstr "Position du sous-total des colonnes"
@@ -3943,7 +3951,7 @@ msgid "Columns to group by on the columns"
 msgstr "Colonnes à regrouper sur les colonnes"
 
 msgid "Columns to group by on the rows"
-msgstr "Colonnes à regrouper sur les rangées"
+msgstr "Colonnes à regrouper sur les lignes"
 
 msgid "Columns to read"
 msgstr "Colonnes à lire"
@@ -4008,9 +4016,9 @@ msgid ""
 "data across multiple periods (like weeks or months) to show period-over-"
 "period trends and patterns."
 msgstr ""
-"Compare les métriques entre différentes périodes. Affiche les données de "
-"séries temporelles sur plusieurs périodes (comme des semaines ou des "
-"mois) pour montrer les tendances et les modèles d'une période à l'autre."
+"Compare les mesures entre deux périodes de temps différentes. Affiche les "
+"données des séries temporelles entre plusieurs périodes pour afficher des "
+"tendances entre période."
 
 msgid "Comparison"
 msgstr "Comparaison"
@@ -4056,10 +4064,10 @@ msgid "Configure Advanced Time Range "
 msgstr "Configuration de la plage horaire avancée "
 
 msgid "Configure Time Range: Current..."
-msgstr "Configurer l'intervalle de temps : Dernier…"
+msgstr "Configurer l'intervalle de temps : actuel..."
 
 msgid "Configure Time Range: Last..."
-msgstr "Configurer l'intervalle de temps : Dernier…"
+msgstr "Configurer l'intervalle de temps : Dernier..."
 
 msgid "Configure Time Range: Previous..."
 msgstr "Configurer intervalle de temps : Précédent…"
@@ -4089,7 +4097,7 @@ msgstr "Configurer la taille du graphique pour chaque niveau de zoom"
 
 msgid "Configure this dashboard to embed it into an external web application."
 msgstr ""
-"Configurez ce tableau de bord pour l’intégrer dans une application Web "
+"Configurez ce tableau de bord pour l'intégrer dans une application Web "
 "externe."
 
 msgid "Configure your how you overlay is displayed here."
@@ -4105,7 +4113,7 @@ msgid "Confirm overwrite"
 msgstr "Confirmer le remplacement"
 
 msgid "Confirm password"
-msgstr ""
+msgstr "Confirmer le mot de passe"
 
 msgid "Confirm save"
 msgstr "Confirmer la sauvegarde"
@@ -4156,7 +4164,7 @@ msgstr "Contient"
 # sr_Latn]
 #, python-format
 msgid "Contains text (ILIKE %x%)"
-msgstr "Contient du texte (ILIKE %x%)"
+msgstr "Contient le texte (ILIKE %x%)"
 
 msgid "Content format"
 msgstr "Format du contenu"
@@ -4192,7 +4200,7 @@ msgid "Copied to clipboard!"
 msgstr "Copié vers le presse-papier!"
 
 msgid "Copied!"
-msgstr "Copié!"
+msgstr "Copié !"
 
 msgid "Copy"
 msgstr "Copier"
@@ -4239,7 +4247,8 @@ msgid "Copy the current data"
 msgstr "Copier les données actuelles"
 
 msgid "Copy the identifier of the account you are trying to connect to."
-msgstr "Copier l'identifiant de compte auquel vous essayez de vous connecter."
+msgstr ""
+"Copiez l'identifiant du compte auquel vous essayez de vous connecter."
 
 msgid "Copy the name of the HTTP Path of your cluster."
 msgstr "Copiez le nom du chemin HTTP de votre grappe."
@@ -4282,7 +4291,7 @@ msgstr "Impossible de trouver l'objet viz"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 msgid "Could not load SQL Lab"
-msgstr "Impossible de charger SQL Lab"
+msgstr "Impossible de charger le SQL Lab"
 
 msgid "Could not load database driver"
 msgstr "Impossible de charger le pilote de la base de données"
@@ -4325,10 +4334,10 @@ msgid "Create"
 msgstr "Créer"
 
 msgid "Create API Key"
-msgstr "Créer une clé d'API"
+msgstr "Créer une clé API"
 
 msgid "Create Tag"
-msgstr "Créer une balise"
+msgstr "Créer une étiquette"
 
 msgid "Create a dataset"
 msgstr "Créer un jeu de données"
@@ -4337,8 +4346,8 @@ msgid ""
 "Create a dataset to begin visualizing your data as a chart or go to\n"
 "          SQL Lab to query your data."
 msgstr ""
-"Créer un ensemble de données pour commencer à visualiser vos données sous"
-" forme de graphique ou aller à SQL Lab pour interroger vos données."
+"Créer un jeu de données pour commencer à visualiser vos données sous forme "
+"de graphique ou aller à SQL Lab pour interroger vos données."
 
 msgid "Create a new Tag"
 msgstr "créer une nouvelle étiquette"
@@ -4360,7 +4369,7 @@ msgid "Create chart"
 msgstr "Créer un graphique"
 
 msgid "Create dataframe index"
-msgstr "Créer un index de cadre de données"
+msgstr "Créer un index du dataframe"
 
 msgid "Create dataset"
 msgstr "Créer un jeu de données"
@@ -4382,7 +4391,7 @@ msgstr "Créé par moi"
 
 #, python-format
 msgid "Created by: %s"
-msgstr "Créé par : %s"
+msgstr "Créé par: %s"
 
 msgid "Created on"
 msgstr "Créé le"
@@ -4400,12 +4409,12 @@ msgid "Crimson"
 msgstr "Cramoisi"
 
 msgid "Cross-filter column"
-msgstr "Colonne du filtrage croisé"
+msgstr "Colonne filtrage croisé"
 
 msgid "Cross-filter will be applied to all of the charts that use this dataset."
 msgstr ""
-"Le filtre croisé sera appliqué à tous les graphiques qui utilisent cet "
-"ensemble de données."
+"Le filtre croisé sera appliqué à tous les graphiques qui utilisent ce jeu "
+"de données."
 
 msgid "Cross-filtering is not enabled for this dashboard."
 msgstr "Le filtrage croisé n'est pas activé pour ce tableau de bord."
@@ -4429,7 +4438,7 @@ msgid "Currency code column"
 msgstr "Colonne du code de devise"
 
 msgid "Currency format"
-msgstr "Format de devise"
+msgstr "Format de la devise"
 
 msgid "Currency prefix or suffix"
 msgstr "Préfixe ou suffixe de la devise"
@@ -4441,7 +4450,7 @@ msgid "Current"
 msgstr "Actuel"
 
 msgid "Current Zoom"
-msgstr "Zoom courant"
+msgstr "Zoom actuel"
 
 msgid "Current day"
 msgstr "Aujourd'hui"
@@ -4476,18 +4485,18 @@ msgstr "SQL personnalisé"
 
 msgid "Custom SQL ad-hoc metrics are not enabled for this dataset"
 msgstr ""
-"Les mesures SQL ponctuelles personnalisées ne sont pas activées pour cet "
-"ensemble de données"
+"Les mesures SQL ponctuelles personnalisées ne sont pas activées pour ce jeu "
+"de données"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Custom SQL fields cannot be parsed as a single SQL statement."
 msgstr ""
-"Les champs SQL personnalisés ne peuvent pas être analysés comme une seule"
-" instruction SQL."
+"Les champs SQL personnalisés ne peuvent pas être traités en tant que seule "
+"instruction SQL"
 
 msgid "Custom SQL fields cannot contain set operations."
-msgstr "Les champs SQL personnalisés ne peuvent pas contenir de sous-requêtes."
+msgstr "Les champs SQL personnalisés ne peuvent pas définir d'opérations."
 
 msgid "Custom SQL fields cannot contain sub-queries."
 msgstr "Les champs SQL personnalisés ne peuvent pas contenir de sous-requêtes."
@@ -4521,17 +4530,17 @@ msgid "Custom..."
 msgstr "Personnalisé"
 
 msgid "Customization and styling"
-msgstr "Personnalisation et styles"
+msgstr "Personnalisation et style"
 
 msgid "Customization type"
 msgstr "Type de personnalisation"
 
 msgid "Customization value is required"
-msgstr "La valeur du filtre est requise"
+msgstr "La valeur personnalisée est requise"
 
 #, python-format
 msgid "Customizations out of scope (%d)"
-msgstr "Filtres hors de portée (%d)"
+msgstr "Personnalisation hors de portée (%d)"
 
 msgid "Customize"
 msgstr "Personnaliser"
@@ -4558,8 +4567,8 @@ msgid ""
 "Customize the label displayed for decreasing values in the chart tooltips"
 " and legend."
 msgstr ""
-"Personnalisez l'étiquette affichée pour les valeurs décroissantes dans "
-"les info-bulles et la légende du graphique."
+"Personnaliser le label affiché pour les valeurs décroissantes dans "
+"l'info-bulle du graphique et la légende."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -4567,8 +4576,8 @@ msgid ""
 "Customize the label displayed for increasing values in the chart tooltips"
 " and legend."
 msgstr ""
-"Personnalisez l'étiquette affichée pour les valeurs croissantes dans les "
-"info-bulles et la légende du graphique."
+"Personnaliser le label affiché pour les valeurs croissantes dans "
+"l'info-bulle du graphique et la légende."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -4576,8 +4585,8 @@ msgid ""
 "Customize the label displayed for total values in the chart tooltips, "
 "legend, and chart axis."
 msgstr ""
-"Personnalisez l'étiquette affichée pour les valeurs totales dans les "
-"info-bulles, la légende et l'axe du graphique."
+"Personnaliser le label affiché pour les valeurs totales dans l'info-bulle "
+"du graphique, la légende et les axes du graphique."
 
 msgid "Customize tooltips template"
 msgstr "Personnaliser le modèle d'infobulles"
@@ -4600,10 +4609,10 @@ msgstr ""
 "les grands nombres"
 
 msgid "D3 time format for datetime columns"
-msgstr "Format d'heure D3 pour les colonnes d’horodatage"
+msgstr "Format d'heure D3 pour les colonnes d'horodatage"
 
 msgid "D3 time format syntax: https://github.com/d3/d3-time-format"
-msgstr "Syntaxe de format d’heure D3 : https://github.com/d3/d3-time-format"
+msgstr "Syntaxe de format d'heure D3 : https://github.com/d3/d3-time-format"
 
 msgid "DATETIME"
 msgstr "HORODATAGE"
@@ -4632,7 +4641,7 @@ msgid "Dark"
 msgstr "Sombre"
 
 msgid "Dark (Carto)"
-msgstr "Sombre (Carto)"
+msgstr "Sombre (carte)"
 
 msgid "Dark Cyan"
 msgstr "Cyan foncé"
@@ -4645,7 +4654,7 @@ msgstr "Tableau de bord"
 
 #, python-format
 msgid "Dashboard %(dashboard_id)s not found"
-msgstr "Graphique %(dashboard_id)s non trouvé"
+msgstr "Tableau de bord %(dashboard_id)s introuvable"
 
 msgid "Dashboard Filter"
 msgstr "Filtre de tableau de bord"
@@ -4663,7 +4672,7 @@ msgstr ""
 "invalides."
 
 msgid "Dashboard cannot be favorited."
-msgstr "Le tableau de bord n'a pas pu être mis en favori."
+msgstr "Le tableau de bord n'a pas pu être ajouté aux favoris."
 
 msgid ""
 "Dashboard cannot be restored because its slug is now used by another "
@@ -4766,45 +4775,44 @@ msgid "Data"
 msgstr "Données"
 
 msgid "Data Connections"
-msgstr "Connexions aux données"
+msgstr "Connexions aux bases de données"
 
 msgid "Data Export Options"
-msgstr "Options d'export des données"
+msgstr "Options d'exportation des données"
 
 msgid "Data Table"
 msgstr "Tableau des données"
 
 msgid "Data URI is not allowed."
-msgstr "L’URI des données n’est pas autorisé."
+msgstr "L'URI des données n'est pas autorisé."
 
 msgid "Data Zoom"
 msgstr "Zoom des données"
 
 msgid "Data connection"
-msgstr "Connexion à la base de données"
+msgstr "Connexion aux données"
 
 msgid "Data connections"
-msgstr "Connexions à la base de données"
+msgstr "Connexions aux données"
 
 msgid ""
 "Data could not be deserialized from the results backend. The storage "
 "format might have changed, rendering the old data stake. You need to re-"
 "run the original query."
 msgstr ""
-"Les données n'ont pas pu être désérialisées à partir du programme dorsal "
-"des résultats. Le format de stockage peut avoir changé, rendant les "
-"anciennes données inutilisables. Vous devez réexécuter la requête "
-"initiale."
+"Les données n'ont pas pu être désérialisées à partir des résultats du "
+"serveur. Le format de stockage peut avoir changé, rendant les anciennes "
+"données inutilisables. Vous devez réexécuter la requête initiale."
 
 msgid ""
 "Data could not be retrieved from the results backend. You need to re-run "
 "the original query."
 msgstr ""
-"Les données n'ont pas pu être extraites du programme dorsal des "
-"résultats. Vous devez réexécuter la requête initiale."
+"Les données n'ont pas pu être extraites des résultats du serveur. Vous "
+"devez réexécuter la requête initiale."
 
 msgid "Data error"
-msgstr "Erreur (données)"
+msgstr "Erreur de données"
 
 #, python-format
 msgid "Data for %s"
@@ -4892,48 +4900,43 @@ msgstr "Port de la base de données"
 
 msgid "Database reference is not allowed on a report"
 msgstr ""
-"Vous ne pouvez pas utiliser une référence à une base de données dans un "
-"rapport"
+"La référence à une base de données n'est pas autorisée dans un rapport"
 
 msgid "Database schema is not allowed for csv uploads."
 msgstr ""
-"Le schéma de base de données n'est pas autorisé pour les téléversements "
-"CSV."
+"Le schéma de base de données n'est pas autorisé pour le chargement de CSV."
 
 msgid "Database settings updated"
 msgstr "Mise à jour des paramètres de la base de données"
 
 msgid "Database type does not support file uploads."
 msgstr ""
-"Ce type de base de données ne prend pas en charge le téléversement de "
+"Ce type de base de données ne prend pas en charge le chargement de "
 "fichiers."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
 msgid "Database upload file exceeds the maximum allowed size."
-msgstr ""
-"Le fichier à téléverser dans la base de données dépasse la taille "
-"maximale autorisée."
+msgstr "Le chargement du fichier dépasse la taille autorisée."
 
 msgid "Database upload file failed"
-msgstr "Échec du téléversement du fichier vers la base de données"
+msgstr "Échec du chargement du fichier vers la base de données"
 
 msgid "Database upload file failed, while saving metadata"
 msgstr ""
-"Échec du téléchargement du fichier, lors de l'enregistrement des "
-"métadonnées"
+"Échec du chargement du fichier, lors de l'enregistrement des métadonnées"
 
 msgid "Databases"
 msgstr "Bases de données"
 
 msgid "Dataset"
-msgstr "Ensemble de données"
+msgstr "Jeux de données"
 
 #, python-format
 msgid "Dataset %(table)s already exists"
 msgstr "Le jeu de données %(table)s existe déjà"
 
 msgid "Dataset Name"
-msgstr "Nom de l’ensemble de données"
+msgstr "Nom du jeu de données"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 msgid ""
@@ -4947,62 +4950,62 @@ msgstr ""
 "table avant de restaurer."
 
 msgid "Dataset column delete failed."
-msgstr "La suppression de l’ensemble de données a échoué."
+msgstr "La suppression de la colonne du jeu de données a échoué."
 
 msgid "Dataset column not found."
-msgstr "Colonne de l’ensemble de données introuvable."
+msgstr "Colonne du jeu de données introuvable."
 
 msgid "Dataset could not be created."
-msgstr "L’ensemble de données n'a pas pu être créé."
+msgstr "Le jeu de données n'a pas pu être créé."
 
 msgid "Dataset could not be duplicated."
-msgstr "L’ensemble de données n'a pas pu être dupliqué."
+msgstr "Le jeu de données n'a pas pu être dupliqué."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 msgid "Dataset could not be restored."
-msgstr "Le jeu de données n'a pas pu être restauré."
+msgstr "Le jeu de données n'a pas pu être restauré"
 
 msgid "Dataset could not be updated."
-msgstr "L’ensemble de données n'a pas pu être mis à jour."
+msgstr "Le jeu de données n'a pas pu être mis à jour."
 
 msgid "Dataset does not exist"
-msgstr "L’ensemble de données n'existe pas"
+msgstr "Le jeu de données n'existe pas"
 
 msgid "Dataset is required"
-msgstr "Un ensemble de données est requis"
+msgstr "Un jeu de données est requis"
 
 msgid "Dataset metric delete failed."
-msgstr "La suppression de l’ensemble de données a échoué."
+msgstr "La suppression du jeu de données a échoué."
 
 msgid "Dataset metric not found."
-msgstr "Mesure de l'ensemble de données non trouvée."
+msgstr "Mesure du jeu de données non trouvée."
 
 msgid "Dataset name"
-msgstr "Nom de l’ensemble de données"
+msgstr "Nom du jeu de données"
 
 msgid "Dataset parameters are invalid."
-msgstr "Les paramètres de l'ensemble de données ne sont pas valides."
+msgstr "Les paramètres du jeu de données ne sont pas valides."
 
 #, python-format
 msgid "Dataset schema is invalid, caused by: %(error)s"
-msgstr "Le schéma de l'ensemble de données n'est pas valide : %(error)s"
+msgstr "Le schéma du jeu de données n'est pas valide : %(error)s"
 
 msgid "Datasets"
-msgstr "Ensembles de données"
+msgstr "Jeux de données"
 
 msgid ""
 "Datasets can be created from database tables or SQL queries. Select a "
 "database table to the left or "
 msgstr ""
-"Les ensembles de données peuvent être créés à partir de tableaux de base "
-"de données ou de requêtes SQL. Sélectionnez un tableau de base de données"
-" à gauche ou "
+"Les jeux de données peuvent être créés à partir de tableaux de base de "
+"données ou de requêtes SQL. Sélectionnez un tableau de base de données à "
+"gauche ou "
 
 msgid "Datasets could not be deleted."
-msgstr "L'ensemble de données n'a pas pu être supprimé."
+msgstr "Les jeux de données n'ont pas pu être supprimés."
 
 msgid "Datasets do not contain a temporal column"
-msgstr "Les ensembles de données ne comportent pas de colonne temporelle"
+msgstr "Les jeux de données ne comportent pas de colonne temporelle"
 
 msgid "Datasource"
 msgstr "Source de données"
@@ -5014,19 +5017,19 @@ msgid "Datasource does not exist"
 msgstr "La source de données n'existe pas"
 
 msgid "Datasource is required"
-msgstr "Une source de données est requise"
+msgstr "La source de données est requise"
 
 msgid "Datasource is required for validation"
 msgstr "Une source de données est requise pour la validation"
 
 msgid "Datasource type is invalid"
-msgstr "Le type de source de données n’est pas valide"
+msgstr "Le type de source de données n'est pas valide"
 
 msgid "Datasource type is required when datasource_id is given"
 msgstr "Le type de source de données est requis quand datasource_id est spécifié"
 
 msgid "Datasources"
-msgstr "Sources de données"
+msgstr "Source de données"
 
 msgid "Date Time Format"
 msgstr "Format de la date et de l'heure"
@@ -5048,7 +5051,7 @@ msgstr ""
 "configuration du tableau et est requise par ce type de graphique"
 
 msgid "Datetime format"
-msgstr "Format d’horodatage"
+msgstr "Format d'horodatage"
 
 msgid "Day"
 msgstr "Jour"
@@ -5114,7 +5117,7 @@ msgid "Deck.gl Layer Visibility"
 msgstr "Deck.gl - Visibilité des couches"
 
 msgid "Deckgl"
-msgstr "deckGL"
+msgstr "DeckGL"
 
 msgid "Decrease"
 msgstr "Diminuer"
@@ -5144,8 +5147,9 @@ msgid ""
 "Default URL to redirect to when accessing from the dataset list page. "
 "Accepts relative URLs such as"
 msgstr ""
-"URL par défaut vers laquelle rediriger lors de l'accès depuis la page de "
-"liste des jeux de données. Accepte les URL relatives comme "
+"URL par défaut vers laquelle rediriger l'utilisateur lorsqu'il accède à la "
+"page depuis la liste des jeux de données. Accepte les URL relatives telles "
+"que"
 
 msgid "Default Value"
 msgstr "Valeur par défaut"
@@ -5154,7 +5158,7 @@ msgid "Default color"
 msgstr "couleur par défaut"
 
 msgid "Default datetime column"
-msgstr "Colonne datetime par défaut"
+msgstr "Colonne temporelle par défaut"
 
 msgid "Default folders cannot be nested"
 msgstr "Les dossiers par défaut ne peuvent pas être imbriqués."
@@ -5235,7 +5239,7 @@ msgid ""
 "specific color in the chart."
 msgstr ""
 "Définit le regroupement d'entités. Chaque série est représentée par une "
-"couleur spécifique sur le graphique"
+"couleur spécifique sur le graphique."
 
 msgid ""
 "Defines the grouping of entities. Each series is shown as a specific "
@@ -5306,7 +5310,7 @@ msgid "Delete Role?"
 msgstr "Supprimer le rôle ?"
 
 msgid "Delete Semantic Layer?"
-msgstr "Effacer la couche sémantique ?"
+msgstr "Supprimer la couche sémantique ?"
 
 msgid "Delete Semantic View?"
 msgstr "Effacer la vue sémantique ?"
@@ -5381,8 +5385,8 @@ msgstr[1] "%(num)d annotations supprimées"
 #, python-format
 msgid "Deleted %(num)d annotation layer"
 msgid_plural "Deleted %(num)d annotation layers"
-msgstr[0] "%(num)d couche d’annotation supprimée"
-msgstr[1] "%(num)d couches d’annotation supprimées"
+msgstr[0] "%(num)d couche d'annotation supprimée"
+msgstr[1] "%(num)d couches d'annotation supprimées"
 
 #, python-format
 msgid "Deleted %(num)d chart"
@@ -5405,8 +5409,8 @@ msgstr[1] "%(num)d tableaux de bord supprimés"
 #, python-format
 msgid "Deleted %(num)d dataset"
 msgid_plural "Deleted %(num)d datasets"
-msgstr[0] "Ensemble de données %(num)d supprimé"
-msgstr[1] "Ensemble de données %(num)d supprimés"
+msgstr[0] "%(num)d jeu de données supprimé"
+msgstr[1] "%(num)d jeux de données supprimés"
 
 #, python-format
 msgid "Deleted %(num)d report schedule"
@@ -5482,8 +5486,8 @@ msgid ""
 "Deleting a tab will remove all content within it and will deactivate any "
 "related alerts or reports. You may still reverse this action with the"
 msgstr ""
-"La suppression d’un onglet supprimera tout le contenu qu’il contient. "
-"Vous pouvez toujours annuler cette action avec le"
+"La suppression d'un onglet supprimera tout le contenu qu'il contient. Vous "
+"pouvez toujours annuler cette action avec le"
 
 msgid "Delimited long & lat single column"
 msgstr "Colonne unique délimitée en long et en lat"
@@ -5532,12 +5536,11 @@ msgid ""
 "free-text input. Warning: ILIKE queries may be slow on large datasets as "
 "they cannot use indexes effectively."
 msgstr ""
-"Détermine comment le filtre fait correspondre les valeurs. « "
-"Correspondance exacte » utilise l'opérateur IN (par défaut). Les options "
-"ILIKE permettent une correspondance partielle de texte avec une saisie "
-"libre. Avertissement : les requêtes ILIKE peuvent être lentes sur de "
-"grands ensembles de données car elles ne peuvent pas utiliser les index "
-"efficacement."
+"Détermine comment le filtre fait correspondre les valeurs. « Correspondance "
+"exacte » utilise l'opérateur IN (par défaut). Les options ILIKE permettent "
+"une correspondance partielle de texte avec une saisie libre. Avertissement "
+": les requêtes ILIKE peuvent être lentes sur de grands jeux de données car "
+"elles ne peuvent pas utiliser les index efficacement."
 
 msgid "Determines how whiskers and outliers are calculated."
 msgstr "Détermine le mode de calcul des moustaches et des valeurs aberrantes."
@@ -5586,10 +5589,10 @@ msgid "Dimension selection"
 msgstr "Sélection de la dimension"
 
 msgid "Dimension to use on x-axis."
-msgstr "Dimension à utiliser sur l’axe des abscisses."
+msgstr "Dimension à utiliser sur l'axe X."
 
 msgid "Dimension to use on y-axis."
-msgstr "Dimension à utiliser sur l’axe des ordonnées."
+msgstr "Dimension à utiliser sur l'axe Y."
 
 msgid "Dimension values"
 msgstr "Valeurs de dimension"
@@ -5634,7 +5637,7 @@ msgid "Disable drill to detail"
 msgstr "Désactiver l'exploration en détail"
 
 msgid "Disable embedding?"
-msgstr "Désactiver l’intégration?"
+msgstr "Désactiver l'intégration ?"
 
 msgid "Disabled"
 msgstr "Désactivé"
@@ -5696,11 +5699,11 @@ msgstr "Contrôles d'affichage"
 
 #, python-format
 msgid "Display controls (%d)"
-msgstr "Contrôles d'affichage (%d)"
+msgstr "Configuration d'affichage (%d)"
 
 #, python-format
 msgid "Display controls (%s)"
-msgstr "Contrôles d'affichage (%s)"
+msgstr "Configuration d'affichage (%s)"
 
 msgid "Display cumulative total at end"
 msgstr "Afficher le total cumulé à la fin"
@@ -5784,7 +5787,7 @@ msgid "Don't refresh"
 msgstr "Ne pas actualiser"
 
 msgid "Done"
-msgstr "Fait"
+msgstr "Terminé"
 
 msgid "Donut"
 msgstr "Anneau"
@@ -5811,7 +5814,7 @@ msgid "Download to CSV"
 msgstr "Télécharger en CSV"
 
 msgid "Download to client"
-msgstr "Télécharger"
+msgstr "Télécharger vers le client"
 
 #, python-format
 msgid ""
@@ -5837,21 +5840,21 @@ msgid ""
 " - items will appear in the same order in tooltips. Click the button to "
 "manually select columns and metrics."
 msgstr ""
-"Faites glisser des colonnes et des métriques ici pour personnaliser le "
-"contenu des info-bulles. L'ordre est important - les éléments "
-"apparaîtront dans le même ordre dans les info-bulles. Cliquez sur le "
-"bouton pour sélectionner manuellement des colonnes et des métriques."
+"Déposer les colonnes et les mesures ici pour personnaliser le contenu d'une "
+"info-bulle. L'ordre est pris en compte pour l'affichage. Cliquer sur le "
+"bouton pour sélectionner manuellement les colonnes et les mesures."
 
 msgid "Drag to reorder"
-msgstr "Déplacer pour réorganiser"
+msgstr "Glisser pour réorganiser"
 
 msgid "Draw a marker on data points. Only applicable for line types."
 msgstr ""
-"Tracer un marqueur sur les points de données. Ne s’applique qu’aux types "
-"de ligne."
+"Tracer un marqueur sur les points de données. Ne s'applique qu'aux types de "
+"ligne."
 
 msgid "Draw area under curves. Only applicable for line types."
-msgstr "Tracer une zone sous les courbes. Ne s’applique qu’aux types de ligne."
+msgstr ""
+"Tracer une zone sous les courbes. Ne s'applique qu'aux types de ligne."
 
 msgid "Draw line from Pie to label when labels outside?"
 msgstr ""
@@ -5859,12 +5862,10 @@ msgstr ""
 " étiquettes sont à l'extérieur?"
 
 msgid "Draw split lines for minor axis ticks"
-msgstr "Tracer des lignes de séparation pour les points de repère de l'axe mineur"
+msgstr "Tracer des lignes de séparation mineures pour l'axe"
 
 msgid "Draw split lines for minor y-axis ticks"
-msgstr ""
-"Tracer des lignes séparées pour les points de repère de l’axe des "
-"ordonnées mineur"
+msgstr "Tracer des lignes de séparation mineures de l'axe Y"
 
 msgid "Drill by"
 msgstr "Explorer par"
@@ -5943,11 +5944,11 @@ msgstr ""
 "toutes les colonnes et tous les indicateurs aient un libellé unique."
 
 msgid "Duplicate dataset"
-msgstr "Dupliquer l'ensemble de données"
+msgstr "Dupliquer le jeu de données"
 
 #, python-format
 msgid "Duplicate folder name: %s"
-msgstr "Nom de dossier dupliqué : %s"
+msgstr "Nom du dossier dupliqué: %s"
 
 msgid "Duplicate role"
 msgstr "Dupliquer le rôle"
@@ -5977,10 +5978,9 @@ msgid ""
 " bypass the cache. Note this defaults to the dataset's timeout if "
 "undefined."
 msgstr ""
-"Durée (en secondes) du délai de mise en cache pour ce graphique. "
-"Définissez -1 pour contourner le cache. Notez que cette valeur correspond"
-" par défaut au délai d'attente de l’ensemble de données s'il n'est pas "
-"défini."
+"Durée (en secondes) du délai de mise en cache pour ce graphique. Définissez "
+"-1 pour contourner le cache. Notez que cette valeur correspond par défaut "
+"au délai d'attente du jeu de données s'il n'est pas défini."
 
 msgid ""
 "Duration (in seconds) of the metadata caching timeout for schemas of this"
@@ -6031,7 +6031,7 @@ msgid "Dynamic group by"
 msgstr "Grouper par"
 
 msgid "Dynamic section description"
-msgstr "Description de section dynamique"
+msgstr "Description dynamique"
 
 msgid "Dynamically search all filter values"
 msgstr "Charge dynamiquement les valeurs du filtre"
@@ -6040,8 +6040,8 @@ msgstr "Charge dynamiquement les valeurs du filtre"
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Dynamically select grouping columns from a dataset"
 msgstr ""
-"Sélectionner dynamiquement des colonnes de regroupement à partir d'un jeu"
-" de données"
+"Sélectionner dynamiquement un groupe de colonnes à partir d'un jeu de "
+"données"
 
 #. do-not-translate
 msgid "ECharts"
@@ -6084,7 +6084,7 @@ msgstr "Modifier %s"
 
 #, python-format
 msgid "Edit %s in modal"
-msgstr "Modifier %s dans fenêtre modale"
+msgstr "Modifier %s dans la modal"
 
 msgid "Edit CSS template properties"
 msgstr "Modifier les propriétés du modèle CSS"
@@ -6093,7 +6093,7 @@ msgid "Edit Dashboard"
 msgstr "Modifier le tableau de bord"
 
 msgid "Edit Dataset "
-msgstr "Modifier l’ensemble de données "
+msgstr "Modifier le jeu de données "
 
 msgid "Edit Group"
 msgstr "Modifier le groupe"
@@ -6117,10 +6117,10 @@ msgid "Edit User"
 msgstr "Modifier l'utilisateur"
 
 msgid "Edit alert"
-msgstr "Modifier l’alerte"
+msgstr "Modifier l'alerte"
 
 msgid "Edit annotation"
-msgstr "Modifier l’annotation"
+msgstr "Modifier l'annotation"
 
 msgid "Edit annotation layer"
 msgstr "Modifier une couche d'annotations"
@@ -6177,7 +6177,7 @@ msgid "Edit theme properties"
 msgstr "Modifier les propriétés du thème"
 
 msgid "Edit time range"
-msgstr "Modifier l’intervalle de temps"
+msgstr "Modifier l'intervalle de temps"
 
 msgid "Edit user"
 msgstr "Modifier l'utilisateur"
@@ -6214,7 +6214,8 @@ msgstr "La base de données est mal orthographiée ou elle n'existe pas."
 
 #, python-format
 msgid "Either the username \"%(username)s\" or the password is incorrect."
-msgstr "Le nom d’utilisateur « %(username)s » ou le mot de passe est incorrect."
+msgstr ""
+"Le nom d'utilisateur « %(username)s » ou le mot de passe est incorrect."
 
 #, python-format
 msgid ""
@@ -6225,10 +6226,10 @@ msgstr ""
 "données « %(database)s » est incorrect."
 
 msgid "Either the username or the password is wrong."
-msgstr "Le nom d’utilisateur ou le mot de passe est incorrect."
+msgstr "Le nom d'utilisateur ou le mot de passe est incorrect."
 
 msgid "Elapsed"
-msgstr "Écoulé"
+msgstr "Temps écoulé"
 
 msgid "Elevation"
 msgstr "Élévation"
@@ -6264,10 +6265,10 @@ msgid "Embedded dashboard could not be deleted."
 msgstr "Le tableau de bord intégré n'a pas pu être supprimé."
 
 msgid "Embedding deactivated."
-msgstr "L’intégration est désactivée."
+msgstr "L'intégration est désactivée."
 
 msgid "Emphasis"
-msgstr "Mettre l’accent sur"
+msgstr "Mettre l'accent sur"
 
 msgid "Empty circle"
 msgstr "Cercle vide"
@@ -6285,12 +6286,12 @@ msgid "Empty query?"
 msgstr "Requête vide ?"
 
 msgid "Empty row"
-msgstr "Rangée vide"
+msgstr "Ligne vide"
 
 msgid "Enable 'Allow file uploads to database' in any database's settings"
 msgstr ""
-"Activez l'option « Autoriser le chargement de données » dans les "
-"paramètres de la base de données"
+"Activez l'option 'Autoriser le chargement de données' dans les paramètres "
+"de la base de données"
 
 msgid "Enable Matrixify"
 msgstr "Activer Matrixify"
@@ -6302,7 +6303,7 @@ msgid "Enable data zooming controls"
 msgstr "Activer les contrôles d'agrandissement des données"
 
 msgid "Enable embedding"
-msgstr "Activer l’intégration"
+msgstr "Activer l'intégration"
 
 msgid "Enable forecast"
 msgstr "Activer la prévision"
@@ -6337,12 +6338,12 @@ msgstr "Activer la pagination des résultats côté serveur (fonction expérimen
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Enables rendering of icons for GeoJSON points"
-msgstr "Active le rendu des icônes pour les points GeoJSON"
+msgstr "Permets le rendu des icônes sur les points GeoJSON"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Enables rendering of labels for GeoJSON points"
-msgstr "Active le rendu des étiquettes pour les points GeoJSON"
+msgstr "Permets le rendu des labels pour les points GeoJSON"
 
 msgid ""
 "Encountered invalid NULL spatial entry,"
@@ -6354,7 +6355,7 @@ msgstr ""
 "ces entrées"
 
 msgid "Encrypted extra fields"
-msgstr "Champs supplémentaires cryptés"
+msgstr "Champs complémentaires chiffrés"
 
 msgid "End"
 msgstr "Fin"
@@ -6388,7 +6389,7 @@ msgstr "Se termine par"
 
 #, python-format
 msgid "Ends with (ILIKE %x)"
-msgstr "Finit par (ILIKE %x)"
+msgstr "Termine avec (ILIKE %x)"
 
 #, python-format
 msgid "Engine \"%(engine)s\" cannot be configured through parameters."
@@ -6408,13 +6409,13 @@ msgid "Enter CA_BUNDLE"
 msgstr "Saisir CA_BUNDLE"
 
 msgid "Enter Primary Credentials"
-msgstr "Saisir les informations de connexion"
+msgstr "Saisir les informations d'identification principales"
 
 msgid "Enter a name for this sheet"
 msgstr "Saisir un nom pour cette feuille"
 
 msgid "Enter a part of the object name"
-msgstr "Entrez une partie du nom de l'objet"
+msgstr "Saisir une partie du nom de l'objet"
 
 msgid "Enter alert name"
 msgstr "Saisir le nom de l'alerte"
@@ -6428,7 +6429,7 @@ msgstr "Passer en plein écran"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Enter minimum and maximum values for the range filter"
-msgstr "Saisissez les valeurs minimale et maximale pour le filtre de plage"
+msgstr "Entrer une valeur minimal et maximal pour la plage du filter"
 
 msgid "Enter report name"
 msgstr "Saisir le nom du rapport"
@@ -6444,7 +6445,7 @@ msgstr "Saisir le nom du groupe"
 
 #, python-format
 msgid "Enter the required %(dbModelName)s credentials"
-msgstr "Saisir les informations d’%(dbModelName)sidentification requises"
+msgstr "Saisir les informations d'%(dbModelName)sidentification requises"
 
 msgid "Enter the unique project id for your database."
 msgstr "Saisir l'identifiant unique du projet pour votre base de données."
@@ -6489,21 +6490,21 @@ msgid "Error"
 msgstr "Erreur"
 
 msgid "Error Fetching Tagged Objects"
-msgstr "Erreur à la récupération des objets taggés"
+msgstr "Erreur lors de la récupération des objets étiquetés"
 
 #, python-format
 msgid "Error deleting %s"
-msgstr "Erreur à la suppression de %s"
+msgstr "Une erreur lors de la suppression %s"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, es, sr,
 # sr_Latn]
 #, python-format
 msgid "Error disabling fullscreen: %s"
-msgstr "Erreur lors de la désactivation du mode plein écran : %s"
+msgstr "Erreur lors de la désactivation du plein écran : %s"
 
 #, python-format
 msgid "Error enabling fullscreen: %s"
-msgstr "Erreur lors de l'activation du mode plein écran: %s"
+msgstr "Erreur lors de l'activiation du mode plein écran : %s"
 
 msgid "Error executing query. "
 msgstr "Erreur lors de l'exécution d'une requête."
@@ -6527,25 +6528,27 @@ msgstr "Erreur d'expression jinja dans la clause WHERE : %(msg)s"
 
 #, python-format
 msgid "Error in jinja expression in adhoc column: %(msg)s"
-msgstr "Erreur d'expression jinja dans la colonne adhoc : %(msg)s"
+msgstr "Erreur de la colonne adhoc dans l'expression jinja : %(msg)s"
 
 #, python-format
 msgid "Error in jinja expression in column expression: %(msg)s"
-msgstr "Erreur dans l'expression jinja dans la colonne expression : %(msg)s"
+msgstr ""
+"Erreur de l'expression de la colonne dans l'expression jinja : %(msg)s"
 
 #, python-format
 msgid "Error in jinja expression in datetime column: %(msg)s"
-msgstr "Erreur d'expression jinja dans colonne datetime : %(msg)s"
+msgstr "Erreur de la colonne temporelle dans l'expression jinja : %(msg)s"
 
 #, python-format
 msgid "Error in jinja expression in fetch values predicate: %(msg)s"
 msgstr ""
-"Erreur dans l'expression jinja dans la réupération du prédicat des "
-"valeurs : %(msg)s"
+"Erreur lors de la récupération du prédicat des valeurs dans l'expression "
+"jinja : %(msg)s"
 
 #, python-format
 msgid "Error in jinja expression in metric expression: %(msg)s"
-msgstr "Erreur d'expression jinja pour la métrique : %(msg)s"
+msgstr ""
+"Erreur dans l'expression de la mesure dans l'expression jinja : %(msg)s"
 
 msgid "Error loading chart datasources. Filters may not work correctly."
 msgstr ""
@@ -6571,14 +6574,14 @@ msgid "Error saving dataset"
 msgstr "Une erreur s'est produite durant la sauvegarde du jeu de données"
 
 msgid "Error unfaving chart"
-msgstr "Une erreur s'est produite lors du retrait des favoris du graphique"
+msgstr "Une erreur s'est produite lors du retrait du graphique des favoris"
 
 msgid "Error while fetching charts"
 msgstr "Une erreur s'est produite durant la récupération des graphiques"
 
 #, python-format
 msgid "Error while fetching data: %s"
-msgstr "Une erreur s'est produite durant la récupération des données : %s"
+msgstr "Erreur lors de la récupération des données : %s"
 
 msgid "Error while fetching groups"
 msgstr "Une erreur s'est produite lors de la récupération des groupes"
@@ -6589,8 +6592,7 @@ msgstr "Une erreur s'est produite lors de la récupération des rôles"
 #, python-format
 msgid "Error while rendering virtual dataset query: %(msg)s"
 msgstr ""
-"Erreur durant le rendu de la requête de l’ensemble de données virtuel : "
-"%(msg)s"
+"Erreur durant le rendu de la requête du jeu de données virtuel : %(msg)s"
 
 #, python-format
 msgid "Error: %(error)s"
@@ -6602,7 +6604,7 @@ msgstr "Erreur : %(msg)s"
 
 #, python-format
 msgid "Error: %s"
-msgstr "Erreur : %s"
+msgstr "Erreur: %s"
 
 msgid "Error: permalink state not found"
 msgstr "Erreur : état du lien permanent introuvable"
@@ -6623,7 +6625,7 @@ msgid "Event flow"
 msgstr "Flux d'événements"
 
 msgid "Event time column"
-msgstr "Colonne temporelle de l’événement"
+msgstr "Colonne temporelle de l'événement"
 
 msgid "Every"
 msgstr "Chaque"
@@ -6658,7 +6660,7 @@ msgid "Excel file format cannot be determined"
 msgstr "Le format du fichier Excel ne peut pas être déterminé"
 
 msgid "Excel upload"
-msgstr "Téléversement d’un fichier Excel"
+msgstr "Chargement d'un fichier Excel"
 
 msgid "Exclude selected values"
 msgstr "Exclure les valeurs sélectionnées"
@@ -6679,7 +6681,7 @@ msgid "Execution log"
 msgstr "Journal d'exécution"
 
 msgid "Existing dataset"
-msgstr "Ensemble de données existant"
+msgstr "Jeu de données existant"
 
 msgid "Exit edit mode"
 msgstr ""
@@ -6700,10 +6702,10 @@ msgid "Expand data panel"
 msgstr "Développer le panneau de données"
 
 msgid "Expand row"
-msgstr "Agrandir la rangée"
+msgstr "Agrandir la ligne"
 
 msgid "Expand row to edit"
-msgstr "Agrandir la rangée pour éditer"
+msgstr "Développer la ligne à modifier"
 
 msgid ""
 "Expects a formula with depending time parameter 'x'\n"
@@ -6784,7 +6786,7 @@ msgstr "Exporter la capture d'écran (png)"
 
 #, python-format
 msgid "Export successful: %s"
-msgstr "Export réussi : %s"
+msgstr "Export réussi: %s"
 
 msgid "Export to .CSV"
 msgstr "Exporter en .CSV"
@@ -6793,7 +6795,7 @@ msgid "Export to .JSON"
 msgstr "Exporter en .JSON"
 
 msgid "Export to CSV"
-msgstr "Exporter en .CSV"
+msgstr "Exporter au format CSV"
 
 msgid "Export to Excel"
 msgstr "Exporter vers Excel"
@@ -6811,7 +6813,7 @@ msgid "Export to full .CSV"
 msgstr "Exporter en CSV intégralement"
 
 msgid "Export to full Excel"
-msgstr "Exporter vers Excel"
+msgstr "Exporter intégralement en Excel"
 
 msgid "Export to original .CSV"
 msgstr "Exporter vers .CSV original"
@@ -6861,7 +6863,7 @@ msgstr "Étendue"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "External link warning"
-msgstr "Avertissement de lien externe"
+msgstr "Avertissement lien externe"
 
 msgid "Extra"
 msgstr "Extra"
@@ -6881,9 +6883,9 @@ msgid ""
 msgstr ""
 "Données supplémentaires pour spécifier les métadonnées du tableau. "
 "Actuellement, les métadonnées sont prises en charge dans le format "
-"suivant : `{ « certification »: { « certified_by »: « Data Platform Team "
-"», « details »: « Ce tableau est la source de la vérité. » }, « "
-"warning_markdown »: « Ceci est un avertissement. » }`."
+"suivant : `{ « certification »: { « certified_by »: « Data Platform Team », "
+" »details« :  »Ce tableau est la source de la vérité.«  }, "
+" »warning_markdown« :  »Ceci est un avertissement.\" }`."
 
 msgid "Extra parameters for use in jinja templated queries"
 msgstr "Paramètres supplémentaires à utiliser dans les modèles de requêtes jinja"
@@ -6929,10 +6931,10 @@ msgid "Failed to copy API key to clipboard"
 msgstr "Échec lors de la copie de la clé d'API dans le presse-papier"
 
 msgid "Failed to copy stack trace to clipboard"
-msgstr "Echoué à copier le message d'erreur vers le presse-papier"
+msgstr "Échec de la copie du journal d'erreur vers le presse-papier"
 
 msgid "Failed to create API key"
-msgstr "Échec de la création de la clé d'API"
+msgstr "Échec de la création de la clé API"
 
 msgid "Failed to create report"
 msgstr "Échec de la création du rapport"
@@ -6951,7 +6953,7 @@ msgstr ""
 
 #, python-format
 msgid "Failed to execute %(query)s"
-msgstr "Échec de l’exécution de %(query)s"
+msgstr "Échec de l'exécution de %(query)s"
 
 msgid ""
 "Failed to export chart data. Please try again or contact your "
@@ -6961,7 +6963,7 @@ msgstr ""
 "administrateur."
 
 msgid "Failed to fetch API keys"
-msgstr "Tout Dé-Sélectionner"
+msgstr "Échec de la récupération des clés API"
 
 msgid "Failed to generate chart edit URL"
 msgstr "Échec de la génération de l'URL de modification du graphique"
@@ -6978,21 +6980,21 @@ msgstr "Échec du chargement des données du graphique."
 
 #, python-format
 msgid "Failed to load columns for %s %s"
-msgstr "Échec du chargement des colonnes pour %s %s"
+msgstr "Échec lors du chargement des colonnes pour %s %s"
 
 msgid "Failed to load top values"
-msgstr "Echec au chargement des valeurs"
+msgstr "Échec lors du chargement des top valeurs"
 
 msgid "Failed to open file. Please try again."
-msgstr "Échec de l'ouverture du fichier. Veuillez réessayer."
+msgstr "Échec lors de l'ouverture du fichier. Veuillez réessayer."
 
 #, python-format
 msgid "Failed to remove system dark theme: %s"
-msgstr "Erreur à la suppression du thème sombre : %s"
+msgstr "Supprimer le thème sombre du système: %s"
 
 #, python-format
 msgid "Failed to remove system default theme: %s"
-msgstr "Erreur à la suppression du thème par défaut : %s"
+msgstr "Supprimer le thème par défaut du système: %s"
 
 #, python-format
 msgid "Failed to restore %(name)s"
@@ -7003,19 +7005,19 @@ msgid "Failed to restore %(name)s: %(errMsg)s"
 msgstr ""
 
 msgid "Failed to retrieve advanced type"
-msgstr "Échec de l'extraction du type avancé"
+msgstr "Échec lors de la récupération du type avancé"
 
 msgid "Failed to revoke API key"
-msgstr "Échec lors de la révocation de la clé d'API"
+msgstr "Échec lors de la révocation de la clé API"
 
 msgid "Failed to save chart customization"
-msgstr "Échec de l'enregistrement de la personnalisation du graphique"
+msgstr "Échec lors de la sauvegarde de la personnalisation du graphique"
 
 msgid "Failed to save cross-filter scoping"
-msgstr "Échec de l'enregistrement de la délimitation des filtres croisés"
+msgstr "Échec de l'enregistrement de la portée du filtre croisé"
 
 msgid "Failed to save cross-filters setting"
-msgstr "Échec de l'enregistrement des paramètres des filtres croisés"
+msgstr "Échec de la sauvegarde des paramètres des filtres croisés"
 
 msgid "Failed to set local theme: Invalid JSON configuration"
 msgstr "Échec de la définition du thème local : configuration JSON invalide"
@@ -7035,10 +7037,10 @@ msgid "Failed to stop query."
 msgstr "Échec de l'arrêt de la requête."
 
 msgid "Failed to store query results. Please try again."
-msgstr "Échec de l'enregistrement des résultats de la requête. Veuillez réessayer."
+msgstr "Échec pour stocker le résultat de la requête. Veuillez réessayer."
 
 msgid "Failed to tag items"
-msgstr "Échec du marquage des éléments"
+msgstr "Échec de l'étiquetage des éléments"
 
 #, python-format
 msgid "Failed to trigger %(alertType)s \"%(alertName)s\": %(error)s"
@@ -7057,7 +7059,9 @@ msgstr "Échec de la vérification des options de sélection : %s"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Falling back to CSV; Excel export library not available."
-msgstr "Retour au format CSV ; bibliothèque d'exportation Excel non disponible."
+msgstr ""
+"Utilisation du CSV; La libraire pour exporter en Excel n'est pas "
+"disponible."
 
 msgid "False"
 msgstr "est faux"
@@ -7066,10 +7070,10 @@ msgid "Favorite"
 msgstr "Favori"
 
 msgid "Feature Not Enabled"
-msgstr "Fonctionnalité non activée"
+msgstr "Fonctionnalité indisponible"
 
 msgid "Featured"
-msgstr "En vedette"
+msgstr "Fréquemment utilisés"
 
 msgid "Featured color palettes"
 msgstr "Palettes de couleurs recommandées"
@@ -7120,7 +7124,7 @@ msgid "File settings"
 msgstr "Paramètres du fichier"
 
 msgid "File upload"
-msgstr "Téléversement"
+msgstr "Charger un fichier"
 
 msgid "Fill Color"
 msgstr "Couleur de remplissage"
@@ -7270,9 +7274,8 @@ msgid ""
 "Fix the trend line to the full time range specified in case filtered "
 "results do not include the start or end dates"
 msgstr ""
-"Corrigez la ligne de tendance à la plage de temps complète spécifiée au "
-"cas où les résultats filtrés n’incluraient pas les dates de début ou de "
-"fin"
+"Corrigez la ligne de tendance à la plage de temps complète spécifiée au cas "
+"où les résultats filtrés n'incluraient pas les dates de début ou de fin"
 
 msgid "Fix to selected Time Range"
 msgstr "Fixer à l'intervalle de temps sélectionné"
@@ -7293,7 +7296,7 @@ msgid "Flow"
 msgstr "Flux"
 
 msgid "Folder with content must have a name"
-msgstr "Le dossier doit avoir un nom"
+msgstr "Les dossiers avec du contenu doivent avoir un nom"
 
 msgid "Folders"
 msgstr "Dossiers"
@@ -7303,8 +7306,8 @@ msgstr "Taille de la police"
 
 msgid "Font size for axis labels, detail value and other text elements"
 msgstr ""
-"Taille de la police pour les étiquettes d’axe, la valeur de détail et "
-"d’autres éléments de texte"
+"Taille de la police pour les étiquettes d'axe, la valeur de détail et "
+"d'autres éléments de texte"
 
 msgid "Font size for the biggest value in the list"
 msgstr "Taille de police pour la plus grande valeur de la liste"
@@ -7353,7 +7356,7 @@ msgstr "Forcer la granularité temporelle comme intervalle maximum"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Force abort (stops task for all subscribers)"
-msgstr "Forcer l'abandon (arrête la tâche pour tous les abonnés)"
+msgstr "Forcer l'arrêt (arrêt de la tâche et de ses souscripteurs)"
 
 msgid ""
 "Force all tables and views to be created in this schema when clicking "
@@ -7381,7 +7384,7 @@ msgid "Force refresh schema list"
 msgstr "Forcer l'actualisation de la liste des schémas"
 
 msgid "Force refresh table list"
-msgstr "Forcer l'actualisation de la liste des tableaux"
+msgstr "Forcer l'actualisation de la liste des tables"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
@@ -7409,14 +7412,14 @@ msgstr ""
 
 msgid "Form data not found in cache, reverting to dataset metadata."
 msgstr ""
-"Les données du formulaire n'ont pas été trouvées dans l’ensemble de "
-"données, les métadonnées du graphique ont été rétablies."
+"Les données du formulaire n'ont pas été trouvées dans le jeu de données, "
+"les métadonnées du graphique ont été rétablies."
 
 msgid "Format"
 msgstr "Format"
 
 msgid "Format JSON configuration"
-msgstr "Formatter la configuration JSON"
+msgstr "Mettre en forme la configuration JSON"
 
 msgid "Format SQL"
 msgstr "Format SQL"
@@ -7444,10 +7447,10 @@ msgid ""
 "are present, formatting falls back to neutral numbers."
 msgstr ""
 "Formatez les métriques ou les colonnes avec des symboles monétaires en "
-"préfixe ou suffixe. Choisissez un symbole manuellement ou utilisez « "
-"Détection automatique » pour appliquer le symbole correct en fonction de "
-"la colonne de code de devise du jeu de données. Lorsque plusieurs devises"
-" sont présentes, le formatage revient aux nombres neutres."
+"préfixe ou suffixe. Choisissez un symbole manuellement ou utilisez "
+"« Détection automatique » pour appliquer le symbole correct en fonction de "
+"la colonne de code de devise du jeu de données. Lorsque plusieurs devises "
+"sont présentes, le formatage revient aux nombres neutres."
 
 msgid "Formatted CSV attached in email"
 msgstr "Fichier CSV mis en forme joint au courriel"
@@ -7462,10 +7465,10 @@ msgid "Formatting"
 msgstr "Formatage"
 
 msgid "Formatting column"
-msgstr "Formatage"
+msgstr "Formatage de la colonne"
 
 msgid "Formatting object"
-msgstr "Formatage"
+msgstr "Formatage de l'objet"
 
 msgid "Formula"
 msgstr "Formule"
@@ -7498,16 +7501,16 @@ msgid "Full name"
 msgstr "Nom complet"
 
 msgid "Fullscreen is not supported in this browser."
-msgstr "Le mode plein écran n'est pas supporté par ce navigateur."
+msgstr "Le mode plein écran n'est pas pris en charge pour ce navigateur"
 
 msgid "Funnel Chart"
 msgstr "Diagramme en entonnoir"
 
 msgid "Further customize how to display each column"
-msgstr "Personnaliser davantage la façon d’afficher chaque colonne"
+msgstr "Personnaliser davantage la façon d'afficher chaque colonne"
 
 msgid "Further customize how to display each metric"
-msgstr "Personnaliser davantage la façon d’afficher chaque mesure"
+msgstr "Personnaliser davantage la façon d'afficher chaque mesure"
 
 #. do-not-translate
 msgid "GROUP BY"
@@ -7583,7 +7586,7 @@ msgid "Grace period"
 msgstr "Période de grâce"
 
 msgid "Grain"
-msgstr "Fragment"
+msgstr "Fragment de temps"
 
 msgid "Graph Chart"
 msgstr "Graphique en réseau"
@@ -7656,7 +7659,7 @@ msgstr "Un utilisateur invité ne peut pas modifier le contenu du graphique"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "HTTP Path"
-msgstr "Chemin HTTP"
+msgstr "Route HTTP"
 
 msgid "Handlebars"
 msgstr "Handlebars"
@@ -7668,13 +7671,13 @@ msgid "Hard value bounds applied for color coding."
 msgstr "Bornes de valeurs strictes appliquées pour le codage des couleurs."
 
 msgid "Has created by"
-msgstr "Créé par"
+msgstr "A été créé par"
 
 msgid "Header"
 msgstr "En-tête"
 
 msgid "Header row"
-msgstr "Rangée d'en-tête"
+msgstr "Ligne d'en-tête"
 
 msgid "Header row is required"
 msgstr "La ligne d'en-tête est obligatoire"
@@ -7826,9 +7829,9 @@ msgid ""
 "If it stays empty, it won't be saved and will be removed from the list. "
 "To remove folders, move metrics and columns to other folders."
 msgstr ""
-"S'il reste vide, il ne sera pas sauvegardé et sera supprimé de la liste. "
-"Pour supprimer des dossiers, déplacez les métriques et les colonnes vers "
-"d'autres dossiers."
+"Si vide, ne sera pas enregistré et sera supprimé de la liste. Pour "
+"supprimer des dossiers, déplacer les mesures et les colonnes dans d'autres "
+"dossiers."
 
 msgid "If table already exists"
 msgstr "Si la table existe déjà"
@@ -7855,7 +7858,8 @@ msgid "Image (PNG) embedded in email"
 msgstr "Image (PNG) encapsulée dans le courriel"
 
 msgid "Image download failed, please refresh and try again."
-msgstr "Échec du téléchargement de l’image, veuillez actualiser et réessayer."
+msgstr ""
+"Échec du téléchargement de l'image, veuillez actualiser et réessayer."
 
 msgid ""
 "Impersonate logged in user (Presto, Trino, Drill, Hive, Databricks, and "
@@ -7870,7 +7874,7 @@ msgid "Import %s"
 msgstr "Importer %s"
 
 msgid "Import Error"
-msgstr "Erreur d'importation"
+msgstr "Erreur lors de l'importation"
 
 msgid "Import chart failed for an unknown reason"
 msgstr "L'import du graphique a échoué pour une raison inconnue"
@@ -7891,7 +7895,7 @@ msgid "Import database from file"
 msgstr "Importer la base de données depuis un fichier"
 
 msgid "Import dataset failed for an unknown reason"
-msgstr "L'import de l’ensemble de données a échoué pour une raison inconnue"
+msgstr "L'import du jeu de données a échoué pour une raison inconnue"
 
 msgid "Import queries"
 msgstr "Importer des requêtes"
@@ -7989,11 +7993,11 @@ msgstr ""
 
 msgid "Input field supports custom rotation. e.g. 30 for 30°"
 msgstr ""
-"Le champ d’entrée prend en charge la rotation personnalisée, p. ex., 30 "
+"Le champ d'entrée prend en charge la rotation personnalisée, p. ex., 30 "
 "pour 30°"
 
 msgid "Insert Layer URL"
-msgstr "Insérer une URL de couche"
+msgstr "Insérer l'URL de la couche"
 
 msgid "Insert Layer title"
 msgstr "Insérer le titre de la couche"
@@ -8005,10 +8009,10 @@ msgid "Inside bottom"
 msgstr "Intérieur en bas"
 
 msgid "Inside bottom left"
-msgstr "En bas à gauche"
+msgstr "Intérieur en bas à gauche"
 
 msgid "Inside bottom right"
-msgstr "En bas à droite"
+msgstr "Intérieur en bas à droite"
 
 msgid "Inside left"
 msgstr "Intérieur à gauche"
@@ -8017,13 +8021,13 @@ msgid "Inside right"
 msgstr "Intérieur à droite"
 
 msgid "Inside top"
-msgstr "En haut à l'intérieur"
+msgstr "Intérieur en haut"
 
 msgid "Inside top left"
-msgstr "Haut à gauche"
+msgstr "Intérieur haut à gauche"
 
 msgid "Inside top right"
-msgstr "Haut à droite"
+msgstr "Intérieur haut à droite"
 
 msgid "Intensity"
 msgstr "Intensité"
@@ -8032,11 +8036,11 @@ msgid "Intensity Radius"
 msgstr "Rayon d'intensité"
 
 msgid "Intensity Radius is the radius at which the weight is distributed"
-msgstr "Le rayon d’intensité est le rayon auquel le poids est distribué"
+msgstr "Le rayon d'intensité est le rayon auquel le poids est distribué"
 
 msgid "Intensity is the value multiplied by the weight to obtain the final weight"
 msgstr ""
-"L’intensité est la valeur multipliée par le poids pour obtenir le poids "
+"L'intensité est la valeur multipliée par le poids pour obtenir le poids "
 "final"
 
 msgid "Interval"
@@ -8068,7 +8072,7 @@ msgid "Invalid JSON"
 msgstr "JSON invalide"
 
 msgid "Invalid JSON configuration"
-msgstr "Configuration JSON invalide."
+msgstr "Configuration JSON non valide"
 
 msgid "Invalid JSON metadata"
 msgstr "Métadonnées JSON invalides"
@@ -8079,7 +8083,7 @@ msgstr "Le schéma du jeu de données n'est pas valide : %(error)s"
 
 #, python-format
 msgid "Invalid advanced data type: %(advanced_data_type)s"
-msgstr "Type de résultat invalide : %(advanced_data_type)s"
+msgstr "Type avancé de données invalide : %(advanced_data_type)s"
 
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
@@ -8091,9 +8095,8 @@ msgid ""
 "Invalid connection string, a valid string usually follows: "
 "backend+driver://user:password@database-host/database-name"
 msgstr ""
-"Chaine de connexion incorrecte, une chaine correcte s'écrit "
-"habituellement : « backend+driver://user:password@database-host/database-"
-"name »"
+"Chaine de connexion non valide, une chaine correcte s'écrit "
+"habituellement : backend+driver://user:password@database-host/database-name"
 
 msgid ""
 "Invalid connection string, a valid string usually "
@@ -8102,9 +8105,9 @@ msgid ""
 "db/database'</p>"
 msgstr ""
 "Chaine de connexion incorrecte, une chaine correcte s'écrit "
-"habituellement : « DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME "
-"»<p>Exemple : « postgresql://user:password@your-postgres-db/database "
-"»</p>"
+"habituellement : "
+"« DRIVER://USER:PASSWORD@DB-HOST/DATABASE-NAME »<p>Exemple : "
+" »postgresql://user:password@your-postgres-db/database »</p>"
 
 msgid "Invalid cron expression"
 msgstr "Expression CRON invalide"
@@ -8114,10 +8117,10 @@ msgid "Invalid cumulative operator: %(operator)s"
 msgstr "Operateur cumulatif invalide : %(operator)s"
 
 msgid "Invalid currency code in saved metrics"
-msgstr "Code de devise invalide dans les métriques sauvegardés"
+msgstr "Code de la devise invalide dans les métriques sauvegardés"
 
 msgid "Invalid date/timestamp format"
-msgstr "Format d’horodatage invalide"
+msgstr "Format d'horodatage invalide"
 
 msgid "Invalid executor type"
 msgstr "Type d'exécuteur invalide"
@@ -8149,7 +8152,7 @@ msgstr "Longitude/latitude invalide"
 
 #, python-format
 msgid "Invalid metric object: %(metric)s"
-msgstr "Objet mesure non valide : %(metric)s"
+msgstr "Mesure non valide : %(metric)s"
 
 #, python-format
 msgid "Invalid numpy function: %(operator)s"
@@ -8183,10 +8186,10 @@ msgstr "État invalide."
 
 #, python-format
 msgid "Invalid tab ids: %(tab_ids)s"
-msgstr "Identifiants d’onglet non valides : %s(tab_ids)"
+msgstr "Identifiants d'onglet non valides : %(tab_ids)s"
 
 msgid "Invalid username or password"
-msgstr "Le nom d’utilisateur ou le mot de passe est incorrect."
+msgstr "Le nom d'utilisateur ou le mot de passe est incorrect."
 
 msgid "Inverse selection"
 msgstr "Sélection inverse"
@@ -8241,8 +8244,7 @@ msgstr "Isoligne"
 
 msgid "Issue 1000 - The dataset is too large to query."
 msgstr ""
-"Problème 1000 - L'ensemble de données est trop volumineux pour être "
-"interrogé."
+"Problème 1000 - Le jeu de données est trop volumineux pour être interrogé."
 
 msgid "Issue 1001 - The database is under an unusual load."
 msgstr "Problème 1001 - La base de données est soumise à une charge inhabituelle."
@@ -8257,7 +8259,8 @@ msgstr ""
 "la vue d'édition du graphique s'il est vide."
 
 msgid "It’s not recommended to truncate Y axis in Bar chart."
-msgstr "Il n’est pas recommandé de tronquer l’axe dans le graphique à barres."
+msgstr ""
+"Il n'est pas recommandé de tronquer l'axe Y dans le graphique à barres."
 
 msgid "JAN"
 msgstr "JAN"
@@ -8302,7 +8305,7 @@ msgid "January"
 msgstr "Janvier"
 
 msgid "Jinja templating"
-msgstr "Modèle Jinja"
+msgstr "Modèles Jinja"
 
 msgid "July"
 msgstr "Juillet"
@@ -8317,13 +8320,13 @@ msgid "Keep control settings?"
 msgstr "Conserver les paramètres de contrôle?"
 
 msgid "Keep editing"
-msgstr "Poursuivre l’édition"
+msgstr "Poursuivre l'édition"
 
 msgid "Key"
 msgstr "Clé"
 
 msgid "Key Prefix"
-msgstr "Préfixe de clé"
+msgstr "Clé du préfixe"
 
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
@@ -8332,8 +8335,8 @@ msgstr "Raccourcis clavier"
 # sr_Latn]
 msgid "Keys are shown only once at creation. Store them securely."
 msgstr ""
-"Les clés ne sont affichées qu'une seule fois lors de la création. "
-"Conservez-les en lieu sûr."
+"Les clés sont affichés une seule et unique fois à leur création. "
+"Enregistrer les de façon sécurisée"
 
 msgid "Kilometers"
 msgstr "Kilomètres"
@@ -8345,7 +8348,7 @@ msgid "Label Contents"
 msgstr "Contenu de l'étiquette"
 
 msgid "Label Line"
-msgstr "Ligne d’étiquette"
+msgstr "Ligne d'étiquette"
 
 msgid "Label Template"
 msgstr "Modèle d'étiquette"
@@ -8357,13 +8360,13 @@ msgid "Label already exists"
 msgstr "L'étiquette existe déjà"
 
 msgid "Label ascending"
-msgstr "valeurs croissantes"
+msgstr "Etiquette croissante"
 
 msgid "Label color"
 msgstr "Couleur de l'étiquette"
 
 msgid "Label descending"
-msgstr "valeurs décroissantes"
+msgstr "Etiquette décroissante"
 
 msgid "Label for the index column. Don't use an existing column name."
 msgstr ""
@@ -8386,10 +8389,10 @@ msgid "Label size"
 msgstr "Taille de l'étiquette"
 
 msgid "Label size unit"
-msgstr "Unité de taille de l'étiquette"
+msgstr "Unité de la taille de l'étiquette"
 
 msgid "Label threshold"
-msgstr "Seuil d’étiquette"
+msgstr "Seuil d'étiquette"
 
 msgid "Labelling"
 msgstr "Étiquetage"
@@ -8436,7 +8439,7 @@ msgid "Last Updated %s by %s"
 msgstr "Dernière mise à jour %s par %s"
 
 msgid "Last Used"
-msgstr "Dernière utilisation"
+msgstr "Utilisé la dernière fois par"
 
 #, python-format
 msgid "Last available value seen on %s"
@@ -8519,7 +8522,7 @@ msgid "Layout type of graph"
 msgstr "Type de disposition du graphique"
 
 msgid "Layout type of tree"
-msgstr "Type de disposition de l’arbre"
+msgstr "Type de disposition de l'arbre"
 
 msgid "Least recently modified"
 msgstr "Dernière modification en date"
@@ -8532,8 +8535,7 @@ msgstr "Marge gauche"
 
 msgid "Left margin, in pixels, allowing for more room for axis labels"
 msgstr ""
-"Marge inférieure, en pixels, offrant plus d’espace pour les étiquettes "
-"d’axe"
+"Marge gauche, en pixels, offrant plus d'espace pour les étiquettes d'axe"
 
 msgid "Left to Right"
 msgstr "Gauche à droite"
@@ -8663,8 +8665,8 @@ msgstr ""
 "Le graphique linéaire est utilisé pour visualiser les mesures prises sur "
 "une catégorie donnée. Le graphique linéaire est un type de graphique qui "
 "affiche les informations sous forme de série de points de données reliés "
-"par des segments linéaires. Il s’agit d’un type de tableau de base commun"
-" dans de nombreux champs."
+"par des segments linéaires. Il s'agit d'un type de tableau de base commun "
+"dans de nombreux champs."
 
 msgid "Line charts on a map"
 msgstr "Graphiques en lignes sur une carte"
@@ -8742,13 +8744,13 @@ msgid "Loaded from cache"
 msgstr "Chargées depuis le cache"
 
 msgid "Loading"
-msgstr "Chargement en cours"
+msgstr "Chargement"
 
 msgid "Loading filter values"
-msgstr "Trier les valeurs de filtre"
+msgstr "Charger les valeurs de filtre"
 
 msgid "Loading timezones..."
-msgstr "Chargement des fuseaux horaires…"
+msgstr "Chargement des fuseaux horaires..."
 
 msgid "Loading..."
 msgstr "Chargement..."
@@ -8779,16 +8781,16 @@ msgid "Logarithmic axis"
 msgstr "Axe logarithmique"
 
 msgid "Logarithmic scale on primary y-axis"
-msgstr "Échelle logarithmique sur l'axe des ordonnées primaire"
+msgstr "Échelle logarithmique sur l'axe Y primaire"
 
 msgid "Logarithmic scale on secondary y-axis"
-msgstr "Échelle logarithmique sur axe des ordonnées secondaire"
+msgstr "Échelle logarithmique sur axe Y secondaire"
 
 msgid "Logarithmic x-axis"
 msgstr "Axe X logarithmique"
 
 msgid "Logarithmic y-axis"
-msgstr "Axe des ordonnées logarithmique"
+msgstr "Axe Y logarithmique"
 
 msgid "Login"
 msgstr "Connexion"
@@ -8896,7 +8898,7 @@ msgid "Mandatory"
 msgstr "Obligatoire"
 
 msgid "Manually set min/max values for the y-axis."
-msgstr "Définir manuellement les valeurs min/max pour l’axe des ordonnées."
+msgstr "Définir manuellement les valeurs min/max pour l'axe Y."
 
 msgid "Map"
 msgstr "Carte"
@@ -8905,7 +8907,7 @@ msgid "Map Options"
 msgstr "Options de carte"
 
 msgid "Map Renderer"
-msgstr "Moteur de rendu de carte"
+msgstr "Rendu de la carte"
 
 msgid "Map Style"
 msgstr "Style de carte"
@@ -8913,7 +8915,7 @@ msgstr "Style de carte"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "MapLibre (open-source)"
-msgstr "MapLibre (open source)"
+msgstr "MapLibre (open-source)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -8921,19 +8923,22 @@ msgid ""
 "MapLibre is open-source and requires no API key. Mapbox requires "
 "MAPBOX_API_KEY to be configured on the server."
 msgstr ""
-"MapLibre est open source et ne nécessite pas de clé API. Mapbox nécessite"
-" que MAPBOX_API_KEY soit configuré sur le serveur."
+"MapLibre est open-source et ne nécessite pas de clé API. Mapbox nécessite "
+"que la variable d'environnement MAPBOX_API_KEY soit configurée sur le "
+"serveur."
 
 msgid "Mapbox"
 msgstr "Mapbox"
 
 msgid "Mapbox (API key required)"
-msgstr "Mapbox (clé d'API nécessaire)"
+msgstr "Mapbox (clé API requise)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Mapbox requires a MAPBOX_API_KEY to be configured on the server."
-msgstr "Mapbox nécessite qu'une clé MAPBOX_API_KEY soit configurée sur le serveur."
+msgstr ""
+"Il est nécessaire de configurer la variable MAPBOX_API_KEY sur le serveur "
+"pour utiliser Mapbox."
 
 msgid "March"
 msgstr "Mars"
@@ -8977,7 +8982,7 @@ msgid "Match time shift color with original series"
 msgstr "Associer la couleur du décalage temporel à la série originale"
 
 msgid "Match type"
-msgstr "Type de correspondance"
+msgstr "Correspondance du type"
 
 msgid "Matrixify"
 msgstr "Matrixify"
@@ -9012,7 +9017,7 @@ msgstr ""
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Maximum folder nesting depth reached"
-msgstr "Profondeur maximale d'imbrication des dossiers atteinte"
+msgstr "Nombre de dossiers imbriqués maximum atteint"
 
 msgid "Maximum number of features to fetch from service"
 msgstr "Nombre maximum de caractéristiques à récupérer depuis le service"
@@ -9028,10 +9033,10 @@ msgid "Maximum value"
 msgstr "Valeur maximale"
 
 msgid "Maximum value on the gauge axis"
-msgstr "Valeur maximale sur l’axe de l’indicateur"
+msgstr "Valeur maximale sur l'axe de l'indicateur"
 
 msgid "Maximum width size of the path, in pixels or meters."
-msgstr "Largeur maximale du chemin, en pixels ou en mètres."
+msgstr "La largeur maximale du chemin, en pixels ou en mètre"
 
 msgid "May"
 msgstr "Mai"
@@ -9102,7 +9107,7 @@ msgid ""
 " operate over the time series data points."
 msgstr ""
 "Méthode pour calculer la valeur affichée. « Valeur globale » calcule une "
-"métrique unique sur l’ensemble de la période filtrée, idéale pour les "
+"métrique unique sur l'ensemble de la période filtrée, idéale pour les "
 "métriques non additives comme les ratios, moyennes ou comptes distincts. "
 "Les autres méthodes s'appliquent aux points de données de la série "
 "temporelle."
@@ -9131,7 +9136,7 @@ msgid "Metric assigned to the [Y] axis"
 msgstr "Mesure assignée à l'axe [Y]"
 
 msgid "Metric change in value from `since` to `until`"
-msgstr "Variation de la valeur mesure de « depuis » à « jusqu’à »"
+msgstr "Variation de la valeur mesure de « depuis » à « jusqu'à »"
 
 msgid "Metric currency"
 msgstr "Devise de la métrique"
@@ -9140,7 +9145,7 @@ msgid "Metric descending"
 msgstr "Mesure descendante"
 
 msgid "Metric factor change from `since` to `until`"
-msgstr "Le facteur mesure passe de « depuis » à « jusqu’à »"
+msgstr "Le facteur mesure passe de « depuis » à « jusqu'à »"
 
 msgid "Metric for node values"
 msgstr "Mesure pour les valeurs de nœud"
@@ -9156,7 +9161,8 @@ msgid "Metric name [%s] is duplicated"
 msgstr "Le nom de mesure [%s] est dupliqué"
 
 msgid "Metric percent change in value from `since` to `until`"
-msgstr "Pourcentage de variation de la valeur mesure de « depuis » à « jusqu’à »"
+msgstr ""
+"Pourcentage de variation de la valeur mesure de « depuis » à « jusqu'à »"
 
 msgid "Metric that defines the size of the bubble"
 msgstr "Mesure qui définit la taille de la bulle"
@@ -9190,9 +9196,9 @@ msgid ""
 "limit is present. If undefined reverts to the first metric (where "
 "appropriate)."
 msgstr ""
-"Mesure utilisée pour définir comment les séries principales sont triées "
-"si une limite de série ou de rangée est définie. Si indéfini, la première"
-" mesure sera utilisée (si approprié)."
+"Mesure utilisée pour définir comment les séries principales sont triées si "
+"une limite de série ou de ligne est définie. Si indéfini, la première "
+"mesure sera utilisée (si approprié)."
 
 msgid "Metrics"
 msgstr "Mesures"
@@ -9205,18 +9211,19 @@ msgstr "Mesures (%s)"
 # sr_Latn]
 msgid "Metrics can't be used for both rows and columns at the same time"
 msgstr ""
-"Les métriques ne peuvent pas être utilisées à la fois pour les lignes et "
-"les colonnes en même temps"
+"Les mesures ne peuvent pas être utilisées en même temps pour les lignes et "
+"les columns"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Metrics folder can only contain metric items"
-msgstr "Le dossier de métriques ne peut contenir que des éléments de métriques"
+msgstr ""
+"Les dossiers de mesures ne peuvent contenir que des éléments de mesure"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Metrics should be inside folders"
-msgstr "Les métriques doivent être dans des dossiers"
+msgstr "Les mesures doivent être à l'intérieur du dossier"
 
 msgid "Metrics to show in the tooltip."
 msgstr "Mesures à afficher dans l'infobulle."
@@ -9228,7 +9235,7 @@ msgid "Midnight"
 msgstr "Minuit"
 
 msgid "Miles"
-msgstr "Milles"
+msgstr "Kilomètres"
 
 msgid "Min"
 msgstr "Min"
@@ -9292,10 +9299,10 @@ msgid "Minimum value for label to be displayed on graph."
 msgstr "Valeur minimale pour que l'étiquette soit affichée sur le graphique."
 
 msgid "Minimum value on the gauge axis"
-msgstr "Valeur minimale sur l’axe de la jauge"
+msgstr "Valeur minimale sur l'axe de la jauge"
 
 msgid "Minimum width size of the path, in pixels or meters."
-msgstr "Largeur minimale du chemin, en pixels ou en mètres."
+msgstr "La taille minimal du path, en pixels ou en mètres"
 
 msgid "Minor Split Line"
 msgstr "Ligne de séparation mineure"
@@ -9462,7 +9469,7 @@ msgid "Name must be unique"
 msgstr "Le nom doit être unique"
 
 msgid "Name of table to be created"
-msgstr "Nom du tableau à créer"
+msgstr "Nom de la table à créer"
 
 msgid "Name of the column containing the id of the parent node"
 msgstr "Nom de la colonne contenant l'ID du nœud parent"
@@ -9471,7 +9478,7 @@ msgid "Name of the id column"
 msgstr "Nom de la colonne d'identification"
 
 msgid "Name of the semantic layer"
-msgstr "Nom de la couche sémantique"
+msgstr "Nom de la la couche sémantique"
 
 msgid "Name of the source nodes"
 msgstr "Nom des nœuds sources"
@@ -9480,7 +9487,7 @@ msgid "Name of the target nodes"
 msgstr "Nom des nœuds cibles"
 
 msgid "Name of your tag"
-msgstr "Nom de votre balise"
+msgstr "Nommez votre étiquette"
 
 msgid "Name your database"
 msgstr "Nom de votre base de données"
@@ -9499,10 +9506,10 @@ msgid "Native filter values has no values"
 msgstr "Le filtre natif n'a pas de valeurs"
 
 msgid "Need help? Learn how to connect your database"
-msgstr "Besoin d’aide? Apprenez comment connecter votre base de données"
+msgstr "Besoin d'aide? Apprenez comment connecter votre base de données"
 
 msgid "Need help? Learn more about"
-msgstr "Besoin d’aide? En savoir plus sur"
+msgstr "Besoin d'aide? En savoir plus sur"
 
 msgid "Network Error"
 msgstr "Erreur de réseau"
@@ -9563,7 +9570,7 @@ msgid "No Data"
 msgstr "Aucune donnée"
 
 msgid "No Logs yet"
-msgstr "Pas encore de logs"
+msgstr "Pas encore de jounaux"
 
 msgid "No Results"
 msgstr "Aucun résultat"
@@ -9575,7 +9582,7 @@ msgid "No SQL query found"
 msgstr "Aucune requête SQL trouvée"
 
 msgid "No Tags created"
-msgstr "Pas d'étiquette"
+msgstr "Aucune étiquette créée"
 
 msgid "No actions"
 msgstr "Aucune action"
@@ -9629,7 +9636,7 @@ msgid "No data in file"
 msgstr "Pas de données dans le fichier"
 
 msgid "No databases available"
-msgstr "Aucune base de données n’est disponible"
+msgstr "Aucune base de données disponible"
 
 msgid "No databases match your search"
 msgstr "Aucune base de données ne correspond à votre recherche"
@@ -9650,7 +9657,7 @@ msgid "No filters"
 msgstr "Aucun filtre"
 
 msgid "No filters applied"
-msgstr "Aucun filtre"
+msgstr "Aucun filtre appliqué"
 
 msgid "No filters are currently added to this dashboard."
 msgstr "Aucun filtre n'est actuellement appliqué à ce tableau de bord."
@@ -9658,7 +9665,7 @@ msgstr "Aucun filtre n'est actuellement appliqué à ce tableau de bord."
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "No filters or customizations created yet"
-msgstr "Aucun filtre ou personnalisation créé pour l'instant"
+msgstr "Aucun filtres ou personnalisations n'existent actuellement"
 
 msgid "No form settings were maintained"
 msgstr "Aucun paramètre de formulaire n'a été conservé"
@@ -9679,7 +9686,7 @@ msgid "No matching records found"
 msgstr "Aucun enregistrement correspondant n'a été trouvé"
 
 msgid "No matching results found"
-msgstr "Aucun enregistrement correspondant n'a été trouvé"
+msgstr "Aucun résultat correspondant trouvé"
 
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr ""
@@ -9726,10 +9733,10 @@ msgid "No samples were returned for this %s"
 msgstr "Aucun échantillon n'a été renvoyé pour ce %s"
 
 msgid "No saved expressions found"
-msgstr "Aucune expression sauvegardée n'a été trouvée"
+msgstr "Aucune expression sauvegardée trouvée"
 
 msgid "No saved metrics found"
-msgstr "Aucune mesure sauvegardée n'a été trouvée"
+msgstr "Aucune mesure sauvegardée trouvée"
 
 msgid "No stored results found, you need to re-run your query"
 msgstr "Aucun résultat stocké n'a été trouvé, vous devez réexécuter votre requête"
@@ -9740,10 +9747,10 @@ msgstr ""
 "essayez l'onglet Custom SQL."
 
 msgid "No table columns"
-msgstr "Pas de colonnes de tableau"
+msgstr "Aucune colonne dans la table"
 
 msgid "No tasks yet"
-msgstr "Pas encore de tâche"
+msgstr "Pas encore de tâches"
 
 msgid "No temporal columns found"
 msgstr "Aucune colonne temporelle trouvée"
@@ -9765,8 +9772,8 @@ msgid ""
 "No validator named %(validator_name)s found (configured for the "
 "%(engine_spec)s engine)"
 msgstr ""
-"Aucun validateur nommé trouvé %(validator_name)s (configuré pour le "
-"moteur %(engine_spec)s)"
+"Aucun validateur nommé %(validator_name)s trouvé (configuré pour le moteur "
+"%(engine_spec)s)"
 
 msgid "Node label position"
 msgstr "Position de l'étiquette du nœud"
@@ -9811,10 +9818,10 @@ msgid "Not Time Series"
 msgstr "Pas de séries temporelles"
 
 msgid "Not a valid ZIP file"
-msgstr "Ce n'est pas un fichier ZIP valide"
+msgstr "Fichier ZIP invalide"
 
 msgid "Not added to any dashboard"
-msgstr "Pas d'ajout à un tableau de bord"
+msgstr "Non ajouté à un tableau de bord"
 
 msgid "Not all required fields are complete. Please provide the following:"
 msgstr ""
@@ -9822,7 +9829,7 @@ msgstr ""
 "éléments suivants :"
 
 msgid "Not available"
-msgstr "Non disponible"
+msgstr "Indisponible"
 
 msgid "Not defined"
 msgstr "Indéfini"
@@ -9849,7 +9856,7 @@ msgid "Not up to date"
 msgstr "Pas à jour"
 
 msgid "Nothing here yet"
-msgstr "Rien ici pour le moment"
+msgstr "Il n'y a rien ici pour l'instant"
 
 msgid "Nothing triggered"
 msgstr "Rien déclenché"
@@ -9893,7 +9900,7 @@ msgid "Number format"
 msgstr "Format des nombres"
 
 msgid "Number format string"
-msgstr "Chaîne de format des nombres"
+msgstr "Format des nombres"
 
 msgid "Number formatting"
 msgstr "Format des nombres"
@@ -9930,7 +9937,7 @@ msgstr "Nombre de périodes à rapporter"
 
 msgid "Number of rows of file to read. Leave empty (default) to read all rows"
 msgstr ""
-"Nombre de lignes du fichier à lire. Laissez vide (par défaut) pour lire "
+"Nombre de lignes du fichier à lire. Laisser vide (par défaut) pour lire "
 "toutes les lignes"
 
 msgid "Number of rows to skip at start of file."
@@ -9963,7 +9970,7 @@ msgid "Numerical range"
 msgstr "Interval numérique"
 
 msgid "OAuth2 client information"
-msgstr "Informations sur le client OAuth2"
+msgstr "Informations du client OAuth2"
 
 msgid "OCT"
 msgstr "OCT"
@@ -10043,7 +10050,7 @@ msgstr ""
 "données sont manquants."
 
 msgid "One or more parameters specified in the query are malformed."
-msgstr "Un ou plusieurs paramètres de la requête sont malformés."
+msgstr "Un ou plusieurs paramètres de la requête sont au mauvais format."
 
 msgid "One or more parameters specified in the query are missing."
 msgstr "Un ou plusieurs paramètres spécifiés dans la requête sont manquants."
@@ -10068,13 +10075,15 @@ msgstr ""
 # sr_Latn]
 msgid "Only exact match is available for non-string columns."
 msgstr ""
-"Seule la correspondance exacte est disponible pour les colonnes non "
+"Seule la correspondance exact est disponible pour les columns non "
 "textuelles."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Only proceed if you trust the destination or its source."
-msgstr "Ne continuez que si vous faites confiance à la destination ou à sa source."
+msgstr ""
+"Continuer uniquement si vous faites confiance à la destionation ou à la "
+"source."
 
 msgid ""
 "Only show the total value on the stacked chart, and not show on the "
@@ -10144,7 +10153,7 @@ msgstr ""
 "Exploiter la base de données en mode asynchrone, ce qui signifie que les "
 "requêtes sont exécutées sur des travailleurs distants plutôt que sur le "
 "serveur web lui-même. Cela suppose que vous disposiez d'un collaborateur "
-"Celery ainsi que d'un programme dorsal de résultats. Reportez-vous à la "
+"Celery ainsi que d'un serveur de résultats. Reportez-vous à la "
 "documentation d'installation pour plus d'informations."
 
 msgid "Operator"
@@ -10162,10 +10171,10 @@ msgstr ""
 "uniquement sur certains moteurs de base de données."
 
 msgid "Optional d3 date format string"
-msgstr "Chaîne de format de date d3 facultative"
+msgstr "Format de date d3 facultatif"
 
 msgid "Optional d3 number format string"
-msgstr "Chaîne de format de nombre d3 facultative"
+msgstr "Format de nombre d3 facultatif"
 
 msgid ""
 "Optional metric used to scale the size of each dot. Dot areas are scaled "
@@ -10274,12 +10283,12 @@ msgid ""
 "the comparison time range by the same length as your time range and use "
 "\"Custom\" to set a custom comparison range."
 msgstr ""
-"Superposez les résultats à partir d'une période de temps relative. Les "
-"deltas temporels relatifs doivent être exprimés en langage naturel "
-"(exemple : 24 heures, 7 jours, 52 semaines, 365 jours). Le texte libre "
-"est pris en charge. Utilisez « Hériter de la plage des filtres temporels "
-"» pour décaler la plage de comparaison de la même durée que votre plage "
-"temporelle, et « Personnalisé » pour définir une plage personnalisée."
+"Superposez une ou plusieurs séries temporelles à partir d'une période de "
+"temps relative. Les deltas temporels relatifs doivent être exprimés en "
+"langage naturel (exemple : 24 heures, 7 jours, 52 semaines, 365 jours). Le "
+"texte libre est pris en charge. Utilisez « Hériter de la plage des filtres "
+"temporels » pour décaler la plage de comparaison de la même durée que votre "
+"plage temporelle, et « Personnalisé » pour définir une plage personnalisée."
 
 msgid ""
 "Overlays a hexagonal grid on a map, and aggregates data within the "
@@ -10305,7 +10314,7 @@ msgid "Overwrite Dashboard [%s]"
 msgstr "Ecraser le tableau de bord [%s]"
 
 msgid "Overwrite existing"
-msgstr "Remplacer les données existantes"
+msgstr "Remplacer l'existant"
 
 msgid "Overwrite text in the editor with a query on this table"
 msgstr "Remplacer le texte de l'éditeur par une requête sur ce tableau"
@@ -10357,13 +10366,13 @@ msgstr "Parent"
 
 #, python-format
 msgid "Parsing error: %(error)s"
-msgstr "Erreur : %(error)s"
+msgstr "Erreur de parsing : %(error)s"
 
 msgid "Part of a Whole"
-msgstr "Ensembles"
+msgstr "Partie d'un tout"
 
 msgid "Partition Chart"
-msgstr "Diagramme de partition"
+msgstr "Graphique de partition"
 
 msgid "Partition Diagram"
 msgstr "Diagramme de partition"
@@ -10425,7 +10434,7 @@ msgstr "Modèle"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Pause auto refresh if tab is inactive"
-msgstr "Suspendre l'actualisation automatique si l'onglet est inactif"
+msgstr "Mettre en pause l'actualisation automatique si l'onglet est inactif"
 
 msgid "Pause auto-refresh"
 msgstr "Suspendre le rafraîchissement automatique"
@@ -10518,7 +10527,8 @@ msgid "Pick a name to help you identify this database."
 msgstr "Choisissez un nom pour vous aider à identifier cette base de données."
 
 msgid "Pick a nickname for how the database will display in Superset."
-msgstr "Choisissez un surnom pour l'affichage de la base de données dans Superset."
+msgstr ""
+"Choisissez un nom pour l'affichage de la base de données dans Superset."
 
 msgid "Pick a title for you annotation."
 msgstr "Choisissez un titre pour votre annotation."
@@ -10562,7 +10572,7 @@ msgid "Pin Right"
 msgstr "Épingler à droite"
 
 msgid "Pin to the result panel"
-msgstr "Épingler au panneau de résultats"
+msgstr "Epingler dans le panneau de résultat"
 
 msgid "Pin to top"
 msgstr "Épingler en haut"
@@ -10746,7 +10756,7 @@ msgid "Plugins"
 msgstr "Plugins"
 
 msgid "Point Cluster Map"
-msgstr "Carte de clusters de points"
+msgstr "Point du cluster de la carte"
 
 msgid "Point Color"
 msgstr "Couleur du point"
@@ -10762,7 +10772,7 @@ msgstr "Unité de rayon de point"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 msgid "Point Radius Units"
-msgstr "Unités du rayon de point"
+msgstr "Unités du rayon du point"
 
 msgid "Point Size"
 msgstr "Taille du point"
@@ -10816,10 +10826,10 @@ msgid "Position of column level subtotal"
 msgstr "Position du sous-total au niveau de la colonne"
 
 msgid "Position of intermediate node label on tree"
-msgstr "Position de l’étiquette de nœud intermédiaire sur l’arbre"
+msgstr "Position de l'étiquette de nœud intermédiaire sur l'arbre"
 
 msgid "Position of row level subtotal"
-msgstr "Position du sous-total au niveau de la rangée"
+msgstr "Position du sous-total au niveau de la ligne"
 
 msgid "Powered by Apache Superset"
 msgstr "Propulsé par Apache Superset"
@@ -10849,7 +10859,7 @@ msgid "Preview"
 msgstr "Prévisualisation"
 
 msgid "Preview uploaded file"
-msgstr "Aperçu du fichier téléversé"
+msgstr "Aperçu du fichier chargé"
 
 msgid "Previous"
 msgstr "Précédent"
@@ -10867,13 +10877,13 @@ msgid "Primary key"
 msgstr "Clé primaire"
 
 msgid "Primary or secondary y-axis"
-msgstr "Axe des ordonnées primaire ou secondaire"
+msgstr "Axe Y primaire ou secondaire"
 
 msgid "Primary y-axis Bounds"
-msgstr "Limites de l’axe des ordonnées primaires"
+msgstr "Limites de l'axe Y primaires"
 
 msgid "Primary y-axis format"
-msgstr "Format de l’axe primaire des ordonnées"
+msgstr "Format de l'axe Y primaire"
 
 msgid "Private"
 msgstr "Privé"
@@ -10894,7 +10904,7 @@ msgstr "Continuer"
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 #, python-format
 msgid "Processing export for %s"
-msgstr "Traitement de l'exportation pour %s"
+msgstr "Export en cours de réalisation pour %s"
 
 msgid "Processing export..."
 msgstr "Traitement de l'export en cours…"
@@ -10914,12 +10924,12 @@ msgstr "Proportionnel"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Public and privately shared sheets"
-msgstr "Feuilles partagées publiquement et en privé"
+msgstr "Feuilles partagées publiquement et privées"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Publicly shared sheets only"
-msgstr "Feuilles partagées publiquement uniquement"
+msgstr "Uniquement les feuilles partagées publiquement"
 
 msgid "Published"
 msgstr "Publié"
@@ -10928,10 +10938,10 @@ msgid "Purple"
 msgstr "Violet"
 
 msgid "Put labels outside"
-msgstr "Placer les étiquettes à l’extérieur"
+msgstr "Placer les étiquettes à l'extérieur"
 
 msgid "Put the labels outside of the pie?"
-msgstr "Placer les étiquettes à l’extérieur du graphique circulaire?"
+msgstr "Placer les étiquettes à l'extérieur du graphique circulaire?"
 
 msgid "Put your code here"
 msgstr "Mettez votre code ici"
@@ -11053,10 +11063,10 @@ msgid "Range filter"
 msgstr "Filtre d'intervalle"
 
 msgid "Range filter plugin using AntD"
-msgstr "Module d'extension de filtre d’intervalle utilisant AntD"
+msgstr "Plugin de filtre d'intervalle utilisant AntD"
 
 msgid "Range labels"
-msgstr "Étiquettes d’intervalle"
+msgstr "Étiquettes d'intervalle"
 
 msgid "Range type"
 msgstr "Type d'intervalle"
@@ -11113,7 +11123,7 @@ msgid "Red for increase, green for decrease"
 msgstr "Rouge pour une augmentation, vert pour une diminution"
 
 msgid "Redo the action"
-msgstr "Refaire l’action"
+msgstr "Refaire l'action"
 
 msgid "Reduce X ticks"
 msgstr "Réduire X points de repère"
@@ -11124,11 +11134,10 @@ msgid ""
 "will be applied to columns and the width may overflow into an horizontal "
 "scroll."
 msgstr ""
-"Réduit le nombre de points de repère de l’axe des abscisses à afficher. "
-"Si la valeur est définie à True, l’axe des abscisses ne débordera pas et "
-"des étiquettes pourraient être manquantes. Si elle est fausse, une "
-"largeur minimale sera appliquée aux colonnes et la largeur pourrait "
-"déborder dans un défilement horizontal."
+"Réduit le nombre de points de repère de l'axe X à afficher. Si la valeur "
+"est définie à True, l'axe X ne débordera pas et des étiquettes pourraient "
+"être manquantes. Si elle est fausse, une largeur minimale sera appliquée "
+"aux colonnes et la largeur pourrait déborder dans un défilement horizontal."
 
 msgid "Refer to the"
 msgstr "Se référer à"
@@ -11149,14 +11158,14 @@ msgid "Refresh delayed"
 msgstr "Actualisation retardée"
 
 msgid "Refresh frequency"
-msgstr "Fréquence d’actualisation"
+msgstr "Fréquence d'actualisation"
 
 #, python-format
 msgid "Refresh frequency must be at least %s seconds"
 msgstr "La fréquence de rafraîchissement doit être d'au moins %s secondes"
 
 msgid "Refresh interval"
-msgstr "Intervalle d’actualisation"
+msgstr "Intervalle d'actualisation"
 
 msgid "Refresh interval saved"
 msgstr "Intervalle d'actualisation enregistré"
@@ -11168,7 +11177,7 @@ msgid "Refresh settings"
 msgstr "Paramètres d'actualisation"
 
 msgid "Refresh table schema"
-msgstr "Voir le schéma du tableau"
+msgstr "Actualiser le schéma de la table"
 
 msgid "Refresh the default values"
 msgstr "Actualiser les valeurs par défaut"
@@ -11180,7 +11189,7 @@ msgid "Refreshing columns"
 msgstr "Actualisation des colonnes"
 
 msgid "Register"
-msgstr "S'inscire"
+msgstr "S'inscrire"
 
 msgid "Registration date"
 msgstr "Date d'inscription"
@@ -11239,7 +11248,7 @@ msgid "Remove cross-filter"
 msgstr "Supprimer le filtre croisé"
 
 msgid "Remove customization"
-msgstr "Supprimer la personnalisation"
+msgstr "Supprimer les personnalisations"
 
 msgid "Remove dependency"
 msgstr "Supprimer la dépendance"
@@ -11248,7 +11257,7 @@ msgid "Remove filter"
 msgstr "Supprimer le filtre"
 
 msgid "Remove item"
-msgstr "Supprimer l’élément"
+msgstr "Supprimer l'élément"
 
 msgid "Remove notification method"
 msgstr "Supprimer le mode de notification"
@@ -11315,13 +11324,13 @@ msgstr ""
 
 msgid "Report Schedule execution failed when generating a pdf."
 msgstr ""
-"L'exécution de la planification de rapport a échoué à la génération d'un "
-"pdf."
+"L'exécution de la planification de rapport a échoué lors de la génération "
+"du pdf."
 
 msgid "Report Schedule execution failed when generating a screenshot."
 msgstr ""
-"L'exécution de la planification de rapport a échoué à la génération d'une"
-" capture d’écran."
+"L'exécution de la planification de rapport a échoué à la génération d'une "
+"capture d'écran."
 
 msgid "Report Schedule execution failed when generating an Excel file."
 msgstr ""
@@ -11354,7 +11363,7 @@ msgstr ""
 "refusé."
 
 msgid "Report Schedule log prune failed."
-msgstr "Échec de l’élagage du journal du planification de rapport."
+msgstr "Échec de l'élagage du journal du planification de rapport."
 
 msgid "Report Schedule not found."
 msgstr "Planification de rapport introuvable."
@@ -11388,10 +11397,10 @@ msgid "Report not yet run"
 msgstr "Rapport pas encore exécuté"
 
 msgid "Report schedule client error"
-msgstr "Erreur du client de la planification de rapport"
+msgstr "Erreur de la planification du rapport par le client"
 
 msgid "Report schedule system error"
-msgstr "Erreur système de la planification de rapport"
+msgstr "Erreur de la planification du rapport par le serveur"
 
 msgid "Report schedule unexpected error"
 msgstr "Erreur inattendue de la planification de rapport"
@@ -11490,12 +11499,12 @@ msgid "Resource already has an attached report."
 msgstr "La ressource a déjà un rapport joint."
 
 msgid "Resource was not found."
-msgstr "Base de données non trouvée."
+msgstr "Ressource introuvable."
 
 msgid "Resource was removed before editorship could be verified"
 msgstr ""
-"La ressource a été supprimée avant que le droit de modification puisse "
-"être vérifié"
+"La ressource a été supprimée avant que le propriétaire de la ressource soit "
+"vérifié."
 
 msgid "Restore filter"
 msgstr "Restaurer le filtre"
@@ -11508,12 +11517,11 @@ msgid "Results %s"
 msgstr "Résultats %s"
 
 msgid "Results backend is not configured."
-msgstr "Le programme dorsal des résultats n'est pas configuré."
+msgstr "Le serveur des résultats n'est pas configuré."
 
 msgid "Results backend needed for asynchronous queries is not configured."
 msgstr ""
-"Le programme dorsal des résultats pour les requêtes asynchrones n'est pas"
-" configuré."
+"Le serveur des résultats pour les requêtes asynchrones n'est pas configuré."
 
 msgid "Resume auto-refresh"
 msgstr "Reprendre le rafraîchissement automatique"
@@ -11525,10 +11533,10 @@ msgid "Retry fetching results"
 msgstr "relancer la récupération des résultats"
 
 msgid "Return to Superset"
-msgstr "Retour à Superset"
+msgstr "Retourner à Superset."
 
 msgid "Return to specific datetime."
-msgstr "Retour à l’horodatage spécifique."
+msgstr "Retour à l'horodatage spécifique."
 
 msgid "Reverse Lat & Long"
 msgstr "Inverser la latitude et la longitude"
@@ -11540,7 +11548,7 @@ msgid "Revoke"
 msgstr "Révoquer"
 
 msgid "Revoke API Key"
-msgstr "Révoquer la clé d'API"
+msgstr "Révoquer la clé API"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, sr,
 # sr_Latn]
@@ -11616,7 +11624,7 @@ msgid "Rose Type"
 msgstr "Type de rose"
 
 msgid "Rotate x axis label"
-msgstr "Faire pivoter l’étiquette de l’axe des absisses"
+msgstr "Faire pivoter l'étiquette de l'axe X"
 
 msgid "Rotate y axis label"
 msgstr "Faire pivoter l'étiquette de l'axe Y"
@@ -11628,33 +11636,33 @@ msgid "Round cap"
 msgstr "Extrémité arrondie"
 
 msgid "Row"
-msgstr "Rangée"
+msgstr "Ligne"
 
 msgid "Row Level Security"
-msgstr "Sécurité au niveau de la rangée"
+msgstr "Sécurité au niveau des lignes"
 
 msgid ""
 "Row Limit: percentages are calculated based on the subset of data "
 "retrieved, respecting the row limit. All Records: Percentages are "
 "calculated based on the total dataset, ignoring the row limit."
 msgstr ""
-"Limite de lignes : les pourcentages sont calculés sur l’ensemble des "
-"données récupérées, en respectant la limite de lignes. Toutes les données"
-" : les pourcentages sont calculés sur l’ensemble du jeu de données, en "
+"Limite de lignes : les pourcentages sont calculés sur l'ensemble des "
+"données récupérées, en respectant la limite de lignes. Toutes les données : "
+"les pourcentages sont calculés sur l'ensemble du jeu de données, en "
 "ignorant la limite de lignes."
 
 msgid ""
 "Row containing the headers to use as column names (0 is first line of "
 "data)."
 msgstr ""
-"Rangée contenant les en-têtes à utiliser comme noms de colonnes (0 est la"
-" première ligne de données)."
+"Ligne contenant les en-têtes à utiliser comme noms de colonnes (0 est la "
+"première ligne de données)."
 
 msgid "Row height"
 msgstr "Hauteur de la ligne"
 
 msgid "Row limit"
-msgstr "Nombre de rangées maximum"
+msgstr "Nombre de lignes maximum"
 
 msgid "Row-Level Security"
 msgstr ""
@@ -11664,19 +11672,19 @@ msgid "Row-Level Security: %d filter(s) may restrict data based on your role."
 msgstr ""
 
 msgid "Rows"
-msgstr "Rangées"
+msgstr "Lignes"
 
 msgid "Rows (vertical layout)"
 msgstr "Lignes (disposition verticale)"
 
 msgid "Rows per page, 0 means no pagination"
-msgstr "Rangées par page, 0 signifie aucune pagination"
+msgstr "lignes par page, 0 signifie aucune pagination"
 
 msgid "Rows subtotal position"
-msgstr "Position du sous-total des rangées"
+msgstr "Position du sous-total des lignes"
 
 msgid "Rows to read"
-msgstr "Rangées à lire"
+msgstr "Lignes à lire"
 
 msgid "Rule"
 msgstr "Règle"
@@ -11718,7 +11726,7 @@ msgid "Run selection"
 msgstr "Exécuter la sélection"
 
 msgid "Running"
-msgstr "En cours d’exécution"
+msgstr "En cours d'exécution"
 
 #, python-format
 msgid "Running block %(block_num)s out of %(block_count)s"
@@ -11743,9 +11751,9 @@ msgid ""
 "Qualify tables explicitly and avoid dynamic SQL inside stored-procedure "
 "or vendor-specific calls."
 msgstr ""
-"SQL Lab ne peut pas autoriser une instruction qui n'a pas pu être "
-"entièrement analysée. Qualifiez explicitement les tables et évitez le SQL"
-" dynamique dans les procédures stockées ou les appels spécifiques au "
+"SQL Lab ne peut pas valider une instruction qui n'a pas pu être entièrement "
+"analysée. Spécifiez explicitement les tables et évitez d'utiliser du SQL "
+"dynamique au sein des procédures stockées ou des appels spécifiques à un "
 "fournisseur."
 
 msgid "SQL Lab queries"
@@ -11762,12 +11770,12 @@ msgid ""
 "Note that you will need to close other SQL Lab windows before you do this."
 msgstr ""
 "SQL Lab utilise le stockage local de votre navigateur pour stocker les "
-"requêtes et les résultats. Actuellement, vous utilisez %(currentUsage)s "
-"ko sur %(maxStorage)d ko à partir de l’espace de stockage. Pour éviter "
-"que SQL Lab ne tombe en panne, veuillez supprimer certains onglets de "
-"requête. Vous pouvez accéder à nouveau à ces requêtes en utilisant la "
-"fonction Enregistrer avant de supprimer l’onglet. Veuillez noter que vous"
-" devrez fermer les autres fenêtres de SQL Lab avant de le faire."
+"requêtes et les résultats. Actuellement, vous utilisez %(currentUsage)s ko "
+"sur %(maxStorage)d ko à partir de l'espace de stockage. Pour éviter que SQL "
+"Lab ne tombe en panne, veuillez supprimer certains onglets de requête. Vous "
+"pouvez accéder à nouveau à ces requêtes en utilisant la fonction "
+"Enregistrer avant de supprimer l'onglet. Veuillez noter que vous devrez "
+"fermer les autres fenêtres de SQL Lab avant de le faire."
 
 msgid "SQL Query"
 msgstr "Requête SQL"
@@ -11779,7 +11787,7 @@ msgid "SQL query"
 msgstr "Requête SQL"
 
 msgid "SQL was formatted"
-msgstr "Le SQL a été formaté"
+msgstr "La requête SQL a été formatée"
 
 msgid "SQLAlchemy URI"
 msgstr "SQLAlchemy URI"
@@ -11868,10 +11876,10 @@ msgstr "Enregistrer sous"
 
 #, python-format
 msgid "Save as %s"
-msgstr "Enregistrer comme %s"
+msgstr "Enregistrer sous %s"
 
 msgid "Save as Dataset"
-msgstr "Enregistrer comme ensemble de données"
+msgstr "Enregistrer comme jeu de données"
 
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
@@ -11907,7 +11915,7 @@ msgid "Save for this session"
 msgstr "Enregistrer pour cette session"
 
 msgid "Save or Overwrite Dataset"
-msgstr "Enregistrer ou remplacer l’ensemble de données"
+msgstr "Enregistrer ou remplacer le jeu de données"
 
 msgid "Save query"
 msgstr "Enregistrer la requête"
@@ -11915,12 +11923,12 @@ msgstr "Enregistrer la requête"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Save this API key securely"
-msgstr "Enregistrez cette clé API en lieu sûr"
+msgstr "Enregistrer cette clé API de manière sécurisée."
 
 msgid "Save this query as a virtual dataset to continue exploring"
 msgstr ""
-"Enregistrez cette requête en tant qu’ensemble de données virtuel pour "
-"continuer à explorer"
+"Enregistrez cette requête en tant que jeu de données virtuel pour continuer "
+"à explorer"
 
 msgid "Saved"
 msgstr "Enregistré"
@@ -11973,8 +11981,8 @@ msgid ""
 "connected in order. It shows a statistical relationship between two "
 "variables."
 msgstr ""
-"Le diagramme de dispersion a l’axe horizontal en unités linéaires et les "
-"points sont connectés dans l’ordre. Il montre une relation statistique "
+"Le diagramme de dispersion a l'axe horizontal en unités linéaires et les "
+"points sont connectés dans l'ordre. Il montre une relation statistique "
 "entre deux variables."
 
 msgid "Schedule"
@@ -11999,7 +12007,7 @@ msgid "Scheduled at (UTC)"
 msgstr "Planifié à (UTC)"
 
 msgid "Scheduled task executor not found"
-msgstr "L'exécuteur de la tâche planifiée n'a pas été trouvé"
+msgstr "Exécuteur de tâche planifiée introuvable"
 
 msgid "Schema"
 msgstr "Schéma"
@@ -12008,7 +12016,7 @@ msgid "Schema cache timeout"
 msgstr "Délai d'attente pour le cache du schéma dépassé"
 
 msgid "Schemas allowed for File upload"
-msgstr "Schémas autorisés pour le téléversement de fichiers"
+msgstr "Schémas autorisés pour charger des fichiers"
 
 msgid "Scope"
 msgstr "Portée"
@@ -12049,7 +12057,7 @@ msgid "Search all charts"
 msgstr "Rechercher tous les graphiques"
 
 msgid "Search all metrics & columns"
-msgstr "Rechercher toutes les mesures et les colonnes"
+msgstr "Rechercher les mesures et les colonnes"
 
 msgid "Search box"
 msgstr "Boîte de recherche"
@@ -12064,13 +12072,13 @@ msgid "Search calculated columns by name"
 msgstr "Rechercher les colonnes calculées par nom"
 
 msgid "Search charts by name, editor, or dashboard"
-msgstr "Rechercher des graphiques par nom, éditeur ou tableau de bord"
+msgstr "Recherche le graphique par nom, éditeur ou tableau de bord"
 
 msgid "Search columns"
 msgstr "Recherche de colonnes"
 
 msgid "Search columns by name"
-msgstr "Rechercher des colonnes par nom"
+msgstr "Rechercher les colonnes par nom"
 
 msgid "Search columns..."
 msgstr "Recherche de colonnes"
@@ -12082,13 +12090,13 @@ msgid "Search in filters"
 msgstr "Recherche dans les filtres"
 
 msgid "Search metrics by key or label"
-msgstr "Rechercher les métriques par clé ou étiquette"
+msgstr "Rechercher les mesures par clé ou intitulé"
 
 msgid "Search records"
 msgstr "Rechercher des enregistrements"
 
 msgid "Search tags"
-msgstr "Rechercher des balises"
+msgstr "Recherche d'étiquettes"
 
 msgid "Search viewers"
 msgstr "Rechercher des lecteurs"
@@ -12111,18 +12119,16 @@ msgid "Secondary Metric"
 msgstr "Mesure secondaire"
 
 msgid "Secondary currency format"
-msgstr ""
-"Format de devise secondaireNombre de pas entre les points de repère lors "
-"de l'affichage de l'échelle des X"
+msgstr "Format de devise secondaire"
 
 msgid "Secondary y-axis Bounds"
-msgstr "Limites secondaires de l'axe des ordonnées"
+msgstr "Limites secondaires de l'axe Y"
 
 msgid "Secondary y-axis format"
-msgstr "Format secondaire de l’axe des ordonnées"
+msgstr "Format secondaire de l'axe Y"
 
 msgid "Secondary y-axis title"
-msgstr "Titre secondaire de l’axe des ordonnées"
+msgstr "Titre secondaire de l'axe Y"
 
 #, python-format
 msgid "Seconds %s"
@@ -12139,7 +12145,7 @@ msgstr "Voir "
 
 #, python-format
 msgid "See all %(tableName)s"
-msgstr "Voir tout %(tableName)s"
+msgstr "Voir tous les %(tableName)s"
 
 msgid "See all dashboards"
 msgstr "Voir tous les tableaux de bord"
@@ -12158,7 +12164,7 @@ msgstr "Sélectionner"
 
 #, python-format
 msgid "Select %s or type to search %s"
-msgstr "Sélectionner %s ou taper pour chercher %s"
+msgstr "Sélectionner %s ou écriver pour rechercher %s"
 
 msgid "Select ..."
 msgstr "Sélectionner…"
@@ -12176,7 +12182,7 @@ msgid "Select Filter"
 msgstr "Sélectionner un filtre"
 
 msgid "Select Tags"
-msgstr "Sélectionner des balises"
+msgstr "Sélectionner les étiquettes"
 
 msgid "Select Value"
 msgstr "Sélectionner une valeur"
@@ -12204,13 +12210,13 @@ msgid "Select a database table."
 msgstr "Sélectionner une table de base de données."
 
 msgid "Select a database to connect"
-msgstr "Sélectionner une base de données à connecter"
+msgstr "Sélectionnez une base de données à connecter"
 
 msgid "Select a database to upload the file to"
-msgstr "Sélectionner une base de données vers laquelle téléverser le fichier"
+msgstr "Sélectionner une base de données vers laquelle charger le fichier"
 
 msgid "Select a database to write a query"
-msgstr "Sélectionner une base de données pour écrire une requête"
+msgstr "Sélectionnez une base de données pour écrire une requête"
 
 msgid "Select a delimiter for this data"
 msgstr "Sélectionner un délimiteur pour ces données"
@@ -12219,10 +12225,10 @@ msgid "Select a dimension"
 msgstr "Sélectionner une dimension"
 
 msgid "Select a linear color scheme"
-msgstr "Sélectionner un schéma de couleurs"
+msgstr "Sélectionnez une palette de couleurs linéaire"
 
 msgid "Select a metric to display on the right axis"
-msgstr "Choisir une mesure pour l'axe de droite"
+msgstr "Choisir une mesure à afficher sur l'axe de droite"
 
 msgid ""
 "Select a metric to display. You can use an aggregation function on a "
@@ -12235,7 +12241,7 @@ msgstr ""
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Select a predefined CSS template to apply to your dashboard"
-msgstr "Sélectionner un modèle CSS prédéfini à appliquer à votre tableau de bord"
+msgstr "Sélectionné un template CSS prédéfini à appliquer au tableau de bord"
 
 msgid "Select a schema"
 msgstr "Sélectionner un schéma"
@@ -12250,7 +12256,7 @@ msgid "Select a semantic layer type"
 msgstr "Sélectionner un type de couche sémantique"
 
 msgid "Select a sheet name from the uploaded file"
-msgstr "Sélectionner un nom de feuille à partir du fichier téléversé"
+msgstr "Sélectionner un nom de feuille à partir du fichier chargé"
 
 msgid "Select a tab"
 msgstr "Sélectionner un onglet"
@@ -12269,7 +12275,7 @@ msgid "Select a visualization type"
 msgstr "Selectionner un type de visualisation"
 
 msgid "Select aggregate options"
-msgstr "Sélectionner les options d’agrégat"
+msgstr "Sélectionner les options d'agrégat"
 
 msgid "Select all"
 msgstr "Sélectionner tout"
@@ -12281,7 +12287,9 @@ msgid "Select all items"
 msgstr "Sélectionner tous les éléments"
 
 msgid "Select catalog or type to search catalogs"
-msgstr "Sélectionner un tableau ou un type de tableau pour effectuer une recherche"
+msgstr ""
+"Sélectionnez le catalogue ou saisissez une partie de son nom pour filtrer "
+"les possibilités"
 
 msgid "Select channels"
 msgstr "Sélectionner des canaux"
@@ -12321,7 +12329,7 @@ msgid "Select currency code column"
 msgstr "Sélectionner la colonne du code de devise"
 
 msgid "Select current page"
-msgstr "Sélectionner la page en cours"
+msgstr "Sélectionner la page actuelle"
 
 msgid "Select dashboard"
 msgstr "Sélectionner un tableau de bord"
@@ -12349,7 +12357,7 @@ msgid "Select dataset source"
 msgstr "Sélectionner la source du jeu de données"
 
 msgid "Select datetime column"
-msgstr "Sélectionner la colonne de date/heure"
+msgstr "Sélectionner une colonne temporelle"
 
 msgid "Select dimension"
 msgstr "Sélectionner une dimension"
@@ -12470,7 +12478,7 @@ msgid "Select scheme"
 msgstr "Sélectionner un schéma"
 
 msgid "Select semantic views"
-msgstr "Sélectionner des vues sémantiques"
+msgstr "Sélectionner la vue sémantique"
 
 msgid ""
 "Select shape for computing values. \"FIXED\" sets all zoom levels to the "
@@ -12489,7 +12497,9 @@ msgid "Select tab"
 msgstr "Sélectionner un onglet"
 
 msgid "Select table or type to search tables"
-msgstr "Sélectionner un tableau ou un type de tableau pour effectuer une recherche"
+msgstr ""
+"Sélectionnez une table ou saisissez une partie de son nom pour filtrer les "
+"possibilités"
 
 msgid "Select the Annotation Layer you would like to use."
 msgstr "Sélectionner la couche d'annotation que vous souhaitez utiliser."
@@ -12501,13 +12511,13 @@ msgid ""
 "\"All charts\" to apply cross-filters to all charts that use the same "
 "dataset or contain the same column name in the dashboard."
 msgstr ""
-"Sélectionnez les graphiques auxquels vous souhaitez appliquer des filtres"
-" croisés dans ce tableau de bord. Si vous désélectionnez un graphique, il"
-" ne sera pas filtré lors de l'application de filtres croisés à partir de "
-"n'importe quel graphique du tableau de bord. Vous pouvez sélectionner « "
-"Tous les graphiques » pour appliquer des filtres croisés à tous les "
-"graphiques qui utilisent le même ensemble de données ou contiennent le "
-"même nom de colonne dans le tableau de bord."
+"Sélectionnez les graphiques auxquels vous souhaitez appliquer des filtres "
+"croisés dans ce tableau de bord. Si vous désélectionnez un graphique, il ne "
+"sera pas filtré lors de l'application de filtres croisés à partir de "
+"n'importe quel graphique du tableau de bord. Vous pouvez sélectionner "
+"« Tous les graphiques » pour appliquer des filtres croisés à tous les "
+"graphiques qui utilisent le même jeu de données ou contiennent le même nom "
+"de colonne dans le tableau de bord."
 
 msgid ""
 "Select the charts to which you want to apply cross-filters when "
@@ -12515,32 +12525,32 @@ msgid ""
 "filters to all charts that use the same dataset or contain the same "
 "column name in the dashboard."
 msgstr ""
-"Sélectionnez les graphiques auxquels vous souhaitez appliquer des filtres"
-" croisés lorsque vous interagissez avec ce graphique. Vous pouvez "
-"sélectionner « Tous les graphiques » pour appliquer des filtres à tous "
-"les graphiques qui utilisent le même ensemble de données ou contiennent "
-"le même nom de colonne dans le tableau de bord."
+"Sélectionnez les graphiques auxquels vous souhaitez appliquer des filtres "
+"croisés lorsque vous interagissez avec ce graphique. Vous pouvez "
+"sélectionner « Tous les graphiques » pour appliquer des filtres à tous les "
+"graphiques qui utilisent le même jeu de données ou contiennent le même nom "
+"de colonne dans le tableau de bord."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Select the color used for values that indicate an increase in the chart"
 msgstr ""
-"Sélectionner la couleur utilisée pour les valeurs indiquant une hausse "
-"dans le graphique"
+"Sélectionner la couleur utilisée pour les valeurs qui indiquent une "
+"augmentation dans le graphique"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Select the color used for values that represent total bars in the chart"
 msgstr ""
-"Sélectionner la couleur utilisée pour les valeurs représentant les barres"
-" totales dans le graphique"
+"Sélectionner la couleur utilisée pour les valeurs qui représentent le total "
+"dans le graphique"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Select the color used for values ​​that indicate a decrease in the chart."
 msgstr ""
-"Sélectionner la couleur utilisée pour les valeurs indiquant une baisse "
-"dans le graphique."
+"Sélectionner la colour utilisée pour les valeurs qui indiquent une "
+"décroissance dans le graphique"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, ja, lv,
 # ru, sk, sr, sr_Latn, tr, uk]
@@ -12551,10 +12561,10 @@ msgid ""
 " currencies, charts will fall back to neutral numeric formatting."
 msgstr ""
 "Sélectionner la colonne contenant les codes de devise tels que USD, EUR, "
-"GBP, etc. Utilisée lors de la création de graphiques lorsque le formatage"
-" de devise « Détection automatique » est activé. Si cette colonne n'est "
-"pas définie ou si une métrique de graphique contient plusieurs devises, "
-"les graphiques utiliseront un formatage numérique neutre."
+"GBP, etc. Utilisée lors de la création de graphiques lorsque le formatage "
+"de devise « Détection automatique » est activé. Si cette colonne n'est pas "
+"définie ou si une métrique de graphique contient plusieurs devises, les "
+"graphiques utiliseront un formatage numérique neutre."
 
 msgid "Select the fixed color"
 msgstr "Sélectionner la couleur fixe"
@@ -12568,9 +12578,9 @@ msgid ""
 "Select the map tile provider. MapLibre is open-source and requires no API"
 " key. Mapbox requires MAPBOX_API_KEY to be configured in Superset."
 msgstr ""
-"Sélectionner le fournisseur de tuiles cartographiques. MapLibre est open "
-"source et ne nécessite pas de clé API. Mapbox requiert que MAPBOX_API_KEY"
-" soit configuré dans Superset."
+"Sélectionner le fournisseur de fond de carte. Maplibre est open-source et "
+"ne nécessite pas de clé API. Mapbox nécessite la variable d'environnement "
+"MAPBOX_API_KEY configurée dans Superset."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -12582,10 +12592,10 @@ msgstr ""
 "point de rupture de couleur tombe chaque chemin."
 
 msgid "Select the type of color scheme to use."
-msgstr "Sélectionner un schéma de couleurs"
+msgstr "Sélectionner le type de couleur de schéma à utiliser"
 
 msgid "Select users"
-msgstr "Sélectionner des utilisateurs"
+msgstr "Sélectionner les utilisateurs"
 
 msgid "Select values"
 msgstr "Sélectionner des valeurs"
@@ -12615,7 +12625,7 @@ msgid "Selected"
 msgstr "Sélectionné"
 
 msgid "Selecting a database is required"
-msgstr "La sélection d'une base de données est requise"
+msgstr "La sélection d'une base de données est nécessaire"
 
 msgid "Selection method"
 msgstr "Méthode de sélection"
@@ -12649,13 +12659,13 @@ msgid "Semantic layer could not be updated."
 msgstr "La couche sémantique n'a pas pu être mise à jour."
 
 msgid "Semantic layer created"
-msgstr "Couche sémantique créée."
+msgstr "Couche sémantique créé."
 
 msgid "Semantic layer does not exist"
 msgstr "La couche sémantique n'existe pas"
 
 msgid "Semantic layer parameters are invalid."
-msgstr "Les paramètres de la couche sémantique sont invalides."
+msgstr "Les paramètres de la couche sémantique ne sont pas valides."
 
 msgid "Semantic layer type"
 msgstr "Type de couche sémantique"
@@ -12664,16 +12674,16 @@ msgid "Semantic layer updated"
 msgstr "La couche sémantique a été mise à jour"
 
 msgid "Semantic view could not be created."
-msgstr "La vue sémantique n’a pas pu être créée."
+msgstr "La vue sémantique n'a pas pu être créée."
 
 msgid "Semantic view could not be deleted."
 msgstr "La vue sémantique n'a pas pu être supprimée."
 
 msgid "Semantic view could not be updated."
-msgstr "La vue sémantique n’a pas pu être mise à jour."
+msgstr "La vue sémantique n'a pas pu être mise à jour."
 
 msgid "Semantic view does not exist"
-msgstr "La vue sémantique n’existe pas"
+msgstr "La vue sémantique n'existe pas"
 
 msgid "Semantic view parameters are invalid."
 msgstr "Les paramètres de la vue sémantique ne sont pas valides."
@@ -12738,10 +12748,10 @@ msgid "Series limit"
 msgstr "Limite de série"
 
 msgid "Series settings"
-msgstr "Paramètres de série"
+msgstr "Paramètres des séries"
 
 msgid "Series total setting"
-msgstr "Paramètre du total de la série"
+msgstr "Paramètres du total des séries"
 
 msgid "Series type"
 msgstr "Type de série"
@@ -12818,10 +12828,10 @@ msgid ""
 " as the time column when building charts that require a time dimension "
 "and used in dashboard level time filters."
 msgstr ""
-"Définit la colonne temporelle par défaut pour ce jeu de données. "
-"Sélectionnée automatiquement comme colonne de temps lors de la création "
-"de graphiques nécessitant une dimension temporelle et utilisée dans les "
-"filtres de temps au niveau du tableau de bord."
+"Défini la colonne temporelle par défaut sur ce jeu de données. Sélectionné "
+"automatiquement en tant que colonne temporelle pendant la création de "
+"graphiques qui nécessitent une dimension temporelle et est utilisée dans "
+"les filtres temporels au niveau du tableau de bord"
 
 msgid ""
 "Sets the hierarchy levels of the chart. Each level is\n"
@@ -12860,7 +12870,7 @@ msgid "Shared query fields"
 msgstr "Champs de requête partagée"
 
 msgid "Sheet name"
-msgstr "Nom de feuille"
+msgstr "Nom de la feuille"
 
 msgid "Shift + Click to sort by multiple columns"
 msgstr "Shift + clic pour classer par plusieurs colonnes"
@@ -12903,7 +12913,7 @@ msgid "Show Bubbles"
 msgstr "Afficher les bulles"
 
 msgid "Show CREATE VIEW statement"
-msgstr "Afficher l’énoncé CREATE VIEW"
+msgstr "Afficher l'énoncé CREATE VIEW"
 
 msgid "Show Dashboard"
 msgstr "Afficher le tableau de bord"
@@ -12930,7 +12940,7 @@ msgid "Show Range Filter"
 msgstr "Afficher l'intervalle de filtre"
 
 msgid "Show SQL"
-msgstr "Afficher le SQL"
+msgstr "Afficher SQL"
 
 msgid "Show Timestamp"
 msgstr "Afficher l'horodatage"
@@ -12951,18 +12961,18 @@ msgid "Show Values"
 msgstr "Afficher les valeurs"
 
 msgid "Show X-axis"
-msgstr "Afficher l'axe des abscisses"
+msgstr "Afficher l'axe X"
 
 msgid "Show Y-axis"
-msgstr "Afficher l’axe des ordonnées"
+msgstr "Afficher l'axe Y"
 
 msgid ""
 "Show Y-axis on the sparkline. Will display the manually set min/max if "
 "set or min/max values in the data otherwise."
 msgstr ""
-"Afficher l’axe des ordonnées sur la ligne de la bougie. Les valeurs "
-"min/max définies manuellement s’afficheront si elles sont définies ou "
-"autrement min/max dans les données."
+"Afficher l'axe Y sur la ligne de la bougie. Les valeurs min/max définies "
+"manuellement s'afficheront si elles sont définies ou autrement min/max dans "
+"les données."
 
 msgid "Show a draggable slider to control the visible range of the Y-axis."
 msgstr "Afficher un curseur déplaçable pour contrôler la plage visible de l'axe Y."
@@ -12981,19 +12991,19 @@ msgid "Show all columns"
 msgstr "Afficher toutes les colonnes"
 
 msgid "Show axis line ticks"
-msgstr "Afficher les coches de ligne d’axe"
+msgstr "Afficher les coches de ligne d'axe"
 
 msgid "Show cell bars"
 msgstr "Afficher les barres de cellules"
 
 msgid "Show cell bars for all columns"
-msgstr "Afficher les barres de cellules pour toutes les colonnes"
+msgstr "Afficher toutes les cellules de toutes les colonnes"
 
 msgid "Show chart description"
 msgstr "Afficher la description de graphique"
 
 msgid "Show chart query timestamps"
-msgstr "Afficher l'horodatage des requêtes du graphique"
+msgstr "Afficher l'horodatage de la requête du graphique"
 
 msgid "Show column headers"
 msgstr "Afficher les en-têtes de colonnes"
@@ -13024,7 +13034,7 @@ msgid ""
 msgstr ""
 "Afficher les relations hiérarchiques des données, avec la valeur "
 "représentée par aire, montrant la proportion et la contribution à "
-"l’ensemble."
+"l'ensemble."
 
 msgid "Show info tooltip"
 msgstr "Afficher l'info-bulle"
@@ -13093,8 +13103,8 @@ msgid ""
 "Show total aggregations of selected metrics. Note that row limit does not"
 " apply to the result."
 msgstr ""
-"Afficher les agrégats totaux des mesures sélectionnées. Notez que la "
-"limite de ligne ne s’applique pas au résultat."
+"Afficher les agrégats totaux des mesures sélectionnées. Notez que la limite "
+"de ligne ne s'applique pas au résultat."
 
 msgid "Show value"
 msgstr "Afficher la valeur"
@@ -13111,8 +13121,8 @@ msgid ""
 "call attention to a KPI or the one thing you want your audience to focus "
 "on."
 msgstr ""
-"Présente une seule mesure au premier plan. Il est préférable d’utiliser "
-"un grand chiffre pour attirer l’attention sur un ICR ou sur la chose sur "
+"Présente une seule mesure au premier plan. Il est préférable d'utiliser un "
+"grand chiffre pour attirer l'attention sur un ICR ou sur la chose sur "
 "laquelle vous voulez que votre public se concentre."
 
 msgid ""
@@ -13120,18 +13130,18 @@ msgid ""
 "attention to an important metric along with its change over time or other"
 " dimension."
 msgstr ""
-"Présente un seul chiffre accompagné d’un graphique linéaire simple pour "
-"attirer l’attention sur une mesure importante ainsi que son changement au"
-" fil du temps ou d’autres dimensions."
+"Présente un seul chiffre accompagné d'un graphique linéaire simple pour "
+"attirer l'attention sur une mesure importante ainsi que son changement au "
+"fil du temps ou d'autres dimensions."
 
 msgid ""
 "Showcases how a metric changes as the funnel progresses. This classic "
 "chart is useful for visualizing drop-off between stages in a pipeline or "
 "lifecycle."
 msgstr ""
-"Montre comment une mesure change au fur et à mesure que l’entonnoir "
-"progresse. Ce graphique classique est utile pour visualiser la baisse "
-"entre les étapes d'un pipeline ou d'un cycle de vie."
+"Montre comment une mesure change au fur et à mesure que l'entonnoir "
+"progresse. Ce graphique classique est utile pour visualiser la baisse entre "
+"les étapes d'un pipeline ou d'un cycle de vie."
 
 msgid ""
 "Showcases the flow or link between categories using thickness of chords. "
@@ -13145,8 +13155,8 @@ msgid ""
 "Showcases the progress of a single metric against a given target. The "
 "higher the fill, the closer the metric is to the target."
 msgstr ""
-"Affiche la progression d’une seule mesure par rapport à une cible donnée."
-" Plus le remplissage est élevé, plus la mesure est proche de la cible."
+"Affiche la progression d'une seule mesure par rapport à une cible donnée. "
+"Plus le remplissage est élevé, plus la mesure est proche de la cible."
 
 #, python-format
 msgid "Showing %s of %s items"
@@ -13172,8 +13182,7 @@ msgstr "Simple"
 
 msgid "Simple ad-hoc metrics are not enabled for this dataset"
 msgstr ""
-"Les mesures ponctuelles simples ne sont pas activées pour cet ensemble de"
-" données"
+"Les mesures ponctuelles simples ne sont pas activées pour ce jeu de données"
 
 msgid "Single"
 msgstr "Unique"
@@ -13197,7 +13206,8 @@ msgid "Size of edge symbols"
 msgstr "Taille des symboles de bord"
 
 msgid "Size of marker. Also applies to forecast observations."
-msgstr "Taille du marqueur. S’applique également aux observations prévisionnelles."
+msgstr ""
+"Taille du marqueur. S'applique également aux observations prévisionnelles."
 
 msgid "Size of the dot representing the largest value of the dot size metric."
 msgstr ""
@@ -13207,8 +13217,8 @@ msgstr ""
 
 msgid "Skip blank lines rather than interpreting them as Not A Number values"
 msgstr ""
-"Ignorer les lignes vides plutôt que de les interpréter comme des valeurs "
-"NaN"
+"Ignorer les lignes vides au lieu des les interpréter comme des valeurs "
+"non-numériques"
 
 msgid "Skip rows"
 msgstr "Sauter des lignes"
@@ -13217,7 +13227,7 @@ msgid "Skip rows is required"
 msgstr "Le nombre de lignes à ignorer est requis"
 
 msgid "Skip spaces after delimiter"
-msgstr "Supprimer l'espace après le délimiteur"
+msgstr "Ignorer l'espace après le délimiteur"
 
 #, python-format
 msgid "Skipped %d system themes that cannot be deleted"
@@ -13267,22 +13277,21 @@ msgstr ""
 # sr_Latn]
 msgid "Some groups could not be resolved and are shown as IDs."
 msgstr ""
-"Certains groupes n'ont pas pu être résolus et sont affichés sous forme "
-"d'identifiants."
+"Certains groupes n'ont pas pu être résolus et sont affichés en tant qu'IDs."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Some permissions could not be resolved and are shown as IDs."
 msgstr ""
-"Certaines autorisations n'ont pas pu être résolues et sont affichées sous"
-" forme d'identifiants."
+"Certaines permissions n'ont pas pu être résolues et sont affichées en tant "
+"qu'IDS."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Some required filters on other tabs have values and will not be cleared"
 msgstr ""
-"Certains filtres obligatoires sur d'autres onglets ont des valeurs et ne "
-"seront pas effacés"
+"Certains filtres nécessaires sur les autres onglets possèdent des valeurs "
+"et ne seront pas réinitialisés."
 
 msgid "Some tables are not shown. Refine your search."
 msgstr "Certaines tables ne sont pas affichées. Affinez votre recherche."
@@ -13343,11 +13352,13 @@ msgstr "Une erreur s'est produite. Réessayez plus tard."
 
 #, python-format
 msgid "Sorry, there was an error saving this %s: %s"
-msgstr "Une erreur s'est produite lors de la sauvegarde de %s : %s"
+msgstr "Désolé, il y a eu une erreur lors de l'enregistrement de %s: %s"
 
 #, python-format
 msgid "Sorry, there was an error saving this dashboard: %s"
-msgstr "Une erreur s'est produite lors de la sauvegarde de ce  graphique : %s"
+msgstr ""
+"Désolé, il y a eu une erreur lors de l'enregistrement ce tableau de bord : "
+"%s"
 
 msgid "Sorry, your browser does not support copying."
 msgstr "Désolé, votre navigateur ne doit pas supporter la copie."
@@ -13374,10 +13385,10 @@ msgid "Sort Series By"
 msgstr "Trier les séries par"
 
 msgid "Sort X Axis"
-msgstr "Trier l’axe des absisses"
+msgstr "Trier l'axe X"
 
 msgid "Sort Y Axis"
-msgstr "Trier l’axe des ordonnées"
+msgstr "Trier l'axe Y"
 
 msgid "Sort ascending"
 msgstr "Trier par ordre croissant"
@@ -13393,10 +13404,10 @@ msgid "Sort by data"
 msgstr "Trier par données"
 
 msgid "Sort by metric"
-msgstr "Trier les mesures"
+msgstr "Trier par mesures"
 
 msgid "Sort by original table order"
-msgstr "Trier par ordre du tableau d'origine"
+msgstr "Trier par l'ordre originel de la table"
 
 msgid "Sort by series"
 msgstr "Trier par séries"
@@ -13411,7 +13422,7 @@ msgid "Sort descending"
 msgstr "Trier par ordre décroissant"
 
 msgid "Sort display control values"
-msgstr "Trier les valeurs de filtre"
+msgstr "Trier les valeurs de contrôles"
 
 msgid "Sort filter values"
 msgstr "Trier les valeurs de filtre"
@@ -13432,13 +13443,13 @@ msgid ""
 " by metric\", this acts as a tiebreaker for equal metric values. Adding "
 "this sort may reduce query performance on some databases."
 msgstr ""
-"Trier les résultats par nom de série en ordre croissant. Combiné avec « "
-"Trier par métrique », cela sert de critère de départage pour les valeurs "
+"Trier les résultats par nom de série en ordre croissant. Combiné avec "
+"« Trier par métrique », cela sert de critère de départage pour les valeurs "
 "de métrique égales. L'ajout de ce tri peut réduire les performances des "
 "requêtes sur certaines bases de données."
 
 msgid "Sort rows by"
-msgstr "Trier les rangées par"
+msgstr "Trier les lignes par"
 
 msgid "Sort series in ascending order"
 msgstr "Trier les séries en ordre croissant"
@@ -13459,7 +13470,7 @@ msgid "Source category"
 msgstr "Catégorie de source"
 
 msgid "Source location"
-msgstr "Emplacement source"
+msgstr "Localisation de la source"
 
 msgid "Sparkline"
 msgstr "Sparkline"
@@ -13480,9 +13491,9 @@ msgid ""
 "Specify the database version. This is used with Presto for query cost "
 "estimation, and Dremio for syntax changes, among others."
 msgstr ""
-"Spécifier la version de la base de données. Ceci est utilisé avec Presto "
-"pour l'estimation du coût des requêtes, et avec Dremio pour les "
-"changements de syntaxe, entre autres."
+"Spécifier la version de la base de données. Cette option est utilisée avec "
+"Presto pour l'estimation du coût de requête et Dremio pour les "
+"modifications de syntaxe, entre autres."
 
 msgid "Split number"
 msgstr "Scinder le nombre"
@@ -13527,7 +13538,7 @@ msgid "Start"
 msgstr "Début"
 
 msgid "Start (Longitude, Latitude): "
-msgstr "Début (longitude, latitude) :"
+msgstr "Début (Longitude, Latitude) :"
 
 msgid "Start (inclusive)"
 msgstr "Début (inclus)"
@@ -13551,14 +13562,14 @@ msgid "Start date included in time range"
 msgstr "Date de début incluse de l'intervalle de temps"
 
 msgid "Start y-axis at 0"
-msgstr "Commencer l’axe des ordonnées à 0"
+msgstr "Commencer l'axe Y à 0"
 
 msgid ""
 "Start y-axis at zero. Uncheck to start y-axis at minimum value in the "
 "data."
 msgstr ""
-"Commencer l’axe des ordonnées à zéro. Décochez pour démarrer l’axe des "
-"ordonnées à la valeur minimale dans les données."
+"Commencer l'axe Y à zéro. Décochez pour démarrer l'axe Y à la valeur "
+"minimale dans les données."
 
 msgid "Started"
 msgstr "Commencé"
@@ -13567,7 +13578,7 @@ msgid "Starts With"
 msgstr "Commence par"
 
 msgid "Starts with (ILIKE x%)"
-msgstr "Commence par (ILIKE x%)"
+msgstr "Commmencer par (ILIKE x%)"
 
 msgid "State"
 msgstr "État"
@@ -13599,11 +13610,11 @@ msgid ""
 "chart can be useful when you want to show the changes that occur at "
 "irregular intervals."
 msgstr ""
-"Le graphique à lignes en escalier (également appelé graphique à étapes) "
-"est une variation du graphique linéaire, mais la ligne formant une série "
-"d’étapes entre les points de données. Un tableau des étapes peut être "
-"utile lorsque vous voulez afficher les changements qui se produisent à "
-"des intervalles irréguliers."
+"Le graphique à lignes en escalier (également appelé graphique à étapes) est "
+"une variation du graphique linéaire, mais la ligne formant une série "
+"d'étapes entre les points de données. Un tableau des étapes peut être utile "
+"lorsque vous voulez afficher les changements qui se produisent à des "
+"intervalles irréguliers."
 
 msgid "Stop"
 msgstr "Arrêter"
@@ -13633,7 +13644,7 @@ msgid "Streets"
 msgstr "Rues"
 
 msgid "Streets (Carto)"
-msgstr "Rues (Carto)"
+msgstr "Rues (carte)"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 msgid "Streets (OSM)"
@@ -13717,7 +13728,7 @@ msgid "Suffix"
 msgstr "Suffixe"
 
 msgid "Suffix to apply after the percentage display"
-msgstr "Suffixe à appliquer après l’affichage du pourcentage"
+msgstr "Suffixe à appliquer après l'affichage du pourcentage"
 
 msgid "Sum"
 msgstr "Somme"
@@ -13763,7 +13774,7 @@ msgid "Swap %s"
 msgstr "Échanger %s"
 
 msgid "Swap rows and columns"
-msgstr "Échanger les rangées et les colonnes"
+msgstr "Échanger les lignes et les colonnes"
 
 msgid "Sweep angle"
 msgstr "Angle de balayage"
@@ -13813,8 +13824,8 @@ msgstr "Syntaxe"
 #, python-format
 msgid "Syntax Error: %(qualifier)s input \"%(input)s\" expecting \"%(expected)s"
 msgstr ""
-"Erreur de syntaxe : %(qualifier)s entrée « %(input)s » en attente « "
-"%(expected)s"
+"Erreur de syntaxe : %(qualifier)s entrée « %(input)s » en attente "
+"\"%(expected)s"
 
 msgid "System"
 msgstr "Système"
@@ -13829,11 +13840,11 @@ msgid "System default theme removed"
 msgstr "Thème par défaut du système supprimé"
 
 msgid "TABLES"
-msgstr "TABLEAUX"
+msgstr "TABLES"
 
 #. do-not-translate
 msgid "TEMPORAL_RANGE"
-msgstr "TEMPORAL_RANGE"
+msgstr "PERIODE_TEMPORELLE"
 
 msgid "THU"
 msgstr "JEU"
@@ -13856,17 +13867,17 @@ msgid "Tab schema is invalid, caused by: %(error)s"
 msgstr "Le schéma du jeu de données n'est pas valide : %(error)s"
 
 msgid "Tab title"
-msgstr "Titre de l’onglet"
+msgstr "Titre de l'onglet"
 
 msgid "Table"
-msgstr "Tableau"
+msgstr "Table"
 
 #, python-format
 msgid "Table %(table)s wasn't found in the database %(db)s"
-msgstr "Le tableau %(table)s n’a pas été trouvé dans la base de données %(db)s"
+msgstr "La table %(table)s n'a pas été trouvé dans la base de données %(db)s"
 
 msgid "Table Name"
-msgstr "Nom du tableau"
+msgstr "Nom de la table"
 
 msgid "Table V2"
 msgstr "Tableau V2"
@@ -13888,23 +13899,23 @@ msgstr ""
 " à utiliser."
 
 msgid "Table cache timeout"
-msgstr "Délai d'attente du cache du tableau dépassé"
+msgstr "Délai d'attente du cache de la table dépassé"
 
 msgid "Table columns"
-msgstr "Colonnes du tableau"
+msgstr "Colonnes de la table"
 
 msgid "Table name"
-msgstr "Nom du tableau"
+msgstr "Nom de la table"
 
 msgid "Table name is required"
-msgstr "Le nom du tableau est obligatoire"
+msgstr "Le nom de la table est obligatoire"
 
 msgid "Table name undefined"
-msgstr "Nom du tableau non défini"
+msgstr "Nom de la table non défini"
 
 #, python-format
 msgid "Table or View \"%(table)s\" does not exist."
-msgstr "Le tableau ou la vue « %(table)s » n'existe pas."
+msgstr "La table ou la vue « %(table)s » n'existe pas."
 
 msgid ""
 "Table that visualizes paired t-tests, which are used to understand "
@@ -13914,7 +13925,7 @@ msgstr ""
 "comprendre les différences statistiques entre les groupes."
 
 msgid "Tables"
-msgstr "Tableaux"
+msgstr "Tables"
 
 msgid "Tabs"
 msgstr "Onglets"
@@ -13926,44 +13937,44 @@ msgid "Tag"
 msgstr "Étiquette"
 
 msgid "Tag could not be created."
-msgstr "La balise n'a pas pu être créée."
+msgstr "L'étiquette n'a pas pu être créée."
 
 msgid "Tag could not be deleted."
-msgstr "La balise n'a pas pu être supprimée."
+msgstr "L'étiquette n'a pas pu être supprimée."
 
 msgid "Tag could not be found."
-msgstr "La balise est introuvable."
+msgstr "L'étiquette est introuvable."
 
 msgid "Tag could not be updated."
-msgstr "La balise n'a pas pu être mise à jour."
+msgstr "L'étiquette n'a pas pu être mise à jour."
 
 msgid "Tag created"
-msgstr "Balise créée"
+msgstr "L'étiquette a été créé"
 
 msgid "Tag description"
-msgstr "Description de la balise"
+msgstr "Description de l'étiquette"
 
 msgid "Tag name"
-msgstr "Nom de la balise"
+msgstr "Nom de l'étiquette"
 
 msgid "Tag name is invalid (cannot contain ':')"
-msgstr "Le nom de la balise n’est pas valide (ne peut pas contenir « : »)"
+msgstr "Le nom de l'étiquette n'est pas valide (ne peut pas contenir « : »)"
 
 msgid "Tag parameters are invalid."
-msgstr "Les paramètres de balise sont invalides."
+msgstr "Les paramètres de l'étiquette ne sont pas valides."
 
 msgid "Tag updated"
-msgstr "Balise mise à jour"
+msgstr "Etiquette mise à jour"
 
 #, python-format
 msgid "Tagged %s %ss"
 msgstr "Étiqueté %s %ss"
 
 msgid "Tagged Object could not be deleted."
-msgstr "L'objet identifié n'a pas pu être supprimé."
+msgstr "L'objet étiqueté n'a pas pu être supprimé."
 
 msgid "Tags"
-msgstr "Balises"
+msgstr "Etiquettes"
 
 msgid "Target"
 msgstr "Cible"
@@ -13982,10 +13993,10 @@ msgstr "Tâche"
 
 #, python-format
 msgid "Task cancelled: %s"
-msgstr "Tâche annulée: %s"
+msgstr "Tâche échouée: %s"
 
 msgid "Task could not be aborted."
-msgstr "La tâche n'a pas pu être annulée."
+msgstr "La tâche n'a pas pu être arrêtée."
 
 msgid "Task could not be created."
 msgstr "La tâche n'a pas pu être créée."
@@ -13999,11 +14010,11 @@ msgid ""
 "Task is not abortable. The task is in progress but has not registered an "
 "abort handler."
 msgstr ""
-"La tâche ne peut pas être interrompue. La tâche est en cours mais n'a pas"
-" enregistré de gestionnaire d'interruption."
+"La tâche ne peut pas être arrếtée. La tâche est en cours et aucun moyen "
+"d'arrêter la tâche n'a été enregistré."
 
 msgid "Task parameters are invalid."
-msgstr "Les paramètres de la tâche sont invalides."
+msgstr "Les paramètres de la tâche ne sont pas valides."
 
 msgid "Tasks"
 msgstr "Tâches"
@@ -14012,8 +14023,8 @@ msgstr "Tâches"
 # sr_Latn]
 msgid "Tasks will appear here as background operations are executed."
 msgstr ""
-"Les tâches apparaîtront ici au fur et à mesure que les opérations en "
-"arrière-plan seront exécutées."
+"Les tâches apparaîtront ici pendant l'exécution des opérations d'arrière "
+"plan."
 
 msgid "Template"
 msgstr "Modèle"
@@ -14033,11 +14044,11 @@ msgstr "Paramètres du modèle"
 
 #, python-format
 msgid "Template processing error: %(error)s"
-msgstr "Erreur de traitement de modèle : %(error)s"
+msgstr "Erreur lors du traitement du modèle : %(error)s"
 
 #, python-format
 msgid "Template processing failed: %(ex)s"
-msgstr "Erreur de traitement de modèle : %(ex)s"
+msgstr "Le traitement du modèle a échoué : %(ex)s"
 
 msgid ""
 "Templated link, it's possible to include {{ metric }} or other values "
@@ -14081,7 +14092,7 @@ msgstr ""
 
 #, python-format
 msgid "The %s"
-msgstr "Le/la %s"
+msgstr "%s"
 
 #, python-format
 msgid "The %s linked to this chart may have been deleted."
@@ -14089,7 +14100,7 @@ msgstr "Le/la %s lié(s) à ce graphique semble avoir été effacé(e)."
 
 #, python-format
 msgid "The API response from %s does not match the IDatabaseTable interface."
-msgstr "La réponse API de %s ne correspond pas à l’interface IDatabaseTable."
+msgstr "La réponse API de %s ne correspond pas à l'interface IDatabaseTable."
 
 msgid ""
 "The CSS for individual dashboards can be altered here, or in the "
@@ -14141,10 +14152,10 @@ msgid ""
 "https://superset.apache.org/docs/configuration/async-queries-celery for "
 "configuration details."
 msgstr ""
-"Le Global Task Framework n'est pas activé. Définissez "
-"GLOBAL_TASK_FRAMEWORK=True dans vos indicateurs de fonctionnalité pour "
-"utiliser @task. Consultez https://superset.apache.org/docs/configuration"
-"/async-queries-celery pour les détails de configuration."
+"Le framework Global Task est désactivé. Définir GLOBAL_TASK_FRAMEWORK=True "
+"dans vos features flags pour utiliser @task. Voir "
+"https://superset.apache.org/docs/configuration/async-queries-celery pour "
+"plus de détails de configuration."
 
 msgid "The SQL query mutator removed all executable statements from this query."
 msgstr ""
@@ -14176,16 +14187,16 @@ msgid "The URL is missing the dataset_id or slice_id parameters."
 msgstr "Il manque à l'URL les paramètres dataset_id ou slice_id."
 
 msgid "The X-axis is not on the filters list"
-msgstr "L’axe des abscisses ne figure pas dans la liste des filtres"
+msgstr "L'axe X ne figure pas dans la liste des filtres"
 
 msgid ""
 "The X-axis is not on the filters list which will prevent it from being "
 "used in time range filters in dashboards. Would you like to add it to the"
 " filters list?"
 msgstr ""
-"L’axe des abscisses ne figure pas dans la liste des filtres, ce qui "
-"l’empêchera d’être utilisé dans les filtres de plage de temps dans les "
-"tableaux de bord. Voulez-vous l’ajouter à la liste des filtres?"
+"L'axe X ne figure pas dans la liste des filtres, ce qui l'empêchera d'être "
+"utilisé dans les filtres de plage de temps dans les tableaux de bord. "
+"Voulez-vous l'ajouter à la liste des filtres?"
 
 msgid "The annotation has been saved"
 msgstr "Cette annotation a été sauvegardée"
@@ -14200,8 +14211,8 @@ msgid ""
 "The category of source nodes used to assign colors. If a node is "
 "associated with more than one category, only the first will be used."
 msgstr ""
-"La catégorie de nœuds sources utilisée pour attribuer des couleurs. Si un"
-" nœud est associé à plus d’une catégorie, seul le premier sera utilisé."
+"La catégorie de nœuds sources utilisée pour attribuer des couleurs. Si un "
+"nœud est associé à plus d'une catégorie, seul le premier sera utilisé."
 
 msgid ""
 "The chart data is too large to download. Please try reducing the date "
@@ -14215,16 +14226,16 @@ msgstr ""
 # sr_Latn]
 msgid "The chart is still loading. Please wait a moment and try again."
 msgstr ""
-"Le graphique est encore en cours de chargement. Veuillez patienter un "
-"instant et réessayer."
+"Le graphique est toujours en chargement. Merci de patienter et de "
+"réessayer."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 msgid ""
 "The chart this report targets was deleted. Restore the chart, or update "
 "the report to point at an active chart."
 msgstr ""
-"Le graphique ciblé par ce rapport a été supprimé. Restaurez le graphique,"
-" ou mettez à jour le rapport pour pointer vers un graphique actif."
+"Le graphique ciblé par ce rapport a été supprimé. Restaurez le graphique, "
+"ou mettez à jour le rapport utiliser un graphique actif."
 
 msgid "The chat failed to load."
 msgstr "La conversation n'a pas pu être chargée."
@@ -14259,7 +14270,7 @@ msgid "The color of the isoline"
 msgstr "La couleur de l'isoligne"
 
 msgid "The color of the point labels"
-msgstr "La couleur des étiquettes de points"
+msgstr "La couleur des étiquettes du point"
 
 msgid "The color scheme for rendering chart"
 msgstr "Le jeu de couleur pour le rendu graphique"
@@ -14320,8 +14331,8 @@ msgid ""
 "update the report to point at an active dashboard."
 msgstr ""
 "Le tableau de bord ciblé par ce rapport a été supprimé. Restaurez le "
-"tableau de bord, ou mettez à jour le rapport pour pointer vers un tableau"
-" de bord actif."
+"tableau de bord, ou mettez à jour le rapport pour utiliser un tableau de "
+"bord actif."
 
 msgid "The dashboard you are looking for may have been deleted or moved."
 msgstr ""
@@ -14357,7 +14368,8 @@ msgid "The database returned an unexpected error."
 msgstr "La base de données a renvoyé une erreur inattendue."
 
 msgid "The database that was used to generate this query could not be found"
-msgstr "La base de données utilisée pour générer cette requête est introuvable"
+msgstr ""
+"La base de données utilisée pour générer cette requête est introuvable."
 
 msgid "The database was deleted."
 msgstr "La base de données a été supprimée."
@@ -14366,7 +14378,7 @@ msgid "The database was not found."
 msgstr "Base de données introuvable."
 
 msgid "The dataset associated with this chart no longer exists"
-msgstr "L’ensemble de donnée associé à ce graphique n'existe plus"
+msgstr "Le jeu de donnée associé à ce graphique n'existe plus"
 
 msgid "The dataset column/metric that returns the values on your chart's x-axis."
 msgstr ""
@@ -14404,7 +14416,7 @@ msgstr ""
 "d'autres graphiques                de manière non voulue."
 
 msgid "The dataset has been saved"
-msgstr "L’ensemble de données a été sauvegardé"
+msgstr "Le jeu de données a été sauvegardé"
 
 msgid "The datasource couldn't be loaded"
 msgstr "La source de données ne peut pas être chargée"
@@ -14435,8 +14447,8 @@ msgid ""
 "The duration of time in seconds before the cache is invalidated. Set to "
 "-1 to bypass the cache."
 msgstr ""
-"Durée en secondes avant l'invalidation du cache. La valeur -1 permet de "
-"court-circuiter le cache."
+"La durée en secondes avant l'invalidation du cache. La valeur -1 permet de "
+"contourner le cache."
 
 msgid "The encoding format of the lines"
 msgstr "Le format d'encodage des lignes"
@@ -14455,7 +14467,7 @@ msgstr ""
 
 #, python-format
 msgid "The extension %(id)s could not be loaded."
-msgstr "L'extension %(id)s n'a pas pu être chargée"
+msgstr "L'extension %(id)s n'a pas pu être chargée."
 
 msgid ""
 "The extent of the map on application start. FIT DATA automatically sets "
@@ -14469,7 +14481,7 @@ msgstr ""
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "The feature property to use for point labels"
-msgstr "La propriété d'entité à utiliser pour les étiquettes de points"
+msgstr "La propriété à utiliser pour les labels des points"
 
 msgid "The following charts could not be exported:"
 msgstr ""
@@ -14498,9 +14510,9 @@ msgid ""
 "The following fields contain sensitive information that was masked during"
 " export. Please provide the values to import this database."
 msgstr ""
-"Les champs suivants contiennent des informations sensibles qui ont été "
-"masquées lors de l'exportation. Veuillez fournir les valeurs pour "
-"importer cette base de données."
+"Les champs suivants contiennent des informations sensibles qui ont étaient "
+"masquées lors de l'export. Merci de renseigner les valeurs pour importer "
+"cette base de données."
 
 #, python-format
 msgid ""
@@ -14516,10 +14528,10 @@ msgstr ""
 "                    de s'afficher : %s"
 
 msgid "The font size of the point labels"
-msgstr "La taille de police des étiquettes de points"
+msgstr "La taille de la police des étiquettes du point"
 
 msgid "The function to use when aggregating points into groups"
-msgstr "La fonction à utiliser lors de l’agrégation de points en groupes"
+msgstr "La fonction à utiliser lors de l'agrégation de points en groupes"
 
 msgid "The group has been created successfully."
 msgstr "Le groupe a été créé avec succès."
@@ -14594,8 +14606,8 @@ msgid ""
 "The initial level (depth) of the tree. If set as -1 all nodes are "
 "expanded."
 msgstr ""
-"Le niveau initial (profondeur) de l'arbre. S'il est défini à -1, tous les"
-" nœuds sont développés."
+"Le niveau initial (profondeur) de l'arbre. Si -1, tous les noeuds sont "
+"développés."
 
 msgid "The layer attribution"
 msgstr "L'attribution de la couche"
@@ -14607,14 +14619,12 @@ msgid ""
 "The maximum number of subdivisions of each group; lower values are pruned"
 " first"
 msgstr ""
-"Le nombre maximal de subdivisions de chaque groupe; les valeurs "
-"inférieures sont d’abord élaguées"
+"Le nombre maximal de subdivisions de chaque groupe; les valeurs inférieures "
+"sont d'abord élaguées"
 
 msgid "The maximum value of metrics. It is an optional configuration"
 msgstr ""
-"La valeur minimale des métriques. Il s’agit d’une configuration "
-"optionnelle. Si elle n’est pas définie, ce sera la valeur minimale des "
-"données."
+"La valeur maximale des mesures. Il s'agit d'une configuration optionnelle"
 
 msgid ""
 "The metadata_cache_timeout must be a mapping from string keys to non-"
@@ -14664,11 +14674,11 @@ msgid ""
 "The minimum value of metrics. It is an optional configuration. If not "
 "set, it will be the minimum value of the data"
 msgstr ""
-"La valeur maximale des mesures. Il s’agit d’une configuration "
-"optionnelle. Par défaut, prendra la valeur minimum des données."
+"La valeur minimale des mesures. Il s'agit d'une configuration optionnelle. "
+"Par défaut, prendra la valeur minimum des données."
 
 msgid "The name of the geometry column"
-msgstr "Le nom de la colonne de géométrie"
+msgstr "Le nom de la colonne géométrique"
 
 msgid "The name of the layer as described in GetCapabilities"
 msgstr "Le nom de la couche tel que décrit dans GetCapabilities"
@@ -14677,7 +14687,7 @@ msgid "The name of the rule must be unique"
 msgstr "Le nom doit être unique"
 
 msgid "The number color \"steps\""
-msgstr "Le nombre d’« étapes » colorées"
+msgstr "Le nombre d'« étapes » colorées"
 
 msgid "The number of bins for the histogram"
 msgstr "Le nombre d'intervalles pour l'histogramme"
@@ -14691,31 +14701,31 @@ msgstr ""
 
 #, python-format
 msgid "The number of results displayed is limited to %(rows)d."
-msgstr "Le nombre de résultats affichés est limité à %(rows)d."
+msgstr "Le nombre de lignes affichées est limité à %(rows)d par la requête"
 
 #, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the dropdown."
 msgstr ""
-"Le nombre de résultats affichés est limité à %(rows)d par la liste "
-"déroulante."
+"Le nombre de lignes affichées est limité à %(rows)d par la liste déroulante "
+"prévue à cet effet."
 
 #, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the limit dropdown."
 msgstr ""
-"Le nombre de rangées affichées est limité à %(rows)d par la liste "
-"déroulante de limite."
+"Le nombre de lignes affichées est limité à %(rows)d par la liste déroulante "
+"de limite."
 
 #, python-format
 msgid "The number of rows displayed is limited to %(rows)d by the query"
-msgstr "Le nombre de rangées affichées est limité à %(rows)d par la requête"
+msgstr "Le nombre de lignes affichées est limité à %(rows)d par la requête"
 
 #, python-format
 msgid ""
 "The number of rows displayed is limited to %(rows)d by the query and "
 "limit dropdown."
 msgstr ""
-"Le nombre de rangées affichées est limité à %(rows)d par la requête et "
-"liste déroulante de limite."
+"Le nombre de lignes affichées est limité à %(rows)d par la requête et liste "
+"déroulante de limite."
 
 msgid "The number of seconds before expiring the cache"
 msgstr "Le nombre de secondes avant l'expiration du cache"
@@ -14737,7 +14747,7 @@ msgid "The password provided when connecting to a database is not valid."
 msgstr "Le mot de passe fourni à une base de données est invalide."
 
 msgid "The password reset was successful"
-msgstr "La réinitialisation du mot de passe a réussi"
+msgstr "Le mot de passe a été réinitialisé avec succès."
 
 msgid ""
 "The passwords for the databases below are needed in order to import them "
@@ -14799,8 +14809,8 @@ msgstr ""
 # sr_Latn]
 msgid "The passwords for the databases below are needed in order to import them."
 msgstr ""
-"Les mots de passe des bases de données ci-dessous sont nécessaires pour "
-"les importer."
+"Les mots de passe des bases de données suivantes sont nécessaires pour les "
+"importer."
 
 msgid "The pattern of timestamp format. For strings use "
 msgstr ""
@@ -14839,10 +14849,10 @@ msgstr "Le numéro de port est invalide."
 msgid "The primary metric is used to define the arc segment sizes"
 msgstr ""
 "La mesure principale est utilisée pour définir les tailles des segments "
-"d’arc"
+"d'arc"
 
 msgid "The provided table was not found in the provided database"
-msgstr "La table fournie est introuvable dans la base de données fournie"
+msgstr "La table est introuvable dans la base de données."
 
 msgid "The query associated with the results was deleted."
 msgstr "La requête associée aux résutlats a été supprimée."
@@ -14870,9 +14880,9 @@ msgid ""
 "The query estimation was killed after %(sqllab_timeout)s seconds. It "
 "might be too complex, or the database might be under heavy load."
 msgstr ""
-"L’estimation de requête a été interrompue après %(sqllab_timeout)s "
-"secondes. Elle est peut-être trop complexe ou la base de donnée est "
-"soumise à une charge trop importante."
+"L'estimation de requête a été interrompue après %(sqllab_timeout)s "
+"secondes. Elle est peut-être trop complexe ou la base de donnée est soumise "
+"à une charge trop importante."
 
 msgid "The query has a syntax error."
 msgstr "La requête a une erreur de syntaxe."
@@ -14894,27 +14904,27 @@ msgid ""
 "to turn off clustering, but beware that a large number of points (>1000) "
 "will cause lag."
 msgstr ""
-"Rayon (en pixels) utilisé par l’algorithme pour définir une grappe. "
-"Choisissez 0 pour désactiver la mise en grappe, mais faites attention, "
-"car un grand nombre de points (>1 000) causera un décalage."
+"Rayon (en pixels) utilisé par l'algorithme pour définir une grappe. "
+"Choisissez 0 pour désactiver la mise en grappe, mais faites attention, car "
+"un grand nombre de points (>1 000) causera un décalage."
 
 msgid ""
 "The radius of individual points (ones that are not in a cluster). Either "
 "a numerical column or `Auto`, which scales the point based on the largest"
 " cluster"
 msgstr ""
-"Le rayon des points individuels (ceux qui ne sont pas dans une grappe). "
-"Une colonne numérique ou « Auto », qui met à l’échelle le point en "
-"fonction de la plus grande grappe"
+"Le rayon des points individuels (ceux qui ne sont pas dans une grappe). Une "
+"colonne numérique ou « Auto », qui met à l'échelle le point en fonction de "
+"la plus grande grappe"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 msgid ""
 "The radius of point features, in the units specified below. The final "
 "rendered size is this value multiplied by Point Radius Scale."
 msgstr ""
-"Le rayon des entités ponctuelles, dans les unités spécifiées ci-dessous. "
-"La taille finale rendue est cette valeur multipliée par l'Échelle de "
-"rayon de point."
+"Le rayon des entités ponctuelles, dans les unités spécifiées ci-dessous. La "
+"taille finale rendue est cette valeur multipliée par l'Échelle de Rayon de "
+"Point."
 
 #, python-format
 msgid "The remaining %s will be moved to Recently Archived."
@@ -14939,19 +14949,18 @@ msgid "The result size exceeds the allowed limit."
 msgstr "La taille du résultat dépasse la limite autorisée."
 
 msgid "The results backend no longer has the data from the query."
-msgstr "Le programme dorsal des résultats n'a plus les données de la requête."
+msgstr "Le serveur des résultats n'a plus les données de la requête."
 
 msgid ""
 "The results stored in the backend were stored in a different format, and "
 "no longer can be deserialized."
 msgstr ""
-"Les résultats stockés dans le programme dorsal le sont dans un format "
-"différent et ne peuvent plus être déserialisés."
+"Les résultats stockés dans le serveur le sont dans un format différent et "
+"ne peuvent plus être déserialisés."
 
 msgid "The rich tooltip shows a list of all series for that point in time"
 msgstr ""
-"L’infobulle détaillée affiche une liste de toutes les séries pour ce "
-"moment"
+"L'infobulle détaillée affiche une liste de toutes les séries pour ce moment"
 
 msgid "The role has been created successfully."
 msgstr "Le rôle a été créé avec succès."
@@ -15011,7 +15020,7 @@ msgid "The size of each cell in meters"
 msgstr "La taille de chaque cellule en mètres"
 
 msgid "The size of the point icons"
-msgstr "La taille des icônes de points"
+msgstr "La taille des icônes du point"
 
 msgid "The size of the square cell, in pixels"
 msgstr "La taille de la cellule carrée, en pixels"
@@ -15022,7 +15031,7 @@ msgstr ""
 "Seulement pour \"LINEAR\""
 
 msgid "The submitted payload failed validation."
-msgstr "Les données fournies ont un schéma incorrect."
+msgstr "Le contenu soumis n'est pas valide."
 
 msgid "The submitted payload has the incorrect format."
 msgstr "Les données utiles soumises ont un format incorrect."
@@ -15108,11 +15117,11 @@ msgid ""
 "The time unit for each block. Should be a smaller unit than "
 "domain_granularity. Should be larger or equal to Time Grain"
 msgstr ""
-"L’unité de temps pour chaque bloc. Doit être une unité plus petite que "
+"L'unité de temps pour chaque bloc. Doit être une unité plus petite que "
 "domain_granularity. Doit être plus grand ou égal au fragment de temps"
 
 msgid "The time unit used for the grouping of blocks"
-msgstr "L’unité de temps utilisée pour le regroupement des blocs"
+msgstr "L'unité de temps utilisée pour le regroupement des blocs"
 
 msgid "The two passwords that you entered do not match!"
 msgstr "Les deux mots de passe saisis ne correspondent pas !"
@@ -15126,7 +15135,7 @@ msgstr "Le type de visualisation à afficher"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "The unit for icon size"
-msgstr "L'unité de taille des icônes"
+msgstr "Unité pour la taille des icônes"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
@@ -15138,8 +15147,8 @@ msgid ""
 "The unit for point radius. Use \"pixels\" for consistent screen-space "
 "sizing regardless of zoom level."
 msgstr ""
-"L'unité du rayon de point. Utilisez « pixels » pour un dimensionnement "
-"cohérent dans l'espace écran quel que soit le niveau de zoom."
+"L'unité du rayon de point. Utilisez les « pixels » pour un dimensionnement "
+"cohérent à l'écran, quel que soit le niveau de zoom."
 
 msgid "The unit of measure for the specified point radius"
 msgstr "L'unité de mesure pour le rayon de point spécifié"
@@ -15183,7 +15192,7 @@ msgid "The visible title of the layer"
 msgstr "Le titre visible de la couche"
 
 msgid "The way the ticks are laid out on the X-axis"
-msgstr "La façon dont les points de repères sont disposés sur l’axe des abscisses"
+msgstr "La façon dont les points de repères sont disposés sur l'axe X"
 
 msgid "The width of the Isoline in pixels"
 msgstr "La largeur de l'isoligne en pixels"
@@ -15197,7 +15206,7 @@ msgid "The width of the elements border"
 msgstr "La largeur des éléments de bordure"
 
 msgid "The width of the lines"
-msgstr "La largeur des lignes"
+msgstr "L'épaisseur des lignes"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -15215,7 +15224,7 @@ msgid "Theme imported"
 msgstr "Thème importé"
 
 msgid "Theme not found."
-msgstr "Thème non trouvé."
+msgstr "Thème introuvable."
 
 msgid "Themes"
 msgstr "Thèmes"
@@ -15273,8 +15282,8 @@ msgid ""
 "There was a problem refreshing your dashboard. We'll try again in %s, as "
 "scheduled."
 msgstr ""
-"Un problème est survenu lors de l'actualisation de votre tableau de bord."
-" Nous réessaierons dans %s, comme prévu."
+"Un problème est survenu lors du rafraîchissement du tableau de bord. Un "
+"nouvel essai aura lieu dans %s, comme planifié."
 
 msgid "There was an error creating the group. Please, try again."
 msgstr ""
@@ -15299,32 +15308,34 @@ msgstr ""
 
 msgid "There was an error fetching dataset's related objects"
 msgstr ""
-"Une erreur s’est produite lors de la récupération des objets liés au jeu "
-"de données"
+"Une erreur s'est produite lors de la récupération des objets associés à ce "
+"jeu de données"
 
 #, python-format
 msgid "There was an error fetching the favorite status: %s"
-msgstr "Erreur à la récupération du statut favori : %s"
+msgstr ""
+"Une erreur s'est produite lors de la récupération des statuts favoris : %s"
 
 msgid "There was an error fetching the filtered charts and dashboards:"
 msgstr ""
-"Une erreur s’est produite lors de la récupération des graphiques et "
-"tableaux de bord filtrés :"
+"Une erreur s'est produite lors de la récupération des graphiques et tableau "
+"de bord filtrés : "
 
 msgid "There was an error generating the permalink."
 msgstr "Une erreur s'est produite lors de la génération du lien permanent."
 
 msgid "There was an error loading groups."
-msgstr "Une erreur s'est produite lors du chargement des groupes."
+msgstr "Une erreur s'est produite lors du chargement des groupes"
 
 msgid "There was an error loading permissions."
-msgstr "Une erreur s'est produite lors du chargement des permissions."
+msgstr "Une erreur s'est produite lors du chargement des permissions"
 
 msgid "There was an error loading the catalogs"
 msgstr "Une erreur s'est produite lors du chargement des catalogues"
 
 msgid "There was an error loading the chart data"
-msgstr "Une erreur s'est produite lors de la récupération des données de graphique"
+msgstr ""
+"Une erreur s'est produite lors du chargement des données du graphique"
 
 msgid "There was an error loading the schemas"
 msgstr "Une erreur s'est produite lors de la récupération des schémas"
@@ -15337,8 +15348,8 @@ msgstr "Une erreur s'est produite lors du chargement des utilisateurs."
 
 msgid "There was an error retrieving dashboard tabs."
 msgstr ""
-"Une erreur s’est produite lors de la récupération des onglets du tableau "
-"de bord."
+"Une erreur s'est produite lors de la récupération des onglets du tableau de "
+"bord"
 
 #, python-format
 msgid "There was an error saving the favorite status: %s"
@@ -15399,7 +15410,7 @@ msgstr "Il y a eu un problème lors de l'annulation de la tâche : %s"
 
 #, python-format
 msgid "There was an issue deleting %s"
-msgstr "Il y a eu un problème lors de la suppression de %s"
+msgstr "Il y a eu un problème lors de la suppression de %s"
 
 #, python-format
 msgid "There was an issue deleting %s: %s"
@@ -15407,11 +15418,13 @@ msgstr "Il y a eu un problème lors de la suppression de %s : %s"
 
 #, python-format
 msgid "There was an issue deleting registration for user: %s"
-msgstr "Un problème s'est posé lors de la suppression des règles : %s"
+msgstr ""
+"Il y a eu un problème lors de la suppression de l'inscription de "
+"l'utilisateur : %s"
 
 #, python-format
 msgid "There was an issue deleting rules: %s"
-msgstr "Un problème s'est posé lors de la suppression des règles : %s"
+msgstr "Il y a eu un problème lors de la suppression des règles : %s"
 
 #, python-format
 msgid "There was an issue deleting the selected %s"
@@ -15457,7 +15470,8 @@ msgstr ""
 
 #, python-format
 msgid "There was an issue deleting the selected themes: %s"
-msgstr "Il y a eu un problème lors de la suppression des thèmes sélectionnés : %s"
+msgstr ""
+"Il y a eu un problème lors de la suppression du thème sélectionnée: %s"
 
 #, python-format
 msgid "There was an issue deleting: %s"
@@ -15495,7 +15509,7 @@ msgid "There was an issue favoriting this dashboard."
 msgstr "Il y a eu un problème pour mettre ce tableau de bord en favori."
 
 msgid "There was an issue fetching reports."
-msgstr "Une erreur s’est produite lors de la récupération des rapports."
+msgstr "Il y a eu une erreur lors de la récupération des rapports"
 
 msgid "There was an issue fetching the favorite status of this dashboard."
 msgstr ""
@@ -15504,13 +15518,13 @@ msgstr ""
 
 #, python-format
 msgid "There was an issue fetching your chart: %s"
-msgstr "Une erreur s'est produite lors de la récupération de votre graphique : %s"
+msgstr "Il y a eu une erreur lors de la récupération vos graphiques : %s"
 
 #, python-format
 msgid "There was an issue fetching your dashboards: %s"
 msgstr ""
-"Une erreur s'est produite lors de la récupération de vos tableaux de bord"
-" : %s"
+"Un problème est survenu lors de la récupération de vos tableaux de bord : "
+"%s"
 
 #, python-format
 msgid "There was an issue fetching your recent activity: %s"
@@ -15521,8 +15535,8 @@ msgstr ""
 #, python-format
 msgid "There was an issue fetching your saved queries: %s"
 msgstr ""
-"Une erreur s'est produite lors de la récupération de vos requêtes "
-"sauvegardées : %s"
+"Un problème est survenu lors de la récupération de vos requêtes "
+"sauvegardées : %s"
 
 #, python-format
 msgid "There was an issue previewing the selected query %s"
@@ -15610,24 +15624,24 @@ msgid ""
 "This chart applies cross-filters to charts whose datasets contain columns"
 " with the same name."
 msgstr ""
-"Ce graphique applique des filtres croisés aux graphiques dont les "
-"ensembles de données contiennent des colonnes du même nom."
+"Ce graphique applique des filtres croisés aux graphiques dont les jeux de "
+"données contiennent des colonnes du même nom."
 
 msgid "This chart has been moved to a different filter scope."
 msgstr "Ce graphique a été déplacé vers un autre champ de filtrage."
 
 msgid "This chart is managed externally and can't be overwritten in Superset."
-msgstr "Ce graphique est géré en externe et ne peut pas être modifié dans Superset"
+msgstr ""
+"Ce graphique est géré en externe et ne peut être modifié dans Superset"
 
 msgid "This chart is managed externally, and can't be edited in Superset"
 msgstr ""
-"Ce graphique est géré à l’externe et ne peut pas être modifié dans "
-"Superset"
+"Ce graphique est géré à l'externe et ne peut pas être modifié dans Superset"
 
 msgid "This chart might be incompatible with the filter (datasets don't match)"
 msgstr ""
-"Ce graphique peut être incompatible avec le filtre (les ensembles de "
-"données ne correspondent pas)"
+"Ce graphique peut être incompatible avec le filtre (les jeux de données ne "
+"correspondent pas)"
 
 msgid ""
 "This chart type is not supported when using an unsaved query as a chart "
@@ -15638,7 +15652,7 @@ msgstr ""
 
 #, python-format
 msgid "This column might be incompatible with current %s"
-msgstr "Cette colonne peut être incompatible avec ls %s actuel"
+msgstr "Cette colonne peut être incompatible avec l'actuelle ressource %s"
 
 msgid "This column might be incompatible with current dataset"
 msgstr "Cette colonne peut être incompatible avec le jeu de données actuel"
@@ -15679,7 +15693,7 @@ msgstr "Ce tableau de bord n'existe pas"
 
 msgid "This dashboard is managed externally, and can't be edited in Superset"
 msgstr ""
-"Ce tableau de bord est géré à l’externe et ne peut pas être modifié dans "
+"Ce tableau de bord est géré à l'externe et ne peut pas être modifié dans "
 "Superset"
 
 msgid ""
@@ -15712,7 +15726,7 @@ msgid ""
 " id to the SDK:"
 msgstr ""
 "Ce tableau de bord est prêt à être intégré. Dans votre application, "
-"transmettez l’identifiant suivant au SDK :"
+"transmettez l'identifiant suivant au SDK :"
 
 msgid "This dashboard was saved successfully."
 msgstr "Ce Tableau de Bord a été sauvegardé avec succès."
@@ -15721,13 +15735,13 @@ msgid ""
 "This database does not allow for DDL/DML, but the query mutates data. "
 "Please contact your administrator for more assistance."
 msgstr ""
-"Cette base de données n'autorise pas les opérations DDL/DML, mais la "
-"requête modifie des données. Veuillez contacter votre administrateur pour"
-" obtenir de l'aide."
+"La requête modifie les données et cette base de données n'autorise pas les "
+"DDL/DML. Veuillez contacter un administrateur pour obtenir davantage "
+"d'aide."
 
 msgid "This database is managed externally, and can't be edited in Superset"
 msgstr ""
-"Cette base de données est gérée à l’externe et ne peut pas être modifiée "
+"Cette base de données est gérée à l'externe et ne peut pas être modifiée "
 "dans Superset"
 
 msgid ""
@@ -15745,16 +15759,15 @@ msgid ""
 "access token will be stored encrypted and used only for queries run by "
 "you."
 msgstr ""
-"Cette base de données utilise OAuth2 pour l'authentification. Veuillez "
-"cliquer sur le lien ci-dessus pour accorder à Apache Superset "
-"l'autorisation d'accéder aux données. Votre jeton d'accès personnel sera "
-"stocké de manière chiffrée et utilisé uniquement pour les requêtes que "
-"vous exécutez."
+"Cette base de données utilises OAuth2 pour l'authentification. Merci de "
+"cliquer sur le lien ci-dessus pour donner les permissions à Apache Superset "
+"d'accéder aux données. Votre clé personnelle sera conserversée, chiffrée et "
+"utilisée uniquement pour vos propres requêtes."
 
 msgid "This dataset is managed externally, and can't be edited in Superset"
 msgstr ""
-"Cet ensemble de données est géré à l'externe et ne peut pas être modifié "
-"dans Superset"
+"Ce jeu de données est géré à l'externe et ne peut pas être modifié dans "
+"Superset"
 
 msgid "This defines the element to be plotted on the chart"
 msgstr "Ceci définit l'élément à tracer sur le graphique"
@@ -15797,17 +15810,17 @@ msgstr "Ce filtre pourrait être incompatible avec le %s actuel"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "This folder is currently empty"
-msgstr "Ce dossier est actuellement vide"
+msgstr "Ce dossier est vide"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "This folder only supports columns"
-msgstr "Ce dossier ne prend en charge que les colonnes"
+msgstr "Ce dossier supporte uniquement les colonnes"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "This folder only supports metrics"
-msgstr "Ce dossier ne prend en charge que les métriques"
+msgstr "Ce dossier supporte uniquement les mesures"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
@@ -15815,9 +15828,8 @@ msgid ""
 "This is a default columns folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept column items."
 msgstr ""
-"Il s'agit d'un dossier de colonnes par défaut. Son nom ne peut pas être "
-"modifié ni supprimé. Il peut rester vide mais n'acceptera que des "
-"éléments de colonne."
+"Dossier par défaut des colonnes. Son nom ne peut pas être changé ou "
+"supprimé. Il peut rester vide mais il acceptera uniquement des colonnes."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
@@ -15825,19 +15837,18 @@ msgid ""
 "This is a default metrics folder. Its name cannot be changed or removed. "
 "It can stay empty but will only accept metric items."
 msgstr ""
-"Il s'agit d'un dossier de métriques par défaut. Son nom ne peut pas être "
-"modifié ni supprimé. Il peut rester vide mais n'acceptera que des "
-"éléments de métrique."
+"Dossier par défaut des mesures. Son nom ne peut pas être changé ou "
+"supprimé. Il peut rester vide mais il acceptera uniquement des mesures."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "This is custom error message for a"
-msgstr "Ceci est un message d'erreur personnalisé pour a"
+msgstr "C'est un message d'erreur personnalisé pour a"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "This is custom error message for b"
-msgstr "Ceci est un message d'erreur personnalisé pour b"
+msgstr "C'est un message d'erreur personnalisé pour b"
 
 msgid ""
 "This is the condition that will be added to the WHERE clause. For "
@@ -15865,7 +15876,8 @@ msgstr "Ceci est le thème clair par défaut du système"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "This is the only time you will see this key. Store it securely."
-msgstr "C'est la seule fois que vous verrez cette clé. Conservez-la en lieu sûr."
+msgstr ""
+"La clé ne sera plus visible après. Sauvegarder la de manière sécurisée."
 
 msgid ""
 "This json object describes the positioning of the widgets in the "
@@ -15891,8 +15903,8 @@ msgid ""
 "This link will take you to an external website. We cannot guarantee the "
 "safety of external destinations."
 msgstr ""
-"Ce lien vous dirigera vers un site web externe. Nous ne pouvons pas "
-"garantir la sécurité des destinations externes."
+"Ce lien vous conduira vers un site web externe. Nous ne pouvons pas en "
+"garantir la sécurité."
 
 msgid "This markdown component has an error."
 msgstr "Ce composant markdown comporte une erreur."
@@ -15939,7 +15951,7 @@ msgid ""
 "This section allows you to configure how to use the slice\n"
 "              to generate annotations."
 msgstr ""
-"Cette section vous permet de configurer l'utilisation de 'slice' pour "
+"Cette section vous permet de configurer l'utilisation de la tranche pour "
 "générer des annotations."
 
 msgid ""
@@ -15963,14 +15975,15 @@ msgstr ""
 "correctement."
 
 msgid "This table already has a dataset"
-msgstr "Ce tableau contient déjà un ensemble de données"
+msgstr "Cette table contient déjà un jeu de données"
 
 msgid ""
 "This table already has a dataset associated with it. You can only "
 "associate one dataset with a table.\n"
 msgstr ""
-"Ce tableau est déjà associé à un ensemble de données. Vous ne pouvez "
-"associer qu'un seul ensemble de données à un tableau.\n"
+"Cette table est déjà associé à un jeu de données. Vous ne pouvez associer "
+"qu'un seul jeu de données à une table.\n"
+""
 
 msgid "This theme is set locally"
 msgstr "Ce thème est défini localement"
@@ -15996,20 +16009,20 @@ msgstr "Ce type de visualisation n'est pas pris en charge."
 msgid "This was triggered by:"
 msgid_plural "This may be triggered by:"
 msgstr[0] "Cela a été déclenché par :"
-msgstr[1] "Ceci peut avoir été déclenché par :"
+msgstr[1] "Ceci peut être déclenché par :"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, python-format
 msgid "This will abort (stop) the task for all %s subscriber(s)."
-msgstr "Cela interrompra (arrêtera) la tâche pour tous les %s abonné(s)."
+msgstr "Cela va arrêter la tâche et ses %s souscripteur(s)"
 
 msgid ""
 "This will be applied to the whole table. Arrows (↑ and ↓) will be added "
 "to main columns for increase and decrease. Basic conditional formatting "
 "can be overwritten by conditional formatting below."
 msgstr ""
-"Cela sera appliqué à l'ensemble du tableau. Des flèches (↑ et ↓) seront "
+"Cela sera appliqué à l'ensemble de la table. Des flèches (↑ et ↓) seront "
 "ajoutées aux colonnes principales pour indiquer les augmentations et les "
 "diminutions. La mise en forme conditionnelle de base peut être remplacée "
 "par la mise en forme conditionnelle ci-dessous."
@@ -16017,10 +16030,10 @@ msgstr ""
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "This will cancel the task."
-msgstr "Cela annulera la tâche."
+msgstr "Cette action arrêtera la tâche"
 
 msgid "This will remove your current embed configuration."
-msgstr "Cela supprimera votre configuration d’intégration actuelle."
+msgstr "Cela supprimera votre configuration d'intégration actuelle."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, pt_BR, ru, sk, sr, sr_Latn, tr, uk]
@@ -16028,14 +16041,14 @@ msgid ""
 "This will reorganize all metrics and columns into default folders. Any "
 "custom folders will be removed."
 msgstr ""
-"Cela réorganisera toutes les métriques et colonnes dans les dossiers par "
-"défaut. Tous les dossiers personnalisés seront supprimés."
+"Cela va réorganiser toutes les métrics et les colonnes vers les dossiers "
+"par défaut. Tous les dossiers personnalisés seront supprimés."
 
 msgid "Threshold"
 msgstr "Seuil"
 
 msgid "Threshold alpha level for determining significance"
-msgstr "Seuil alpha pour déterminer l’importance"
+msgstr "Seuil alpha pour déterminer l'importance"
 
 msgid "Threshold for Other"
 msgstr "Seuil pour \"Autre\""
@@ -16062,7 +16075,7 @@ msgid "Time Format"
 msgstr "Format de temps"
 
 msgid "Time Grain"
-msgstr "Fragment de temps"
+msgstr "Granularité temporelle"
 
 msgid "Time Grain must be specified when using Time Comparison."
 msgstr ""
@@ -16070,16 +16083,16 @@ msgstr ""
 "comparaison de temps."
 
 msgid "Time Granularity"
-msgstr "Fragmentation de Temps"
+msgstr "Granulartié temporelle"
 
 msgid "Time Lag"
-msgstr "Décalage de temps"
+msgstr "Décalage temporel"
 
 msgid "Time Range"
-msgstr ""
+msgstr "Intervalle de temps"
 
 msgid "Time Ratio"
-msgstr "Ratio de temps"
+msgstr "Ratio temporel"
 
 msgid "Time Series"
 msgstr "Séries temporelles"
@@ -16106,14 +16119,15 @@ msgid "Time Shift"
 msgstr "Décalage temporel"
 
 msgid "Time Table View"
-msgstr "Vue du tableau chronologique"
+msgstr "Vue chronologique du tableau"
 
 msgid "Time column"
 msgstr "Colonne de temps"
 
 #, python-format
 msgid "Time column \"%(col)s\" does not exist in dataset"
-msgstr "La colonne temporelle « %(col)s » n'existe pas dans l’ensemble de données"
+msgstr ""
+"La colonne temporelle « %(col)s » n'existe pas dans le jeu de données"
 
 msgid "Time column chart customization plugin"
 msgstr "Plugin de personnalisation des colonnes chronologiques"
@@ -16164,7 +16178,7 @@ msgid "Time grain missing"
 msgstr "Fragment de temps manquant"
 
 msgid "Time grain options"
-msgstr "Options de granularité temporelle"
+msgstr "Options de la granularité temporelle"
 
 msgid "Time granularity"
 msgstr "Granularité temporelle"
@@ -16179,7 +16193,7 @@ msgid "Time range"
 msgstr "Intervalle de temps"
 
 msgid "Time ratio"
-msgstr "Ratio de temps"
+msgstr "Ratio temporel"
 
 msgid "Time related form attributes"
 msgstr "Attributs du formulaire liés au temps"
@@ -16202,16 +16216,16 @@ msgstr ""
 "ago] ou [%(human_readable)s later]."
 
 msgid "Time-series Percent Change"
-msgstr "Pourcentage de changement de séries temporelles"
+msgstr "Evolution en pourcentage des séries temporelles"
 
 msgid "Time-series Period Pivot"
-msgstr "Période Pivot de séries temporelles"
+msgstr "Période du pivot de séries temporelles"
 
 msgid "Time-series Table"
 msgstr "Tableau des séries temporelles"
 
 msgid "Timed Out"
-msgstr "Délai dépassé"
+msgstr "Délai terminé"
 
 msgid "Timeline"
 msgstr "Chronologie"
@@ -16262,11 +16276,11 @@ msgid ""
 "queried and visualized. This database will hold all of your individual "
 "Google Sheets you choose to connect here."
 msgstr ""
-"Pour commencer à utiliser vos Google Sheets, vous devez d'abord créer une"
-" base de données. Les bases de données sont utilisées comme moyen "
-"d'identifier vos données afin qu'elles puissent être interrogées et "
-"visualisées. Cette base de données contiendra toutes vos Google Sheets "
-"individuelles que vous choisissez de connecter ici."
+"Pour utiliser vos Google Sheets, vous devez d'abord créer une base de "
+"données. Les bases de données sont utilisées comme moyen d'identification "
+"de vos données pour qu'elles puissent être requêtées et visualisées. Cette "
+"databases contiendra toutes vos Google Sheets individuelles que vous "
+"choisirez de connecter."
 
 msgid ""
 "To enable multiple column sorting, hold down the ⇧ Shift key while "
@@ -16284,7 +16298,7 @@ msgstr "Pour obtenir une URL lisible pour votre tableau de bord"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Token Request URI"
-msgstr "URI de demande de jeton"
+msgstr "URL de requête du Token"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
 #, python-format
@@ -16292,7 +16306,7 @@ msgid ""
 "Too many sub-slices requested. The maximum allowed is %(max)s, but "
 "%(count)s were requested."
 msgstr ""
-"Trop de sous-tranches demandées. Le maximum autorisé est %(max)s, mais "
+"Trop de sous-graphes demandées. Le maximum autorisé est de %(max)s, mais "
 "%(count)s ont été demandées."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja]
@@ -16301,7 +16315,7 @@ msgid ""
 "Too many time comparisons requested. The maximum allowed is %(max)s, but "
 "%(count)s were requested."
 msgstr ""
-"Trop de comparaisons temporelles demandées. Le maximum autorisé est "
+"Trop de comparaisons temporelles demandées. Le maximum autorisé est de "
 "%(max)s, mais %(count)s ont été demandées."
 
 msgid "Tool Panel"
@@ -16338,7 +16352,7 @@ msgid "Top n"
 msgstr "Top n"
 
 msgid "Top right"
-msgstr "Haut à droite"
+msgstr "Haut droite"
 
 msgid "Top to Bottom"
 msgstr "De haut en bas"
@@ -16364,7 +16378,7 @@ msgid "Total color"
 msgstr "Couleur du total"
 
 msgid "Total label"
-msgstr "Valeur totale"
+msgstr "Etiquette totale"
 
 msgid "Total value"
 msgstr "Valeur totale"
@@ -16438,12 +16452,12 @@ msgstr ""
 "max. Seulement applicable sur les axes X numériques."
 
 msgid "Truncate Y Axis"
-msgstr "Tronquer l’axe des abscisses"
+msgstr "Tronquer l'axe Y"
 
 msgid "Truncate Y Axis. Can be overridden by specifying a min or max bound."
 msgstr ""
-"Tronquer l’axe des ordonnées. Peut être modifié en spécifiant une limite "
-"minimale ou maximale."
+"Tronquer l'axe Y. Peut être modifié en spécifiant une limite minimale ou "
+"maximale."
 
 msgid "Truncate long cells to the \"min width\" set above"
 msgstr "Tronquer les cellules longues à la « largeur minimale » définie ci-dessus"
@@ -16459,15 +16473,15 @@ msgstr "Tronquer la date spécifiée à la précision spécifiée par l'unité d
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Trust this URL and don't ask again"
-msgstr "Faire confiance à cette URL et ne plus demander"
+msgstr "Faire confiance à cette URL et sauvegarder le choix"
 
 msgid "Try applying different filters or ensuring your datasource has data"
 msgstr ""
-"Essayez d’appliquer différents filtres ou de vous assurer que votre "
-"source de données contient des données"
+"Essayez d'appliquer différents filtres ou de vous assurer que votre source "
+"de données contient des données"
 
 msgid "Try different criteria to display results."
-msgstr "Essayer un critère pour afficher les résultats."
+msgstr "Essayer différents critères pour afficher les résultats."
 
 msgid "Tuesday"
 msgstr "Mardi"
@@ -16489,7 +16503,7 @@ msgid "Type a value here"
 msgstr "Saisir une valeur ici"
 
 msgid "Type a value..."
-msgstr "Saisissez une valeur"
+msgstr "Saisir une valeur..."
 
 msgid "Type is required"
 msgstr "Le type est requis"
@@ -16497,7 +16511,7 @@ msgstr "Le type est requis"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Type of Google Sheets allowed"
-msgstr "Type de Google Sheets autorisé"
+msgstr "Types de feuilles de calcul Google autorisés"
 
 msgid "Type of chart to display in sparkline"
 msgstr "Type de graphique à afficher dans sparkline"
@@ -16506,17 +16520,17 @@ msgid "Type of comparison, value difference or percentage"
 msgstr "Type de comparaison, différence de valeur ou pourcentage"
 
 msgid "Type to search (contains)..."
-msgstr "Saisissez pour rechercher (contient)..."
+msgstr "Saisir pour rechercher (contient)..."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Type to search (ends with)..."
-msgstr "Tapez pour rechercher (se termine par)..."
+msgstr "Saisir pour rechercher (termine par)..."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Type to search (starts with)..."
-msgstr "Tapez pour rechercher (commence par)..."
+msgstr "Saisir pour rechercher (commence par)..."
 
 msgid "UI Configuration"
 msgstr "Configuration UI"
@@ -16528,13 +16542,13 @@ msgid "URL"
 msgstr "URL"
 
 msgid "URL Filters"
-msgstr "Filtres URL"
+msgstr "URl des filtres"
 
 msgid "URL Parameters"
 msgstr "Paramètres URL"
 
 msgid "URL Slug"
-msgstr "Identifiant URL"
+msgstr "URL Slug"
 
 msgid "URL parameters"
 msgstr "Paramètres URL"
@@ -16560,8 +16574,10 @@ msgid ""
 "\"bigquery.readsessions.create\", \"bigquery.readsessions.getData\""
 msgstr ""
 "Impossible de se connecter. Vérifiez que les rôles suivants sont définis "
-"sur le compte de service : « Cloud Datastore Viewer », « Cloud Datastore "
-"User », « Cloud Datastore Creator »"
+"sur le compte de service : « BigQuery Data Viewer », « BigQuery Metadata "
+"Viewer », « BigQuery Job User » et que les permissions suivantes sont "
+"définies « bigquery.readsessions.create », "
+"« bigquery.readsessions.getData »"
 
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
@@ -16595,15 +16611,15 @@ msgstr "Impossible de coder la valeur"
 # sr_Latn]
 msgid "Unable to fetch semantic views. Check the layer configuration."
 msgstr ""
-"Impossible de récupérer les vues sémantiques. Vérifiez la configuration "
-"de la couche."
+"Impossible de récupérer la vue sémantique. Vérifier la configuration des "
+"couches."
 
 #, python-format
 msgid "Unable to find such a holiday: [%(holiday)s]"
 msgstr "Impossible de trouver un tel congé : [%(holiday)s]"
 
 msgid "Unable to generate download payload"
-msgstr "Impossible de générer les données de téléchargement"
+msgstr "Impossible de générer le contenu à télécharger"
 
 #, python-format
 msgid "Unable to generate forecast: %(error)s"
@@ -16629,8 +16645,8 @@ msgid ""
 "Unable to load columns for the selected table. Please select a different "
 "table."
 msgstr ""
-"Impossible de charger les colonnes pour le tableau sélectionné. Veuillez "
-"sélectionner un autre tableau."
+"Impossible de charger les colonnes pour la table sélectionnée. Veuillez "
+"sélectionner une autre table."
 
 msgid "Unable to load dashboard"
 msgstr "Impossible de charger le tableau de bord"
@@ -16647,20 +16663,20 @@ msgid ""
 "Unable to migrate query state to backend. Superset will retry later. "
 "Please contact your administrator if this problem persists."
 msgstr ""
-"Impossible de migrer l'état de la requête vers le programme dorsal. "
-"Superset réessayera plus tard. Veuillez contacter votre administrateur si"
-" ce problème persiste."
+"Impossible de migrer l'état de la requête vers le serveur. Superset "
+"réessayera plus tard. Veuillez contacter votre administrateur si ce "
+"problème persiste."
 
 msgid ""
 "Unable to migrate table schema state to backend. Superset will retry "
 "later. Please contact your administrator if this problem persists."
 msgstr ""
-"Impossible de migrer l'état du schéma de tableau vers le programme "
-"dorsal. Superset réessayera plus tard. Veuillez contacter votre "
-"administrateur si ce problème persiste."
+"Impossible de migrer l'état du schéma de la table vers le serveur. Superset "
+"réessayera plus tard. Veuillez contacter votre administrateur si ce "
+"problème persiste."
 
 msgid "Unable to parse SQL"
-msgstr "Impossible d’analyser le SQL"
+msgstr "Impossible d'analyser le SQL"
 
 msgid "Unable to read the file, please refresh and try again."
 msgstr "Impossible de lire le fichier, veuillez actualiser et réessayer."
@@ -16686,7 +16702,7 @@ msgid "Undo?"
 msgstr "Annuler?"
 
 msgid "Unexpected HTTP 401 response. Check your credentials."
-msgstr "Réponse HTTP 401 inattendue. Vérifiez vos informations d'identification."
+msgstr "Erreur HTTP 401 inattendue. Vérifier votre identifiants."
 
 msgid "Unexpected error"
 msgstr "Erreur inattendue"
@@ -16700,7 +16716,7 @@ msgid "Unexpected error: "
 msgstr "Erreur inattendue :"
 
 msgid "Unexpected no file extension found"
-msgstr "Extension de fichier introuvable (inattendue)"
+msgstr "Extension du fichier introuvable"
 
 #, python-format
 msgid "Unexpected time range: %(error)s"
@@ -16717,7 +16733,7 @@ msgstr "Inconnu"
 
 #, python-format
 msgid "Unknown Doris server host \"%(hostname)s\"."
-msgstr "Hôte Doris \"%(hostname)s\" inconnu."
+msgstr "Hôte du serveur Doris \"%(hostname)s\" inconnu."
 
 msgid "Unknown Error"
 msgstr "Erreur inconnue"
@@ -16728,7 +16744,7 @@ msgstr "Hôte inconnu du serveur MySQL \"%(hostname)s\"."
 
 #, python-format
 msgid "Unknown OceanBase server host \"%(hostname)s\"."
-msgstr "Hôte OceanBase \"%(hostname)s\" inconnu."
+msgstr "Hôte du serveur OceanBase \"%(hostname)s\" inconnu."
 
 msgid "Unknown Presto Error"
 msgstr "Erreur Presto inconnue"
@@ -16749,7 +16765,7 @@ msgstr "Format d'entrée inconnu"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Unknown tokens will be highlighted as warnings."
-msgstr "Les jetons inconnus seront mis en évidence comme avertissements."
+msgstr "Les tokens inconnus seront mis en surbrillance comme avertissements."
 
 msgid "Unknown type"
 msgstr "Type inconnu"
@@ -16763,7 +16779,7 @@ msgstr "Désépingler"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Unpin from the result panel"
-msgstr "Détacher du panneau de résultats"
+msgstr "Détacher du panneau de résultat"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -16790,8 +16806,8 @@ msgstr "Type de clause non pris en charge : %(clause)s"
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Unsupported file type. Please use CSV, Excel, or Columnar files."
 msgstr ""
-"Type de fichier non pris en charge. Veuillez utiliser des fichiers CSV, "
-"Excel ou en colonnes."
+"Type de fichier non supporté. Merci d'utiliser des fichiers CSV, Excel ou "
+"des fichiers colonnes."
 
 #, python-format
 msgid "Unsupported post processing operation: %(operation)s"
@@ -16825,7 +16841,7 @@ msgid "Update"
 msgstr "Mettre à jour"
 
 msgid "Update auto-refresh"
-msgstr "Mettre à jour le rafraîchissement automatique"
+msgstr "Mettre à jour l'intervalle de rafraîchissement automatique"
 
 msgid "Update chart"
 msgstr "Mettre à jour le graphique"
@@ -16834,47 +16850,47 @@ msgid "Updating chart was stopped"
 msgstr "La mise à jour du graphique a été interrompue"
 
 msgid "Upload"
-msgstr "Téléversement"
+msgstr "Charger"
 
 msgid "Upload CSV"
-msgstr "Téléverser un fichier CSV"
+msgstr "Charger un fichier CSV"
 
 msgid "Upload CSV to database"
-msgstr "Téléverser un fichier CSV vers la base de données"
+msgstr "Charger un fichier CSV vers la base de données"
 
 msgid "Upload Columnar"
-msgstr "Téléverser un fichier en colonnes"
+msgstr "Charger un fichier en colonnes"
 
 msgid "Upload Columnar file to database"
-msgstr "Téléverser un fichier en colonnes vers la base de données"
+msgstr "Charger un fichier en colonnes vers la base de données"
 
 msgid "Upload Enabled"
-msgstr "Téléversement activé"
+msgstr "Chargement activé"
 
 msgid "Upload Excel"
-msgstr "Téléverser un fichier Excel"
+msgstr "Charger un fichier Excel"
 
 msgid "Upload Excel to database"
-msgstr "Téléverser un fichier Excel vers la base de données"
+msgstr "Charger un fichier Excel vers la base de données"
 
 msgid "Upload JSON file"
-msgstr "Téléverser un fichier JSON"
+msgstr "Charger un fichier JSON"
 
 #, python-format
 msgid "Upload a file with a valid extension. Valid: [%s]"
-msgstr "Téléverser un fichier avec une extension valide. Valide: [%s]"
+msgstr "Charger un fichier avec une extension valide. Valide: [%s]"
 
 msgid "Upload credentials"
-msgstr "Téléverser les informations de connexion"
+msgstr "Charger les informations de connexion"
 
 msgid "Upload file to database"
-msgstr "Téléverser un fichier vers la base de données"
+msgstr "Charger un fichier vers la base de données"
 
 msgid "Upload file to preview columns"
-msgstr "Téléverser un fichier pour prévisualiser les colonnes"
+msgstr "Charger un fichier pour prévisualiser les colonnes"
 
 msgid "Uploading a file is required"
-msgstr "Le téléversement d'un fichier est requis"
+msgstr "Le chargement d'un fichier est obligatoire"
 
 msgid "Upper Threshold"
 msgstr "Seuil haut"
@@ -16892,7 +16908,7 @@ msgstr "Utilisation"
 
 #, python-format
 msgid "Use %s to open in a new tab."
-msgstr "Utilisez %s pour ouvrir dans un nouvel onglet."
+msgstr "Utilisez %s pour ouvrir un nouvel onglet."
 
 msgid "Use Area Proportions"
 msgstr "Utiliser les proportions d'aires"
@@ -16903,18 +16919,18 @@ msgid ""
 "Use Handlebars syntax to create custom tooltips. Available variables are "
 "based on your tooltip contents selection above."
 msgstr ""
-"Utilisez la syntaxe Handlebars pour créer des info-bulles personnalisées."
-" Les variables disponibles sont basées sur votre sélection de contenu d"
-"'info-bulle ci-dessus."
+"Utiliser la synthaxe Handlebars pour créer des info-bulles personnalisées. "
+"Les variables disponibles sont basées sur le contenu de l'info-bulle "
+"sélectionné précédemment"
 
 msgid "Use a log scale"
 msgstr "Utiliser une échelle de journalisation"
 
 msgid "Use a log scale for the X-axis"
-msgstr "Utiliser une échelle de journalisation pour l’axe des abscisses"
+msgstr "Utiliser une échelle de journalisation pour l'axe X"
 
 msgid "Use a log scale for the Y-axis"
-msgstr "Utiliser une échelle de journalisation pour l’axe des ordonnées"
+msgstr "Utiliser une échelle de journalisation pour l'axe Y"
 
 msgid "Use an encrypted connection to the database"
 msgstr "Utiliser une connexion cryptée vers la base de données"
@@ -16932,7 +16948,7 @@ msgstr ""
 "visualisation : [%s]"
 
 msgid "Use automatic color"
-msgstr "Couleur automatique"
+msgstr "Utiliser les couleurs automatiques"
 
 msgid "Use current extent"
 msgstr "Utiliser l'étendue actuelle"
@@ -16951,16 +16967,17 @@ msgstr ""
 "ou les lignes"
 
 msgid "Use only a single value."
-msgstr "N’utiliser qu’une seule valeur."
+msgstr "N'utiliser qu'une seule valeur."
 
 msgid "Use the Advanced Analytics options below"
-msgstr "Utiliser les options d’analyse avancée ci-dessous"
+msgstr "Utiliser les options d'analyse avancée ci-dessous"
 
 msgid "Use this section if you want a query that aggregates"
 msgstr "Utiliser cette section si vous voulez une requête qui regroupe"
 
 msgid "Use this section if you want to query atomic rows"
-msgstr "Utiliser cette section si vous souhaitez interroger des rangées atomiques"
+msgstr ""
+"Utiliser cette section si vous souhaitez interroger des lignes atomiques"
 
 msgid "Use this to define a static color for all circles"
 msgstr "Utiliser ceci pour définir une couleur statique pour tous les cercles"
@@ -17029,14 +17046,14 @@ msgstr "Utilisateurs"
 
 msgid "Users are not allowed to set a search path for security reasons."
 msgstr ""
-"%(dialect)s ne peut pas être utilisé comme source de données pour des "
-"raisons de sécurité."
+"Les utilisateurs ne sont pas autorisés à définir une recherche de chemin "
+"pour des raisons de sécurité."
 
 msgid ""
 "Uses Gaussian Kernel Density Estimation to visualize spatial distribution"
 " of data"
 msgstr ""
-"Utilise l’estimation de la densité du noyau gaussien pour visualiser la "
+"Utilise l'estimation de la densité du noyau gaussien pour visualiser la "
 "distribution spatiale des données"
 
 msgid ""
@@ -17044,9 +17061,9 @@ msgid ""
 "position of the dial represents the progress and the terminal value in "
 "the gauge represents the target value."
 msgstr ""
-"Utilise une jauge pour montrer la progression d’une mesure vers une "
-"cible. La position du cadran représente la progression et la valeur de "
-"borne dans la jauge représente la valeur cible."
+"Utilise une jauge pour montrer la progression d'une mesure vers une cible. "
+"La position du cadran représente la progression et la valeur de borne dans "
+"la jauge représente la valeur cible."
 
 msgid ""
 "Uses circles to visualize the flow of data through different stages of a "
@@ -17055,15 +17072,17 @@ msgid ""
 "funnels and pipelines."
 msgstr ""
 "Utilise des cercles pour visualiser le flux de données à travers les "
-"différentes étapes d’un système. Placez le curseur sur les chemins "
-"individuels dans la visualisation pour comprendre les étapes qu’une "
-"valeur a suivies. Utile pour la visualisation d’entonnoirs et de "
-"pipelines à plusieurs étapes et groupes."
+"différentes étapes d'un système. Placez le curseur sur les chemins "
+"individuels dans la visualisation pour comprendre les étapes qu'une valeur "
+"a suivies. Utile pour la visualisation d'entonnoirs et de pipelines à "
+"plusieurs étapes et groupes."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Uses the first 25 values if the dimension has more."
-msgstr "Utilise les 25 premières valeurs si la dimension en contient davantage."
+msgstr ""
+"Utiliser uniquement les 25 premières valeurs de la dimension s'il en existe "
+"plus."
 
 msgid "Valid SQL expression"
 msgstr "Expression SQL valide"
@@ -17072,14 +17091,14 @@ msgid "Validate query"
 msgstr "Valider la requête"
 
 msgid "Validate your expression"
-msgstr "Validez votre expression"
+msgstr "Valider votre expression"
 
 #, python-format
 msgid "Validating connectivity for %s"
 msgstr "Validation de la connectivité pour %s"
 
 msgid "Validating..."
-msgstr "Chargement..."
+msgstr "Validation..."
 
 msgid "Value"
 msgstr "Valeur"
@@ -17175,13 +17194,13 @@ msgid "View All »"
 msgstr "Tout voir »"
 
 msgid "View Dataset"
-msgstr "Afficher l'ensemble de données"
+msgstr "Voir le jeu de données"
 
 msgid "View all charts"
 msgstr "Voir tous les graphiques"
 
 msgid "View as table"
-msgstr "Voir sous forme de tableau"
+msgstr "Voir en tant que table"
 
 msgid "View in SQL Lab"
 msgstr "Voir dans SQL Lab"
@@ -17197,7 +17216,7 @@ msgstr "Consulté"
 
 #, python-format
 msgid "Viewed %s"
-msgstr "Vu %s"
+msgstr "%s consultés"
 
 msgid "Viewer"
 msgstr "Lecteur"
@@ -17225,17 +17244,15 @@ msgid "Virtual (SQL)"
 msgstr "Virtuel (SQL)"
 
 msgid "Virtual dataset query cannot be empty"
-msgstr "L’ensemble de données virtuel ne peut pas être vide"
+msgstr "Le jeu de données virtuel ne peut pas être vide"
 
 msgid "Virtual dataset query cannot consist of multiple statements"
 msgstr ""
-"Une requête sur un ensemble de données virtuel ne peut pas être composée "
-"de plusieurs instructions"
+"Une requête sur un jeu de données virtuel ne peut pas être composée de "
+"plusieurs instructions"
 
 msgid "Virtual dataset query must be read-only"
-msgstr ""
-"L'interrogation de l'ensemble de données virtuel doit être en lecture "
-"seule"
+msgstr "L'interrogation du jeu de données virtuel doit être en lecture seule"
 
 msgid "Visual Tweaks"
 msgstr "Modifications visuelles"
@@ -17276,7 +17293,7 @@ msgid ""
 "Visualize multiple levels of hierarchy using a familiar tree-like "
 "structure."
 msgstr ""
-"Visualisez plusieurs niveaux de hiérarchie à l’aide d’une structure "
+"Visualisez plusieurs niveaux de hiérarchie à l'aide d'une structure "
 "familière semblable à un arbre."
 
 msgid ""
@@ -17293,10 +17310,9 @@ msgid ""
 "axis, Y axis, and bubble size). Bubbles from the same group can be "
 "showcased using bubble color."
 msgstr ""
-"Visualise une mesure sur trois dimensions de données dans un seul "
-"graphique (axe des abscisses, axe des ordonnées et taille des bulles). "
-"Les bulles du même groupe peuvent être présentées en utilisant la couleur"
-" des bulles."
+"Visualise une mesure sur trois dimensions de données dans un seul graphique "
+"(axe X, axe Y et taille des bulles). Les bulles du même groupe peuvent être "
+"présentées en utilisant la couleur des bulles."
 
 msgid "Visualizes connected points, which form a path, on a map."
 msgstr "Visualise les points connectés, qui forment un chemin, sur une carte."
@@ -17307,18 +17323,17 @@ msgid ""
 msgstr ""
 "Visualise les zones géographiques de vos données sous forme de polygones "
 "sur une carte rendue par Mapbox. Les polygones peuvent être colorés à "
-"l’aide d’une mesure."
+"l'aide d'une mesure."
 
 msgid ""
 "Visualizes how a metric has changed over a time using a color scale and a"
 " calendar view. Gray values are used to indicate missing values and the "
 "linear color scheme is used to encode the magnitude of each day's value."
 msgstr ""
-"Visualise la façon dont une mesure a changé au fil du temps à l’aide "
-"d’une échelle de couleurs et d’une vue de calendrier. Les valeurs grises "
-"sont utilisées pour indiquer les valeurs manquantes et le schéma de "
-"couleurs linéaires est utilisé pour coder l’amplitude de la valeur de "
-"chaque jour."
+"Visualise la façon dont une mesure a changé au fil du temps à l'aide d'une "
+"échelle de couleurs et d'une vue de calendrier. Les valeurs grises sont "
+"utilisées pour indiquer les valeurs manquantes et le schéma de couleurs "
+"linéaires est utilisé pour coder l'amplitude de la valeur de chaque jour."
 
 msgid ""
 "Visualizes how a single metric varies across a country's principal "
@@ -17327,7 +17342,7 @@ msgid ""
 "geographic boundary."
 msgstr ""
 "Visualise la façon dont une seule mesure varie entre les principales "
-"subdivisions d’un pays (États, provinces, etc.) sur une carte de "
+"subdivisions d'un pays (États, provinces, etc.) sur une carte de "
 "choroplète. La valeur de chaque subdivision est élevée lorsque vous "
 "survolez la limite géographique correspondante."
 
@@ -17336,9 +17351,9 @@ msgid ""
 "chart is being deprecated and we recommend using the Time-series Chart "
 "instead."
 msgstr ""
-"Visualise de nombreux objets de séries temporelles différents dans un "
-"seul tableau. Ce graphique est en cours d’amortissement et nous vous "
-"recommandons d’utiliser plutôt le graphique des séries temporelles."
+"Visualise de nombreux objets de séries temporelles différents dans un seul "
+"tableau. Ce graphique est en cours d'amortissement et nous vous "
+"recommandons d'utiliser plutôt le graphique des séries temporelles."
 
 msgid ""
 "Visualizes the words in a column that appear the most often. Bigger font "
@@ -17367,7 +17382,7 @@ msgstr "WMS"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "Waiting for first refresh"
-msgstr "En attente du premier rafraîchissement"
+msgstr "En attente de la 1ère actualisation"
 
 #, python-format
 msgid "Waiting on %s"
@@ -17394,8 +17409,8 @@ msgid ""
 "Warning! Changing the dataset may break the chart if the metadata does "
 "not exist."
 msgstr ""
-"Attention! Changer l’ensemble de données peut mettre en erreur le "
-"graphique si la métadonnées n'existe pas."
+"Attention! Changer le jeu de données peut mettre en erreur le graphique si "
+"la métadonnées n'existe pas."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -17403,9 +17418,8 @@ msgid ""
 "Warning: ILIKE queries may be slow on large datasets as they cannot use "
 "indexes effectively."
 msgstr ""
-"Avertissement : les requêtes ILIKE peuvent être lentes sur les grands "
-"ensembles de données car elles ne peuvent pas utiliser les index "
-"efficacement."
+"Attention: les requêtes ILIKE peuvent être lente sur des datasets important "
+"car elles ne peuvent pas utiliser les indexes de manière efficiente."
 
 msgid "Was unable to check your query"
 msgstr "Impossible de vérifier votre requête"
@@ -17448,8 +17462,8 @@ msgid ""
 "We were unable to carry over any controls when switching to this new "
 "dataset."
 msgstr ""
-"Nous n’avons pas été en mesure de reporter les contrôles lors du passage "
-"à ce nouvel ensemble de données."
+"Nous n'avons pas été en mesure de reporter les contrôles lors du passage à "
+"ce nouveau jeu de données."
 
 #, python-format
 msgid ""
@@ -17541,13 +17555,13 @@ msgid ""
 "When `Calculation type` is set to \"Percentage change\", the Y Axis "
 "Format is forced to `.1%`"
 msgstr ""
-"Lorsque « Type de calcul » vaut « Pourcentage de changement », le format "
-"de l'axe des ordonnées est à forcé à « .1% »"
+"Lorsque « Type de calcul » vaut « Pourcentage de changement », le format de "
+"l'axe Y est à forcé à « .1% »"
 
 msgid "When a secondary metric is provided, a linear color scale is used."
 msgstr ""
-"Lorsqu’une mesure secondaire est fournie, une échelle de couleur linéaire"
-" est utilisée."
+"Lorsqu'une mesure secondaire est fournie, une échelle de couleur linéaire "
+"est utilisée."
 
 msgid "When checked, the map will zoom to your data after each query"
 msgstr ""
@@ -17558,8 +17572,8 @@ msgid ""
 "When enabled, the axis will display labels for the minimum and maximum "
 "values of your data"
 msgstr ""
-"Lorsqu’activé, l’axe affichera les étiquettes des valeurs minimales et "
-"maximales de vos données"
+"Si activé, affiche dans l'axe les valeurs minimal et maximal de vos données "
+""
 
 msgid "When enabled, users are able to visualize SQL Lab results in Explore."
 msgstr ""
@@ -17577,11 +17591,11 @@ msgid ""
 "generated parent queries.If changes are made to your SQL query, columns "
 "in your dataset will be synced when saving the dataset."
 msgstr ""
-"Lorsque vous spécifiez du SQL, la source de données agit comme une vue. "
-"Superset utilisera cette déclaration comme une sous-requête lors du "
-"regroupement et du filtrage des requêtes parentes générées. Si des "
-"modifications sont apportées à votre requête SQL, les colonnes de votre "
-"ensemble de données seront synchronisées lors de l'enregistrement."
+"Lorsque vous spécifiez SQL, la source de données agit comme une vue. "
+"Superset utilisera cette déclaration comme une sous-requête tout en "
+"regroupant et en filtrant les requêtes parentales générées. Si des "
+"modifications sont apportées à votre requête SQL, les colonnes de votre jeu "
+"de données seront synchronisées lors de l'enregistrement."
 
 msgid ""
 "When the secondary temporal columns are filtered, apply the same filter "
@@ -17611,12 +17625,11 @@ msgid ""
 "relative time filter on a partitioned or indexed time-related field."
 msgstr ""
 "Lorsque vous utilisez les « filtres de saisie semi-automatique », cette "
-"option peut être utilisée pour améliorer les performances de la requête "
-"qui récupère les valeurs. Utilisez cette option pour appliquer un "
-"prédicat (clause WHERE) à la requête en sélectionnant les valeurs "
-"distinctes du tableau. Généralement, l'objectif est de limiter l'analyse "
-"en appliquant un filtre temporel relatif sur un champ temporel "
-"partitionné ou indexé."
+"option peut être utilisée pour améliorer les performances de la requête qui "
+"récupère les valeurs. Utilisez cette option pour appliquer un prédicat "
+"(clause WHERE) à la requête en sélectionnant les valeurs distinctes de la "
+"table. Généralement, l'objectif est de limiter l'analyse en appliquant un "
+"filtre temporel relatif sur un champ temporel partitionné ou indexé."
 
 msgid "When using 'Group By' you are limited to use a single metric"
 msgstr "Quand vous utilisez « Grouper par » vous êtes limité à une seule mesure"
@@ -17636,8 +17649,8 @@ msgstr ""
 
 msgid "Whether the progress bar overlaps when there are multiple groups of data"
 msgstr ""
-"Si la barre de progression se chevauche lorsqu’il y a plusieurs groupes "
-"de données"
+"Si la barre de progression se chevauche lorsqu'il y a plusieurs groupes de "
+"données"
 
 msgid ""
 "Whether to align background charts with both positive and negative values"
@@ -17659,8 +17672,8 @@ msgstr "Animation ou non de la progression et la valeur ou simplement les affich
 
 msgid "Whether to apply a normal distribution based on rank on the color scale"
 msgstr ""
-"Application ou non d’une distribution normale en fonction du classement "
-"sur l’échelle de couleurs"
+"Application ou non d'une distribution normale en fonction du classement sur "
+"l'échelle de couleurs"
 
 msgid "Whether to colorize numeric values by if they are positive or negative"
 msgstr ""
@@ -17691,13 +17704,13 @@ msgstr ""
 "hiérarchie"
 
 msgid "Whether to display in the chart"
-msgstr "Afficher ou non dans le graphique"
+msgstr "Affichage dans le graphique"
 
 msgid "Whether to display the X Axis"
-msgstr "Afficher ou non l'axe des abscisses"
+msgstr "Afficher l'axe X."
 
 msgid "Whether to display the Y Axis"
-msgstr "Afficher ou non l'axe des ordonnées"
+msgstr "Afficher l'axe Y."
 
 msgid "Whether to display the aggregate count"
 msgstr "Affichage ou non du nombre total"
@@ -17718,13 +17731,13 @@ msgid "Whether to display the metric name as a title"
 msgstr "Affichage ou non du nom de la mesure sous forme de titre"
 
 msgid "Whether to display the min and max values of the X-axis"
-msgstr "Affichage ou non des valeurs min et max de l’axe des abscisses"
+msgstr "Affichage ou non des valeurs min et max de l'axe X"
 
 msgid "Whether to display the min and max values of the Y-axis"
-msgstr "Affichage ou non des valeurs min et max de l’axe des ordonnées"
+msgstr "Affichage ou non des valeurs min et max de l'axe Y"
 
 msgid "Whether to display the numbered column"
-msgstr "Afficher ou non la colonne numérotée"
+msgstr "Affichage ou non le numéro de la colonne"
 
 msgid "Whether to display the numerical values within the cells"
 msgstr "Affichage ou non des valeurs numériques dans les cellules"
@@ -17733,30 +17746,30 @@ msgid "Whether to display the percentage value in the tooltip"
 msgstr "Indiquer si le pourcentage doit être inclus dans l'infobulle"
 
 msgid "Whether to display the stroke"
-msgstr "Affichage ou non du trait"
+msgstr "Affichage du trait"
 
 msgid "Whether to display the time range interactive selector"
 msgstr "Affichage ou non du sélecteur interactif de plage horaire"
 
 msgid "Whether to display the timestamp"
-msgstr "Affichage ou non de l’horodatage"
+msgstr "Affichage ou non de l'horodatage"
 
 msgid "Whether to display the tooltip labels."
-msgstr "Afficher ou non les étiquettes de l'infobulle."
+msgstr "Affichage de l'infobulle des étiquettes."
 
 msgid "Whether to display the total value in the tooltip"
-msgstr "Afficher ou non la valeur totale dans l'infobulle"
+msgstr "Affichage du total dans l'infobulle"
 
 msgid "Whether to display the trend line"
 msgstr "Affichage ou non de la ligne de tendance"
 
 msgid "Whether to display the type icon (#, Δ, %)"
-msgstr "Afficher ou non l'icône de type (#, Δ, %)"
+msgstr "Affichage du type d'icône (#, Δ, %)"
 
 msgid "Whether to enable changing graph position and scaling."
 msgstr ""
 "Activation ou non de la modification de la position et de la mise à "
-"l’échelle du graphique."
+"l'échelle du graphique."
 
 msgid "Whether to enable node dragging in force layout mode."
 msgstr "Activation ou non du glissement de nœud en mode de disposition en force."
@@ -17785,15 +17798,15 @@ msgid "Whether to populate autocomplete filters options"
 msgstr "Remplir ou non les options des filtres d'autocomplétion"
 
 msgid "Whether to show as Nightingale chart."
-msgstr "Afficher ou non en graphique de type Nightingale."
+msgstr "Afficher en tant que graphique Nightingale"
 
 msgid ""
 "Whether to show extra controls or not. Extra controls include things like"
 " making multiBar charts stacked or side by side."
 msgstr ""
-"Montrer ou non des contrôles supplémentaires. Les contrôles "
-"supplémentaires comprennent des choses comme faire des tableaux à barres "
-"multiples empilés ou côte à côte."
+"Afficher des contrôles supplémentaires. Les contrôles supplémentaires "
+"comprennent des choses comme faire des tableaux à barres multiples empilés "
+"ou côte à côte."
 
 msgid "Whether to show minor ticks on the axis"
 msgstr "Montrer ou non les taches mineures sur l'axe"
@@ -17803,14 +17816,14 @@ msgstr "Montrer ou non le pointeur"
 
 msgid "Whether to show the progress of gauge chart"
 msgstr ""
-"Indiquer ou non s’il y a lieu de montrer la progression du graphique de "
+"Indiquer ou non s'il y a lieu de montrer la progression du graphique de "
 "jauge"
 
 msgid "Whether to show the split lines on the axis"
-msgstr "Indiquer ou non s’il faut afficher les lignes divisées sur l’axe"
+msgstr "Indiquer ou non s'il faut afficher les lignes divisées sur l'axe"
 
 msgid "Whether to sort ascending or descending on the base Axis."
-msgstr "Trier ou non par ordre décroissant ou croissant sur l'axe de base."
+msgstr "Tri croissant ou décroissant sur l'axe de base."
 
 msgid "Whether to sort descending or ascending"
 msgstr "Trier ou non par ordre décroissant ou croissant"
@@ -17853,7 +17866,7 @@ msgid "Width of the sparkline"
 msgstr "Largeur de la ligne d'étincelles"
 
 msgid "Width scale multiplier"
-msgstr "Multiplicateur d'échelle de largeur"
+msgstr "Echelle du multiplicateur d'épaisseur"
 
 msgid "Window must be > 0"
 msgstr "La fenêtre doit être > 0"
@@ -17883,28 +17896,28 @@ msgid "Write a handlebars template to render the data"
 msgstr "Écrire un modèle handlebar pour afficher les données"
 
 msgid "X Axis"
-msgstr "Axe des abscisses"
+msgstr "Axe X"
 
 msgid "X Axis Bounds"
-msgstr "Limite de l'axe des abscisses"
+msgstr "Limite de l'axe X"
 
 msgid "X Axis Format"
-msgstr "Format de l'axe des abscisses"
+msgstr "Format de l'axe X"
 
 msgid "X Axis Label"
-msgstr "Étiquette de l’axe des abscisses"
+msgstr "Étiquette de l'axe X"
 
 msgid "X Axis Label Interval"
 msgstr "Intervalle d'étiquette de l'axe X"
 
 msgid "X Axis Number Format"
-msgstr "Format de nombre de l'axe des abscisses"
+msgstr "Format de nombre de l'axe X"
 
 msgid "X Axis Title"
-msgstr "Titre de l’axe des abscisses"
+msgstr "Titre de l'axe X"
 
 msgid "X Axis Title Margin"
-msgstr "Marge du titre de l'axe des abscisses"
+msgstr "Marge du titre de l'axe X"
 
 msgid "X Log Scale"
 msgstr "Échelle logarithmique X"
@@ -17913,19 +17926,19 @@ msgid "X Tick Layout"
 msgstr "Disposition des points de repère X"
 
 msgid "X axis title margin"
-msgstr "MARGE DU TITRE DE L'AXE DES ABCISSES"
+msgstr "Marge du titre de l'axe X"
 
 msgid "X bounds"
 msgstr "Limites X"
 
 msgid "X-Axis Sort Ascending"
-msgstr "Tri croissant sur l'axe des abscisses"
+msgstr "Tri croissant sur l'axe X"
 
 msgid "X-Axis Sort By"
-msgstr "Axe des abscisses – Trier par"
+msgstr "Axe X – Trier par"
 
 msgid "X-axis"
-msgstr "Axe des abscisses"
+msgstr "Axe X"
 
 msgid "X-scale interval"
 msgstr "Intervalle XScale"
@@ -17935,55 +17948,55 @@ msgid "XYZ"
 msgstr "XYZ"
 
 msgid "Y 2 bounds"
-msgstr "Limites ordonnées 2"
+msgstr "Axe Y - 2 limites"
 
 msgid "Y Axis"
-msgstr "Axe des ordonnées"
+msgstr "Axe Y"
 
 msgid "Y Axis 2 Bounds"
-msgstr "Limites de l’axe des ordonnées 2"
+msgstr "Limites de l'axe Y 2"
 
 msgid "Y Axis Bounds"
-msgstr "Limites de l’axe des ordonnées"
+msgstr "Limites de l'axe Y"
 
 msgid "Y Axis Format"
-msgstr "Format de l'axe des ordonnées"
+msgstr "Format de l'axe Y"
 
 msgid "Y Axis Label"
-msgstr "Étiquette de l’axe des ordonnées"
+msgstr "Étiquette de l'axe Y"
 
 msgid "Y Axis Title"
-msgstr "Titre de l’axe des ordonnées"
+msgstr "Titre de l'axe Y"
 
 msgid "Y Axis Title Margin"
-msgstr "Marge du titre de l'axe des ordonnées"
+msgstr "Marge du titre de l'axe Y"
 
 msgid "Y Axis Title Position"
 msgstr "Position du titre de l'axe des ordonées"
 
 msgid "Y Log Scale"
-msgstr "Échelle logarithmique des ordonnées"
+msgstr "Échelle logarithmique de l'axe Y"
 
 msgid "Y axis title margin"
-msgstr "MARGE DU TITRE DE L'AXE DES ORDONNÉES"
+msgstr "Marge du titre de l'axe Y"
 
 msgid "Y bounds"
-msgstr "Limites des ordonnées"
+msgstr "Limites de l'axe Y"
 
 msgid "Y-Axis"
-msgstr "Axe des ordonnées"
+msgstr "Axe Y"
 
 msgid "Y-Axis Sort Ascending"
-msgstr "Tri croissant sur l'axe des ordonnées"
+msgstr "Tri croissant sur l'axe Y"
 
 msgid "Y-Axis Sort By"
-msgstr "Axe des ordonnées – Trier par"
+msgstr "Axe Y – Trier par"
 
 msgid "Y-axis"
-msgstr "Axe des ordonnées"
+msgstr "Axe Y"
 
 msgid "Y-axis bounds"
-msgstr "Limites de l’axe des ordonnées"
+msgstr "Limites de l'axe Y"
 
 msgid "Y-axis range slider"
 msgstr "Curseur de plage de l'axe Y"
@@ -18055,7 +18068,7 @@ msgid ""
 "might cause you to lose some of your work. Are you sure you want to "
 "overwrite?"
 msgstr ""
-"Vous importez un ou plusieurs ensembles de données qui existent déjà. "
+"Vous importez un ou plusieurs jeux de données qui existent déjà. "
 "L'écrasement pourrait vous faire perdre une partie de votre travail. "
 "Êtes-vous sûr de vouloir les écraser?"
 
@@ -18160,10 +18173,11 @@ msgid "You do not have permission to edit this dashboard"
 msgstr "Vous n'avez pas les permission pour modifier ce tableau de bord"
 
 msgid "You do not have permission to perform this operation"
-msgstr "Vous n'avez pas la permission d'effectuer cette opération"
+msgstr ""
+"Vous n'avez pas les permissions suffisantes pour réaliser cette opération"
 
 msgid "You do not have permission to read tags"
-msgstr "Vous n'avez pas la permission de lire les balises"
+msgstr "Vous n'avez pas la permission de lire les étiquettes"
 
 msgid "You do not have permissions to edit this dashboard."
 msgstr "Vous n'avez pas les permission pour modifier ce tableau de bord."
@@ -18178,7 +18192,7 @@ msgstr ""
 "référencées."
 
 msgid "You don't have access to this chart."
-msgstr "Vous n'avez pas accès à ce graphique."
+msgstr "Vous n'avez pas le droit d'accéder à ce graphique."
 
 msgid "You don't have access to this dashboard."
 msgstr "Vous n'avez pas accès à ce tableau de bord."
@@ -18193,26 +18207,29 @@ msgid "You don't have access to this semantic view."
 msgstr "Vous n'avez pas accès à cette vue sémantique."
 
 msgid "You don't have permission to copy to clipboard"
-msgstr "Vous n'avez pas la permission de copier dans le presse-papier"
+msgstr ""
+"Vous n'avez pas les permissions suffisantes pour copier dans le "
+"presse-papier."
 
 msgid "You don't have permission to export data"
-msgstr "Vous n'avez pas la permission d'exporter des données"
+msgstr ""
+"Vous n'avez pas les permissions suffisantes pour exporter les données"
 
 msgid "You don't have permission to export images"
-msgstr "Vous n'avez pas la permission d'exporter des images"
+msgstr "Vous n'avez pas les permissions suffisantes pour exporter les images"
 
 msgid "You don't have permission to modify the value."
 msgstr "Vous n'avez pas la permission de modifier la valeur."
 
 #, python-format
 msgid "You don't have the rights to alter %(resource)s"
-msgstr "Vous n'avez pas les droits pour modifier %(resource)s"
+msgstr "Vous n'avez pas le droit de modifier %(resource)s"
 
 msgid "You don't have the rights to alter this chart"
-msgstr "Vous n'avez pas les droits pour modifier ce graphique"
+msgstr "Vous n'avez pas le droit de modifier ce graphique"
 
 msgid "You don't have the rights to alter this dashboard"
-msgstr "Vous n'avez pas les droits pour modifier ce tableau de bord"
+msgstr "Vous n'avez pas le droit de modifier ce tableau de bord"
 
 msgid "You don't have the rights to alter this title."
 msgstr "Vous n'avez pas les droits pour modifier ce titre."
@@ -18224,11 +18241,11 @@ msgid "You don't have the rights to create a dashboard"
 msgstr "Vous n'avez pas les droits de créer un tableau de bord"
 
 msgid "You don't have the rights to export data"
-msgstr "Vous n'avez pas les droits pour exporter des données"
+msgstr "Vous n'avez pas le droit d'exporter les données"
 
 #, python-format
 msgid "You have been removed from task: %s"
-msgstr "Vous avez été supprimé de cette tâche %s"
+msgstr "Vous avez été retiré de la tâche: %s"
 
 msgid "You have removed this filter."
 msgstr "Vous avez supprimé ce filtre."
@@ -18245,17 +18262,17 @@ msgid ""
 "fully undo subsequent actions. You may save your current state to reset "
 "the history."
 msgstr ""
-"Vous avez utilisé tous les emplacements d%(historyLength)s'annulation et "
-"ne pourrez pas annuler complètement les actions subséquentes. Vous pouvez"
-" enregistrer votre état actuel pour réinitialiser l’historique."
+"Vous avez utilisé tous les emplacements d%(historyLength)s'annulation et ne "
+"pourrez pas annuler complètement les actions subséquentes. Vous pouvez "
+"enregistrer votre état actuel pour réinitialiser l'historique."
 
 #, python-format
 msgid ""
 "You must be a %s editor in order to edit. Please reach out to a %s editor"
 " to request modifications or edit access."
 msgstr ""
-"Vous devez être éditeur de %s pour modifier. Contactez un éditeur de %s "
-"pour demander des modifications ou un accès en modification."
+"Vous devez être éditeur de %s pour modifier le graphique. Contactez un "
+"éditeur de %s pour demander des modifications ou un accès en modification."
 
 msgid ""
 "You must be a chart editor in order to delete. Please reach out to a "
@@ -18307,7 +18324,7 @@ msgstr ""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ja, tr]
 msgid "You must change your password before continuing."
-msgstr "Vous devez changer votre mot de passe avant de continuer."
+msgstr "Vous devez modifier votre mot de passe avant de continuer."
 
 msgid "You must pick a name for the new dashboard"
 msgstr "Vous devez entrer un nom pour le nouveau tableau de Bord"
@@ -18335,7 +18352,7 @@ msgid ""
 "button or"
 msgstr ""
 "Vous avez mis à jour les valeurs dans le panneau de commande, mais le "
-"graphique n’a pas été mis à jour automatiquement. Exécutez la requête en "
+"graphique n'a pas été mis à jour automatiquement. Exécutez la requête en "
 "cliquant sur le bouton « Mettre à jour le graphique » ou"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
@@ -18352,9 +18369,9 @@ msgid ""
 "You've changed datasets. Any controls with data (columns, metrics) that "
 "match this new dataset have been retained."
 msgstr ""
-"Vous avez modifié les ensembles de données. Tous les contrôles contenant "
-"des données (colonnes, mesures) qui correspondent à ce nouveau ensemble "
-"de données ont été conservés."
+"Vous avez modifié les jeux de données. Tous les contrôles contenant des "
+"données (colonnes, mesures) qui correspondent à ce nouveau jeu de données "
+"ont été conservés."
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
@@ -18364,10 +18381,10 @@ msgstr "Votre compte est activé. Vous pouvez vous connecter avec vos identifian
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ro, ru, sk, sr, sr_Latn, tr, uk]
 msgid "Your changes will be lost if you leave without saving."
-msgstr "Vos modifications seront perdues si vous quittez sans enregistrer."
+msgstr "Vos changements seront perdus si vous quittez sans enregistrer."
 
 msgid "Your chart is not up to date"
-msgstr "Votre graphique n’est pas à jour"
+msgstr "Votre graphique n'est pas à jour"
 
 msgid "Your chart is ready to go!"
 msgstr "Votre graphique est prêt!"
@@ -18472,7 +18489,7 @@ msgid "[Longitude] and [Latitude] must be set"
 msgstr "Les colonnes [Longitude] et [Latitude] doivent êtres définies"
 
 msgid "[Missing Dataset]"
-msgstr "[Ensemble de données manquant]"
+msgstr "[Jeu de données manquant]"
 
 msgid "[Untitled]"
 msgstr "[Sans titre]"
@@ -18498,7 +18515,7 @@ msgstr ""
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: cs, de, ja,
 # lv, ru, sk, sr, sr_Latn, tr, uk]
 msgid "[untitled customization]"
-msgstr "[personnalisation sans titre]"
+msgstr "[customisation sans nom]"
 
 msgid "`compare_columns` must have the same length as `source_columns`."
 msgstr "« compare_columns » doit être de même longueur que « source_columns »."
@@ -18515,9 +18532,9 @@ msgid ""
 "label points. Leave empty to get a count of points in each cluster."
 msgstr ""
 "« count » est COUNT(*) si un groupe par est utilisé. Les colonnes "
-"numériques seront regroupées avec l’agrégateur. Les colonnes non "
-"numériques seront utilisées pour étiqueter les points. Laissez vide pour "
-"obtenir un compte de points dans chaque regroupement."
+"numériques seront regroupées avec l'agrégateur. Les colonnes non numériques "
+"seront utilisées pour étiqueter les points. Laissez vide pour obtenir un "
+"compte de points dans chaque regroupement."
 
 msgid "`operation` property of post processing object undefined"
 msgstr "La propriété « operation » de l'objet de post-traitement est indéfinie"
@@ -18525,7 +18542,7 @@ msgstr "La propriété « operation » de l'objet de post-traitement est indé
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [no refs]
 #, python-format
 msgid "`periods` must be between 1 and %(max)s"
-msgstr "`periods` doit être compris entre 1 et %(max)s"
+msgstr "`periods` doit être entre 1 et %(max)s"
 
 msgid "`prophet` package not installed"
 msgstr "Paquet « prophet » non installée"
@@ -18551,7 +18568,7 @@ msgid "`window` must be between 1 and 10000"
 msgstr "`window` doit être compris entre 1 et 10000"
 
 msgid "a few seconds"
-msgstr "quelques secondes"
+msgstr "il y a quelques secondes"
 
 msgid "aggregate"
 msgstr "agrégat"
@@ -18636,7 +18653,7 @@ msgid "bottom"
 msgstr "bas"
 
 msgid "button (cmd + z) until you save your changes."
-msgstr "(cmd + z) jusqu’à ce que vous sauvegardiez vos modifications."
+msgstr "(cmd + z) jusqu'à ce que vous sauvegardiez vos modifications."
 
 msgid "by using"
 msgstr "en utilisant"
@@ -18648,7 +18665,7 @@ msgid "cardinal"
 msgstr "cardinal"
 
 msgid "cell bar"
-msgstr "barre de cellule"
+msgstr "barre de la cellule"
 
 msgid "change"
 msgstr "changement"
@@ -18706,7 +18723,7 @@ msgid "create a new chart"
 msgstr "créer un nouveau graphique"
 
 msgid "create dataset from SQL query"
-msgstr "créer un ensemble de données à partir d'une requête SQL"
+msgstr "créer un jeu de données à partir d'une requête SQL"
 
 #. do-not-translate
 msgid "crontab"
@@ -18728,16 +18745,16 @@ msgid "dashboards"
 msgstr "Tableaux de bord"
 
 msgid "data connection"
-msgstr "connexion de données"
+msgstr "Connexion aux données"
 
 msgid "data connections"
-msgstr "connexions de données"
+msgstr "Connexions aux données"
 
 msgid "database"
 msgstr "base de données"
 
 msgid "databases"
-msgstr "bases de données"
+msgstr "Bases de données"
 
 msgid "dataset"
 msgstr "jeu de données"
@@ -18749,10 +18766,10 @@ msgid "datasets"
 msgstr "jeux de données"
 
 msgid "datasource"
-msgstr "source de données"
+msgstr "Source de données"
 
 msgid "datasources"
-msgstr "sources de données"
+msgstr "Sources de données"
 
 msgid "date"
 msgstr "date"
@@ -18767,10 +18784,10 @@ msgid "day of the week"
 msgstr "jour de la semaine"
 
 msgid "deck.gl 3D Hexagon"
-msgstr "Hexagone 3D deck.gl"
+msgstr "deck.gl - Hexagone 3D"
 
 msgid "deck.gl Arc"
-msgstr "Arc deck.gl "
+msgstr "deck.gl - Arc"
 
 msgid "deck.gl Contour"
 msgstr "Deck.gl - Contour"
@@ -18780,28 +18797,28 @@ msgid "deck.gl Geojson"
 msgstr "deck.gl Geojson"
 
 msgid "deck.gl Grid"
-msgstr "Grille deck.gl"
+msgstr "deck.gl - Grille"
 
 msgid "deck.gl Heatmap"
-msgstr "Carte thermique Deck.gl"
+msgstr "deck.gl - Carte thermique "
 
 msgid "deck.gl Multiple Layers"
-msgstr "Couches multiples Deck.gl"
+msgstr "deck.gl - multiples couches"
 
 msgid "deck.gl Path"
-msgstr "Path deck.gl"
+msgstr "deck.gl - Path"
 
 msgid "deck.gl Polygon"
-msgstr "Polygon deck.gl"
+msgstr "deck.gl - Polygon"
 
 msgid "deck.gl Scatterplot"
-msgstr "Diagramme de dispersion Deck.gl"
+msgstr "deck.gl - Graphique de dispersion"
 
 msgid "deck.gl Screen Grid"
-msgstr "Grille d'écran Deck.gl"
+msgstr "deck.gl - Grille d'écran"
 
 msgid "deck.gl layers (charts)"
-msgstr "Graphiques deck.gl"
+msgstr "deck.gl - Couches (graphiques)"
 
 msgid "deckGL"
 msgstr "deckGL"
@@ -18882,7 +18899,7 @@ msgid "ends with"
 msgstr "se termine par"
 
 msgid "entire row"
-msgstr "rangée entière"
+msgstr "ligne entière"
 
 msgid "entries"
 msgstr "entrées"
@@ -18926,7 +18943,7 @@ msgstr "échoué"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "farewell"
-msgstr "au revoir"
+msgstr "adieu"
 
 msgid "fetching"
 msgstr "récupération"
@@ -18938,7 +18955,7 @@ msgid "flat"
 msgstr "plat"
 
 msgid "for a list of available helpers."
-msgstr "pour une liste des aides disponibles."
+msgstr "pour une liste d'aides disponibles."
 
 msgid "for more information on how to structure your URI."
 msgstr "pour plus d'information sur comment structurer votre URI."
@@ -18953,7 +18970,7 @@ msgid "geohash (square)"
 msgstr "geohash (carré)"
 
 msgid "greeting"
-msgstr "message d'accueil"
+msgstr "salutation"
 
 msgid "heatmap"
 msgstr "carte thermique"
@@ -18966,7 +18983,7 @@ msgstr ""
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "hello"
-msgstr "bonjour"
+msgstr "hey"
 
 msgid "here"
 msgstr "ici"
@@ -18980,7 +18997,7 @@ msgstr "dans"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "in order to run this operation."
-msgstr "afin d'exécuter cette opération."
+msgstr "pour pouvoir exécuter cette opération"
 
 msgid "invalid email"
 msgstr "email invalide"
@@ -19020,9 +19037,9 @@ msgid ""
 "is linked to %s charts that appear on %s dashboards. Are you sure you "
 "want to continue? Deleting the dataset will break those objects."
 msgstr ""
-"est lié à %s graphiques qui apparaissent sur %s tableaux de bord. Êtes-"
-"vous sûr de vouloir continuer ? La suppression de l'ensemble de données "
-"brisera ces objets."
+"est lié à %s graphiques qui apparaissent sur %s tableaux de bord. Êtes-vous "
+"sûr de vouloir continuer ? La suppression du jeu de données brisera ces "
+"objets."
 
 msgid "is not"
 msgstr "n'est pas"
@@ -19123,13 +19140,13 @@ msgstr "nativeFilters doit être une liste"
 # sr_Latn]
 #, python-format
 msgid "nativeFilters[%(idx)s] missing required keys: %(keys)s"
-msgstr "nativeFilters[%(idx)s] clés requises manquantes : %(keys)s"
+msgstr "nativeFilters[%(idx)s] nécessite les clés suivantes: %(keys)s"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 #, python-format
 msgid "nativeFilters[%(idx)s] must be an object"
-msgstr "nativeFilters[%(idx)s] doit être un objet"
+msgstr "nativeFilters[%(idx)s] doit être un object"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -19158,7 +19175,7 @@ msgstr "aucun validateur SQL n'est configuré"
 
 #, python-format
 msgid "no SQL validator is configured for %(engine_spec)s"
-msgstr "aucun validateur SQL n'est défini pour %(engine_spec)s"
+msgstr "aucun validateur SQL n'est configuré pour %(engine_spec)s."
 
 msgid "not containing"
 msgstr "ne contient pas"
@@ -19230,7 +19247,7 @@ msgstr "état du lien permanent introuvable"
 
 #. do-not-translate
 msgid "pivoted_xlsx"
-msgstr "pivoted_xlsx"
+msgstr "xlsx pivoté"
 
 msgid "pixels"
 msgstr "pixels"
@@ -19281,13 +19298,13 @@ msgid "restore zoom"
 msgstr "restaurer le zoom"
 
 msgid "right"
-msgstr "droit"
+msgstr "droite"
 
 msgid "rowlevelsecurity"
 msgstr "Sécurité d'accès par ligne (RLS)"
 
 msgid "running"
-msgstr "en cours d’exécution"
+msgstr "en cours d'exécution"
 
 msgid "save"
 msgstr "Enregistrer"
@@ -19303,16 +19320,16 @@ msgid "semantic layer"
 msgstr "couche sémantique"
 
 msgid "series"
-msgstr "série"
+msgstr "séries"
 
 msgid ""
 "series: Treat each series independently; overall: All series use the same"
 " scale; change: Show changes compared to the first data point in each "
 "series"
 msgstr ""
-"série : traiter chaque série indépendamment; dans l’ensemble : toutes les"
-" séries utilisent la même échelle; changement : afficher les changements "
-"par rapport au premier point de données de chaque série"
+"série : traiter chaque série indépendamment; dans l'ensemble : toutes les "
+"séries utilisent la même échelle; changement : afficher les changements par "
+"rapport au premier point de données de chaque série"
 
 #. do-not-translate
 msgid "sql"
@@ -19345,10 +19362,10 @@ msgid "stream"
 msgstr "flux"
 
 msgid "string"
-msgstr "chaîne de caractère"
+msgstr "chaîne de caractères"
 
 msgid "string type icon"
-msgstr "icône de type de chaîne"
+msgstr "type d'icône de la chaîne de caractères"
 
 msgid "success"
 msgstr "succès"
@@ -19364,7 +19381,7 @@ msgid "syntax."
 msgstr "syntaxe."
 
 msgid "tag"
-msgstr "balise"
+msgstr "étiquette"
 
 msgid "task"
 msgstr "tâche"
@@ -19373,7 +19390,7 @@ msgid "temporal type icon"
 msgstr "icône de type temporel"
 
 msgid "text color"
-msgstr "couleur du texte"
+msgstr "Couleur textuelle"
 
 msgid "textarea"
 msgstr "textarea"
@@ -19399,13 +19416,13 @@ msgid "undo"
 msgstr "annuler"
 
 msgid "unknown type icon"
-msgstr "icône de type inconnu"
+msgstr "type d'icône inconnu"
 
 msgid "unset"
 msgstr "non défini"
 
 msgid "updated"
-msgstr "mis à jour"
+msgstr "Dernière mise à jour"
 
 msgid ""
 "upper percentile must be greater than 0 and less than 100. Must be higher"
@@ -19466,7 +19483,7 @@ msgid "y"
 msgstr "y"
 
 msgid "y: values are normalized within each row"
-msgstr "y : les valeurs sont normalisées dans chaque rangée"
+msgstr "y : les valeurs sont normalisées dans chaque ligne"
 
 msgid "year"
 msgstr "année"
@@ -19484,4 +19501,4 @@ msgstr "© Attribution de la couche"
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
 msgid "№"
-msgstr "№"
+msgstr "N°"


### PR DESCRIPTION
### SUMMARY
Update the french po file to match the translation template. The current file has some weird translations and misses some keys from the template.

### Steps
[X] Add all missing translation
[X] Check the file compilation
[X] Check the translation typo and meaning
[X] Define global translation consistency
[Not fully done] Check the translation pertinence (from UI and user actions)
[X] Check the new translations from master merge

### BEFORE/AFTER SCREENSHOTS

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION

To get the new values from .pot template, I ran the following command : `msgmerge --update superset/translations/fr/LC_MESSAGES/messages.po superset/translations/messages.pot`

IMO, there is a huge work to adress on french translation. The same word can use multiple translation which can lead the user to confusion.
Few example
`rows` => `rangées` or ` lignes`
`dataset` => `ensemble de données` or `jeu de données` 

I suggest to define a single "admited" translation from now on and future evolution. Here is the list for the most common terms which needs consistency.

| Eng | French |
|--------|--------|
|  `chart` | `graphique`|
| `dataset` | `jeu de données` |
| `tag` | `etiquette`|
| `currency` | `devise` |
| `plugin` | `plugin` |
| `upload` | `charger` | 
| `layers` (in context of map) | `couche` | 
| `layers` (in context of annotation) | `couche` | 
| `email` | `mail` | 
| `table` (in contexte of database) | `table` | 
| `rows` | `lignes` | 
| `X-axis` | `axe X`| 
| `Y-axis` | `axe Y` | 
| `Gender user` | `Non` | 

Any feedback from french users are welcomed !