### PR TITLE
fix(auth): redirect to login on failure to access dashboard permalink

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -853,7 +853,11 @@ class Superset(BaseSupersetView):
     ) -> FlaskResponse:
         try:
             value = GetDashboardPermalinkCommand(key).run()
-        except (DashboardPermalinkGetFailedError, DashboardAccessDeniedError) as ex:
+        except DashboardAccessDeniedError as ex:
+            if not get_current_user():
+                return redirect_to_login()
+            return json_error_response(__("Error: %(msg)s", msg=ex.message), status=404)
+        except DashboardPermalinkGetFailedError as ex:
             return json_error_response(__("Error: %(msg)s", msg=ex.message), status=404)
         if not value:
             return json_error_response(_("permalink state not found"), status=404)

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -37,6 +37,7 @@ import superset.views.utils
 from superset import dataframe, db, security_manager, sql_lab
 from superset.commands.chart.data.get_data_command import ChartDataCommand
 from superset.commands.chart.exceptions import ChartDataQueryFailedError
+from superset.commands.dashboard.exceptions import DashboardAccessDeniedError
 from superset.common.db_query_status import QueryStatus
 from superset.connectors.sqla.models import SqlaTable
 from superset.db_engine_specs.base import BaseEngineSpec
@@ -936,6 +937,36 @@ class TestCore(SupersetTestCase):
         # Round-trips back to the original value when decoded.
         parsed = parse_qs(urlsplit(location).query)
         assert parsed["native_filters"] == [native_filters_value]
+
+    @mock.patch(
+        "superset.commands.dashboard.permalink.get.GetDashboardPermalinkCommand.run"
+    )
+    def test_dashboard_permalink_redirects_anonymous_access_denied(
+        self,
+        get_dashboard_permalink_mock,
+    ):
+        get_dashboard_permalink_mock.side_effect = DashboardAccessDeniedError()
+
+        resp = self.client.get("/superset/dashboard/p/123/")
+
+        expected_url = "/login/?next=%2Fsuperset%2Fdashboard%2Fp%2F123%2F"
+
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == expected_url
+
+    @mock.patch(
+        "superset.commands.dashboard.permalink.get.GetDashboardPermalinkCommand.run"
+    )
+    def test_dashboard_permalink_returns_404_for_missing_state(
+        self,
+        get_dashboard_permalink_mock,
+    ):
+        get_dashboard_permalink_mock.return_value = None
+
+        resp = self.client.get("/superset/dashboard/p/123/")
+
+        assert resp.status_code == 404
+        assert "Location" not in resp.headers
 
 
 class TestLocalePatch(SupersetTestCase):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #40768, where accessing a permalink to a private dashboard without being logged in would return an error instead of redirecting to the login page. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: `{"error": "Error: You don't have access to this dashboard."}`
After: redirect to login page

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Enable RBAC, share a dashboard with a role.
Share -> copy permalink
Open that link on a private tab (or log out before)
You should be redirected to the login page instead of getting Error `{"error": "Error: You don't have access to this dashboard."} `

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #40768
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

~Copies functionality from #30380. I've set noqa: C901 to be able to pass listing while copying the section of code verbatim.~
If wanted, this could be refactored into a helper function to reduce complexity