### PR TITLE
fix(dashboard): address post-approval review feedback on #40528

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -254,7 +254,9 @@ const PropertiesModal = ({
     selectedOwners: OwnerOption[],
     options: OwnerOption[],
   ) => {
-    setOwners(parseSelectedOwners(selectedOwners, options, owners));
+    // Use the functional updater so the parse always reads the latest owners
+    // state rather than the value captured in this render's closure.
+    setOwners(prev => parseSelectedOwners(selectedOwners, options, prev));
   };
 
   const handleOnChangeRoles = (roles: { value: number; label: string }[]) => {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/utils.test.ts
@@ -60,13 +60,14 @@ test('builds a new owner from the option text label when not already in state', 
 });
 
 test('falls back to a string label when the option has no text label', () => {
+  // No option in the cache => email stays undefined (not an empty string).
   expect(
     parseSelectedOwners([{ value: 4, label: 'Plain Name' }], [], []),
-  ).toEqual([{ id: 4, full_name: 'Plain Name', email: '' }]);
+  ).toEqual([{ id: 4, full_name: 'Plain Name', email: undefined }]);
 });
 
 test('yields an empty name for a non-string label with no text label', () => {
   expect(parseSelectedOwners([{ value: 5, label: 1 }], [], [])).toEqual([
-    { id: 5, full_name: '', email: '' },
+    { id: 5, full_name: '', email: undefined },
   ]);
 });

--- a/superset-frontend/src/dashboard/components/PropertiesModal/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/utils.test.ts
@@ -59,6 +59,23 @@ test('builds a new owner from the option text label when not already in state', 
   ]);
 });
 
+test('leaves email undefined when option is cached but carries no email', () => {
+  // The option exists in the cache (so `opt` is defined) but has no
+  // OWNER_EMAIL_PROP, exercising the `?? undefined` branch directly.
+  const options = [
+    {
+      value: 6,
+      label: 'Dave Doe',
+      [OWNER_TEXT_LABEL_PROP]: 'Dave Doe',
+      // intentionally no OWNER_EMAIL_PROP
+    },
+  ];
+
+  expect(
+    parseSelectedOwners([{ value: 6, label: 'Dave Doe' }], options, []),
+  ).toEqual([{ id: 6, full_name: 'Dave Doe', email: undefined }]);
+});
+
 test('falls back to a string label when the option has no text label', () => {
   // No option in the cache => email stays undefined (not an empty string).
   expect(

--- a/superset-frontend/src/dashboard/components/PropertiesModal/utils.ts
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/utils.ts
@@ -73,7 +73,9 @@ export function parseSelectedOwners(
         // `label` is a React element unless the option came from a plain-text
         // source, so only use it as a name when it is actually a string.
         (typeof o.label === 'string' ? o.label : ''),
-      email: opt?.[OWNER_EMAIL_PROP] || '',
+      // Leave email undefined when the option carries no email, rather than
+      // fabricating an empty string — keeps the optional `email?` type honest.
+      email: opt?.[OWNER_EMAIL_PROP] ?? undefined,
     };
   });
 }


### PR DESCRIPTION
### SUMMARY
Follow-up to #40528. That PR was squash-merged before @aminghadersohi's re-review (posted after the `merge-if-green` label) was addressed, so this PR resolves those points:

- **MEDIUM — stale `owners` closure in `handleOnChangeOwners`.** Switched to the functional updater `setOwners(prev => parseSelectedOwners(selectedOwners, options, prev))` so the parse always reads the latest `owners` state rather than the value captured at render time. `selectedOwners`/`options` come from the `onChange` call and are closed over correctly; only the prior-state read needed the functional form.
- **NIT — `email` empty-string vs undefined.** `parseSelectedOwners` now leaves `email` undefined when the option carries no email (instead of `|| ''`), keeping the optional `email?` type honest. Unit tests updated.

### TESTING INSTRUCTIONS
`npm run test -- src/dashboard/components/PropertiesModal/utils.test.ts` (4 passed). prettier / oxlint / frontend type-check clean.

### ADDITIONAL INFORMATION
- [ ] Has associated issue
- [x] Required feature flags: n/a
- [x] Changes UI: no (behavior-preserving hardening)
- [x] Includes DB Migration: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)