### PR TITLE
fix(dashboard): clean up JSON formatting and contribution suffix in V…

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
@@ -37,10 +37,28 @@ export function useGridColumns(
             .filter((column: string) => Object.keys(data[0]).includes(column))
             .map((key, index) => {
               const colType = coltypes?.[index];
-              const headerLabel = columnDisplayNames?.[key] ?? key;
+
+              const rawHeader = columnDisplayNames?.[key] ?? key;
+              let cleanHeader = rawHeader;
+
+              try {
+                let jsonToParse = rawHeader;
+                let suffix = '';
+
+                if (rawHeader.endsWith('__contribution')) {
+                  jsonToParse = rawHeader.replace('__contribution', '');
+                  suffix = ' (contribution)';
+                }
+
+                const parsed = JSON.parse(jsonToParse);
+                if (parsed && typeof parsed === 'object' && parsed.label) {
+                  cleanHeader = `${parsed.label}${suffix}`;
+                }
+              } catch (_) {}
+
               return {
                 label: key,
-                headerName: headerLabel,
+                headerName: cleanHeader,
                 render: ({ value }: { value: unknown }) => {
                   if (value === true) {
                     return Constants.BOOL_TRUE_DISPLAY;

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
@@ -24,11 +24,13 @@ import {
   getMetricLabel,
   QueryFormMetric,
 } from '@superset-ui/core';
+import { t } from '@apache-superset/core/translation';
 import { Constants } from '@superset-ui/core/components';
 import { GenericDataType } from '@apache-superset/core/common';
 import type { IRowNode } from 'ag-grid-community';
 
 const timeFormatter = getTimeFormatter(TimeFormats.DATABASE_DATETIME);
+const CONTRIBUTION_SUFFIX = '__contribution';
 
 export function useGridColumns(
   colnames: string[] | undefined,
@@ -45,17 +47,15 @@ export function useGridColumns(
               const colType = coltypes?.[index];
 
               const rawHeader = columnDisplayNames?.[key] ?? key;
-              let cleanHeader = rawHeader;
-
               let cleaned = rawHeader;
               let suffix = '';
 
-              if (rawHeader.endsWith('__contribution')) {
+              if (rawHeader.endsWith(CONTRIBUTION_SUFFIX)) {
                 cleaned = rawHeader.slice(
                   0,
-                  rawHeader.length - '__contribution'.length,
+                  rawHeader.length - CONTRIBUTION_SUFFIX.length,
                 );
-                suffix = ' (contribution)';
+                suffix = ` (${t('contribution')})`;
               }
 
               try {
@@ -67,7 +67,7 @@ export function useGridColumns(
                 /* not a JSON-encoded metric – keep original display name */
               }
 
-              cleanHeader = `${cleaned}${suffix}`;
+              const cleanHeader = `${cleaned}${suffix}`;
 
               return {
                 label: key,

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useGridResultTable.tsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 import { useMemo, useCallback, useRef, useState } from 'react';
-import { getTimeFormatter, safeHtmlSpan, TimeFormats } from '@superset-ui/core';
+import {
+  getTimeFormatter,
+  safeHtmlSpan,
+  TimeFormats,
+  getMetricLabel,
+  QueryFormMetric,
+} from '@superset-ui/core';
 import { Constants } from '@superset-ui/core/components';
 import { GenericDataType } from '@apache-superset/core/common';
 import type { IRowNode } from 'ag-grid-community';
@@ -41,20 +47,27 @@ export function useGridColumns(
               const rawHeader = columnDisplayNames?.[key] ?? key;
               let cleanHeader = rawHeader;
 
+              let cleaned = rawHeader;
+              let suffix = '';
+
+              if (rawHeader.endsWith('__contribution')) {
+                cleaned = rawHeader.slice(
+                  0,
+                  rawHeader.length - '__contribution'.length,
+                );
+                suffix = ' (contribution)';
+              }
+
               try {
-                let jsonToParse = rawHeader;
-                let suffix = '';
-
-                if (rawHeader.endsWith('__contribution')) {
-                  jsonToParse = rawHeader.replace('__contribution', '');
-                  suffix = ' (contribution)';
+                const parsed = JSON.parse(cleaned);
+                if (parsed && typeof parsed === 'object') {
+                  cleaned = getMetricLabel(parsed as QueryFormMetric);
                 }
+              } catch {
+                /* not a JSON-encoded metric – keep original display name */
+              }
 
-                const parsed = JSON.parse(jsonToParse);
-                if (parsed && typeof parsed === 'object' && parsed.label) {
-                  cleanHeader = `${parsed.label}${suffix}`;
-                }
-              } catch (_) {}
+              cleanHeader = `${cleaned}${suffix}`;
 
               return {
                 label: key,

--- a/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
@@ -227,4 +227,44 @@ describe('DataTablesPane', () => {
       screen.queryByLabelText('Collapse data panel'),
     ).not.toBeInTheDocument();
   });
+
+  test('Should handle column label rendering and clean up headers properly via hook', async () => {
+    fetchMock.post(
+      'glob:*/api/v1/chart/data?form_data=%7B%22slice_id%22%3A111%7D',
+      {
+        result: [
+          {
+            data: [
+              {
+                plain_column: 'val1',
+                revenue__contribution: 'val2',
+                '{"label": "Custom Metric"}': 'val3',
+                '{"label": "Custom Metric"}__contribution': 'val4',
+              },
+            ],
+            colnames: [
+              'plain_column',
+              'revenue__contribution',
+              '{"label": "Custom Metric"}',
+              '{"label": "Custom Metric"}__contribution',
+            ],
+            coltypes: [1, 1, 1, 1],
+            rowcount: 1,
+            sql_rowcount: 1,
+          },
+        ],
+      },
+    );
+
+    const props = createDataTablesPaneProps(111);
+    render(<DataTablesPane {...props} />, { useRedux: true });
+    userEvent.click(screen.getByText('Results'));
+
+    expect(await screen.findByText('plain_column')).toBeVisible();
+    expect(screen.getByText('revenue (contribution)')).toBeVisible();
+    expect(screen.getByText('Custom Metric')).toBeVisible();
+    expect(screen.getByText('Custom Metric (contribution)')).toBeVisible();
+
+    fetchMock.clearHistory().removeRoutes();
+  });
 });


### PR DESCRIPTION
### SUMMARY
This PR fixes a bug where the "View as Table" modal displays raw JSON strings (e.g., `{"label": "..."}`) and raw suffixes (e.g., `__contribution`) in column headers instead of clean, human-readable labels. 

This builds directly on top of the previous autonomous attempt to resolve the custom-labeled metrics bug, ensuring data row values populate correctly without breaking AG Grid field matching while fully cleaning up the header names.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before (Raw JSON)
<img width="1918" height="1012" alt="34" src="https://github.com/user-attachments/assets/4e06d21b-e280-4568-8f2e-1b0b6da5e528" />

#### After (Clean Headers)
<img width="1907" height="1042" alt="45" src="https://github.com/user-attachments/assets/9160c480-7b4b-4804-bc39-51711abfecc4" />

### TESTING INSTRUCTIONS
1. Open a dashboard containing a Pie Chart that uses custom metric labels.
2. Click the three dots (`...`) on the chart and select **View as table**.
3. Verify that the table headers show clean names and that the row data populates numbers correctly instead of saying `undefined`.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #40432
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API