### PR TITLE
fix(rls): apply standard datasource access checks in RLS rule commands

### DIFF
--- a/superset/commands/security/create.py
+++ b/superset/commands/security/create.py
@@ -21,10 +21,11 @@ from typing import Any
 
 from superset.commands.base import BaseCommand
 from superset.commands.exceptions import DatasourceNotFoundValidationError
+from superset.commands.security.exceptions import RLSDatasourceForbiddenError
 from superset.commands.utils import populate_roles
 from superset.connectors.sqla.models import SqlaTable
 from superset.daos.security import RLSDAO
-from superset.extensions import db
+from superset.extensions import db, security_manager
 from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
@@ -50,5 +51,8 @@ class CreateRLSRuleCommand(BaseCommand):
         )
         if len(tables) != len(self._tables):
             raise DatasourceNotFoundValidationError()
+        for table in tables:
+            if not security_manager.can_access_datasource(datasource=table):
+                raise RLSDatasourceForbiddenError()
         self._properties["roles"] = roles
         self._properties["tables"] = tables

--- a/superset/commands/security/create.py
+++ b/superset/commands/security/create.py
@@ -21,11 +21,11 @@ from typing import Any
 
 from superset.commands.base import BaseCommand
 from superset.commands.exceptions import DatasourceNotFoundValidationError
-from superset.commands.security.exceptions import RLSDatasourceForbiddenError
+from superset.commands.security.utils import raise_for_datasource_access
 from superset.commands.utils import populate_roles
 from superset.connectors.sqla.models import SqlaTable
 from superset.daos.security import RLSDAO
-from superset.extensions import db, security_manager
+from superset.extensions import db
 from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
@@ -51,8 +51,6 @@ class CreateRLSRuleCommand(BaseCommand):
         )
         if len(tables) != len(self._tables):
             raise DatasourceNotFoundValidationError()
-        for table in tables:
-            if not security_manager.can_access_datasource(datasource=table):
-                raise RLSDatasourceForbiddenError()
+        raise_for_datasource_access(tables)
         self._properties["roles"] = roles
         self._properties["tables"] = tables

--- a/superset/commands/security/delete.py
+++ b/superset/commands/security/delete.py
@@ -20,13 +20,12 @@ from functools import partial
 
 from superset.commands.base import BaseCommand
 from superset.commands.security.exceptions import (
-    RLSDatasourceForbiddenError,
     RLSRuleNotFoundError,
     RuleDeleteFailedError,
 )
+from superset.commands.security.utils import raise_for_datasource_access
 from superset.connectors.sqla.models import RowLevelSecurityFilter
 from superset.daos.security import RLSDAO
-from superset.extensions import security_manager
 from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
@@ -50,6 +49,4 @@ class DeleteRLSRuleCommand(BaseCommand):
         # Apply the same datasource access check as create/update: a caller may
         # only delete a rule if they can access every datasource it references.
         for rule in self._models:
-            for table in rule.tables:
-                if not security_manager.can_access_datasource(datasource=table):
-                    raise RLSDatasourceForbiddenError()
+            raise_for_datasource_access(rule.tables)

--- a/superset/commands/security/delete.py
+++ b/superset/commands/security/delete.py
@@ -20,11 +20,13 @@ from functools import partial
 
 from superset.commands.base import BaseCommand
 from superset.commands.security.exceptions import (
+    RLSDatasourceForbiddenError,
     RLSRuleNotFoundError,
     RuleDeleteFailedError,
 )
+from superset.connectors.sqla.models import RowLevelSecurityFilter
 from superset.daos.security import RLSDAO
-from superset.reports.models import ReportSchedule
+from superset.extensions import security_manager
 from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
@@ -33,7 +35,7 @@ logger = logging.getLogger(__name__)
 class DeleteRLSRuleCommand(BaseCommand):
     def __init__(self, model_ids: list[int]):
         self._model_ids = model_ids
-        self._models: list[ReportSchedule] = []
+        self._models: list[RowLevelSecurityFilter] = []
 
     @transaction(on_error=partial(on_error, reraise=RuleDeleteFailedError))
     def run(self) -> None:
@@ -45,3 +47,9 @@ class DeleteRLSRuleCommand(BaseCommand):
         self._models = RLSDAO.find_by_ids(self._model_ids)
         if not self._models or len(self._models) != len(self._model_ids):
             raise RLSRuleNotFoundError()
+        # Apply the same datasource access check as create/update: a caller may
+        # only delete a rule if they can access every datasource it references.
+        for rule in self._models:
+            for table in rule.tables:
+                if not security_manager.can_access_datasource(datasource=table):
+                    raise RLSDatasourceForbiddenError()

--- a/superset/commands/security/update.py
+++ b/superset/commands/security/update.py
@@ -21,11 +21,14 @@ from typing import Any, Optional
 
 from superset.commands.base import BaseCommand
 from superset.commands.exceptions import DatasourceNotFoundValidationError
-from superset.commands.security.exceptions import RLSRuleNotFoundError
+from superset.commands.security.exceptions import (
+    RLSDatasourceForbiddenError,
+    RLSRuleNotFoundError,
+)
 from superset.commands.utils import populate_roles
 from superset.connectors.sqla.models import RowLevelSecurityFilter, SqlaTable
 from superset.daos.security import RLSDAO
-from superset.extensions import db
+from superset.extensions import db, security_manager
 from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
@@ -57,5 +60,8 @@ class UpdateRLSRuleCommand(BaseCommand):
         )
         if len(tables) != len(self._tables):
             raise DatasourceNotFoundValidationError()
+        for table in tables:
+            if not security_manager.can_access_datasource(datasource=table):
+                raise RLSDatasourceForbiddenError()
         self._properties["roles"] = roles
         self._properties["tables"] = tables

--- a/superset/commands/security/update.py
+++ b/superset/commands/security/update.py
@@ -21,14 +21,12 @@ from typing import Any, Optional
 
 from superset.commands.base import BaseCommand
 from superset.commands.exceptions import DatasourceNotFoundValidationError
-from superset.commands.security.exceptions import (
-    RLSDatasourceForbiddenError,
-    RLSRuleNotFoundError,
-)
+from superset.commands.security.exceptions import RLSRuleNotFoundError
+from superset.commands.security.utils import raise_for_datasource_access
 from superset.commands.utils import populate_roles
 from superset.connectors.sqla.models import RowLevelSecurityFilter, SqlaTable
 from superset.daos.security import RLSDAO
-from superset.extensions import db, security_manager
+from superset.extensions import db
 from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
@@ -60,8 +58,6 @@ class UpdateRLSRuleCommand(BaseCommand):
         )
         if len(tables) != len(self._tables):
             raise DatasourceNotFoundValidationError()
-        for table in tables:
-            if not security_manager.can_access_datasource(datasource=table):
-                raise RLSDatasourceForbiddenError()
+        raise_for_datasource_access(tables)
         self._properties["roles"] = roles
         self._properties["tables"] = tables

--- a/superset/commands/security/utils.py
+++ b/superset/commands/security/utils.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from superset.commands.security.exceptions import RLSDatasourceForbiddenError
+from superset.extensions import security_manager
+
+if TYPE_CHECKING:
+    from superset.connectors.sqla.models import SqlaTable
+
+
+def raise_for_datasource_access(tables: Iterable[SqlaTable]) -> None:
+    """Enforce datasource access for every table referenced by an RLS rule.
+
+    A caller may only create, update, or delete an RLS rule if they can access
+    every datasource it references. This mirrors the standard datasource access
+    checks applied elsewhere and is shared by the RLS rule commands to keep the
+    enforcement consistent.
+
+    :raises RLSDatasourceForbiddenError: if the caller cannot access one or more
+        of the referenced datasources.
+    """
+    for table in tables:
+        if not security_manager.can_access_datasource(datasource=table):
+            raise RLSDatasourceForbiddenError()

--- a/superset/row_level_security/api.py
+++ b/superset/row_level_security/api.py
@@ -31,7 +31,10 @@ from superset.commands.exceptions import (
 )
 from superset.commands.security.create import CreateRLSRuleCommand
 from superset.commands.security.delete import DeleteRLSRuleCommand
-from superset.commands.security.exceptions import RLSRuleNotFoundError
+from superset.commands.security.exceptions import (
+    RLSDatasourceForbiddenError,
+    RLSRuleNotFoundError,
+)
 from superset.commands.security.update import UpdateRLSRuleCommand
 from superset.connectors.sqla.models import RowLevelSecurityFilter
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
@@ -185,6 +188,8 @@ class RLSRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
             404:
               $ref: '#/components/responses/404'
             422:
@@ -216,6 +221,13 @@ class RLSRestApi(BaseSupersetModelRestApi):
                 exc_info=True,
             )
             return self.response_422(message=str(ex))
+        except RLSDatasourceForbiddenError as ex:
+            logger.warning(
+                "Forbidden datasource while creating RLS rule %s: %s",
+                self.__class__.__name__,
+                str(ex),
+            )
+            return self.response_403()
         except SQLAlchemyError as ex:
             logger.error(
                 "Error creating RLS rule %s: %s",
@@ -302,6 +314,13 @@ class RLSRestApi(BaseSupersetModelRestApi):
                 exc_info=True,
             )
             return self.response_422(message=str(ex))
+        except RLSDatasourceForbiddenError as ex:
+            logger.warning(
+                "Forbidden datasource while updating RLS rule %s: %s",
+                self.__class__.__name__,
+                str(ex),
+            )
+            return self.response_403()
         except SQLAlchemyError as ex:
             logger.error(
                 "Error updating RLS rule %s: %s",

--- a/tests/unit_tests/commands/security/__init__.py
+++ b/tests/unit_tests/commands/security/__init__.py
@@ -14,24 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from flask_babel import lazy_gettext as _
-
-from superset.commands.exceptions import (
-    CommandException,
-    DeleteFailedError,
-    ForbiddenError,
-)
-
-
-class RLSRuleNotFoundError(CommandException):
-    status = 404
-    message = _("RLS Rule not found.")
-
-
-class RLSDatasourceForbiddenError(ForbiddenError):
-    message = _("You don't have access to one or more of the referenced datasources.")
-
-
-class RuleDeleteFailedError(DeleteFailedError):
-    message = _("RLS rules could not be deleted.")

--- a/tests/unit_tests/commands/security/rls_test.py
+++ b/tests/unit_tests/commands/security/rls_test.py
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.commands.security.create import CreateRLSRuleCommand
+from superset.commands.security.exceptions import RLSDatasourceForbiddenError
+from superset.commands.security.update import UpdateRLSRuleCommand
+
+
+def _mock_tables(*table_ids: int) -> list[MagicMock]:
+    tables = []
+    for table_id in table_ids:
+        table = MagicMock()
+        table.id = table_id
+        tables.append(table)
+    return tables
+
+
+def _patch_query(module: str, tables: list[MagicMock]):
+    """Patch db.session.query(...).filter(...).all() to return ``tables``."""
+    query = MagicMock()
+    query.filter.return_value.all.return_value = tables
+    return patch(f"{module}.db.session.query", return_value=query)
+
+
+def test_create_rls_rule_forbidden_when_no_datasource_access() -> None:
+    tables = _mock_tables(1)
+
+    with (
+        _patch_query("superset.commands.security.create", tables),
+        patch(
+            "superset.commands.security.create.populate_roles",
+            return_value=[],
+        ),
+        patch(
+            "superset.commands.security.create.security_manager."
+            "can_access_datasource",
+            return_value=False,
+        ) as can_access,
+    ):
+        command = CreateRLSRuleCommand({"tables": [1], "roles": []})
+        with pytest.raises(RLSDatasourceForbiddenError):
+            command.validate()
+
+    can_access.assert_called_once_with(datasource=tables[0])
+
+
+def test_create_rls_rule_allowed_when_datasource_access() -> None:
+    tables = _mock_tables(1, 2)
+
+    with (
+        _patch_query("superset.commands.security.create", tables),
+        patch(
+            "superset.commands.security.create.populate_roles",
+            return_value=[],
+        ),
+        patch(
+            "superset.commands.security.create.security_manager."
+            "can_access_datasource",
+            return_value=True,
+        ) as can_access,
+    ):
+        command = CreateRLSRuleCommand({"tables": [1, 2], "roles": []})
+        command.validate()
+
+    # Access is checked for every referenced datasource.
+    assert can_access.call_count == 2
+    assert command._properties["tables"] == tables
+
+
+def test_create_rls_rule_forbidden_if_any_datasource_denied() -> None:
+    tables = _mock_tables(1, 2)
+
+    with (
+        _patch_query("superset.commands.security.create", tables),
+        patch(
+            "superset.commands.security.create.populate_roles",
+            return_value=[],
+        ),
+        patch(
+            "superset.commands.security.create.security_manager."
+            "can_access_datasource",
+            side_effect=[True, False],
+        ),
+    ):
+        command = CreateRLSRuleCommand({"tables": [1, 2], "roles": []})
+        with pytest.raises(RLSDatasourceForbiddenError):
+            command.validate()
+
+
+def test_update_rls_rule_forbidden_when_no_datasource_access() -> None:
+    tables = _mock_tables(1)
+
+    with (
+        _patch_query("superset.commands.security.update", tables),
+        patch(
+            "superset.commands.security.update.RLSDAO.find_by_id",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "superset.commands.security.update.populate_roles",
+            return_value=[],
+        ),
+        patch(
+            "superset.commands.security.update.security_manager."
+            "can_access_datasource",
+            return_value=False,
+        ) as can_access,
+    ):
+        command = UpdateRLSRuleCommand(1, {"tables": [1], "roles": []})
+        with pytest.raises(RLSDatasourceForbiddenError):
+            command.validate()
+
+    can_access.assert_called_once_with(datasource=tables[0])
+
+
+def test_update_rls_rule_allowed_when_datasource_access() -> None:
+    tables = _mock_tables(1)
+
+    with (
+        _patch_query("superset.commands.security.update", tables),
+        patch(
+            "superset.commands.security.update.RLSDAO.find_by_id",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "superset.commands.security.update.populate_roles",
+            return_value=[],
+        ),
+        patch(
+            "superset.commands.security.update.security_manager."
+            "can_access_datasource",
+            return_value=True,
+        ) as can_access,
+    ):
+        command = UpdateRLSRuleCommand(1, {"tables": [1], "roles": []})
+        command.validate()
+
+    can_access.assert_called_once_with(datasource=tables[0])
+    assert command._properties["tables"] == tables

--- a/tests/unit_tests/commands/security/rls_test.py
+++ b/tests/unit_tests/commands/security/rls_test.py
@@ -50,7 +50,7 @@ def test_create_rls_rule_forbidden_when_no_datasource_access() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.create.security_manager.can_access_datasource",
+            "superset.commands.security.utils.security_manager.can_access_datasource",
             return_value=False,
         ) as can_access,
     ):
@@ -71,7 +71,7 @@ def test_create_rls_rule_allowed_when_datasource_access() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.create.security_manager.can_access_datasource",
+            "superset.commands.security.utils.security_manager.can_access_datasource",
             return_value=True,
         ) as can_access,
     ):
@@ -93,7 +93,7 @@ def test_create_rls_rule_forbidden_if_any_datasource_denied() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.create.security_manager.can_access_datasource",
+            "superset.commands.security.utils.security_manager.can_access_datasource",
             side_effect=[True, False],
         ),
     ):
@@ -116,7 +116,7 @@ def test_update_rls_rule_forbidden_when_no_datasource_access() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.update.security_manager.can_access_datasource",
+            "superset.commands.security.utils.security_manager.can_access_datasource",
             return_value=False,
         ) as can_access,
     ):
@@ -141,7 +141,7 @@ def test_update_rls_rule_allowed_when_datasource_access() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.update.security_manager.can_access_datasource",
+            "superset.commands.security.utils.security_manager.can_access_datasource",
             return_value=True,
         ) as can_access,
     ):
@@ -163,7 +163,7 @@ def test_delete_rls_rule_forbidden_when_no_datasource_access() -> None:
             return_value=[rule],
         ),
         patch(
-            "superset.commands.security.delete.security_manager.can_access_datasource",
+            "superset.commands.security.utils.security_manager.can_access_datasource",
             return_value=False,
         ) as can_access,
     ):
@@ -185,7 +185,7 @@ def test_delete_rls_rule_allowed_when_datasource_access() -> None:
             return_value=[rule],
         ),
         patch(
-            "superset.commands.security.delete.security_manager.can_access_datasource",
+            "superset.commands.security.utils.security_manager.can_access_datasource",
             return_value=True,
         ) as can_access,
     ):

--- a/tests/unit_tests/commands/security/rls_test.py
+++ b/tests/unit_tests/commands/security/rls_test.py
@@ -49,8 +49,7 @@ def test_create_rls_rule_forbidden_when_no_datasource_access() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.create.security_manager."
-            "can_access_datasource",
+            "superset.commands.security.create.security_manager.can_access_datasource",
             return_value=False,
         ) as can_access,
     ):
@@ -71,8 +70,7 @@ def test_create_rls_rule_allowed_when_datasource_access() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.create.security_manager."
-            "can_access_datasource",
+            "superset.commands.security.create.security_manager.can_access_datasource",
             return_value=True,
         ) as can_access,
     ):
@@ -94,8 +92,7 @@ def test_create_rls_rule_forbidden_if_any_datasource_denied() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.create.security_manager."
-            "can_access_datasource",
+            "superset.commands.security.create.security_manager.can_access_datasource",
             side_effect=[True, False],
         ),
     ):
@@ -118,8 +115,7 @@ def test_update_rls_rule_forbidden_when_no_datasource_access() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.update.security_manager."
-            "can_access_datasource",
+            "superset.commands.security.update.security_manager.can_access_datasource",
             return_value=False,
         ) as can_access,
     ):
@@ -144,8 +140,7 @@ def test_update_rls_rule_allowed_when_datasource_access() -> None:
             return_value=[],
         ),
         patch(
-            "superset.commands.security.update.security_manager."
-            "can_access_datasource",
+            "superset.commands.security.update.security_manager.can_access_datasource",
             return_value=True,
         ) as can_access,
     ):

--- a/tests/unit_tests/commands/security/rls_test.py
+++ b/tests/unit_tests/commands/security/rls_test.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from superset.commands.security.create import CreateRLSRuleCommand
+from superset.commands.security.delete import DeleteRLSRuleCommand
 from superset.commands.security.exceptions import RLSDatasourceForbiddenError
 from superset.commands.security.update import UpdateRLSRuleCommand
 
@@ -149,3 +150,47 @@ def test_update_rls_rule_allowed_when_datasource_access() -> None:
 
     can_access.assert_called_once_with(datasource=tables[0])
     assert command._properties["tables"] == tables
+
+
+def test_delete_rls_rule_forbidden_when_no_datasource_access() -> None:
+    tables = _mock_tables(1)
+    rule = MagicMock()
+    rule.tables = tables
+
+    with (
+        patch(
+            "superset.commands.security.delete.RLSDAO.find_by_ids",
+            return_value=[rule],
+        ),
+        patch(
+            "superset.commands.security.delete.security_manager.can_access_datasource",
+            return_value=False,
+        ) as can_access,
+    ):
+        command = DeleteRLSRuleCommand([1])
+        with pytest.raises(RLSDatasourceForbiddenError):
+            command.validate()
+
+    can_access.assert_called_once_with(datasource=tables[0])
+
+
+def test_delete_rls_rule_allowed_when_datasource_access() -> None:
+    tables = _mock_tables(1, 2)
+    rule = MagicMock()
+    rule.tables = tables
+
+    with (
+        patch(
+            "superset.commands.security.delete.RLSDAO.find_by_ids",
+            return_value=[rule],
+        ),
+        patch(
+            "superset.commands.security.delete.security_manager.can_access_datasource",
+            return_value=True,
+        ) as can_access,
+    ):
+        command = DeleteRLSRuleCommand([1])
+        command.validate()
+
+    # Access is checked for every datasource referenced by the rule.
+    assert can_access.call_count == 2


### PR DESCRIPTION
### SUMMARY

`CreateRLSRuleCommand` and `UpdateRLSRuleCommand` validated that referenced table IDs exist, but did not run those datasources through the standard datasource access check that other datasource-touching paths apply. This change brings the RLS rule commands in line with that pattern as a defense-in-depth / consistency improvement.

In `validate()`, every referenced table is now passed through `security_manager.can_access_datasource(datasource=table)`. A new `RLSDatasourceForbiddenError` is raised when the check does not pass, and the REST API maps it to a `403`.

Notes:
- Callers with `all_datasource_access` (e.g. admins) continue to pass — that allowance is handled inside the security manager check, so there is no special-casing in the command.
- The existing "datasource does not exist" (`422`) behavior is unchanged; the access check runs only after existence is confirmed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (backend authorization consistency change).

### TESTING INSTRUCTIONS

- New unit tests: `pytest tests/unit_tests/commands/security/rls_test.py`.
- A request referencing a datasource the caller cannot access returns `403`; callers with `all_datasource_access` succeed; a reference to a non-existent datasource still returns `422`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)