### PR TITLE
ci: gate docker image builds at the job level

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,26 @@ concurrency:
 
 jobs:
 
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.check.outputs.python }}
+      frontend: ${{ steps.check.outputs.frontend }}
+      docker: ${{ steps.check.outputs.docker }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   setup_matrix:
     runs-on: ubuntu-24.04
     outputs:
@@ -32,7 +52,11 @@ jobs:
 
   docker-build:
     name: docker-build
-    needs: setup_matrix
+    needs: [setup_matrix, changes]
+    if: >-
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -50,14 +74,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup Docker Environment
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         uses: ./.github/actions/setup-docker
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
@@ -65,11 +82,9 @@ jobs:
           build: "true"
 
       - name: Setup supersetbot
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         uses: ./.github/actions/setup-supersetbot/
 
       - name: Build Docker Image
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,7 +110,7 @@ jobs:
 
       # in the context of push (using multi-platform build), we need to pull the image locally
       - name: Docker pull
-        if: github.event_name == 'push' && (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker)
+        if: github.event_name == 'push'
         run: |
           for i in 1 2 3; do
             docker pull $IMAGE_TAG && break
@@ -103,7 +118,6 @@ jobs:
           done
 
       - name: Print docker stats
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         run: |
           echo "SHA: ${{ github.sha }}"
           echo "IMAGE: $IMAGE_TAG"
@@ -111,7 +125,7 @@ jobs:
           docker history $IMAGE_TAG
 
       - name: docker-compose sanity check
-        if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && matrix.build_preset == 'dev'
+        if: matrix.build_preset == 'dev'
         shell: bash
         env:
           BUILD_PRESET: ${{ matrix.build_preset }}
@@ -124,20 +138,15 @@ jobs:
   docker-compose-image-tag:
     # Run this job only on pushes to master (not for PRs)
     # goal is to check that building the latest image works, not required for all PR pushes
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: changes
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Docker Environment
-        if: steps.check.outputs.docker
         uses: ./.github/actions/setup-docker
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
@@ -145,7 +154,6 @@ jobs:
           build: "false"
           install-docker-compose: "true"
       - name: docker-compose sanity check
-        if: steps.check.outputs.docker
         shell: bash
         run: |
           docker compose -f docker-compose-image-tag.yml up superset-init --exit-code-from superset-init


### PR DESCRIPTION
### What this changes (plain-language version)

Building Docker images is one of the more expensive things our CI does. Today,
**every PR kicks off those Docker build machines** — even a PR that only edits
documentation. The build machines start up, look around, realize "oh, nothing
here actually affects Docker," and then quit without doing anything. We still
paid for them to start up.

This PR moves the "does this PR even touch anything Docker cares about?" check
to **before** the build machines start, instead of after. So now:

- **PR changes code / Docker stuff** → Docker builds run, exactly like before.
- **PR only changes docs (or other unrelated files)** → the Docker builds are
  skipped entirely, and no build machines spin up at all.

Same coverage, just no longer paying to start machines that were only going to
quit immediately. It reuses the exact pattern our frontend workflow already
uses.

---

### SUMMARY

`docker.yml` ran change-detection at the **step level**: the `docker-build`
matrix (2 presets on PRs, 7 on push) provisioned a runner per preset, checked
out the repo, ran the `change-detector` action, and *then* skipped its build
steps when no relevant files changed. Docs-only and other unrelated PRs still
spun up those build runners only to no-op.

This adopts the lead-`changes`-job pattern already used by
`superset-frontend.yml` (and proposed for the test workflows in #40718): one
lightweight job runs the change-detector once and exposes `python` / `frontend`
/ `docker` outputs, and the build jobs gate at the **job level**:

\`\`\`yaml
  docker-build:
    needs: [setup_matrix, changes]
    if: >-
      needs.changes.outputs.python == 'true' ||
      needs.changes.outputs.frontend == 'true' ||
      needs.changes.outputs.docker == 'true'
\`\`\`

The push-to-master-only `docker-compose-image-tag` job now also gates on the
`docker` output at the job level. Redundant per-job change-detector steps and
per-step `if:` guards are removed.

### TESTING INSTRUCTIONS

- Code/docker PR: confirm `docker-build` runs its presets as before.
- Docs-only PR: confirm `docker-build` is **skipped** (no build runners spin up).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)