### PR TITLE
fix(reports): sanitize error text in email notification template

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -100,13 +100,19 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
 
     def _error_template(self, text: str) -> str:
         call_to_action = self._get_call_to_action()
+        # The error text is derived from exception messages that can embed
+        # data-controlled content (e.g. crafted table/column names in a DB
+        # error). Strip all HTML before interpolating it into the email body,
+        # matching the sanitization applied to the normal content path.
+        # pylint: disable=no-member
+        safe_text = nh3.clean(text, tags=set(), attributes={})
         return __(
             """
             <p>Your report/alert was unable to be generated because of the following error: %(text)s</p>
             <p>Please check your dashboard/chart for errors.</p>
             <p><b><a href="%(url)s">%(call_to_action)s</a></b></p>
             """,  # noqa: E501
-            text=text,
+            text=safe_text,
             url=self._content.url,
             call_to_action=call_to_action,
         )

--- a/tests/unit_tests/reports/notifications/email_tests.py
+++ b/tests/unit_tests/reports/notifications/email_tests.py
@@ -64,6 +64,41 @@ def test_render_description_with_html() -> None:
     assert '<td>&lt;a href="http://www.example.com"&gt;333&lt;/a&gt;</td>' in email_body
 
 
+def test_error_template_sanitizes_html() -> None:
+    # `superset.models.helpers`, a dependency of following imports,
+    # requires app context
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.email import EmailNotification
+
+    content = NotificationContent(
+        name="test alert",
+        text='DB error near "<img src=x onerror=alert(1)><script>alert(2)</script>"',
+        header_data={
+            "notification_format": "PNG",
+            "notification_type": "Alert",
+            "owners": [1],
+            "notification_source": None,
+            "chart_id": None,
+            "dashboard_id": None,
+            "slack_channels": None,
+            "execution_id": "test-execution-id",
+        },
+    )
+    email_body = (
+        EmailNotification(
+            recipient=ReportRecipients(type=ReportRecipientType.EMAIL), content=content
+        )
+        ._get_content()
+        .body
+    )
+
+    # Injected markup in the error text must be stripped, not rendered.
+    assert "<img" not in email_body
+    assert "<script>" not in email_body
+    assert "onerror=alert(1)" not in email_body
+
+
 @with_feature_flags(DATE_FORMAT_IN_EMAIL_SUBJECT=True)
 def test_email_subject_with_datetime() -> None:
     # `superset.models.helpers`, a dependency of following imports,


### PR DESCRIPTION
### SUMMARY

In `superset/reports/notifications/email.py`, `_error_template()` interpolated the report/alert error message directly into the HTML email body **without sanitization**, while the normal content path runs `description` and embedded data through `nh3.clean()`. The error text originates from exception messages (`str(ex)`) that can embed data-controlled content — e.g. crafted table/column names that surface in a database error — so HTML could be injected into notification emails sent to all recipients.

This runs the error text through `nh3.clean(text, tags=set(), attributes={})` (strip all tags — error text is plain text) before interpolation, aligning it with the file's existing sanitization posture.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/reports/notifications/email_tests.py
```

New test `test_error_template_sanitizes_html`: an error text containing `<img onerror=…>` / `<script>` produces an email body with that markup stripped.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
