### PR TITLE
fix(dashboard): URL-encode native_filters in permalink redirect

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -864,12 +864,11 @@ class Superset(BaseSupersetView):
         )
         if url_params := state.get("urlParams"):
             for param_key, param_val in url_params:
-                if param_key == "native_filters":
-                    # native_filters doesnt need to be encoded here
-                    url = f"{url}&native_filters={param_val}"
-                else:
-                    params = parse.urlencode([(param_key, param_val)])
-                    url = f"{url}&{params}"
+                # URL-encode every param value (including native_filters) so a
+                # value containing '&'/'#'/'=' cannot inject extra parameters
+                # into the redirect target. Flask decodes the value back on read.
+                params = parse.urlencode([(param_key, param_val)])
+                url = f"{url}&{params}"
         if original_params := request.query_string.decode():
             url = f"{url}&{original_params}"
         if hash_ := state.get("anchor", state.get("hash")):

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -23,7 +23,7 @@ import logging
 import random
 import unittest
 from unittest import mock
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, urlsplit
 
 import pandas as pd
 import pytest
@@ -908,6 +908,34 @@ class TestCore(SupersetTestCase):
 
         assert resp.headers["Location"] == expected_url
         assert resp.status_code == 302
+
+    @mock.patch("superset.views.core.request")
+    @mock.patch(
+        "superset.commands.dashboard.permalink.get.GetDashboardPermalinkCommand.run"
+    )
+    def test_dashboard_permalink_native_filters_encoded(
+        self, get_dashboard_permalink_mock, request_mock
+    ):
+        # A native_filters value containing reserved characters must be
+        # percent-encoded in the redirect target so it cannot inject extra
+        # query parameters into the Location header.
+        request_mock.query_string = b""
+        native_filters_value = "value&injected=evil#frag"
+        get_dashboard_permalink_mock.return_value = {
+            "dashboardId": 1,
+            "state": {"urlParams": [["native_filters", native_filters_value]]},
+        }
+        self.login(ADMIN_USERNAME)
+        resp = self.client.get("superset/dashboard/p/123/")
+
+        location = resp.headers["Location"]
+        assert resp.status_code == 302
+        # The reserved characters are encoded, so no extra params/anchors leak in.
+        assert "native_filters=value%26injected%3Devil%23frag" in location
+        assert "injected=evil" not in location
+        # Round-trips back to the original value when decoded.
+        parsed = parse_qs(urlsplit(location).query)
+        assert parsed["native_filters"] == [native_filters_value]
 
 
 class TestLocalePatch(SupersetTestCase):


### PR DESCRIPTION
### SUMMARY

`dashboard_permalink` (`superset/views/core.py`) concatenated the `native_filters` URL-param value into the redirect URL **without** URL-encoding, while every other param went through `parse.urlencode`. The code even had a comment "native_filters doesnt need to be encoded here." A permalink whose stored `native_filters` value contained `&`/`#`/`=` could therefore inject additional query parameters into the redirect target, altering the dashboard filter state shown to a victim who opens the permalink (ASVS 1.2.2).

Fix: encode all param values uniformly via `parse.urlencode`. Flask URL-decodes them back when reading `request.args`, so legitimate `native_filters` values render identically — the encoding is transparent for valid input and only neutralizes injection.

### TESTING INSTRUCTIONS

```
pytest tests/integration_tests/dashboards/permalink/api_tests.py
```

A permalink whose `native_filters` value contains special characters now appears percent-encoded in the redirect `Location` (no extra params injected).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
