### PR TITLE
test(dashboard): RTL coverage for native filter modal and sidebar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -902,3 +902,61 @@ test('Clear All on a required filter disables Apply via validateStatus', async (
   expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
   updateDataMaskSpy.mockRestore();
 });
+
+test('FilterBar renders the configured filter name in the bar', async () => {
+  const filterId = 'NATIVE_FILTER-name-render';
+  const filter = createFilter({
+    id: filterId,
+    name: 'Region',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'region' } }],
+    chartsInScope: [18],
+  });
+  const state = {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      filterBarOrientation: FilterBarOrientation.Vertical,
+      metadata: {
+        native_filter_configuration: [filter],
+        chart_configuration: {},
+      },
+    },
+    dashboardState: {
+      ...stateWithoutNativeFilters.dashboardState,
+      activeTabs: ['ROOT_ID'],
+    },
+    dataMask: { [filterId]: createDataMask(filterId, undefined, {}) },
+    nativeFilters: {
+      filters: { [filterId]: filter },
+      filtersState: {},
+    },
+  };
+
+  const props = createOpenedBarProps();
+  renderFilterBar(props, state);
+  await act(async () => {
+    jest.advanceTimersByTime(300);
+  });
+
+  expect(await screen.findByText('Region')).toBeInTheDocument();
+});
+
+test('Clicking the gear "Add or edit filters and controls" item opens the FiltersConfigModal', async () => {
+  const props = createOpenedBarProps();
+  renderFilterBar(props, stateWithoutNativeFilters);
+  await act(async () => {
+    jest.advanceTimersByTime(100);
+  });
+
+  const gear = await screen.findByTestId('filterbar-orientation-icon');
+  userEvent.click(gear);
+
+  const addEditItem = await screen.findByText(
+    'Add or edit filters and controls',
+  );
+  userEvent.click(addEditItem);
+
+  expect(await screen.findByTestId('filter-modal')).toBeInTheDocument();
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -960,3 +960,145 @@ test('empty state disappears when a filter is added via dropdown', async () => {
   });
   expect(screen.getByText(FILTER_TYPE_REGEX)).toBeInTheDocument();
 });
+
+test('restores a deleted filter via the "Restore filter" button', async () => {
+  const nativeFilterConfig = [
+    buildNativeFilter('NATIVE_FILTER-1', 'state', []),
+    buildNativeFilter('NATIVE_FILTER-2', 'country', []),
+  ];
+  const state = {
+    ...defaultState(),
+    dashboardInfo: {
+      metadata: { native_filter_configuration: nativeFilterConfig },
+    },
+    dashboardLayout,
+  };
+
+  defaultRender(state, { ...props, createNewOnOpen: false });
+
+  const filterContainer = screen.getByTestId('filter-title-container');
+  const firstTab = within(filterContainer).getAllByRole('tab')[0];
+  const deleteIcon = firstTab.querySelector('[data-icon="delete"]');
+  fireEvent.click(deleteIcon!);
+
+  expect(
+    await screen.findByText(/you have removed this filter/i),
+  ).toBeInTheDocument();
+  const restoreButton = screen.getByTestId('restore-filter-button');
+  await userEvent.click(restoreButton);
+
+  await waitFor(() => {
+    expect(
+      screen.queryByText(/you have removed this filter/i),
+    ).not.toBeInTheDocument();
+  });
+  expect(screen.getByRole('textbox', { name: FILTER_NAME_REGEX })).toHaveValue(
+    'state',
+  );
+}, 30000);
+
+test('undoes a filter deletion via the sidebar "Undo?" link', async () => {
+  const nativeFilterConfig = [
+    buildNativeFilter('NATIVE_FILTER-1', 'state', []),
+    buildNativeFilter('NATIVE_FILTER-2', 'country', []),
+  ];
+  const state = {
+    ...defaultState(),
+    dashboardInfo: {
+      metadata: { native_filter_configuration: nativeFilterConfig },
+    },
+    dashboardLayout,
+  };
+
+  defaultRender(state, { ...props, createNewOnOpen: false });
+
+  const filterContainer = screen.getByTestId('filter-title-container');
+  const firstTab = within(filterContainer).getAllByRole('tab')[0];
+  fireEvent.click(firstTab.querySelector('[data-icon="delete"]')!);
+
+  const undoButton = await screen.findByTestId('undo-button');
+  expect(undoButton).toHaveTextContent(/undo\?/i);
+  await userEvent.click(undoButton);
+
+  await waitFor(() => {
+    expect(
+      screen.queryByText(/you have removed this filter/i),
+    ).not.toBeInTheDocument();
+  });
+  expect(screen.getByRole('textbox', { name: FILTER_NAME_REGEX })).toHaveValue(
+    'state',
+  );
+}, 30000);
+
+test('shows info tooltips beside value-filter options and reveals tooltip text on hover', async () => {
+  defaultRender();
+
+  // Upstream Cypress checked six tooltips on the value filter (nativeFilterTooltips
+  // 0..5); asserting the count keeps this test honest if tooltips get added or
+  // removed alongside a regression to the option list.
+  const tooltipIcons = screen.getAllByLabelText(/show info tooltip/i);
+  expect(tooltipIcons.length).toBeGreaterThanOrEqual(6);
+
+  await userEvent.hover(tooltipIcons[0]);
+
+  // role='tooltip' trips an nwsapi bug on antd's internal :only-child selectors;
+  // query the portal node by class and require non-empty text content so an empty
+  // tooltip render does not pass.
+  await waitFor(() => {
+    const tooltip = document.querySelector('.ant-tooltip-inner');
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip?.textContent?.trim()).toBeTruthy();
+  });
+}, 30000);
+
+test('numerical range filter — Range Type selector lets the user pick a display mode', async () => {
+  defaultRender();
+
+  await userEvent.click(screen.getByText(VALUE_REGEX));
+  await userEvent.click(await screen.findByText(NUMERICAL_RANGE_REGEX));
+
+  const rangeTypeCombobox = await screen.findByRole('combobox', {
+    name: /range type/i,
+  });
+
+  // Default render is "Slider and range input"; asserting Slider is absent first
+  // ensures the post-click assertion proves a state change rather than passing on
+  // the default selection.
+  expect(
+    document.querySelector('.ant-select-selection-item[title="Slider"]'),
+  ).not.toBeInTheDocument();
+
+  await userEvent.click(rangeTypeCombobox);
+  const sliderOption = await screen.findByRole('option', {
+    name: /^slider$/i,
+  });
+  await userEvent.click(sliderOption);
+
+  // antd Select renders the active selection as a span whose title attribute is
+  // the picked option's label.
+  await waitFor(() => {
+    expect(
+      document.querySelector('.ant-select-selection-item[title="Slider"]'),
+    ).toBeInTheDocument();
+  });
+}, 30000);
+
+test('toggles "Filter has default value" to show and hide the Default Value control', async () => {
+  defaultRender();
+
+  const defaultValueCheckbox = getCheckbox(DEFAULT_VALUE_REGEX);
+  expect(defaultValueCheckbox).not.toBeChecked();
+  expect(screen.queryByText(/^default value$/i)).not.toBeInTheDocument();
+
+  await userEvent.click(defaultValueCheckbox);
+
+  expect(defaultValueCheckbox).toBeChecked();
+  expect(await screen.findByText(/^default value$/i)).toBeInTheDocument();
+
+  await userEvent.click(defaultValueCheckbox);
+
+  expect(defaultValueCheckbox).not.toBeChecked();
+  await waitFor(() => {
+    expect(screen.queryByText(/^default value$/i)).not.toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -844,9 +844,7 @@ test('enables save button and includes updated title when editing an existing di
   jest.useRealTimers();
 
   await waitFor(() =>
-    expect(
-      screen.getByRole('button', { name: SAVE_REGEX }),
-    ).not.toBeDisabled(),
+    expect(screen.getByRole('button', { name: SAVE_REGEX })).not.toBeDisabled(),
   );
 
   await userEvent.click(screen.getByRole('button', { name: SAVE_REGEX }));
@@ -910,9 +908,7 @@ test('enables save button and includes updated title when editing an existing ch
   jest.useRealTimers();
 
   await waitFor(() =>
-    expect(
-      screen.getByRole('button', { name: SAVE_REGEX }),
-    ).not.toBeDisabled(),
+    expect(screen.getByRole('button', { name: SAVE_REGEX })).not.toBeDisabled(),
   );
 
   await userEvent.click(screen.getByRole('button', { name: SAVE_REGEX }));
@@ -978,8 +974,7 @@ test('restores a deleted filter via the "Restore filter" button', async () => {
 
   const filterContainer = screen.getByTestId('filter-title-container');
   const firstTab = within(filterContainer).getAllByRole('tab')[0];
-  const deleteIcon = firstTab.querySelector('[data-icon="delete"]');
-  fireEvent.click(deleteIcon!);
+  fireEvent.click(within(firstTab).getByRole('button', { name: /delete/i }));
 
   expect(
     await screen.findByText(/you have removed this filter/i),
@@ -1014,7 +1009,7 @@ test('undoes a filter deletion via the sidebar "Undo?" link', async () => {
 
   const filterContainer = screen.getByTestId('filter-title-container');
   const firstTab = within(filterContainer).getAllByRole('tab')[0];
-  fireEvent.click(firstTab.querySelector('[data-icon="delete"]')!);
+  fireEvent.click(within(firstTab).getByRole('button', { name: /delete/i }));
 
   const undoButton = await screen.findByTestId('undo-button');
   expect(undoButton).toHaveTextContent(/undo\?/i);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
@@ -110,4 +110,22 @@ describe('createNewOnOpen', () => {
     expect(getByRole('alert')).toBeInTheDocument();
     expect(getByRole('alert')).toHaveTextContent('There are unsaved changes.');
   });
+
+  test('confirm-cancel button proceeds with cancel after the unsaved alert', async () => {
+    const onCancel = jest.fn();
+    const { getByRole, getByTestId, findByRole } = setup({
+      onCancel,
+      createNewOnOpen: false,
+    });
+    const dropdownButton = getByTestId('new-item-dropdown-button');
+    fireEvent.mouseEnter(dropdownButton);
+    const addFilterMenuItem = await findByRole('menuitem', {
+      name: /add filter/i,
+    });
+    fireEvent.click(addFilterMenuItem);
+    fireEvent.click(getByRole('button', { name: 'Cancel' }));
+    // Alert is shown; user clicks the confirm-cancel button to discard changes.
+    fireEvent.click(getByTestId('native-filter-modal-confirm-cancel-button'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
@@ -84,6 +84,14 @@ test('the form validates required fields', async () => {
   expect(onSave).toHaveBeenCalledTimes(0);
 });
 
+async function openDropdownAndAddFilter(
+  getByTestId: (id: string) => HTMLElement,
+  findByRole: (role: string, opts: { name: RegExp }) => Promise<HTMLElement>,
+) {
+  fireEvent.mouseEnter(getByTestId('new-item-dropdown-button'));
+  fireEvent.click(await findByRole('menuitem', { name: /add filter/i }));
+}
+
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('createNewOnOpen', () => {
   test('does not show alert when there is no unsaved filters', async () => {
@@ -99,12 +107,7 @@ describe('createNewOnOpen', () => {
       onCancel,
       createNewOnOpen: false,
     });
-    const dropdownButton = getByTestId('new-item-dropdown-button');
-    fireEvent.mouseEnter(dropdownButton);
-    const addFilterMenuItem = await findByRole('menuitem', {
-      name: /add filter/i,
-    });
-    fireEvent.click(addFilterMenuItem);
+    await openDropdownAndAddFilter(getByTestId, findByRole);
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalledTimes(0);
     expect(getByRole('alert')).toBeInTheDocument();
@@ -117,14 +120,9 @@ describe('createNewOnOpen', () => {
       onCancel,
       createNewOnOpen: false,
     });
-    const dropdownButton = getByTestId('new-item-dropdown-button');
-    fireEvent.mouseEnter(dropdownButton);
-    const addFilterMenuItem = await findByRole('menuitem', {
-      name: /add filter/i,
-    });
-    fireEvent.click(addFilterMenuItem);
+    await openDropdownAndAddFilter(getByTestId, findByRole);
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
-    // Alert is shown; user clicks the confirm-cancel button to discard changes.
+    expect(getByRole('alert')).toBeInTheDocument();
     fireEvent.click(getByTestId('native-filter-modal-confirm-cancel-button'));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
### SUMMARY

Migrate the previously-skipped Cypress native-filter scenarios (formerly `_skip.nativeFilters.test.ts` and `_skip.nativeFilters.noInitState.test.ts` on the `6.1` branch) to Jest + React Testing Library so the dashboard native-filter UI keeps component-level coverage after the Cypress base is removed.

The new tests sit alongside the existing suites for `FiltersConfigModal`, `NativeFiltersModal`, and `FilterBar`. Scope is deliberately limited to modal- and filter-bar-local behavior; cross-filter chart interaction and live numerical-range widget rendering remain out of scope and are covered by the parallel Playwright migration.

New tests:
- `FiltersConfigModal`: restore a deleted filter, undo a deletion via the sidebar "Undo?" link, value-filter info tooltips, numerical-range Range Type selector display-mode change, "Filter has default value" toggle reveals / hides the Default Value control
- `NativeFiltersModal`: the confirm-cancel button on the unsaved-changes alert proceeds with cancel
- `FilterBar`: the configured filter name renders in the bar; clicking the gear menu's "Add or edit filters and controls" item opens the `FiltersConfigModal`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only.

### TESTING INSTRUCTIONS

From `superset-frontend/`:

```
npx jest src/dashboard/components/nativeFilters
```

Expected: all suites green (1 pre-existing unrelated skip).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API