### PR TITLE
test(core): add unit tests for split function

### DIFF
--- a/tests/unit_tests/utils/test_split.py
+++ b/tests/unit_tests/utils/test_split.py
@@ -17,9 +17,6 @@
 
 from superset.utils.core import split
 
-# ======================================
-#  (BLACK BOX)
-# ======================================
 
 def test_split_empty_string():
     assert list(split("")) == [""]
@@ -58,9 +55,6 @@ def test_split_nested_parentheses():
     ]
 
 
-# ======================================
-#  (WHITE BOX)
-# ======================================
 
 def test_branch_separator_found():
     assert list(split("a b")) == [

--- a/tests/unit_tests/utils/test_split.py
+++ b/tests/unit_tests/utils/test_split.py
@@ -1,8 +1,3 @@
-from superset.utils.core import split
-
-
-# ======================================
-# CAIXA PRETA (BLACK BOX)
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -19,6 +14,12 @@ from superset.utils.core import split
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from superset.utils.core import split
+
+# ======================================
+#  (BLACK BOX)
+# ======================================
 
 def test_split_empty_string():
     assert list(split("")) == [""]
@@ -58,7 +59,7 @@ def test_split_nested_parentheses():
 
 
 # ======================================
-# CAIXA BRANCA (WHITE BOX)
+#  (WHITE BOX)
 # ======================================
 
 def test_branch_separator_found():

--- a/tests/unit_tests/utils/test_split.py
+++ b/tests/unit_tests/utils/test_split.py
@@ -3,7 +3,22 @@ from superset.utils.core import split
 
 # ======================================
 # CAIXA PRETA (BLACK BOX)
-# ======================================
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 def test_split_empty_string():
     assert list(split("")) == [""]

--- a/tests/unit_tests/utils/test_split.py
+++ b/tests/unit_tests/utils/test_split.py
@@ -55,7 +55,6 @@ def test_split_nested_parentheses():
     ]
 
 
-
 def test_branch_separator_found():
     assert list(split("a b")) == [
         "a",

--- a/tests/unit_tests/utils/test_split.py
+++ b/tests/unit_tests/utils/test_split.py
@@ -1,0 +1,72 @@
+from superset.utils.core import split
+
+
+# ======================================
+# CAIXA PRETA (BLACK BOX)
+# ======================================
+
+def test_split_empty_string():
+    assert list(split("")) == [""]
+
+
+def test_split_leading_delimiter():
+    assert list(split(" a")) == [
+        "",
+        "a",
+    ]
+
+
+def test_split_trailing_delimiter():
+    assert list(split("a ")) == [
+        "a",
+        "",
+    ]
+
+
+def test_split_only_delimiter():
+    assert list(split(" ")) == [
+        "",
+        "",
+    ]
+
+
+def test_split_nested_parentheses():
+    assert list(
+        split(
+            "a,(b,(c,d))",
+            delimiter=",",
+        )
+    ) == [
+        "a",
+        "(b,(c,d))",
+    ]
+
+
+# ======================================
+# CAIXA BRANCA (WHITE BOX)
+# ======================================
+
+def test_branch_separator_found():
+    assert list(split("a b")) == [
+        "a",
+        "b",
+    ]
+
+
+def test_branch_separator_not_found():
+    assert list(split("ab")) == [
+        "ab",
+    ]
+
+
+def test_branch_parentheses():
+    assert list(split("(a b)")) == [
+        "(a b)",
+    ]
+
+
+def test_branch_escaped_quote():
+    assert list(split(r'"a\"b c" d')) == [
+        r'"a\"b c"',
+        "d",
+    ]


### PR DESCRIPTION
### SUMMARY

Adds unit tests for the `split` utility function located in `superset/utils/core.py`.

The test suite includes both black-box and white-box test cases to validate expected behavior and exercise key execution paths of the function.

Black-box tests cover:

* Empty string input
* Leading delimiter
* Trailing delimiter
* Delimiter-only string
* Nested parentheses

White-box tests cover:

* Delimiter found branch
* Delimiter not found branch
* Parentheses handling branch
* Escaped quote handling branch

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable.

### TESTING INSTRUCTIONS

Run:

```bash
pytest --noconftest tests/unit_tests/utils/test_split.py -v
```

Expected result:

```text
9 passed
```

### ADDITIONAL INFORMATION

* [ ] Has associated issue:
* [ ] Required feature flags:
* [ ] Changes UI
* [ ] Includes DB Migration
* [ ] Introduces new feature or API
* [ ] Removes existing feature or API
