### PR TITLE
fix(chart): require chart access for query_context-only updates

### DIFF
--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -120,8 +120,13 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
         if not self._model:
             raise ChartNotFoundError()
 
-        # Check and update ownership; when only updating query context we ignore
-        # ownership so the update can be performed by report workers
+        # Check and update ownership; when only updating query context we relax
+        # the ownership requirement so that non-owners (report workers and any
+        # viewer whose UI lazily backfills a missing query_context) can perform
+        # the update. We still require access to the chart in that case, so a
+        # user cannot rewrite the query_context of a chart they cannot access
+        # (raise_for_access permits admins, owners, and users with access to the
+        # chart's datasource).
         if not is_query_context_update(self._properties):
             try:
                 security_manager.raise_for_ownership(self._model)
@@ -134,6 +139,11 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
                 raise ChartForbiddenError() from ex
             except ValidationError as ex:
                 exceptions.append(ex)
+        else:
+            try:
+                security_manager.raise_for_access(chart=self._model)
+            except SupersetSecurityException as ex:
+                raise ChartForbiddenError() from ex
 
         # validate tags
         try:

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -25,6 +25,7 @@ from flask import g  # noqa: F401
 from superset import db, security_manager
 from superset.commands.chart.create import CreateChartCommand
 from superset.commands.chart.exceptions import (
+    ChartForbiddenError,
     ChartNotFoundError,
     WarmUpCacheChartNotFoundError,
 )
@@ -451,6 +452,32 @@ class TestChartsUpdateCommand(SupersetTestCase):
         assert chart.query_context == query_context
         assert len(chart.owners) == 1
         assert chart.owners[0] == admin
+
+    @patch("superset.commands.chart.update.g")
+    @patch("superset.utils.core.g")
+    @patch("superset.security.manager.g")
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_query_context_update_requires_chart_access(self, mock_sm_g, mock_g):
+        """
+        A query_context-only update relaxes the ownership requirement but must
+        still require access to the chart: a non-owner without access to the
+        chart's datasource is rejected with ChartForbiddenError.
+        """
+        chart = db.session.query(Slice).all()[0]
+        pk = chart.id
+        admin = security_manager.find_user(username="admin")
+        chart.owners = [admin]
+        db.session.commit()
+
+        # gamma has no access to the energy datasource and does not own the chart
+        gamma = security_manager.find_user(username="gamma")
+        mock_g.user = mock_sm_g.user = gamma
+        json_obj = {
+            "query_context_generation": True,
+            "query_context": json.dumps({"foo": "bar"}),
+        }
+        with pytest.raises(ChartForbiddenError):
+            UpdateChartCommand(pk, json_obj).run()
 
     @patch("superset.commands.chart.update.g")
     @patch("superset.utils.core.g")

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -457,7 +457,9 @@ class TestChartsUpdateCommand(SupersetTestCase):
     @patch("superset.utils.core.g")
     @patch("superset.security.manager.g")
     @pytest.mark.usefixtures("load_energy_table_with_slice")
-    def test_query_context_update_requires_chart_access(self, mock_sm_g, mock_g):
+    def test_query_context_update_requires_chart_access(
+        self, mock_sm_g, mock_g, mock_u_g
+    ):
         """
         A query_context-only update relaxes the ownership requirement but must
         still require access to the chart: a non-owner without access to the
@@ -471,7 +473,7 @@ class TestChartsUpdateCommand(SupersetTestCase):
 
         # gamma has no access to the energy datasource and does not own the chart
         gamma = security_manager.find_user(username="gamma")
-        mock_g.user = mock_sm_g.user = gamma
+        mock_g.user = mock_sm_g.user = mock_u_g.user = gamma
         json_obj = {
             "query_context_generation": True,
             "query_context": json.dumps({"foo": "bar"}),

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -453,34 +453,41 @@ class TestChartsUpdateCommand(SupersetTestCase):
         assert len(chart.owners) == 1
         assert chart.owners[0] == admin
 
+    @patch("superset.commands.chart.update.ChartDAO.find_by_id")
     @patch("superset.commands.chart.update.g")
     @patch("superset.utils.core.g")
     @patch("superset.security.manager.g")
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_query_context_update_requires_chart_access(
-        self, mock_sm_g, mock_g, mock_u_g
-    ):
+        self, mock_sm_g, mock_core_g, mock_update_g, mock_find_by_id
+    ) -> None:
         """
         A query_context-only update relaxes the ownership requirement but must
-        still require access to the chart. A non-owner with no access to the
-        chart (nor its datasource) is rejected -- either by the DAO access
-        filter (ChartNotFoundError) or by the explicit access check
-        (ChartForbiddenError), depending on which layer denies first.
+        still require access to the chart. We bypass the DAO ``ChartFilter``
+        base filter (by patching ``find_by_id`` to return the chart directly)
+        so the request reaches the new explicit ``raise_for_access`` check, and
+        assert that a non-owner with no access to the chart's datasource is
+        rejected with ``ChartForbiddenError``. This deterministically exercises
+        the new branch and would fail on master, where the check is absent.
         """
-        chart = db.session.query(Slice).all()[0]
+        chart = db.session.query(Slice).filter_by(slice_name="Energy Sankey").one()
         pk = chart.id
         admin = security_manager.find_user(username="admin")
         chart.owners = [admin]
         db.session.commit()
 
+        # Return the chart directly, bypassing ChartFilter, so the command's
+        # own raise_for_access gate is what denies the request.
+        mock_find_by_id.return_value = chart
+
         # gamma has no access to the energy datasource and does not own the chart
         gamma = security_manager.find_user(username="gamma")
-        mock_g.user = mock_sm_g.user = mock_u_g.user = gamma
+        mock_core_g.user = mock_sm_g.user = mock_update_g.user = gamma
         json_obj = {
             "query_context_generation": True,
             "query_context": json.dumps({"foo": "bar"}),
         }
-        with pytest.raises((ChartForbiddenError, ChartNotFoundError)):
+        with pytest.raises(ChartForbiddenError):
             UpdateChartCommand(pk, json_obj).run()
 
     @patch("superset.commands.chart.update.g")

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -462,8 +462,10 @@ class TestChartsUpdateCommand(SupersetTestCase):
     ):
         """
         A query_context-only update relaxes the ownership requirement but must
-        still require access to the chart: a non-owner without access to the
-        chart's datasource is rejected with ChartForbiddenError.
+        still require access to the chart. A non-owner with no access to the
+        chart (nor its datasource) is rejected -- either by the DAO access
+        filter (ChartNotFoundError) or by the explicit access check
+        (ChartForbiddenError), depending on which layer denies first.
         """
         chart = db.session.query(Slice).all()[0]
         pk = chart.id
@@ -478,7 +480,7 @@ class TestChartsUpdateCommand(SupersetTestCase):
             "query_context_generation": True,
             "query_context": json.dumps({"foo": "bar"}),
         }
-        with pytest.raises(ChartForbiddenError):
+        with pytest.raises((ChartForbiddenError, ChartNotFoundError)):
             UpdateChartCommand(pk, json_obj).run()
 
     @patch("superset.commands.chart.update.g")

--- a/tests/unit_tests/commands/chart/update_test.py
+++ b/tests/unit_tests/commands/chart/update_test.py
@@ -54,12 +54,16 @@ def test_update_chart_ownership_enforced_for_regular_update(
 def test_update_chart_query_context_skips_ownership_check(
     mocker: MockerFixture,
 ) -> None:
-    """Query-context-only updates skip ownership so report workers can save context."""
+    """Query-context-only updates skip the ownership check (so report workers can
+    save context) but still require access to the chart."""
     find_by_id = mocker.patch("superset.commands.chart.update.ChartDAO.find_by_id")
     find_by_id.return_value = mocker.MagicMock(id=1, tags=[], dashboards=[])
     raise_for_ownership = mocker.patch(
         "superset.commands.chart.update.security_manager.raise_for_ownership",
         side_effect=_ownership_exc(),
+    )
+    raise_for_access = mocker.patch(
+        "superset.commands.chart.update.security_manager.raise_for_access",
     )
 
     UpdateChartCommand(
@@ -67,7 +71,27 @@ def test_update_chart_query_context_skips_ownership_check(
     ).validate()
 
     find_by_id.assert_called_once_with(1)
+    # ownership is relaxed, but chart access is still enforced
     raise_for_ownership.assert_not_called()
+    raise_for_access.assert_called_once()
+
+
+def test_update_chart_query_context_requires_chart_access(
+    mocker: MockerFixture,
+) -> None:
+    """A query-context-only update by someone without access to the chart is
+    rejected, even though the ownership check is relaxed for this path."""
+    find_by_id = mocker.patch("superset.commands.chart.update.ChartDAO.find_by_id")
+    find_by_id.return_value = mocker.MagicMock(id=1, tags=[], dashboards=[])
+    mocker.patch(
+        "superset.commands.chart.update.security_manager.raise_for_access",
+        side_effect=_ownership_exc(),
+    )
+
+    with pytest.raises(ChartForbiddenError):
+        UpdateChartCommand(
+            1, {"query_context": "{}", "query_context_generation": True}
+        ).validate()
 
 
 def test_update_chart_owner_can_perform_regular_update(

--- a/tests/unit_tests/commands/chart/update_test.py
+++ b/tests/unit_tests/commands/chart/update_test.py
@@ -94,6 +94,32 @@ def test_update_chart_query_context_requires_chart_access(
         ).validate()
 
 
+def test_update_chart_query_context_non_owner_with_access_allowed(
+    mocker: MockerFixture,
+) -> None:
+    """A non-owner who *does* have access to the chart (e.g. an alpha user with
+    datasource access, or a report worker) can perform a query-context-only
+    backfill: ownership is relaxed and ``raise_for_access`` does not deny."""
+    find_by_id = mocker.patch("superset.commands.chart.update.ChartDAO.find_by_id")
+    find_by_id.return_value = mocker.MagicMock(id=1, tags=[], dashboards=[])
+    raise_for_ownership = mocker.patch(
+        "superset.commands.chart.update.security_manager.raise_for_ownership",
+        side_effect=_ownership_exc(),
+    )
+    # access check passes (no exception) -> the non-owner is permitted
+    raise_for_access = mocker.patch(
+        "superset.commands.chart.update.security_manager.raise_for_access",
+    )
+
+    # Should not raise: the update is allowed despite the user not being an owner
+    UpdateChartCommand(
+        1, {"query_context": "{}", "query_context_generation": True}
+    ).validate()
+
+    raise_for_ownership.assert_not_called()
+    raise_for_access.assert_called_once()
+
+
 def test_update_chart_owner_can_perform_regular_update(
     mocker: MockerFixture,
 ) -> None:

--- a/tests/unit_tests/commands/chart/update_test.py
+++ b/tests/unit_tests/commands/chart/update_test.py
@@ -33,6 +33,16 @@ def _ownership_exc() -> SupersetSecurityException:
     )
 
 
+def _access_exc() -> SupersetSecurityException:
+    return SupersetSecurityException(
+        SupersetError(
+            error_type=SupersetErrorType.CHART_SECURITY_ACCESS_ERROR,
+            message="User does not have access to this chart",
+            level=ErrorLevel.ERROR,
+        )
+    )
+
+
 def test_update_chart_ownership_enforced_for_regular_update(
     mocker: MockerFixture,
 ) -> None:
@@ -73,7 +83,7 @@ def test_update_chart_query_context_skips_ownership_check(
     find_by_id.assert_called_once_with(1)
     # ownership is relaxed, but chart access is still enforced
     raise_for_ownership.assert_not_called()
-    raise_for_access.assert_called_once()
+    raise_for_access.assert_called_once_with(chart=find_by_id.return_value)
 
 
 def test_update_chart_query_context_requires_chart_access(
@@ -85,7 +95,7 @@ def test_update_chart_query_context_requires_chart_access(
     find_by_id.return_value = mocker.MagicMock(id=1, tags=[], dashboards=[])
     mocker.patch(
         "superset.commands.chart.update.security_manager.raise_for_access",
-        side_effect=_ownership_exc(),
+        side_effect=_access_exc(),
     )
 
     with pytest.raises(ChartForbiddenError):
@@ -117,7 +127,7 @@ def test_update_chart_query_context_non_owner_with_access_allowed(
     ).validate()
 
     raise_for_ownership.assert_not_called()
-    raise_for_access.assert_called_once()
+    raise_for_access.assert_called_once_with(chart=find_by_id.return_value)
 
 
 def test_update_chart_owner_can_perform_regular_update(


### PR DESCRIPTION

### SUMMARY

`UpdateChartCommand.validate()` skips the ownership check for "query_context-only" updates — when the payload is exactly `{query_context, query_context_generation: true}` (`is_query_context_update()`). This bypass exists so report workers and the Explore UI's lazy `query_context` backfill can run as non-owners.

The problem: it skipped **all** authorization, gated only by the coarse `can_write on Chart` FAB permission. So any authenticated user with `can_write on Chart` (Gamma has it in many deployments) could PUT `{query_context, query_context_generation: true}` to **any** chart id and rewrite its `query_context` — a chart they don't own and may have no access to (CWE-639 / broken object-level authorization).

### APPROACH

Replace the unconditional skip with `security_manager.raise_for_access(chart=self._model)` on the query_context path. `raise_for_access(chart=...)` permits **admins, owners, and users with access to the chart's datasource**, and rejects everyone else. That preserves the legitimate non-owner flows:

- the Explore UI backfill — any user who can *view/render* the chart already has datasource access;
- report workers — the screenshot runs as the executor user, who must be able to render the chart;

…while closing the "any `can_write Chart` holder can tamper with any chart" gap.

### WORTH NOTING:

The report-execution path renders the chart via a headless browser as the configured **executor** user, then that session hits the chart PUT. This change assumes the executor always passes `raise_for_access(chart=...)`. That's expected (the executor must be able to render the chart), but it depends on the executor configuration (`THUMBNAIL_EXECUTE_AS` / report executor settings) and should be validated against the report/alert flow before merge. 

### TESTING INSTRUCTIONS

```
pytest tests/integration_tests/charts/commands_tests.py -k query_context
```

- New `test_query_context_update_requires_chart_access`: a non-owner without datasource access (gamma) is rejected with `ChartForbiddenError`.
- **To validate before merge:** confirm the report/alert execution flow (and the Explore lazy-backfill flow) still succeed end-to-end for non-owner users with chart access.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
