### PR TITLE
feat(charts): Customizable filter names for dynamic titles

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -76,6 +76,7 @@ erd.puml
 erd.svg
 intro_header.txt
 TODO.md
+HOTUPDATE.md
 
 # for LLMs
 llm-context.md

--- a/HOTUPDATE.md
+++ b/HOTUPDATE.md
@@ -1,0 +1,32 @@
+# How to enable hot update with Apache Superset
+
+1. Clone the Superset repo
+```
+git clone https://github.com/apache/superset.git
+```
+
+2. Install dependenices on the local frontend
+```
+cd superset-frontend
+npm install
+```
+
+3. Start the local frontend
+```
+cd superset-frontend
+npm run dev-server
+```
+
+4. Update `docker-compose.override.yml` to point to local frontend
+```
+version: "3"
+services:
+  superset:
+    volumes:
+      - ./superset-frontend:/app/superset-frontend
+```
+
+5. Start Docker instance
+```
+docker compose -f docker-compose-light.yml up
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "css566-bugslife-superset",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -22229,6 +22229,15 @@
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
       "license": "ISC"
     },
+    "node_modules/d3-cloud": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/d3-cloud/-/d3-cloud-1.2.9.tgz",
+      "integrity": "sha512-leL1GLneC9ZQtnV+6TGWrNlGfI1WX7S2arcTv2vae12DaXo5wjm6GBCkskXbrDlyOymd/A75Pyj1H37MW4BZ/Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3"
+      }
+    },
     "node_modules/d3-collection": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
@@ -33630,21 +33639,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/css-tree": {
@@ -49680,21 +49674,6 @@
         }
       }
     },
-    "node_modules/whatwg-url/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/whatwg-url/node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -51130,17 +51109,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/superset-ui-core/node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "packages/superset-ui-core/node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
@@ -52159,12 +52127,6 @@
         "node": ">=12"
       }
     },
-    "plugins/legacy-plugin-chart-horizon/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC"
-    },
     "plugins/legacy-plugin-chart-map-box": {
       "name": "@superset-ui/legacy-plugin-chart-map-box",
       "version": "0.20.3",
@@ -52332,41 +52294,6 @@
         "react-map-gl": "^6.1.19"
       }
     },
-    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/aggregation-layers": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.2.11.tgz",
-      "integrity": "sha512-MRFbBHtMcDkOthxXnMPm6nF08DjFDACaIQsJSyHkdWtLUTSLHsWnOTn/8QbB4ka86WyNyfJy3dibLu/m3ei2ow==",
-      "license": "MIT",
-      "dependencies": {
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/shadertools": "~9.2.6",
-        "@math.gl/core": "^4.1.0",
-        "@math.gl/web-mercator": "^4.1.0",
-        "d3-hexbin": "^0.2.1"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@deck.gl/layers": "~9.2.0",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6"
-      }
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/extensions": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.2.11.tgz",
-      "integrity": "sha512-zlpM4Bg1ifBziW1Juiii9NY5gyW2rEhyVTWnhagH/bpTCZ2E73OhnToYt1ouqmoxL6lMtIjhRXz6LPb7tJbHHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/shadertools": "~9.2.6",
-        "@math.gl/core": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6"
-      }
-    },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/mesh-layers": {
       "version": "9.2.5",
       "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.2.5.tgz",
@@ -52384,18 +52311,6 @@
         "@luma.gl/engine": "~9.2.4",
         "@luma.gl/gltf": "~9.2.4",
         "@luma.gl/shadertools": "~9.2.4"
-      }
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/react": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.2.11.tgz",
-      "integrity": "sha512-7xrXlM++3A7cKZdDKSW2/EPT6sc0ob7J24sTPaHe3YlIIFvCZTkQ1U1rAT9cN2gjhkI6XsE+TugUsqhx4TGwHQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@deck.gl/widgets": "~9.2.0",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@luma.gl/gltf": {
@@ -52433,12 +52348,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC"
     },
     "plugins/legacy-preset-chart-nvd3": {
       "name": "@superset-ui/legacy-preset-chart-nvd3",
@@ -52716,15 +52625,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
-      }
-    },
-    "plugins/plugin-chart-word-cloud/node_modules/d3-cloud": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/d3-cloud/-/d3-cloud-1.2.8.tgz",
-      "integrity": "sha512-K0qBFkgystNlgFW/ufdwIES5kDiC8cGJxMw4ULzN9UU511v89A6HXs1X8vUPxqurehzqJZS5KzZI4c8McT+4UA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dispatch": "^1.0.3"
       }
     },
     "tools/eslint-i18n-strings": {

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
@@ -69,6 +69,7 @@ export type Filter = {
   defaultDataMask: DataMask;
   id: string; // randomly generated at filter creation
   name: string;
+  titleLabel?: string;
   scope: NativeFilterScope;
   filterType: string;
   targets: Partial<NativeFilterTarget>[];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/controlPanel.tsx
@@ -120,6 +120,19 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [<ControlSubSectionHeader>{t('Chart Title')}</ControlSubSectionHeader>],
+        [
+          {
+            name: 'show_dynamic_title',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show dynamic chart title'),
+              renderTrigger: true,
+              default: false,
+              description: t('Update the chart title dynamically based on the data.'),
+            },
+          },
+        ],
       ],
     },
   ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/types.ts
@@ -40,6 +40,7 @@ export type EchartsTreemapFormData = QueryFormData & {
   labelPosition: LabelPositionEnum;
   showLabels: boolean;
   showUpperLabels: boolean;
+  showDynamicTitle: boolean;
   numberFormat: string;
   dateFormat: string;
   dashboardId?: number;
@@ -63,6 +64,7 @@ export const DEFAULT_FORM_DATA: Partial<EchartsTreemapFormData> = {
   numberFormat: 'SMART_NUMBER',
   showLabels: true,
   showUpperLabels: true,
+  showDynamicTitle: false,
   dateFormat: 'smart_date',
 };
 export interface TreemapSeriesCallbackDataParams extends CallbackDataParams {

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -118,6 +118,10 @@ export const FiltersDetailsContainer = styled.div`
     overflow-x: hidden;
 
     color: ${theme.colorText};
+    
+    &:focus:not(:focus-visible) {
+      outline: none;
+    }
   `}
 `;
 

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -118,7 +118,7 @@ export const FiltersDetailsContainer = styled.div`
     overflow-x: hidden;
 
     color: ${theme.colorText};
-    
+
     &:focus:not(:focus-visible) {
       outline: none;
     }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -1007,6 +1007,30 @@ const FiltersConfigForm = (
                     </StyledFormItem>
                   )}
                 </StyledContainer>
+                {!isChartCustomization && (
+                  <StyledRowContainer>
+                    <StyledFormItem
+                      expanded={expanded}
+                      name={['filters', filterId, 'titleLabel']}
+                      label={
+                        <StyledLabel>
+                          {t('Chart title label')}
+                          <InfoTooltip
+                            tooltip={t(
+                              'When set, this label is used instead of the filter name in dynamic chart titles.',
+                            )}
+                          />
+                        </StyledLabel>
+                      }
+                      initialValue={filterToEdit?.titleLabel}
+                    >
+                      <Input
+                        placeholder={t('e.g. West Coast Region')}
+                        onChange={debouncedFormChanged}
+                      />
+                    </StyledFormItem>
+                  </StyledRowContainer>
+                )}
                 {formFilter?.filterType === 'filter_time' && (
                   <FilterTypeInfo expanded={expanded}>
                     {t(`Dashboard time range filters apply to temporal columns defined in

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/filterTransformer.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/filterTransformer.ts
@@ -131,6 +131,7 @@ function transformFormInput(
     requiredFirst: formInputs.requiredFirst
       ? Object.values(formInputs.requiredFirst).find(rf => rf)
       : undefined,
+    titleLabel: formInputs.titleLabel || undefined,
   };
 }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
@@ -32,6 +32,7 @@ import { ReactNode } from 'react';
 export interface NativeFiltersFormItem {
   scope: NativeFilterScope;
   name: string;
+  titleLabel?: string;
   filterType: string;
   dataset: {
     value: number;

--- a/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
@@ -199,6 +199,7 @@ const getRejectedColumns = (chart: any): Set<string> =>
 export type Indicator = {
   column?: QueryFormColumn;
   name: string;
+  titleLabel?: string;
   value?: any;
   status?: IndicatorStatus;
   path?: string[];

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -391,6 +391,158 @@ describe('ExploreChartHeader', () => {
     );
   });
 
+  test('does not allow editing title when showDynamicTitle is enabled', async () => {
+    const props = createProps({
+      formData: {
+        ...createProps().chart.latestQueryFormData,
+        showDynamicTitle: true,
+        adhoc_filters: [{ subject: 'country' }],
+      },
+      chart: {
+        ...createProps().chart,
+        queriesResponse: [
+          {
+            applied_filters: [{ column: 'country' }],
+          },
+        ],
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    const titleInput = await screen.findByDisplayValue(
+      'Age distribution of respondents by country',
+    );
+    expect(titleInput).toBeDisabled();
+
+    await userEvent.click(titleInput);
+    expect(props.actions.updateChartTitle).not.toHaveBeenCalled();
+  });
+
+  test('shows dynamic title in chart properties modal', async () => {
+    const props = createProps({
+      formData: {
+        ...createProps().chart.latestQueryFormData,
+        showDynamicTitle: true,
+        adhoc_filters: [{ subject: 'country' }],
+      },
+      chart: {
+        ...createProps().chart,
+        queriesResponse: [
+          {
+            applied_filters: [{ column: 'country' }],
+          },
+        ],
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    await userEvent.click(screen.getByLabelText('Menu actions trigger'));
+    await userEvent.click(screen.getByText('Edit chart properties'));
+
+    const nameInput = await screen.findByRole('textbox', { name: 'Name' });
+    expect(nameInput).toHaveValue('Age distribution of respondents by country');
+  });
+
+  test('does not append duplicate dynamic suffix when title already matches', async () => {
+    const props = createProps({
+      sliceName: 'Age distribution of respondents by country',
+      formData: {
+        ...createProps().chart.latestQueryFormData,
+        showDynamicTitle: true,
+        adhoc_filters: [{ subject: 'country' }],
+      },
+      chart: {
+        ...createProps().chart,
+        queriesResponse: [
+          {
+            applied_filters: [{ column: 'country' }],
+          },
+        ],
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    expect(
+      await screen.findByDisplayValue(
+        'Age distribution of respondents by country',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByDisplayValue(
+        'Age distribution of respondents by country by country',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test('updates dynamic title when filters are added, edited, or removed', async () => {
+    const baseProps = createProps({
+      formData: {
+        ...createProps().chart.latestQueryFormData,
+        showDynamicTitle: true,
+        adhoc_filters: [],
+      },
+      chart: {
+        ...createProps().chart,
+        queriesResponse: null,
+      },
+    });
+
+    const { rerender } = render(<ExploreHeader {...baseProps} />, {
+      useRedux: true,
+    });
+
+    expect(
+      await screen.findByDisplayValue('Age distribution of respondents'),
+    ).toBeInTheDocument();
+
+    rerender(
+      <ExploreHeader
+        {...baseProps}
+        formData={{
+          ...baseProps.formData,
+          adhoc_filters: [{ subject: 'country' }],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByDisplayValue(
+        'Age distribution of respondents by country',
+      ),
+    ).toBeInTheDocument();
+
+    rerender(
+      <ExploreHeader
+        {...baseProps}
+        formData={{
+          ...baseProps.formData,
+          adhoc_filters: [{ subject: 'state' }],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByDisplayValue('Age distribution of respondents by state'),
+    ).toBeInTheDocument();
+
+    rerender(
+      <ExploreHeader
+        {...baseProps}
+        formData={{
+          ...baseProps.formData,
+          adhoc_filters: [],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByDisplayValue('Age distribution of respondents'),
+    ).toBeInTheDocument();
+  });
+
   test('Save chart', async () => {
     const setSaveChartModalVisibilitySpy = jest.spyOn(
       saveModalActions,

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -241,6 +241,46 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     [originalFormData, currentFormData],
   );
 
+  const displayTitle = useMemo(() => {
+    const shouldShowDynamicTitle =
+      formData?.show_dynamic_title === true ||
+      formData?.showDynamicTitle === true;
+    if (!shouldShowDynamicTitle) {
+      return sliceName ?? '';
+    }
+
+    const appliedFilters = chart.queriesResponse?.[0]?.applied_filters;
+    const activeFilterNames = Array.isArray(appliedFilters)
+      ? [
+          ...new Set(
+            appliedFilters
+              .map(filter => {
+                if (!filter || typeof filter !== 'object') {
+                  return undefined;
+                }
+                const filterMeta = filter as Record<string, unknown>;
+                const candidates = [
+                  filterMeta.column,
+                  filterMeta.label,
+                  filterMeta.name,
+                ];
+                return candidates.find(
+                  candidate =>
+                    typeof candidate === 'string' && candidate.length > 0,
+                ) as string | undefined;
+              })
+              .filter((name): name is string => Boolean(name)),
+          ),
+        ]
+      : [];
+
+    if (!activeFilterNames.length) {
+      return sliceName ?? '';
+    }
+
+    return `${sliceName ?? ''} by ${activeFilterNames.join(', ')}`;
+  }, [chart.queriesResponse, formData, sliceName]);
+
   const {
     showModal: showUnsavedChangesModal,
     setShowModal: setShowUnsavedChangesModal,
@@ -274,12 +314,13 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     <>
       <PageHeaderWithActions
         editableTitleProps={{
-          title: sliceName ?? '',
+          title: displayTitle,
           canEdit:
             !slice ||
-            canOverwrite ||
-            (user?.userId !== undefined &&
-              (slice?.owners || []).includes(user.userId)),
+            ((canOverwrite ||
+              (user?.userId !== undefined &&
+                (slice?.owners || []).includes(user.userId))) &&
+             formData?.show_dynamic_title !== true),
           onSave: actions.updateChartTitle,
           placeholder: t('Add the name of the chart'),
           label: t('Chart title'),

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -19,7 +19,7 @@
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import { QueryFormData, JsonObject } from '@superset-ui/core';
+import { QueryFormData, JsonObject, LatestQueryFormData } from '@superset-ui/core';
 import {
   Tooltip,
   Button,
@@ -59,7 +59,7 @@ interface ExploreActions {
   fetchFaveStar: (sliceId: number) => void;
   saveFaveStar: (sliceId: number, isStarred: boolean) => void;
   redirectSQLLab: (
-    formData: QueryFormData,
+    formData: QueryFormData | LatestQueryFormData,
     history?: ReturnType<typeof useHistory> | false,
   ) => void;
 }
@@ -191,7 +191,7 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
   const { redirectSQLLab } = actions;
 
   const redirectToSQLLab = useCallback(
-    (redirectFormData: QueryFormData, openNewWindow = false) => {
+    (redirectFormData: LatestQueryFormData, openNewWindow = false) => {
       redirectSQLLab(redirectFormData, !openNewWindow && history);
     },
     [redirectSQLLab, history],

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -251,6 +251,12 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     }
 
     const filterMeta = filter as Record<string, unknown>;
+    if (
+      typeof filterMeta.titleLabel === 'string' &&
+      filterMeta.titleLabel.length > 0
+    ) {
+      return filterMeta.titleLabel;
+    }
     const subject = filterMeta.subject;
     const subjectName =
       typeof subject === 'string'

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -236,50 +236,100 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     [formData, sliceName],
   );
 
+  const shouldShowDynamicTitle =
+    formData?.show_dynamic_title === true ||
+    formData?.showDynamicTitle === true;
+
   const formDiffs = useMemo(
     () => getChartFormDiffs(originalFormData, currentFormData),
     [originalFormData, currentFormData],
   );
 
+  const getFilterName = useCallback((filter: unknown): string | undefined => {
+    if (!filter || typeof filter !== 'object') {
+      return undefined;
+    }
+
+    const filterMeta = filter as Record<string, unknown>;
+    const subject = filterMeta.subject;
+    const subjectName =
+      typeof subject === 'string'
+        ? subject
+        : subject && typeof subject === 'object'
+          ? [
+              (subject as Record<string, unknown>).label,
+              (subject as Record<string, unknown>).column_name,
+              (subject as Record<string, unknown>).name,
+              (subject as Record<string, unknown>).column,
+            ].find(
+              candidate =>
+                typeof candidate === 'string' && candidate.length > 0,
+            )
+          : undefined;
+
+    if (typeof subjectName === 'string' && subjectName.length > 0) {
+      return subjectName;
+    }
+
+    const candidates = [filterMeta.column, filterMeta.label, filterMeta.name];
+    return candidates.find(
+      candidate => typeof candidate === 'string' && candidate.length > 0,
+    ) as string | undefined;
+  }, []);
+
+  const getBaseTitleWithoutDynamicSuffix = useCallback((title: string) => {
+    return title.replace(/\s+by\s+.+$/i, '').trimEnd();
+  }, []);
+
   const displayTitle = useMemo(() => {
-    const shouldShowDynamicTitle =
-      formData?.show_dynamic_title === true ||
-      formData?.showDynamicTitle === true;
     if (!shouldShowDynamicTitle) {
-      return sliceName ?? '';
+      return getBaseTitleWithoutDynamicSuffix(sliceName ?? '');
     }
 
     const appliedFilters = chart.queriesResponse?.[0]?.applied_filters;
-    const activeFilterNames = Array.isArray(appliedFilters)
+    const adhocFilters = formData?.adhoc_filters;
+    const extraFormData = formData?.extra_form_data as
+      | Record<string, unknown>
+      | undefined;
+    const nativeFilters = extraFormData?.filters;
+
+    const hasFormDataFilterSource =
+      Array.isArray(adhocFilters) || Array.isArray(nativeFilters);
+    const activeFilters = hasFormDataFilterSource
+      ? [
+          ...(Array.isArray(adhocFilters) ? adhocFilters : []),
+          ...(Array.isArray(nativeFilters) ? nativeFilters : []),
+        ]
+      : Array.isArray(appliedFilters)
+        ? appliedFilters
+        : [];
+
+    const activeFilterNames = Array.isArray(activeFilters)
       ? [
           ...new Set(
-            appliedFilters
-              .map(filter => {
-                if (!filter || typeof filter !== 'object') {
-                  return undefined;
-                }
-                const filterMeta = filter as Record<string, unknown>;
-                const candidates = [
-                  filterMeta.column,
-                  filterMeta.label,
-                  filterMeta.name,
-                ];
-                return candidates.find(
-                  candidate =>
-                    typeof candidate === 'string' && candidate.length > 0,
-                ) as string | undefined;
-              })
+            activeFilters
+              .map(filter => getFilterName(filter))
               .filter((name): name is string => Boolean(name)),
           ),
         ]
       : [];
 
+    const baseTitle = getBaseTitleWithoutDynamicSuffix(sliceName ?? '');
+
     if (!activeFilterNames.length) {
-      return sliceName ?? '';
+      return baseTitle;
     }
 
-    return `${sliceName ?? ''} by ${activeFilterNames.join(', ')}`;
-  }, [chart.queriesResponse, formData, sliceName]);
+    const dynamicSuffix = `by ${activeFilterNames.join(', ')}`;
+    return baseTitle ? `${baseTitle} ${dynamicSuffix}` : dynamicSuffix;
+  }, [
+    chart.queriesResponse,
+    formData,
+    getBaseTitleWithoutDynamicSuffix,
+    getFilterName,
+    shouldShowDynamicTitle,
+    sliceName,
+  ]);
 
   const {
     showModal: showUnsavedChangesModal,
@@ -320,7 +370,7 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
             ((canOverwrite ||
               (user?.userId !== undefined &&
                 (slice?.owners || []).includes(user.userId))) &&
-             formData?.show_dynamic_title !== true),
+             !shouldShowDynamicTitle),
           onSave: actions.updateChartTitle,
           placeholder: t('Add the name of the chart'),
           label: t('Chart title'),
@@ -386,6 +436,7 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
       {isPropertiesModalOpen && (
         <PropertiesModal
           show={isPropertiesModalOpen}
+          initialName={displayTitle}
           onHide={closePropertiesModal}
           onSave={updateSlice}
           slice={slice}

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -106,7 +106,11 @@ jest.mock(
 
 jest.mock('lodash/debounce', () => ({
   __esModule: true,
-  default: (fuc: Function) => fuc,
+  default: (fuc: Function) => {
+    const debounced = (...args: unknown[]) => fuc(...args);
+    (debounced as { cancel: () => void }).cancel = jest.fn();
+    return debounced;
+  },
 }));
 
 fetchMock.post('glob:*/api/v1/explore/form_data*', { key: KEY });
@@ -184,6 +188,134 @@ test('renders chart in standalone mode', () => {
     },
   });
   expect(queryByTestId('standalone-app')).toBeInTheDocument();
+});
+
+test('prefills SaveModal with dynamic title when enabled', async () => {
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: 'Age distribution of respondents',
+      controls: {
+        ...reduxState.explore.controls,
+        show_dynamic_title: { value: true },
+      },
+    },
+    charts: {
+      ...reduxState.charts,
+      1: {
+        ...reduxState.charts[1],
+        queriesResponse: [
+          {
+            applied_filters: [{ column: 'country' }],
+          },
+        ],
+      },
+    },
+    saveModal: {
+      isVisible: true,
+      dashboards: [],
+      saveModalAlert: null,
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const chartNameInput = await screen.findByTestId('new-chart-name');
+  expect(chartNameInput).toHaveValue(
+    'Age distribution of respondents by country',
+  );
+});
+
+test('does not duplicate dynamic suffix in SaveModal prefill when already matched', async () => {
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: 'Age distribution of respondents by country',
+      controls: {
+        ...reduxState.explore.controls,
+        show_dynamic_title: { value: true },
+      },
+    },
+    charts: {
+      ...reduxState.charts,
+      1: {
+        ...reduxState.charts[1],
+        queriesResponse: [
+          {
+            applied_filters: [{ column: 'country' }],
+          },
+        ],
+      },
+    },
+    saveModal: {
+      isVisible: true,
+      dashboards: [],
+      saveModalAlert: null,
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const chartNameInput = await screen.findByTestId('new-chart-name');
+  expect(chartNameInput).toHaveValue('Age distribution of respondents by country');
+});
+
+test('prefills SaveModal title from current adhoc filters when dynamic title is enabled', async () => {
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: 'Age distribution of respondents',
+      controls: {
+        ...reduxState.explore.controls,
+        show_dynamic_title: { value: true },
+        adhoc_filters: { value: [{ subject: 'state' }] },
+      },
+    },
+    charts: {
+      ...reduxState.charts,
+      1: {
+        ...reduxState.charts[1],
+        queriesResponse: null,
+      },
+    },
+    saveModal: {
+      isVisible: true,
+      dashboards: [],
+      saveModalAlert: null,
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const chartNameInput = await screen.findByTestId('new-chart-name');
+  expect(chartNameInput).toHaveValue('Age distribution of respondents by state');
+});
+
+test('strips dynamic suffix from SaveModal prefill when dynamic title is disabled', async () => {
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: 'Age distribution of respondents by country',
+      controls: {
+        ...reduxState.explore.controls,
+        show_dynamic_title: { value: false },
+      },
+    },
+    saveModal: {
+      isVisible: true,
+      dashboards: [],
+      saveModalAlert: null,
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const chartNameInput = await screen.findByTestId('new-chart-name');
+  expect(chartNameInput).toHaveValue('Age distribution of respondents');
 });
 
 test('generates a form_data param with datasource_id when mounting with existing key', async () => {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
@@ -320,6 +320,12 @@ function getDisplaySliceTitle(
     }
 
     const filterMeta = filter as Record<string, unknown>;
+    if (
+      typeof filterMeta.titleLabel === 'string' &&
+      filterMeta.titleLabel.length > 0
+    ) {
+      return filterMeta.titleLabel;
+    }
     const subject = filterMeta.subject;
     const subjectName =
       typeof subject === 'string'

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
@@ -281,6 +281,91 @@ function isAggregatedChartType(vizType: string | undefined): boolean {
   return vizType ? AGGREGATED_CHART_TYPES.includes(vizType) : false;
 }
 
+function getDisplaySliceTitle(
+  sliceName: string | null,
+  formData: QueryFormData,
+  chart: ChartState,
+): string {
+  const getBaseTitleWithoutDynamicSuffix = (title: string) =>
+    title.replace(/\s+by\s+.+$/i, '').trimEnd();
+
+  const shouldShowDynamicTitle =
+    formData?.show_dynamic_title === true ||
+    formData?.showDynamicTitle === true;
+  if (!shouldShowDynamicTitle) {
+    return getBaseTitleWithoutDynamicSuffix(sliceName ?? '');
+  }
+
+  const appliedFilters = chart.queriesResponse?.[0]?.applied_filters;
+  const adhocFilters = formData?.adhoc_filters;
+  const extraFormData = formData?.extra_form_data as
+    | Record<string, unknown>
+    | undefined;
+  const nativeFilters = extraFormData?.filters;
+
+  const hasFormDataFilterSource =
+    Array.isArray(adhocFilters) || Array.isArray(nativeFilters);
+  const activeFilters = hasFormDataFilterSource
+    ? [
+        ...(Array.isArray(adhocFilters) ? adhocFilters : []),
+        ...(Array.isArray(nativeFilters) ? nativeFilters : []),
+      ]
+    : Array.isArray(appliedFilters)
+      ? appliedFilters
+      : [];
+
+  const getFilterName = (filter: unknown): string | undefined => {
+    if (!filter || typeof filter !== 'object') {
+      return undefined;
+    }
+
+    const filterMeta = filter as Record<string, unknown>;
+    const subject = filterMeta.subject;
+    const subjectName =
+      typeof subject === 'string'
+        ? subject
+        : subject && typeof subject === 'object'
+          ? [
+              (subject as Record<string, unknown>).label,
+              (subject as Record<string, unknown>).column_name,
+              (subject as Record<string, unknown>).name,
+              (subject as Record<string, unknown>).column,
+            ].find(
+              candidate =>
+                typeof candidate === 'string' && candidate.length > 0,
+            )
+          : undefined;
+
+    if (typeof subjectName === 'string' && subjectName.length > 0) {
+      return subjectName;
+    }
+
+    const candidates = [filterMeta.column, filterMeta.label, filterMeta.name];
+    return candidates.find(
+      candidate => typeof candidate === 'string' && candidate.length > 0,
+    ) as string | undefined;
+  };
+
+  const activeFilterNames = Array.isArray(activeFilters)
+    ? [
+        ...new Set(
+          activeFilters
+            .map(filter => getFilterName(filter))
+            .filter((name): name is string => Boolean(name)),
+        ),
+      ]
+    : [];
+
+  const baseTitle = getBaseTitleWithoutDynamicSuffix(sliceName ?? '');
+
+  if (!activeFilterNames.length) {
+    return baseTitle;
+  }
+
+  const dynamicSuffix = `by ${activeFilterNames.join(', ')}`;
+  return baseTitle ? `${baseTitle} ${dynamicSuffix}` : dynamicSuffix;
+}
+
 interface ExploreRootState {
   explore: {
     controls: ControlStateMapping;
@@ -839,6 +924,11 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
     return dataTabErrorMessage;
   }, [props.controls]);
 
+  const saveModalSliceName = useMemo(
+    () => getDisplaySliceTitle(props.sliceName, props.form_data, props.chart),
+    [props.chart, props.form_data, props.sliceName],
+  );
+
   function renderChartContainer() {
     return (
       <ExploreChartPanel
@@ -1035,7 +1125,7 @@ function ExploreViewContainer(props: ExploreViewContainerProps) {
           addDangerToast={props.addDangerToast}
           actions={props.actions}
           form_data={props.form_data}
-          sliceName={props.sliceName ?? undefined}
+          sliceName={saveModalSliceName}
           dashboardId={props.dashboardId ?? null}
         />
       )}

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -54,6 +54,7 @@ import {
 export type PropertiesModalProps = {
   slice: Slice;
   show: boolean;
+  initialName?: string;
   onHide: () => void;
   onSave: (chart: Chart) => void;
   permissionsError?: string;
@@ -64,6 +65,7 @@ export type PropertiesModalProps = {
 
 function PropertiesModal({
   slice,
+  initialName,
   onHide,
   onSave,
   show,
@@ -72,7 +74,7 @@ function PropertiesModal({
 }: PropertiesModalProps) {
   const [submitting, setSubmitting] = useState(false);
   // values of form inputs
-  const [name, setName] = useState(slice.slice_name || '');
+  const [name, setName] = useState((initialName ?? slice.slice_name) || '');
   const [description, setDescription] = useState(slice.description || '');
   const [cacheTimeout, setCacheTimeout] = useState(
     slice.cache_timeout != null ? String(slice.cache_timeout) : '',
@@ -295,8 +297,8 @@ function PropertiesModal({
 
   // update name after it's changed in another modal
   useEffect(() => {
-    setName(slice.slice_name || '');
-  }, [slice.slice_name]);
+    setName((initialName ?? slice.slice_name) || '');
+  }, [initialName, slice.slice_name]);
 
   // Validate general section when name changes
   useEffect(() => {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
@@ -44,6 +44,7 @@ interface AdhocFilterInput {
   deck_slices?: unknown;
   layerFilterScope?: unknown;
   filterOptionName?: string;
+  titleLabel?: string;
   // Allow additional properties for flexibility
   [key: string]: unknown;
 }
@@ -62,6 +63,7 @@ export default class AdhocFilter {
   deck_slices?: unknown;
   layerFilterScope?: unknown;
   filterOptionName: string;
+  titleLabel?: string;
 
   constructor(adhocFilter: AdhocFilterInput) {
     this.expressionType = adhocFilter.expressionType || ExpressionTypes.Simple;
@@ -111,6 +113,8 @@ export default class AdhocFilter {
       `filter_${Math.random().toString(36).substring(2, 15)}_${Math.random()
         .toString(36)
         .substring(2, 15)}`;
+
+    this.titleLabel = adhocFilter.titleLabel as string | undefined;
   }
 
   duplicateWith(nextFields: Partial<AdhocFilterInput>): AdhocFilter {
@@ -129,6 +133,7 @@ export default class AdhocFilter {
       deck_slices: this.deck_slices,
       layerFilterScope: this.layerFilterScope,
       filterOptionName: this.filterOptionName,
+      titleLabel: this.titleLabel,
       ...nextFields,
     };
     return new AdhocFilter(currentFields);
@@ -142,7 +147,8 @@ export default class AdhocFilter {
       adhocFilter.operator === this.operator &&
       adhocFilter.operatorId === this.operatorId &&
       adhocFilter.comparator === this.comparator &&
-      adhocFilter.subject === this.subject
+      adhocFilter.subject === this.subject &&
+      adhocFilter.titleLabel === this.titleLabel
     );
   }
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
@@ -19,7 +19,7 @@
 import type React from 'react';
 import { createRef, Component, type RefObject } from 'react';
 import { type SupersetTheme } from '@apache-superset/core/theme';
-import { Button, Icons, Select } from '@superset-ui/core/components';
+import { Button, Icons, Input, Select } from '@superset-ui/core/components';
 import { ErrorBoundary } from 'src/components';
 import { SupersetClient } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
@@ -432,6 +432,20 @@ export default class AdhocFilterEditPopover extends Component<
             },
           ]}
         />
+        <div style={{ marginTop: 8 }}>
+          <Input
+            value={this.state.adhocFilter.titleLabel ?? ''}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              this.onAdhocFilterChange(
+                this.state.adhocFilter.duplicateWith({
+                  titleLabel: e.target.value || undefined,
+                }),
+              );
+            }}
+            placeholder={t('Title label (optional)')}
+            maxLength={100}
+          />
+        </div>
         {hasDeckSlices && (
           <LayerSelectContainer>
             <Select

--- a/superset-frontend/src/filters/components/Select/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Select/controlPanel.ts
@@ -225,6 +225,21 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'dynamicDashboardTitle',
+            config: {
+              type: 'CheckboxControl',
+              renderTrigger: true,
+              affectsDataMask: true,
+              label: t('Dynamically update dashboard title'),
+              default: false,
+              description: t(
+                'When checked, the dashboard title will be updated dynamically based on the filter value. ',
+              ),
+            },
+          },
+        ],
       ],
     },
   ],

--- a/superset-frontend/src/filters/components/Select/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Select/controlPanel.ts
@@ -225,21 +225,6 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [
-          {
-            name: 'dynamicDashboardTitle',
-            config: {
-              type: 'CheckboxControl',
-              renderTrigger: true,
-              affectsDataMask: true,
-              label: t('Dynamically update dashboard title'),
-              default: false,
-              description: t(
-                'When checked, the dashboard title will be updated dynamically based on the filter value. ',
-              ),
-            },
-          },
-        ],
       ],
     },
   ],

--- a/superset-frontend/tsconfig.json
+++ b/superset-frontend/tsconfig.json
@@ -42,6 +42,7 @@
 
     /* Completeness */
     "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
 
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="990" height="990" alt="image" src="https://github.com/user-attachments/assets/40531bb4-7282-4b8d-8337-2688b2773fb3" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Click Charts in the top navigation
2. Select a chart of the type `Treemap`
3. Click the Customize tab
4. Click the Show dynamic chart title checkbox
5. Observe the list of active filters is appended to the chart title
6. Click the 'Data' tab
7. Add or remove filters from the Filters list
8. Select a filter to customize
9. Update the name of the filter
10. Observe the chart title is updated to reflect the updated filter title
11. Click the Save button
12. Verify the Chart name field includes the list of active filters with custom name
13. Click the Save button
14. Click Charts from the top navigation
15. Verify the dynamic chart title and custom name persisted

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
