### PR TITLE
ci: harden CI against Docker Hub registry flakes (retries + auth)

### DIFF
--- a/.github/workflows/check-python-deps.yml
+++ b/.github/workflows/check-python-deps.yml
@@ -38,6 +38,19 @@ jobs:
         if: steps.check.outputs.python
         uses: ./.github/actions/setup-backend/
 
+      # Authenticate the Docker daemon so the python:slim pull in
+      # uv-pip-compile.sh uses our (much higher) authenticated rate limit
+      # instead of the shared-runner anonymous one. Best-effort: on fork PRs the
+      # secrets are unavailable, so this no-ops and the pull falls back to
+      # anonymous (covered by the retry loop in the script).
+      - name: Login to Docker Hub
+        if: steps.check.outputs.python
+        continue-on-error: true
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Run uv
         if: steps.check.outputs.python
         run: ./scripts/uv-pip-compile.sh

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -27,6 +27,11 @@ jobs:
     services:
       mysql:
         image: mysql:8.0
+        # Authenticated pulls use our higher Docker Hub rate limit. Empty on
+        # fork PRs (secrets unavailable) -> runner falls back to anonymous.
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
@@ -38,6 +43,9 @@ jobs:
           --health-retries=5
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         options: --entrypoint redis-server
         ports:
           - 16379:6379
@@ -121,6 +129,9 @@ jobs:
     services:
       postgres:
         image: postgres:17-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -130,6 +141,9 @@ jobs:
           - 15432:5432
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 16379:6379
     steps:
@@ -186,6 +200,9 @@ jobs:
     services:
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 16379:6379
     steps:

--- a/scripts/uv-pip-compile.sh
+++ b/scripts/uv-pip-compile.sh
@@ -31,11 +31,32 @@ if [ -z "$RUNNING_IN_DOCKER" ]; then
 
   echo "Running in Docker (Python ${PYTHON_VERSION} on Linux)..."
 
+  IMAGE="python:${PYTHON_VERSION}-slim"
+
+  # Pre-pull the image with a few retries to absorb transient Docker Hub
+  # registry failures ("context deadline exceeded" / anonymous rate-limit blips
+  # on shared CI runners). Without this a flaky pull fails the whole
+  # check-python-deps job on an infrastructure hiccup rather than a real
+  # dependency drift. The pull is in the `until` condition so `set -e` does not
+  # abort on an individual failed attempt.
+  attempt=1
+  max_attempts=4
+  until docker pull "$IMAGE"; do
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "docker pull $IMAGE failed after ${max_attempts} attempts" >&2
+      exit 1
+    fi
+    delay=$((attempt * 10))
+    echo "docker pull $IMAGE failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+
   docker run --rm \
     -v "$(pwd)":/app \
     -w /app \
     -e RUNNING_IN_DOCKER=1 \
-    python:${PYTHON_VERSION}-slim \
+    "$IMAGE" \
     bash -c "pip install uv && ./scripts/uv-pip-compile.sh $*"
 
   exit $?


### PR DESCRIPTION
### SUMMARY

Several CI jobs intermittently fail on **Docker Hub registry hiccups** rather than real problems — `check-python-deps`, and the `test-sqlite` / `test-postgres` / `test-mysql` integration jobs. The errors look like:

```
docker: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
##[error]Process completed with exit code 125
```

Two root causes feed this: (1) bare `docker run`/service-container pulls with **no retry**, and (2) **anonymous** pulls that share GitHub's runner-IP Docker Hub rate limit, so throttling surfaces as connection timeouts. This PR addresses both.

### Changes

**Retry (universal — works on fork PRs too)**
- `scripts/uv-pip-compile.sh` — pre-pull `python:${VERSION}-slim` in a small backoff loop (4 attempts) before `docker run`, so a flaky pull no longer fails the whole `check-python-deps` job. The pull sits in an `until` condition so `set -e` doesn't abort on a single failed attempt; genuine errors still fail fast in the subsequent `docker run`.

**Auth (raises the pull rate limit ~25× on `apache/superset` branches)**
- `.github/workflows/check-python-deps.yml` — add a best-effort `docker/login-action` (pinned `v4.2.0`, same as `setup-docker`) before the uv step, so the in-step pull is authenticated.
- `.github/workflows/superset-python-integrationtest.yml` — add `credentials:` to the `mysql` / `postgres` / `redis` service containers so the runner-managed pulls (which can't be wrapped in a step-level retry) authenticate too.

### Fork-PR safety

`DOCKERHUB_USER` / `DOCKERHUB_TOKEN` already exist as repo secrets (used by `docker.yml`). On **fork** PRs those secrets are withheld by GitHub, so:
- the login step is `continue-on-error: true` → it no-ops, and the script's retry loop covers anonymous-pull flakes;
- the service `credentials:` resolve to empty → the runner falls back to an anonymous pull.

So external contributors see no regression; main-repo branches (including maintainers' own PRs) get the authenticated, higher rate limit. Worth a maintainer's eye on the fork path during review since the repo hasn't used `services.credentials` before.

### Not covered (follow-up)

The `docker-build` job's intermittent pull is inside the third-party `docker/setup-qemu-action` (binfmt image) — not wrapped here since it's not ours to retry. Can be addressed separately (e.g. pre-pull-with-retry of the pinned binfmt image).

### TESTING INSTRUCTIONS

- `bash -n scripts/uv-pip-compile.sh` passes; both workflow YAMLs parse and pass `zizmor`.
- This PR's own `check-python-deps` + integration jobs exercise the authenticated path (secrets present on a main-repo branch).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)