### PR TITLE
fix(nav): prevent top navbar from flashing to vertical layout on load

### DIFF
--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -912,9 +912,10 @@ describe('active tab highlighting (regression #36403)', () => {
   });
 });
 
-test('navbar renders horizontal when breakpoints are not yet measured (regression for layout flash)', async () => {
-  // Simulate first paint: useBreakpoint returns {} before the viewport is measured.
-  // screens.md is undefined, so isMd = (undefined !== false) = true → mode="horizontal".
+test('navbar renders horizontal when breakpoints are not yet measured on a wide viewport (regression for layout flash)', async () => {
+  // Simulate first paint: useBreakpoint returns {} before the viewport is
+  // measured, so the layout falls back to the viewport width (jsdom defaults
+  // to 1024px, above the md threshold) → mode="horizontal".
   mockUseBreakpoint.mockReturnValue({});
   useSelectorMock.mockReturnValue({ roles: user.roles });
   render(<Menu {...mockedProps} />, {
@@ -928,9 +929,40 @@ test('navbar renders horizontal when breakpoints are not yet measured (regressio
   expect(navbar).not.toHaveClass('ant-menu-inline');
 });
 
+test('navbar renders inline when breakpoints are not yet measured on a narrow viewport', async () => {
+  // Simulate first paint on a mobile-sized window: useBreakpoint returns {}
+  // and the viewport-width fallback (below the md threshold) → mode="inline",
+  // so mobile users don't see a horizontal flash either.
+  const originalInnerWidth = window.innerWidth;
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 500,
+  });
+  try {
+    mockUseBreakpoint.mockReturnValue({});
+    useSelectorMock.mockReturnValue({ roles: user.roles });
+    render(<Menu {...mockedProps} />, {
+      useRedux: true,
+      useQueryParams: true,
+      useRouter: true,
+      useTheme: true,
+    });
+    const navbar = await screen.findByTestId('navbar-top');
+    expect(navbar).toHaveClass('ant-menu-inline');
+    expect(navbar).not.toHaveClass('ant-menu-horizontal');
+  } finally {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: originalInnerWidth,
+    });
+  }
+});
+
 test('navbar renders inline on mobile viewport (md: false)', async () => {
-  // Simulate a mobile viewport where the md breakpoint is explicitly false.
-  // isMd = (false !== false) = false → mode="inline".
+  // Simulate a mobile viewport where the md breakpoint has resolved to false,
+  // which takes precedence over the viewport-width fallback → mode="inline".
   mockUseBreakpoint.mockReturnValue({ md: false });
   useSelectorMock.mockReturnValue({ roles: user.roles });
   render(<Menu {...mockedProps} />, {

--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -30,11 +30,13 @@ jest.mock('@apache-superset/core/theme', () => ({
   useTheme: jest.fn(),
 }));
 
+const mockUseBreakpoint = jest.fn<{ md?: boolean }, []>(() => ({ md: true }));
+
 jest.mock('antd', () => ({
   ...jest.requireActual('antd'),
   Grid: {
     ...jest.requireActual('antd').Grid,
-    useBreakpoint: () => ({ md: true }),
+    useBreakpoint: () => mockUseBreakpoint(),
   },
 }));
 
@@ -273,6 +275,8 @@ beforeEach(() => {
   applicationRootMock.mockReturnValue('');
   // By default useTheme returns the real default theme (brandLogoUrl is falsy)
   useThemeMock.mockReturnValue(CoreTheme.supersetTheme);
+  // By default simulate a desktop viewport (md breakpoint active)
+  mockUseBreakpoint.mockReturnValue({ md: true });
 });
 
 test('should render', async () => {
@@ -903,4 +907,35 @@ describe('active tab highlighting (regression #36403)', () => {
       'ant-menu-submenu-selected',
     );
   });
+});
+
+test('navbar renders horizontal when breakpoints are not yet measured (regression for layout flash)', async () => {
+  // Simulate first paint: useBreakpoint returns {} before the viewport is measured.
+  // screens.md is undefined, so isMd = (undefined !== false) = true → mode="horizontal".
+  mockUseBreakpoint.mockReturnValue({});
+  useSelectorMock.mockReturnValue({ roles: user.roles });
+  render(<Menu {...mockedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+    useTheme: true,
+  });
+  const navbar = await screen.findByTestId('navbar-top');
+  expect(navbar).toHaveClass('ant-menu-horizontal');
+  expect(navbar).not.toHaveClass('ant-menu-inline');
+});
+
+test('navbar renders inline on mobile viewport (md: false)', async () => {
+  // Simulate a mobile viewport where the md breakpoint is explicitly false.
+  // isMd = (false !== false) = false → mode="inline".
+  mockUseBreakpoint.mockReturnValue({ md: false });
+  useSelectorMock.mockReturnValue({ roles: user.roles });
+  render(<Menu {...mockedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+    useTheme: true,
+  });
+  const navbar = await screen.findByTestId('navbar-top');
+  expect(navbar).toHaveClass('ant-menu-inline');
 });

--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -32,13 +32,16 @@ jest.mock('@apache-superset/core/theme', () => ({
 
 const mockUseBreakpoint = jest.fn<{ md?: boolean }, []>(() => ({ md: true }));
 
-jest.mock('antd', () => ({
-  ...jest.requireActual('antd'),
-  Grid: {
-    ...jest.requireActual('antd').Grid,
-    useBreakpoint: () => mockUseBreakpoint(),
-  },
-}));
+jest.mock('antd', () => {
+  const actual = jest.requireActual('antd');
+  return {
+    ...actual,
+    Grid: {
+      ...actual.Grid,
+      useBreakpoint: () => mockUseBreakpoint(),
+    },
+  };
+});
 
 const dropdownItems = [
   {

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -199,6 +199,9 @@ export function Menu({
   isFrontendRoute = () => false,
 }: MenuProps) {
   const screens = useBreakpoint();
+  // screens.md is undefined on the first render before breakpoints are measured;
+  // treat undefined as true so the nav renders horizontal instead of flashing to inline
+  const isMd = screens.md !== false;
   const uiConfig = useUiConfig();
   const theme = useTheme();
 
@@ -301,7 +304,7 @@ export function Menu({
     return {
       key,
       label,
-      ...(screens.md && {
+      ...(isMd && {
         icon: <Icons.DownOutlined iconSize="xs" />,
         popupOffset: NAVBAR_MENU_POPUP_OFFSET,
       }),
@@ -385,7 +388,7 @@ export function Menu({
             </StyledBrandText>
           )}
           <StyledMainNav
-            mode={screens.md ? 'horizontal' : 'inline'}
+            mode={isMd ? 'horizontal' : 'inline'}
             data-test="navbar-top"
             className="main-nav"
             selectedKeys={activeTabs}
@@ -413,7 +416,7 @@ export function Menu({
         </StyledCol>
         <Col md={8} xs={24}>
           <RightMenu
-            align={screens.md ? 'flex-end' : 'flex-start'}
+            align={isMd ? 'flex-end' : 'flex-start'}
             settings={settings}
             navbarRight={navbarRight}
             isFrontendRoute={isFrontendRoute}

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -199,11 +199,13 @@ export function Menu({
   isFrontendRoute = () => false,
 }: MenuProps) {
   const screens = useBreakpoint();
-  // screens.md is undefined on the first render before breakpoints are measured;
-  // treat undefined as true so the nav renders horizontal instead of flashing to inline
-  const isMd = screens.md !== false;
   const uiConfig = useUiConfig();
   const theme = useTheme();
+  // screens.md is undefined on the first render before breakpoints are measured;
+  // fall back to the actual viewport width (using the same threshold as antd's
+  // md media query) so the first paint matches the device layout instead of
+  // flashing to the wrong mode on either desktop or mobile
+  const isMd = screens.md ?? window.innerWidth >= theme.screenMDMin;
 
   enum Paths {
     Explore = '/explore',


### PR DESCRIPTION
### Summary

`Grid.useBreakpoint()` (Ant Design) returns an empty object `{}` on the first render before viewport breakpoints are measured. This made `screens.md` `undefined` (falsy), so `screens.md ? 'horizontal' : 'inline'` evaluated to `'inline'` on first paint — rendering the navbar as a vertical stack. After the next render cycle the breakpoint resolved and the nav snapped to horizontal, producing a visible layout flash on every page load.

**Fix:** Replace `screens.md` with `const isMd = screens.md !== false`, which treats the initial `undefined` as `true` (desktop/horizontal layout) and only switches to mobile/inline layout when `screens.md` is explicitly `false`. All three `screens.md` usages in `Menu.tsx` (`mode`, `align`, and the dropdown icon spread) are updated to use `isMd`.

### Testing

Tested by loading a Superset workspace and verifying the top navbar renders horizontally on first paint with no layout flash. Responsive behavior (switching to inline on narrow viewports) is preserved.

### Checklist

- [x] Local testing done
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)

Fixes: [sc-108034](https://app.shortcut.com/preset/story/108034)

🤖 Generated with [Claude Code](https://claude.com/claude-code)