### PR TITLE
feat(security): per-dashboard guest token revocation

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -32,6 +32,10 @@ Disabling a user account (setting `active` to `False`, via the admin UI, REST AP
 
 YDB SQL parsing now relies on the dedicated [`ydb-sqlglot-plugin`](https://pypi.org/project/ydb-sqlglot-plugin/) dialect, which registers itself with sqlglot automatically. YDB users must install this plugin (e.g., via `pip install "apache-superset[ydb]"`) to avoid a `ValueError` when Superset parses YDB queries.
 
+### Per-dashboard guest token revocation
+
+Embedded dashboards can now revoke their outstanding guest tokens without affecting other dashboards or rotating the global `GUEST_TOKEN_JWT_SECRET`. `POST /api/v1/dashboard/<id_or_slug>/embedded/revoke` stamps `embedded_dashboards.guest_token_revoked_before` (added by a migration); guest tokens for that dashboard whose `iat` predates the timestamp are then rejected. Tokens issued afterwards are unaffected, and dashboards that were never revoked (NULL) behave exactly as before.
+
 ### Dataset import validates catalog against the target connection
 
 Importing a dataset now validates the `catalog` field against the target database connection. When the connection has multi-catalog disabled (`allow_multi_catalog` off) and the dataset's catalog is not the connection's default catalog, the import fails instead of silently persisting the non-default catalog. This matches the validation already enforced on the dataset update path and prevents imported datasets from querying an unintended database.

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from flask import g
@@ -618,6 +618,17 @@ class EmbeddedDashboardDAO(BaseDAO[EmbeddedDashboard]):
         embedded.allow_domain_list = ",".join(allowed_domains)
         dashboard.embedded = [embedded]
         return embedded
+
+    @staticmethod
+    def revoke_guest_tokens(dashboard: Dashboard) -> None:
+        """
+        Revoke outstanding guest tokens for this dashboard's embedded
+        configuration by stamping ``guest_token_revoked_before`` to now. Guest
+        tokens issued before this instant are rejected on their next request.
+        """
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        for embedded in dashboard.embedded:
+            embedded.guest_token_revoked_before = now
 
     @classmethod
     def create(

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -244,6 +244,7 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
         "get_embedded",
         "set_embedded",
         "delete_embedded",
+        "revoke_embedded",
         "thumbnail",
         "copy_dash",
         "cache_dashboard_screenshot",
@@ -2132,6 +2133,57 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
               $ref: '#/components/responses/500'
         """
         DeleteEmbeddedDashboardCommand(dashboard).run()
+        return self.response(200, message="OK")
+
+    @expose("/<id_or_slug>/embedded/revoke", methods=("POST",))
+    @protect()
+    @safe
+    @permission_name("set_embedded")
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.revoke_embedded"
+        ),
+        log_to_statsd=False,
+    )
+    @with_dashboard
+    def revoke_embedded(self, dashboard: Dashboard) -> Response:
+        """Revoke outstanding guest tokens for the dashboard's embedded config.
+        ---
+        post:
+          summary: Revoke active guest sessions for the dashboard
+          description: >-
+            Rejects guest tokens for this dashboard that were issued before now,
+            terminating outstanding embedded guest sessions without affecting
+            other dashboards.
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: id_or_slug
+            description: The dashboard id or slug
+          responses:
+            200:
+              description: Successfully revoked active guest tokens
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+            401:
+              $ref: '#/components/responses/401'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        # When the dashboard has no embedded configuration there are no guest
+        # tokens to revoke. Mirror ``delete_embedded`` and treat this as an
+        # idempotent no-op (200) rather than a 404 so cleanup/retry flows that
+        # call revoke unconditionally succeed.
+        if dashboard.embedded:
+            EmbeddedDashboardDAO.revoke_guest_tokens(dashboard)
+            db.session.commit()  # pylint: disable=consider-using-transaction
         return self.response(200, message="OK")
 
     @expose("/<id_or_slug>/copy/", methods=("POST",))

--- a/superset/migrations/versions/2026-06-02_12-00_c4d5e6f7a8b9_add_guest_token_revoked_before.py
+++ b/superset/migrations/versions/2026-06-02_12-00_c4d5e6f7a8b9_add_guest_token_revoked_before.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add guest_token_revoked_before to embedded_dashboards
+
+Revision ID: c4d5e6f7a8b9
+Revises: f7a1c93e0b21
+Create Date: 2026-06-02 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from superset.migrations.shared.utils import add_columns, drop_columns
+
+# revision identifiers, used by Alembic.
+revision = "c4d5e6f7a8b9"
+down_revision = "f7a1c93e0b21"
+
+TABLE = "embedded_dashboards"
+COLUMN = "guest_token_revoked_before"
+
+
+def upgrade():
+    add_columns(TABLE, sa.Column(COLUMN, sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    drop_columns(TABLE, COLUMN)

--- a/superset/models/embedded_dashboard.py
+++ b/superset/models/embedded_dashboard.py
@@ -17,7 +17,7 @@
 import uuid
 
 from flask_appbuilder import Model
-from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy_utils import UUIDType
 
@@ -50,6 +50,10 @@ class EmbeddedDashboard(Model, AuditMixinNullable):
         back_populates="embedded",
         foreign_keys=[dashboard_id],
     )
+    # Guest tokens for this embedded dashboard issued (``iat``) before this
+    # timestamp are rejected, revoking outstanding guest sessions for just this
+    # dashboard. NULL means "never revoked".
+    guest_token_revoked_before = Column(DateTime, nullable=True)
 
     @property
     def allowed_domains(self) -> list[str]:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -3588,6 +3588,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 raise ValueError("Guest token does not contain an rls_rules claim")
             if token.get("type") != "guest":
                 raise ValueError("This is not a guest token.")
+            if self._guest_token_is_revoked(token):
+                raise ValueError("Guest token has been revoked.")
         except Exception:  # pylint: disable=broad-except
             # The login manager will handle sending 401s.
             # We don't need to send a special error message.
@@ -3595,6 +3597,58 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             return None
 
         return self.get_guest_user_from_token(cast(GuestToken, token))
+
+    def _guest_token_is_revoked(self, token: dict[str, Any]) -> bool:
+        """
+        Return True if any dashboard resource referenced by the token has been
+        revoked since the token was issued — i.e. the token's ``iat`` predates
+        that embedded dashboard's ``guest_token_revoked_before``.
+
+        Revocation is per embedded dashboard, so revoking one embed does not
+        affect guest tokens for other dashboards. Superset always issues guest
+        tokens with an ``iat`` claim, so a token that lacks one cannot be
+        positioned relative to a revocation instant; such tokens are treated as
+        revoked (fail closed) rather than silently bypassing the check.
+        """
+        # pylint: disable=import-outside-toplevel
+        from datetime import timezone
+
+        from superset.daos.dashboard import EmbeddedDashboardDAO
+        from superset.models.dashboard import Dashboard
+
+        iat = token.get("iat")
+        if iat is None:
+            return True
+        for resource in token.get("resources") or []:
+            if resource.get("type") != GuestTokenResourceType.DASHBOARD.value:
+                continue
+            resource_id = str(resource["id"])
+            # A resource id may be an embedded uuid or, for legacy tokens, a
+            # dashboard id/slug. Resolve both so revocation applies regardless of
+            # which form the token carries.
+            embedded = EmbeddedDashboardDAO.find_by_id(resource_id)
+            if embedded:
+                embedded_configs = [embedded]
+            else:
+                dashboard = Dashboard.get(resource_id)
+                embedded_configs = list(dashboard.embedded) if dashboard else []
+            revoked_before = next(
+                (
+                    config.guest_token_revoked_before
+                    for config in embedded_configs
+                    if config.guest_token_revoked_before is not None
+                ),
+                None,
+            )
+            if revoked_before is None:
+                continue
+            # The column is a naive UTC ``DateTime``; compare in UTC so the
+            # check isn't skewed by the server's local offset.
+            if revoked_before.tzinfo is None:
+                revoked_before = revoked_before.replace(tzinfo=timezone.utc)
+            if iat < revoked_before.timestamp():
+                return True
+        return False
 
     def get_guest_user_from_token(self, token: GuestToken) -> GuestUser:
         return self.guest_user_cls(

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -700,6 +700,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             "can_get_embedded",
             "can_delete_embedded",
             "can_set_embedded",
+            "can_revoke_embedded",
             "can_cache_dashboard_screenshot",
             "can_put_chart_customizations",
         }

--- a/tests/integration_tests/security/guest_token_revocation_tests.py
+++ b/tests/integration_tests/security/guest_token_revocation_tests.py
@@ -32,6 +32,7 @@ from superset.security.guest_token import (
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices_class_scope,  # noqa: F401
+    load_birth_names_data,  # noqa: F401
 )
 from tests.integration_tests.test_app import app
 

--- a/tests/integration_tests/security/guest_token_revocation_tests.py
+++ b/tests/integration_tests/security/guest_token_revocation_tests.py
@@ -30,6 +30,9 @@ from superset.security.guest_token import (
     GuestTokenResourceType,
 )
 from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.fixtures.birth_names_dashboard import (
+    load_birth_names_dashboard_with_slices_class_scope,  # noqa: F401
+)
 from tests.integration_tests.test_app import app
 
 

--- a/tests/integration_tests/security/guest_token_revocation_tests.py
+++ b/tests/integration_tests/security/guest_token_revocation_tests.py
@@ -86,21 +86,23 @@ class TestGuestTokenRevocation(SupersetTestCase):
             return security_manager.get_guest_user_from_request(request)
 
     def test_token_issued_before_revocation_is_rejected(self) -> None:
+        # Anchor all ``iat`` values at or before the real current time so PyJWT
+        # does not reject a token as not-yet-valid (ImmatureSignatureError).
         base = int(time.time())
-        token = self._mint(iat=base)
+        token = self._mint(iat=base - 20)
 
         # Valid before any revocation.
         assert self._validate(token) is not None
 
-        # Revoke at base + 10: tokens issued before that instant are rejected.
+        # Revoke at base - 10: tokens issued before that instant are rejected.
         self.embedded.guest_token_revoked_before = datetime.fromtimestamp(
-            base + 10, timezone.utc
+            base - 10, timezone.utc
         ).replace(tzinfo=None)
         db.session.commit()
         assert self._validate(token) is None
 
         # A token issued after the revocation instant is still accepted.
-        newer_token = self._mint(iat=base + 20)
+        newer_token = self._mint(iat=base)
         assert self._validate(newer_token) is not None
 
     def test_revoke_endpoint_revokes_outstanding_tokens(self) -> None:
@@ -149,19 +151,21 @@ class TestGuestTokenRevocation(SupersetTestCase):
 
     def test_legacy_dashboard_id_token_is_revoked(self) -> None:
         # Tokens carrying a dashboard id (rather than the embedded uuid) must
-        # also be subject to per-dashboard revocation.
+        # also be subject to per-dashboard revocation. Anchor all ``iat`` values
+        # at or before the real current time so PyJWT does not reject a token as
+        # not-yet-valid (ImmatureSignatureError).
         base = int(time.time())
-        token = self._mint_with_dashboard_id(iat=base)
+        token = self._mint_with_dashboard_id(iat=base - 20)
         assert self._validate(token) is not None
 
         self.embedded.guest_token_revoked_before = datetime.fromtimestamp(
-            base + 10, timezone.utc
+            base - 10, timezone.utc
         ).replace(tzinfo=None)
         db.session.commit()
         assert self._validate(token) is None
 
         # A dashboard-id token issued after the revocation instant is accepted.
-        assert self._validate(self._mint_with_dashboard_id(iat=base + 20)) is not None
+        assert self._validate(self._mint_with_dashboard_id(iat=base)) is not None
 
     def test_token_without_iat_is_treated_as_revoked(self) -> None:
         # A signed token that omits ``iat`` cannot be positioned against a

--- a/tests/integration_tests/security/guest_token_revocation_tests.py
+++ b/tests/integration_tests/security/guest_token_revocation_tests.py
@@ -1,0 +1,188 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import time
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+from flask import request
+
+from superset import db, security_manager
+from superset.daos.dashboard import EmbeddedDashboardDAO
+from superset.models.dashboard import Dashboard
+from superset.security.guest_token import (
+    GuestTokenResources,
+    GuestTokenResourceType,
+)
+from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.test_app import app
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices_class_scope")
+class TestGuestTokenRevocation(SupersetTestCase):
+    def setUp(self) -> None:
+        with app.app_context():
+            app.config["EMBEDDED_SUPERSET"] = True
+        self.dash = self.get_dash_by_slug("births")
+        self.embedded = EmbeddedDashboardDAO.upsert(self.dash, [])
+        db.session.commit()
+
+    def tearDown(self) -> None:
+        self.embedded.guest_token_revoked_before = None
+        db.session.commit()
+
+    def _mint(self, iat: int) -> str:
+        resources: GuestTokenResources = [
+            {
+                "type": GuestTokenResourceType.DASHBOARD,
+                "id": str(self.embedded.uuid),
+            }
+        ]
+        with patch.object(
+            security_manager, "_get_current_epoch_time", return_value=iat
+        ):
+            token = security_manager.create_guest_access_token({}, resources, [])
+        return token if isinstance(token, str) else token.decode()
+
+    def _mint_with_dashboard_id(self, iat: int) -> str:
+        # A legacy token whose resource id is the numeric dashboard id rather
+        # than the embedded uuid.
+        resources: GuestTokenResources = [
+            {
+                "type": GuestTokenResourceType.DASHBOARD,
+                "id": str(self.dash.id),
+            }
+        ]
+        with patch.object(
+            security_manager, "_get_current_epoch_time", return_value=iat
+        ):
+            token = security_manager.create_guest_access_token({}, resources, [])
+        return token if isinstance(token, str) else token.decode()
+
+    def _validate(self, token: str) -> Optional[object]:
+        header = app.config["GUEST_TOKEN_HEADER_NAME"]
+        with app.test_request_context(headers={header: token}):
+            return security_manager.get_guest_user_from_request(request)
+
+    def test_token_issued_before_revocation_is_rejected(self) -> None:
+        base = int(time.time())
+        token = self._mint(iat=base)
+
+        # Valid before any revocation.
+        assert self._validate(token) is not None
+
+        # Revoke at base + 10: tokens issued before that instant are rejected.
+        self.embedded.guest_token_revoked_before = datetime.fromtimestamp(
+            base + 10, timezone.utc
+        ).replace(tzinfo=None)
+        db.session.commit()
+        assert self._validate(token) is None
+
+        # A token issued after the revocation instant is still accepted.
+        newer_token = self._mint(iat=base + 20)
+        assert self._validate(newer_token) is not None
+
+    def test_revoke_endpoint_revokes_outstanding_tokens(self) -> None:
+        base = int(time.time())
+        token = self._mint(iat=base)
+        assert self._validate(token) is not None
+
+        self.login(username="admin")
+        response = self.client.post(f"/api/v1/dashboard/{self.dash.id}/embedded/revoke")
+        assert response.status_code == 200
+
+        db.session.expire_all()
+        assert self.embedded.guest_token_revoked_before is not None
+        # The token issued before the revoke call is now rejected.
+        assert self._validate(token) is None
+
+    def test_revoking_one_dashboard_does_not_affect_others(self) -> None:
+        base = int(time.time())
+        token = self._mint(iat=base)
+        self.embedded.guest_token_revoked_before = datetime.fromtimestamp(
+            base + 10, timezone.utc
+        ).replace(tzinfo=None)
+        db.session.commit()
+        # Token is revoked for this dashboard...
+        assert self._validate(token) is None
+        # ...but a token for a *different* (unrevoked) resource is unaffected.
+        other_resources: GuestTokenResources = [
+            {
+                "type": GuestTokenResourceType.DASHBOARD,
+                "id": "06383667-3e02-4e5e-843f-44e9c5896b6c",
+            }
+        ]
+        with patch.object(
+            security_manager, "_get_current_epoch_time", return_value=base
+        ):
+            raw_other_token = security_manager.create_guest_access_token(
+                {}, other_resources, []
+            )
+        other_token = (
+            raw_other_token
+            if isinstance(raw_other_token, str)
+            else raw_other_token.decode()
+        )
+        # Not revoked (no embedded config / no revoked_before for that id).
+        assert self._validate(other_token) is not None
+
+    def test_legacy_dashboard_id_token_is_revoked(self) -> None:
+        # Tokens carrying a dashboard id (rather than the embedded uuid) must
+        # also be subject to per-dashboard revocation.
+        base = int(time.time())
+        token = self._mint_with_dashboard_id(iat=base)
+        assert self._validate(token) is not None
+
+        self.embedded.guest_token_revoked_before = datetime.fromtimestamp(
+            base + 10, timezone.utc
+        ).replace(tzinfo=None)
+        db.session.commit()
+        assert self._validate(token) is None
+
+        # A dashboard-id token issued after the revocation instant is accepted.
+        assert self._validate(self._mint_with_dashboard_id(iat=base + 20)) is not None
+
+    def test_token_without_iat_is_treated_as_revoked(self) -> None:
+        # A signed token that omits ``iat`` cannot be positioned against a
+        # revocation instant, so it must fail closed.
+        resources: GuestTokenResources = [
+            {
+                "type": GuestTokenResourceType.DASHBOARD,
+                "id": str(self.embedded.uuid),
+            }
+        ]
+        raw_token = security_manager.create_guest_access_token({}, resources, [])
+        token = raw_token if isinstance(raw_token, str) else raw_token.decode()
+        decoded = security_manager.parse_jwt_guest_token(token)
+        assert security_manager._guest_token_is_revoked(  # noqa: SLF001
+            {k: v for k, v in decoded.items() if k != "iat"}
+        )
+
+    def test_revoke_endpoint_no_embedded_config_is_noop_200(self) -> None:
+        # Revoking a dashboard that has no embedded config is an idempotent
+        # no-op, mirroring delete_embedded, rather than a 404.
+        dash = Dashboard(dashboard_title="no-embed", slug="no-embed-revoke")
+        db.session.add(dash)
+        db.session.commit()
+        try:
+            self.login(username="admin")
+            response = self.client.post(f"/api/v1/dashboard/{dash.id}/embedded/revoke")
+            assert response.status_code == 200
+        finally:
+            db.session.delete(dash)
+            db.session.commit()

--- a/tests/integration_tests/security/guest_token_revocation_tests.py
+++ b/tests/integration_tests/security/guest_token_revocation_tests.py
@@ -37,11 +37,13 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
 from tests.integration_tests.test_app import app
 
 
+@patch.dict(
+    "superset.extensions.feature_flag_manager._feature_flags",
+    EMBEDDED_SUPERSET=True,
+)
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices_class_scope")
 class TestGuestTokenRevocation(SupersetTestCase):
     def setUp(self) -> None:
-        with app.app_context():
-            app.config["EMBEDDED_SUPERSET"] = True
         self.dash = self.get_dash_by_slug("births")
         self.embedded = EmbeddedDashboardDAO.upsert(self.dash, [])
         db.session.commit()


### PR DESCRIPTION
### SUMMARY

Implements **Part A3** of the session/token-lifecycle SIP (#40674): **granular, per-embedded-dashboard guest-token revocation**.

Guest tokens are self-contained JWTs with no revocation — when an embed's access should be cut off, you previously had to wait out the token `exp` or rotate the global `GUEST_TOKEN_JWT_SECRET` (which nukes *every* embed). This adds a per-dashboard revoke.

**How it works**
- `embedded_dashboards.guest_token_revoked_before` (new column + migration) records the revocation instant for one embedded dashboard.
- `get_guest_user_from_request` rejects a guest token whose `iat` predates the `guest_token_revoked_before` of any dashboard resource it references (UTC-safe comparison). Tokens issued *after* the revoke, and dashboards that were never revoked (NULL), are unaffected — so it's backwards compatible by default.
- `POST /api/v1/dashboard/<id_or_slug>/embedded/revoke` (gated by the existing `can_set_embedded` permission) stamps the timestamp via `EmbeddedDashboardDAO.revoke_guest_tokens`.

Guest tokens already carry `iat`, so there's **no token-format change**. This complements the global revocation primitive (break-glass-all vs. revoke-one-embed).

Closes part of #40674 (A3).

### TESTING INSTRUCTIONS

```bash
pytest tests/integration_tests/security/guest_token_revocation_tests.py
```

**Validated end-to-end against a local Docker stack:**
- Token valid → revoke the dashboard → same token **rejected** → a newly-issued token **valid**.
- Revoking one dashboard does **not** affect tokens for another.
- `POST .../embedded/revoke` returns **200** and stamps the column.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)