### PR TITLE
ci: add timeout-minutes to compute-heavy workflow jobs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -42,6 +43,7 @@ jobs:
     # the change-detector returns "all changed" for non-PR events.
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,7 @@ jobs:
 
   changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -41,6 +42,7 @@ jobs:
 
   setup_matrix:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       matrix_config: ${{ steps.set_matrix.outputs.matrix_config }}
     steps:
@@ -58,6 +60,7 @@ jobs:
       needs.changes.outputs.frontend == 'true' ||
       needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       matrix:
         build_preset: ${{fromJson(needs.setup_matrix.outputs.matrix_config)}}
@@ -141,6 +144,7 @@ jobs:
     needs: changes
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["current", "previous", "next"]

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -51,6 +52,7 @@ jobs:
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     # Somehow one test flakes on 24.04 for unknown reasons, this is the only GHA left on 22.04
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read
@@ -170,6 +172,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/superset-extensions-cli.yml
+++ b/.github/workflows/superset-extensions-cli.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   test-superset-extensions-cli-package:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["previous", "current", "next"]

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   frontend-build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     outputs:
       should-run: ${{ steps.check.outputs.frontend }}
     steps:
@@ -74,6 +75,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
       fail-fast: false
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Download Docker Image Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -103,6 +105,7 @@ jobs:
     needs: [sharded-jest-tests]
     if: needs.frontend-build.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       id-token: write
     steps:
@@ -144,6 +147,7 @@ jobs:
     needs: frontend-build
     if: needs.frontend-build.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Download Docker Image Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -168,6 +172,7 @@ jobs:
     needs: frontend-build
     if: needs.frontend-build.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Download Docker Image Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -187,6 +192,7 @@ jobs:
     needs: frontend-build
     if: needs.frontend-build.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 25
     steps:
       - name: Download Docker Image Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -48,6 +49,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     continue-on-error: true
     permissions:
       contents: read

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -36,6 +37,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       id-token: write
     env:
@@ -121,6 +123,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       id-token: write
     strategy:
@@ -179,6 +182,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       id-token: write
     env:

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -37,6 +38,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       id-token: write
     env:
@@ -99,6 +101,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       id-token: write
     env:

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -37,6 +38,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       id-token: write
     strategy:

--- a/.github/workflows/superset-websocket.yml
+++ b/.github/workflows/superset-websocket.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   app-checks:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
### SUMMARY

None of our CI jobs set `timeout-minutes`, so every job inherits GitHub's
default of **360 minutes (6 hours)**. A single hung or wedged job — a stuck dev
server, a deadlocked Cypress/Playwright process, a stalled network call — keeps
a runner busy for up to 6 hours before it's reclaimed. On the matrix workflows
(Cypress/Playwright shards, the integration-test databases, the docker build
presets) that's a large amount of wasted runner time per incident, and it's
silent until someone notices the run hasn't finished.

This adds right-sized per-job caps across the compute-heavy workflows, with
generous headroom above observed run times (so legitimate slow runs aren't
killed — the goal is only to catch hangs):

| job(s) | timeout |
|---|---|
| lead `changes` jobs | 10m |
| `setup_matrix` (docker) | 5m |
| `pre-commit`, `sharded-jest-tests`, `lint-frontend`, `validate-frontend`, websocket | 20m |
| `report-coverage` | 15m |
| `test-storybook` | 25m |
| `frontend-build`, `cypress-matrix`, `playwright-tests`, `playwright-tests-experimental`, `unit-tests`, `analyze` (CodeQL), `docker-compose-image-tag`, extensions-cli | 30m |
| integration (`test-mysql/postgres/sqlite`), presto/hive | 45m |
| `docker-build` (multi-platform on push) | 60m |

Steady-state cost is unchanged — this only **bounds the worst case** (a hang now
dies in minutes, not hours). Purely additive; no other lines touched.

### TESTING INSTRUCTIONS

CI-only change. Jobs run as before; confirm each shows its `timeout-minutes` in
the run UI.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)