### PR TITLE
fix(mcp): escape LIKE wildcards in MCP list tool search filters

### DIFF
--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -80,13 +80,24 @@ class ColumnOperatorEnum(str, Enum):
         return op_func(column, value)
 
 
+def _escape_like(value: str) -> str:
+    """Escape LIKE/ILIKE wildcards to prevent wildcard injection."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 # Define operator_map as a module-level dict after the enum is defined
 operator_map: Dict[ColumnOperatorEnum, Any] = {
     ColumnOperatorEnum.eq: lambda col, val: col == val,
     ColumnOperatorEnum.ne: lambda col, val: col != val,
-    ColumnOperatorEnum.sw: lambda col, val: col.like(f"{val}%"),
-    ColumnOperatorEnum.ew: lambda col, val: col.like(f"%{val}"),
-    ColumnOperatorEnum.ct: lambda col, val: col.ilike(f"%{val}%"),
+    ColumnOperatorEnum.sw: lambda col, val: col.like(
+        f"{_escape_like(val)}%", escape="\\"
+    ),
+    ColumnOperatorEnum.ew: lambda col, val: col.like(
+        f"%{_escape_like(val)}", escape="\\"
+    ),
+    ColumnOperatorEnum.ct: lambda col, val: col.ilike(
+        f"%{_escape_like(val)}%", escape="\\"
+    ),
     ColumnOperatorEnum.in_: lambda col, val: col.in_(
         val if isinstance(val, (list, tuple)) else [val]
     ),
@@ -97,8 +108,12 @@ operator_map: Dict[ColumnOperatorEnum, Any] = {
     ColumnOperatorEnum.gte: lambda col, val: col >= val,
     ColumnOperatorEnum.lt: lambda col, val: col < val,
     ColumnOperatorEnum.lte: lambda col, val: col <= val,
-    ColumnOperatorEnum.like: lambda col, val: col.like(f"%{val}%"),
-    ColumnOperatorEnum.ilike: lambda col, val: col.ilike(f"%{val}%"),
+    ColumnOperatorEnum.like: lambda col, val: col.like(
+        f"%{_escape_like(val)}%", escape="\\"
+    ),
+    ColumnOperatorEnum.ilike: lambda col, val: col.ilike(
+        f"%{_escape_like(val)}%", escape="\\"
+    ),
     ColumnOperatorEnum.is_null: lambda col, _: col.is_(None),
     ColumnOperatorEnum.is_not_null: lambda col, _: col.isnot(None),
 }
@@ -632,11 +647,6 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
 
         return result
 
-    @staticmethod
-    def _escape_like(value: str) -> str:
-        """Escape LIKE/ILIKE wildcards to prevent wildcard injection."""
-        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
     @classmethod
     def _build_query(
         cls,
@@ -664,7 +674,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
                     column = getattr(cls.model_cls, column_name)
                     search_filters.append(
                         cast(column, Text).ilike(
-                            f"%{cls._escape_like(search)}%", escape="\\"
+                            f"%{_escape_like(search)}%", escape="\\"
                         )
                     )
             if search_filters:
@@ -735,7 +745,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
                     column = getattr(cls.model_cls, column_name)
                     search_filters.append(
                         cast(column, Text).ilike(
-                            f"%{cls._escape_like(search)}%", escape="\\"
+                            f"%{_escape_like(search)}%", escape="\\"
                         )
                     )
             if search_filters:

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -632,6 +632,11 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
 
         return result
 
+    @staticmethod
+    def _escape_like(value: str) -> str:
+        """Escape LIKE/ILIKE wildcards to prevent wildcard injection."""
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
     @classmethod
     def _build_query(
         cls,
@@ -657,7 +662,11 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
             for column_name in search_columns:
                 if hasattr(cls.model_cls, column_name):
                     column = getattr(cls.model_cls, column_name)
-                    search_filters.append(cast(column, Text).ilike(f"%{search}%"))
+                    search_filters.append(
+                        cast(column, Text).ilike(
+                            f"%{cls._escape_like(search)}%", escape="\\"
+                        )
+                    )
             if search_filters:
                 query = query.filter(or_(*search_filters))
         if custom_filters:
@@ -724,7 +733,11 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
             for column_name in search_columns:
                 if hasattr(cls.model_cls, column_name):
                     column = getattr(cls.model_cls, column_name)
-                    search_filters.append(cast(column, Text).ilike(f"%{search}%"))
+                    search_filters.append(
+                        cast(column, Text).ilike(
+                            f"%{cls._escape_like(search)}%", escape="\\"
+                        )
+                    )
             if search_filters:
                 query = query.filter(or_(*search_filters))
         if custom_filters:

--- a/tests/integration_tests/dao/base_dao_test.py
+++ b/tests/integration_tests/dao/base_dao_test.py
@@ -838,6 +838,46 @@ def test_base_dao_list_search_wildcard_injection(user_with_data: Session) -> Non
     user_with_data.commit()
 
 
+def test_base_dao_list_column_operator_wildcard_injection(
+    user_with_data: Session,
+) -> None:
+    """Verify that column_operators with '%' values are treated literally."""
+    users = []
+    for i in range(3):
+        user = User(
+            id=430 + i,
+            username=f"opwildcard_{i}",
+            first_name=f"OpWild{i}",
+            last_name="Card",
+            email=f"opwild{i}@example.com",
+            active=True,
+        )
+        users.append(user)
+        user_with_data.add(user)
+    user_with_data.commit()
+
+    # Each wildcard operator with '%' as the value must not match plain-name rows
+    for opr in (
+        ColumnOperatorEnum.ct,
+        ColumnOperatorEnum.like,
+        ColumnOperatorEnum.ilike,
+        ColumnOperatorEnum.sw,
+        ColumnOperatorEnum.ew,
+    ):
+        results, _ = UserDAO.list(
+            column_operators=[ColumnOperator(col="username", opr=opr, value="%")]
+        )
+        result_usernames = {r.username for r in results}
+        for user in users:
+            assert user.username not in result_usernames, (
+                f"opr={opr!r} with value='%' should not match '{user.username}'"
+            )
+
+    for user in users:
+        user_with_data.delete(user)
+    user_with_data.commit()
+
+
 def test_base_dao_list_custom_filter(user_with_data: Session) -> None:
     """Test BaseDAO.list with custom filters."""
     # Create users with specific attributes

--- a/tests/integration_tests/dao/base_dao_test.py
+++ b/tests/integration_tests/dao/base_dao_test.py
@@ -809,6 +809,35 @@ def test_base_dao_list_search(user_with_data: Session) -> None:
     user_with_data.commit()
 
 
+def test_base_dao_list_search_wildcard_injection(user_with_data: Session) -> None:
+    """Verify that search='%' is treated literally and does not match all rows."""
+    users = []
+    for i in range(3):
+        user = User(
+            id=420 + i,
+            username=f"nowildcard_{i}",
+            first_name=f"NoWild{i}",
+            last_name="Card",
+            email=f"nowild{i}@example.com",
+            active=True,
+        )
+        users.append(user)
+        user_with_data.add(user)
+    user_with_data.commit()
+
+    # '%' must be escaped; it should not match any of our plain-name users
+    results, total = UserDAO.list(search="%", search_columns=["username", "first_name"])
+    result_usernames = {r.username for r in results}
+    for user in users:
+        assert user.username not in result_usernames, (
+            f"search='%' should not match '{user.username}' — LIKE wildcard injection"
+        )
+
+    for user in users:
+        user_with_data.delete(user)
+    user_with_data.commit()
+
+
 def test_base_dao_list_custom_filter(user_with_data: Session) -> None:
     """Test BaseDAO.list with custom filters."""
     # Create users with specific attributes


### PR DESCRIPTION
### SUMMARY

All 10+ MCP list tools (`list_users`, `list_rls_filters`, `list_roles`, `list_reports`, etc.) delegate to `BaseDAO._build_query()` and `BaseDAO.list()` in `superset/daos/base.py`. Both methods build search filters with:

```python
cast(column, Text).ilike(f"%{search}%")
```

`search="%"` is a single character that passes every existing Pydantic validator. The resulting pattern `ILIKE '%%'` matches **every row**, allowing an admin to enumerate all records regardless of the intended search intent — LIKE wildcard injection.

**Fix:** Added a `_escape_like()` static method that escapes `\`, `%`, and `_` before interpolation, and passes `escape="\\"` to `ilike()`. Applied at **both** call sites.

```python
@staticmethod
def _escape_like(value: str) -> str:
    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

# usage
cast(column, Text).ilike(f"%{cls._escape_like(search)}%", escape="\\")
```

All affected tools are admin-only (the MCP API enforces admin authentication), so blast radius is limited. Related prior fix for `find_users`: #40631.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

1. Run the new regression test:
   ```bash
   pytest tests/integration_tests/dao/base_dao_test.py::test_base_dao_list_search_wildcard_injection -v
   ```
2. Verify `search="%"` returns 0 results for an admin with no users whose username contains a literal `%`.
3. Verify `search="admin"` still returns users matching "admin" normally.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API