### PR TITLE
fix(models): HTML-escape data-controlled values in dashboard_link and Slice.icons

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -221,7 +221,10 @@ class Dashboard(CoreDashboard, AuditMixinNullable, ImportExportMixin):
     @renders("dashboard_title")
     def dashboard_link(self) -> Markup:
         title = escape(self.dashboard_title or "<empty>")
-        return Markup(f'<a href="{self.url}">{title}</a>')
+        # self.url embeds the user-controlled slug; escape it before it is
+        # marked safe via Markup (mirrors SqlaTable.link).
+        url = escape(self.url)
+        return Markup(f'<a href="{url}">{title}</a>')
 
     @property
     def digest(self) -> str | None:

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -326,11 +326,15 @@ class Slice(  # pylint: disable=too-many-public-methods
 
     @property
     def icons(self) -> str:
+        # Escape the data-controlled datasource name and edit URL before they
+        # are interpolated into HTML attributes.
+        url = escape(self.datasource_edit_url)
+        datasource = escape(self.datasource)
         return f"""
         <a
-                href="{self.datasource_edit_url}"
+                href="{url}"
                 data-toggle="tooltip"
-                title="{self.datasource}">
+                title="{datasource}">
             <i class="fa fa-database"></i>
         </a>
         """

--- a/tests/unit_tests/models/dashboard_test.py
+++ b/tests/unit_tests/models/dashboard_test.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from superset.models.dashboard import Dashboard
+
+
+def test_dashboard_link_escapes_slug() -> None:
+    """dashboard_link must HTML-escape the user-controlled slug in the href.
+
+    The slug can carry markup via the import path (which does not run the REST
+    API's slug sanitization), so the rendered FAB list-view link must escape it.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.dashboard_title = "My Dashboard"
+    dash.slug = '"><script>alert(1)</script>'
+
+    link = str(dash.dashboard_link())
+
+    # The injected script tag / attribute breakout must be escaped away.
+    assert "<script>" not in link
+    assert '"><script' not in link
+    # The legitimate anchor markup is still present.
+    assert link.startswith("<a href=")
+    assert "My Dashboard" in link
+
+
+def test_dashboard_link_renders_plain_slug() -> None:
+    """A normal slug renders a working link."""
+    dash = Dashboard()
+    dash.id = 7
+    dash.dashboard_title = "Sales"
+    dash.slug = "sales"
+
+    link = str(dash.dashboard_link())
+
+    assert "/superset/dashboard/sales/" in link
+    assert "Sales" in link

--- a/tests/unit_tests/models/slice_test.py
+++ b/tests/unit_tests/models/slice_test.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import uuid
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
 from parameterized import parameterized
@@ -123,3 +123,26 @@ class TestSlice:
 
         result = slc.datasource_url()
         assert result is None
+
+    def test_icons_escapes_datasource_html(self):
+        """icons must HTML-escape the datasource name and edit URL."""
+        slc = Slice()
+        with (
+            patch.object(
+                Slice,
+                "datasource_edit_url",
+                new_callable=PropertyMock,
+                return_value='/x"onmouseover=alert(1)',
+            ),
+            patch.object(
+                Slice,
+                "datasource",
+                new_callable=PropertyMock,
+                return_value="<img src=x onerror=alert(1)>",
+            ),
+        ):
+            html = slc.icons
+
+        # The injected tag and attribute-breakout quote are escaped.
+        assert "<img" not in html
+        assert '"onmouseover' not in html


### PR DESCRIPTION
### SUMMARY

Two model render helpers interpolated data-controlled values into HTML that is marked safe (`Markup`) or returned as raw HTML, without escaping:

- **`Dashboard.dashboard_link()`** (`superset/models/dashboard.py`) embedded the user-controlled **slug** (via `self.url`) directly in an `href` attribute, escaping only the title. The REST API sanitizes slugs (`re.sub(r"[^\w\-]+", "", slug)`), but the **import path** (`ImportV1DashboardSchema`) does not, so a crafted import can persist a slug with markup — a stored-XSS sink in the FAB dashboard list view. Now escapes the URL too, matching the established `SqlaTable.link` pattern.
- **`Slice.icons`** (`superset/models/slice.py`) interpolated the datasource name and edit URL into HTML attributes without escaping. Now escapes both (defense-in-depth; consistent with `Slice.slice_link`).

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/models/dashboard_test.py tests/unit_tests/models/slice_test.py
```

New tests: a slug containing `"><script>…` is escaped in `dashboard_link` (and a normal slug still renders); injected markup in the datasource name / edit URL is escaped in `Slice.icons`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
