### PR TITLE
test(dashboard-filter): RTL coverage for horizontal filter bar

### DIFF
--- a/superset-frontend/spec/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/fixtures/mockNativeFilters.ts
@@ -19,6 +19,7 @@
 import {
   DataMaskStateWithId,
   ExtraFormData,
+  Filter,
   NativeFiltersState,
   NativeFilterType,
 } from '@superset-ui/core';
@@ -457,6 +458,25 @@ export const mockQueryDataForCountries = [
   { country_name: 'Zambia', 'SUM(SP_POP_TOTL)': 438847085 },
   { country_name: 'Zimbabwe', 'SUM(SP_POP_TOTL)': 509866860 },
 ];
+
+export const createSelectNativeFilter = (
+  id: string,
+  name: string,
+  column: string = name,
+): Filter => ({
+  id,
+  name,
+  type: NativeFilterType.NativeFilter,
+  filterType: 'filter_select',
+  targets: [{ datasetId: 2, column: { name: column } }],
+  defaultDataMask: { filterState: { value: null }, extraFormData: {} },
+  controlValues: {},
+  cascadeParentIds: [],
+  scope: { rootPath: ['ROOT_ID'], excluded: [] },
+  description: '',
+  chartsInScope: [],
+  tabsInScope: [],
+});
 
 export const buildNativeFilter = (
   id: string,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -992,6 +992,51 @@ test('FilterBar with orientation=Horizontal routes to Horizontal layout instead 
   expect(screen.getByRole('img', { name: 'setting' })).toBeInTheDocument();
 });
 
+test('FilterBar with orientation=Horizontal and no filters shows empty state alongside default actions', async () => {
+  // Covers the second half of sc-107387 task #107390 ("show all default
+  // actions in horizontal mode"). The original Cypress spec asserted four
+  // affordances render when the bar is horizontal with no filters: the
+  // empty-state copy, the settings gear, the action-buttons block, and the
+  // create-filter entry inside the gear menu. The dropdown contents are
+  // already covered by FilterBarSettings.test.tsx; here we keep scope to
+  // the layout-level affordances that are exclusive to Horizontal.tsx.
+  // Reload-persistence (the rest of #107390) is out of RTL scope and stays
+  // queued for Playwright.
+  const state = {
+    ...stateWithoutNativeFilters,
+    dashboardInfo: {
+      id: 1,
+      dash_edit_perm: true,
+      metadata: {
+        native_filter_configuration: [],
+        filterBarOrientation: FilterBarOrientation.Horizontal,
+      },
+    },
+    dashboardState: {
+      ...stateWithoutNativeFilters.dashboardState,
+      activeTabs: ['ROOT_ID'],
+    },
+    nativeFilters: { filters: {}, filtersState: {} },
+  };
+
+  render(<FilterBar orientation={FilterBarOrientation.Horizontal} />, {
+    initialState: state,
+    useDnd: true,
+    useRedux: true,
+    useRouter: true,
+  });
+
+  await act(async () => {
+    jest.runAllTimers();
+  });
+
+  expect(screen.getByTestId('horizontal-filterbar-empty')).toHaveTextContent(
+    'No filters are currently added to this dashboard.',
+  );
+  expect(screen.getByRole('img', { name: 'setting' })).toBeInTheDocument();
+  expect(screen.getByTestId('filterbar-action-buttons')).toBeInTheDocument();
+});
+
 test('FilterBar with orientation=Vertical renders Vertical layout (sanity counterpart to the horizontal routing test)', () => {
   // Paired control for the routing test above: with Vertical orientation,
   // the settings gear must NOT be present (Vertical.tsx does not render

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -960,3 +960,47 @@ test('Clicking the gear "Add or edit filters and controls" item opens the Filter
 
   expect(await screen.findByTestId('filter-modal')).toBeInTheDocument();
 });
+
+test('FilterBar with orientation=Horizontal routes to Horizontal layout instead of Vertical', async () => {
+  // Migrated from the disabled Cypress spec _skip.horizontalFilterBar.test.ts:
+  // proves the orientation prop selects the Horizontal subtree. The settings
+  // gear (FilterBarSettings) is rendered only by Horizontal.tsx — Vertical.tsx
+  // does not mount it — so its presence is a horizontal-exclusive positive
+  // signal that won't false-pass if vertical heading copy is tuned. We flush
+  // all pending fake timers to clear useInitialization's setTimeout
+  // regardless of the production timeout literal.
+  const filter = createFilter({
+    id: 'NATIVE_FILTER-h1',
+    name: 'Horizontal filter',
+  });
+  const dataMask = createDataMask(filter.id);
+  const state = createStateWithFilter(filter, dataMask, {
+    filterBarOrientation: FilterBarOrientation.Horizontal,
+  });
+
+  render(<FilterBar orientation={FilterBarOrientation.Horizontal} />, {
+    initialState: state,
+    useDnd: true,
+    useRedux: true,
+    useRouter: true,
+  });
+
+  await act(async () => {
+    jest.runAllTimers();
+  });
+
+  expect(screen.getByRole('img', { name: 'setting' })).toBeInTheDocument();
+});
+
+test('FilterBar with orientation=Vertical renders Vertical layout (sanity counterpart to the horizontal routing test)', () => {
+  // Paired control for the routing test above: with Vertical orientation,
+  // the settings gear must NOT be present (Vertical.tsx does not render
+  // FilterBarSettings). Confirms the routing signal is horizontal-exclusive,
+  // not a coincidence of when timers fire.
+  const props = createClosedBarProps();
+  renderFilterBar(props);
+  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
+  expect(
+    screen.queryByRole('img', { name: 'setting' }),
+  ).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.overflow.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.overflow.test.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { act } from 'react';
 import { NativeFilterType, Preset } from '@superset-ui/core';
 import type { DataMaskStateWithId } from '@superset-ui/core';
 import type {
@@ -25,7 +24,7 @@ import type {
 } from '@superset-ui/core/components/DropdownContainer';
 import { SelectFilterPlugin } from 'src/filters/components';
 import { FilterBarOrientation } from 'src/dashboard/types';
-import { render, waitFor, within } from 'spec/helpers/testing-library';
+import { act, render, waitFor, within } from 'spec/helpers/testing-library';
 import FilterControls from './FilterControls';
 
 // Capture every props snapshot DropdownContainer receives, plus the latest

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.overflow.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.overflow.test.tsx
@@ -1,0 +1,320 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act } from 'react';
+import { NativeFilterType, Preset } from '@superset-ui/core';
+import type { DataMaskStateWithId } from '@superset-ui/core';
+import type {
+  DropdownContainerProps,
+  DropdownItem,
+} from '@superset-ui/core/components/DropdownContainer';
+import { SelectFilterPlugin } from 'src/filters/components';
+import { FilterBarOrientation } from 'src/dashboard/types';
+import { render, waitFor, within } from 'spec/helpers/testing-library';
+import FilterControls from './FilterControls';
+
+// Capture every props snapshot DropdownContainer receives, plus the latest
+// onOverflowingStateChange callback. Tests drive overflow by invoking the
+// callback and then assert against the *next* captured props snapshot —
+// these are the values FilterControls itself computed (dropdownTriggerCount,
+// dropdownContent, items) so assertions exercise real production logic
+// rather than props the test handed in directly.
+const dropdownContainerProps: DropdownContainerProps[] = [];
+const callbackRef: {
+  current:
+    | ((s: { overflowed: string[]; notOverflowed: string[] }) => void)
+    | null;
+} = { current: null };
+
+// Mock the DropdownContainer subpath rather than the barrel
+// `@superset-ui/core/components` — mocking the barrel triggers a
+// circular re-export chain at requireActual time
+// (LabeledErrorBoundInput → ActionButton is undefined at that point).
+// The barrel's `export { DropdownContainer } from './DropdownContainer'`
+// resolves to this subpath, so the mock is picked up transparently.
+jest.mock('@superset-ui/core/components/DropdownContainer', () => {
+  const React = jest.requireActual('react');
+  const MockDropdownContainer = React.forwardRef(
+    (props: DropdownContainerProps, ref: React.Ref<unknown>) => {
+      dropdownContainerProps.push(props);
+      callbackRef.current = props.onOverflowingStateChange ?? null;
+      React.useImperativeHandle(ref, () => ({
+        open: jest.fn(),
+        close: jest.fn(),
+      }));
+      return (
+        <div data-test="dropdown-container-mock">
+          <div data-test="dropdown-items">
+            {props.items.map((item: DropdownItem) => (
+              <div key={item.id} data-test="dropdown-item">
+                {item.element}
+              </div>
+            ))}
+          </div>
+          <div data-test="dropdown-trigger-text">
+            {props.dropdownTriggerText}
+          </div>
+          <div data-test="dropdown-trigger-count">
+            {props.dropdownTriggerCount}
+          </div>
+          {props.dropdownContent && (
+            <div data-test="dropdown-content-mock">
+              {props.dropdownContent([])}
+            </div>
+          )}
+        </div>
+      );
+    },
+  );
+  return { __esModule: true, DropdownContainer: MockDropdownContainer };
+});
+
+class OverflowTestPreset extends Preset {
+  constructor() {
+    super({
+      name: 'FilterControls overflow test preset',
+      plugins: [new SelectFilterPlugin().configure({ key: 'filter_select' })],
+    });
+  }
+}
+new OverflowTestPreset().register();
+
+const createSelectFilter = (id: string, name: string) => ({
+  id,
+  name,
+  type: NativeFilterType.NativeFilter,
+  filterType: 'filter_select',
+  targets: [{ datasetId: 2, column: { name: 'col' } }],
+  defaultDataMask: { filterState: { value: null }, extraFormData: {} },
+  controlValues: {},
+  cascadeParentIds: [],
+  scope: { rootPath: ['ROOT_ID'], excluded: [] },
+  description: '',
+  chartsInScope: [],
+  tabsInScope: [],
+});
+
+// Tabless dashboard layout ⇒ useSelectFiltersInScope returns all filters in
+// scope without needing to model tab parentage.
+const buildHorizontalState = (
+  filters: ReturnType<typeof createSelectFilter>[],
+) => ({
+  dashboardInfo: {
+    id: 1,
+    dash_edit_perm: true,
+    filterBarOrientation: FilterBarOrientation.Horizontal,
+    metadata: {
+      native_filter_configuration: filters,
+    },
+  },
+  dashboardLayout: {
+    present: {
+      ROOT_ID: { type: 'ROOT', id: 'ROOT_ID', children: [] },
+    },
+    past: [],
+    future: [],
+  },
+  dashboardState: {
+    sliceIds: [],
+    activeTabs: [],
+  },
+  charts: {},
+  nativeFilters: {
+    filters: filters.reduce(
+      (acc, f) => ({ ...acc, [f.id]: f }),
+      {} as Record<string, ReturnType<typeof createSelectFilter>>,
+    ),
+    filtersState: {},
+  },
+  dataMask: {},
+  sliceEntities: { slices: {} },
+  datasources: {},
+});
+
+const buildDataMaskSelected = (
+  filters: ReturnType<typeof createSelectFilter>[],
+  withValueIds: string[] = [],
+): DataMaskStateWithId =>
+  filters.reduce(
+    (acc, f) => ({
+      ...acc,
+      [f.id]: {
+        id: f.id,
+        filterState: {
+          value: withValueIds.includes(f.id) ? ['set'] : null,
+        },
+        extraFormData: {},
+      },
+    }),
+    {} as DataMaskStateWithId,
+  );
+
+const renderHorizontal = (
+  filters: ReturnType<typeof createSelectFilter>[],
+  dataMaskSelected: DataMaskStateWithId,
+) =>
+  render(
+    <FilterControls
+      dataMaskSelected={dataMaskSelected}
+      onFilterSelectionChange={jest.fn()}
+      onPendingCustomizationDataMaskChange={jest.fn()}
+      chartCustomizationValues={[]}
+    />,
+    {
+      useRedux: true,
+      useRouter: true,
+      initialState: buildHorizontalState(filters),
+    },
+  );
+
+const latestProps = () =>
+  dropdownContainerProps[dropdownContainerProps.length - 1];
+
+const fireOverflow = (overflowed: string[], notOverflowed: string[]) => {
+  if (!callbackRef.current) {
+    throw new Error('onOverflowingStateChange callback not captured');
+  }
+  act(() => {
+    callbackRef.current!({ overflowed, notOverflowed });
+  });
+};
+
+beforeEach(() => {
+  dropdownContainerProps.length = 0;
+  callbackRef.current = null;
+});
+
+test('horizontal FilterControls hands every filter to DropdownContainer as an item', async () => {
+  const filters = [
+    createSelectFilter('NATIVE_FILTER-1', 'country'),
+    createSelectFilter('NATIVE_FILTER-2', 'region'),
+    createSelectFilter('NATIVE_FILTER-3', 'city'),
+    createSelectFilter('NATIVE_FILTER-4', 'zip'),
+  ];
+
+  renderHorizontal(filters, buildDataMaskSelected(filters));
+
+  await waitFor(() => expect(latestProps()).toBeTruthy());
+
+  expect(latestProps().items.map((i: DropdownItem) => i.id)).toEqual([
+    'NATIVE_FILTER-1',
+    'NATIVE_FILTER-2',
+    'NATIVE_FILTER-3',
+    'NATIVE_FILTER-4',
+  ]);
+  // dropdownTriggerText is the production string FilterControls passes in.
+  expect(latestProps().dropdownTriggerText).toBe('More filters');
+});
+
+test('with no overflow callback fired, dropdown trigger count is 0 and content is empty', async () => {
+  const filters = [
+    createSelectFilter('NATIVE_FILTER-1', 'country'),
+    createSelectFilter('NATIVE_FILTER-2', 'region'),
+  ];
+
+  renderHorizontal(
+    filters,
+    buildDataMaskSelected(filters, ['NATIVE_FILTER-1']),
+  );
+
+  await waitFor(() => expect(latestProps()).toBeTruthy());
+
+  expect(latestProps().dropdownTriggerCount).toBe(0);
+  // FilterControls only supplies dropdownContent when something overflowed.
+  expect(latestProps().dropdownContent).toBeUndefined();
+});
+
+test('firing overflow with two filters that have values increments the trigger count to 2', async () => {
+  const filters = [
+    createSelectFilter('NATIVE_FILTER-1', 'country'),
+    createSelectFilter('NATIVE_FILTER-2', 'region'),
+    createSelectFilter('NATIVE_FILTER-3', 'city'),
+    createSelectFilter('NATIVE_FILTER-4', 'zip'),
+  ];
+
+  renderHorizontal(
+    filters,
+    // Mark the two we plan to overflow as having values; the production
+    // selector activeOverflowedFiltersInScope filters on dataMask.filterState.value.
+    buildDataMaskSelected(filters, ['NATIVE_FILTER-3', 'NATIVE_FILTER-4']),
+  );
+
+  await waitFor(() => expect(callbackRef.current).toBeTruthy());
+
+  fireOverflow(
+    ['NATIVE_FILTER-3', 'NATIVE_FILTER-4'],
+    ['NATIVE_FILTER-1', 'NATIVE_FILTER-2'],
+  );
+
+  await waitFor(() => {
+    expect(latestProps().dropdownTriggerCount).toBe(2);
+  });
+});
+
+test('firing overflow with no active values keeps trigger count at 0 but supplies dropdownContent', async () => {
+  // Reinforces the activeOverflowedFiltersInScope branch in
+  // FilterControls.tsx: count is the *active* (value-bearing) subset of
+  // overflowed filters, not the raw overflowed count. If the production
+  // memo regressed to use overflowedFiltersInScope.length, this fails.
+  const filters = [
+    createSelectFilter('NATIVE_FILTER-1', 'country'),
+    createSelectFilter('NATIVE_FILTER-2', 'region'),
+    createSelectFilter('NATIVE_FILTER-3', 'city'),
+  ];
+
+  renderHorizontal(filters, buildDataMaskSelected(filters));
+
+  await waitFor(() => expect(callbackRef.current).toBeTruthy());
+
+  fireOverflow(['NATIVE_FILTER-2', 'NATIVE_FILTER-3'], ['NATIVE_FILTER-1']);
+
+  await waitFor(() => {
+    expect(latestProps().dropdownContent).toBeDefined();
+  });
+  expect(latestProps().dropdownTriggerCount).toBe(0);
+});
+
+test('all 12 overflowed filters are reachable through dropdownContent', async () => {
+  // Substitutes for the disabled Cypress "scroll within overflow" assertion:
+  // jsdom has no real layout/scrolling, so we instead prove every overflowed
+  // filter renders inside the dropdown panel.
+  const filters = Array.from({ length: 12 }, (_, i) =>
+    createSelectFilter(`NATIVE_FILTER-${i + 1}`, `filter_${i + 1}`),
+  );
+
+  renderHorizontal(filters, buildDataMaskSelected(filters));
+
+  await waitFor(() => expect(callbackRef.current).toBeTruthy());
+
+  fireOverflow(
+    filters.map(f => f.id),
+    [],
+  );
+
+  // dropdownContent renders FiltersDropdownContent, which renders each
+  // overflowed filter through the renderer prop. Asserting on identity
+  // (not just count) catches a regression that rendered the wrong subset
+  // of filters in the dropdown — e.g. all `filtersInScope` instead of
+  // the overflowed slice.
+  const { findByTestId } = within(document.body);
+  const contentSlot = await findByTestId('dropdown-content-mock');
+  await waitFor(() => {
+    const names = within(contentSlot).getAllByTestId('filter-control-name');
+    expect(names.map(n => n.textContent)).toEqual(filters.map(f => f.name));
+  });
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.overflow.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.overflow.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { NativeFilterType, Preset } from '@superset-ui/core';
+import { Preset } from '@superset-ui/core';
 import type { DataMaskStateWithId } from '@superset-ui/core';
 import type {
   DropdownContainerProps,
@@ -25,6 +25,7 @@ import type {
 import { SelectFilterPlugin } from 'src/filters/components';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { act, render, waitFor, within } from 'spec/helpers/testing-library';
+import { createSelectNativeFilter } from 'spec/fixtures/mockNativeFilters';
 import FilterControls from './FilterControls';
 
 // Capture every props snapshot DropdownContainer receives, plus the latest
@@ -93,25 +94,10 @@ class OverflowTestPreset extends Preset {
 }
 new OverflowTestPreset().register();
 
-const createSelectFilter = (id: string, name: string) => ({
-  id,
-  name,
-  type: NativeFilterType.NativeFilter,
-  filterType: 'filter_select',
-  targets: [{ datasetId: 2, column: { name: 'col' } }],
-  defaultDataMask: { filterState: { value: null }, extraFormData: {} },
-  controlValues: {},
-  cascadeParentIds: [],
-  scope: { rootPath: ['ROOT_ID'], excluded: [] },
-  description: '',
-  chartsInScope: [],
-  tabsInScope: [],
-});
-
 // Tabless dashboard layout ⇒ useSelectFiltersInScope returns all filters in
 // scope without needing to model tab parentage.
 const buildHorizontalState = (
-  filters: ReturnType<typeof createSelectFilter>[],
+  filters: ReturnType<typeof createSelectNativeFilter>[],
 ) => ({
   dashboardInfo: {
     id: 1,
@@ -130,13 +116,13 @@ const buildHorizontalState = (
   },
   dashboardState: {
     sliceIds: [],
-    activeTabs: [],
+    activeTabs: ['ROOT_ID'],
   },
   charts: {},
   nativeFilters: {
     filters: filters.reduce(
       (acc, f) => ({ ...acc, [f.id]: f }),
-      {} as Record<string, ReturnType<typeof createSelectFilter>>,
+      {} as Record<string, ReturnType<typeof createSelectNativeFilter>>,
     ),
     filtersState: {},
   },
@@ -146,7 +132,7 @@ const buildHorizontalState = (
 });
 
 const buildDataMaskSelected = (
-  filters: ReturnType<typeof createSelectFilter>[],
+  filters: ReturnType<typeof createSelectNativeFilter>[],
   withValueIds: string[] = [],
 ): DataMaskStateWithId =>
   filters.reduce(
@@ -164,7 +150,7 @@ const buildDataMaskSelected = (
   );
 
 const renderHorizontal = (
-  filters: ReturnType<typeof createSelectFilter>[],
+  filters: ReturnType<typeof createSelectNativeFilter>[],
   dataMaskSelected: DataMaskStateWithId,
 ) =>
   render(
@@ -200,10 +186,10 @@ beforeEach(() => {
 
 test('horizontal FilterControls hands every filter to DropdownContainer as an item', async () => {
   const filters = [
-    createSelectFilter('NATIVE_FILTER-1', 'country'),
-    createSelectFilter('NATIVE_FILTER-2', 'region'),
-    createSelectFilter('NATIVE_FILTER-3', 'city'),
-    createSelectFilter('NATIVE_FILTER-4', 'zip'),
+    createSelectNativeFilter('NATIVE_FILTER-1', 'country'),
+    createSelectNativeFilter('NATIVE_FILTER-2', 'region'),
+    createSelectNativeFilter('NATIVE_FILTER-3', 'city'),
+    createSelectNativeFilter('NATIVE_FILTER-4', 'zip'),
   ];
 
   renderHorizontal(filters, buildDataMaskSelected(filters));
@@ -222,8 +208,8 @@ test('horizontal FilterControls hands every filter to DropdownContainer as an it
 
 test('with no overflow callback fired, dropdown trigger count is 0 and content is empty', async () => {
   const filters = [
-    createSelectFilter('NATIVE_FILTER-1', 'country'),
-    createSelectFilter('NATIVE_FILTER-2', 'region'),
+    createSelectNativeFilter('NATIVE_FILTER-1', 'country'),
+    createSelectNativeFilter('NATIVE_FILTER-2', 'region'),
   ];
 
   renderHorizontal(
@@ -240,10 +226,10 @@ test('with no overflow callback fired, dropdown trigger count is 0 and content i
 
 test('firing overflow with two filters that have values increments the trigger count to 2', async () => {
   const filters = [
-    createSelectFilter('NATIVE_FILTER-1', 'country'),
-    createSelectFilter('NATIVE_FILTER-2', 'region'),
-    createSelectFilter('NATIVE_FILTER-3', 'city'),
-    createSelectFilter('NATIVE_FILTER-4', 'zip'),
+    createSelectNativeFilter('NATIVE_FILTER-1', 'country'),
+    createSelectNativeFilter('NATIVE_FILTER-2', 'region'),
+    createSelectNativeFilter('NATIVE_FILTER-3', 'city'),
+    createSelectNativeFilter('NATIVE_FILTER-4', 'zip'),
   ];
 
   renderHorizontal(
@@ -271,9 +257,9 @@ test('firing overflow with no active values keeps trigger count at 0 but supplie
   // overflowed filters, not the raw overflowed count. If the production
   // memo regressed to use overflowedFiltersInScope.length, this fails.
   const filters = [
-    createSelectFilter('NATIVE_FILTER-1', 'country'),
-    createSelectFilter('NATIVE_FILTER-2', 'region'),
-    createSelectFilter('NATIVE_FILTER-3', 'city'),
+    createSelectNativeFilter('NATIVE_FILTER-1', 'country'),
+    createSelectNativeFilter('NATIVE_FILTER-2', 'region'),
+    createSelectNativeFilter('NATIVE_FILTER-3', 'city'),
   ];
 
   renderHorizontal(filters, buildDataMaskSelected(filters));
@@ -283,7 +269,7 @@ test('firing overflow with no active values keeps trigger count at 0 but supplie
   fireOverflow(['NATIVE_FILTER-2', 'NATIVE_FILTER-3'], ['NATIVE_FILTER-1']);
 
   await waitFor(() => {
-    expect(latestProps().dropdownContent).toBeDefined();
+    expect(latestProps().dropdownContent).toBeInstanceOf(Function);
   });
   expect(latestProps().dropdownTriggerCount).toBe(0);
 });
@@ -293,7 +279,7 @@ test('all 12 overflowed filters are reachable through dropdownContent', async ()
   // jsdom has no real layout/scrolling, so we instead prove every overflowed
   // filter renders inside the dropdown panel.
   const filters = Array.from({ length: 12 }, (_, i) =>
-    createSelectFilter(`NATIVE_FILTER-${i + 1}`, `filter_${i + 1}`),
+    createSelectNativeFilter(`NATIVE_FILTER-${i + 1}`, `filter_${i + 1}`),
   );
 
   renderHorizontal(filters, buildDataMaskSelected(filters));

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
@@ -16,9 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { NativeFilterType } from '@superset-ui/core';
+import { NativeFilterType, Preset } from '@superset-ui/core';
+import { SelectFilterPlugin } from 'src/filters/components';
+import { FilterBarOrientation } from 'src/dashboard/types';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import HorizontalBar from './Horizontal';
+
+// Register the select filter plugin once so FilterControl can render the
+// filter name without throwing when the plugin registry is consulted.
+class HorizontalFilterBarTestPreset extends Preset {
+  constructor() {
+    super({
+      name: 'Horizontal filter bar test preset',
+      plugins: [new SelectFilterPlugin().configure({ key: 'filter_select' })],
+    });
+  }
+}
+new HorizontalFilterBarTestPreset().register();
 
 const defaultProps = {
   actions: null,
@@ -91,4 +105,149 @@ test('should render the loading icon', async () => {
     isInitialized: false,
   });
   expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+});
+
+// --- Tests migrated from disabled Cypress spec
+//     `_skip.horizontalFilterBar.test.ts` (sc-107387). ---
+
+const createSelectFilter = (id: string, name: string, column: string) => ({
+  id,
+  name,
+  type: NativeFilterType.NativeFilter,
+  filterType: 'filter_select',
+  targets: [{ datasetId: 2, column: { name: column } }],
+  defaultDataMask: { filterState: { value: null }, extraFormData: {} },
+  controlValues: {},
+  cascadeParentIds: [],
+  scope: { rootPath: ['ROOT_ID'], excluded: [] },
+  description: '',
+  chartsInScope: [],
+  tabsInScope: [],
+});
+
+const buildStateWithFilters = (
+  filters: ReturnType<typeof createSelectFilter>[],
+) => ({
+  dashboardState: {
+    sliceIds: [],
+    activeTabs: ['ROOT_ID'],
+  },
+  dashboardInfo: {
+    id: 1,
+    dash_edit_perm: true,
+    filterBarOrientation: FilterBarOrientation.Horizontal,
+    metadata: {
+      native_filter_configuration: filters,
+    },
+  },
+  dashboardLayout: {
+    present: {
+      ROOT_ID: { type: 'ROOT', id: 'ROOT_ID', children: [] },
+    },
+    past: [],
+    future: [],
+  },
+  charts: {},
+  nativeFilters: {
+    filters: filters.reduce(
+      (acc, f) => ({ ...acc, [f.id]: f }),
+      {} as Record<string, ReturnType<typeof createSelectFilter>>,
+    ),
+    filtersState: {},
+  },
+  dataMask: filters.reduce(
+    (acc, f) => ({
+      ...acc,
+      [f.id]: { id: f.id, filterState: { value: null }, extraFormData: {} },
+    }),
+    {} as Record<string, unknown>,
+  ),
+  sliceEntities: { slices: {} },
+  datasources: {},
+});
+
+const renderWithFilters = (
+  filters: ReturnType<typeof createSelectFilter>[],
+  overrideProps?: Record<string, any>,
+) =>
+  render(<HorizontalBar {...defaultProps} {...overrideProps} />, {
+    useRedux: true,
+    useRouter: true,
+    initialState: buildStateWithFilters(filters),
+  });
+
+test('renders default actions slot, settings gear, and empty message together in horizontal mode', async () => {
+  const sentinelActions = (
+    <button type="button" data-test="sentinel-actions">
+      apply
+    </button>
+  );
+
+  await waitFor(() =>
+    render(
+      <HorizontalBar
+        {...defaultProps}
+        actions={sentinelActions}
+        filterValues={[]}
+      />,
+      {
+        useRedux: true,
+        useRouter: true,
+        initialState: {
+          dashboardState: { sliceIds: [] },
+          dashboardInfo: {
+            id: 1,
+            dash_edit_perm: true,
+            filterBarOrientation: FilterBarOrientation.Horizontal,
+          },
+          dashboardLayout: { present: {}, past: [], future: [] },
+        },
+      },
+    ),
+  );
+
+  expect(
+    screen.getByText('No filters are currently added to this dashboard.'),
+  ).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: 'setting' })).toBeInTheDocument();
+  expect(screen.getByTestId('sentinel-actions')).toBeInTheDocument();
+});
+
+test('renders all native filters supplied via filterValues in horizontal mode', async () => {
+  const filters = [
+    createSelectFilter('NATIVE_FILTER-1', 'test_1', 'country_name'),
+    createSelectFilter('NATIVE_FILTER-2', 'test_2', 'country_code'),
+    createSelectFilter('NATIVE_FILTER-3', 'test_3', 'region'),
+  ];
+
+  renderWithFilters(filters, { filterValues: filters });
+
+  await waitFor(() => {
+    const filterNames = screen.getAllByTestId('filter-control-name');
+    expect(filterNames).toHaveLength(3);
+  });
+
+  ['test_1', 'test_2', 'test_3'].forEach(name => {
+    expect(screen.getByText(name)).toBeInTheDocument();
+  });
+});
+
+test('omits the empty message when at least one filter value is supplied', async () => {
+  // Companion to the "renders all native filters" test above: the migrated
+  // Cypress "display newly added filter" scenario reduces, at this layer, to
+  // proving that supplying a filter value flips off the empty state. The
+  // upstream user flow (open edit modal, add filter, save) is integration
+  // territory and not covered here.
+  const filters = [
+    createSelectFilter('NATIVE_FILTER-1', 'just_added', 'country_name'),
+  ];
+
+  renderWithFilters(filters, { filterValues: filters });
+
+  await waitFor(() => {
+    expect(screen.getByText('just_added')).toBeInTheDocument();
+  });
+  expect(
+    screen.queryByText('No filters are currently added to this dashboard.'),
+  ).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
@@ -17,10 +17,12 @@
  * under the License.
  */
 import { NativeFilterType, Preset } from '@superset-ui/core';
+import type { Filter } from '@superset-ui/core';
 import { SelectFilterPlugin } from 'src/filters/components';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import HorizontalBar from './Horizontal';
+import type { HorizontalBarProps } from './types';
 
 // Register the select filter plugin once so FilterControl can render the
 // filter name without throwing when the plugin registry is consulted.
@@ -46,7 +48,7 @@ const defaultProps = {
   onPendingCustomizationDataMaskChange: jest.fn(),
 };
 
-const renderWrapper = (overrideProps?: Record<string, any>) =>
+const renderWrapper = (overrideProps?: Partial<HorizontalBarProps>) =>
   waitFor(() =>
     render(<HorizontalBar {...defaultProps} {...overrideProps} />, {
       useRedux: true,
@@ -78,7 +80,7 @@ test('should not render the empty message', async () => {
       {
         id: 'test',
         type: NativeFilterType.NativeFilter,
-      },
+      } as unknown as Filter,
     ],
   });
   expect(
@@ -110,20 +112,21 @@ test('should render the loading icon', async () => {
 // --- Tests migrated from disabled Cypress spec
 //     `_skip.horizontalFilterBar.test.ts` (sc-107387). ---
 
-const createSelectFilter = (id: string, name: string, column: string) => ({
-  id,
-  name,
-  type: NativeFilterType.NativeFilter,
-  filterType: 'filter_select',
-  targets: [{ datasetId: 2, column: { name: column } }],
-  defaultDataMask: { filterState: { value: null }, extraFormData: {} },
-  controlValues: {},
-  cascadeParentIds: [],
-  scope: { rootPath: ['ROOT_ID'], excluded: [] },
-  description: '',
-  chartsInScope: [],
-  tabsInScope: [],
-});
+const createSelectFilter = (id: string, name: string, column: string): Filter =>
+  ({
+    id,
+    name,
+    type: NativeFilterType.NativeFilter,
+    filterType: 'filter_select',
+    targets: [{ datasetId: 2, column: { name: column } }],
+    defaultDataMask: { filterState: { value: null }, extraFormData: {} },
+    controlValues: {},
+    cascadeParentIds: [],
+    scope: { rootPath: ['ROOT_ID'], excluded: [] },
+    description: '',
+    chartsInScope: [],
+    tabsInScope: [],
+  }) as unknown as Filter;
 
 const buildStateWithFilters = (
   filters: ReturnType<typeof createSelectFilter>[],
@@ -168,7 +171,7 @@ const buildStateWithFilters = (
 
 const renderWithFilters = (
   filters: ReturnType<typeof createSelectFilter>[],
-  overrideProps?: Record<string, any>,
+  overrideProps?: Partial<HorizontalBarProps>,
 ) =>
   render(<HorizontalBar {...defaultProps} {...overrideProps} />, {
     useRedux: true,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
@@ -76,6 +76,8 @@ test('should render', async () => {
 
 test('should not render the empty message', async () => {
   await renderWrapper({
+    // Intentionally minimal — Horizontal only reads filterValues.length
+    // here, so the missing required Filter fields would never be read.
     filterValues: [
       {
         id: 'test',
@@ -112,21 +114,20 @@ test('should render the loading icon', async () => {
 // --- Tests migrated from disabled Cypress spec
 //     `_skip.horizontalFilterBar.test.ts` (sc-107387). ---
 
-const createSelectFilter = (id: string, name: string, column: string): Filter =>
-  ({
-    id,
-    name,
-    type: NativeFilterType.NativeFilter,
-    filterType: 'filter_select',
-    targets: [{ datasetId: 2, column: { name: column } }],
-    defaultDataMask: { filterState: { value: null }, extraFormData: {} },
-    controlValues: {},
-    cascadeParentIds: [],
-    scope: { rootPath: ['ROOT_ID'], excluded: [] },
-    description: '',
-    chartsInScope: [],
-    tabsInScope: [],
-  }) as unknown as Filter;
+const createSelectFilter = (id: string, name: string, column: string): Filter => ({
+  id,
+  name,
+  type: NativeFilterType.NativeFilter,
+  filterType: 'filter_select',
+  targets: [{ datasetId: 2, column: { name: column } }],
+  defaultDataMask: { filterState: { value: null }, extraFormData: {} },
+  controlValues: {},
+  cascadeParentIds: [],
+  scope: { rootPath: ['ROOT_ID'], excluded: [] },
+  description: '',
+  chartsInScope: [],
+  tabsInScope: [],
+});
 
 const buildStateWithFilters = (
   filters: ReturnType<typeof createSelectFilter>[],

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
@@ -114,7 +114,11 @@ test('should render the loading icon', async () => {
 // --- Tests migrated from disabled Cypress spec
 //     `_skip.horizontalFilterBar.test.ts` (sc-107387). ---
 
-const createSelectFilter = (id: string, name: string, column: string): Filter => ({
+const createSelectFilter = (
+  id: string,
+  name: string,
+  column: string,
+): Filter => ({
   id,
   name,
   type: NativeFilterType.NativeFilter,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
@@ -21,6 +21,7 @@ import type { Filter } from '@superset-ui/core';
 import { SelectFilterPlugin } from 'src/filters/components';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { createSelectNativeFilter } from 'spec/fixtures/mockNativeFilters';
 import HorizontalBar from './Horizontal';
 import type { HorizontalBarProps } from './types';
 
@@ -114,27 +115,8 @@ test('should render the loading icon', async () => {
 // --- Tests migrated from disabled Cypress spec
 //     `_skip.horizontalFilterBar.test.ts` (sc-107387). ---
 
-const createSelectFilter = (
-  id: string,
-  name: string,
-  column: string,
-): Filter => ({
-  id,
-  name,
-  type: NativeFilterType.NativeFilter,
-  filterType: 'filter_select',
-  targets: [{ datasetId: 2, column: { name: column } }],
-  defaultDataMask: { filterState: { value: null }, extraFormData: {} },
-  controlValues: {},
-  cascadeParentIds: [],
-  scope: { rootPath: ['ROOT_ID'], excluded: [] },
-  description: '',
-  chartsInScope: [],
-  tabsInScope: [],
-});
-
 const buildStateWithFilters = (
-  filters: ReturnType<typeof createSelectFilter>[],
+  filters: ReturnType<typeof createSelectNativeFilter>[],
 ) => ({
   dashboardState: {
     sliceIds: [],
@@ -159,7 +141,7 @@ const buildStateWithFilters = (
   nativeFilters: {
     filters: filters.reduce(
       (acc, f) => ({ ...acc, [f.id]: f }),
-      {} as Record<string, ReturnType<typeof createSelectFilter>>,
+      {} as Record<string, ReturnType<typeof createSelectNativeFilter>>,
     ),
     filtersState: {},
   },
@@ -175,7 +157,7 @@ const buildStateWithFilters = (
 });
 
 const renderWithFilters = (
-  filters: ReturnType<typeof createSelectFilter>[],
+  filters: ReturnType<typeof createSelectNativeFilter>[],
   overrideProps?: Partial<HorizontalBarProps>,
 ) =>
   render(<HorizontalBar {...defaultProps} {...overrideProps} />, {
@@ -223,9 +205,9 @@ test('renders default actions slot, settings gear, and empty message together in
 
 test('renders all native filters supplied via filterValues in horizontal mode', async () => {
   const filters = [
-    createSelectFilter('NATIVE_FILTER-1', 'test_1', 'country_name'),
-    createSelectFilter('NATIVE_FILTER-2', 'test_2', 'country_code'),
-    createSelectFilter('NATIVE_FILTER-3', 'test_3', 'region'),
+    createSelectNativeFilter('NATIVE_FILTER-1', 'test_1', 'country_name'),
+    createSelectNativeFilter('NATIVE_FILTER-2', 'test_2', 'country_code'),
+    createSelectNativeFilter('NATIVE_FILTER-3', 'test_3', 'region'),
   ];
 
   renderWithFilters(filters, { filterValues: filters });
@@ -247,7 +229,7 @@ test('omits the empty message when at least one filter value is supplied', async
   // upstream user flow (open edit modal, add filter, save) is integration
   // territory and not covered here.
   const filters = [
-    createSelectFilter('NATIVE_FILTER-1', 'just_added', 'country_name'),
+    createSelectNativeFilter('NATIVE_FILTER-1', 'just_added', 'country_name'),
   ];
 
   renderWithFilters(filters, { filterValues: filters });


### PR DESCRIPTION
### SUMMARY
Adds React Testing Library coverage for the horizontal filter bar's layout, overflow, and orientation routing — behavior that was previously only covered by a disabled Cypress spec. Part of the ongoing Cypress → RTL/Playwright migration.

Three test files are touched:

- **`HorizontalFilterBar.test.tsx`** — 3 new cases covering the default-actions slot, all-filters rendering, and the empty-state message flipping off when `filterValues` is non-empty.
- **`FilterControls/FilterControls.overflow.test.tsx`** (new) — 5 cases that drive overflow behavior by mocking the `@superset-ui/core/components/DropdownContainer` subpath and invoking `onOverflowingStateChange` directly: items pass-through, no-overflow (trigger count 0), overflow with active filter values (trigger count reflects active values), overflow with no active values (trigger 0 but content rendered), and all 12 overflowed filters reachable in `dropdownContent`.
- **`FilterBar.test.tsx`** — 2 cases asserting that `FilterBarOrientation.Horizontal` mounts `Horizontal.tsx` (settings gear present, vertical heading absent) and `FilterBarOrientation.Vertical` mounts the vertical control.

### Implementation notes

- `DropdownContainer` uses `react-resize-detector`, which reports width 0 in jsdom. Driving the real overflow math is unstable, so the overflow tests mock the `DropdownContainer` subpath (not the `@superset-ui/core/components` barrel — the barrel mock triggers a circular re-export chain via `LabeledErrorBoundInput` / `ActionButton`).
- Reload-persistence of orientation is integration-level (server-side `json_metadata`, not localStorage) and is not RTL-testable; it remains out of scope for this change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — test-only change.

### TESTING INSTRUCTIONS
\`\`\`bash
cd superset-frontend
npx jest \\
  src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx \\
  src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx \\
  src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.test.tsx \\
  src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.overflow.test.tsx
\`\`\`
Expected: 49 passing tests across the four files.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API