### PR TITLE
fix(explore): apply RLS to matrixify dimension values at render

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridRenderer.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridRenderer.test.tsx
@@ -23,10 +23,19 @@ import { ThemeProvider, supersetTheme } from '@apache-superset/core/theme';
 import MatrixifyGridRenderer from './MatrixifyGridRenderer';
 import type { MatrixifyMode } from '../../types/matrixify';
 import { generateMatrixifyGrid } from './MatrixifyGridGenerator';
+import { useMatrixifyAllowedValues } from './useMatrixifyAllowedValues';
 
 // Mock the MatrixifyGridGenerator
 jest.mock('./MatrixifyGridGenerator', () => ({
   generateMatrixifyGrid: jest.fn(),
+}));
+
+// Mock the RLS allow-list hook so the renderer can be tested without network
+jest.mock('./useMatrixifyAllowedValues', () => ({
+  useMatrixifyAllowedValues: jest.fn(() => ({
+    status: 'success',
+    allowedByColumn: {},
+  })),
 }));
 
 // Mock MatrixifyGridCell component
@@ -40,12 +49,20 @@ jest.mock('./MatrixifyGridCell', () =>
 const mockGenerateMatrixifyGrid = generateMatrixifyGrid as jest.MockedFunction<
   typeof generateMatrixifyGrid
 >;
+const mockUseMatrixifyAllowedValues =
+  useMatrixifyAllowedValues as jest.MockedFunction<
+    typeof useMatrixifyAllowedValues
+  >;
 
 const renderWithTheme = (component: React.ReactElement) =>
   render(<ThemeProvider theme={supersetTheme}>{component}</ThemeProvider>);
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockUseMatrixifyAllowedValues.mockReturnValue({
+    status: 'success',
+    allowedByColumn: {},
+  });
 });
 
 test('should create single group when fitting columns dynamically', () => {
@@ -415,4 +432,81 @@ test('should use default values for missing configuration', () => {
   expect(container).not.toBeEmptyDOMElement();
   const gridCells = container.querySelectorAll('[data-testid^="grid-cell-"]');
   expect(gridCells).toHaveLength(2);
+});
+
+test('shows a loading indicator while the RLS allow-list resolves', () => {
+  mockUseMatrixifyAllowedValues.mockReturnValue({
+    status: 'loading',
+    allowedByColumn: {},
+  });
+
+  const formData = {
+    viz_type: 'test_chart',
+    matrixify_enable: true,
+    matrixify_mode_rows: 'dimensions' as MatrixifyMode,
+    matrixify_dimension_rows: { dimension: 'region', values: ['US'] },
+  };
+
+  const { container } = renderWithTheme(
+    <MatrixifyGridRenderer formData={formData} />,
+  );
+
+  // The grid is never built while resolution is in flight
+  expect(mockGenerateMatrixifyGrid).not.toHaveBeenCalled();
+  const gridCells = container.querySelectorAll('[data-testid^="grid-cell-"]');
+  expect(gridCells).toHaveLength(0);
+  expect(
+    container.querySelector('[data-test="loading-indicator"]'),
+  ).toBeInTheDocument();
+});
+
+test('fails closed and renders no cells when the allow-list errors', () => {
+  mockUseMatrixifyAllowedValues.mockReturnValue({
+    status: 'error',
+    allowedByColumn: {},
+  });
+
+  const formData = {
+    viz_type: 'test_chart',
+    matrixify_enable: true,
+    matrixify_mode_rows: 'dimensions' as MatrixifyMode,
+    matrixify_dimension_rows: { dimension: 'region', values: ['US'] },
+  };
+
+  const { container, getByText } = renderWithTheme(
+    <MatrixifyGridRenderer formData={formData} />,
+  );
+
+  expect(mockGenerateMatrixifyGrid).not.toHaveBeenCalled();
+  const gridCells = container.querySelectorAll('[data-testid^="grid-cell-"]');
+  expect(gridCells).toHaveLength(0);
+  expect(
+    getByText('Unable to verify access to dimension values.'),
+  ).toBeInTheDocument();
+});
+
+test('filters stored dimension values to the RLS allow-list before building the grid', () => {
+  mockUseMatrixifyAllowedValues.mockReturnValue({
+    status: 'success',
+    allowedByColumn: { region: new Set(['US']) },
+  });
+  mockGenerateMatrixifyGrid.mockReturnValue({
+    rowHeaders: [],
+    colHeaders: [],
+    cells: [],
+  } as any);
+
+  const formData = {
+    viz_type: 'test_chart',
+    matrixify_enable: true,
+    matrixify_mode_rows: 'dimensions' as MatrixifyMode,
+    // 'EU' is not in the viewer's allow-list and must be dropped
+    matrixify_dimension_rows: { dimension: 'region', values: ['US', 'EU'] },
+  };
+
+  renderWithTheme(<MatrixifyGridRenderer formData={formData} />);
+
+  expect(mockGenerateMatrixifyGrid).toHaveBeenCalledTimes(1);
+  const passedFormData = mockGenerateMatrixifyGrid.mock.calls[0][0] as any;
+  expect(passedFormData.matrixify_dimension_rows.values).toEqual(['US']);
 });

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridRenderer.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridRenderer.tsx
@@ -19,9 +19,19 @@
 
 import { useMemo } from 'react';
 import { styled } from '@apache-superset/core/theme';
+import { t } from '@apache-superset/core/translation';
+import { Loading } from '../../../components/Loading';
+import type { QueryFormData } from '../../../query';
 import { MatrixifyFormData } from '../../types/matrixify';
 import { generateMatrixifyGrid } from './MatrixifyGridGenerator';
+import { useMatrixifyAllowedValues } from './useMatrixifyAllowedValues';
 import MatrixifyGridCell from './MatrixifyGridCell';
+
+// formData keys holding the frozen dimension axis values
+const DIMENSION_AXIS_KEYS = [
+  'matrixify_dimension_rows',
+  'matrixify_dimension_columns',
+] as const;
 
 // Layout constants
 const HEADER_HEIGHT = 24; // Height for column headers and width for row headers (reduced from 32)
@@ -74,6 +84,17 @@ const GridGroup = styled.div<{ isLast: boolean }>`
   margin-bottom: ${({ isLast }) => (isLast ? 0 : GROUP_SPACING)}px;
 `;
 
+const GridMessage = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: ${({ theme }) => theme.sizeUnit * 4}px;
+  text-align: center;
+  color: ${({ theme }) => theme.colorTextTertiary};
+`;
+
 const GridHeader = styled.div`
   background-color: ${({ theme }) => theme.colorFillAlter};
   padding: ${({ theme }) => theme.sizeUnit / 2}px; /* Reduced padding */
@@ -121,10 +142,48 @@ function MatrixifyGridRenderer({
   height,
   hooks,
 }: MatrixifyGridRendererProps) {
-  // Generate grid structure from form data
+  // Resolve which dimension values the current viewer is allowed to see, with
+  // row-level security applied server-side. Matrixify axis values are frozen
+  // into formData at design time, so without this the grid would be built from
+  // the chart author's RLS context and leak values to restricted viewers.
+  const { status: allowedStatus, allowedByColumn } =
+    useMatrixifyAllowedValues(formData);
+
+  // Drop any stored axis values the viewer is not entitled to before building
+  // the grid, so forbidden subplots (and their value labels) are never emitted.
+  const sanitizedFormData = useMemo(() => {
+    if (allowedStatus !== 'success') {
+      return formData;
+    }
+    const next: MatrixifyFormData = { ...formData };
+    DIMENSION_AXIS_KEYS.forEach(key => {
+      const dimension = next[key];
+      if (!dimension?.dimension || !Array.isArray(dimension.values)) {
+        return;
+      }
+      const allowed = allowedByColumn[dimension.dimension];
+      if (!allowed) {
+        return;
+      }
+      next[key] = {
+        ...dimension,
+        values: dimension.values.filter(value => allowed.has(String(value))),
+      };
+    });
+    return next;
+  }, [formData, allowedStatus, allowedByColumn]);
+
+  // Generate grid structure from the RLS-filtered form data. Never build it
+  // until the allow-list resolves, so a grid is never derived from unfiltered
+  // (potentially leaking) values.
   const grid = useMemo(
-    () => generateMatrixifyGrid(formData as any),
-    [formData],
+    () =>
+      allowedStatus === 'success'
+        ? generateMatrixifyGrid(
+            sanitizedFormData as QueryFormData & MatrixifyFormData,
+          )
+        : null,
+    [sanitizedFormData, allowedStatus],
   );
 
   // Determine layout parameters - only show headers/labels if layout is enabled
@@ -163,6 +222,28 @@ function MatrixifyGridRenderer({
     }
     return groups;
   }, [grid, fitColumnsDynamically, chartsPerRow]);
+
+  // Wait for the allow-list before rendering anything, so unfiltered values are
+  // never shown — even briefly — while resolution is in flight.
+  if (allowedStatus === 'loading') {
+    return (
+      <GridContainer height={height}>
+        <Loading />
+      </GridContainer>
+    );
+  }
+
+  // Fail closed: if the allow-list could not be resolved, render nothing rather
+  // than falling back to the unfiltered (leaking) value list.
+  if (allowedStatus === 'error') {
+    return (
+      <GridContainer height={height}>
+        <GridMessage>
+          {t('Unable to verify access to dimension values.')}
+        </GridMessage>
+      </GridContainer>
+    );
+  }
 
   if (!grid) {
     return null;

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/useMatrixifyAllowedValues.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/useMatrixifyAllowedValues.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { SupersetClient } from '../../..';
+import {
+  MatrixifyAllowedValuesFormData,
+  useMatrixifyAllowedValues,
+} from './useMatrixifyAllowedValues';
+
+jest.mock('../../..', () => ({
+  SupersetClient: { get: jest.fn() },
+}));
+
+const mockGet = SupersetClient.get as jest.Mock;
+
+const rowDimensionFormData = (
+  dimension: string,
+): MatrixifyAllowedValuesFormData => ({
+  datasource: '7__table',
+  matrixify_enable: true,
+  matrixify_mode_rows: 'dimensions',
+  matrixify_dimension_rows: { dimension, values: ['US'] },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('resolves immediately without fetching for metrics-only matrixify', () => {
+  const { result } = renderHook(() =>
+    useMatrixifyAllowedValues({
+      datasource: '1__table',
+      matrixify_enable: true,
+      matrixify_mode_rows: 'metrics',
+      matrixify_mode_columns: 'metrics',
+    }),
+  );
+
+  expect(result.current.status).toBe('success');
+  expect(result.current.allowedByColumn).toEqual({});
+  expect(mockGet).not.toHaveBeenCalled();
+});
+
+test('fetches RLS-allowed values for each dimension axis', async () => {
+  mockGet.mockImplementation(({ endpoint }: { endpoint: string }) => {
+    if (endpoint.includes('/column/region/')) {
+      return Promise.resolve({ json: { result: ['US', 'CA'] } });
+    }
+    return Promise.resolve({ json: { result: [2024, 2025] } });
+  });
+
+  const { result } = renderHook(() =>
+    useMatrixifyAllowedValues({
+      datasource: '7__table',
+      matrixify_enable: true,
+      matrixify_mode_rows: 'dimensions',
+      matrixify_dimension_rows: { dimension: 'region', values: ['US', 'EU'] },
+      matrixify_mode_columns: 'dimensions',
+      matrixify_dimension_columns: { dimension: 'year', values: [2024] },
+    }),
+  );
+
+  await waitFor(() => expect(result.current.status).toBe('success'));
+
+  expect(mockGet).toHaveBeenCalledTimes(2);
+  expect(result.current.allowedByColumn.region).toEqual(new Set(['US', 'CA']));
+  // values are string-normalized so they can be compared regardless of type
+  expect(result.current.allowedByColumn.year).toEqual(
+    new Set(['2024', '2025']),
+  );
+});
+
+test('fails closed when the values endpoint errors', async () => {
+  mockGet.mockRejectedValue(new Error('boom'));
+
+  const { result } = renderHook(() =>
+    useMatrixifyAllowedValues(rowDimensionFormData('region')),
+  );
+
+  await waitFor(() => expect(result.current.status).toBe('error'));
+  expect(result.current.allowedByColumn).toEqual({});
+});
+
+test('fails closed when datasource is missing', async () => {
+  const { result } = renderHook(() =>
+    useMatrixifyAllowedValues({
+      matrixify_enable: true,
+      matrixify_mode_rows: 'dimensions',
+      matrixify_dimension_rows: { dimension: 'region', values: ['US'] },
+    }),
+  );
+
+  await waitFor(() => expect(result.current.status).toBe('error'));
+  expect(mockGet).not.toHaveBeenCalled();
+});
+
+test('reports loading again as soon as the dimension column changes', async () => {
+  mockGet.mockImplementation(({ endpoint }: { endpoint: string }) =>
+    Promise.resolve({
+      json: {
+        result: endpoint.includes('/column/region/') ? ['US'] : ['red'],
+      },
+    }),
+  );
+
+  const { result, rerender } = renderHook(
+    ({ dimension }: { dimension: string }) =>
+      useMatrixifyAllowedValues(rowDimensionFormData(dimension)),
+    { initialProps: { dimension: 'region' } },
+  );
+
+  await waitFor(() => expect(result.current.status).toBe('success'));
+
+  rerender({ dimension: 'color' });
+
+  // The first render seeing the new column must not expose the previous
+  // allow-list: it holds no entry for `color`, so the grid would filter
+  // nothing and render the frozen (unfiltered) values.
+  expect(result.current.status).toBe('loading');
+  expect(result.current.allowedByColumn).toEqual({});
+
+  await waitFor(() => expect(result.current.status).toBe('success'));
+  expect(result.current.allowedByColumn).toEqual({ color: new Set(['red']) });
+});
+
+test('discards a response that resolves after its request was superseded', async () => {
+  const pending: ((value: unknown) => void)[] = [];
+  mockGet.mockImplementation(
+    () =>
+      new Promise(resolve => {
+        pending.push(resolve);
+      }),
+  );
+
+  const { result, rerender } = renderHook(
+    ({ dimension }: { dimension: string }) =>
+      useMatrixifyAllowedValues(rowDimensionFormData(dimension)),
+    { initialProps: { dimension: 'region' } },
+  );
+
+  rerender({ dimension: 'color' });
+
+  await act(async () => {
+    pending[0]({ json: { result: ['US', 'EU'] } });
+  });
+
+  expect(result.current.status).toBe('loading');
+  expect(result.current.allowedByColumn).toEqual({});
+
+  await act(async () => {
+    pending[1]({ json: { result: ['red'] } });
+  });
+
+  expect(result.current.status).toBe('success');
+  expect(result.current.allowedByColumn).toEqual({ color: new Set(['red']) });
+});
+
+test('a superseded request failing does not surface an error', async () => {
+  const pending: ((reason: Error) => void)[] = [];
+  mockGet.mockImplementation(
+    () =>
+      new Promise((_resolve, reject) => {
+        pending.push(reject);
+      }),
+  );
+
+  const { result, rerender } = renderHook(
+    ({ dimension }: { dimension: string }) =>
+      useMatrixifyAllowedValues(rowDimensionFormData(dimension)),
+    { initialProps: { dimension: 'region' } },
+  );
+
+  rerender({ dimension: 'color' });
+
+  await act(async () => {
+    pending[0](new Error('aborted'));
+  });
+
+  expect(result.current.status).toBe('loading');
+});

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/useMatrixifyAllowedValues.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/useMatrixifyAllowedValues.ts
@@ -1,0 +1,182 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { SupersetClient } from '../../..';
+import { getMatrixifyConfig, MatrixifyFormData } from '../../types/matrixify';
+
+export type MatrixifyAllowedValuesStatus = 'success' | 'loading' | 'error';
+
+export interface MatrixifyAllowedValuesState {
+  status: MatrixifyAllowedValuesStatus;
+  /**
+   * Map of dimension column name -> set of string-normalized values the
+   * current viewer is allowed to see (RLS applied by the backend).
+   */
+  allowedByColumn: Record<string, Set<string>>;
+}
+
+export interface MatrixifyAllowedValuesFormData extends MatrixifyFormData {
+  /** ``${id}__${type}`` identifier the column-values endpoint is keyed by */
+  datasource?: string;
+}
+
+/**
+ * A resolution tagged with the request it belongs to, so a result fetched for a
+ * previous datasource/axis is never mistaken for the current one.
+ */
+interface ResolvedAllowedValues extends MatrixifyAllowedValuesState {
+  key: string;
+}
+
+const NO_ALLOWED_VALUES: Record<string, Set<string>> = {};
+const NO_DIMENSIONS_KEY = '[]';
+
+/**
+ * Collect the distinct dimension columns referenced by the matrixify axes.
+ */
+function getDimensionColumns(formData: MatrixifyFormData): string[] {
+  const config = getMatrixifyConfig(formData);
+  if (!config) {
+    return [];
+  }
+  const columns = new Set<string>();
+  [config.rows, config.columns].forEach(axis => {
+    if (axis.mode === 'dimensions' && axis.dimension?.dimension) {
+      columns.add(axis.dimension.dimension);
+    }
+  });
+  return Array.from(columns);
+}
+
+/**
+ * Fetch the distinct values a viewer is permitted to see for a column. This
+ * reuses the datasource ``/column/<col>/values/`` endpoint, which applies the
+ * requesting user's row-level security filters server-side.
+ */
+async function fetchAllowedValues(
+  datasource: string,
+  column: string,
+  signal: AbortSignal,
+): Promise<unknown[]> {
+  const [id, type] = String(datasource).split('__');
+  const endpoint = `/api/v1/datasource/${type}/${id}/column/${encodeURIComponent(
+    column,
+  )}/values/`;
+  const { json } = await SupersetClient.get({ endpoint, signal });
+  return json?.result || [];
+}
+
+/**
+ * Resolve, per render, which dimension values the current viewer is allowed to
+ * see. Matrixify axis values are frozen into ``formData`` at design time, so
+ * without this the grid would be built from the chart author's RLS context and
+ * leak values (as subplot headers + empty cells) to restricted viewers. The
+ * renderer intersects the stored values against the returned allow-list.
+ *
+ * Fails closed: while loading the grid must not render, and on error the
+ * allow-list is treated as empty rather than falling back to the unfiltered
+ * (leaking) list.
+ */
+export function useMatrixifyAllowedValues(
+  formData: MatrixifyAllowedValuesFormData,
+): MatrixifyAllowedValuesState {
+  const { datasource } = formData;
+  // Serialize the dimension columns to a primitive key. ``formData`` is a fresh
+  // object on most renders, so the effect must depend on this stable string
+  // rather than the (always-new) array, otherwise it would refetch in a loop.
+  const columnsKey = useMemo(
+    () => JSON.stringify([...getDimensionColumns(formData)].sort()),
+    [formData],
+  );
+  // Identifies the resolution this render requires; state tagged with any other
+  // key describes a datasource/axis the viewer is no longer looking at.
+  const fetchKey = `${datasource ?? ''}|${columnsKey}`;
+
+  const [resolved, setResolved] = useState<ResolvedAllowedValues | null>(null);
+
+  useEffect(() => {
+    const dimensionColumns: string[] = JSON.parse(columnsKey);
+
+    // Metrics-only matrixify has no dimension axes: nothing to resolve.
+    if (dimensionColumns.length === 0) {
+      return undefined;
+    }
+
+    if (!datasource) {
+      setResolved({
+        key: fetchKey,
+        status: 'error',
+        allowedByColumn: NO_ALLOWED_VALUES,
+      });
+      return undefined;
+    }
+
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const results = await Promise.all(
+          dimensionColumns.map(column =>
+            fetchAllowedValues(datasource, column, controller.signal).then(
+              values => [column, values] as const,
+            ),
+          ),
+        );
+        if (controller.signal.aborted) {
+          return;
+        }
+        const allowedByColumn: Record<string, Set<string>> = {};
+        results.forEach(([column, values]) => {
+          allowedByColumn[column] = new Set(values.map(value => String(value)));
+        });
+        setResolved({ key: fetchKey, status: 'success', allowedByColumn });
+      } catch {
+        if (!controller.signal.aborted) {
+          setResolved({
+            key: fetchKey,
+            status: 'error',
+            allowedByColumn: NO_ALLOWED_VALUES,
+          });
+        }
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [datasource, columnsKey, fetchKey]);
+
+  return useMemo<MatrixifyAllowedValuesState>(() => {
+    if (columnsKey === NO_DIMENSIONS_KEY) {
+      return { status: 'success', allowedByColumn: NO_ALLOWED_VALUES };
+    }
+    // Derive the status from the key rather than from a state reset inside the
+    // effect: when the axis or datasource changes, the render that observes the
+    // new key must already report loading, or the grid would be built once from
+    // the previous allow-list (missing the new column, so unfiltered).
+    if (resolved?.key !== fetchKey) {
+      return { status: 'loading', allowedByColumn: NO_ALLOWED_VALUES };
+    }
+    return {
+      status: resolved.status,
+      allowedByColumn: resolved.allowedByColumn,
+    };
+  }, [columnsKey, fetchKey, resolved]);
+}


### PR DESCRIPTION
### SUMMARY

Matrixify (subplot grid) builds its row/column axes from dimension **values frozen into `formData` at design time**. The cell data queries already enforce RLS, but the *grid structure itself* — which subplots exist and their header labels — is generated client-side from that frozen list with no per-viewer check. So an RLS-restricted viewer (notably an embedded guest) gets a subplot, with a value label, for **every** value the chart author could see — leaking the value identifiers and producing a grid of empty cells. This made the feature hard to use in embedded contexts.

Fix: resolve the allowed dimension values **per render** and intersect the stored axis values against them before building the grid.

- New `useMatrixifyAllowedValues` hook fetches the RLS-filtered distinct values for each dimension axis via the existing `/datasource/<type>/<id>/column/<col>/values/` endpoint, which applies the *requesting viewer's* RLS server-side.
- `MatrixifyGridRenderer` drops any frozen value not in the allow-list before generating the grid, so forbidden subplots and their labels are never emitted.
- **Fails closed**: the grid renders nothing until the allow-list resolves (loading spinner), and on fetch error it shows a message rather than the unfiltered list. The grid is never built from unfiltered values.
- No fetch for metrics-only matrixify. Effect is keyed on primitives so it won't refetch-loop when `formData` identity changes each render.

Applies in all contexts (explore, dashboard, embedded) since `MatrixifyGridRenderer` is the single render path via `SuperChart`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — behavior change is per-viewer RLS filtering of which subplots appear; not easily captured as a static screenshot without an RLS-configured fixture.

### TESTING INSTRUCTIONS

1. Create a dataset with an RLS rule restricting a dimension (e.g. `region` to `US`) for a non-admin/embedded role.
2. As admin, build a chart with Matrixify enabled, rows = that dimension, selecting values the admin can see (e.g. `US`, `EU`, `APAC`).
3. View the chart (or embed it) as the restricted role/guest token.
4. **Before:** subplots/headers appear for `EU`, `APAC` (empty cells). **After:** only `US` renders.

Automated: `npm run test -- packages/superset-ui-core/src/chart/components/Matrixify` (hook + renderer suites: fetch/normalize, fail-closed, loading/error gates, value filtering).

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Fixes #43258
- [ ] Required feature flags: No
- [x] Changes UI — RLS-restricted viewers now see fewer/empty-free matrixify subplots; adds loading/error states to the grid
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No — reuses the existing datasource column-values endpoint
- [ ] Removes existing feature or API: No

Follow-ups (not in this PR): confirm the values endpoint is reachable under an embedded **guest token**; `topn` mode currently intersects rather than re-ranking per viewer, so a restricted viewer may see fewer than N subplots.