### PR TITLE
ci: required-check anchors for cypress-matrix and playwright-tests (unblock docs-only PRs)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,11 +77,10 @@ github:
         # combination here.
         contexts:
           - lint-check
-          - cypress-matrix (0, chrome)
-          - cypress-matrix (1, chrome)
+          - cypress-matrix-required
           - dependency-review
           - frontend-build
-          - playwright-tests (chromium)
+          - playwright-tests-required
           - pre-commit (current)
           - test-mysql
           - test-postgres-required

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -292,6 +292,7 @@ jobs:
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Check cypress-matrix result
         env:
@@ -308,6 +309,7 @@ jobs:
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Check playwright-tests result
         env:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -287,6 +287,13 @@ jobs:
   # always-running jobs report a single stable context that passes when the
   # underlying matrix job succeeded or was skipped, and fails only on a real
   # failure. Require these in .asf.yaml instead of the matrix-expanded names.
+  #
+  # A matrix job reads as "skipped" in two distinct cases, and only the first
+  # is a legitimate pass: (a) change detection succeeded and gated the job off
+  # (docs-only PR); (b) the `changes` job itself failed or was cancelled, in
+  # which case GHA skips its dependents too. Accepting (b) would let a broken
+  # change-detector report a false green, so each anchor first requires
+  # `changes` to have succeeded before honouring a skip.
   cypress-matrix-required:
     needs: [changes, cypress-matrix]
     if: always()
@@ -296,13 +303,18 @@ jobs:
     steps:
       - name: Check cypress-matrix result
         env:
+          CHANGES: ${{ needs.changes.result }}
           RESULT: ${{ needs.cypress-matrix.result }}
         run: |
+          if [ "$CHANGES" != "success" ]; then
+            echo "change detection did not succeed (result: $CHANGES); refusing to pass on a skipped matrix"
+            exit 1
+          fi
           if [ "$RESULT" != "success" ] && [ "$RESULT" != "skipped" ]; then
             echo "cypress-matrix did not pass (result: $RESULT)"
             exit 1
           fi
-          echo "cypress-matrix result: $RESULT"
+          echo "cypress-matrix result: $RESULT (changes: $CHANGES)"
 
   playwright-tests-required:
     needs: [changes, playwright-tests]
@@ -313,10 +325,15 @@ jobs:
     steps:
       - name: Check playwright-tests result
         env:
+          CHANGES: ${{ needs.changes.result }}
           RESULT: ${{ needs.playwright-tests.result }}
         run: |
+          if [ "$CHANGES" != "success" ]; then
+            echo "change detection did not succeed (result: $CHANGES); refusing to pass on a skipped matrix"
+            exit 1
+          fi
           if [ "$RESULT" != "success" ] && [ "$RESULT" != "skipped" ]; then
             echo "playwright-tests did not pass (result: $RESULT)"
             exit 1
           fi
-          echo "playwright-tests result: $RESULT"
+          echo "playwright-tests result: $RESULT (changes: $CHANGES)"

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -277,3 +277,44 @@ jobs:
             ${{ github.workspace }}/superset-frontend/playwright-results/
             ${{ github.workspace }}/superset-frontend/test-results/
           name: playwright-artifact-${{ github.run_id }}-${{ github.job }}-${{ matrix.browser }}--${{ steps.set-safe-app-root.outputs.safe_app_root }}
+
+  # Stable required-status-check anchors. cypress-matrix and playwright-tests
+  # are matrix jobs gated on change detection (python || frontend). On a PR
+  # that touches neither — e.g. a docs-only PR — they are skipped at the job
+  # level, which happens before matrix expansion, so the per-combination
+  # contexts (`cypress-matrix (0, chrome)`, `playwright-tests (chromium)`) are
+  # never produced and branch protection waits on them forever. These
+  # always-running jobs report a single stable context that passes when the
+  # underlying matrix job succeeded or was skipped, and fails only on a real
+  # failure. Require these in .asf.yaml instead of the matrix-expanded names.
+  cypress-matrix-required:
+    needs: [changes, cypress-matrix]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check cypress-matrix result
+        env:
+          RESULT: ${{ needs.cypress-matrix.result }}
+        run: |
+          if [ "$RESULT" != "success" ] && [ "$RESULT" != "skipped" ]; then
+            echo "cypress-matrix did not pass (result: $RESULT)"
+            exit 1
+          fi
+          echo "cypress-matrix result: $RESULT"
+
+  playwright-tests-required:
+    needs: [changes, playwright-tests]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check playwright-tests result
+        env:
+          RESULT: ${{ needs.playwright-tests.result }}
+        run: |
+          if [ "$RESULT" != "success" ] && [ "$RESULT" != "skipped" ]; then
+            echo "playwright-tests did not pass (result: $RESULT)"
+            exit 1
+          fi
+          echo "playwright-tests result: $RESULT"


### PR DESCRIPTION
### SUMMARY

Follow-up to #40772. **Docs-only PRs currently can't merge** — they hang on
`cypress-matrix (0, chrome)`, `cypress-matrix (1, chrome)`, and
`playwright-tests (chromium)` showing *"Expected — Waiting for status to be
reported"* (e.g. #38108).

**Root cause** (same as #40772): `cypress-matrix` and `playwright-tests` are
matrix jobs gated on change detection (`python || frontend`). On a PR that
touches neither group — a docs-only PR — they're skipped at the **job level**,
which happens *before* matrix expansion, so the per-combination contexts are
never produced. Branch protection requires them → it waits forever.

The frontend Dependabot case (#40772) didn't expose this for the e2e jobs
because a frontend change sets `frontend=true`, so cypress/playwright run.
Only docs-only / neither-group PRs hit it — and the docs "build" people expect
(the Netlify Deploy Preview) does run and pass; it just isn't a required GHA
check, so the orphaned cypress/playwright contexts are what actually gate.

**Fix:** add always-running `cypress-matrix-required` / `playwright-tests-required`
anchors that pass when the underlying job is `success` **or** `skipped`, and
require those instead of the matrix-expanded names. A single
`cypress-matrix-required` replaces both shard contexts. The matrix jobs stay
fully skipped on unrelated PRs.

`.asf.yaml`:
- `cypress-matrix (0, chrome)` + `cypress-matrix (1, chrome)` → `cypress-matrix-required`
- `playwright-tests (chromium)` → `playwright-tests-required`

With this, every required matrix job (`unit-tests`, `test-postgres` via #40772;
`cypress-matrix`, `playwright-tests` here) has a stable anchor, so PRs of any
shape — python, frontend, or docs-only — can satisfy branch protection.

### TESTING INSTRUCTIONS

- Docs-only PR: cypress/playwright skip; the anchors run and pass → mergeable.
- Code PR: the matrix jobs run; the anchors pass after them (and fail if any
  shard genuinely fails).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)