### PR TITLE
fix(mcp): redirect stdio click echo without recursion

### DIFF
--- a/superset/mcp_service/__main__.py
+++ b/superset/mcp_service/__main__.py
@@ -25,21 +25,37 @@ import io
 import logging
 import os
 import sys
-from typing import Any
+from typing import Any, Callable
 
 # Must redirect click output BEFORE importing anything that uses it
 import click
 
 # Monkey-patch click to redirect output to stderr in stdio mode
 if os.environ.get("FASTMCP_TRANSPORT", "stdio") == "stdio":
+    original_echo = click.echo
     original_secho = click.secho
 
-    def secho_to_stderr(*args: Any, **kwargs: Any) -> Any:
-        kwargs["file"] = sys.stderr
-        return original_secho(*args, **kwargs)
+    def redirect_to_stderr(
+        original_func: Callable[..., None],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        if len(args) >= 2:
+            args = (args[0], sys.stderr, *args[2:])
+            kwargs.pop("file", None)
+        else:
+            kwargs["file"] = sys.stderr
 
+        original_func(*args, **kwargs)
+
+    def echo_to_stderr(*args: Any, **kwargs: Any) -> None:
+        redirect_to_stderr(original_echo, *args, **kwargs)
+
+    def secho_to_stderr(*args: Any, **kwargs: Any) -> None:
+        redirect_to_stderr(original_secho, *args, **kwargs)
+
+    click.echo = echo_to_stderr
     click.secho = secho_to_stderr
-    click.echo = lambda *args, **kwargs: click.echo(*args, file=sys.stderr, **kwargs)
 
 from superset.mcp_service.app import init_fastmcp_server, mcp
 from superset.mcp_service.middleware import create_response_size_guard_middleware

--- a/tests/unit_tests/test_mcp_stdio_entrypoint.py
+++ b/tests/unit_tests/test_mcp_stdio_entrypoint.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import io
+import sys
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import click
+import pytest
+
+_ENTRYPOINT_PATH = (
+    Path(__file__).resolve().parents[2] / "superset/mcp_service/__main__.py"
+)
+
+
+def _install_entrypoint_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    superset_module = cast(Any, ModuleType("superset"))
+    superset_module.__path__ = []
+
+    mcp_service_module = cast(Any, ModuleType("superset.mcp_service"))
+    mcp_service_module.__path__ = []
+
+    app_module = cast(Any, ModuleType("superset.mcp_service.app"))
+    app_module.init_fastmcp_server = MagicMock()
+    app_module.mcp = MagicMock()
+
+    middleware_module = cast(Any, ModuleType("superset.mcp_service.middleware"))
+    middleware_module.create_response_size_guard_middleware = lambda: None
+
+    server_module = cast(Any, ModuleType("superset.mcp_service.server"))
+    server_module.build_middleware_list = lambda: []
+
+    monkeypatch.setitem(sys.modules, "superset", superset_module)
+    monkeypatch.setitem(sys.modules, "superset.mcp_service", mcp_service_module)
+    monkeypatch.setitem(sys.modules, "superset.mcp_service.app", app_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "superset.mcp_service.middleware",
+        middleware_module,
+    )
+    monkeypatch.setitem(sys.modules, "superset.mcp_service.server", server_module)
+
+
+def _load_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    module_name = "superset.mcp_service.__main__"
+    spec = util.spec_from_file_location(module_name, _ENTRYPOINT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+
+
+def test_stdio_click_output_is_redirected_to_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """click output should use the saved original functions in stdio mode."""
+    original_echo = click.echo
+    original_secho = click.secho
+
+    monkeypatch.setenv("FASTMCP_TRANSPORT", "stdio")
+    monkeypatch.setattr(click, "echo", original_echo)
+    monkeypatch.setattr(click, "secho", original_secho)
+    _install_entrypoint_stubs(monkeypatch)
+
+    try:
+        _load_entrypoint(monkeypatch)
+
+        other_stream = io.StringIO()
+        click.echo("plain message")
+        click.echo("keyword file message", file=other_stream)
+        click.echo("positional file message", other_stream)
+        click.secho("styled message")
+        click.secho("styled keyword file message", file=other_stream)
+        click.secho("styled positional file message", other_stream)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert other_stream.getvalue() == ""
+        assert "plain message" in captured.err
+        assert "keyword file message" in captured.err
+        assert "positional file message" in captured.err
+        assert "styled message" in captured.err
+        assert "styled keyword file message" in captured.err
+        assert "styled positional file message" in captured.err
+    finally:
+        click.echo = original_echo
+        click.secho = original_secho


### PR DESCRIPTION
### Summary

Fix the MCP stdio entry point so the `click.echo` monkey-patch calls the saved original function instead of calling the patched attribute again.

### Root cause

In stdio mode, `superset.mcp_service.__main__` replaced `click.echo` with a lambda that called `click.echo` again. After assignment, that name points back to the lambda itself, so normal Click output can fail instead of being redirected to stderr.

### Changes

- Save `click.echo` before patching it, matching the existing `click.secho` pattern.
- Add a focused regression test that loads the stdio entry point with lightweight stubs and verifies `click.echo` and `click.secho` write to stderr without writing to stdout.

### Checks

- `uv run --no-project --with ruff ruff check --config pyproject.toml superset/mcp_service/__main__.py tests/unit_tests/test_mcp_stdio_entrypoint.py`
- Standalone stdio redirection check with `click` and stubbed MCP imports
