### PR TITLE
fix(embedded): add Sec-Fetch-Dest defense-in-depth check on the embedded view

### DIFF
--- a/superset/embedded/view.py
+++ b/superset/embedded/view.py
@@ -66,6 +66,20 @@ class EmbeddedView(BaseSupersetView):
         if not is_referrer_allowed:
             abort(403)
 
+        # Defense in depth: when the browser sends a Sec-Fetch-Dest header,
+        # require an embeddable destination (iframe/frame) or a direct
+        # document/fetch load, rather than e.g. an <img>/<script>/<object> tag.
+        # The header is unforgeable by page script; an absent header (older
+        # browsers / non-browser clients) is allowed for compatibility.
+        sec_fetch_dest = request.headers.get("Sec-Fetch-Dest")
+        if sec_fetch_dest and sec_fetch_dest not in {
+            "iframe",
+            "frame",
+            "document",
+            "empty",
+        }:
+            abort(403)
+
         # Log in as an anonymous user, just for this view.
         # This view needs to be visible to all users,
         # and building the page fails if g.user and/or ctx.user aren't present.

--- a/tests/integration_tests/embedded/test_view.py
+++ b/tests/integration_tests/embedded/test_view.py
@@ -105,3 +105,36 @@ def test_get_embedded_dashboard_non_found(client: FlaskClient[Any]):  # noqa: F8
     uri = "embedded/bad-uuid"  # noqa: F541
     response = client.get(uri)
     assert response.status_code == 404
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@mock.patch.dict(
+    "superset.extensions.feature_flag_manager._feature_flags",
+    EMBEDDED_SUPERSET=True,
+)
+def test_get_embedded_dashboard_rejects_bad_sec_fetch_dest(
+    client: FlaskClient[Any],  # noqa: F811
+):
+    dash = db.session.query(Dashboard).filter_by(slug="births").first()
+    embedded = EmbeddedDashboardDAO.upsert(dash, [])
+    db.session.flush()
+    uri = f"embedded/{embedded.uuid}"
+    # A non-embeddable destination (e.g. loaded via <img>/<script>) is rejected.
+    response = client.get(uri, headers={"Sec-Fetch-Dest": "image"})
+    assert response.status_code == 403
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@mock.patch.dict(
+    "superset.extensions.feature_flag_manager._feature_flags",
+    EMBEDDED_SUPERSET=True,
+)
+def test_get_embedded_dashboard_allows_iframe_sec_fetch_dest(
+    client: FlaskClient[Any],  # noqa: F811
+):
+    dash = db.session.query(Dashboard).filter_by(slug="births").first()
+    embedded = EmbeddedDashboardDAO.upsert(dash, [])
+    db.session.flush()
+    uri = f"embedded/{embedded.uuid}"
+    response = client.get(uri, headers={"Sec-Fetch-Dest": "iframe"})
+    assert response.status_code == 200


### PR DESCRIPTION
### SUMMARY

The embedded dashboard view (`superset/embedded/view.py`) performs `login_user(AnonymousUserMixin(), force=True)` on a GET request, gated only by an optional referrer check (`same_origin`). This adds a **`Sec-Fetch-Dest`** guard as defense-in-depth: when the browser sends the header (which page script cannot forge), the request must target an embeddable destination (`iframe`/`frame`) or a direct `document`/`empty` (fetch) load — rejecting contexts like `<img>`/`<script>`/`<object>`. An **absent** header (older browsers / non-browser clients) is allowed for backward compatibility.

This is defense-in-depth only — the view grants no privileges (anonymous user; the real authorization for embedded dashboards is the guest token sent later by the host page) — but it further constrains how the page can be loaded cross-site.

### TESTING INSTRUCTIONS

```
pytest tests/integration_tests/embedded/test_view.py
```

New tests: a non-embeddable `Sec-Fetch-Dest: image` is rejected (403); `Sec-Fetch-Dest: iframe` is allowed (200).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: EMBEDDED_SUPERSET
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
