### PR TITLE
feat(extensions): static supply-chain controls — denylist + version policy

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -40,6 +40,15 @@ Importing a dataset now validates the `catalog` field against the target databas
 
 If you relied on importing datasets with a non-default catalog, enable "Allow changing catalogs" on the target connection, or set the dataset's catalog to the connection's default before importing.
 
+### Extension supply-chain controls (denylist + version policy)
+
+Two opt-in static gates control which extensions are allowed to load:
+
+- `EXTENSION_DENYLIST` refuses extensions matching an id (every version) or `id@version` (a single version), e.g. `["compromised-extension", "other-ext@1.2.3"]`.
+- `EXTENSION_VERSION_POLICY` enforces a minimum version per extension id, e.g. `{"acme.widget": "1.2.0"}` (PEP 440 comparison); a release below the minimum is refused.
+
+Both default to empty (no behavior change). They apply to both the `LOCAL_EXTENSIONS` and `EXTENSIONS_PATH` load paths.
+
 ### Granular Export Controls
 
 A new feature flag `GRANULAR_EXPORT_CONTROLS` introduces three fine-grained permissions that replace the legacy `can_csv` permission:

--- a/superset/config.py
+++ b/superset/config.py
@@ -2541,6 +2541,12 @@ EXTENSIONS_PATH: str | None = None
 # extension found to be vulnerable or otherwise undesirable.
 EXTENSION_DENYLIST: list[str] = []
 
+# Minimum allowed version per extension id. An extension whose version is below
+# the configured minimum is refused, so a vulnerable release can be required to
+# be patched before it loads. Versions are compared with PEP 440 semantics, e.g.
+#   EXTENSION_VERSION_POLICY = {"acme.widget": "1.2.0"}
+EXTENSION_VERSION_POLICY: dict[str, str] = {}
+
 # Default polling interval for tasks (seconds)
 TASK_ABORT_POLLING_DEFAULT_INTERVAL = 10
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -2535,6 +2535,11 @@ except ImportError:
 
 LOCAL_EXTENSIONS: list[str] = []
 EXTENSIONS_PATH: str | None = None
+# Extensions that must not be loaded, even if present in LOCAL_EXTENSIONS or
+# EXTENSIONS_PATH. Each entry is an extension id (blocks every version) or
+# "<id>@<version>" (blocks a specific version). Use this to disable an
+# extension found to be vulnerable or otherwise undesirable.
+EXTENSION_BLOCKLIST: list[str] = []
 
 # Default polling interval for tasks (seconds)
 TASK_ABORT_POLLING_DEFAULT_INTERVAL = 10

--- a/superset/config.py
+++ b/superset/config.py
@@ -2536,10 +2536,10 @@ except ImportError:
 LOCAL_EXTENSIONS: list[str] = []
 EXTENSIONS_PATH: str | None = None
 # Extensions that must not be loaded, even if present in LOCAL_EXTENSIONS or
-# EXTENSIONS_PATH. Each entry is an extension id (blocks every version) or
-# "<id>@<version>" (blocks a specific version). Use this to disable an
+# EXTENSIONS_PATH. Each entry is an extension id (denies every version) or
+# "<id>@<version>" (denies a specific version). Use this to disable an
 # extension found to be vulnerable or otherwise undesirable.
-EXTENSION_BLOCKLIST: list[str] = []
+EXTENSION_DENYLIST: list[str] = []
 
 # Default polling interval for tasks (seconds)
 TASK_ABORT_POLLING_DEFAULT_INTERVAL = 10

--- a/superset/extensions/utils.py
+++ b/superset/extensions/utils.py
@@ -254,18 +254,17 @@ def build_extension_data(extension: LoadedExtension) -> dict[str, Any]:
     return extension_data
 
 
-def is_extension_blocked(extension: LoadedExtension) -> bool:
+def is_extension_denied(extension: LoadedExtension) -> bool:
     """
-    Return True if the extension is denied by the ``EXTENSION_BLOCKLIST`` config.
+    Return True if the extension is denied by the ``EXTENSION_DENYLIST`` config.
 
-    Each blocklist entry is either an extension id (blocks every version of that
-    extension) or ``"<id>@<version>"`` (blocks only that exact version).
+    Each denylist entry is either an extension id (denies every version of that
+    extension) or ``"<id>@<version>"`` (denies only that exact version).
     """
-    blocklist = set(current_app.config.get("EXTENSION_BLOCKLIST") or [])
-    if not blocklist:
+    denylist = set(current_app.config.get("EXTENSION_DENYLIST") or [])
+    if not denylist:
         return False
-    manifest = extension.manifest
-    return manifest.id in blocklist or f"{manifest.id}@{manifest.version}" in blocklist
+    return extension.id in denylist or f"{extension.id}@{extension.version}" in denylist
 
 
 def get_extensions() -> dict[str, LoadedExtension]:
@@ -279,9 +278,9 @@ def get_extensions() -> dict[str, LoadedExtension]:
             abs_dist_path = str((Path(path) / "dist").resolve())
             extension = get_loaded_extension(files, source_base_path=abs_dist_path)
             extension_id = extension.manifest.id
-            if is_extension_blocked(extension):
+            if is_extension_denied(extension):
                 logger.warning(
-                    "Refusing to load blocklisted extension %s (ID: %s, "
+                    "Refusing to load denylisted extension %s (ID: %s, "
                     "version: %s) from local filesystem",
                     extension.name,
                     extension_id,
@@ -303,9 +302,9 @@ def get_extensions() -> dict[str, LoadedExtension]:
 
         for extension in discover_and_load_extensions(extensions_path):
             extension_id = extension.manifest.id
-            if is_extension_blocked(extension):
+            if is_extension_denied(extension):
                 logger.warning(
-                    "Refusing to load blocklisted extension %s (ID: %s, "
+                    "Refusing to load denylisted extension %s (ID: %s, "
                     "version: %s) from discovery path",
                     extension.name,
                     extension_id,

--- a/superset/extensions/utils.py
+++ b/superset/extensions/utils.py
@@ -267,6 +267,52 @@ def is_extension_denied(extension: LoadedExtension) -> bool:
     return extension.id in denylist or f"{extension.id}@{extension.version}" in denylist
 
 
+def is_extension_below_min_version(extension: LoadedExtension) -> bool:
+    """
+    Return True if the extension's version is below the minimum required for its
+    id by the ``EXTENSION_VERSION_POLICY`` config.
+
+    Versions are compared with PEP 440 semantics. An unparseable version (the
+    extension's or the configured minimum) fails closed — the extension is
+    treated as below the minimum rather than allowed past the policy.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    policy: dict[str, str] = current_app.config.get("EXTENSION_VERSION_POLICY") or {}
+    minimum = policy.get(extension.id)
+    if not minimum:
+        return False
+    try:
+        return Version(extension.version) < Version(minimum)
+    except InvalidVersion:
+        logger.warning(
+            "Could not compare extension %s version %r against the minimum %r "
+            "required by EXTENSION_VERSION_POLICY; refusing it",
+            extension.id,
+            extension.version,
+            minimum,
+        )
+        return True
+
+
+def get_extension_rejection_reason(extension: LoadedExtension) -> str | None:
+    """
+    Return why an extension must not be loaded, or None if it may load.
+
+    Combines the static supply-chain checks (``EXTENSION_DENYLIST`` and
+    ``EXTENSION_VERSION_POLICY``).
+    """
+    if is_extension_denied(extension):
+        return "it is in EXTENSION_DENYLIST"
+    if is_extension_below_min_version(extension):
+        minimum = current_app.config["EXTENSION_VERSION_POLICY"][extension.id]
+        return (
+            f"its version {extension.version} is below the minimum {minimum} "
+            "required by EXTENSION_VERSION_POLICY"
+        )
+    return None
+
+
 def get_extensions() -> dict[str, LoadedExtension]:
     extensions: dict[str, LoadedExtension] = {}
 
@@ -278,13 +324,14 @@ def get_extensions() -> dict[str, LoadedExtension]:
             abs_dist_path = str((Path(path) / "dist").resolve())
             extension = get_loaded_extension(files, source_base_path=abs_dist_path)
             extension_id = extension.manifest.id
-            if is_extension_denied(extension):
+            if reason := get_extension_rejection_reason(extension):
                 logger.warning(
-                    "Refusing to load denylisted extension %s (ID: %s, "
-                    "version: %s) from local filesystem",
+                    "Refusing to load extension %s (ID: %s, version: %s) from "
+                    "local filesystem: %s",
                     extension.name,
                     extension_id,
-                    extension.manifest.version,
+                    extension.version,
+                    reason,
                 )
                 continue
             extensions[extension_id] = extension
@@ -302,13 +349,14 @@ def get_extensions() -> dict[str, LoadedExtension]:
 
         for extension in discover_and_load_extensions(extensions_path):
             extension_id = extension.manifest.id
-            if is_extension_denied(extension):
+            if reason := get_extension_rejection_reason(extension):
                 logger.warning(
-                    "Refusing to load denylisted extension %s (ID: %s, "
-                    "version: %s) from discovery path",
+                    "Refusing to load extension %s (ID: %s, version: %s) from "
+                    "discovery path: %s",
                     extension.name,
                     extension_id,
-                    extension.manifest.version,
+                    extension.version,
+                    reason,
                 )
                 continue
             if extension_id not in extensions:  # Don't override LOCAL_EXTENSIONS

--- a/superset/extensions/utils.py
+++ b/superset/extensions/utils.py
@@ -254,6 +254,20 @@ def build_extension_data(extension: LoadedExtension) -> dict[str, Any]:
     return extension_data
 
 
+def is_extension_blocked(extension: LoadedExtension) -> bool:
+    """
+    Return True if the extension is denied by the ``EXTENSION_BLOCKLIST`` config.
+
+    Each blocklist entry is either an extension id (blocks every version of that
+    extension) or ``"<id>@<version>"`` (blocks only that exact version).
+    """
+    blocklist = set(current_app.config.get("EXTENSION_BLOCKLIST") or [])
+    if not blocklist:
+        return False
+    manifest = extension.manifest
+    return manifest.id in blocklist or f"{manifest.id}@{manifest.version}" in blocklist
+
+
 def get_extensions() -> dict[str, LoadedExtension]:
     extensions: dict[str, LoadedExtension] = {}
 
@@ -265,6 +279,15 @@ def get_extensions() -> dict[str, LoadedExtension]:
             abs_dist_path = str((Path(path) / "dist").resolve())
             extension = get_loaded_extension(files, source_base_path=abs_dist_path)
             extension_id = extension.manifest.id
+            if is_extension_blocked(extension):
+                logger.warning(
+                    "Refusing to load blocklisted extension %s (ID: %s, "
+                    "version: %s) from local filesystem",
+                    extension.name,
+                    extension_id,
+                    extension.manifest.version,
+                )
+                continue
             extensions[extension_id] = extension
             logger.info(
                 "Loading extension %s (ID: %s) from local filesystem",
@@ -280,6 +303,15 @@ def get_extensions() -> dict[str, LoadedExtension]:
 
         for extension in discover_and_load_extensions(extensions_path):
             extension_id = extension.manifest.id
+            if is_extension_blocked(extension):
+                logger.warning(
+                    "Refusing to load blocklisted extension %s (ID: %s, "
+                    "version: %s) from discovery path",
+                    extension.name,
+                    extension_id,
+                    extension.manifest.version,
+                )
+                continue
             if extension_id not in extensions:  # Don't override LOCAL_EXTENSIONS
                 extensions[extension_id] = extension
                 logger.info(

--- a/tests/unit_tests/extensions/test_utils.py
+++ b/tests/unit_tests/extensions/test_utils.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock
+
+from flask import current_app
+
+from superset.extensions.utils import is_extension_blocked
+
+
+def _extension(ext_id: str, version: str) -> MagicMock:
+    extension = MagicMock()
+    extension.manifest.id = ext_id
+    extension.manifest.version = version
+    return extension
+
+
+def test_is_extension_blocked() -> None:
+    original = current_app.config.get("EXTENSION_BLOCKLIST")
+    try:
+        # Empty blocklist: nothing is blocked.
+        current_app.config["EXTENSION_BLOCKLIST"] = []
+        assert is_extension_blocked(_extension("acme.widget", "1.0.0")) is False
+
+        # Block by id: every version of that id is blocked.
+        current_app.config["EXTENSION_BLOCKLIST"] = ["acme.widget"]
+        assert is_extension_blocked(_extension("acme.widget", "1.0.0")) is True
+        assert is_extension_blocked(_extension("acme.widget", "2.0.0")) is True
+        assert is_extension_blocked(_extension("acme.other", "1.0.0")) is False
+
+        # Block by id@version: only that exact version is blocked.
+        current_app.config["EXTENSION_BLOCKLIST"] = ["acme.widget@1.0.0"]
+        assert is_extension_blocked(_extension("acme.widget", "1.0.0")) is True
+        assert is_extension_blocked(_extension("acme.widget", "2.0.0")) is False
+    finally:
+        current_app.config["EXTENSION_BLOCKLIST"] = original

--- a/tests/unit_tests/extensions/test_utils.py
+++ b/tests/unit_tests/extensions/test_utils.py
@@ -19,32 +19,32 @@ from unittest.mock import MagicMock
 
 from flask import current_app
 
-from superset.extensions.utils import is_extension_blocked
+from superset.extensions.utils import is_extension_denied
 
 
 def _extension(ext_id: str, version: str) -> MagicMock:
     extension = MagicMock()
-    extension.manifest.id = ext_id
-    extension.manifest.version = version
+    extension.id = ext_id
+    extension.version = version
     return extension
 
 
-def test_is_extension_blocked() -> None:
-    original = current_app.config.get("EXTENSION_BLOCKLIST")
+def test_is_extension_denied() -> None:
+    original = current_app.config.get("EXTENSION_DENYLIST")
     try:
-        # Empty blocklist: nothing is blocked.
-        current_app.config["EXTENSION_BLOCKLIST"] = []
-        assert is_extension_blocked(_extension("acme.widget", "1.0.0")) is False
+        # Empty denylist: nothing is denied.
+        current_app.config["EXTENSION_DENYLIST"] = []
+        assert is_extension_denied(_extension("acme.widget", "1.0.0")) is False
 
-        # Block by id: every version of that id is blocked.
-        current_app.config["EXTENSION_BLOCKLIST"] = ["acme.widget"]
-        assert is_extension_blocked(_extension("acme.widget", "1.0.0")) is True
-        assert is_extension_blocked(_extension("acme.widget", "2.0.0")) is True
-        assert is_extension_blocked(_extension("acme.other", "1.0.0")) is False
+        # Deny by id: every version of that id is denied.
+        current_app.config["EXTENSION_DENYLIST"] = ["acme.widget"]
+        assert is_extension_denied(_extension("acme.widget", "1.0.0")) is True
+        assert is_extension_denied(_extension("acme.widget", "2.0.0")) is True
+        assert is_extension_denied(_extension("acme.other", "1.0.0")) is False
 
-        # Block by id@version: only that exact version is blocked.
-        current_app.config["EXTENSION_BLOCKLIST"] = ["acme.widget@1.0.0"]
-        assert is_extension_blocked(_extension("acme.widget", "1.0.0")) is True
-        assert is_extension_blocked(_extension("acme.widget", "2.0.0")) is False
+        # Deny by id@version: only that exact version is denied.
+        current_app.config["EXTENSION_DENYLIST"] = ["acme.widget@1.0.0"]
+        assert is_extension_denied(_extension("acme.widget", "1.0.0")) is True
+        assert is_extension_denied(_extension("acme.widget", "2.0.0")) is False
     finally:
-        current_app.config["EXTENSION_BLOCKLIST"] = original
+        current_app.config["EXTENSION_DENYLIST"] = original

--- a/tests/unit_tests/extensions/test_utils.py
+++ b/tests/unit_tests/extensions/test_utils.py
@@ -19,7 +19,11 @@ from unittest.mock import MagicMock
 
 from flask import current_app
 
-from superset.extensions.utils import is_extension_denied
+from superset.extensions.utils import (
+    get_extension_rejection_reason,
+    is_extension_below_min_version,
+    is_extension_denied,
+)
 
 
 def _extension(ext_id: str, version: str) -> MagicMock:
@@ -48,3 +52,45 @@ def test_is_extension_denied() -> None:
         assert is_extension_denied(_extension("acme.widget", "2.0.0")) is False
     finally:
         current_app.config["EXTENSION_DENYLIST"] = original
+
+
+def test_is_extension_below_min_version() -> None:
+    too_old = is_extension_below_min_version
+    original = current_app.config.get("EXTENSION_VERSION_POLICY")
+    try:
+        # No policy: nothing is too old.
+        current_app.config["EXTENSION_VERSION_POLICY"] = {}
+        assert too_old(_extension("acme.widget", "1.0.0")) is False
+
+        current_app.config["EXTENSION_VERSION_POLICY"] = {"acme.widget": "1.2.0"}
+        # PEP 440 comparison, not string compare (1.10.0 > 1.2.0).
+        assert too_old(_extension("acme.widget", "1.10.0")) is False
+        assert too_old(_extension("acme.widget", "1.1.9")) is True
+        # At or above the minimum -> allowed.
+        assert too_old(_extension("acme.widget", "1.2.0")) is False
+        assert too_old(_extension("acme.widget", "2.0.0")) is False
+        # A different id is unaffected by this id's policy.
+        assert too_old(_extension("acme.other", "0.1.0")) is False
+        # Unparseable version fails closed.
+        assert too_old(_extension("acme.widget", "not-a-version")) is True
+    finally:
+        current_app.config["EXTENSION_VERSION_POLICY"] = original or {}
+
+
+def test_get_extension_rejection_reason() -> None:
+    deny = current_app.config.get("EXTENSION_DENYLIST")
+    policy = current_app.config.get("EXTENSION_VERSION_POLICY")
+    try:
+        current_app.config["EXTENSION_DENYLIST"] = ["acme.bad"]
+        current_app.config["EXTENSION_VERSION_POLICY"] = {"acme.widget": "1.2.0"}
+
+        assert get_extension_rejection_reason(_extension("acme.ok", "9.9.9")) is None
+        assert "EXTENSION_DENYLIST" in (
+            get_extension_rejection_reason(_extension("acme.bad", "1.0.0")) or ""
+        )
+        assert "EXTENSION_VERSION_POLICY" in (
+            get_extension_rejection_reason(_extension("acme.widget", "1.0.0")) or ""
+        )
+    finally:
+        current_app.config["EXTENSION_DENYLIST"] = deny or []
+        current_app.config["EXTENSION_VERSION_POLICY"] = policy or {}


### PR DESCRIPTION
### SUMMARY

Extensions execute arbitrary Python, but once a valid `.supx` (or `LOCAL_EXTENSIONS`) bundle is discovered it is loaded unconditionally — there is no way for an operator to refuse a specific extension known to be vulnerable or undesirable (ASVS 15.2.1, CWE-1104).

This adds an **`EXTENSION_BLOCKLIST`** config. Each entry is either:
- an extension **id** (blocks every version of that extension), or
- **`"<id>@<version>"`** (blocks only that exact version).

`get_extensions()` now skips blocklisted extensions (with a warning) in **both** load paths — `LOCAL_EXTENSIONS` and the `EXTENSIONS_PATH` discovery. Default is `[]` (no change to existing behavior).

This is the self-contained slice of the extension supply-chain finding; the full vulnerability-database / dependency-audit integration (OSV/GHSA, max-age) remains out of scope.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/extensions/test_utils.py
```

New test covers `is_extension_blocked`: empty list allows all; an id blocks all its versions; `<id>@<version>` blocks only that version.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
