### PR TITLE
fix(mcp): honor AUTH_ROLE_ADMIN and warn on permission-less protected tools

### DIFF
--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -65,6 +65,10 @@ PERMISSION_PREFIX = "can_"
 CLASS_PERMISSION_ATTR = "_class_permission_name"
 METHOD_PERMISSION_ATTR = "_method_permission_name"
 
+# Tools already warned about for declaring no class_permission_name, so the
+# warning surfaces once per tool instead of on every protected-tool call.
+_warned_permissionless_tools: set[str] = set()
+
 
 class MCPNoAuthSourceError(ValueError):
     """Raised when no authentication source is available for a request.
@@ -140,13 +144,16 @@ def check_tool_permission(func: Callable[..., Any], *, log_denial: bool = True) 
         if not class_permission_name:
             # No RBAC configured for this tool; allow by default. This is a
             # supported configuration (a protected tool may intentionally
-            # declare no permission class), but surface it so an accidental
-            # omission on a sensitive tool doesn't silently fail open.
-            logger.warning(
-                "Tool %s is permission-protected but declares no "
-                "class_permission_name; allowing access without an RBAC check",
-                func.__name__,
-            )
+            # declare no permission class), but surface it ONCE per tool so an
+            # accidental omission on a sensitive tool doesn't silently fail open
+            # — without emitting a WARNING on every protected-tool call.
+            if func.__name__ not in _warned_permissionless_tools:
+                _warned_permissionless_tools.add(func.__name__)
+                logger.warning(
+                    "Tool %s is permission-protected but declares no "
+                    "class_permission_name; allowing access without an RBAC check",
+                    func.__name__,
+                )
             return True
 
         method_permission_name = getattr(func, METHOD_PERMISSION_ATTR, "read")

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -138,7 +138,15 @@ def check_tool_permission(func: Callable[..., Any], *, log_denial: bool = True) 
 
         class_permission_name = getattr(func, CLASS_PERMISSION_ATTR, None)
         if not class_permission_name:
-            # No RBAC configured for this tool; allow by default.
+            # No RBAC configured for this tool; allow by default. This is a
+            # supported configuration (a protected tool may intentionally
+            # declare no permission class), but surface it so an accidental
+            # omission on a sensitive tool doesn't silently fail open.
+            logger.warning(
+                "Tool %s is permission-protected but declares no "
+                "class_permission_name; allowing access without an RBAC check",
+                func.__name__,
+            )
             return True
 
         method_permission_name = getattr(func, METHOD_PERMISSION_ATTR, "read")

--- a/superset/mcp_service/utils/permissions_utils.py
+++ b/superset/mcp_service/utils/permissions_utils.py
@@ -89,10 +89,15 @@ def user_has_permission(
         return False
 
     try:
-        # Check if user is admin (has all permissions)
+        from flask import current_app
+
+        # Check if user is admin (has all permissions). Use the configured
+        # admin role name rather than hardcoding "Admin", so deployments that
+        # rename the admin role (AUTH_ROLE_ADMIN) still grant admins the bypass.
+        admin_role_name = current_app.config["AUTH_ROLE_ADMIN"]
         if hasattr(user, "roles"):
             for role in user.roles:
-                if role.name in ("Admin", "admin"):
+                if role.name == admin_role_name:
                     return True
 
         # Check specific permission

--- a/superset/mcp_service/utils/permissions_utils.py
+++ b/superset/mcp_service/utils/permissions_utils.py
@@ -95,10 +95,14 @@ def user_has_permission(
         # admin role name rather than hardcoding "Admin", so deployments that
         # rename the admin role (AUTH_ROLE_ADMIN) still grant admins the bypass.
         admin_role_name = current_app.config["AUTH_ROLE_ADMIN"]
-        if hasattr(user, "roles"):
-            for role in user.roles:
-                if role.name == admin_role_name:
-                    return True
+        # Collect role names granted directly AND inherited via group
+        # membership (FAB users can receive the admin role through a group),
+        # so a group-admin still gets the bypass.
+        role_names = {role.name for role in getattr(user, "roles", None) or []}
+        for group in getattr(user, "groups", None) or []:
+            role_names.update(role.name for role in getattr(group, "roles", None) or [])
+        if admin_role_name in role_names:
+            return True
 
         # Check specific permission
         from superset import security_manager

--- a/tests/unit_tests/mcp_service/utils/test_permissions_utils.py
+++ b/tests/unit_tests/mcp_service/utils/test_permissions_utils.py
@@ -17,7 +17,7 @@
 
 """Tests for MCP field-level permission helpers."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from flask import current_app
 
@@ -42,13 +42,21 @@ def test_user_has_permission_admin_uses_configured_role_name():
     try:
         admin = Mock()
         admin.roles = [_role("Superuser")]
+        admin.groups = []
         assert user_has_permission(admin, "can_read", "Chart") is True
 
         # The previously-hardcoded "Admin" name no longer grants the bypass;
-        # it falls through to the real permission check, which denies here.
+        # it falls through to the real permission check. Mock that check to
+        # deny explicitly (rather than relying on incidental Mock behavior) and
+        # assert the helper actually consulted security_manager.has_access.
         not_admin = Mock()
         not_admin.roles = [_role("Admin")]
-        assert user_has_permission(not_admin, "can_read", "Chart") is False
+        not_admin.groups = []
+        with patch(
+            "superset.security_manager.has_access", return_value=False
+        ) as has_access:
+            assert user_has_permission(not_admin, "can_read", "Chart") is False
+        has_access.assert_called_once_with("can_read", "Chart", not_admin)
     finally:
         current_app.config["AUTH_ROLE_ADMIN"] = original
 

--- a/tests/unit_tests/mcp_service/utils/test_permissions_utils.py
+++ b/tests/unit_tests/mcp_service/utils/test_permissions_utils.py
@@ -19,11 +19,38 @@
 
 from unittest.mock import Mock
 
+from flask import current_app
+
 from superset.mcp_service.utils.permissions_utils import (
     apply_field_permissions_to_columns,
     filter_sensitive_data,
     get_allowed_fields,
+    user_has_permission,
 )
+
+
+def test_user_has_permission_admin_uses_configured_role_name():
+    """The admin bypass honors AUTH_ROLE_ADMIN, not a hardcoded 'Admin'."""
+
+    def _role(name: str) -> Mock:
+        role = Mock()
+        role.name = name  # set after construction (Mock intercepts name=)
+        return role
+
+    original = current_app.config["AUTH_ROLE_ADMIN"]
+    current_app.config["AUTH_ROLE_ADMIN"] = "Superuser"
+    try:
+        admin = Mock()
+        admin.roles = [_role("Superuser")]
+        assert user_has_permission(admin, "can_read", "Chart") is True
+
+        # The previously-hardcoded "Admin" name no longer grants the bypass;
+        # it falls through to the real permission check, which denies here.
+        not_admin = Mock()
+        not_admin.roles = [_role("Admin")]
+        assert user_has_permission(not_admin, "can_read", "Chart") is False
+    finally:
+        current_app.config["AUTH_ROLE_ADMIN"] = original
 
 
 def test_get_allowed_fields_always_denies_user_directory_fields():


### PR DESCRIPTION
### SUMMARY

Two MCP authorization-hardening fixes:

- **FINDING-040** — `user_has_permission()` (`superset/mcp_service/utils/permissions_utils.py`) hardcoded the admin check to role name `"Admin"`/`"admin"`, ignoring the configurable `AUTH_ROLE_ADMIN`. In deployments that rename the admin role, admins would be **over-filtered** (denied the field-level sensitive-data bypass) — a functionality regression, not an escalation. Now uses `current_app.config["AUTH_ROLE_ADMIN"]`.
- **FINDING-039** — `check_tool_permission()` (`superset/mcp_service/auth.py`) silently allows a permission-protected tool that declares no `class_permission_name`. That's a supported configuration, so a blanket fail-closed would break legitimate tools — but an *accidentally* permission-less sensitive tool would fail open with no signal. Keep the allow behavior, but **log a warning** so the misconfiguration is visible.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/mcp_service/utils/test_permissions_utils.py
```

New test: the admin bypass follows `AUTH_ROLE_ADMIN` (a renamed admin role is honored; the hardcoded "Admin" no longer grants it).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
