### PR TITLE
fix: remove registration_hash in the registrations API

### DIFF
--- a/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
@@ -30,7 +30,6 @@ const mockUserRegistrations = Array.from({ length: 5 }, (_, i) => ({
   last_name: `Test${i}`,
   email: `user${i}@test.com`,
   registration_date: new Date(2025, 2, 25, 11, 4, 32 + i).toISOString(),
-  registration_hash: `hash${i}`,
 }));
 
 fetchMock.get(userRegistrationsEndpoint, {
@@ -52,5 +51,11 @@ describe('UserRegistrations', () => {
     expect(await screen.findByText('User registrations')).toBeVisible();
     const calls = fetchMock.callHistory.calls(userRegistrationsEndpoint);
     expect(calls.length).toBeGreaterThan(0);
+  });
+
+  test('does not expose the registration hash', async () => {
+    expect(await screen.findByText('User registrations')).toBeVisible();
+    // The activation hash is a bearer token and must not be shown in the UI.
+    expect(screen.queryByText('Registration hash')).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/pages/UserRegistrations/index.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/index.tsx
@@ -40,7 +40,6 @@ export type UserRegistration = {
   last_name: string;
   email: string;
   registration_date: string;
-  registration_hash: string;
 };
 
 export default function UserRegistrations() {
@@ -111,12 +110,6 @@ export default function UserRegistrations() {
         Cell: ({ row: { original } }: any) => original.email,
       },
       {
-        accessor: 'registration_hash',
-        id: 'registration_hash',
-        Header: t('Registration hash'),
-        Cell: ({ row: { original } }: any) => original.registration_hash,
-      },
-      {
         accessor: 'registration_date',
         id: 'registration_date',
         Header: t('Registration date'),
@@ -174,13 +167,6 @@ export default function UserRegistrations() {
         Header: t('Email'),
         key: 'email',
         id: 'email',
-        input: 'search',
-        operator: ListViewFilterOperator.Contains,
-      },
-      {
-        Header: t('Registration hash'),
-        key: 'registration_hash',
-        id: 'registration_hash',
         input: 'search',
         operator: ListViewFilterOperator.Contains,
       },

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -370,6 +370,11 @@ class UserRegistrationsRestAPI(BaseSupersetModelRestApi):
     resource_name = "security/user_registrations"
     datamodel = SQLAInterface(RegisterUser)
     allow_browser_login = True
+    # NOTE: registration_hash is intentionally excluded from both list_columns
+    # and search_columns. It is a bearer token for the
+    # /register/activation/<hash> flow; exposing it in API responses (and thus
+    # logs/caches) or allowing it to be filtered on would let a holder activate
+    # the pending account.
     list_columns = [
         "id",
         "username",
@@ -377,5 +382,11 @@ class UserRegistrationsRestAPI(BaseSupersetModelRestApi):
         "first_name",
         "last_name",
         "registration_date",
-        "registration_hash",
+    ]
+    search_columns = [
+        "username",
+        "email",
+        "first_name",
+        "last_name",
+        "registration_date",
     ]


### PR DESCRIPTION
### SUMMARY

`UserRegistrationsRestAPI` (`superset/security/api.py`) listed `registration_hash` in `list_columns`, exposing it in admin API responses — and therefore in proxy logs, response caches, and browser history. That hash is a **bearer token** for the `/register/activation/<hash>` flow: anyone who obtains it can activate the pending account (with the registrant's chosen password and the configured registration role), bypassing the intended email delivery channel. Per project policy, secret material should be masked regardless of caller privilege.

Changes:
- Remove `registration_hash` from `list_columns`, and add an explicit `search_columns` that omits it (so it can't be enumerated via `sw`/`ct` filter probing either).
- Remove the corresponding column, filter, and type field from the `UserRegistrations` admin page (`superset-frontend/src/pages/UserRegistrations/index.tsx`).
- Update the page test to assert the "Registration hash" column is no longer rendered.

(Self-registration is off by default — `AUTH_USER_REGISTRATION` defaults to `False` — and this API is admin-only, which bounds severity.)

### TESTING INSTRUCTIONS

```
cd superset-frontend
npm run test -- src/pages/UserRegistrations/UserRegistrations.test.tsx
```

The list endpoint no longer returns `registration_hash`; the admin page no longer renders or filters on it.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
