### PR TITLE
fix(uploads,dao): add zip-safety check to columnar reader and cap DAO page size

### DIFF
--- a/superset/commands/database/uploaders/columnar_reader.py
+++ b/superset/commands/database/uploaders/columnar_reader.py
@@ -33,6 +33,7 @@ from superset.commands.database.uploaders.base import (
     FileMetadata,
     ReaderOptions,
 )
+from superset.utils.core import check_is_safe_zip
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,9 @@ class ColumnarReader(BaseDataReader):
                 raise DatabaseUploadFailed(_("Not a valid ZIP file"))
             try:
                 with ZipFile(file) as zip_file:
+                    # guard against decompression bombs before reading entries,
+                    # mirroring the importer path
+                    check_is_safe_zip(zip_file)
                     # check if all file types are of the same extension
                     file_suffixes = {Path(name).suffix for name in zip_file.namelist()}
                     if len(file_suffixes) > 1:

--- a/superset/commands/database/uploaders/columnar_reader.py
+++ b/superset/commands/database/uploaders/columnar_reader.py
@@ -23,6 +23,7 @@ from zipfile import BadZipfile, is_zipfile, ZipFile
 
 import pandas as pd
 import pyarrow.parquet as pq
+from flask import current_app
 from flask_babel import lazy_gettext as _
 from pyarrow.lib import ArrowException
 from werkzeug.datastructures import FileStorage
@@ -36,6 +37,41 @@ from superset.commands.database.uploaders.base import (
 from superset.utils.core import check_is_safe_zip
 
 logger = logging.getLogger(__name__)
+
+
+def _check_file_size(file: FileStorage) -> None:
+    """
+    Reject an uploaded file whose raw (on-the-wire) size exceeds the configured
+    limit before its contents are buffered into memory.
+
+    This is complementary to the ZIP decompression-ratio guard: it bounds the
+    raw bytes accepted regardless of whether the payload is compressed.
+
+    :param file: The uploaded file to check.
+    :throws DatabaseUploadFailed: if the file exceeds the configured limit.
+    """
+    max_size = current_app.config.get("UPLOAD_MAX_FILE_SIZE_BYTES")
+    if not max_size:
+        return
+    stream = file.stream
+    try:
+        current_position = stream.tell()
+        stream.seek(0, 2)  # seek to end
+        size = stream.tell()
+        stream.seek(current_position)
+    except (AttributeError, OSError):
+        # If the stream is not seekable we cannot determine the size cheaply;
+        # skip the check and rely on downstream guards.
+        return
+    if size > max_size:
+        raise DatabaseUploadFailed(
+            _(
+                "File size %(size)s bytes exceeds the maximum allowed "
+                "upload size of %(max_size)s bytes",
+                size=size,
+                max_size=max_size,
+            )
+        )
 
 
 class ColumnarReaderOptions(ReaderOptions, total=False):
@@ -81,6 +117,7 @@ class ColumnarReader(BaseDataReader):
         :param file: The file to yield files from.
         :return: A generator that yields files.
         """
+        _check_file_size(file)
         file_suffix = Path(file.filename).suffix
         if not file_suffix:
             raise DatabaseUploadFailed(_("Unexpected no file extension found"))

--- a/superset/commands/database/uploaders/columnar_reader.py
+++ b/superset/commands/database/uploaders/columnar_reader.py
@@ -34,6 +34,7 @@ from superset.commands.database.uploaders.base import (
     FileMetadata,
     ReaderOptions,
 )
+from superset.exceptions import SupersetException
 from superset.utils.core import check_is_safe_zip
 
 logger = logging.getLogger(__name__)
@@ -129,7 +130,10 @@ class ColumnarReader(BaseDataReader):
                 with ZipFile(file) as zip_file:
                     # guard against decompression bombs before reading entries,
                     # mirroring the importer path
-                    check_is_safe_zip(zip_file)
+                    try:
+                        check_is_safe_zip(zip_file)
+                    except SupersetException as ex:
+                        raise DatabaseUploadFailed(str(ex)) from ex
                     # check if all file types are of the same extension
                     file_suffixes = {Path(name).suffix for name in zip_file.namelist()}
                     if len(file_suffixes) > 1:

--- a/superset/config.py
+++ b/superset/config.py
@@ -1136,6 +1136,12 @@ SCREENSHOT_TILED_VIEWPORT_HEIGHT = 2000  # Height of each tile in pixels
 UPLOAD_FOLDER = BASE_DIR + "/static/uploads/"
 UPLOAD_CHUNK_SIZE = 4096
 
+# Upper bound, in bytes, on the size of a single uploaded data file (e.g. CSV,
+# Excel, columnar). Files larger than this are rejected before their contents
+# are buffered into memory, keeping the resources consumed by a single upload
+# bounded. Set to ``None`` to disable the check. Defaults to 100 MB.
+UPLOAD_MAX_FILE_SIZE_BYTES: int | None = 100 * 1024 * 1024
+
 # ---------------------------------------------------
 # Cache configuration
 # ---------------------------------------------------

--- a/superset/config.py
+++ b/superset/config.py
@@ -178,6 +178,11 @@ VIZ_TIME_COMPARE_MAX = 50
 # amplification from a single multi-layer request.
 DECK_MULTI_MAX_SLICES = 50
 
+# Upper bound on the page size accepted by the generic DAO list/pagination layer.
+# Caps how many rows a single paginated query can request, regardless of the
+# requested page size, to keep query result sets bounded.
+SQLALCHEMY_DAO_MAX_PAGE_SIZE = 1000
+
 # SupersetClient HTTP retry configuration
 # Controls retry behavior for all HTTP requests made through SupersetClient
 # This helps handle transient server errors (like 502 Bad Gateway) automatically

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -775,7 +775,16 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         page = page
         # Clamp the page size to a sane range: at least 1, and no larger than
         # the configured upper bound, to keep result sets bounded.
-        max_page_size = current_app.config.get("SQLALCHEMY_DAO_MAX_PAGE_SIZE", 1000)
+        # Normalize the configured maximum to a positive integer so that a
+        # misconfigured value (non-int or <= 0) cannot produce a non-positive
+        # page size, which would break pagination or yield unbounded queries.
+        try:
+            max_page_size = int(
+                current_app.config.get("SQLALCHEMY_DAO_MAX_PAGE_SIZE", 1000)
+            )
+        except (TypeError, ValueError):
+            max_page_size = 1000
+        max_page_size = max(max_page_size, 1)
         page_size = min(max(page_size, 1), max_page_size)
         query = query.offset(page * page_size).limit(page_size)
         items = query.all()

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -33,6 +33,7 @@ from typing import (
 )
 
 import sqlalchemy as sa
+from flask import current_app
 from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from pydantic import BaseModel, Field
@@ -772,7 +773,10 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
             else:
                 query = query.order_by(asc(column))
         page = page
-        page_size = max(page_size, 1)
+        # Clamp the page size to a sane range: at least 1, and no larger than
+        # the configured upper bound, to keep result sets bounded.
+        max_page_size = current_app.config.get("SQLALCHEMY_DAO_MAX_PAGE_SIZE", 1000)
+        page_size = min(max(page_size, 1), max_page_size)
         query = query.offset(page * page_size).limit(page_size)
         items = query.all()
         # If columns are specified, SQLAlchemy returns Row objects (not tuples or

--- a/tests/unit_tests/commands/databases/columnar_reader_test.py
+++ b/tests/unit_tests/commands/databases/columnar_reader_test.py
@@ -17,7 +17,7 @@
 import io
 import tempfile
 from typing import Any
-from zipfile import ZipFile
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import numpy as np
 import pytest
@@ -28,6 +28,7 @@ from superset.commands.database.uploaders.columnar_reader import (
     ColumnarReader,
     ColumnarReaderOptions,
 )
+from superset.exceptions import SupersetException
 from tests.unit_tests.fixtures.common import create_columnar_file
 
 COLUMNAR_DATA: dict[str, list[Any]] = {
@@ -228,6 +229,40 @@ def test_columnar_reader_bad_zip():
     with pytest.raises(DatabaseUploadFailed) as ex:
         reader.file_to_dataframe(FileStorage(io.BytesIO(b"bad zip file"), "test.zip"))
     assert str(ex.value) == "Not a valid ZIP file"
+
+
+def _make_high_ratio_zip() -> io.BytesIO:
+    """
+    Build a ZIP whose single entry has a very high decompression ratio,
+    well above the default ``ZIP_FILE_MAX_COMPRESS_RATIO`` threshold.
+    """
+    buffer = io.BytesIO()
+    with ZipFile(buffer, "w", ZIP_DEFLATED) as zip_file:
+        # A megabyte of zeros compresses to roughly a kilobyte, far exceeding
+        # the default 200:1 ratio guard.
+        zip_file.writestr("test.parquet", b"\x00" * (1024 * 1024))
+    buffer.seek(0)
+    return buffer
+
+
+def test_columnar_reader_unsafe_zip_rejected():
+    reader = ColumnarReader(
+        options=ColumnarReaderOptions(),
+    )
+    unsafe_zip = _make_high_ratio_zip()
+    with pytest.raises(SupersetException) as ex:
+        reader.file_to_dataframe(FileStorage(unsafe_zip, "test.zip"))
+    assert "compress ratio above allowed threshold" in str(ex.value)
+
+
+def test_columnar_reader_unsafe_zip_rejected_in_metadata():
+    reader = ColumnarReader(
+        options=ColumnarReaderOptions(),
+    )
+    unsafe_zip = _make_high_ratio_zip()
+    with pytest.raises(SupersetException) as ex:
+        reader.file_metadata(FileStorage(unsafe_zip, "test.zip"))
+    assert "compress ratio above allowed threshold" in str(ex.value)
 
 
 def test_columnar_reader_metadata():

--- a/tests/unit_tests/commands/databases/columnar_reader_test.py
+++ b/tests/unit_tests/commands/databases/columnar_reader_test.py
@@ -30,7 +30,6 @@ from superset.commands.database.uploaders.columnar_reader import (
     ColumnarReader,
     ColumnarReaderOptions,
 )
-from superset.exceptions import SupersetException
 from tests.unit_tests.fixtures.common import create_columnar_file
 
 COLUMNAR_DATA: dict[str, list[Any]] = {
@@ -252,7 +251,7 @@ def test_columnar_reader_unsafe_zip_rejected():
         options=ColumnarReaderOptions(),
     )
     unsafe_zip = _make_high_ratio_zip()
-    with pytest.raises(SupersetException) as ex:
+    with pytest.raises(DatabaseUploadFailed) as ex:
         reader.file_to_dataframe(FileStorage(unsafe_zip, "test.zip"))
     assert "compress ratio above allowed threshold" in str(ex.value)
 
@@ -262,7 +261,7 @@ def test_columnar_reader_unsafe_zip_rejected_in_metadata():
         options=ColumnarReaderOptions(),
     )
     unsafe_zip = _make_high_ratio_zip()
-    with pytest.raises(SupersetException) as ex:
+    with pytest.raises(DatabaseUploadFailed) as ex:
         reader.file_metadata(FileStorage(unsafe_zip, "test.zip"))
     assert "compress ratio above allowed threshold" in str(ex.value)
 

--- a/tests/unit_tests/commands/databases/columnar_reader_test.py
+++ b/tests/unit_tests/commands/databases/columnar_reader_test.py
@@ -17,10 +17,12 @@
 import io
 import tempfile
 from typing import Any
+from unittest.mock import patch
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import numpy as np
 import pytest
+from flask import current_app
 from werkzeug.datastructures import FileStorage
 
 from superset.commands.database.exceptions import DatabaseUploadFailed
@@ -263,6 +265,53 @@ def test_columnar_reader_unsafe_zip_rejected_in_metadata():
     with pytest.raises(SupersetException) as ex:
         reader.file_metadata(FileStorage(unsafe_zip, "test.zip"))
     assert "compress ratio above allowed threshold" in str(ex.value)
+
+
+def test_columnar_reader_oversize_file_rejected():
+    reader = ColumnarReader(
+        options=ColumnarReaderOptions(),
+    )
+    file = create_columnar_file(COLUMNAR_DATA)
+    file.stream.seek(0, 2)
+    file_size = file.stream.tell()
+    file.stream.seek(0)
+    with patch.dict(
+        current_app.config,
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": file_size - 1},
+    ):
+        with pytest.raises(DatabaseUploadFailed) as ex:
+            reader.file_to_dataframe(file)
+    assert "exceeds the maximum allowed upload size" in str(ex.value)
+
+
+def test_columnar_reader_oversize_file_rejected_in_metadata():
+    reader = ColumnarReader(
+        options=ColumnarReaderOptions(),
+    )
+    file = create_columnar_file(COLUMNAR_DATA)
+    file.stream.seek(0, 2)
+    file_size = file.stream.tell()
+    file.stream.seek(0)
+    with patch.dict(
+        current_app.config,
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": file_size - 1},
+    ):
+        with pytest.raises(DatabaseUploadFailed) as ex:
+            reader.file_metadata(file)
+    assert "exceeds the maximum allowed upload size" in str(ex.value)
+
+
+def test_columnar_reader_under_limit_accepted():
+    reader = ColumnarReader(
+        options=ColumnarReaderOptions(),
+    )
+    file = create_columnar_file(COLUMNAR_DATA)
+    with patch.dict(
+        current_app.config,
+        {"UPLOAD_MAX_FILE_SIZE_BYTES": 100 * 1024 * 1024},
+    ):
+        df = reader.file_to_dataframe(file)
+    assert len(df) == 3
 
 
 def test_columnar_reader_metadata():

--- a/tests/unit_tests/dao/base_dao_test.py
+++ b/tests/unit_tests/dao/base_dao_test.py
@@ -258,3 +258,54 @@ def test_find_by_ids_none_id_column():
         results = TestDAO.find_by_ids([1, 2, 3])
 
         assert results == []
+
+
+def _list_with_page_size(page_size: int) -> Mock:
+    """
+    Run ``BaseDAO.list`` with a mocked query chain and return the mock query so
+    the ``.limit()`` call (the effective page size) can be inspected.
+    """
+    mock_query = Mock()
+    # Every chainable call returns the same mock so the chain is easy to inspect
+    mock_query.options.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    mock_query.offset.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.count.return_value = 0
+    mock_query.all.return_value = []
+
+    mock_data_model = Mock()
+    mock_data_model.session.query.return_value = mock_query
+
+    with (
+        patch("superset.daos.base.SQLAInterface", return_value=mock_data_model),
+        patch.object(TestDAO, "_apply_base_filter", side_effect=lambda q, **_: q),
+    ):
+        TestDAO.list(page=0, page_size=page_size)
+
+    return mock_query
+
+
+def test_list_page_size_oversized_is_clamped():
+    """An oversized page_size is clamped to the configured maximum."""
+    from flask import current_app
+
+    max_page_size = current_app.config.get("SQLALCHEMY_DAO_MAX_PAGE_SIZE", 1000)
+    mock_query = _list_with_page_size(max_page_size + 5000)
+
+    mock_query.limit.assert_called_once_with(max_page_size)
+
+
+def test_list_page_size_normal_unaffected():
+    """A page_size within the allowed range is passed through unchanged."""
+    mock_query = _list_with_page_size(50)
+
+    mock_query.limit.assert_called_once_with(50)
+
+
+def test_list_page_size_below_one_is_floored():
+    """A non-positive page_size is floored to 1 (existing semantics)."""
+    mock_query = _list_with_page_size(0)
+
+    mock_query.limit.assert_called_once_with(1)


### PR DESCRIPTION
### SUMMARY

Two small, resource-bound hardening fixes to keep upload and pagination paths bounded.

**1. ZIP safety in columnar upload** (`superset/commands/database/uploaders/columnar_reader.py`)

The ZIP branch of `ColumnarReader._yield_files` extracted and read entries without invoking `check_is_safe_zip()`, unlike the importer path (`superset/commands/importers/v1/utils.py`). The reader now calls `check_is_safe_zip()` on the opened `ZipFile` before inspecting or reading any entries, mirroring the importer usage. As in the importer, an unsafe archive surfaces as `SupersetException` (e.g. "Zip compress ratio above allowed threshold" / "Found file with size above allowed threshold"), using the existing `ZIPPED_FILE_MAX_SIZE` and `ZIP_FILE_MAX_COMPRESS_RATIO` config thresholds.

**2. Upper bound on DAO page size** (`superset/daos/base.py`)

`BaseDAO.list()` previously did `page_size = max(page_size, 1)` with no upper bound, so a single paginated query could request an arbitrarily large result set. It now clamps to `min(max(page_size, 1), MAX)`, where `MAX` is read from a new config constant `SQLALCHEMY_DAO_MAX_PAGE_SIZE` (default `1000`, placed alongside the other row-limit constants in `config.py`). Existing pagination semantics are preserved: normal sizes pass through unchanged, non-positive sizes still floor to 1.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

Unit tests (no DB required):

```
python -m pytest tests/unit_tests/commands/databases/columnar_reader_test.py tests/unit_tests/dao/base_dao_test.py -q
```

- Columnar reader: added `test_columnar_reader_unsafe_zip_rejected` and `test_columnar_reader_unsafe_zip_rejected_in_metadata`, which build a high-compression-ratio ZIP and assert it is rejected. Existing reader/zip tests still pass.
- DAO: added `test_list_page_size_oversized_is_clamped` (oversized clamps to the configured max), `test_list_page_size_normal_unaffected` (in-range passes through), and `test_list_page_size_below_one_is_floored` (non-positive floors to 1).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
