### PR TITLE
fix: show truncated table list message

### DIFF
--- a/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
+++ b/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
@@ -150,6 +150,22 @@ test('renders table options without Select All option', async () => {
   );
 }, 15000);
 
+test('shows a helper message when table results are truncated', async () => {
+  fetchMock.get(catalogApiRoute, { result: [] });
+  fetchMock.get(schemaApiRoute, { result: ['test_schema'] });
+  fetchMock.get(tablesApiRoute, {
+    ...getTableMockFunction(),
+    count: 5,
+  });
+
+  const props = createProps();
+  render(<TableSelector {...props} />, { useRedux: true, store });
+
+  expect(
+    await screen.findByText('Some tables are not shown. Refine your search.'),
+  ).toBeInTheDocument();
+});
+
 test('table select retain value if not in SQL Lab mode', async () => {
   fetchMock.get(catalogApiRoute, { result: [] });
   fetchMock.get(schemaApiRoute, { result: ['test_schema'] });

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -68,6 +68,12 @@ const TableSelectorWrapper = styled.div`
       flex: 1;
       max-width: calc(100% - ${theme.sizeUnit + REFRESH_WIDTH}px)
     }
+
+    .truncated-table-message {
+      color: ${theme.colorTextSecondary};
+      font-size: ${theme.fontSizeSM}px;
+      margin-top: ${theme.sizeUnit}px;
+    }
   `}
 `;
 
@@ -339,6 +345,11 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       <>
         <StyledFormLabel>{label}</StyledFormLabel>
         {renderSelectRow(select, refreshLabel)}
+        {data?.hasMore && (
+          <div className="truncated-table-message">
+            {t('Some tables are not shown. Refine your search.')}
+          </div>
+        )}
       </>
     );
   }


### PR DESCRIPTION
## Summary

- consume the existing table API `hasMore` flag in `TableSelector`
- show a helper message when the table dropdown response is truncated
- add a focused regression test for the truncated table response case

## Verification

- `git diff --check` passed
- `npm run test -- src/components/TableSelector/TableSelector.test.tsx --runInBand` could not run locally because `node_modules` is not installed (`cross-env` missing)
- `npm ci` could not complete on current checkout: npm reported package/lockfile drift and local Node/npm are outside the repo engine range (repo requires Node `^22.22.0`, npm `^10.8.1`; local is Node `v24.16.0`, npm `11.13.0`)

Closes #40407