### PR TITLE
ci: gate CodeQL analysis at the job level for docs-only PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,8 +15,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.check.outputs.python }}
+      frontend: ${{ steps.check.outputs.frontend }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   analyze:
     name: Analyze
+    needs: changes
+    # Skip on PRs that touch neither code group (e.g. docs-only) so the
+    # analysis runners don't spin up. push/schedule runs always proceed:
+    # the change-detector returns "all changed" for non-PR events.
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-24.04
     permissions:
       actions: read
@@ -35,12 +59,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
@@ -54,7 +72,6 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        if: steps.check.outputs.python || steps.check.outputs.frontend
         uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       frontend: ${{ steps.check.outputs.frontend }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Check for file changes
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
### SUMMARY

CodeQL gated only its final `Perform CodeQL Analysis` step on the
change-detector. On a docs-only PR that meant both language runners
(`python`, `javascript`) still spun up, checked out, ran the detector, and ran
`Initialize CodeQL` before skipping the actual analysis.

This moves the gate to the **job level** using the shared lead-`changes`-job
pattern (same as #40718 / #40723), so the analysis runners don't start at all
when no code changed:

```yaml
  analyze:
    needs: changes
    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
```

**Why job-level skip instead of `paths-ignore`:** a skipped *required* check is
treated as passing by branch protection, whereas a `paths-ignore`d workflow
never reports its check at all — which would **deadlock merges** if CodeQL is a
required check. push and scheduled (nightly) runs are unaffected: the detector
returns "all changed" for non-PR events, so full security coverage is preserved.

### TESTING INSTRUCTIONS

- Code PR: confirm `Analyze (python)` / `Analyze (javascript)` run as before.
- Docs-only PR: confirm both are **skipped** (no CodeQL runners spin up).
- Confirm the nightly schedule and push-to-master still run the full analysis.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)