### PR TITLE
ci: cache npm downloads in frontend-heavy workflows

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -46,6 +46,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'superset-frontend/package-lock.json'
 
       - name: Install Frontend Dependencies
         run: |

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -131,6 +131,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: './superset-frontend/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'superset-frontend/package-lock.json'
       - name: Install npm dependencies
         uses: ./.github/actions/cached-dependencies
         with:
@@ -239,6 +241,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: './superset-frontend/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'superset-frontend/package-lock.json'
       - name: Install npm dependencies
         uses: ./.github/actions/cached-dependencies
         with:

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -117,6 +117,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: './superset-frontend/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'superset-frontend/package-lock.json'
       - name: Install npm dependencies
         uses: ./.github/actions/cached-dependencies
         with:


### PR DESCRIPTION
### SUMMARY

The `pre-commit`, E2E (Cypress + Playwright), and experimental-Playwright jobs
run `npm ci` for the frontend with **no download cache** — `actions/setup-node`
was configured without `cache:`, and the `cached-dependencies` npm cache is
disabled (`# cache-restore npm` is commented out in `bashlib.sh`). So every one
of those jobs re-downloads the full package set from the registry, and npm
install is a large chunk of the per-job setup time that dominates these
workflows.

This enables `setup-node`'s built-in npm cache — the **lightweight** option:

```yaml
      - uses: actions/setup-node@… # v6
        with:
          node-version-file: './superset-frontend/.nvmrc'
          cache: 'npm'
          cache-dependency-path: 'superset-frontend/package-lock.json'
```

It caches the `~/.npm` **download** cache (not `node_modules`), keyed on the
frontend lockfile. `npm ci` still does a clean install but skips re-fetching
unchanged tarballs. Deliberately avoiding full-`node_modules` caching, which is
large and could evict the more valuable **instrumented-assets** cache under the
repo's 10 GB cache budget.

### TESTING INSTRUCTIONS

CI-only. First run on each workflow primes the cache; subsequent runs should
show a cache hit on the "Setup Node.js" step and a faster `npm ci`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)