### PR TITLE
ci: add cancel-in-progress concurrency to PR helper workflows

### DIFF
--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: read
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   validate-all-ghas:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,11 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,6 +8,11 @@ on:
     # Possible values: https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
     types: [opened, edited, reopened, synchronize]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint-check:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### SUMMARY

`pr-lint`, the GitHub Actions validator (`github-action-validator`), and the
`labeler` all re-run on every push to a PR (`synchronize`) but had **no
concurrency group**, so rapid successive pushes left superseded runs going to
completion instead of being cancelled.

Add the standard PR-keyed concurrency block already used across the other
workflows:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: true
```

These are idempotent / last-run-wins workflows (title lint, action validation,
label sync), so cancelling an in-flight run is safe — the newest push re-runs
them. Small per-PR savings, but free.

Left intentionally untouched: `welcome-new-users` (one-shot on PR open),
`showtime-trigger` (label/unlabel semantics where cancellation could drop a
sync), and `issue_creation` (not `synchronize`-driven).

### TESTING INSTRUCTIONS

Push twice in quick succession to a PR and confirm the first run of each of
these workflows is cancelled in favor of the latest.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)