### PR TITLE
fix(dashboard): hide Edit button in embedded dashboards

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -611,6 +611,21 @@ test('should toggle the edit mode', () => {
   expect(logEvent).toHaveBeenCalled();
 });
 
+test('should NOT render the Edit dashboard button when embedded', () => {
+  // Embedded (Embedded SDK) dashboards authenticate with a guest token and so
+  // have no userId. The Edit button must be hidden even with edit permission,
+  // since the embedded context cannot handle entering/exiting edit mode.
+  const embeddedCanEditState = {
+    dashboardInfo: {
+      ...initialState.dashboardInfo,
+      dash_edit_perm: true,
+      userId: undefined,
+    },
+  };
+  setup(embeddedCanEditState);
+  expect(screen.queryByTestId('edit-dashboard-button')).not.toBeInTheDocument();
+});
+
 test('should render the dropdown icon', () => {
   setup();
   expect(screen.getByRole('img', { name: 'ellipsis' })).toBeInTheDocument();

--- a/superset-frontend/src/dashboard/components/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/index.tsx
@@ -749,7 +749,7 @@ const Header = (): JSX.Element => {
         ) : (
           <div css={actionButtonsStyle}>
             {NavExtension && <NavExtension />}
-            {userCanEdit && (
+            {userCanEdit && !isEmbedded && (
               <Button
                 buttonStyle="secondary"
                 onClick={handleEnterEditMode}
@@ -776,6 +776,7 @@ const Header = (): JSX.Element => {
       handleCtrlZ,
       handleEnterEditMode,
       hasUnsavedChanges,
+      isEmbedded,
       overwriteDashboard,
       redoLength,
       undoLength,


### PR DESCRIPTION
### SUMMARY

Embedded dashboards (rendered via the Embedded SDK) authenticate with a guest token, so they have no logged-in `userId`. The dashboard header already derives embedded state from this (`isEmbedded = !dashboardInfo?.userId`, used elsewhere e.g. to hide the metadata bar), but the **Edit dashboard** button was gated only on `userCanEdit`. As a result it rendered inside embedded dashboards, where editing isn't a supported flow.

Per #30893, clicking **Edit dashboard** → **Discard** in an embedded dashboard leaves the iframe stuck on a perpetual loading screen (the discard navigation can't resolve in the embedded context). Hiding the Edit button removes that broken entry point.

This gates the Edit button on `!isEmbedded` in addition to `userCanEdit`. No behavior change for normal (logged-in) dashboards.

Closes #30893

### BEFORE/AFTER

Before: embedded dashboards with edit permission show the **Edit dashboard** button → entering edit mode and discarding hangs the iframe.
After: the **Edit dashboard** button is not rendered in embedded dashboards.

### TESTING INSTRUCTIONS

1. Embed a dashboard via the Embedded SDK with a guest token whose role has edit permission.
2. Confirm the **Edit dashboard** button no longer appears.
3. Confirm a normal (logged-in) dashboard with edit permission still shows the button and can enter edit mode.

Unit test added: `Header.test.tsx` → "should NOT render the Edit dashboard button when embedded" (asserts the button is absent when `userId` is undefined even with `dash_edit_perm: true`).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)