### PR TITLE
feat(security): enforce password complexity policy (min length + common-password blocklist)

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -45,6 +45,19 @@ service requires visible `© OpenStreetMap contributors` attribution and should
 be used through normal browser map tile requests and caching; it is not intended
 for bulk prefetch or offline tile downloads.
 
+### Password complexity policy enabled by default
+
+Superset now ships a default password-complexity policy, enforced (via Flask-AppBuilder) across self-registration, the user create/edit/reset forms, and the User REST API. The policy requires a minimum password length of 8 characters and rejects a built-in blocklist of common/guessable passwords.
+
+This is enabled by default (`FAB_PASSWORD_COMPLEXITY_ENABLED = True`), so new or reset passwords that are too short or appear in the blocklist will be rejected where they were previously accepted. Existing stored passwords are unaffected until they are next changed.
+
+Operators can tune or disable the policy via config:
+
+- `AUTH_PASSWORD_MIN_LENGTH` — minimum length (default `8`).
+- `AUTH_PASSWORD_COMMON_BLOCKLIST` — extra passwords to reject, in addition to the built-in list.
+- `FAB_PASSWORD_COMPLEXITY_VALIDATOR` — replace with your own callable for custom rules.
+- `FAB_PASSWORD_COMPLEXITY_ENABLED = False` — disable enforcement entirely.
+
 ### Duration formatter precision
 
 The `DURATION` number formatter now uses `Intl.DurationFormat` for locale-aware output. By default, sub-second fields are omitted, so values that previously displayed fractional seconds with `pretty-ms`, such as `10500` milliseconds rendering as `10.5s`, now render as `10s`.

--- a/superset/config.py
+++ b/superset/config.py
@@ -367,6 +367,21 @@ AUTH_RATE_LIMIT = "5 per second"
 # (e.g. accounts provisioned by an administrator) are redirected to the
 # password-reset page until they set a new password. Off by default.
 ENABLE_FORCE_PASSWORD_CHANGE = False
+
+# Password complexity policy, enforced (via Flask-AppBuilder) across
+# self-registration, the user edit/reset forms, and the User REST API.
+# The Superset validator requires a minimum length and rejects common
+# passwords; tune via AUTH_PASSWORD_MIN_LENGTH / AUTH_PASSWORD_COMMON_BLOCKLIST,
+# or replace FAB_PASSWORD_COMPLEXITY_VALIDATOR with your own callable.
+from superset.security.password_complexity import (  # noqa: E402
+    validate_password_complexity as _validate_password_complexity,
+)
+
+FAB_PASSWORD_COMPLEXITY_ENABLED = True
+FAB_PASSWORD_COMPLEXITY_VALIDATOR = _validate_password_complexity
+AUTH_PASSWORD_MIN_LENGTH = 8
+AUTH_PASSWORD_COMMON_BLOCKLIST: list[str] = []
+
 # A storage location conforming to the scheme in storage-scheme. See the limits
 # library for allowed values: https://limits.readthedocs.io/en/stable/storage.html
 # RATELIMIT_STORAGE_URI = "redis://host:port"

--- a/superset/security/password_complexity.py
+++ b/superset/security/password_complexity.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Superset password-complexity validator.
+
+Wired in via ``FAB_PASSWORD_COMPLEXITY_VALIDATOR`` (with
+``FAB_PASSWORD_COMPLEXITY_ENABLED``). Flask-AppBuilder runs this callable from
+both the WTForms password fields (self-registration, user edit, reset password)
+and the User REST API, so a single function enforces the policy across all
+password-setting flows.
+
+The default policy is a minimum length plus a common-password blocklist —
+intentionally less draconian than FAB's built-in ``default_password_complexity``
+(which requires 2 uppercase, 1 special, 2 digits, 3 lowercase and length 10).
+"""
+
+from __future__ import annotations
+
+from flask import current_app
+from flask_appbuilder.exceptions import PasswordComplexityValidationError
+from flask_babel import gettext as __
+
+# A small built-in blocklist of the most common/guessable passwords. Operators
+# can extend it with AUTH_PASSWORD_COMMON_BLOCKLIST. (A fuller list or a
+# Have-I-Been-Pwned k-anonymity check is a possible follow-up.)
+COMMON_PASSWORDS: frozenset[str] = frozenset(
+    {
+        "123456",
+        "123456789",
+        "12345678",
+        "1234567890",
+        "12345",
+        "111111",
+        "123123",
+        "000000",
+        "password",
+        "password1",
+        "password123",
+        "passw0rd",
+        "qwerty",
+        "qwerty123",
+        "qwertyuiop",
+        "abc123",
+        "letmein",
+        "welcome",
+        "welcome1",
+        "admin",
+        "admin123",
+        "administrator",
+        "root",
+        "superset",
+        "changeme",
+        "iloveyou",
+        "monkey",
+        "dragon",
+        "sunshine",
+        "princess",
+        "football",
+        "baseball",
+        "trustno1",
+        "login",
+        "master",
+        "hello123",
+        "secret",
+        "default",
+    }
+)
+
+DEFAULT_MIN_LENGTH = 8
+
+
+def validate_password_complexity(password: str) -> None:
+    """Validate a plaintext password against the configured policy.
+
+    :raises PasswordComplexityValidationError: if the password is too short or
+        appears in the common-password blocklist.
+    """
+    min_length = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH", DEFAULT_MIN_LENGTH)
+    if len(password) < min_length:
+        raise PasswordComplexityValidationError(
+            __(
+                "Password must be at least %(min_length)s characters long.",
+                min_length=min_length,
+            )
+        )
+
+    extra = current_app.config.get("AUTH_PASSWORD_COMMON_BLOCKLIST") or []
+    blocklist = COMMON_PASSWORDS | {str(item).lower() for item in extra}
+    if password.lower() in blocklist:
+        raise PasswordComplexityValidationError(
+            __("This password is too common; please choose a less guessable one.")
+        )

--- a/superset/security/password_complexity.py
+++ b/superset/security/password_complexity.py
@@ -88,7 +88,18 @@ def validate_password_complexity(password: str) -> None:
     :raises PasswordComplexityValidationError: if the password is too short or
         appears in the common-password blocklist.
     """
-    min_length = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH", DEFAULT_MIN_LENGTH)
+    raw_min_length = current_app.config.get(
+        "AUTH_PASSWORD_MIN_LENGTH", DEFAULT_MIN_LENGTH
+    )
+    # Operators commonly wire config via env vars, so AUTH_PASSWORD_MIN_LENGTH can
+    # arrive as a string (or be left unset/None). Coerce defensively and fall back
+    # to the default rather than blowing up every password-setting flow with a
+    # TypeError on the length comparison.
+    try:
+        min_length = int(raw_min_length)
+    except (TypeError, ValueError):
+        min_length = DEFAULT_MIN_LENGTH
+
     if len(password) < min_length:
         raise PasswordComplexityValidationError(
             __(
@@ -98,8 +109,13 @@ def validate_password_complexity(password: str) -> None:
         )
 
     extra = current_app.config.get("AUTH_PASSWORD_COMMON_BLOCKLIST") or []
-    blocklist = COMMON_PASSWORDS | {str(item).lower() for item in extra}
-    if password.lower() in blocklist:
+    # A bare string is iterable but would be split into characters, so treat a
+    # misconfigured string as a single entry. casefold() gives correct
+    # case-insensitive matching for non-ASCII passwords too.
+    if isinstance(extra, str):
+        extra = [extra]
+    blocklist = COMMON_PASSWORDS | {str(item).casefold() for item in extra}
+    if password.casefold() in blocklist:
         raise PasswordComplexityValidationError(
             __("This password is too common; please choose a less guessable one.")
         )

--- a/superset/security/password_complexity.py
+++ b/superset/security/password_complexity.py
@@ -99,6 +99,10 @@ def validate_password_complexity(password: str) -> None:
         min_length = int(raw_min_length)
     except (TypeError, ValueError):
         min_length = DEFAULT_MIN_LENGTH
+    # A zero or negative value would silently disable the length check, so
+    # treat non-positive values as misconfiguration and use the default.
+    if min_length < 1:
+        min_length = DEFAULT_MIN_LENGTH
 
     if len(password) < min_length:
         raise PasswordComplexityValidationError(

--- a/tests/integration_tests/security/password_complexity_tests.py
+++ b/tests/integration_tests/security/password_complexity_tests.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Integration tests asserting the password-complexity policy is wired into
+Flask-AppBuilder's User REST API (not just the validator function itself)."""
+
+from superset import db, security_manager
+from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.constants import ADMIN_USERNAME
+
+USERS_API_URI = "/api/v1/security/users/"
+
+
+class TestPasswordComplexityUserApi(SupersetTestCase):
+    """Exercise the real FAB ``/api/v1/security/users/`` path so that a future
+    Flask-AppBuilder bump that drops enforcement fails these tests."""
+
+    def _user_payload(self, password: str) -> dict[str, object]:
+        """Build a valid user-creation payload with the given password."""
+        gamma_role = security_manager.find_role("Gamma")
+        return {
+            "active": True,
+            "email": "pw_complexity_test@example.com",
+            "first_name": "Password",
+            "last_name": "Complexity",
+            "username": "pw_complexity_test_user",
+            "roles": [gamma_role.id],
+            "password": password,
+        }
+
+    def test_create_user_rejects_short_password(self):
+        """A too-short password is rejected by the User REST API with a 400."""
+        self.login(ADMIN_USERNAME)
+        rv = self.client.post(USERS_API_URI, json=self._user_payload("Ab1!"))
+        assert rv.status_code == 400
+        assert b"at least" in rv.data
+        assert security_manager.find_user(username="pw_complexity_test_user") is None
+
+    def test_create_user_rejects_common_password(self):
+        """A blocklisted common password is rejected by the User REST API."""
+        self.login(ADMIN_USERNAME)
+        rv = self.client.post(USERS_API_URI, json=self._user_payload("password123"))
+        assert rv.status_code == 400
+        assert b"too common" in rv.data
+        assert security_manager.find_user(username="pw_complexity_test_user") is None
+
+    def test_create_user_accepts_compliant_password(self):
+        """A password satisfying the policy is accepted by the User REST API."""
+        self.login(ADMIN_USERNAME)
+        rv = self.client.post(
+            USERS_API_URI, json=self._user_payload("correct-horse-battery")
+        )
+        assert rv.status_code == 201
+        user = security_manager.find_user(username="pw_complexity_test_user")
+        assert user is not None
+        db.session.delete(user)
+        db.session.commit()

--- a/tests/unit_tests/security/test_password_complexity.py
+++ b/tests/unit_tests/security/test_password_complexity.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from flask import current_app
+from flask_appbuilder.exceptions import PasswordComplexityValidationError
+
+from superset.security.password_complexity import validate_password_complexity
+
+
+def test_validate_password_complexity_accepts_strong_password() -> None:
+    # No exception for a sufficiently long, uncommon password.
+    validate_password_complexity("a-Good-Long-Passphrase-42")
+
+
+def test_validate_password_complexity_rejects_short_password() -> None:
+    with pytest.raises(PasswordComplexityValidationError):
+        validate_password_complexity("short1")  # < 8 chars
+
+
+def test_validate_password_complexity_rejects_common_password() -> None:
+    # Common even though length >= 8.
+    with pytest.raises(PasswordComplexityValidationError):
+        validate_password_complexity("password123")
+    # Case-insensitive.
+    with pytest.raises(PasswordComplexityValidationError):
+        validate_password_complexity("PASSWORD123")
+
+
+def test_validate_password_complexity_honors_configured_min_length() -> None:
+    original = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH")
+    current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = 16
+    try:
+        with pytest.raises(PasswordComplexityValidationError):
+            validate_password_complexity("only12chars!")  # 12 < 16
+    finally:
+        current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = original
+
+
+def test_validate_password_complexity_honors_extra_blocklist() -> None:
+    original = current_app.config.get("AUTH_PASSWORD_COMMON_BLOCKLIST")
+    current_app.config["AUTH_PASSWORD_COMMON_BLOCKLIST"] = ["AcmeCorp2024"]
+    try:
+        with pytest.raises(PasswordComplexityValidationError):
+            validate_password_complexity("acmecorp2024")
+    finally:
+        current_app.config["AUTH_PASSWORD_COMMON_BLOCKLIST"] = original

--- a/tests/unit_tests/security/test_password_complexity.py
+++ b/tests/unit_tests/security/test_password_complexity.py
@@ -59,3 +59,39 @@ def test_validate_password_complexity_honors_extra_blocklist() -> None:
             validate_password_complexity("acmecorp2024")
     finally:
         current_app.config["AUTH_PASSWORD_COMMON_BLOCKLIST"] = original
+
+
+def test_validate_password_complexity_coerces_string_min_length() -> None:
+    # Operators wiring config via env vars may pass min length as a string.
+    original = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH")
+    current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = "16"  # noqa: S105
+    try:
+        with pytest.raises(PasswordComplexityValidationError):
+            validate_password_complexity("only12chars!")  # 12 < 16
+    finally:
+        current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = original
+
+
+def test_validate_password_complexity_tolerates_invalid_min_length() -> None:
+    # A non-numeric/None min length must not blow up; fall back to the default.
+    original = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH")
+    current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = "not-a-number"  # noqa: S105
+    try:
+        validate_password_complexity("a-Good-Long-Passphrase-42")
+        with pytest.raises(PasswordComplexityValidationError):
+            validate_password_complexity("short1")  # < default 8
+    finally:
+        current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = original
+
+
+def test_validate_password_complexity_blocklist_string_not_split() -> None:
+    # A misconfigured string blocklist must be treated as one entry, not chars.
+    original = current_app.config.get("AUTH_PASSWORD_COMMON_BLOCKLIST")
+    current_app.config["AUTH_PASSWORD_COMMON_BLOCKLIST"] = "AcmeCorp2024"  # noqa: S105
+    try:
+        with pytest.raises(PasswordComplexityValidationError):
+            validate_password_complexity("acmecorp2024")
+        # A single character from the string must NOT become blocked.
+        validate_password_complexity("a-Good-Long-Passphrase-42")
+    finally:
+        current_app.config["AUTH_PASSWORD_COMMON_BLOCKLIST"] = original

--- a/tests/unit_tests/security/test_password_complexity.py
+++ b/tests/unit_tests/security/test_password_complexity.py
@@ -23,16 +23,18 @@ from superset.security.password_complexity import validate_password_complexity
 
 
 def test_validate_password_complexity_accepts_strong_password() -> None:
-    # No exception for a sufficiently long, uncommon password.
+    """A sufficiently long, uncommon password passes without raising."""
     validate_password_complexity("a-Good-Long-Passphrase-42")
 
 
 def test_validate_password_complexity_rejects_short_password() -> None:
+    """A password below the default minimum length is rejected."""
     with pytest.raises(PasswordComplexityValidationError):
         validate_password_complexity("short1")  # < 8 chars
 
 
 def test_validate_password_complexity_rejects_common_password() -> None:
+    """Blocklisted passwords are rejected, case-insensitively."""
     # Common even though length >= 8.
     with pytest.raises(PasswordComplexityValidationError):
         validate_password_complexity("password123")
@@ -42,6 +44,7 @@ def test_validate_password_complexity_rejects_common_password() -> None:
 
 
 def test_validate_password_complexity_honors_configured_min_length() -> None:
+    """A configured AUTH_PASSWORD_MIN_LENGTH overrides the default."""
     original = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH")
     current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = 16
     try:
@@ -52,6 +55,7 @@ def test_validate_password_complexity_honors_configured_min_length() -> None:
 
 
 def test_validate_password_complexity_honors_extra_blocklist() -> None:
+    """Entries in AUTH_PASSWORD_COMMON_BLOCKLIST are enforced."""
     original = current_app.config.get("AUTH_PASSWORD_COMMON_BLOCKLIST")
     current_app.config["AUTH_PASSWORD_COMMON_BLOCKLIST"] = ["AcmeCorp2024"]
     try:
@@ -62,7 +66,7 @@ def test_validate_password_complexity_honors_extra_blocklist() -> None:
 
 
 def test_validate_password_complexity_coerces_string_min_length() -> None:
-    # Operators wiring config via env vars may pass min length as a string.
+    """A string min length (e.g. from an env var) is coerced to int."""
     original = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH")
     current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = "16"  # noqa: S105
     try:
@@ -73,7 +77,7 @@ def test_validate_password_complexity_coerces_string_min_length() -> None:
 
 
 def test_validate_password_complexity_tolerates_invalid_min_length() -> None:
-    # A non-numeric/None min length must not blow up; fall back to the default.
+    """A non-numeric min length falls back to the default instead of raising."""
     original = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH")
     current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = "not-a-number"  # noqa: S105
     try:
@@ -85,7 +89,7 @@ def test_validate_password_complexity_tolerates_invalid_min_length() -> None:
 
 
 def test_validate_password_complexity_blocklist_string_not_split() -> None:
-    # A misconfigured string blocklist must be treated as one entry, not chars.
+    """A bare-string blocklist is one entry, not split into characters."""
     original = current_app.config.get("AUTH_PASSWORD_COMMON_BLOCKLIST")
     current_app.config["AUTH_PASSWORD_COMMON_BLOCKLIST"] = "AcmeCorp2024"  # noqa: S105
     try:
@@ -95,3 +99,15 @@ def test_validate_password_complexity_blocklist_string_not_split() -> None:
         validate_password_complexity("a-Good-Long-Passphrase-42")
     finally:
         current_app.config["AUTH_PASSWORD_COMMON_BLOCKLIST"] = original
+
+
+def test_validate_password_complexity_clamps_non_positive_min_length() -> None:
+    """A zero or negative min length must not disable the length check."""
+    original = current_app.config.get("AUTH_PASSWORD_MIN_LENGTH")
+    for bad_value in (0, -1):
+        current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = bad_value
+        try:
+            with pytest.raises(PasswordComplexityValidationError):
+                validate_password_complexity("short1")  # < default 8
+        finally:
+            current_app.config["AUTH_PASSWORD_MIN_LENGTH"] = original


### PR DESCRIPTION


### SUMMARY

`SupersetSecurityManager` enforced **no** password policy, so DB-auth self-registration and password changes accepted trivially short or common passwords (FINDING-014 / 015 — ASVS 6.2.1, 6.2.4, CWE-521).

This adds `superset.security.password_complexity.validate_password_complexity`:
- **minimum length** via `AUTH_PASSWORD_MIN_LENGTH` (default **8**), and
- a **common-password blocklist** (built-in set of the most common passwords; extendable via `AUTH_PASSWORD_COMMON_BLOCKLIST`).

It's wired through Flask-AppBuilder's `FAB_PASSWORD_COMPLEXITY_ENABLED` + `FAB_PASSWORD_COMPLEXITY_VALIDATOR`. FAB runs this callable from **both** the WTForms password fields (self-registration, user edit, reset password) **and** the User REST API — so a single function covers every password-setting flow, with clean validation errors. The policy is intentionally less draconian than FAB's built-in `default_password_complexity` (which requires 2 uppercase + 1 special + 2 digits + 3 lowercase + length 10).

### WORTH NOTING

Enabling the policy by default changes behavior: short/common passwords are now rejected at registration, password change, and API-driven user provisioning. Needs validation that the form flows and the User API surface the error cleanly and that no existing automated provisioning relies on weak passwords.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/security/test_password_complexity.py
```

Tests: strong password accepted; short rejected; common rejected (case-insensitive); configurable min length; extra blocklist honored.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API (config-driven policy)
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
