### PR TITLE
ci: run full Python-version matrix on push, current-only on PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -83,7 +83,6 @@ github:
           - frontend-build
           - playwright-tests (chromium)
           - pre-commit (current)
-          - pre-commit (previous)
           - test-mysql
           - test-postgres-required
           - test-postgres-hive

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,10 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["current", "previous", "next"]
+        # Run the full version spread on push (master/release) and nightly,
+        # but only the current version on PRs — lint/format/type results
+        # rarely differ across patch versions, so 3x per PR is wasteful.
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["current"]') || fromJSON('["current", "previous", "next"]') }}
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/superset-extensions-cli.yml
+++ b/.github/workflows/superset-extensions-cli.yml
@@ -23,7 +23,9 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["previous", "current", "next"]
+        # Full version spread on push (master/release) + nightly; current only
+        # on PRs to cut runner cost (cross-version breaks are caught at merge).
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["current"]') || fromJSON('["previous", "current", "next"]') }}
     defaults:
       run:
         working-directory: superset-extensions-cli

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -128,7 +128,9 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ["current", "previous", "next"]
+        # Full version spread on push (master/release) + nightly; current only
+        # on PRs to cut runner cost (cross-version breaks are caught at merge).
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["current"]') || fromJSON('["current", "previous", "next"]') }}
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -43,7 +43,9 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ["previous", "current", "next"]
+        # Full version spread on push (master/release) + nightly; current only
+        # on PRs to cut runner cost (cross-version breaks are caught at merge).
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["current"]') || fromJSON('["previous", "current", "next"]') }}
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:


### PR DESCRIPTION
### SUMMARY

`pre-commit`, the Python **unit tests**, and the Postgres **integration tests**
each fan out across Python **3.10 / 3.11 / 3.12** (`previous` / `current` /
`next`) on *every* PR push. pre-commit (lint/format/mypy) results almost never
differ across patch versions, and the test suites rarely do — so running all
three per PR roughly triples the runner cost of these jobs for little added
signal.

This runs **only `current` (3.11) on `pull_request`** events and keeps the
**full 3-version spread on push** (master/release) and the nightly schedule, so
cross-version regressions are still caught before/at merge. It uses the same
event-conditional matrix idiom already in the repo for `app_root` in the E2E
workflow:

```yaml
python-version: ${{ github.event_name == 'pull_request'
  && fromJSON('["current"]')
  || fromJSON('["current", "previous", "next"]') }}
```

**Per-PR job reduction:** pre-commit 3→1, unit-tests 3→1, integration
`test-postgres` 3→1 (the mysql/sqlite integration jobs aren't version-matrixed).

> **Branch protection note:** if any per-version job is a *required* status
> check (e.g. `unit-tests (previous)`), update branch protection to require the
> current-only job instead — the other versions no longer run on PRs and their
> checks would otherwise never report.

### TESTING INSTRUCTIONS

- On this PR: confirm pre-commit / unit-tests / integration `test-postgres` each
  run a **single** Python 3.11 job.
- On push to master: confirm all three versions run.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)