### PR TITLE
ci(bashlib): drop the dead bc-based NONCE (perf + reliability)

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -20,10 +20,6 @@ set -e
 GITHUB_WORKSPACE=${GITHUB_WORKSPACE:-.}
 ASSETS_MANIFEST="$GITHUB_WORKSPACE/superset/static/assets/manifest.json"
 
-# Rounded job start time, used to create a unique Cypress build id for
-# parallelization so we can manually rerun a job after 20 minutes
-NONCE=$(echo "$(date "+%Y%m%d%H%M") - ($(date +%M)%20)" | bc)
-
 # Echo only when not in parallel mode
 say() {
   if [[ $(echo "$INPUT_PARALLEL" | tr '[:lower:]' '[:upper:]') != 'TRUE' ]]; then


### PR DESCRIPTION
### SUMMARY
`bashlib.sh` computes `NONCE` at the top level on every source:
```bash
NONCE=$(echo "$(date "+%Y%m%d%H%M") - ($(date +%M)%20)" | bc)
```
…but **`NONCE` is never referenced anywhere in the repo** (confirmed with `git grep NONCE` — only this definition line). It's dead code.

**Performance:** it runs two `date` subshells plus an external `bc` on *every* `cached-dependencies` action invocation (npm-install, build-instrumented-assets, build-embedded-sdk, playwright-install, cypress-*), for a value nobody uses.

**Reliability:** `bashlib.sh` runs under `set -e`, and this is the only top-level line that shells out. If `bc` is not present on a runner image (it is not guaranteed to be), or the expression otherwise errors, **sourcing aborts here — before the shortcut functions below it are defined**. The action then invokes the requested shortcut and dies with `<cmd>: command not found` (exit 127). This is a strong candidate for the intermittent **"Build embedded SDK" playwright failures** (`build-embedded-sdk: command not found`) that have been blocking merges, since `build-embedded-sdk()` is defined *after* this line.

Removing the unused line is behaviorally a no-op and eliminates both the per-source cost and the failure mode.

### BEFORE/AFTER
Before: every bashlib source runs `bc` + 2 `date` calls for an unused var; a missing `bc` aborts sourcing under `set -e`.
After: line removed; all shortcut functions source reliably regardless of `bc` availability.

### TESTING INSTRUCTIONS
`bash -n .github/workflows/bashlib.sh` passes; `source`-ing the file still defines `build-embedded-sdk` and the other shortcuts. `git grep NONCE` shows no remaining references.

### ADDITIONAL INFORMATION
- [ ] Has associated issue
- [x] Required feature flags: n/a
- [x] Changes UI: no
- [x] Includes DB Migration: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)