### PR TITLE
fix(deps): revert joserfc JWT error migration — fastmcp still uses authlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,6 @@ exasol = ["sqlalchemy-exasol >= 2.4.0, < 8.0"]
 excel = ["xlrd>=1.2.0, <1.3"]
 fastmcp = [
     "fastmcp>=3.2.4,<4.0",
-    "joserfc>=1.0.0,<2.0",
     # tiktoken backs the response-size-guard token estimator. Without
     # it, the middleware falls back to a coarser character-based
     # heuristic that under-counts JSON-heavy MCP responses.

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -183,7 +183,6 @@ cryptography==46.0.7
     #   -c requirements/base-constraint.txt
     #   apache-superset
     #   authlib
-    #   joserfc
     #   paramiko
     #   pyjwt
     #   pyopenssl
@@ -472,8 +471,6 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-joserfc==1.6.8
-    # via apache-superset
 jsonpath-ng==1.7.0
     # via
     #   -c requirements/base-constraint.txt

--- a/superset/mcp_service/jwt_verifier.py
+++ b/superset/mcp_service/jwt_verifier.py
@@ -33,14 +33,14 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, cast
 
-from fastmcp.server.auth.auth import AccessToken
-from fastmcp.server.auth.providers.jwt import JWTVerifier
-from joserfc.errors import (
+from authlib.jose.errors import (
     BadSignatureError,
     DecodeError,
     ExpiredTokenError,
     JoseError,
 )
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.providers.jwt import JWTVerifier
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend
 from starlette.authentication import AuthenticationError

--- a/tests/unit_tests/mcp_service/test_jwt_verifier.py
+++ b/tests/unit_tests/mcp_service/test_jwt_verifier.py
@@ -23,7 +23,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from joserfc.errors import BadSignatureError, DecodeError, ExpiredTokenError
+from authlib.jose.errors import BadSignatureError, DecodeError, ExpiredTokenError
 
 from superset.mcp_service.jwt_verifier import (
     _auth_error_handler,
@@ -108,7 +108,7 @@ async def test_signature_verification_failed(hs256_verifier):
     with patch.object(
         hs256_verifier.jwt,
         "decode",
-        side_effect=BadSignatureError(),
+        side_effect=BadSignatureError(result=None),
     ):
         result = await hs256_verifier.load_access_token(token)
 
@@ -686,7 +686,7 @@ async def test_expired_token_during_decode(hs256_verifier):
     with patch.object(
         hs256_verifier.jwt,
         "decode",
-        side_effect=ExpiredTokenError("exp"),
+        side_effect=ExpiredTokenError(),
     ):
         result = await hs256_verifier.load_access_token(token)
 


### PR DESCRIPTION
## Summary

Reverts #40582 (`chore(deps): migrate MCP service JWT errors from authlib.jose to joserfc`).

The migration was premature. `fastmcp` through at least version 3.3.1 still uses `authlib` internally — `JWTVerifier.__init__` sets `self.jwt = JsonWebToken([self.algorithm])` from `authlib.jose`. The Superset `DetailedJWTVerifier` inherits this and calls `self.jwt.decode()`, which raises `authlib.jose.errors.*` exceptions.

After #40582, the catch blocks in `DetailedJWTVerifier.load_access_token()` were updated to catch `joserfc.errors.*` classes, which have a completely separate class hierarchy (`authlib.jose.errors.JoseError → AuthlibBaseError → Exception` vs `joserfc.errors.JoseError → Exception`). The authlib exceptions are not caught, propagate through Starlette's `AuthenticationMiddleware` (which only catches `AuthenticationError`), and produce **500 Internal Server Error** instead of 401 for every invalid or expired token.

The unit tests in #40582 did not catch this because they mock `self.jwt.decode` with `side_effect=joserfc.errors.BadSignatureError()` — the mock raises a joserfc exception that IS caught. The real authlib object raises authlib exceptions.

## Changes

- Reverts `superset/mcp_service/jwt_verifier.py`: restores `from authlib.jose.errors import`; restores original import order
- Reverts `tests/unit_tests/mcp_service/test_jwt_verifier.py`: restores authlib-compatible constructor calls (`BadSignatureError(result=None)`, `ExpiredTokenError()`)
- Reverts `pyproject.toml`: removes `joserfc>=1.0.0,<2.0` from fastmcp extras
- Reverts `requirements/development.txt`: removes `joserfc==1.6.8` pin

## When to re-do the migration

When a version of `fastmcp` within the `>=3.2.4,<4.0` constraint replaces `authlib.jose.JsonWebToken` with a joserfc-based JWT object internally, the migration can be re-applied. At that point `self.jwt.decode()` will raise joserfc exceptions and the catch blocks will match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)