### PR TITLE
ci: gate expensive test workflows at the job level

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -27,7 +27,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.check.outputs.python }}
+      frontend: ${{ steps.check.outputs.frontend }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   cypress-matrix:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     # Somehow one test flakes on 24.04 for unknown reasons, this is the only GHA left on 22.04
     runs-on: ubuntu-22.04
     permissions:
@@ -89,46 +110,33 @@ jobs:
           ref: refs/pull/${{ github.event.inputs.pr_id }}/merge
           submodules: recursive
       # -------------------------------------------------------
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python || steps.check.outputs.frontend
       - name: Setup postgres
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Import test data
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: testdata
       - name: Setup Node.js
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: './superset-frontend/.nvmrc'
       - name: Install npm dependencies
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: npm-install
       - name: Build javascript packages
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
       - name: Install cypress
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: cypress-install
       - name: Run Cypress
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         env:
           CYPRESS_BROWSER: ${{ matrix.browser }}
@@ -154,6 +162,8 @@ jobs:
           name: cypress-artifact-${{ github.run_id }}-${{ github.job }}-${{ matrix.browser }}-${{ matrix.parallel_id }}--${{ steps.set-safe-app-root.outputs.safe_app_root }}
 
   playwright-tests:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -207,51 +217,37 @@ jobs:
           ref: refs/pull/${{ github.event.inputs.pr_id }}/merge
           submodules: recursive
       # -------------------------------------------------------
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python || steps.check.outputs.frontend
       - name: Setup postgres
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Import test data
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: playwright_testdata
       - name: Setup Node.js
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: './superset-frontend/.nvmrc'
       - name: Install npm dependencies
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: npm-install
       - name: Build javascript packages
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
       - name: Build embedded SDK
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-embedded-sdk
       - name: Install Playwright
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: playwright-install
       - name: Run Playwright (Required Tests)
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -23,9 +23,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.check.outputs.python }}
+      frontend: ${{ steps.check.outputs.frontend }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   # NOTE: Required Playwright tests are in superset-e2e.yml (E2E / playwright-tests)
   # This workflow contains only experimental tests that run in shadow mode
   playwright-tests-experimental:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-22.04
     continue-on-error: true
     permissions:
@@ -80,58 +101,43 @@ jobs:
           ref: refs/pull/${{ github.event.inputs.pr_id }}/merge
           submodules: recursive
       # -------------------------------------------------------
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python || steps.check.outputs.frontend
       - name: Setup postgres
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Import test data
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: playwright_testdata
       - name: Setup Node.js
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: './superset-frontend/.nvmrc'
       - name: Install npm dependencies
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: npm-install
       - name: Build javascript packages
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
       - name: Build embedded SDK
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-embedded-sdk
       - name: Install Playwright
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         with:
           run: playwright-install
       - name: Run Playwright (Experimental Tests)
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         with:
           run: playwright-run "${{ matrix.app_root }}" experimental/
       - name: Run Playwright (Embedded Tests)
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -14,7 +14,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.check.outputs.python }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   test-mysql:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -55,26 +75,17 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python
       - name: Setup MySQL
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: setup-mysql
       - name: Start Celery worker
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python integration tests (MySQL)
-        if: steps.check.outputs.python
         run: |
           ./scripts/python_tests.sh
       - name: Upload code coverage
@@ -85,7 +96,6 @@ jobs:
           use_oidc: true
           slug: apache/superset
       - name: Generate database diagnostics for docs
-        if: steps.check.outputs.python
         env:
           SUPERSET_CONFIG: tests.integration_tests.superset_test_config
           SUPERSET__SQLALCHEMY_DATABASE_URI: |
@@ -108,13 +118,14 @@ jobs:
               print(f'Generated diagnostics for {len(docs)} databases')
           "
       - name: Upload database diagnostics artifact
-        if: steps.check.outputs.python
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: database-diagnostics
           path: databases-diagnostics.json
           retention-days: 7
   test-postgres:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -152,29 +163,20 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Postgres
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: |
             setup-postgres
       - name: Start Celery worker
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python integration tests (PostgreSQL)
-        if: steps.check.outputs.python
         run: |
           ./scripts/python_tests.sh
       - name: Upload code coverage
@@ -186,6 +188,8 @@ jobs:
           slug: apache/superset
 
   test-sqlite:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -211,28 +215,19 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python
       - name: Install dependencies
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: |
             # sqlite needs this working directory
             mkdir ${{ github.workspace }}/.temp
       - name: Start Celery worker
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python integration tests (SQLite)
-        if: steps.check.outputs.python
         run: |
           ./scripts/python_tests.sh
       - name: Upload code coverage

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -15,7 +15,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.check.outputs.python }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   test-postgres-presto:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -54,28 +74,17 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python == 'true'
       - name: Setup Postgres
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
-          run: |
-            echo "${{ steps.check.outputs.python }}"
-            setup-postgres
+          run: setup-postgres
       - name: Start Celery worker
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python unit tests (PostgreSQL)
-        if: steps.check.outputs.python
         run: |
           ./scripts/python_tests.sh -m 'chart_data_flow or sql_json_flow'
       - name: Upload code coverage
@@ -87,6 +96,8 @@ jobs:
           slug: apache/superset
 
   test-postgres-hive:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -117,35 +128,23 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create csv upload directory
-        if: steps.check.outputs.python
         run: sudo mkdir -p /tmp/.superset/uploads
       - name: Give write access to the csv upload directory
-        if: steps.check.outputs.python
         run: sudo chown -R $USER:$USER /tmp/.superset
       - name: Start hadoop and hive
-        if: steps.check.outputs.python
         run: docker compose -f scripts/databases/hive/docker-compose.yml up -d
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python
       - name: Setup Postgres
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Start Celery worker
-        if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python unit tests (PostgreSQL)
-        if: steps.check.outputs.python
         run: |
           pip install -e .[hive]
           ./scripts/python_tests.sh -m 'chart_data_flow or sql_json_flow'

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -15,7 +15,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.check.outputs.python }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   unit-tests:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -30,25 +50,17 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-        if: steps.check.outputs.python
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python unit tests
-        if: steps.check.outputs.python
         env:
           SUPERSET_TESTENV: true
           SUPERSET_SECRET_KEY: not-a-secret
         run: |
           pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50
       - name: Python 100% coverage unit tests
-        if: steps.check.outputs.python
         env:
           SUPERSET_TESTENV: true
           SUPERSET_SECRET_KEY: not-a-secret


### PR DESCRIPTION
### SUMMARY

The Cypress, Playwright, and Python test workflows ran change-detection at the
**step level**: every matrix runner spun up, checked out the repo, ran the
`change-detector` action, and *then* skipped its individual steps when the
relevant files weren't touched. On a docs-only or otherwise unrelated PR, that
still provisioned all of those runners — 12+ Cypress shards, the 3
integration-test databases, the Presto/Hive jobs, the experimental Playwright
matrix — only to no-op step by step.

This PR adopts the pattern `superset-frontend.yml` already uses: a single
lightweight `changes` job runs the change-detector **once** and exposes its
outputs, and each expensive job gates on it at the **job level**:

```yaml
  changes:
    outputs:
      python: ${{ steps.check.outputs.python }}
      frontend: ${{ steps.check.outputs.frontend }}
    steps: [checkout, change-detector]

  <expensive-job>:
    needs: changes
    if: needs.changes.outputs.python == 'true'   # (|| frontend for e2e/playwright)
```

Jobs that don't apply to a PR are now **skipped outright** instead of
provisioning a runner just to skip every step. The redundant per-job
change-detector step and the per-step `if:` guards are removed.

Workflows touched:
- `superset-e2e.yml` (Cypress + required Playwright)
- `superset-playwright.yml` (experimental Playwright)
- `superset-python-unittest.yml`
- `superset-python-integrationtest.yml` (mysql / postgres / sqlite)
- `superset-python-presto-hive.yml` (presto / hive)

**Behavior preserved:**
- `workflow_dispatch` / `schedule` runs still execute everything — the detector
  returns "all changed" for those events, so the gate evaluates true.
- Skipped required jobs are treated as passing by branch protection (same as the
  existing `superset-frontend.yml` behavior), so this doesn't block merges.

### TESTING INSTRUCTIONS

- On a code PR: confirm the `changes` job runs and the relevant test jobs run as
  before.
- On a docs-only PR: confirm the test jobs are **skipped** (not just no-op'd) and
  no Cypress/Python runners are provisioned.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)