### PR TITLE
fix(asyncEvent): use Map for job listener/retry registries

### DIFF
--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -172,6 +172,34 @@ describe('asyncEvent middleware', () => {
       expect(fetchMock.callHistory.calls(EVENTS_ENDPOINT)).toHaveLength(1);
       expect(fetchMock.callHistory.calls(CACHED_DATA_ENDPOINT)).toHaveLength(1);
     });
+
+    // Regression guard for the motivating CodeQL case: a job_id that collides
+    // with a built-in Object property (e.g. "__proto__"/"constructor") must be
+    // routed through the Map-based registries without triggering prototype
+    // pollution or losing the listener to a prototype-bearing lookup.
+    test.each(['__proto__', 'constructor', 'prototype', 'hasOwnProperty'])(
+      'resolves listeners keyed by reserved job_id "%s"',
+      async jobId => {
+        fetchMock.clearHistory().removeRoutes();
+        fetchMock.get(EVENTS_ENDPOINT, {
+          status: 200,
+          body: { result: [{ ...asyncDoneEvent, job_id: jobId }] },
+        });
+        fetchMock.get(CACHED_DATA_ENDPOINT, {
+          status: 200,
+          body: { result: chartData },
+        });
+
+        const actualResolved = await asyncEvent.waitForAsyncData({
+          ...asyncPendingEvent,
+          job_id: jobId,
+        });
+        expect(actualResolved).toEqual([chartData]);
+        expect(fetchMock.callHistory.calls(CACHED_DATA_ENDPOINT)).toHaveLength(
+          1,
+        );
+      },
+    );
   });
 
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -63,17 +63,17 @@ let config: AppConfig;
 let transport: string;
 let pollingDelayMs: number;
 let pollingTimeoutId: number;
-let listenersByJobId: Record<string, ListenerFn>;
-let retriesByJobId: Record<string, number>;
+let listenersByJobId: Map<string, ListenerFn>;
+let retriesByJobId: Map<string, number>;
 let lastReceivedEventId: string | null | undefined;
 
-const addListener = (id: string, fn: any) => {
-  listenersByJobId[id] = fn;
+const addListener = (id: string, fn: ListenerFn) => {
+  listenersByJobId.set(id, fn);
 };
 
 const removeListener = (id: string) => {
-  if (!listenersByJobId[id]) return;
-  delete listenersByJobId[id];
+  if (!listenersByJobId.has(id)) return;
+  listenersByJobId.delete(id);
 };
 
 const fetchCachedData = async (
@@ -143,27 +143,22 @@ const setLastId = (asyncEvent: AsyncEvent) => {
 export const processEvents = async (events: AsyncEvent[]) => {
   events.forEach((asyncEvent: AsyncEvent) => {
     const jobId = asyncEvent.job_id;
-    const listener = Object.prototype.hasOwnProperty.call(
-      listenersByJobId,
-      jobId,
-    )
-      ? listenersByJobId[jobId]
-      : undefined;
+    const listener = listenersByJobId.get(jobId);
     if (listener) {
       listener(asyncEvent);
-      delete retriesByJobId[jobId];
+      retriesByJobId.delete(jobId);
     } else {
       // handle race condition where event is received
       // before listener is registered
-      if (!retriesByJobId[jobId]) retriesByJobId[jobId] = 0;
-      retriesByJobId[jobId] += 1;
+      const retries = (retriesByJobId.get(jobId) ?? 0) + 1;
+      retriesByJobId.set(jobId, retries);
 
-      if (retriesByJobId[jobId] <= MAX_RETRIES) {
+      if (retries <= MAX_RETRIES) {
         setTimeout(() => {
           processEvents([asyncEvent]);
-        }, RETRY_DELAY * retriesByJobId[jobId]);
+        }, RETRY_DELAY * retries);
       } else {
-        delete retriesByJobId[jobId];
+        retriesByJobId.delete(jobId);
         logging.warn('listener not found for job_id', asyncEvent.job_id);
       }
     }
@@ -173,7 +168,7 @@ export const processEvents = async (events: AsyncEvent[]) => {
 
 const loadEventsFromApi = async () => {
   const eventArgs = lastReceivedEventId ? { last_id: lastReceivedEventId } : {};
-  if (Object.keys(listenersByJobId).length) {
+  if (listenersByJobId.size) {
     try {
       const { result: events } = await fetchEvents(eventArgs);
       if (events?.length) await processEvents(events);
@@ -236,8 +231,8 @@ export const init = (appConfig?: AppConfig) => {
   if (!isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) return;
   if (pollingTimeoutId) clearTimeout(pollingTimeoutId);
 
-  listenersByJobId = {};
-  retriesByJobId = {};
+  listenersByJobId = new Map();
+  retriesByJobId = new Map();
   lastReceivedEventId = null;
 
   config = appConfig || getBootstrapData().common.conf;


### PR DESCRIPTION
### SUMMARY

Addresses a CodeQL **`js/unvalidated-dynamic-method-call`** (high) alert at
`superset-frontend/src/middleware/asyncEvent.ts`. In `processEvents`, the
listener is looked up from a plain object (`listenersByJobId`) keyed by
`asyncEvent.job_id` — a server-supplied value — and then invoked. Because a
plain object carries `Object.prototype`, a `job_id` matching an inherited member
name (`toString`, `constructor`, …) could resolve the lookup to a prototype
method, so the subsequent call would dispatch to an unexpected target. A
`hasOwnProperty` guard mitigated it, but the lookup target was still a
prototype-bearing object.

This switches `listenersByJobId` and `retriesByJobId` from plain objects to
**`Map`**. `Map.get()` only ever returns explicitly-`set` values — never
inherited prototype methods — which removes the dynamic-dispatch hazard at the
source and is the canonical remediation for this rule. The `hasOwnProperty`
guard is dropped (no longer needed), and `addListener`'s `any` parameter is
tightened to `ListenerFn`.

**Behavior is unchanged** — the registry semantics (add/remove/lookup, the
race-condition retry up to `MAX_RETRIES`, and the `loadEventsFromApi` empty
check) are all preserved, just expressed via `Map` (`.set/.get/.has/.delete/.size`).

### TESTING INSTRUCTIONS

`asyncEvent.test.ts` exercises the public API and passes unchanged. Type-check,
prettier, and oxlint all pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)