### PR TITLE
fix(reports): guard SUCCESS-state report execution against duplicate sends and stuck WORKING state

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -1043,13 +1043,18 @@ class ReportSuccessState(BaseReportState):
                 # ERROR, even if sending the error notification itself fails —
                 # otherwise the schedule is stuck in WORKING until the working
                 # timeout. Mirrors ReportNotTriggeredErrorState.next().
+                # Only record the marker when the notification was actually
+                # delivered; otherwise record the send failure so the grace-
+                # period check doesn't incorrectly suppress future notifications.
+                error_message = REPORT_SCHEDULE_ERROR_NOTIFICATION_MARKER
                 try:
                     self.send_error(
                         f"Error occurred for {self._report_schedule.type}:"
                         f" {self._report_schedule.name}",
                         str(ex),
                     )
-                except Exception:  # noqa: BLE001  # pylint: disable=broad-except
+                except Exception as send_ex:  # noqa: BLE001  # pylint: disable=broad-except
+                    error_message = str(send_ex) or str(ex)
                     logger.warning(
                         "Failed to send error notification for report schedule "
                         "(execution %s)",
@@ -1060,7 +1065,7 @@ class ReportSuccessState(BaseReportState):
                     try:
                         self.update_report_schedule_and_log(
                             ReportState.ERROR,
-                            error_message=REPORT_SCHEDULE_ERROR_NOTIFICATION_MARKER,
+                            error_message=error_message,
                         )
                     except ReportScheduleUnexpectedError:
                         logger.warning(

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -1039,16 +1039,44 @@ class ReportSuccessState(BaseReportState):
                     )
                     return
             except Exception as ex:
-                self.send_error(
-                    f"Error occurred for {self._report_schedule.type}:"
-                    f" {self._report_schedule.name}",
-                    str(ex),
-                )
-                self.update_report_schedule_and_log(
-                    ReportState.ERROR,
-                    error_message=REPORT_SCHEDULE_ERROR_NOTIFICATION_MARKER,
-                )
+                # Ensure the schedule always transitions out of WORKING to
+                # ERROR, even if sending the error notification itself fails —
+                # otherwise the schedule is stuck in WORKING until the working
+                # timeout. Mirrors ReportNotTriggeredErrorState.next().
+                try:
+                    self.send_error(
+                        f"Error occurred for {self._report_schedule.type}:"
+                        f" {self._report_schedule.name}",
+                        str(ex),
+                    )
+                except Exception:  # noqa: BLE001  # pylint: disable=broad-except
+                    logger.warning(
+                        "Failed to send error notification for report schedule "
+                        "(execution %s)",
+                        self._execution_id,
+                        exc_info=True,
+                    )
+                finally:
+                    try:
+                        self.update_report_schedule_and_log(
+                            ReportState.ERROR,
+                            error_message=REPORT_SCHEDULE_ERROR_NOTIFICATION_MARKER,
+                        )
+                    except ReportScheduleUnexpectedError:
+                        logger.warning(
+                            "Failed to log ERROR state for report schedule "
+                            "(execution %s) due to database issue",
+                            self._execution_id,
+                            exc_info=True,
+                        )
                 raise
+
+        # For REPORT types the ALERT branch above is skipped, so WORKING has not
+        # been set yet. Set it before the (potentially slow) send() so a
+        # concurrent scheduler tick is blocked by ReportWorkingState, preventing
+        # duplicate notifications. ALERT types already set WORKING above.
+        if self._report_schedule.type != ReportScheduleType.ALERT:
+            self.update_report_schedule_and_log(ReportState.WORKING)
 
         try:
             self.send()

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -1541,15 +1541,43 @@ def test_success_state_report_sends_and_logs_success(
         schedule_type=ReportScheduleType.REPORT,
     )
     mock_send = mocker.patch.object(state, "send")
-    mocker.patch.object(state, "update_report_schedule_and_log")
+    mock_update = mocker.patch.object(state, "update_report_schedule_and_log")
 
     state.next()
 
     mock_send.assert_called_once()
-    state.update_report_schedule_and_log.assert_called_once_with(  # type: ignore[attr-defined]
-        ReportState.SUCCESS,
-        error_message=None,
+    # WORKING is set before send() (concurrency guard against duplicate sends),
+    # then SUCCESS after.
+    assert mock_update.call_args_list == [
+        mocker.call(ReportState.WORKING),
+        mocker.call(ReportState.SUCCESS, error_message=None),
+    ]
+
+
+def test_success_state_error_logged_when_send_error_raises(
+    mocker: MockerFixture,
+) -> None:
+    """If send_error() itself raises, the schedule must still transition to
+    ERROR (not stay stuck in WORKING)."""
+    state = _make_state_instance(
+        mocker, ReportSuccessState, schedule_type=ReportScheduleType.ALERT
     )
+    mocker.patch.object(state, "is_in_grace_period", return_value=False)
+    mock_update = mocker.patch.object(state, "update_report_schedule_and_log")
+    mocker.patch.object(
+        state, "send_error", side_effect=RuntimeError("notification boom")
+    )
+    mocker.patch(
+        "superset.commands.report.execute.AlertCommand"
+    ).return_value.run.side_effect = RuntimeError("alert boom")
+
+    # The original alert error propagates...
+    with pytest.raises(RuntimeError, match="alert boom"):
+        state.next()
+
+    # ...but ERROR was still logged despite send_error() failing.
+    states = [call.args[0] for call in mock_update.call_args_list]
+    assert ReportState.ERROR in states
 
 
 def test_get_url_for_csv_uses_post_processed_type(


### PR DESCRIPTION
### SUMMARY

Two correctness/security defects in `ReportSuccessState.next()` (`superset/commands/report/execute.py`), both diverging from the robust pattern already used by the sibling `ReportNotTriggeredErrorState.next()`:

1. **Concurrent execution / duplicate notifications (CWE-362).** The WORKING-state guard blocks a concurrent scheduler tick from re-running a report. It's set before `send()` for ALERT types and on the not-triggered/error path, but **not for REPORT types in the SUCCESS/GRACE state** — they go straight to `send()` with no WORKING marker. A second scheduler tick (which sees `last_state == SUCCESS` and routes back into `ReportSuccessState`) is therefore not blocked, allowing duplicate sends. Now sets WORKING before `send()` for REPORT types too.

2. **Stuck WORKING state (CWE-755).** In the ALERT error path, if `send_error()` itself raises, the `ERROR`-state transition was skipped, leaving the schedule stuck in WORKING until the working timeout. `send_error()` is now wrapped so the `ERROR` transition always runs (and a logging failure there is swallowed), mirroring the sibling's `finally` pattern.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/commands/report/execute_test.py
```

Updated `test_success_state_report_sends_and_logs_success` to expect `WORKING` → `SUCCESS`; added `test_success_state_error_logged_when_send_error_raises` asserting ERROR is logged even when `send_error()` raises.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
