### PR TITLE
fix(ssh-tunnel): validate server_address format (SSRF defense-in-depth)

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -34,7 +34,7 @@ from marshmallow import (
     validates,
     validates_schema,
 )
-from marshmallow.validate import Length, OneOf, Range, ValidationError
+from marshmallow.validate import Length, OneOf, Range, Regexp, ValidationError
 from sqlalchemy import MetaData
 from werkzeug.datastructures import FileStorage
 
@@ -449,7 +449,21 @@ class DatabaseSSHTunnel(Schema):
     id = fields.Integer(
         allow_none=True, metadata={"description": "SSH Tunnel ID (for updates)"}
     )
-    server_address = fields.String()
+    # Restrict the SSH tunnel host to a plausible hostname / IP literal. This
+    # rejects values carrying URL structure, whitespace, or path separators —
+    # defense in depth against using the tunnel host as an SSRF vector.
+    server_address = fields.String(
+        validate=[
+            Length(min=1, max=256),
+            Regexp(
+                r"^[A-Za-z0-9._:\-\[\]]+$",
+                error=(
+                    "server_address must be a valid hostname or IP address "
+                    "(letters, digits, '.', '-', ':' only)"
+                ),
+            ),
+        ]
+    )
     server_port = fields.Integer()
     username = fields.String()
 

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -459,7 +459,7 @@ class DatabaseSSHTunnel(Schema):
                 r"^[A-Za-z0-9._:\-\[\]]+$",
                 error=(
                     "server_address must be a valid hostname or IP address "
-                    "(letters, digits, '.', '-', ':' only)"
+                    "(letters, digits, and '.', '_', '-', ':', '[', ']' only)"
                 ),
             ),
         ]

--- a/tests/unit_tests/databases/schema_tests.py
+++ b/tests/unit_tests/databases/schema_tests.py
@@ -378,3 +378,18 @@ def test_import_schema_allows_masked_fields_for_existing_db(
     }
     # Should not raise - masked values are allowed for existing DBs
     schema.load(config)
+
+
+def test_ssh_tunnel_server_address_rejects_non_hostnames() -> None:
+    """server_address must look like a hostname/IP, not a URL or arbitrary text."""
+    from superset.databases.schemas import DatabaseSSHTunnel
+
+    schema = DatabaseSSHTunnel()
+    base = {"server_port": 22, "username": "u", "private_key": "k"}
+
+    for address in ("10.0.0.5", "ssh.internal.example.com", "[::1]", "bastion_host"):
+        schema.load({**base, "server_address": address})
+
+    for bad in ("http://evil/", "1.2.3.4/../x", "a b", "file:///etc/passwd"):
+        with pytest.raises(ValidationError):
+            schema.load({**base, "server_address": bad})


### PR DESCRIPTION
### SUMMARY

The SSH tunnel `server_address` (`DatabaseSSHTunnel` schema) accepted arbitrary text with no format validation. While the current paramiko-based `sshtunnel` library doesn't shell out, an unvalidated host is a latent SSRF surface (and a footgun against future implementation changes) — ASVS 1.2.5 / CWE-918.

This constrains `server_address` to a plausible hostname / IP literal — `^[A-Za-z0-9._:\-\[\]]+$`, length 1–256 — rejecting values carrying URL structure (`http://…`, `file://…`), whitespace, or path separators (`../`). Defense-in-depth format validation only (no allowlist/denylist config, which the finding lists as optional).

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/databases/schema_tests.py -k ssh_tunnel
```

New test: accepts hostnames / IPv4 / `[::1]` / internal names; rejects `http://evil/`, `1.2.3.4/../x`, whitespace, and `file:///…`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
