### PR TITLE
chore(config): default SMTP_SSL_SERVER_AUTH to True

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -149,6 +149,18 @@ Runbook to adopt:
 2. Set that value on the tunnel's `server_host_key` (via the database/SSH tunnel API or UI payload).
 3. Optionally set `SSH_TUNNEL_STRICT_HOST_KEY_CHECKING = True` in `superset_config.py` to require host-key verification on all tunnels.
 
+### SMTP server certificate validation enabled by default
+
+`SMTP_SSL_SERVER_AUTH` now defaults to `True` (previously `False`). With this default, STARTTLS/SSL connections to the configured SMTP server validate the server's TLS certificate against the system trusted CA store. This makes outbound email (alerts and reports) verify the mail server's identity out of the box.
+
+If your SMTP server presents a self-signed certificate, or a certificate that is not trusted by the system CA store, email delivery may now fail with a certificate verification error. To restore the previous behavior of skipping certificate validation, set the following in `superset_config.py`:
+
+```python
+SMTP_SSL_SERVER_AUTH = False
+```
+
+The recommended fix is to add the SMTP server's certificate (or its issuing CA) to the system trust store rather than disabling validation.
+
 ### Dataset import validates catalog against the target connection
 
 Importing a dataset now validates the `catalog` field against the target database connection. When the connection has multi-catalog disabled (`allow_multi_catalog` off) and the dataset's catalog is not the connection's default catalog, the import fails instead of silently persisting the non-default catalog. This matches the validation already enforced on the dataset update path and prevents imported datasets from querying an unintended database.

--- a/superset/config.py
+++ b/superset/config.py
@@ -1767,8 +1767,13 @@ SMTP_PORT = 25
 SMTP_PASSWORD = "superset"  # noqa: S105
 SMTP_MAIL_FROM = "superset@superset.com"
 # If True creates a default SSL context with ssl.Purpose.CLIENT_AUTH using the
-# default system root CA certificates.
-SMTP_SSL_SERVER_AUTH = False
+# default system root CA certificates. This makes STARTTLS/SSL connections to the
+# SMTP server validate the server's certificate against the trusted CA store.
+# Defaults to True so the mail server identity is verified out of the box. Set to
+# False to restore the previous behavior of skipping certificate validation (for
+# example, when using a self-signed certificate that is not in the system CA
+# store).
+SMTP_SSL_SERVER_AUTH = True
 # Socket timeout (in seconds) for the SMTP connection used when sending
 # alert/report emails. Without a timeout the underlying socket blocks
 # indefinitely if the SMTP server becomes unreachable, which leaves report

--- a/superset/config.py
+++ b/superset/config.py
@@ -1766,7 +1766,7 @@ SMTP_USER = "superset"
 SMTP_PORT = 25
 SMTP_PASSWORD = "superset"  # noqa: S105
 SMTP_MAIL_FROM = "superset@superset.com"
-# If True creates a default SSL context with ssl.Purpose.CLIENT_AUTH using the
+# If True creates a default SSL context with ssl.Purpose.SERVER_AUTH using the
 # default system root CA certificates. This makes STARTTLS/SSL connections to the
 # SMTP server validate the server's certificate against the trusted CA store.
 # Defaults to True so the mail server identity is verified out of the box. Set to

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -39,13 +39,13 @@ logger = logging.getLogger(__name__)
 class TestEmailSmtp(SupersetTestCase):
     SMTP_CONFIG_KEYS = ("SMTP_SSL", "SMTP_SSL_SERVER_AUTH", "SMTP_STARTTLS")
 
-    def setUp(self):
+    def setUp(self) -> None:
         self._original_smtp_config = {
             key: current_app.config[key] for key in self.SMTP_CONFIG_KEYS
         }
         current_app.config["SMTP_SSL"] = False
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         current_app.config.update(self._original_smtp_config)
         super().tearDown()
 

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -210,6 +210,7 @@ class TestEmailSmtp(SupersetTestCase):
     @mock.patch("smtplib.SMTP")
     def test_send_mime_ssl(self, mock_smtp, mock_smtp_ssl):
         current_app.config["SMTP_SSL"] = True
+        current_app.config["SMTP_SSL_SERVER_AUTH"] = False
         mock_smtp.return_value = mock.Mock()
         mock_smtp_ssl.return_value = mock.Mock()
         utils.send_mime_email(

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -37,8 +37,17 @@ logger = logging.getLogger(__name__)
 
 
 class TestEmailSmtp(SupersetTestCase):
+    SMTP_CONFIG_KEYS = ("SMTP_SSL", "SMTP_SSL_SERVER_AUTH", "SMTP_STARTTLS")
+
     def setUp(self):
+        self._original_smtp_config = {
+            key: current_app.config[key] for key in self.SMTP_CONFIG_KEYS
+        }
         current_app.config["SMTP_SSL"] = False
+
+    def tearDown(self):
+        current_app.config.update(self._original_smtp_config)
+        super().tearDown()
 
     @mock.patch("superset.utils.core.send_mime_email")
     def test_send_smtp(self, mock_send_mime):

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -408,7 +408,7 @@ def test_send_mime_email_ssl_server_auth_passes_context(
     create_default_context.assert_called_once_with()
     assert not smtp.called
     smtp_ssl.assert_called_once_with(
-        "localhost", 25, context=create_default_context.return_value
+        "localhost", 25, context=create_default_context.return_value, timeout=30
     )
 
 
@@ -468,4 +468,4 @@ def test_send_mime_email_server_auth_disabled_skips_context(
     )
 
     assert not create_default_context.called
-    smtp_ssl.assert_called_once_with("localhost", 25, context=None)
+    smtp_ssl.assert_called_once_with("localhost", 25, context=None, timeout=30)

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -359,3 +359,109 @@ def test_smtp_ssl_server_auth_defaults_to_true() -> None:
     from superset import config
 
     assert config.SMTP_SSL_SERVER_AUTH is True
+
+
+def _smtp_config(**overrides: Any) -> dict[str, Any]:
+    config = {
+        "SMTP_HOST": "localhost",
+        "SMTP_PORT": 25,
+        "SMTP_USER": "",
+        "SMTP_PASSWORD": "",
+        "SMTP_STARTTLS": False,
+        "SMTP_SSL": False,
+        "SMTP_SSL_SERVER_AUTH": True,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_send_mime_email_ssl_server_auth_passes_context(
+    mocker: MockerFixture,
+) -> None:
+    """
+    With SMTP_SSL and SMTP_SSL_SERVER_AUTH enabled, ``send_mime_email`` builds a
+    default SSL context and threads it through to ``smtplib.SMTP_SSL`` so the
+    server certificate is validated.
+    """
+    from email.mime.multipart import MIMEMultipart
+
+    from superset.utils import core as utils
+
+    create_default_context = mocker.patch(
+        "superset.utils.core.ssl.create_default_context"
+    )
+    smtp_ssl = mocker.patch("smtplib.SMTP_SSL")
+    smtp = mocker.patch("smtplib.SMTP")
+
+    utils.send_mime_email(
+        "from",
+        ["to"],
+        MIMEMultipart(),
+        _smtp_config(SMTP_SSL=True, SMTP_SSL_SERVER_AUTH=True),
+        dryrun=False,
+    )
+
+    create_default_context.assert_called_once_with()
+    assert not smtp.called
+    smtp_ssl.assert_called_once_with(
+        "localhost", 25, context=create_default_context.return_value
+    )
+
+
+def test_send_mime_email_starttls_server_auth_passes_context(
+    mocker: MockerFixture,
+) -> None:
+    """
+    With STARTTLS and SMTP_SSL_SERVER_AUTH enabled, ``send_mime_email`` builds a
+    default SSL context and threads it through to ``starttls`` so the server
+    certificate is validated.
+    """
+    from email.mime.multipart import MIMEMultipart
+
+    from superset.utils import core as utils
+
+    create_default_context = mocker.patch(
+        "superset.utils.core.ssl.create_default_context"
+    )
+    smtp = mocker.patch("smtplib.SMTP")
+
+    utils.send_mime_email(
+        "from",
+        ["to"],
+        MIMEMultipart(),
+        _smtp_config(SMTP_STARTTLS=True, SMTP_SSL_SERVER_AUTH=True),
+        dryrun=False,
+    )
+
+    create_default_context.assert_called_once_with()
+    smtp.return_value.starttls.assert_called_once_with(
+        context=create_default_context.return_value
+    )
+
+
+def test_send_mime_email_server_auth_disabled_skips_context(
+    mocker: MockerFixture,
+) -> None:
+    """
+    When SMTP_SSL_SERVER_AUTH is disabled no SSL context is built and ``None`` is
+    passed through, preserving the opt-out (certificate validation skipped).
+    """
+    from email.mime.multipart import MIMEMultipart
+
+    from superset.utils import core as utils
+
+    create_default_context = mocker.patch(
+        "superset.utils.core.ssl.create_default_context"
+    )
+    smtp_ssl = mocker.patch("smtplib.SMTP_SSL")
+
+    utils.send_mime_email(
+        "from",
+        ["to"],
+        MIMEMultipart(),
+        _smtp_config(SMTP_SSL=True, SMTP_SSL_SERVER_AUTH=False),
+        dryrun=False,
+    )
+
+    assert not create_default_context.called
+    smtp_ssl.assert_called_once_with("localhost", 25, context=None)

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -349,3 +349,13 @@ def test_theme_default_logo_defaults() -> None:
     assert config.LOGO_TARGET_PATH is None
     assert config.THEME_DEFAULT["token"]["brandLogoHref"] == "/"
     assert config.THEME_DEFAULT["token"]["brandLogoUrl"] == config.APP_ICON
+
+
+def test_smtp_ssl_server_auth_defaults_to_true() -> None:
+    """
+    The shipped default for SMTP_SSL_SERVER_AUTH validates the SMTP server's
+    TLS certificate. Operators can still opt out by overriding it to False.
+    """
+    from superset import config
+
+    assert config.SMTP_SSL_SERVER_AUTH is True

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -362,6 +362,10 @@ def test_smtp_ssl_server_auth_defaults_to_true() -> None:
 
 
 def _smtp_config(**overrides: Any) -> dict[str, Any]:
+    """
+    Build a minimal SMTP config dict for ``send_mime_email`` tests, with
+    plaintext transport defaults; keyword ``overrides`` replace any key.
+    """
     config = {
         "SMTP_HOST": "localhost",
         "SMTP_PORT": 25,


### PR DESCRIPTION
### SUMMARY

This changes a **shipped default**: `SMTP_SSL_SERVER_AUTH` now defaults to `True` (previously `False`) in `superset/config.py`.

When STARTTLS or implicit SSL is used for outbound email (alerts & reports), Superset builds an SSL context via `ssl.create_default_context()` only when `SMTP_SSL_SERVER_AUTH` is truthy (see `superset/utils/core.py`). With the old `False` default, the SMTP server's TLS certificate was **not** validated against the system CA store. Defaulting to `True` verifies the mail server's identity out of the box, generic transport hardening for email notifications.

**Back-compat escape hatch:** the setting is unchanged in shape and remains fully overridable. Operators who rely on a self-signed or otherwise untrusted certificate can restore the prior behavior with:

```python
SMTP_SSL_SERVER_AUTH = False
```

An `UPDATING.md` entry under `## Next` documents the default change and the opt-out (recommending adding the cert/CA to the system trust store as the preferred fix).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (config default).

### TESTING INSTRUCTIONS

- Unit test added: `tests/unit_tests/config_test.py::test_smtp_ssl_server_auth_defaults_to_true` asserts the default is `True`. Ran locally: passes.
- Manual: configure SMTP with STARTTLS against a server with a CA-trusted cert and send a test report — delivery succeeds with validation on. Against an untrusted cert, delivery fails until `SMTP_SSL_SERVER_AUTH = False` is set.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

> Note: this PR changes a shipped default. The back-compat escape hatch (`SMTP_SSL_SERVER_AUTH = False`) and an `UPDATING.md` entry are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
