### PR TITLE
fix(mcp): escape LIKE wildcards in find_users tool

### DIFF
--- a/superset/mcp_service/system/tool/find_users.py
+++ b/superset/mcp_service/system/tool/find_users.py
@@ -64,17 +64,20 @@ async def find_users(request: FindUsersRequest, ctx: Context) -> FindUsersRespon
     )
 
     user_model = security_manager.user_model
-    needle = f"%{request.query.strip()}%"
+    escaped = (
+        request.query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    )
+    needle = f"%{escaped}%"
 
     with event_logger.log_context(action="mcp.find_users.query"):
         query = (
             db.session.query(user_model)
             .filter(
                 or_(
-                    user_model.username.ilike(needle),
-                    user_model.first_name.ilike(needle),
-                    user_model.last_name.ilike(needle),
-                    user_model.email.ilike(needle),
+                    user_model.username.ilike(needle, escape="\\"),
+                    user_model.first_name.ilike(needle, escape="\\"),
+                    user_model.last_name.ilike(needle, escape="\\"),
+                    user_model.email.ilike(needle, escape="\\"),
                 )
             )
             .order_by(user_model.username.asc())

--- a/tests/unit_tests/mcp_service/system/tool/test_find_users.py
+++ b/tests/unit_tests/mcp_service/system/tool/test_find_users.py
@@ -206,6 +206,104 @@ def test_find_users_request_strips_query_whitespace():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.asyncio
+async def test_find_users_escapes_percent_wildcard(mcp_server):
+    """query='%' must not match every user — percent is escaped before LIKE."""
+    session, chain = _patch_user_query([])
+
+    with (
+        patch.object(find_users_module, "db") as mock_db,
+        patch.object(find_users_module, "security_manager") as mock_sm,
+        patch.object(find_users_module, "or_"),
+    ):
+        mock_db.session = session
+        user_col = MagicMock()
+        mock_sm.user_model = MagicMock(
+            username=user_col,
+            first_name=user_col,
+            last_name=user_col,
+            email=user_col,
+        )
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("find_users", {"request": {"query": "%"}})
+
+    # The needle passed to ilike must have the literal percent escaped.
+    ilike_calls = user_col.ilike.call_args_list
+    assert ilike_calls, "ilike was never called"
+    needle_arg = ilike_calls[0].args[0]
+    assert needle_arg == "%\\%%", f"Expected '%\\%%' but got {needle_arg!r}"
+    # Each call must pass escape="\\"
+    for call in ilike_calls:
+        assert call.kwargs.get("escape") == "\\", (
+            f"escape kwarg missing or wrong: {call.kwargs!r}"
+        )
+
+    data = json.loads(result.content[0].text)
+    assert data["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_find_users_escapes_underscore_wildcard(mcp_server):
+    """query='_' must not match single-character names — underscore is escaped."""
+    session, chain = _patch_user_query([])
+
+    with (
+        patch.object(find_users_module, "db") as mock_db,
+        patch.object(find_users_module, "security_manager") as mock_sm,
+        patch.object(find_users_module, "or_"),
+    ):
+        mock_db.session = session
+        user_col = MagicMock()
+        mock_sm.user_model = MagicMock(
+            username=user_col,
+            first_name=user_col,
+            last_name=user_col,
+            email=user_col,
+        )
+
+        async with Client(mcp_server) as client:
+            await client.call_tool("find_users", {"request": {"query": "_"}})
+
+    ilike_calls = user_col.ilike.call_args_list
+    assert ilike_calls, "ilike was never called"
+    needle_arg = ilike_calls[0].args[0]
+    assert needle_arg == "%\\_%", f"Expected '%\\_%' but got {needle_arg!r}"
+    for call in ilike_calls:
+        assert call.kwargs.get("escape") == "\\", (
+            f"escape kwarg missing or wrong: {call.kwargs!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_find_users_escapes_backslash(mcp_server):
+    """A literal backslash in the query must itself be escaped."""
+    session, chain = _patch_user_query([])
+
+    with (
+        patch.object(find_users_module, "db") as mock_db,
+        patch.object(find_users_module, "security_manager") as mock_sm,
+        patch.object(find_users_module, "or_"),
+    ):
+        mock_db.session = session
+        user_col = MagicMock()
+        mock_sm.user_model = MagicMock(
+            username=user_col,
+            first_name=user_col,
+            last_name=user_col,
+            email=user_col,
+        )
+
+        async with Client(mcp_server) as client:
+            await client.call_tool("find_users", {"request": {"query": "\\"}})
+
+    ilike_calls = user_col.ilike.call_args_list
+    assert ilike_calls, "ilike was never called"
+    needle_arg = ilike_calls[0].args[0]
+    # single backslash in query -> double backslash in needle, wrapped in %…%
+    assert needle_arg == "%\\\\%", f"Expected '%\\\\\\\\%' but got {needle_arg!r}"
+
+
 @patch("superset.daos.dashboard.DashboardDAO.list")
 @pytest.mark.asyncio
 async def test_list_dashboards_passes_created_by_fk_filter_to_dao(


### PR DESCRIPTION
### SUMMARY

The `find_users` MCP tool built its LIKE needle without escaping SQL LIKE metacharacters:

```python
needle = f"%{request.query.strip()}%"
```

A caller passing `query="%"` produced `needle="%%"` which matched every user via `ILIKE '%%'`. Similarly `query="_"` matched any single-character username/name. The `_reject_blank_query` validator correctly blocked empty strings but `%` and `_` are single non-whitespace characters that passed all validators.

This directly contradicted the docstring's claim that "this tool does not enumerate the full user directory."

**Fix:** Escape `\`, `%`, and `_` before building the needle and pass `escape="\\"` to each `ilike()` call so the database treats them as literals:

```python
escaped = (
    request.query
    .replace("\\", "\\\\")
    .replace("%", "\\%")
    .replace("_", "\\_")
)
needle = f"%{escaped}%"
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change.

### TESTING INSTRUCTIONS

1. Run the unit tests: `pytest tests/unit_tests/mcp_service/system/tool/test_find_users.py -v`
2. Three new tests verify wildcard escaping: `test_find_users_escapes_percent_wildcard`, `test_find_users_escapes_underscore_wildcard`, `test_find_users_escapes_backslash`
3. All existing tests continue to pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API