### PR TITLE
chore: correct typos in config.py and models_test.py comments

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1193,7 +1193,7 @@ HTML_SANITIZATION_SCHEMA_EXTENSIONS: dict[str, Any] = {}
 # than 6 slices in dashboard, a lot of time fetch requests are queued up and wait for
 # next available socket. PR #5039 added domain sharding for Superset,
 # and this feature can be enabled by configuration only (by default Superset
-# doesn't allow cross-domain request). This feature is deprecated, annd will be removed
+# doesn't allow cross-domain request). This feature is deprecated, and will be removed
 # in the next major version of Superset, as enabling HTTP2 will serve the same goals.
 SUPERSET_WEBSERVER_DOMAINS = None  # deprecated
 

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -269,7 +269,7 @@ def test_dataset_uniqueness(session: Session) -> None:
 
 def test_normalize_prequery_result_type_custom_sql() -> None:
     """
-    Test that the `_normalize_prequery_result_type` can hanndle custom SQL.
+    Test that the `_normalize_prequery_result_type` can handle custom SQL.
     """
     sqla_table = SqlaTable(
         table_name="my_sqla_table",


### PR DESCRIPTION
### SUMMARY
Fixed two small spelling typos in code comments:

1. `superset/config.py` line 1196: `annd` → `and`
2.    - Comment said: "This feature is deprecated, annd will be removed"
2. `tests/unit_tests/connectors/sqla/models_test.py` line 272: `hanndle` → `handle`
3.    - Docstring said: "can hanndle custom SQL"
### TESTING INSTRUCTIONS
No functional changes — only comment/docstring text was modified. No tests needed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] - [ ] Required feature flags: