### PR TITLE
chore(excel): strip document metadata from Excel exports

### DIFF
--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -15,11 +15,31 @@
 # specific language governing permissions and limitations
 # under the License.
 import io
+from datetime import datetime
 from typing import Any
 
 import pandas as pd
 
 from superset.utils.core import GenericDataType
+
+# Fixed, neutral timestamp applied to workbook document properties so that
+# exported files do not carry an environment-specific generation time.
+NEUTRAL_TIMESTAMP = datetime(2000, 1, 1)
+
+# Document properties that are reset to empty values on export so that
+# exported workbooks do not carry identifying information.
+NEUTRAL_DOCUMENT_PROPERTIES: dict[str, Any] = {
+    "title": "",
+    "subject": "",
+    "author": "",
+    "manager": "",
+    "company": "",
+    "category": "",
+    "keywords": "",
+    "comments": "",
+    "status": "",
+    "created": NEUTRAL_TIMESTAMP,
+}
 
 
 def quote_formulas(df: pd.DataFrame) -> pd.DataFrame:
@@ -49,6 +69,10 @@ def df_to_excel(df: pd.DataFrame, **kwargs: Any) -> Any:
     # pylint: disable=abstract-class-instantiated
     with pd.ExcelWriter(output, engine="xlsxwriter") as writer:
         df.to_excel(writer, **kwargs)
+
+        # Reset workbook document properties so the exported file does not
+        # carry identifying details (authoring info, generation timestamps).
+        writer.book.set_properties(NEUTRAL_DOCUMENT_PROPERTIES)
 
     return output.getvalue()
 

--- a/tests/unit_tests/utils/excel_tests.py
+++ b/tests/unit_tests/utils/excel_tests.py
@@ -15,13 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import io
 from datetime import datetime, timezone
 
 import pandas as pd
+from openpyxl import load_workbook
 from pandas.api.types import is_numeric_dtype
 
 from superset.utils.core import GenericDataType
-from superset.utils.excel import apply_column_types, df_to_excel
+from superset.utils.excel import (
+    apply_column_types,
+    df_to_excel,
+    NEUTRAL_TIMESTAMP,
+)
 
 
 def test_timezone_conversion() -> None:
@@ -45,6 +51,35 @@ def test_quote_formulas() -> None:
         "normal",
         "'@SUM(A1:A2)",
     ]
+
+
+def test_document_properties_are_neutral() -> None:
+    """
+    Test that exported workbooks do not carry identifying document properties.
+    """
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    contents = df_to_excel(df, index=False)
+
+    workbook = load_workbook(io.BytesIO(contents))
+    properties = workbook.properties
+
+    # Authoring/descriptive fields are cleared.
+    for field in (
+        "creator",
+        "lastModifiedBy",
+        "title",
+        "subject",
+        "description",
+        "keywords",
+        "category",
+    ):
+        value = getattr(properties, field)
+        assert value in (None, ""), f"{field} should be empty, got {value!r}"
+
+    # Timestamps are pinned to a fixed, neutral value rather than the
+    # actual generation time.
+    assert properties.created == NEUTRAL_TIMESTAMP
+    assert properties.modified == NEUTRAL_TIMESTAMP
 
 
 def test_column_data_types_with_one_numeric_column():


### PR DESCRIPTION
### SUMMARY

When generating `.xlsx` exports via `superset/utils/excel.py` (`df_to_excel`), the underlying `xlsxwriter` engine embeds workbook document properties into `docProps/core.xml` — notably `created`/`modified` timestamps set to the actual generation time of the file. This change resets the workbook document properties before the file is written so exported workbooks carry a clean, neutral set of metadata rather than environment-specific details.

Specifically, `df_to_excel` now calls `workbook.set_properties(...)` to:
- Clear the authoring/descriptive fields: `title`, `subject`, `author`, `manager`, `company`, `category`, `keywords`, `comments`, `status`.
- Pin `created`/`modified` to a fixed, neutral timestamp (`2000-01-01`) instead of the real generation time.

The actual sheet data is untouched — only the workbook's core document properties are normalized. This is the single shared export path used by both the chart/dashboard data export (`query_context_processor`) and the legacy CSV/Excel view export (`views/core.py`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (no UI change).

Before — `docProps/core.xml` contained live generation timestamps:
```xml
<dcterms:created>2026-06-02T01:55:41Z</dcterms:created>
<dcterms:modified>2026-06-02T01:55:41Z</dcterms:modified>
```

After — neutral, fixed values:
```xml
<dcterms:created>2000-01-01T00:00:00Z</dcterms:created>
<dcterms:modified>2000-01-01T00:00:00Z</dcterms:modified>
```

### TESTING INSTRUCTIONS

- Run the unit test: `pytest tests/unit_tests/utils/excel_tests.py`
- A new test `test_document_properties_are_neutral` generates an xlsx via `df_to_excel`, loads the bytes back with `openpyxl`, and asserts the core properties are empty/neutral and timestamps are pinned.
- Manually: export a chart/dashboard to Excel and inspect `docProps/core.xml` inside the `.xlsx` (it is a zip); confirm authoring fields are empty and timestamps are neutral.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
