### PR TITLE
ci: cache npm downloads in the translations workflow

### DIFF
--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -41,6 +41,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file:  './superset-frontend/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'superset-frontend/package-lock.json'
       - name: Install dependencies
         if: steps.check.outputs.frontend
         uses: ./.github/actions/cached-dependencies


### PR DESCRIPTION
### SUMMARY

The `frontend-check-translations` job in `superset-translations.yml` runs an
uncached npm install via the `cached-dependencies` action — `actions/setup-node`
is configured without `cache:`, and the npm download cache is otherwise disabled
(`# cache-restore npm` is commented out in `bashlib.sh`). So it re-downloads the
full package set from the registry on every run.

Besides being slow, an uncached install is prone to transient registry failures.
This was observed concretely on #40744, where this exact job failed with
`npm error code ECONNRESET` / `network aborted` mid-download — unrelated to that
PR's changes.

This enables `setup-node`'s built-in npm **download** cache, keyed on the
frontend lockfile, matching the pattern applied to the other frontend-heavy
workflows in #40744 (`pre-commit`, E2E, Playwright):

```yaml
      - uses: actions/setup-node@… # v6
        with:
          node-version-file: './superset-frontend/.nvmrc'
          cache: 'npm'
          cache-dependency-path: 'superset-frontend/package-lock.json'
```

`npm ci` still does a clean install but skips re-fetching unchanged tarballs.
It caches only `~/.npm` (not `node_modules`), keeping it lightweight under the
repo's cache budget.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI configuration only.

### TESTING INSTRUCTIONS

CI-only. The first run on this workflow primes the cache; subsequent runs should
show a cache hit on the "Setup Node.js" step and a faster `npm ci`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Split out from #40744 so the translations workflow can be assessed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)