### PR TITLE
fix: set charset via content_type to avoid malformed Content-Type headers

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -754,7 +754,10 @@ class ChartDataRestApi(ChartRestApi):
         # Create response with streaming headers
         response = Response(
             csv_generator_callable(),  # Call the callable to get generator
-            mimetype=f"text/csv; charset={encoding}",
+            # Use content_type (not mimetype) so the charset is set verbatim;
+            # passing a charset via mimetype makes Werkzeug append a second
+            # charset, producing a malformed doubled Content-Type header.
+            content_type=f"text/csv; charset={encoding}",
             headers={
                 "Content-Disposition": f'attachment; filename="{filename}"',
                 "Cache-Control": "no-cache",

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -141,7 +141,9 @@ def get_error_msg() -> str:
 
 
 def json_success(json_msg: str, status: int = 200) -> FlaskResponse:
-    return Response(json_msg, status=status, mimetype="application/json")
+    return Response(
+        json_msg, status=status, content_type="application/json; charset=utf-8"
+    )
 
 
 def data_payload_response(payload_json: str, has_error: bool = False) -> FlaskResponse:
@@ -214,7 +216,7 @@ class BaseSupersetView(BaseView):
         return Response(
             json.dumps(obj, default=json.json_int_dttm_ser, ignore_nan=True),
             status=status,
-            mimetype="application/json",
+            content_type="application/json; charset=utf-8",
         )
 
     def render_app_template(

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1765,7 +1765,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         rv = self.client.get(uri)
         data = json.loads(rv.data.decode("utf-8"))
         assert rv.status_code == 200
-        assert rv.content_type == "application/json"
+        assert rv.content_type == "application/json; charset=utf-8"
         if slice:
             assert data["slice_id"] == slice.id
 


### PR DESCRIPTION
### SUMMARY

Two Content-Type construction issues (CWE-116 / ASVS 4.1.1):

1. **Streaming CSV export** (`superset/charts/data/api.py`) passed `mimetype=f"text/csv; charset={encoding}"` to Flask's `Response`. Werkzeug appends its own default charset to the `mimetype` value, producing a **doubled, malformed** header — `Content-Type: text/csv; charset=utf-8; charset=utf-8`. Switched to `content_type=`, which is used verbatim. (Reproduced on the pinned Werkzeug 3.x.)
2. **`json_success` and `BaseSupersetView.json_response`** (`superset/views/base.py`) returned `application/json` with no charset, inconsistent with `_send_chart_response`. Set `content_type="application/json; charset=utf-8"`.

Updated the one test that asserted the exact `application/json` content type.

(Note: the related FINDING-024 — `X-Content-Type-Options: nosniff` on chart screenshots — is **not** included: Flask-Talisman already sets that header globally, so it's a false positive.)

### TESTING INSTRUCTIONS

```
pytest tests/integration_tests/charts/api_tests.py -k get_data_no_query_context
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
