### PR TITLE
fix(mcp): address post-approval review feedback on auth logging PR #40646

### DIFF
--- a/superset/mcp_service/chart/validation/pipeline.py
+++ b/superset/mcp_service/chart/validation/pipeline.py
@@ -149,8 +149,10 @@ class ValidationPipeline:
                 ChartErrorBuilder,
             )
 
-            # SECURITY FIX: Sanitize validation error to prevent information disclosure
-            sanitized_reason = _sanitize_validation_error(e)
+            # SECURITY FIX: Sanitize validation error to prevent information disclosure.
+            # logger.exception above already logged the original error; pass
+            # log_original=False so the sanitizer does not log it a second time at INFO.
+            sanitized_reason = _sanitize_validation_error(e, log_original=False)
             error = ChartErrorBuilder.build_error(
                 error_type="validation_system_error",
                 template_key="validation_error",

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -564,7 +564,7 @@ class DetailedJWTVerifier(MCPJWTVerifier):
                 "JWT authentication succeeded: client_id='%s', scopes=%s, "
                 "auth_method='bearer_jwt'",
                 _sanitize_for_log(client_id),
-                _sanitize_for_log(" ".join(sorted(scopes))),
+                _sanitize_for_log(" ".join(sorted(scopes)) or "(none)"),
             )
             return AccessToken(
                 token=token,

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -325,7 +325,7 @@ def _auth_error_handler(conn: HTTPConnection, exc: AuthenticationError) -> Respo
 
     logger.warning(
         "JWT authentication failed: %s (source_ip=%s, path=%s, user_agent=%s)",
-        exc,
+        _sanitize_for_log(exc),
         client_host,
         request_path,
         user_agent,
@@ -564,7 +564,7 @@ class DetailedJWTVerifier(MCPJWTVerifier):
                 "JWT authentication succeeded: client_id='%s', scopes=%s, "
                 "auth_method='bearer_jwt'",
                 _sanitize_for_log(client_id),
-                _sanitize_for_log(sorted(scopes)),
+                _sanitize_for_log(" ".join(sorted(scopes))),
             )
             return AccessToken(
                 token=token,


### PR DESCRIPTION
### SUMMARY
Follow-up to #40646. That PR was squash-merged before @aminghadersohi's re-review (posted after the `merge-if-green` label) was addressed, so this PR resolves those points:

- **MEDIUM — double-log in the chart validation pipeline.** `chart/validation/pipeline.py` already `logger.exception("Validation pipeline error")`s the original error, then called `_sanitize_validation_error(e)` which (with the new `log_original=True` default added in #40646) logged the same error again at INFO. Pass `log_original=False` at that call site.
- **NIT — sanitize `exc` in `_auth_error_handler`.** Wrap it with `_sanitize_for_log` for consistency with the defense-in-depth applied to every other auth log site.
- **NIT — readable scopes in the success log.** `" ".join(sorted(scopes))` so the line reads `scopes=read write` instead of `['read', 'write']`.

### TESTING INSTRUCTIONS
`pytest tests/unit_tests/mcp_service/test_jwt_verifier.py` (28 passed). pre-commit clean (mypy/ruff/pylint).

### ADDITIONAL INFORMATION
- [ ] Has associated issue
- [x] Required feature flags: n/a
- [x] Changes UI: no
- [x] Includes DB Migration: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)