### PR TITLE
feat(charts): validate post-processing options against per-operation schemas

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -22,7 +22,15 @@ from typing import Any, TYPE_CHECKING
 
 from flask import current_app
 from flask_babel import gettext as _
-from marshmallow import EXCLUDE, fields, post_load, Schema, validate
+from marshmallow import (
+    EXCLUDE,
+    fields,
+    post_load,
+    Schema,
+    validate,
+    validates_schema,
+    ValidationError,
+)
 from marshmallow.validate import Length, Range
 from marshmallow_union import Union
 
@@ -936,6 +944,42 @@ class ChartDataPostProcessingOperationSchema(Schema):
             },
         },
     )
+
+    # Map post-processing operation -> its options schema, for operations that
+    # declare one. Operations without a dedicated schema are not structurally
+    # validated here.
+    _OPTIONS_SCHEMAS: dict[str, type[Schema]] = {
+        "aggregate": ChartDataAggregateOptionsSchema,
+        "rolling": ChartDataRollingOptionsSchema,
+        "select": ChartDataSelectOptionsSchema,
+        "sort": ChartDataSortOptionsSchema,
+        "contribution": ChartDataContributionOptionsSchema,
+        "prophet": ChartDataProphetOptionsSchema,
+        "boxplot": ChartDataBoxplotOptionsSchema,
+        "pivot": ChartDataPivotOptionsSchema,
+        "geohash_decode": ChartDataGeohashDecodeOptionsSchema,
+        "geohash_encode": ChartDataGeohashEncodeOptionsSchema,
+        "geodetic_parse": ChartDataGeodeticParseOptionsSchema,
+    }
+
+    @validates_schema
+    def validate_options(self, data: dict[str, Any], **kwargs: Any) -> None:
+        """Validate ``options`` against the operation's option schema.
+
+        Validation is lenient (unknown keys are ignored) so it surfaces wrong
+        types / out-of-range values on declared fields without rejecting
+        payloads that carry extra keys.
+        """
+        operation = data.get("operation")
+        options = data.get("options")
+        if not isinstance(operation, str) or not isinstance(options, dict):
+            return
+        schema_cls = self._OPTIONS_SCHEMAS.get(operation)
+        if schema_cls is None:
+            return
+        errors = schema_cls(unknown=EXCLUDE).validate(options)
+        if errors:
+            raise ValidationError({"options": errors})
 
 
 class ChartDataFilterSchema(Schema):

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -152,3 +152,53 @@ def test_time_grain_validation_with_config_addons(app_context: None) -> None:
     }
     result = schema.load(custom_data)
     assert result["time_grain"] == "PT10M"
+
+
+def test_post_processing_operation_validates_options(app_context: None) -> None:
+    """options are validated against the operation's option schema (leniently)."""
+    from superset.charts.schemas import ChartDataPostProcessingOperationSchema
+
+    schema = ChartDataPostProcessingOperationSchema()
+
+    # Valid prophet options load.
+    schema.load(
+        {
+            "operation": "prophet",
+            "options": {
+                "time_grain": "P1D",
+                "periods": 7,
+                "confidence_interval": 0.8,
+            },
+        }
+    )
+
+    # Out-of-range confidence_interval (must be 0-1) on a declared field is
+    # rejected.
+    with pytest.raises(ValidationError) as exc_info:
+        schema.load(
+            {
+                "operation": "prophet",
+                "options": {
+                    "time_grain": "P1D",
+                    "periods": 7,
+                    "confidence_interval": 2.0,
+                },
+            }
+        )
+    assert "options" in exc_info.value.messages
+
+    # Extra/unknown keys are tolerated (lenient validation).
+    schema.load(
+        {
+            "operation": "prophet",
+            "options": {
+                "time_grain": "P1D",
+                "periods": 7,
+                "confidence_interval": 0.8,
+                "some_future_option": True,
+            },
+        }
+    )
+
+    # An operation without a dedicated schema accepts arbitrary options.
+    schema.load({"operation": "flatten", "options": {"anything": [1, 2, 3]}})


### PR DESCRIPTION
> **Draft / `hold:testing`** — wires previously-unused option schemas into validation. Needs a per-schema audit before strict validation (see "Why draft").

### SUMMARY

`ChartDataPostProcessingOperationSchema` accepted `options` as a free-form `fields.Dict()`. The per-operation option schemas (`ChartDataAggregateOptionsSchema`, `…RollingOptionsSchema`, `…ProphetOptionsSchema`, `…PivotOptionsSchema`, etc.) existed **only for OpenAPI docs** and were never connected to the validation pipeline (FINDING-029 / ASVS 2.1.1, CWE-20).

This adds a `@validates_schema` hook that maps each operation to its option schema and validates `options` against it. Validation is **lenient** (`unknown=EXCLUDE`): it surfaces wrong types / out-of-range values on **declared** fields without rejecting payloads that carry extra keys. Operations with no dedicated schema (e.g. `flatten`, `diff`, `compare`) are unaffected.

### WHY DRAFT (`hold:testing`)

These option schemas were never exercised as validators and have latent issues — e.g. `ChartDataAggregateOptionsSchema.groupby` is accidentally defined as a **tuple** (`groupby = (fields.List(...),)`), so it isn't a field and isn't validated. Before tightening to strict (`unknown=RAISE`) validation, each option schema should be audited against the real `pandas_postprocessing` signatures so currently-valid requests aren't rejected. The lenient approach here is the safe first step.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/charts/test_schemas.py -k post_processing_operation_validates
```

Test: valid prophet options load; an out-of-range `confidence_interval` is rejected (`options` error); extra/unknown keys are tolerated; a schema-less operation accepts arbitrary options.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
