### PR TITLE
fix(sqllab): Invalid multi sorting state in table header

### DIFF
--- a/superset-frontend/src/components/GridTable/Header.test.tsx
+++ b/superset-frontend/src/components/GridTable/Header.test.tsx
@@ -38,9 +38,70 @@ jest.mock('@superset-ui/core/components/Icons', () => {
   };
 });
 
-class MockApi extends EventTarget {
+class MockColumn {
+  private colListeners = new Map<string, Set<Function>>();
+
+  sortValue: string | null = 'asc';
+
+  sortIndexValue: number | null = null;
+
+  getColId() {
+    return '123';
+  }
+
+  isPinnedLeft() {
+    return true;
+  }
+
+  isPinnedRight() {
+    return false;
+  }
+
+  isVisible() {
+    return true;
+  }
+
+  getSort() {
+    return this.sortValue;
+  }
+
+  getSortIndex() {
+    return this.sortIndexValue;
+  }
+
+  addEventListener(eventType: string, listener: Function) {
+    if (!this.colListeners.has(eventType)) {
+      this.colListeners.set(eventType, new Set());
+    }
+    this.colListeners.get(eventType)!.add(listener);
+  }
+
+  removeEventListener(eventType: string, listener: Function) {
+    this.colListeners.get(eventType)?.delete(listener);
+  }
+
+  triggerEvent(eventType: string) {
+    this.colListeners.get(eventType)?.forEach(listener => listener({}));
+  }
+}
+
+class MockOtherColumn extends MockColumn {
+  getColId() {
+    return 'other-col';
+  }
+}
+
+class MockApi {
+  mockColumn = new MockColumn();
+
+  otherColumn = new MockOtherColumn();
+
   getAllDisplayedColumns() {
-    return [];
+    return [this.mockColumn, this.otherColumn];
+  }
+
+  getColumns() {
+    return [this.mockColumn, this.otherColumn];
   }
 
   isDestroyed() {
@@ -48,18 +109,14 @@ class MockApi extends EventTarget {
   }
 }
 
+const mockApi = new MockApi();
+
 const mockedProps = {
   displayName: 'test column',
-  setSort: jest.fn(),
+  progressSort: jest.fn(),
   enableSorting: true,
-  column: {
-    getColId: () => '123',
-    isPinnedLeft: () => true,
-    isPinnedRight: () => false,
-    getSort: () => 'asc',
-    getSortIndex: () => null,
-  } as any as Column,
-  api: new MockApi() as any as GridApi,
+  column: mockApi.mockColumn as any as Column,
+  api: mockApi as any as GridApi,
 };
 
 test('renders display name for the column', () => {
@@ -67,27 +124,59 @@ test('renders display name for the column', () => {
   expect(queryByText(mockedProps.displayName)).toBeInTheDocument();
 });
 
-test('sorts by clicking a column header', () => {
-  const { getByText, queryByTestId } = render(<Header {...mockedProps} />);
+test('calls progressSort without shiftKey on click', () => {
+  const { getByText } = render(<Header {...mockedProps} />);
   fireEvent.click(getByText(mockedProps.displayName));
-  expect(mockedProps.setSort).toHaveBeenCalledWith('asc', false);
-  expect(queryByTestId('mock-sort-asc')).toBeInTheDocument();
-  fireEvent.click(getByText(mockedProps.displayName));
-  expect(mockedProps.setSort).toHaveBeenCalledWith('desc', false);
-  expect(queryByTestId('mock-sort-desc')).toBeInTheDocument();
-  fireEvent.click(getByText(mockedProps.displayName));
-  expect(mockedProps.setSort).toHaveBeenCalledWith(null, false);
-  expect(queryByTestId('mock-sort-asc')).not.toBeInTheDocument();
-  expect(queryByTestId('mock-sort-desc')).not.toBeInTheDocument();
+  expect(mockedProps.progressSort).toHaveBeenCalledWith(false);
 });
 
-test('synchronizes the current sort when sortChanged event occurred', async () => {
-  const { findByTestId } = render(<Header {...mockedProps} />);
+test('calls progressSort with shiftKey on shift-click', () => {
+  const { getByText } = render(<Header {...mockedProps} />);
+  fireEvent.click(getByText(mockedProps.displayName), { shiftKey: true });
+  expect(mockedProps.progressSort).toHaveBeenCalledWith(true);
+});
+
+test('synchronizes sort icon when columnStateUpdated fires on column', async () => {
+  const { findByTestId, queryByTestId } = render(<Header {...mockedProps} />);
+  expect(queryByTestId('mock-sort-asc')).not.toBeInTheDocument();
+
   act(() => {
-    mockedProps.api.dispatchEvent(new Event('sortChanged'));
+    mockApi.mockColumn.triggerEvent('columnStateUpdated');
   });
+
   const sortAsc = await findByTestId('mock-sort-asc');
   expect(sortAsc).toBeInTheDocument();
+});
+
+test('shows sortIndex label when multi-sort is active', async () => {
+  const { findByText } = render(<Header {...mockedProps} />);
+
+  act(() => {
+    mockApi.mockColumn.sortIndexValue = 1;
+    mockApi.otherColumn.sortValue = 'desc';
+    mockApi.mockColumn.triggerEvent('columnStateUpdated');
+  });
+
+  const label = await findByText('2');
+  expect(label).toBeInTheDocument();
+});
+
+test('hides sortIndex label when multi-sort is cleared', async () => {
+  const { queryByText } = render(<Header {...mockedProps} />);
+
+  act(() => {
+    mockApi.mockColumn.sortIndexValue = 1;
+    mockApi.otherColumn.sortValue = 'desc';
+    mockApi.mockColumn.triggerEvent('columnStateUpdated');
+  });
+
+  act(() => {
+    mockApi.mockColumn.sortIndexValue = null;
+    mockApi.otherColumn.sortValue = null;
+    mockApi.mockColumn.triggerEvent('columnStateUpdated');
+  });
+
+  expect(queryByText('2')).not.toBeInTheDocument();
 });
 
 test('disable menu when enableFilterButton is false', () => {
@@ -99,18 +188,11 @@ test('disable menu when enableFilterButton is false', () => {
 });
 
 test('hide display name for PIVOT_COL_ID', () => {
+  const pivotColumn = new MockColumn();
+  (pivotColumn as any).getColId = () => PIVOT_COL_ID;
+
   const { queryByText } = render(
-    <Header
-      {...mockedProps}
-      column={
-        {
-          getColId: () => PIVOT_COL_ID,
-          isPinnedLeft: () => true,
-          isPinnedRight: () => false,
-          getSortIndex: () => null,
-        } as any as Column
-      }
-    />,
+    <Header {...mockedProps} column={pivotColumn as any as Column} />,
   );
   expect(queryByText(mockedProps.displayName)).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/components/GridTable/Header.test.tsx
+++ b/superset-frontend/src/components/GridTable/Header.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import type { Column, GridApi } from 'ag-grid-community';
+import type { Column, GridApi, IHeaderParams } from 'ag-grid-community';
 import { act, fireEvent, render } from 'spec/helpers/testing-library';
 import { Header } from './Header';
 import { PIVOT_COL_ID } from './constants';
@@ -117,7 +117,7 @@ const mockedProps = {
   enableSorting: true,
   column: mockApi.mockColumn as any as Column,
   api: mockApi as any as GridApi,
-};
+} as IHeaderParams;
 
 test('renders display name for the column', () => {
   const { queryByText } = render(<Header {...mockedProps} />);

--- a/superset-frontend/src/components/GridTable/Header.test.tsx
+++ b/superset-frontend/src/components/GridTable/Header.test.tsx
@@ -117,7 +117,7 @@ const mockedProps = {
   enableSorting: true,
   column: mockApi.mockColumn as any as Column,
   api: mockApi as any as GridApi,
-} as IHeaderParams;
+} as unknown as IHeaderParams;
 
 test('renders display name for the column', () => {
   const { queryByText } = render(<Header {...mockedProps} />);

--- a/superset-frontend/src/components/GridTable/Header.test.tsx
+++ b/superset-frontend/src/components/GridTable/Header.test.tsx
@@ -196,3 +196,31 @@ test('hide display name for PIVOT_COL_ID', () => {
   );
   expect(queryByText(mockedProps.displayName)).not.toBeInTheDocument();
 });
+
+test('does not attach click handler when enableSorting is false', () => {
+  const { getByText } = render(
+    <Header {...mockedProps} enableSorting={false} />,
+  );
+  const cell = getByText(mockedProps.displayName).closest(
+    '.ag-header-cell-label',
+  );
+  expect(cell).not.toHaveAttribute('role', 'button');
+});
+
+test('does not call progressSort on click when enableSorting is false', () => {
+  const progressSort = jest.fn();
+  const { getByText } = render(
+    <Header {...mockedProps} enableSorting={false} progressSort={progressSort} />,
+  );
+  fireEvent.click(getByText(mockedProps.displayName));
+  expect(progressSort).not.toHaveBeenCalled();
+});
+
+test('does not render sort icons when enableSorting is false', () => {
+  const { queryByTestId } = render(
+    <Header {...mockedProps} enableSorting={false} />,
+  );
+  expect(queryByTestId('mock-sort')).not.toBeInTheDocument();
+  expect(queryByTestId('mock-sort-asc')).not.toBeInTheDocument();
+  expect(queryByTestId('mock-sort-desc')).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/components/GridTable/Header.tsx
+++ b/superset-frontend/src/components/GridTable/Header.tsx
@@ -16,18 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  type MouseEvent,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import type { Column, GridApi, SortDirection } from 'ag-grid-community';
+
 import { t } from '@apache-superset/core/translation';
 import { styled, useTheme } from '@apache-superset/core/theme';
-import type { Column, GridApi } from 'ag-grid-community';
-
 import { Icons } from '@superset-ui/core/components/Icons';
+
 import { PIVOT_COL_ID } from './constants';
 import { HeaderMenu } from './HeaderMenu';
 
@@ -37,10 +32,8 @@ interface Params {
   displayName: string;
   column: Column;
   api: GridApi;
-  setSort: (sort: string | null, multiSort: boolean) => void;
+  progressSort: (multiSort?: boolean) => void;
 }
-
-const SORT_DIRECTION = [null, 'asc', 'desc'];
 
 const HeaderCell = styled.div`
   display: flex;
@@ -91,7 +84,7 @@ export const Header: React.FC<Params> = ({
   enableFilterButton,
   enableSorting,
   displayName,
-  setSort,
+  progressSort,
   column,
   api,
 }: Params) => {
@@ -99,18 +92,14 @@ export const Header: React.FC<Params> = ({
   const colId = column.getColId();
   const pinnedLeft = column.isPinnedLeft();
   const pinnedRight = column.isPinnedRight();
-  const sortOption = useRef<number>(0);
   const [invisibleColumns, setInvisibleColumns] = useState<Column[]>([]);
-  const [currentSort, setCurrentSort] = useState<string | null>(null);
+  const [currentSort, setCurrentSort] = useState<SortDirection>(null);
   const [sortIndex, setSortIndex] = useState<number | null>();
   const onSort = useCallback(
-    (event: MouseEvent) => {
-      sortOption.current = (sortOption.current + 1) % SORT_DIRECTION.length;
-      const sort = SORT_DIRECTION[sortOption.current];
-      setSort(sort, event.shiftKey);
-      setCurrentSort(sort);
+    (event: React.MouseEvent) => {
+      progressSort(event.shiftKey);
     },
-    [setSort],
+    [progressSort],
   );
   const onVisibleChange = useCallback(
     (isVisible: boolean) => {
@@ -123,24 +112,22 @@ export const Header: React.FC<Params> = ({
     [api],
   );
 
-  const onSortChanged = useCallback(() => {
+  const syncSortState = useCallback(() => {
     const hasMultiSort = api
       .getAllDisplayedColumns()
-      .some(c => c.getSortIndex());
-    const updatedSortIndex = column.getSortIndex();
-    sortOption.current = SORT_DIRECTION.indexOf(column.getSort() ?? null);
+      .some(c => c.getColId() !== colId && c.getSort() !== null);
     setCurrentSort(column.getSort() ?? null);
-    setSortIndex(hasMultiSort ? updatedSortIndex : null);
-  }, [api, column]);
+    setSortIndex(hasMultiSort ? column.getSortIndex() : null);
+  }, [api, column, colId]);
 
   useEffect(() => {
-    api.addEventListener('sortChanged', onSortChanged);
+    column.addEventListener('columnStateUpdated', syncSortState);
 
     return () => {
       if (api.isDestroyed()) return;
-      api.removeEventListener('sortChanged', onSortChanged);
+      column.removeEventListener('columnStateUpdated', syncSortState);
     };
-  }, [api, onSortChanged]);
+  }, [column, syncSortState]);
 
   return (
     <>

--- a/superset-frontend/src/components/GridTable/Header.tsx
+++ b/superset-frontend/src/components/GridTable/Header.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useCallback, useEffect, useState } from 'react';
-import type { Column, GridApi, SortDirection } from 'ag-grid-community';
+import type { IHeaderParams, SortDirection } from 'ag-grid-community';
 
 import { t } from '@apache-superset/core/translation';
 import { styled, useTheme } from '@apache-superset/core/theme';
@@ -25,15 +25,6 @@ import { Icons } from '@superset-ui/core/components/Icons';
 
 import { PIVOT_COL_ID } from './constants';
 import { HeaderMenu } from './HeaderMenu';
-
-interface Params {
-  enableFilterButton?: boolean;
-  enableSorting?: boolean;
-  displayName: string;
-  column: Column;
-  api: GridApi;
-  progressSort: (multiSort?: boolean) => void;
-}
 
 const HeaderCell = styled.div`
   display: flex;
@@ -80,14 +71,14 @@ const IconPlaceholder = styled.div`
   top: 0;
 `;
 
-export const Header: React.FC<Params> = ({
+export const Header: React.FC<IHeaderParams> = ({
   enableFilterButton,
   enableSorting,
   displayName,
   progressSort,
   column,
   api,
-}: Params) => {
+}: IHeaderParams) => {
   const theme = useTheme();
   const colId = column.getColId();
   const pinnedLeft = column.isPinnedLeft();

--- a/superset-frontend/src/components/GridTable/Header.tsx
+++ b/superset-frontend/src/components/GridTable/Header.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useCallback, useEffect, useState } from 'react';
-import type { IHeaderParams, SortDirection } from 'ag-grid-community';
+import type { IHeaderParams, Column, SortDirection } from 'ag-grid-community';
 
 import { t } from '@apache-superset/core/translation';
 import { styled, useTheme } from '@apache-superset/core/theme';


### PR DESCRIPTION
### SUMMARY
Fixes invalid multi-sort state in the AG Grid table header component after upgrading to ag-grid-community v35.

Root cause: passing null via setSort triggered an equality check inside _areSortDefsEqual that silently skipped dispatchColEvent('sortChanged'), so the sortChanged listener never fired when clearing a sort.

Changes:
- Replaced setSort with progressSort — AG Grid internally computes the next sort direction from sortingOrder, eliminating the need for the component to track sort state via a useRef cycle and avoiding the null-dispatch bug entirely.
- Replaced api.addEventListener('sortChanged', cb) with column.addEventListener('columnStateUpdated', cb) — columnStateUpdated fires synchronously via colEventSvc after both the sort direction and sortIndex are written, whereas sortChanged fires before updateSortIndex completes (stale getSortIndex()) and is dispatched asynchronously.
- Multi-sort detection changed from iterating getAllDisplayedColumns() with a falsy getSortIndex() check (broken for 0-based index) to c.getColId() !== colId && c.getSort() !== null — checks other columns' sort direction rather than relying on index truthiness.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before

https://github.com/user-attachments/assets/a4ec9f59-2579-419a-b8fe-d77145b916d4

- After

https://github.com/user-attachments/assets/a11ff02b-6e20-4d37-9548-c78370daaab0


### TESTING INSTRUCTIONS

1. Open a table chart with multiple sortable columns.
2. Click a column header to sort ascending → verify sort icon appears.
3. Shift-click a second column → verify both columns show sort icons with sequence numbers (1, 2).
4. Click the first column again to cycle through desc → no sort → verify the second column's sort index updates to 1 and its sequence number updates accordingly.
5. Run npm run test -- Header.test.tsx — all 8 tests should pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
