### PR TITLE
ci: stable required-check anchors for skippable matrix test jobs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -85,11 +85,11 @@ github:
           - pre-commit (current)
           - pre-commit (previous)
           - test-mysql
-          - test-postgres (current)
+          - test-postgres-required
           - test-postgres-hive
           - test-postgres-presto
           - test-sqlite
-          - unit-tests (current)
+          - unit-tests-required
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -222,3 +222,25 @@ jobs:
           verbose: true
           use_oidc: true
           slug: apache/superset
+
+  # Stable required-status-check anchor for the matrix-based test-postgres job.
+  # It is gated on change detection, so on non-Python PRs it is skipped and
+  # never produces its `test-postgres (current)` context (a job-level skip
+  # happens before matrix expansion). This always-running job reports a single
+  # context branch protection can require: it passes when test-postgres
+  # succeeded or was skipped, and fails only on a real failure.
+  test-postgres-required:
+    needs: [changes, test-postgres]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check test-postgres result
+        env:
+          RESULT: ${{ needs.test-postgres.result }}
+        run: |
+          if [ "$RESULT" != "success" ] && [ "$RESULT" != "skipped" ]; then
+            echo "test-postgres did not pass (result: $RESULT)"
+            exit 1
+          fi
+          echo "test-postgres result: $RESULT"

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -74,3 +74,25 @@ jobs:
           verbose: true
           use_oidc: true
           slug: apache/superset
+
+  # Stable required-status-check anchor. `unit-tests` is a matrix job gated on
+  # change detection, so on non-Python PRs it is skipped and never produces its
+  # `unit-tests (current)` context (a job-level skip happens before matrix
+  # expansion). This always-running job reports a single context that branch
+  # protection can require: it passes when unit-tests succeeded or was skipped,
+  # and fails only on a real failure.
+  unit-tests-required:
+    needs: [changes, unit-tests]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check unit-tests result
+        env:
+          RESULT: ${{ needs.unit-tests.result }}
+        run: |
+          if [ "$RESULT" != "success" ] && [ "$RESULT" != "skipped" ]; then
+            echo "unit-tests did not pass (result: $RESULT)"
+            exit 1
+          fi
+          echo "unit-tests result: $RESULT"


### PR DESCRIPTION
### SUMMARY

Follow-up to #40770. Frontend-only PRs (e.g. Dependabot npm bumps like #40757)
are still blocked from merging — stuck on **`unit-tests (current)`** and
**`test-postgres (current)`** showing *"Expected — Waiting for status to be
reported."*

**Root cause:** #40718 moved `unit-tests` and `test-postgres` to **job-level**
change-detection gating (`if: needs.changes.outputs.python == 'true'`). On a
non-Python PR the job is skipped — and a job-level skip happens **before matrix
expansion**, so the per-combination contexts `unit-tests (current)` /
`test-postgres (current)` are **never created**. Branch protection requires
them, so the PR waits forever.

This only bites *matrix* jobs. Non-matrix gated jobs (`test-mysql`,
`test-sqlite`) publish a `skipped` check that branch protection treats as
success — which is why only the two matrix contexts were stuck.

**Fix:** add an always-running `*-required` anchor job for each matrix job that
passes when the underlying job is `success` **or** `skipped`, and fails only on
a real failure. Point the required status checks at those anchors:

```yaml
  unit-tests-required:
    needs: [changes, unit-tests]
    if: always()
    steps:
      - run: |
          [ "$RESULT" = success ] || [ "$RESULT" = skipped ] || exit 1
        env: { RESULT: "${{ needs.unit-tests.result }}" }
```

`.asf.yaml`: `unit-tests (current)` → `unit-tests-required`, `test-postgres
(current)` → `test-postgres-required`. The expensive matrix jobs stay **fully
skipped** on unrelated PRs (no wasted Postgres/Redis service containers); the
anchor is a ~5-second no-op.

> 📝 Related follow-up: #40722 (Python matrix → current-only on PRs) will stop
> producing `pre-commit (previous)` on PRs. That's a *matrix reduction*, not a
> job-skip, so it just needs the `pre-commit (previous)` context removed from
> `.asf.yaml` — handled in that PR, no shim required.

### TESTING INSTRUCTIONS

- Python PR: `unit-tests-required` / `test-postgres-required` run after the
  matrix jobs and pass.
- Frontend-only / docs PR: the matrix jobs skip; the anchors run and pass; the
  PR is mergeable.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)